### PR TITLE
feat: remove legacy node pool delete code paths now that control is on backend

### DIFF
--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -43,6 +43,7 @@ import (
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/managementclustercontrollers"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/metricscontrollers"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/mismatchcontrollers"
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/nodepooldeletion"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/operationcontrollers"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/upgradecontrollers"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/validationcontrollers"
@@ -567,7 +568,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 	)
 
 	maestroCreateNodePoolScopedReadonlyBundlesController := controllers.NewCreateNodePoolScopedMaestroReadonlyBundlesController(
-		activeOperationLister, b.options.ResourcesDBClient, b.options.ClustersServiceClient,
+		activeOperationLister, b.options.ResourcesDBClient, b.options.FleetDBClient, b.options.ClustersServiceClient,
 		backendInformers, b.options.MaestroSourceEnvironmentIdentifier, maestroClientBuilder,
 	)
 	maestroReadAndPersistNodePoolScopedReadonlyBundlesContentController := controllers.NewReadAndPersistNodePoolScopedMaestroReadonlyBundlesContentController(
@@ -630,6 +631,30 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		unionKubeApplierInformers,
 	)
 
+	nodePoolDeletionClusterServiceDeleteDispatchController := nodepooldeletion.NewNodePoolClusterServiceDeleteDispatchController(
+		utilsclock.RealClock{},
+		b.options.ResourcesDBClient,
+		b.options.ClustersServiceClient,
+		activeOperationLister,
+		backendInformers,
+	)
+	nodePoolClusterServiceIDClearerController := nodepooldeletion.NewNodePoolClusterServiceIDClearerController(
+		b.options.ResourcesDBClient,
+		b.options.ClustersServiceClient,
+		activeOperationLister,
+		backendInformers,
+	)
+	nodePoolChildResourcesCleanupController := nodepooldeletion.NewNodePoolChildResourcesCleanupController(
+		b.options.ResourcesDBClient,
+		activeOperationLister,
+		backendInformers,
+	)
+	nodePoolDeletionController := nodepooldeletion.NewNodePoolDeletionController(
+		b.options.ResourcesDBClient,
+		activeOperationLister,
+		backendInformers,
+	)
+
 	le, err := leaderelection.NewLeaderElector(leaderelection.LeaderElectionConfig{
 		Lock:          b.options.LeaderElectionLock,
 		LeaseDuration: leaderElectionLeaseDuration,
@@ -690,6 +715,10 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 				go maestroReadAndPersistNodePoolScopedReadonlyBundlesContentController.Run(ctx, 20)
 				go maestroDeleteOrphanedReadonlyBundlesController.Run(ctx, 20)
 				go triggerNodePoolUpgradeController.Run(ctx, 20)
+				go nodePoolDeletionClusterServiceDeleteDispatchController.Run(ctx, 20)
+				go nodePoolClusterServiceIDClearerController.Run(ctx, 20)
+				go nodePoolChildResourcesCleanupController.Run(ctx, 20)
+				go nodePoolDeletionController.Run(ctx, 20)
 				go operationPhaseMetricsController.Run(ctx, 1)
 				go clusterMetricsController.Run(ctx, 1)
 				go nodePoolMetricsController.Run(ctx, 1)

--- a/backend/pkg/controllers/create_cluster_scoped_maestro_readonly_bundles_controller.go
+++ b/backend/pkg/controllers/create_cluster_scoped_maestro_readonly_bundles_controller.go
@@ -173,7 +173,7 @@ func (c *createClusterScopedMaestroReadonlyBundlesSyncer) SyncOnce(ctx context.C
 	// This is important to avoid leaking resources when the sync is done.
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	maestroClient, err := createMaestroClientFromCSProvisionShard(ctx, c.maestroSourceEnvironmentIdentifier, c.maestroClientBuilder, clusterProvisionShard)
+	maestroClient, err := CreateMaestroClientFromCSProvisionShard(ctx, c.maestroSourceEnvironmentIdentifier, c.maestroClientBuilder, clusterProvisionShard)
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to create Maestro client: %w", err))
 	}

--- a/backend/pkg/controllers/create_nodepool_scoped_maestro_readonly_bundles_controller.go
+++ b/backend/pkg/controllers/create_nodepool_scoped_maestro_readonly_bundles_controller.go
@@ -152,13 +152,6 @@ func (c *createNodePoolScopedMaestroReadonlyBundlesSyncer) shouldReconcileCreate
 // is considered as fully deleted from Cluster's Service perspective (ClusterServiceDeletionTimestamp set, ClusterServiceID cleared), and
 // and the ServiceProviderNodePool still lists Maestro readonly bundle references to remove.
 func (c *createNodePoolScopedMaestroReadonlyBundlesSyncer) shouldReconcileDelete(nodePool *api.HCPOpenShiftClusterNodePool, serviceProviderNodePool *api.ServiceProviderNodePool) bool {
-	// TODO temporary check to skip the new deletion approach for NodePools that were created before the new approach was implemented.
-	// This will be removed once all nodepools whose deletion was triggered before the new approach is fully rolled out have been
-	// fully deleted in all ARO-HCP permanent environments, for all regions.
-	if !nodePool.ServiceProviderProperties.UsesNewNodePoolDeletionApproach {
-		return false
-	}
-
 	return nodePool.ServiceProviderProperties.DeletionTimestamp != nil &&
 		nodePool.ServiceProviderProperties.ClusterServiceDeletionTimestamp != nil &&
 		nodePool.ServiceProviderProperties.ClusterServiceID == nil &&

--- a/backend/pkg/controllers/create_nodepool_scoped_maestro_readonly_bundles_controller.go
+++ b/backend/pkg/controllers/create_nodepool_scoped_maestro_readonly_bundles_controller.go
@@ -21,6 +21,7 @@ import (
 
 	workv1 "open-cluster-management.io/api/work/v1"
 
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -32,6 +33,7 @@ import (
 	"github.com/Azure/ARO-HCP/backend/pkg/listers"
 	"github.com/Azure/ARO-HCP/backend/pkg/maestro"
 	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/fleet"
 	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/ocm"
@@ -45,18 +47,27 @@ const (
 	readonlyBundleManagedByK8sLabelValueNodePoolScoped = "create-nodepool-scoped-maestro-readonly-bundles-controller"
 )
 
-// createNodePoolScopedMaestroReadonlyBundlesSyncer is a controller that creates Maestro readonly bundles for the node pools.
-// It is responsible for creating the Maestro readonly bundles and storing a reference to them in Cosmos. It does
-// not persist the content of the Maestro bundles themselves. That is the responsibility of the
-// readAndPersistMaestroReadonlyBundlesContentSyncer controller.
-// As of now we support the creation of a Maestro readonly bundle for the Hypershift's NodePool CRs associated to
-// the Cluster.
+// createNodePoolScopedMaestroReadonlyBundlesSyncer reconciles Maestro readonly bundles scoped to a node pool.
+//
+// While the node pool is not being deleted, it is responsible for creating the Maestro readonly bundles and storing a reference to them in Cosmos.
+// It does not persist the content of the Maestro bundles themselves. That is handled by readAndPersistMaestroReadonlyBundlesContentSyncer.
+//
+// During node pool deletion, when the "serviceProviderProperties.clusterServiceID" property of the node pool is cleared, it deletes Maestro bundles and
+// clears references from the ServiceProviderNodePool document when possible.
+//
+// TODO the name of this controller is no longer accurate, at some point we should rename it to reflect the fact that now it has
+// both create and delete reconciliation paths. When doing that, we should make sure it does not impact functionality and
+// references to the old name in Cosmos are cleaned up.
 type createNodePoolScopedMaestroReadonlyBundlesSyncer struct {
 	cooldownChecker controllerutil.CooldownChecker
 
 	activeOperationLister listers.ActiveOperationLister
 
 	resourcesDBClient database.ResourcesDBClient
+	fleetDBClient     database.FleetDBClient
+
+	nodePoolLister                listers.NodePoolLister
+	serviceProviderNodePoolLister listers.ServiceProviderNodePoolLister
 
 	clusterServiceClient ocm.ClusterServiceClientSpec
 
@@ -69,18 +80,28 @@ type createNodePoolScopedMaestroReadonlyBundlesSyncer struct {
 
 var _ controllerutils.NodePoolSyncer = (*createNodePoolScopedMaestroReadonlyBundlesSyncer)(nil)
 
+// NewCreateNodePoolScopedMaestroReadonlyBundlesController returns a node pool watching controller that reconciles Maestro
+// readonly bundles scoped to a node pool. This includes both create and delete reconciliation paths.
 func NewCreateNodePoolScopedMaestroReadonlyBundlesController(
 	activeOperationLister listers.ActiveOperationLister,
 	resourcesDBClient database.ResourcesDBClient,
+	fleetDBClient database.FleetDBClient,
+
 	clusterServiceClient ocm.ClusterServiceClientSpec,
 	informers informers.BackendInformers,
 	maestroSourceEnvironmentIdentifier string,
 	maestroClientBuilder maestro.MaestroClientBuilder,
 ) controllerutils.Controller {
 
+	_, nodePoolLister := informers.NodePools()
+	_, serviceProviderNodePoolLister := informers.ServiceProviderNodePools()
+
 	syncer := &createNodePoolScopedMaestroReadonlyBundlesSyncer{
 		cooldownChecker:                      controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
 		resourcesDBClient:                    resourcesDBClient,
+		fleetDBClient:                        fleetDBClient,
+		nodePoolLister:                       nodePoolLister,
+		serviceProviderNodePoolLister:        serviceProviderNodePoolLister,
 		clusterServiceClient:                 clusterServiceClient,
 		activeOperationLister:                activeOperationLister,
 		maestroSourceEnvironmentIdentifier:   maestroSourceEnvironmentIdentifier,
@@ -99,7 +120,69 @@ func NewCreateNodePoolScopedMaestroReadonlyBundlesController(
 	return controller
 }
 
+// cachedShouldReconcileCreateOrDelete is a cache-only coarse gate used before reading Cosmos. It returns whether create or
+// delete reconciliation may be worth attempting. syncCreate and syncDelete can still no-op after the authoritative read.
+func (c *createNodePoolScopedMaestroReadonlyBundlesSyncer) cachedShouldReconcileCreateOrDelete(ctx context.Context, cachedNodePool *api.HCPOpenShiftClusterNodePool) (bool, error) {
+	if cachedNodePool.ServiceProviderProperties.DeletionTimestamp == nil {
+		return c.shouldReconcileCreate(cachedNodePool), nil
+	}
+
+	cachedServiceProviderNodePool, err := c.serviceProviderNodePoolLister.Get(ctx, cachedNodePool.ID.SubscriptionID, cachedNodePool.ID.ResourceGroupName, cachedNodePool.ID.Parent.Name, cachedNodePool.ID.Name)
+	if database.IsNotFoundError(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, utils.TrackError(fmt.Errorf("failed to get ServiceProviderNodePool from cache: %w", err))
+	}
+	if c.shouldReconcileDelete(cachedNodePool, cachedServiceProviderNodePool) {
+		return true, nil
+	}
+	return false, nil
+}
+
+// shouldReconcileCreate returns whether the create reconciliation path may run: the node pool is not deleting and has a
+// ClusterServiceID. It does not check whether bundles still need to be created. syncCreate decides that from
+// ServiceProviderNodePool status.
+func (c *createNodePoolScopedMaestroReadonlyBundlesSyncer) shouldReconcileCreate(nodePool *api.HCPOpenShiftClusterNodePool) bool {
+	return nodePool.ServiceProviderProperties.DeletionTimestamp == nil &&
+		(nodePool.ServiceProviderProperties.ClusterServiceID != nil && len(nodePool.ServiceProviderProperties.ClusterServiceID.String()) > 0)
+}
+
+// shouldReconcileDelete returns whether the delete reconciliation path may run: the node pool is deleting, The node pool
+// is considered as fully deleted from Cluster's Service perspective (ClusterServiceDeletionTimestamp set, ClusterServiceID cleared), and
+// and the ServiceProviderNodePool still lists Maestro readonly bundle references to remove.
+func (c *createNodePoolScopedMaestroReadonlyBundlesSyncer) shouldReconcileDelete(nodePool *api.HCPOpenShiftClusterNodePool, serviceProviderNodePool *api.ServiceProviderNodePool) bool {
+	// TODO temporary check to skip the new deletion approach for NodePools that were created before the new approach was implemented.
+	// This will be removed once all nodepools whose deletion was triggered before the new approach is fully rolled out have been
+	// fully deleted in all ARO-HCP permanent environments, for all regions.
+	if !nodePool.ServiceProviderProperties.UsesNewNodePoolDeletionApproach {
+		return false
+	}
+
+	return nodePool.ServiceProviderProperties.DeletionTimestamp != nil &&
+		nodePool.ServiceProviderProperties.ClusterServiceDeletionTimestamp != nil &&
+		nodePool.ServiceProviderProperties.ClusterServiceID == nil &&
+		len(serviceProviderNodePool.Status.MaestroReadonlyBundles) > 0
+}
+
 func (c *createNodePoolScopedMaestroReadonlyBundlesSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPNodePoolKey) error {
+	// First we do a quick check to see if there's some work needed. If not, we return early. If the cache is outdated
+	// a next reconcile cycle should deal with it.
+	cachedNodePool, err := c.nodePoolLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get node pool from cache: %w", err))
+	}
+	cachedWorkNeeded, err := c.cachedShouldReconcileCreateOrDelete(ctx, cachedNodePool)
+	if err != nil {
+		return err
+	}
+	if !cachedWorkNeeded {
+		return nil
+	}
+
 	existingNodePool, err := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).NodePools(key.HCPClusterName).Get(ctx, key.HCPNodePoolName)
 	if database.IsNotFoundError(err) {
 		return nil // nodepool doesn't exist, no work to do
@@ -107,11 +190,31 @@ func (c *createNodePoolScopedMaestroReadonlyBundlesSyncer) SyncOnce(ctx context.
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to get NodePool: %w", err))
 	}
-	if existingNodePool.ServiceProviderProperties.ClusterServiceID == nil || len(existingNodePool.ServiceProviderProperties.ClusterServiceID.String()) == 0 {
+
+	err = c.syncCreateOrDelete(ctx, existingNodePool)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to sync create or deletion: %w", err))
+	}
+
+	return nil
+}
+
+// syncCreateOrDelete runs the create or delete path for Maestro readonly bundles on a node pool, depending on its deletion state.
+func (c *createNodePoolScopedMaestroReadonlyBundlesSyncer) syncCreateOrDelete(ctx context.Context, existingNodePool *api.HCPOpenShiftClusterNodePool) error {
+	if existingNodePool.ServiceProviderProperties.DeletionTimestamp == nil {
+		return c.syncCreate(ctx, existingNodePool)
+	}
+
+	return c.syncDelete(ctx, existingNodePool)
+}
+
+// syncCreate ensures that each recognized readonly bundle internal name is created in Maestro and a reference to it is stored in Cosmos.
+func (c *createNodePoolScopedMaestroReadonlyBundlesSyncer) syncCreate(ctx context.Context, existingNodePool *api.HCPOpenShiftClusterNodePool) error {
+	if !c.shouldReconcileCreate(existingNodePool) {
 		return nil
 	}
 
-	existingServiceProviderNodePool, err := database.GetOrCreateServiceProviderNodePool(ctx, c.resourcesDBClient, key.GetResourceID())
+	existingServiceProviderNodePool, err := database.GetOrCreateServiceProviderNodePool(ctx, c.resourcesDBClient, existingNodePool.ID)
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to get or create ServiceProviderNodePool: %w", err))
 	}
@@ -149,10 +252,10 @@ func (c *createNodePoolScopedMaestroReadonlyBundlesSyncer) SyncOnce(ctx context.
 	}
 
 	serviceProviderNodePoolsDBClient := c.resourcesDBClient.ServiceProviderNodePools(
-		key.SubscriptionID,
-		key.ResourceGroupName,
-		key.HCPClusterName,
-		key.HCPNodePoolName,
+		existingNodePool.ID.SubscriptionID,
+		existingNodePool.ID.ResourceGroupName,
+		existingNodePool.ID.Parent.Name,
+		existingNodePool.Name,
 	)
 
 	// We get the provision shard (management cluster) the CS cluster is allocated to.
@@ -173,7 +276,7 @@ func (c *createNodePoolScopedMaestroReadonlyBundlesSyncer) SyncOnce(ctx context.
 	// This is important to avoid leaking resources when the sync is done.
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	maestroClient, err := createMaestroClientFromCSProvisionShard(ctx, c.maestroSourceEnvironmentIdentifier, c.maestroClientBuilder, clusterProvisionShard)
+	maestroClient, err := CreateMaestroClientFromCSProvisionShard(ctx, c.maestroSourceEnvironmentIdentifier, c.maestroClientBuilder, clusterProvisionShard)
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to create Maestro client: %w", err))
 	}
@@ -204,9 +307,107 @@ func (c *createNodePoolScopedMaestroReadonlyBundlesSyncer) SyncOnce(ctx context.
 	return utils.TrackError(errors.Join(syncErrors...))
 }
 
+// syncDelete ensures, when possible, that the Maestro readonly bundles referenced by the node pool's ServiceProviderNodePool are deleted in Maestro
+// and from Cosmos. It runs after the node pool's serviceProviderProperties.clusterServiceID attribute has been cleared and
+// removes each bundle from the Maestro API, then clears the corresponding reference from the ServiceProviderNodePool in Cosmos.
+func (c *createNodePoolScopedMaestroReadonlyBundlesSyncer) syncDelete(ctx context.Context, existingNodePool *api.HCPOpenShiftClusterNodePool) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	spnpCRUD := c.resourcesDBClient.ServiceProviderNodePools(existingNodePool.ID.SubscriptionID, existingNodePool.ID.ResourceGroupName, existingNodePool.ID.Parent.Name, existingNodePool.Name)
+	existingSPNP, err := spnpCRUD.Get(ctx, api.ServiceProviderNodePoolResourceName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get ServiceProviderNodePool: %w", err))
+	}
+	if !c.shouldReconcileDelete(existingNodePool, existingSPNP) {
+		return nil
+	}
+
+	clearBundleRefs := func(reason string) error {
+		logger.Info(reason + ", deferring maestro bundle cleanup to orphaned bundles controller")
+		existingSPNP.Status.MaestroReadonlyBundles = nil
+		_, err := spnpCRUD.Replace(ctx, existingSPNP, nil)
+		if err != nil {
+			return utils.TrackError(fmt.Errorf("failed to persist ServiceProviderNodePool: %w", err))
+		}
+		return nil
+	}
+
+	spc, err := c.resourcesDBClient.ServiceProviderClusters(existingNodePool.ID.SubscriptionID, existingNodePool.ID.ResourceGroupName, existingNodePool.ID.Parent.Name).Get(ctx, api.ServiceProviderClusterResourceName)
+	if err != nil && !database.IsNotFoundError(err) {
+		return utils.TrackError(fmt.Errorf("failed to get ServiceProviderCluster: %w", err))
+	}
+	if database.IsNotFoundError(err) {
+		return clearBundleRefs("ServiceProviderCluster not found")
+	}
+	if spc.Status.ManagementClusterResourceID == nil {
+		return clearBundleRefs("ServiceProviderCluster has no management cluster resource ID")
+	}
+
+	managementCluster, err := c.fleetDBClient.Stamps().ManagementClusters(spc.Status.ManagementClusterResourceID.Parent.Name).Get(ctx, spc.Status.ManagementClusterResourceID.Name)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get management cluster: %w", err))
+	}
+	// We create a new context with a cancel function so we can cancel the Maestro client when the sync is done.
+	// This is important to avoid leaking resources when the sync is done.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	maestroClient, err := c.createMaestroClientFromManagementCluster(ctx, managementCluster, c.maestroClientBuilder, c.maestroSourceEnvironmentIdentifier)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to create Maestro client: %w", err))
+	}
+
+	var syncErrors []error
+	var bundlesToRemove []api.MaestroBundleInternalName
+	for _, ref := range existingSPNP.Status.MaestroReadonlyBundles {
+		if len(ref.MaestroAPIMaestroBundleName) == 0 {
+			logger.Info("adding bundle reference with empty Maestro API name to removal list", "bundleInternalName", ref.Name)
+			bundlesToRemove = append(bundlesToRemove, ref.Name)
+			continue
+		}
+
+		logger.Info("sending Maestro readonly bundle delete", "bundleInternalName", ref.Name, "maestroAPIMaestroBundleName", ref.MaestroAPIMaestroBundleName)
+		err := maestroClient.Delete(ctx, ref.MaestroAPIMaestroBundleName, metav1.DeleteOptions{})
+		if err != nil && !k8serrors.IsNotFound(err) {
+			syncErrors = append(syncErrors, utils.TrackError(fmt.Errorf("failed to delete Maestro Bundle %q: %w", ref.MaestroAPIMaestroBundleName, err)))
+			continue
+		}
+
+		_, err = maestroClient.Get(ctx, ref.MaestroAPIMaestroBundleName, metav1.GetOptions{})
+		if err != nil && !k8serrors.IsNotFound(err) {
+			syncErrors = append(syncErrors, utils.TrackError(fmt.Errorf("failed to verify deletion of Maestro Bundle %q: %w", ref.MaestroAPIMaestroBundleName, err)))
+			continue
+		}
+		if err == nil {
+			logger.Info("Maestro readonly bundle still exists after delete, will retry", "bundleInternalName", ref.Name, "maestroAPIMaestroBundleName", ref.MaestroAPIMaestroBundleName)
+			continue
+		}
+
+		logger.Info("deleted Maestro readonly bundle. Adding to removal list", "bundleInternalName", ref.Name, "maestroAPIMaestroBundleName", ref.MaestroAPIMaestroBundleName)
+		bundlesToRemove = append(bundlesToRemove, ref.Name)
+	}
+
+	if len(bundlesToRemove) > 0 {
+		logger.Info("removing bundle references from ServiceProviderNodePool", "bundlesToRemove", bundlesToRemove)
+		for _, name := range bundlesToRemove {
+			if err := existingSPNP.Status.MaestroReadonlyBundles.Remove(name); err != nil {
+				syncErrors = append(syncErrors, utils.TrackError(fmt.Errorf("failed to remove bundle reference %q: %w", name, err)))
+			}
+		}
+		_, err = spnpCRUD.Replace(ctx, existingSPNP, nil)
+		if err != nil {
+			syncErrors = append(syncErrors, utils.TrackError(fmt.Errorf("failed to persist ServiceProviderNodePool after deleting bundles: %w", err)))
+		}
+	}
+
+	return utils.TrackError(errors.Join(syncErrors...))
+}
+
 // syncMaestroBundle ensures the given Maestro bundle exists in Maestro, as well as a reference to it in ServiceProviderNodePool.
 // It returns the updated ServiceProviderNodePool (after any Replace calls) so the caller can pass it into the next sync.
-// On error, the first return value is always the lastest persisted ServiceProviderNodePool, so the
+// On error, the first return value is always the latest persisted ServiceProviderNodePool, so the
 // caller can keep in-memory state in sync and subsequent bundle syncs in the same run never see stale data.
 func (c *createNodePoolScopedMaestroReadonlyBundlesSyncer) syncMaestroBundle(
 	ctx context.Context,
@@ -370,4 +571,19 @@ func (c *createNodePoolScopedMaestroReadonlyBundlesSyncer) getNodePoolName(csClu
 
 func (c *createNodePoolScopedMaestroReadonlyBundlesSyncer) CooldownChecker() controllerutil.CooldownChecker {
 	return c.cooldownChecker
+}
+
+// createMaestroClientFromManagementCluster creates a Maestro client for the given management cluster.
+// the client is scoped to the Consumer Name associated to the management cluster, and to
+// the source ID associated to the management cluster and the environment specified
+// in maestroSourceEnvironmentIdentifier, which is a configuration parameter at
+// deployment time.
+func (c *createNodePoolScopedMaestroReadonlyBundlesSyncer) createMaestroClientFromManagementCluster(ctx context.Context, managementCluster *fleet.ManagementCluster, maestroClientBuilder maestro.MaestroClientBuilder, maestroSourceEnvironmentIdentifier string) (maestro.Client, error) {
+	maestroRESTAPIEndpoint := managementCluster.Status.MaestroRESTAPIURL
+	maestroGRPCAPIEndpoint := managementCluster.Status.MaestroGRPCTarget
+	maestroConsumerName := managementCluster.Status.MaestroConsumerName
+	maestroSourceID := maestro.GenerateMaestroSourceID(maestroSourceEnvironmentIdentifier, managementCluster.Status.ClusterServiceProvisionShardID.ID())
+
+	maestroClient, err := maestroClientBuilder.NewClient(ctx, maestroRESTAPIEndpoint, maestroGRPCAPIEndpoint, maestroConsumerName, maestroSourceID)
+	return maestroClient, err
 }

--- a/backend/pkg/controllers/create_nodepool_scoped_maestro_readonly_bundles_controller_test.go
+++ b/backend/pkg/controllers/create_nodepool_scoped_maestro_readonly_bundles_controller_test.go
@@ -19,7 +19,9 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/go-logr/logr/testr"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -30,6 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
@@ -37,12 +40,15 @@ import (
 	hsv1beta1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
 	"github.com/Azure/ARO-HCP/backend/pkg/maestro"
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/api/fleet"
 	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/databasetesting"
 	"github.com/Azure/ARO-HCP/internal/ocm"
+	"github.com/Azure/ARO-HCP/internal/utils"
 )
 
 // errorInjectingResourcesDBClientForNodePoolCreate wraps mockResourcesDBClient to return error-injecting CRUDs.
@@ -522,6 +528,8 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_SyncOnce_NodePoolNotFo
 	syncer := &createNodePoolScopedMaestroReadonlyBundlesSyncer{
 		cooldownChecker:                      &alwaysSyncCooldownChecker{},
 		resourcesDBClient:                    mockResourcesDBClient,
+		nodePoolLister:                       &listertesting.SliceNodePoolLister{},
+		serviceProviderNodePoolLister:        &listertesting.SliceServiceProviderNodePoolLister{},
 		maestroSourceEnvironmentIdentifier:   "test-env",
 		maestroAPIMaestroBundleNameGenerator: maestro.NewMaestroAPIMaestroBundleNameGenerator(),
 	}
@@ -533,7 +541,7 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_SyncOnce_NodePoolNotFo
 		HCPNodePoolName:   "test-nodepool",
 	}
 
-	// No nodepool in DB -> Get returns NotFound -> SyncOnce returns nil (no work to do)
+	// No nodepool in cache -> SyncOnce returns nil (no work to do)
 	err := syncer.SyncOnce(context.Background(), key)
 	assert.NoError(t, err)
 }
@@ -544,14 +552,6 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_SyncOnce_EmptyClusterS
 
 	mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
 	mockClusterService := ocm.NewMockClusterServiceClientSpec(ctrl)
-
-	syncer := &createNodePoolScopedMaestroReadonlyBundlesSyncer{
-		cooldownChecker:                      &alwaysSyncCooldownChecker{},
-		resourcesDBClient:                    mockResourcesDBClient,
-		clusterServiceClient:                 mockClusterService,
-		maestroSourceEnvironmentIdentifier:   "test-env",
-		maestroAPIMaestroBundleNameGenerator: maestro.NewMaestroAPIMaestroBundleNameGenerator(),
-	}
 
 	key := controllerutils.HCPNodePoolKey{
 		SubscriptionID:    "test-sub",
@@ -588,6 +588,16 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_SyncOnce_EmptyClusterS
 	spnpCRUD := mockResourcesDBClient.ServiceProviderNodePools(key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
 	_, err = spnpCRUD.Create(ctx, spnp, nil)
 	require.NoError(t, err)
+
+	syncer := &createNodePoolScopedMaestroReadonlyBundlesSyncer{
+		cooldownChecker:                      &alwaysSyncCooldownChecker{},
+		resourcesDBClient:                    mockResourcesDBClient,
+		nodePoolLister:                       &listertesting.SliceNodePoolLister{NodePools: []*api.HCPOpenShiftClusterNodePool{nodepool}},
+		serviceProviderNodePoolLister:        &listertesting.SliceServiceProviderNodePoolLister{ServiceProviderNodePools: []*api.ServiceProviderNodePool{spnp}},
+		clusterServiceClient:                 mockClusterService,
+		maestroSourceEnvironmentIdentifier:   "test-env",
+		maestroAPIMaestroBundleNameGenerator: maestro.NewMaestroAPIMaestroBundleNameGenerator(),
+	}
 
 	// Cluster service ID not yet populated: skip sync (no OCM / Maestro calls), even though a bundle still needs syncing.
 	err = syncer.SyncOnce(ctx, key)
@@ -642,6 +652,8 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_SyncOnce_GetServicePro
 	syncer := &createNodePoolScopedMaestroReadonlyBundlesSyncer{
 		cooldownChecker:                      &alwaysSyncCooldownChecker{},
 		resourcesDBClient:                    mockResourcesDBClient,
+		nodePoolLister:                       &listertesting.SliceNodePoolLister{NodePools: []*api.HCPOpenShiftClusterNodePool{nodepool}},
+		serviceProviderNodePoolLister:        &listertesting.SliceServiceProviderNodePoolLister{},
 		maestroSourceEnvironmentIdentifier:   "test-env",
 		maestroAPIMaestroBundleNameGenerator: maestro.NewMaestroAPIMaestroBundleNameGenerator(),
 	}
@@ -654,13 +666,6 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_SyncOnce_GetServicePro
 func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_SyncOnce_AllBundlesAlreadySynced(t *testing.T) {
 	ctx := context.Background()
 	mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
-	syncer := &createNodePoolScopedMaestroReadonlyBundlesSyncer{
-		cooldownChecker:                      &alwaysSyncCooldownChecker{},
-		resourcesDBClient:                    mockResourcesDBClient,
-		maestroSourceEnvironmentIdentifier:   "test-env",
-		maestroAPIMaestroBundleNameGenerator: maestro.NewMaestroAPIMaestroBundleNameGenerator(),
-	}
-
 	key := controllerutils.HCPNodePoolKey{
 		SubscriptionID:    "test-sub",
 		ResourceGroupName: "test-rg",
@@ -703,6 +708,15 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_SyncOnce_AllBundlesAlr
 	_, err = spnpCRUD.Create(ctx, spnp, nil)
 	require.NoError(t, err)
 
+	syncer := &createNodePoolScopedMaestroReadonlyBundlesSyncer{
+		cooldownChecker:                      &alwaysSyncCooldownChecker{},
+		resourcesDBClient:                    mockResourcesDBClient,
+		nodePoolLister:                       &listertesting.SliceNodePoolLister{NodePools: []*api.HCPOpenShiftClusterNodePool{nodepool}},
+		serviceProviderNodePoolLister:        &listertesting.SliceServiceProviderNodePoolLister{ServiceProviderNodePools: []*api.ServiceProviderNodePool{spnp}},
+		maestroSourceEnvironmentIdentifier:   "test-env",
+		maestroAPIMaestroBundleNameGenerator: maestro.NewMaestroAPIMaestroBundleNameGenerator(),
+	}
+
 	// Since all bundles are synced, no cluster service or maestro calls should be made
 	err = syncer.SyncOnce(ctx, key)
 	assert.NoError(t, err)
@@ -716,15 +730,6 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_SyncOnce_SyncLoopExecu
 	mockClusterService := ocm.NewMockClusterServiceClientSpec(ctrl)
 	mockMaestroBuilder := maestro.NewMockMaestroClientBuilder(ctrl)
 	mockMaestroClient := maestro.NewMockClient(ctrl)
-
-	syncer := &createNodePoolScopedMaestroReadonlyBundlesSyncer{
-		cooldownChecker:                      &alwaysSyncCooldownChecker{},
-		resourcesDBClient:                    mockResourcesDBClient,
-		clusterServiceClient:                 mockClusterService,
-		maestroClientBuilder:                 mockMaestroBuilder,
-		maestroSourceEnvironmentIdentifier:   "test-env",
-		maestroAPIMaestroBundleNameGenerator: maestro.NewMaestroAPIMaestroBundleNameGenerator(),
-	}
 
 	key := controllerutils.HCPNodePoolKey{
 		SubscriptionID:    "test-sub",
@@ -761,6 +766,17 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_SyncOnce_SyncLoopExecu
 	spnpCRUD := mockResourcesDBClient.ServiceProviderNodePools(key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
 	_, err = spnpCRUD.Create(ctx, spnp, nil)
 	require.NoError(t, err)
+
+	syncer := &createNodePoolScopedMaestroReadonlyBundlesSyncer{
+		cooldownChecker:                      &alwaysSyncCooldownChecker{},
+		resourcesDBClient:                    mockResourcesDBClient,
+		nodePoolLister:                       &listertesting.SliceNodePoolLister{NodePools: []*api.HCPOpenShiftClusterNodePool{nodepool}},
+		serviceProviderNodePoolLister:        &listertesting.SliceServiceProviderNodePoolLister{ServiceProviderNodePools: []*api.ServiceProviderNodePool{spnp}},
+		clusterServiceClient:                 mockClusterService,
+		maestroClientBuilder:                 mockMaestroBuilder,
+		maestroSourceEnvironmentIdentifier:   "test-env",
+		maestroAPIMaestroBundleNameGenerator: maestro.NewMaestroAPIMaestroBundleNameGenerator(),
+	}
 
 	provisionShard := buildTestProvisionShard("test-consumer")
 	mockClusterService.EXPECT().
@@ -818,15 +834,6 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_SyncOnce_ProcessesPart
 	mockMaestroBuilder := maestro.NewMockMaestroClientBuilder(ctrl)
 	mockMaestroClient := maestro.NewMockClient(ctrl)
 
-	syncer := &createNodePoolScopedMaestroReadonlyBundlesSyncer{
-		cooldownChecker:                      &alwaysSyncCooldownChecker{},
-		resourcesDBClient:                    mockResourcesDBClient,
-		clusterServiceClient:                 mockClusterService,
-		maestroClientBuilder:                 mockMaestroBuilder,
-		maestroSourceEnvironmentIdentifier:   "test-env",
-		maestroAPIMaestroBundleNameGenerator: maestro.NewMaestroAPIMaestroBundleNameGenerator(),
-	}
-
 	key := controllerutils.HCPNodePoolKey{
 		SubscriptionID:    "test-sub",
 		ResourceGroupName: "test-rg",
@@ -874,6 +881,17 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_SyncOnce_ProcessesPart
 	_, err = spnpCRUD.Create(ctx, spnp, nil)
 	require.NoError(t, err)
 
+	syncer := &createNodePoolScopedMaestroReadonlyBundlesSyncer{
+		cooldownChecker:                      &alwaysSyncCooldownChecker{},
+		resourcesDBClient:                    mockResourcesDBClient,
+		nodePoolLister:                       &listertesting.SliceNodePoolLister{NodePools: []*api.HCPOpenShiftClusterNodePool{nodepool}},
+		serviceProviderNodePoolLister:        &listertesting.SliceServiceProviderNodePoolLister{ServiceProviderNodePools: []*api.ServiceProviderNodePool{spnp}},
+		clusterServiceClient:                 mockClusterService,
+		maestroClientBuilder:                 mockMaestroBuilder,
+		maestroSourceEnvironmentIdentifier:   "test-env",
+		maestroAPIMaestroBundleNameGenerator: maestro.NewMaestroAPIMaestroBundleNameGenerator(),
+	}
+
 	provisionShard := buildTestProvisionShard("test-consumer")
 	mockClusterService.EXPECT().
 		GetClusterProvisionShard(gomock.Any(), *nodepool.ServiceProviderProperties.ClusterServiceID).
@@ -902,4 +920,624 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_SyncOnce_ProcessesPart
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to sync Maestro Bundle")
 	assert.Contains(t, err.Error(), "maestro API error")
+}
+
+const (
+	nodePoolMaestroDeleteTestSubscriptionID    = "00000000-0000-0000-0000-000000000000"
+	nodePoolMaestroDeleteTestResourceGroupName = "test-rg"
+	nodePoolMaestroDeleteTestClusterName       = "test-cluster"
+	nodePoolMaestroDeleteTestNodePoolName      = "test-nodepool"
+	nodePoolMaestroDeleteTestClusterServiceID  = "/api/aro_hcp/v1alpha1/clusters/abc123"
+	nodePoolMaestroDeleteTestNodePoolCSID      = nodePoolMaestroDeleteTestClusterServiceID + "/node_pools/" + nodePoolMaestroDeleteTestNodePoolName
+
+	nodePoolMaestroDeleteTestRESTURL  = "https://maestro.example.com:8000"
+	nodePoolMaestroDeleteTestGRPC     = "maestro.example.com:8090"
+	nodePoolMaestroDeleteTestConsumer = "test-consumer"
+	nodePoolMaestroDeleteTestEnv      = "test-env"
+	// Stamp name must be 1-3 lowercase alphanumeric characters (fleet validation).
+	nodePoolMaestroDeleteTestStampID = "ts1"
+)
+
+func nodePoolMaestroDeleteTestProvisionShardInternalID(t *testing.T) *api.InternalID {
+	t.Helper()
+	return api.Ptr(api.Must(api.NewInternalID(
+		"/api/aro_hcp/v1alpha1/provision_shards/22222222-2222-2222-2222-222222222222")))
+}
+
+func nodePoolMaestroDeleteTestMaestroSourceID(t *testing.T) string {
+	t.Helper()
+	return maestro.GenerateMaestroSourceID(nodePoolMaestroDeleteTestEnv, nodePoolMaestroDeleteTestProvisionShardInternalID(t).ID())
+}
+
+func newNodePoolMaestroDeleteTestManagementCluster(t *testing.T) *fleet.ManagementCluster {
+	t.Helper()
+	mcRID := api.Must(fleet.ToManagementClusterResourceID(nodePoolMaestroDeleteTestStampID))
+	shardID := api.Must(api.NewInternalID(
+		"/api/aro_hcp/v1alpha1/provision_shards/22222222-2222-2222-2222-222222222222"))
+	return &fleet.ManagementCluster{
+		CosmosMetadata: arm.CosmosMetadata{ResourceID: mcRID},
+		ResourceID:     mcRID,
+		Spec: fleet.ManagementClusterSpec{
+			SchedulingPolicy: fleet.ManagementClusterSchedulingPolicySchedulable,
+		},
+		Status: fleet.ManagementClusterStatus{
+			AKSResourceID: api.Must(azcorearm.ParseResourceID(
+				"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.ContainerService/managedClusters/test-mgmt")),
+			PublicDNSZoneResourceID: api.Must(azcorearm.ParseResourceID(
+				"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Network/dnszones/example.com")),
+			HostedClustersSecretsKeyVaultURL:                     "https://kv-cx-secrets.vault.azure.net",
+			HostedClustersManagedIdentitiesKeyVaultURL:           "https://kv-cx-mi.vault.azure.net",
+			HostedClustersSecretsKeyVaultManagedIdentityClientID: "12345678-1234-1234-1234-123456789012",
+			ClusterServiceProvisionShardID:                       ptr.To(shardID),
+			MaestroConsumerName:                                  nodePoolMaestroDeleteTestConsumer,
+			MaestroRESTAPIURL:                                    nodePoolMaestroDeleteTestRESTURL,
+			MaestroGRPCTarget:                                    nodePoolMaestroDeleteTestGRPC,
+			KubeApplierCosmosContainerName:                       "Manifests-MC-ts1",
+		},
+	}
+}
+
+func newNodePoolMaestroDeleteTestServiceProviderCluster(t *testing.T, mcResourceID *azcorearm.ResourceID) *api.ServiceProviderCluster {
+	t.Helper()
+	spcRID := api.Must(azcorearm.ParseResourceID(api.ToServiceProviderClusterResourceIDString(
+		nodePoolMaestroDeleteTestSubscriptionID, nodePoolMaestroDeleteTestResourceGroupName, nodePoolMaestroDeleteTestClusterName)))
+	return &api.ServiceProviderCluster{
+		CosmosMetadata: arm.CosmosMetadata{ResourceID: spcRID},
+		Status: api.ServiceProviderClusterStatus{
+			ManagementClusterResourceID: mcResourceID,
+		},
+	}
+}
+
+func newNodePoolMaestroDeleteTestSPNP(t *testing.T, bundles api.MaestroBundleReferenceList) *api.ServiceProviderNodePool {
+	t.Helper()
+	spnpResourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + nodePoolMaestroDeleteTestSubscriptionID +
+			"/resourceGroups/" + nodePoolMaestroDeleteTestResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + nodePoolMaestroDeleteTestClusterName +
+			"/nodePools/" + nodePoolMaestroDeleteTestNodePoolName +
+			"/serviceProviderNodePools/default"))
+	return &api.ServiceProviderNodePool{
+		CosmosMetadata: arm.CosmosMetadata{ResourceID: spnpResourceID},
+		Status: api.ServiceProviderNodePoolStatus{
+			MaestroReadonlyBundles: bundles,
+		},
+	}
+}
+
+func newNodePoolMaestroTestNodePoolWithOldDeletionApproach(t *testing.T, opts func(*api.HCPOpenShiftClusterNodePool)) *api.HCPOpenShiftClusterNodePool {
+	t.Helper()
+	resourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + nodePoolMaestroDeleteTestSubscriptionID +
+			"/resourceGroups/" + nodePoolMaestroDeleteTestResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + nodePoolMaestroDeleteTestClusterName +
+			"/nodePools/" + nodePoolMaestroDeleteTestNodePoolName))
+	nodePoolInternalID := api.Ptr(api.Must(api.NewInternalID(nodePoolMaestroDeleteTestNodePoolCSID)))
+	np := &api.HCPOpenShiftClusterNodePool{
+		TrackedResource: arm.TrackedResource{
+			Resource: arm.Resource{
+				ID:   resourceID,
+				Name: nodePoolMaestroDeleteTestNodePoolName,
+				Type: api.NodePoolResourceType.String(),
+			},
+			Location: "eastus",
+		},
+		CosmosMetadata: arm.CosmosMetadata{ResourceID: resourceID},
+		Properties: api.HCPOpenShiftClusterNodePoolProperties{
+			Platform: api.NodePoolPlatformProfile{
+				OSDisk: api.OSDiskProfile{
+					DiskStorageAccountType: api.DiskStorageAccountTypePremium_LRS,
+					DiskType:               api.OsDiskTypeManaged,
+				},
+			},
+		},
+		ServiceProviderProperties: api.HCPOpenShiftClusterNodePoolServiceProviderProperties{
+			ClusterServiceID: nodePoolInternalID,
+		},
+	}
+	if opts != nil {
+		opts(np)
+	}
+	return np
+}
+
+func newNodePoolMaestroTestNodePoolWithNewDeletionApproach(t *testing.T, opts func(*api.HCPOpenShiftClusterNodePool)) *api.HCPOpenShiftClusterNodePool {
+	t.Helper()
+	np := newNodePoolMaestroTestNodePoolWithOldDeletionApproach(t, opts)
+	np.ServiceProviderProperties.UsesNewNodePoolDeletionApproach = true
+	return np
+}
+
+func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_shouldReconcileCreate(t *testing.T) {
+	fixedNow := time.Now().UTC().Truncate(time.Second)
+	syncer := &createNodePoolScopedMaestroReadonlyBundlesSyncer{}
+
+	testCases := []struct {
+		name     string
+		nodePool *api.HCPOpenShiftClusterNodePool
+		want     bool
+	}{
+		{
+			name:     "no DeletionTimestamp and ClusterServiceID set -- true",
+			nodePool: newNodePoolMaestroTestNodePoolWithOldDeletionApproach(t, nil),
+			want:     true,
+		},
+		{
+			name: "DeletionTimestamp set -- false",
+			nodePool: newNodePoolMaestroTestNodePoolWithOldDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow}
+			}),
+			want: false,
+		},
+		{
+			name: "no ClusterServiceID -- false",
+			nodePool: newNodePoolMaestroTestNodePoolWithOldDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				np.ServiceProviderProperties.ClusterServiceID = nil
+			}),
+			want: false,
+		},
+		{
+			name: "DeletionTimestamp set and no ClusterServiceID -- false",
+			nodePool: newNodePoolMaestroTestNodePoolWithOldDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow}
+				np.ServiceProviderProperties.ClusterServiceID = nil
+			}),
+			want: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := syncer.shouldReconcileCreate(tc.nodePool)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_shouldReconcileDelete(t *testing.T) {
+	fixedNow := time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+	syncer := &createNodePoolScopedMaestroReadonlyBundlesSyncer{}
+	bundles := api.MaestroBundleReferenceList{
+		{Name: "bundleA", MaestroAPIMaestroBundleName: "name-a", MaestroAPIMaestroBundleID: "id-a"},
+	}
+
+	tests := []struct {
+		name     string
+		nodePool *api.HCPOpenShiftClusterNodePool
+		spnp     *api.ServiceProviderNodePool
+		want     bool
+	}{
+		{
+			name:     "all nil: false",
+			nodePool: newNodePoolMaestroTestNodePoolWithNewDeletionApproach(t, nil),
+			spnp:     newNodePoolMaestroDeleteTestSPNP(t, bundles),
+			want:     false,
+		},
+		{
+			name: "DeletionTimestamp set only: false",
+			nodePool: newNodePoolMaestroTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow}
+			}),
+			spnp: newNodePoolMaestroDeleteTestSPNP(t, bundles),
+			want: false,
+		},
+		{
+			name: "DeletionTimestamp + CSDeletionTimestamp but CSID set: false",
+			nodePool: newNodePoolMaestroTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow}
+				np.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: fixedNow}
+			}),
+			spnp: newNodePoolMaestroDeleteTestSPNP(t, bundles),
+			want: false,
+		},
+		{
+			name: "all node pool conditions met but no bundles: false",
+			nodePool: newNodePoolMaestroTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow}
+				np.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: fixedNow}
+				np.ServiceProviderProperties.ClusterServiceID = nil
+			}),
+			spnp: newNodePoolMaestroDeleteTestSPNP(t, nil),
+			want: false,
+		},
+		{
+			name: "all conditions met: true",
+			nodePool: newNodePoolMaestroTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow}
+				np.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: fixedNow}
+				np.ServiceProviderProperties.ClusterServiceID = nil
+			}),
+			spnp: newNodePoolMaestroDeleteTestSPNP(t, bundles),
+			want: true,
+		},
+		{
+			name: "nodepool with old deletion approach set: false",
+			nodePool: newNodePoolMaestroTestNodePoolWithOldDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow}
+				np.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: fixedNow}
+				np.ServiceProviderProperties.ClusterServiceID = nil
+			}),
+			spnp: newNodePoolMaestroDeleteTestSPNP(t, bundles),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := syncer.shouldReconcileDelete(tt.nodePool, tt.spnp)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_SyncOnce_Delete(t *testing.T) {
+	fixedNow := time.Now().UTC().Truncate(time.Second)
+	readyToDeleteNodePoolOptsFunc := func(np *api.HCPOpenShiftClusterNodePool) {
+		np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-time.Hour)}
+		np.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-30 * time.Minute)}
+		np.ServiceProviderProperties.ClusterServiceID = nil
+	}
+
+	mcResourceID := api.Must(fleet.ToManagementClusterResourceID(nodePoolMaestroDeleteTestStampID))
+
+	getSPNPBundles := func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) api.MaestroBundleReferenceList {
+		t.Helper()
+		spnpCRUD := db.ServiceProviderNodePools(
+			nodePoolMaestroDeleteTestSubscriptionID,
+			nodePoolMaestroDeleteTestResourceGroupName,
+			nodePoolMaestroDeleteTestClusterName,
+			nodePoolMaestroDeleteTestNodePoolName,
+		)
+		updatedSPNP, err := spnpCRUD.Get(ctx, api.ServiceProviderNodePoolResourceName)
+		require.NoError(t, err)
+		return updatedSPNP.Status.MaestroReadonlyBundles
+	}
+
+	verifyBundlesCleared := func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+		t.Helper()
+		assert.Empty(t, getSPNPBundles(t, ctx, db), "expected all bundle references to be cleared")
+	}
+
+	testCases := []struct {
+		name             string
+		existingNodePool *api.HCPOpenShiftClusterNodePool
+		existingSPNP     *api.ServiceProviderNodePool
+		existingSPC      *api.ServiceProviderCluster
+		fleetResources   []any
+		setupMocks       func(*maestro.MockMaestroClientBuilder, *maestro.MockClient)
+		wantErr          bool
+		wantErrSubstr    string
+		verifyDB         func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient)
+	}{
+		{
+			name: "nodepool not found -- no-op",
+		},
+		{
+			name:             "no SPNP -- no-op",
+			existingNodePool: newNodePoolMaestroTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+		},
+		{
+			name:             "SPNP with no bundle list -- no-op",
+			existingNodePool: newNodePoolMaestroTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			existingSPNP:     newNodePoolMaestroDeleteTestSPNP(t, nil),
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				assert.Empty(t, getSPNPBundles(t, ctx, db), "expected bundle list to remain empty")
+			},
+		},
+		{
+			name:             "ServiceProviderCluster not found -- clears bundle refs",
+			existingNodePool: newNodePoolMaestroTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			existingSPNP: newNodePoolMaestroDeleteTestSPNP(t, api.MaestroBundleReferenceList{
+				{Name: "bundleA", MaestroAPIMaestroBundleName: "name-a", MaestroAPIMaestroBundleID: "id-a"},
+			}),
+			verifyDB: verifyBundlesCleared,
+		},
+		{
+			name:             "SPC without management cluster -- clears bundle refs",
+			existingNodePool: newNodePoolMaestroTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			existingSPC:      newNodePoolMaestroDeleteTestServiceProviderCluster(t, nil),
+			existingSPNP: newNodePoolMaestroDeleteTestSPNP(t, api.MaestroBundleReferenceList{
+				{Name: "bundleA", MaestroAPIMaestroBundleName: "name-a", MaestroAPIMaestroBundleID: "id-a"},
+			}),
+			verifyDB: verifyBundlesCleared,
+		},
+		{
+			name:             "single bundle -- successful delete and confirmed gone",
+			existingNodePool: newNodePoolMaestroTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			existingSPC:      newNodePoolMaestroDeleteTestServiceProviderCluster(t, mcResourceID),
+			existingSPNP: newNodePoolMaestroDeleteTestSPNP(t, api.MaestroBundleReferenceList{
+				{Name: "bundleA", MaestroAPIMaestroBundleName: "name-a", MaestroAPIMaestroBundleID: "id-a"},
+			}),
+			fleetResources: []any{newNodePoolMaestroDeleteTestManagementCluster(t)},
+			setupMocks: func(mb *maestro.MockMaestroClientBuilder, mc *maestro.MockClient) {
+				mb.EXPECT().NewClient(gomock.Any(), nodePoolMaestroDeleteTestRESTURL, nodePoolMaestroDeleteTestGRPC,
+					nodePoolMaestroDeleteTestConsumer, nodePoolMaestroDeleteTestMaestroSourceID(t)).Return(mc, nil)
+				mc.EXPECT().Delete(gomock.Any(), "name-a", metav1.DeleteOptions{}).Return(nil)
+				mc.EXPECT().Get(gomock.Any(), "name-a", metav1.GetOptions{}).Return(nil,
+					k8serrors.NewNotFound(schema.GroupResource{}, "name-a"))
+			},
+			verifyDB: verifyBundlesCleared,
+		},
+		{
+			name:             "single bundle -- delete ok but still exists in maestro, reference kept",
+			existingNodePool: newNodePoolMaestroTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			existingSPC:      newNodePoolMaestroDeleteTestServiceProviderCluster(t, mcResourceID),
+			existingSPNP: newNodePoolMaestroDeleteTestSPNP(t, api.MaestroBundleReferenceList{
+				{Name: "bundleA", MaestroAPIMaestroBundleName: "name-a", MaestroAPIMaestroBundleID: "id-a"},
+			}),
+			fleetResources: []any{newNodePoolMaestroDeleteTestManagementCluster(t)},
+			setupMocks: func(mb *maestro.MockMaestroClientBuilder, mc *maestro.MockClient) {
+				mb.EXPECT().NewClient(gomock.Any(), nodePoolMaestroDeleteTestRESTURL, nodePoolMaestroDeleteTestGRPC,
+					nodePoolMaestroDeleteTestConsumer, nodePoolMaestroDeleteTestMaestroSourceID(t)).Return(mc, nil)
+				mc.EXPECT().Delete(gomock.Any(), "name-a", metav1.DeleteOptions{}).Return(nil)
+				mc.EXPECT().Get(gomock.Any(), "name-a", metav1.GetOptions{}).Return(&workv1.ManifestWork{}, nil)
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				bundles := getSPNPBundles(t, ctx, db)
+				assert.Len(t, bundles, 1)
+			},
+		},
+		{
+			name:             "single bundle -- delete ok but Get returns error, reference kept",
+			existingNodePool: newNodePoolMaestroTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			existingSPC:      newNodePoolMaestroDeleteTestServiceProviderCluster(t, mcResourceID),
+			existingSPNP: newNodePoolMaestroDeleteTestSPNP(t, api.MaestroBundleReferenceList{
+				{Name: "bundleA", MaestroAPIMaestroBundleName: "name-a", MaestroAPIMaestroBundleID: "id-a"},
+			}),
+			fleetResources: []any{newNodePoolMaestroDeleteTestManagementCluster(t)},
+			setupMocks: func(mb *maestro.MockMaestroClientBuilder, mc *maestro.MockClient) {
+				mb.EXPECT().NewClient(gomock.Any(), nodePoolMaestroDeleteTestRESTURL, nodePoolMaestroDeleteTestGRPC,
+					nodePoolMaestroDeleteTestConsumer, nodePoolMaestroDeleteTestMaestroSourceID(t)).Return(mc, nil)
+				mc.EXPECT().Delete(gomock.Any(), "name-a", metav1.DeleteOptions{}).Return(nil)
+				mc.EXPECT().Get(gomock.Any(), "name-a", metav1.GetOptions{}).Return(nil, fmt.Errorf("maestro connection error"))
+			},
+			wantErr:       true,
+			wantErrSubstr: "failed to verify deletion of Maestro Bundle",
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				bundles := getSPNPBundles(t, ctx, db)
+				assert.Len(t, bundles, 1)
+			},
+		},
+		{
+			name:             "single bundle -- maestro delete 404 then Get 404 treated as success",
+			existingNodePool: newNodePoolMaestroTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			existingSPC:      newNodePoolMaestroDeleteTestServiceProviderCluster(t, mcResourceID),
+			existingSPNP: newNodePoolMaestroDeleteTestSPNP(t, api.MaestroBundleReferenceList{
+				{Name: "bundleA", MaestroAPIMaestroBundleName: "name-a", MaestroAPIMaestroBundleID: "id-a"},
+			}),
+			fleetResources: []any{newNodePoolMaestroDeleteTestManagementCluster(t)},
+			setupMocks: func(mb *maestro.MockMaestroClientBuilder, mc *maestro.MockClient) {
+				mb.EXPECT().NewClient(gomock.Any(), nodePoolMaestroDeleteTestRESTURL, nodePoolMaestroDeleteTestGRPC,
+					nodePoolMaestroDeleteTestConsumer, nodePoolMaestroDeleteTestMaestroSourceID(t)).Return(mc, nil)
+				mc.EXPECT().Delete(gomock.Any(), "name-a", metav1.DeleteOptions{}).Return(
+					k8serrors.NewNotFound(schema.GroupResource{}, "name-a"))
+				mc.EXPECT().Get(gomock.Any(), "name-a", metav1.GetOptions{}).Return(nil,
+					k8serrors.NewNotFound(schema.GroupResource{}, "name-a"))
+			},
+			verifyDB: verifyBundlesCleared,
+		},
+		{
+			name:             "single bundle -- maestro error",
+			existingNodePool: newNodePoolMaestroTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			existingSPC:      newNodePoolMaestroDeleteTestServiceProviderCluster(t, mcResourceID),
+			existingSPNP: newNodePoolMaestroDeleteTestSPNP(t, api.MaestroBundleReferenceList{
+				{Name: "bundleA", MaestroAPIMaestroBundleName: "name-a", MaestroAPIMaestroBundleID: "id-a"},
+			}),
+			fleetResources: []any{newNodePoolMaestroDeleteTestManagementCluster(t)},
+			setupMocks: func(mb *maestro.MockMaestroClientBuilder, mc *maestro.MockClient) {
+				mb.EXPECT().NewClient(gomock.Any(), nodePoolMaestroDeleteTestRESTURL, nodePoolMaestroDeleteTestGRPC,
+					nodePoolMaestroDeleteTestConsumer, nodePoolMaestroDeleteTestMaestroSourceID(t)).Return(mc, nil)
+				mc.EXPECT().Delete(gomock.Any(), "name-a", metav1.DeleteOptions{}).Return(fmt.Errorf("maestro connection error"))
+			},
+			wantErr:       true,
+			wantErrSubstr: "failed to delete Maestro Bundle",
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				bundles := getSPNPBundles(t, ctx, db)
+				assert.Len(t, bundles, 1)
+			},
+		},
+		{
+			name:             "multiple bundles -- all succeed",
+			existingNodePool: newNodePoolMaestroTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			existingSPC:      newNodePoolMaestroDeleteTestServiceProviderCluster(t, mcResourceID),
+			existingSPNP: newNodePoolMaestroDeleteTestSPNP(t, api.MaestroBundleReferenceList{
+				{Name: "bundleA", MaestroAPIMaestroBundleName: "name-a", MaestroAPIMaestroBundleID: "id-a"},
+				{Name: "bundleB", MaestroAPIMaestroBundleName: "name-b", MaestroAPIMaestroBundleID: "id-b"},
+			}),
+			fleetResources: []any{newNodePoolMaestroDeleteTestManagementCluster(t)},
+			setupMocks: func(mb *maestro.MockMaestroClientBuilder, mc *maestro.MockClient) {
+				mb.EXPECT().NewClient(gomock.Any(), nodePoolMaestroDeleteTestRESTURL, nodePoolMaestroDeleteTestGRPC,
+					nodePoolMaestroDeleteTestConsumer, nodePoolMaestroDeleteTestMaestroSourceID(t)).Return(mc, nil)
+				mc.EXPECT().Delete(gomock.Any(), "name-a", metav1.DeleteOptions{}).Return(nil)
+				mc.EXPECT().Get(gomock.Any(), "name-a", metav1.GetOptions{}).Return(nil,
+					k8serrors.NewNotFound(schema.GroupResource{}, "name-a"))
+				mc.EXPECT().Delete(gomock.Any(), "name-b", metav1.DeleteOptions{}).Return(nil)
+				mc.EXPECT().Get(gomock.Any(), "name-b", metav1.GetOptions{}).Return(nil,
+					k8serrors.NewNotFound(schema.GroupResource{}, "name-b"))
+			},
+			verifyDB: verifyBundlesCleared,
+		},
+		{
+			name:             "multiple bundles -- second delete fails",
+			existingNodePool: newNodePoolMaestroTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			existingSPC:      newNodePoolMaestroDeleteTestServiceProviderCluster(t, mcResourceID),
+			existingSPNP: newNodePoolMaestroDeleteTestSPNP(t, api.MaestroBundleReferenceList{
+				{Name: "bundleA", MaestroAPIMaestroBundleName: "name-a", MaestroAPIMaestroBundleID: "id-a"},
+				{Name: "bundleB", MaestroAPIMaestroBundleName: "name-b", MaestroAPIMaestroBundleID: "id-b"},
+			}),
+			fleetResources: []any{newNodePoolMaestroDeleteTestManagementCluster(t)},
+			setupMocks: func(mb *maestro.MockMaestroClientBuilder, mc *maestro.MockClient) {
+				mb.EXPECT().NewClient(gomock.Any(), nodePoolMaestroDeleteTestRESTURL, nodePoolMaestroDeleteTestGRPC,
+					nodePoolMaestroDeleteTestConsumer, nodePoolMaestroDeleteTestMaestroSourceID(t)).Return(mc, nil)
+				mc.EXPECT().Delete(gomock.Any(), "name-a", metav1.DeleteOptions{}).Return(nil)
+				mc.EXPECT().Get(gomock.Any(), "name-a", metav1.GetOptions{}).Return(nil,
+					k8serrors.NewNotFound(schema.GroupResource{}, "name-a"))
+				mc.EXPECT().Delete(gomock.Any(), "name-b", metav1.DeleteOptions{}).Return(fmt.Errorf("maestro error"))
+			},
+			wantErr:       true,
+			wantErrSubstr: "failed to delete Maestro Bundle",
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				bundles := getSPNPBundles(t, ctx, db)
+				require.Len(t, bundles, 1)
+				ref, err := bundles.Get("bundleB")
+				require.NoError(t, err)
+				assert.NotNil(t, ref, "expected bundleB to remain")
+			},
+		},
+		{
+			name:             "multiple bundles -- first still exists after delete",
+			existingNodePool: newNodePoolMaestroTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			existingSPC:      newNodePoolMaestroDeleteTestServiceProviderCluster(t, mcResourceID),
+			existingSPNP: newNodePoolMaestroDeleteTestSPNP(t, api.MaestroBundleReferenceList{
+				{Name: "bundleA", MaestroAPIMaestroBundleName: "name-a", MaestroAPIMaestroBundleID: "id-a"},
+				{Name: "bundleB", MaestroAPIMaestroBundleName: "name-b", MaestroAPIMaestroBundleID: "id-b"},
+			}),
+			fleetResources: []any{newNodePoolMaestroDeleteTestManagementCluster(t)},
+			setupMocks: func(mb *maestro.MockMaestroClientBuilder, mc *maestro.MockClient) {
+				mb.EXPECT().NewClient(gomock.Any(), nodePoolMaestroDeleteTestRESTURL, nodePoolMaestroDeleteTestGRPC,
+					nodePoolMaestroDeleteTestConsumer, nodePoolMaestroDeleteTestMaestroSourceID(t)).Return(mc, nil)
+				mc.EXPECT().Delete(gomock.Any(), "name-a", metav1.DeleteOptions{}).Return(nil)
+				mc.EXPECT().Get(gomock.Any(), "name-a", metav1.GetOptions{}).Return(&workv1.ManifestWork{}, nil)
+				mc.EXPECT().Delete(gomock.Any(), "name-b", metav1.DeleteOptions{}).Return(nil)
+				mc.EXPECT().Get(gomock.Any(), "name-b", metav1.GetOptions{}).Return(nil,
+					k8serrors.NewNotFound(schema.GroupResource{}, "name-b"))
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				bundles := getSPNPBundles(t, ctx, db)
+				require.Len(t, bundles, 1)
+				ref, err := bundles.Get("bundleA")
+				require.NoError(t, err)
+				assert.NotNil(t, ref, "expected bundleA to remain")
+			},
+		},
+		{
+			name:             "bundle with empty maestro name -- removed without maestro call",
+			existingNodePool: newNodePoolMaestroTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			existingSPC:      newNodePoolMaestroDeleteTestServiceProviderCluster(t, mcResourceID),
+			existingSPNP: newNodePoolMaestroDeleteTestSPNP(t, api.MaestroBundleReferenceList{
+				{Name: "bundleA", MaestroAPIMaestroBundleName: "", MaestroAPIMaestroBundleID: ""},
+			}),
+			fleetResources: []any{newNodePoolMaestroDeleteTestManagementCluster(t)},
+			setupMocks: func(mb *maestro.MockMaestroClientBuilder, mc *maestro.MockClient) {
+				mb.EXPECT().NewClient(gomock.Any(), nodePoolMaestroDeleteTestRESTURL, nodePoolMaestroDeleteTestGRPC,
+					nodePoolMaestroDeleteTestConsumer, nodePoolMaestroDeleteTestMaestroSourceID(t)).Return(mc, nil)
+			},
+			verifyDB: verifyBundlesCleared,
+		},
+		{
+			name:             "management cluster not in fleet DB",
+			existingNodePool: newNodePoolMaestroTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			existingSPC:      newNodePoolMaestroDeleteTestServiceProviderCluster(t, mcResourceID),
+			existingSPNP: newNodePoolMaestroDeleteTestSPNP(t, api.MaestroBundleReferenceList{
+				{Name: "bundleA", MaestroAPIMaestroBundleName: "name-a", MaestroAPIMaestroBundleID: "id-a"},
+			}),
+			fleetResources: nil,
+			wantErr:        true,
+			wantErrSubstr:  "failed to get management cluster",
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				bundles := getSPNPBundles(t, ctx, db)
+				assert.Len(t, bundles, 1)
+			},
+		},
+		{
+			name:             "maestro client creation fails",
+			existingNodePool: newNodePoolMaestroTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			existingSPC:      newNodePoolMaestroDeleteTestServiceProviderCluster(t, mcResourceID),
+			existingSPNP: newNodePoolMaestroDeleteTestSPNP(t, api.MaestroBundleReferenceList{
+				{Name: "bundleA", MaestroAPIMaestroBundleName: "name-a", MaestroAPIMaestroBundleID: "id-a"},
+			}),
+			fleetResources: []any{newNodePoolMaestroDeleteTestManagementCluster(t)},
+			setupMocks: func(mb *maestro.MockMaestroClientBuilder, mc *maestro.MockClient) {
+				mb.EXPECT().NewClient(gomock.Any(), nodePoolMaestroDeleteTestRESTURL, nodePoolMaestroDeleteTestGRPC,
+					nodePoolMaestroDeleteTestConsumer, nodePoolMaestroDeleteTestMaestroSourceID(t)).Return(nil, fmt.Errorf("client error"))
+			},
+			wantErr:       true,
+			wantErrSubstr: "failed to create Maestro client",
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				bundles := getSPNPBundles(t, ctx, db)
+				assert.Len(t, bundles, 1)
+			},
+		},
+		{
+			name:             "nodepool with old deletion approach -- no-op",
+			existingNodePool: newNodePoolMaestroTestNodePoolWithOldDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			existingSPC:      newNodePoolMaestroDeleteTestServiceProviderCluster(t, mcResourceID),
+			existingSPNP: newNodePoolMaestroDeleteTestSPNP(t, api.MaestroBundleReferenceList{
+				{Name: "bundleA", MaestroAPIMaestroBundleName: "name-a", MaestroAPIMaestroBundleID: "id-a"},
+			}),
+			fleetResources: []any{newNodePoolMaestroDeleteTestManagementCluster(t)},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				bundles := getSPNPBundles(t, ctx, db)
+				assert.Len(t, bundles, 1, "expected bundle references to remain unchanged")
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+			ctrl := gomock.NewController(t)
+			mockMaestroBuilder := maestro.NewMockMaestroClientBuilder(ctrl)
+			mockMaestroClient := maestro.NewMockClient(ctrl)
+
+			if tc.setupMocks != nil {
+				tc.setupMocks(mockMaestroBuilder, mockMaestroClient)
+			}
+
+			resources := []any{}
+			if tc.existingNodePool != nil {
+				resources = append(resources, tc.existingNodePool)
+			}
+			if tc.existingSPC != nil {
+				resources = append(resources, tc.existingSPC)
+			}
+			if tc.existingSPNP != nil {
+				resources = append(resources, tc.existingSPNP)
+			}
+			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, resources)
+			require.NoError(t, err)
+
+			fleetDBClient, err := databasetesting.NewMockFleetDBClientWithResources(ctx, tc.fleetResources)
+			require.NoError(t, err)
+
+			nodePoolsForLister := []*api.HCPOpenShiftClusterNodePool{}
+			if tc.existingNodePool != nil {
+				nodePoolsForLister = append(nodePoolsForLister, tc.existingNodePool)
+			}
+			spnpForLister := []*api.ServiceProviderNodePool{}
+			if tc.existingSPNP != nil {
+				spnpForLister = append(spnpForLister, tc.existingSPNP)
+			}
+
+			syncer := &createNodePoolScopedMaestroReadonlyBundlesSyncer{
+				cooldownChecker:                      &alwaysSyncCooldownChecker{},
+				resourcesDBClient:                    mockResourcesDBClient,
+				fleetDBClient:                        fleetDBClient,
+				nodePoolLister:                       &listertesting.SliceNodePoolLister{NodePools: nodePoolsForLister},
+				serviceProviderNodePoolLister:        &listertesting.SliceServiceProviderNodePoolLister{ServiceProviderNodePools: spnpForLister},
+				maestroSourceEnvironmentIdentifier:   nodePoolMaestroDeleteTestEnv,
+				maestroClientBuilder:                 mockMaestroBuilder,
+				maestroAPIMaestroBundleNameGenerator: maestro.NewMaestroAPIMaestroBundleNameGenerator(),
+			}
+
+			key := controllerutils.HCPNodePoolKey{
+				SubscriptionID:    nodePoolMaestroDeleteTestSubscriptionID,
+				ResourceGroupName: nodePoolMaestroDeleteTestResourceGroupName,
+				HCPClusterName:    nodePoolMaestroDeleteTestClusterName,
+				HCPNodePoolName:   nodePoolMaestroDeleteTestNodePoolName,
+			}
+
+			err = syncer.SyncOnce(ctx, key)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErrSubstr)
+			} else {
+				require.NoError(t, err)
+			}
+
+			if tc.verifyDB != nil {
+				tc.verifyDB(t, ctx, mockResourcesDBClient)
+			}
+		})
+	}
 }

--- a/backend/pkg/controllers/create_nodepool_scoped_maestro_readonly_bundles_controller_test.go
+++ b/backend/pkg/controllers/create_nodepool_scoped_maestro_readonly_bundles_controller_test.go
@@ -1005,7 +1005,7 @@ func newNodePoolMaestroDeleteTestSPNP(t *testing.T, bundles api.MaestroBundleRef
 	}
 }
 
-func newNodePoolMaestroTestNodePoolWithOldDeletionApproach(t *testing.T, opts func(*api.HCPOpenShiftClusterNodePool)) *api.HCPOpenShiftClusterNodePool {
+func newNodePoolMaestroTestNodePool(t *testing.T, opts func(*api.HCPOpenShiftClusterNodePool)) *api.HCPOpenShiftClusterNodePool {
 	t.Helper()
 	resourceID := api.Must(azcorearm.ParseResourceID(
 		"/subscriptions/" + nodePoolMaestroDeleteTestSubscriptionID +
@@ -1041,13 +1041,6 @@ func newNodePoolMaestroTestNodePoolWithOldDeletionApproach(t *testing.T, opts fu
 	return np
 }
 
-func newNodePoolMaestroTestNodePoolWithNewDeletionApproach(t *testing.T, opts func(*api.HCPOpenShiftClusterNodePool)) *api.HCPOpenShiftClusterNodePool {
-	t.Helper()
-	np := newNodePoolMaestroTestNodePoolWithOldDeletionApproach(t, opts)
-	np.ServiceProviderProperties.UsesNewNodePoolDeletionApproach = true
-	return np
-}
-
 func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_shouldReconcileCreate(t *testing.T) {
 	fixedNow := time.Now().UTC().Truncate(time.Second)
 	syncer := &createNodePoolScopedMaestroReadonlyBundlesSyncer{}
@@ -1059,26 +1052,26 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_shouldReconcileCreate(
 	}{
 		{
 			name:     "no DeletionTimestamp and ClusterServiceID set -- true",
-			nodePool: newNodePoolMaestroTestNodePoolWithOldDeletionApproach(t, nil),
+			nodePool: newNodePoolMaestroTestNodePool(t, nil),
 			want:     true,
 		},
 		{
 			name: "DeletionTimestamp set -- false",
-			nodePool: newNodePoolMaestroTestNodePoolWithOldDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+			nodePool: newNodePoolMaestroTestNodePool(t, func(np *api.HCPOpenShiftClusterNodePool) {
 				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow}
 			}),
 			want: false,
 		},
 		{
 			name: "no ClusterServiceID -- false",
-			nodePool: newNodePoolMaestroTestNodePoolWithOldDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+			nodePool: newNodePoolMaestroTestNodePool(t, func(np *api.HCPOpenShiftClusterNodePool) {
 				np.ServiceProviderProperties.ClusterServiceID = nil
 			}),
 			want: false,
 		},
 		{
 			name: "DeletionTimestamp set and no ClusterServiceID -- false",
-			nodePool: newNodePoolMaestroTestNodePoolWithOldDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+			nodePool: newNodePoolMaestroTestNodePool(t, func(np *api.HCPOpenShiftClusterNodePool) {
 				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow}
 				np.ServiceProviderProperties.ClusterServiceID = nil
 			}),
@@ -1109,13 +1102,13 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_shouldReconcileDelete(
 	}{
 		{
 			name:     "all nil: false",
-			nodePool: newNodePoolMaestroTestNodePoolWithNewDeletionApproach(t, nil),
+			nodePool: newNodePoolMaestroTestNodePool(t, nil),
 			spnp:     newNodePoolMaestroDeleteTestSPNP(t, bundles),
 			want:     false,
 		},
 		{
 			name: "DeletionTimestamp set only: false",
-			nodePool: newNodePoolMaestroTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+			nodePool: newNodePoolMaestroTestNodePool(t, func(np *api.HCPOpenShiftClusterNodePool) {
 				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow}
 			}),
 			spnp: newNodePoolMaestroDeleteTestSPNP(t, bundles),
@@ -1123,7 +1116,7 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_shouldReconcileDelete(
 		},
 		{
 			name: "DeletionTimestamp + CSDeletionTimestamp but CSID set: false",
-			nodePool: newNodePoolMaestroTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+			nodePool: newNodePoolMaestroTestNodePool(t, func(np *api.HCPOpenShiftClusterNodePool) {
 				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow}
 				np.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: fixedNow}
 			}),
@@ -1132,7 +1125,7 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_shouldReconcileDelete(
 		},
 		{
 			name: "all node pool conditions met but no bundles: false",
-			nodePool: newNodePoolMaestroTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+			nodePool: newNodePoolMaestroTestNodePool(t, func(np *api.HCPOpenShiftClusterNodePool) {
 				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow}
 				np.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: fixedNow}
 				np.ServiceProviderProperties.ClusterServiceID = nil
@@ -1142,23 +1135,13 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_shouldReconcileDelete(
 		},
 		{
 			name: "all conditions met: true",
-			nodePool: newNodePoolMaestroTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+			nodePool: newNodePoolMaestroTestNodePool(t, func(np *api.HCPOpenShiftClusterNodePool) {
 				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow}
 				np.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: fixedNow}
 				np.ServiceProviderProperties.ClusterServiceID = nil
 			}),
 			spnp: newNodePoolMaestroDeleteTestSPNP(t, bundles),
 			want: true,
-		},
-		{
-			name: "nodepool with old deletion approach set: false",
-			nodePool: newNodePoolMaestroTestNodePoolWithOldDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
-				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow}
-				np.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: fixedNow}
-				np.ServiceProviderProperties.ClusterServiceID = nil
-			}),
-			spnp: newNodePoolMaestroDeleteTestSPNP(t, bundles),
-			want: false,
 		},
 	}
 
@@ -1214,11 +1197,11 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_SyncOnce_Delete(t *tes
 		},
 		{
 			name:             "no SPNP -- no-op",
-			existingNodePool: newNodePoolMaestroTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			existingNodePool: newNodePoolMaestroTestNodePool(t, readyToDeleteNodePoolOptsFunc),
 		},
 		{
 			name:             "SPNP with no bundle list -- no-op",
-			existingNodePool: newNodePoolMaestroTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			existingNodePool: newNodePoolMaestroTestNodePool(t, readyToDeleteNodePoolOptsFunc),
 			existingSPNP:     newNodePoolMaestroDeleteTestSPNP(t, nil),
 			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				assert.Empty(t, getSPNPBundles(t, ctx, db), "expected bundle list to remain empty")
@@ -1226,7 +1209,7 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_SyncOnce_Delete(t *tes
 		},
 		{
 			name:             "ServiceProviderCluster not found -- clears bundle refs",
-			existingNodePool: newNodePoolMaestroTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			existingNodePool: newNodePoolMaestroTestNodePool(t, readyToDeleteNodePoolOptsFunc),
 			existingSPNP: newNodePoolMaestroDeleteTestSPNP(t, api.MaestroBundleReferenceList{
 				{Name: "bundleA", MaestroAPIMaestroBundleName: "name-a", MaestroAPIMaestroBundleID: "id-a"},
 			}),
@@ -1234,7 +1217,7 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_SyncOnce_Delete(t *tes
 		},
 		{
 			name:             "SPC without management cluster -- clears bundle refs",
-			existingNodePool: newNodePoolMaestroTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			existingNodePool: newNodePoolMaestroTestNodePool(t, readyToDeleteNodePoolOptsFunc),
 			existingSPC:      newNodePoolMaestroDeleteTestServiceProviderCluster(t, nil),
 			existingSPNP: newNodePoolMaestroDeleteTestSPNP(t, api.MaestroBundleReferenceList{
 				{Name: "bundleA", MaestroAPIMaestroBundleName: "name-a", MaestroAPIMaestroBundleID: "id-a"},
@@ -1243,7 +1226,7 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_SyncOnce_Delete(t *tes
 		},
 		{
 			name:             "single bundle -- successful delete and confirmed gone",
-			existingNodePool: newNodePoolMaestroTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			existingNodePool: newNodePoolMaestroTestNodePool(t, readyToDeleteNodePoolOptsFunc),
 			existingSPC:      newNodePoolMaestroDeleteTestServiceProviderCluster(t, mcResourceID),
 			existingSPNP: newNodePoolMaestroDeleteTestSPNP(t, api.MaestroBundleReferenceList{
 				{Name: "bundleA", MaestroAPIMaestroBundleName: "name-a", MaestroAPIMaestroBundleID: "id-a"},
@@ -1260,7 +1243,7 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_SyncOnce_Delete(t *tes
 		},
 		{
 			name:             "single bundle -- delete ok but still exists in maestro, reference kept",
-			existingNodePool: newNodePoolMaestroTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			existingNodePool: newNodePoolMaestroTestNodePool(t, readyToDeleteNodePoolOptsFunc),
 			existingSPC:      newNodePoolMaestroDeleteTestServiceProviderCluster(t, mcResourceID),
 			existingSPNP: newNodePoolMaestroDeleteTestSPNP(t, api.MaestroBundleReferenceList{
 				{Name: "bundleA", MaestroAPIMaestroBundleName: "name-a", MaestroAPIMaestroBundleID: "id-a"},
@@ -1279,7 +1262,7 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_SyncOnce_Delete(t *tes
 		},
 		{
 			name:             "single bundle -- delete ok but Get returns error, reference kept",
-			existingNodePool: newNodePoolMaestroTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			existingNodePool: newNodePoolMaestroTestNodePool(t, readyToDeleteNodePoolOptsFunc),
 			existingSPC:      newNodePoolMaestroDeleteTestServiceProviderCluster(t, mcResourceID),
 			existingSPNP: newNodePoolMaestroDeleteTestSPNP(t, api.MaestroBundleReferenceList{
 				{Name: "bundleA", MaestroAPIMaestroBundleName: "name-a", MaestroAPIMaestroBundleID: "id-a"},
@@ -1300,7 +1283,7 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_SyncOnce_Delete(t *tes
 		},
 		{
 			name:             "single bundle -- maestro delete 404 then Get 404 treated as success",
-			existingNodePool: newNodePoolMaestroTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			existingNodePool: newNodePoolMaestroTestNodePool(t, readyToDeleteNodePoolOptsFunc),
 			existingSPC:      newNodePoolMaestroDeleteTestServiceProviderCluster(t, mcResourceID),
 			existingSPNP: newNodePoolMaestroDeleteTestSPNP(t, api.MaestroBundleReferenceList{
 				{Name: "bundleA", MaestroAPIMaestroBundleName: "name-a", MaestroAPIMaestroBundleID: "id-a"},
@@ -1318,7 +1301,7 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_SyncOnce_Delete(t *tes
 		},
 		{
 			name:             "single bundle -- maestro error",
-			existingNodePool: newNodePoolMaestroTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			existingNodePool: newNodePoolMaestroTestNodePool(t, readyToDeleteNodePoolOptsFunc),
 			existingSPC:      newNodePoolMaestroDeleteTestServiceProviderCluster(t, mcResourceID),
 			existingSPNP: newNodePoolMaestroDeleteTestSPNP(t, api.MaestroBundleReferenceList{
 				{Name: "bundleA", MaestroAPIMaestroBundleName: "name-a", MaestroAPIMaestroBundleID: "id-a"},
@@ -1338,7 +1321,7 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_SyncOnce_Delete(t *tes
 		},
 		{
 			name:             "multiple bundles -- all succeed",
-			existingNodePool: newNodePoolMaestroTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			existingNodePool: newNodePoolMaestroTestNodePool(t, readyToDeleteNodePoolOptsFunc),
 			existingSPC:      newNodePoolMaestroDeleteTestServiceProviderCluster(t, mcResourceID),
 			existingSPNP: newNodePoolMaestroDeleteTestSPNP(t, api.MaestroBundleReferenceList{
 				{Name: "bundleA", MaestroAPIMaestroBundleName: "name-a", MaestroAPIMaestroBundleID: "id-a"},
@@ -1359,7 +1342,7 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_SyncOnce_Delete(t *tes
 		},
 		{
 			name:             "multiple bundles -- second delete fails",
-			existingNodePool: newNodePoolMaestroTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			existingNodePool: newNodePoolMaestroTestNodePool(t, readyToDeleteNodePoolOptsFunc),
 			existingSPC:      newNodePoolMaestroDeleteTestServiceProviderCluster(t, mcResourceID),
 			existingSPNP: newNodePoolMaestroDeleteTestSPNP(t, api.MaestroBundleReferenceList{
 				{Name: "bundleA", MaestroAPIMaestroBundleName: "name-a", MaestroAPIMaestroBundleID: "id-a"},
@@ -1386,7 +1369,7 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_SyncOnce_Delete(t *tes
 		},
 		{
 			name:             "multiple bundles -- first still exists after delete",
-			existingNodePool: newNodePoolMaestroTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			existingNodePool: newNodePoolMaestroTestNodePool(t, readyToDeleteNodePoolOptsFunc),
 			existingSPC:      newNodePoolMaestroDeleteTestServiceProviderCluster(t, mcResourceID),
 			existingSPNP: newNodePoolMaestroDeleteTestSPNP(t, api.MaestroBundleReferenceList{
 				{Name: "bundleA", MaestroAPIMaestroBundleName: "name-a", MaestroAPIMaestroBundleID: "id-a"},
@@ -1412,7 +1395,7 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_SyncOnce_Delete(t *tes
 		},
 		{
 			name:             "bundle with empty maestro name -- removed without maestro call",
-			existingNodePool: newNodePoolMaestroTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			existingNodePool: newNodePoolMaestroTestNodePool(t, readyToDeleteNodePoolOptsFunc),
 			existingSPC:      newNodePoolMaestroDeleteTestServiceProviderCluster(t, mcResourceID),
 			existingSPNP: newNodePoolMaestroDeleteTestSPNP(t, api.MaestroBundleReferenceList{
 				{Name: "bundleA", MaestroAPIMaestroBundleName: "", MaestroAPIMaestroBundleID: ""},
@@ -1426,7 +1409,7 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_SyncOnce_Delete(t *tes
 		},
 		{
 			name:             "management cluster not in fleet DB",
-			existingNodePool: newNodePoolMaestroTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			existingNodePool: newNodePoolMaestroTestNodePool(t, readyToDeleteNodePoolOptsFunc),
 			existingSPC:      newNodePoolMaestroDeleteTestServiceProviderCluster(t, mcResourceID),
 			existingSPNP: newNodePoolMaestroDeleteTestSPNP(t, api.MaestroBundleReferenceList{
 				{Name: "bundleA", MaestroAPIMaestroBundleName: "name-a", MaestroAPIMaestroBundleID: "id-a"},
@@ -1441,7 +1424,7 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_SyncOnce_Delete(t *tes
 		},
 		{
 			name:             "maestro client creation fails",
-			existingNodePool: newNodePoolMaestroTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			existingNodePool: newNodePoolMaestroTestNodePool(t, readyToDeleteNodePoolOptsFunc),
 			existingSPC:      newNodePoolMaestroDeleteTestServiceProviderCluster(t, mcResourceID),
 			existingSPNP: newNodePoolMaestroDeleteTestSPNP(t, api.MaestroBundleReferenceList{
 				{Name: "bundleA", MaestroAPIMaestroBundleName: "name-a", MaestroAPIMaestroBundleID: "id-a"},
@@ -1456,19 +1439,6 @@ func TestCreateNodePoolScopedMaestroReadonlyBundlesSyncer_SyncOnce_Delete(t *tes
 			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				bundles := getSPNPBundles(t, ctx, db)
 				assert.Len(t, bundles, 1)
-			},
-		},
-		{
-			name:             "nodepool with old deletion approach -- no-op",
-			existingNodePool: newNodePoolMaestroTestNodePoolWithOldDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
-			existingSPC:      newNodePoolMaestroDeleteTestServiceProviderCluster(t, mcResourceID),
-			existingSPNP: newNodePoolMaestroDeleteTestSPNP(t, api.MaestroBundleReferenceList{
-				{Name: "bundleA", MaestroAPIMaestroBundleName: "name-a", MaestroAPIMaestroBundleID: "id-a"},
-			}),
-			fleetResources: []any{newNodePoolMaestroDeleteTestManagementCluster(t)},
-			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
-				bundles := getSPNPBundles(t, ctx, db)
-				assert.Len(t, bundles, 1, "expected bundle references to remain unchanged")
 			},
 		},
 	}

--- a/backend/pkg/controllers/cs_maestro_utils.go
+++ b/backend/pkg/controllers/cs_maestro_utils.go
@@ -22,12 +22,12 @@ import (
 	"github.com/Azure/ARO-HCP/backend/pkg/maestro"
 )
 
-// createMaestroClientFromCSProvisionShard creates a Maestro client for the given cluster provision shard.
+// CreateMaestroClientFromCSProvisionShard creates a Maestro client for the given cluster provision shard.
 // the client is scoped to the Consumer Name associated to the provision shard, and to
 // the source ID associated to the provision shard and the environment specified
 // in c.maestroSourceEnvironmentIdentifier, which is a configuration parameter at
 // deployment time.
-func createMaestroClientFromCSProvisionShard(
+func CreateMaestroClientFromCSProvisionShard(
 	ctx context.Context, maestroSourceEnvironmentIdentifier string, maestroClientBuilder maestro.MaestroClientBuilder, clusterProvisionShard *arohcpv1alpha1.ProvisionShard,
 ) (maestro.Client, error) {
 	provisionShardMaestroConsumerName := clusterProvisionShard.MaestroConfig().ConsumerName()

--- a/backend/pkg/controllers/delete_orphaned_maestro_readonly_bundles_controller.go
+++ b/backend/pkg/controllers/delete_orphaned_maestro_readonly_bundles_controller.go
@@ -198,7 +198,7 @@ func (c *deleteOrphanedMaestroReadonlyBundles) buildMaestroClientsByProvisionSha
 		// We create a new context with a cancel function so we can cancel the Maestro client when the sync is done.
 		// This is important to avoid leaking resources when the sync is done.
 		maestroClientCtx, cancel := context.WithCancel(ctx)
-		maestroClient, err := createMaestroClientFromCSProvisionShard(maestroClientCtx, c.maestroSourceEnvironmentIdentifier, c.maestroClientBuilder, provisionShard)
+		maestroClient, err := CreateMaestroClientFromCSProvisionShard(maestroClientCtx, c.maestroSourceEnvironmentIdentifier, c.maestroClientBuilder, provisionShard)
 		if err != nil {
 			cancel() // on error creating the Maestro client we ensure we cancel the context that we just created too
 			return maestroClientsByProvisionShard, utils.TrackError(fmt.Errorf("failed to create Maestro client: %w", err))

--- a/backend/pkg/controllers/managementclustercontrollers/management_cluster_placement_sync_test.go
+++ b/backend/pkg/controllers/managementclustercontrollers/management_cluster_placement_sync_test.go
@@ -162,7 +162,7 @@ func TestManagementClusterPlacementSyncer_SyncOnce(t *testing.T) {
 			cachedSPC:   newTestSPC(),
 			existingSPC: newTestSPC(),
 			cachedCluster: newTestHCPCluster(func(c *api.HCPOpenShiftCluster) {
-				c.ServiceProviderProperties.ClusterServiceID = &api.InternalID{}
+				c.ServiceProviderProperties.ClusterServiceID = nil
 			}),
 			expectCSCall:                        false,
 			expectError:                         false,

--- a/backend/pkg/controllers/nodepooldeletion/node_pool_child_resources_cleanup_controller.go
+++ b/backend/pkg/controllers/nodepooldeletion/node_pool_child_resources_cleanup_controller.go
@@ -71,13 +71,6 @@ func (c *nodePoolChildResourcesCleanupController) CooldownChecker() controllerut
 }
 
 func (c *nodePoolChildResourcesCleanupController) NeedsWork(nodePool *api.HCPOpenShiftClusterNodePool) bool {
-	// TODO temporary check to skip the new deletion approach for NodePools that were created before the new approach was implemented.
-	// This will be removed once all nodepools whose deletion was triggered before the new approach is fully rolled out have been
-	// fully deleted in all ARO-HCP permanent environments, for all regions.
-	if !nodePool.ServiceProviderProperties.UsesNewNodePoolDeletionApproach {
-		return false
-	}
-
 	return nodePool.ServiceProviderProperties.DeletionTimestamp != nil &&
 		nodePool.ServiceProviderProperties.ClusterServiceDeletionTimestamp != nil &&
 		nodePool.ServiceProviderProperties.ClusterServiceID == nil

--- a/backend/pkg/controllers/nodepooldeletion/node_pool_child_resources_cleanup_controller.go
+++ b/backend/pkg/controllers/nodepooldeletion/node_pool_child_resources_cleanup_controller.go
@@ -1,0 +1,191 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodepooldeletion
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/internal/api"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// nodePoolChildResourcesCleanupController deletes child resources scoped
+// under a NodePool (e.g. ManagementClusterContent documents) recursively once
+// the NodePool is marked for deletion and Cluster Service has confirmed the
+// delete on its side. Controller status documents (NodePoolControllerResourceType)
+// are left alone. The orphan scraper handles those after the NodePool document
+// itself is removed.
+type nodePoolChildResourcesCleanupController struct {
+	cooldownChecker   controllerutil.CooldownChecker
+	nodePoolLister    listers.NodePoolLister
+	resourcesDBClient database.ResourcesDBClient
+}
+
+var _ controllerutils.NodePoolSyncer = (*nodePoolChildResourcesCleanupController)(nil)
+
+func NewNodePoolChildResourcesCleanupController(
+	resourcesDBClient database.ResourcesDBClient,
+	activeOperationLister listers.ActiveOperationLister,
+	informers informers.BackendInformers,
+) controllerutils.Controller {
+	_, nodePoolLister := informers.NodePools()
+	syncer := &nodePoolChildResourcesCleanupController{
+		cooldownChecker:   controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		nodePoolLister:    nodePoolLister,
+		resourcesDBClient: resourcesDBClient,
+	}
+
+	return controllerutils.NewNodePoolWatchingController(
+		"NodePoolChildResourcesCleanupController",
+		resourcesDBClient,
+		informers,
+		time.Minute,
+		syncer,
+	)
+}
+
+func (c *nodePoolChildResourcesCleanupController) CooldownChecker() controllerutil.CooldownChecker {
+	return c.cooldownChecker
+}
+
+func (c *nodePoolChildResourcesCleanupController) NeedsWork(nodePool *api.HCPOpenShiftClusterNodePool) bool {
+	// TODO temporary check to skip the new deletion approach for NodePools that were created before the new approach was implemented.
+	// This will be removed once all nodepools whose deletion was triggered before the new approach is fully rolled out have been
+	// fully deleted in all ARO-HCP permanent environments, for all regions.
+	if !nodePool.ServiceProviderProperties.UsesNewNodePoolDeletionApproach {
+		return false
+	}
+
+	return nodePool.ServiceProviderProperties.DeletionTimestamp != nil &&
+		nodePool.ServiceProviderProperties.ClusterServiceDeletionTimestamp != nil &&
+		nodePool.ServiceProviderProperties.ClusterServiceID == nil
+}
+
+func (c *nodePoolChildResourcesCleanupController) SyncOnce(ctx context.Context, key controllerutils.HCPNodePoolKey) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	cachedNodePool, err := c.nodePoolLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get node pool from cache: %w", err))
+	}
+	if !c.NeedsWork(cachedNodePool) {
+		return nil
+	}
+
+	nodePoolCRUD := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).NodePools(key.HCPClusterName)
+	nodePool, err := nodePoolCRUD.Get(ctx, key.HCPNodePoolName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get node pool: %w", err))
+	}
+	if !c.NeedsWork(nodePool) {
+		return nil
+	}
+
+	nodePoolResourceID := key.GetResourceID()
+	untypedCRUD, err := c.resourcesDBClient.UntypedCRUD(*nodePoolResourceID)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to create untyped CRUD for node pool children: %w", err))
+	}
+
+	// extraDeleteGates is a map of resource types to extra delete gates that are used to determine if a resource should be deleted.
+	// Keys are strings.ToLower(api resource type strings) so lookups match TypedDocument.resourceType regardless of casing.
+	// The value of the map is a function that takes a context and a resource ID and returns a boolean indicating if the resource should be deleted, or
+	// an error.
+	// If the resource type is not in the map, the resource is deleted.
+	extraDeleteGates := map[string]func(ctx context.Context, resourceID *azcorearm.ResourceID) (bool, error){
+		strings.ToLower(api.ServiceProviderNodePoolResourceType.String()): c.extraDeleteGateShouldDeleteServiceProviderNodePool,
+		// We never delete node pool controllers here, as there might be controllers still running for the NodePool until the very
+		// end of the deletion process
+		strings.ToLower(api.NodePoolControllerResourceType.String()): func(ctx context.Context, resourceID *azcorearm.ResourceID) (bool, error) { return false, nil },
+	}
+
+	childIterator, err := untypedCRUD.ListRecursive(ctx, nil)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to list node pool child resources: %w", err))
+	}
+	for _, childResource := range childIterator.Items(ctx) {
+		if childResource.ResourceID == nil {
+			return utils.TrackError(fmt.Errorf("child resource at cosmosID %q has no resourceID; refusing to delete", childResource.ID))
+		}
+
+		extraDeleteGate, ok := extraDeleteGates[strings.ToLower(childResource.ResourceType)]
+		if ok {
+			shouldDelete, err := extraDeleteGate(ctx, childResource.ResourceID)
+			if err != nil {
+				return utils.TrackError(err)
+			}
+			if !shouldDelete {
+				continue
+			}
+		}
+
+		logger.Info("deleting child resource", "childResourceID", childResource.ResourceID)
+		if err := untypedCRUD.Delete(ctx, childResource.ResourceID); err != nil {
+			return utils.TrackError(err)
+		}
+	}
+	if err := childIterator.GetError(); err != nil {
+		return utils.TrackError(err)
+	}
+
+	return nil
+}
+
+// extraDeleteGateShouldDeleteServiceProviderNodePool is an extra delete gate that checks if the ServiceProviderNodePool has any Maestro readonly bundles.
+// serviceProviderNodePoolResourceID is the child's ARM resource ID (serviceProviderNodePools/default).
+// If there are bundles it returns false, otherwise it returns true.
+func (c *nodePoolChildResourcesCleanupController) extraDeleteGateShouldDeleteServiceProviderNodePool(ctx context.Context, serviceProviderNodePoolResourceID *azcorearm.ResourceID) (bool, error) {
+	logger := utils.LoggerFromContext(ctx)
+
+	if serviceProviderNodePoolResourceID.Parent == nil || serviceProviderNodePoolResourceID.Parent.Parent == nil {
+		return false, utils.TrackError(fmt.Errorf(
+			"service provider node pool resource ID missing cluster or node pool parent: %s",
+			serviceProviderNodePoolResourceID.String()))
+	}
+
+	clusterName := serviceProviderNodePoolResourceID.Parent.Parent.Name
+	nodePoolName := serviceProviderNodePoolResourceID.Parent.Name
+
+	spnp, err := c.resourcesDBClient.ServiceProviderNodePools(serviceProviderNodePoolResourceID.SubscriptionID, serviceProviderNodePoolResourceID.ResourceGroupName, clusterName, nodePoolName).Get(ctx, api.ServiceProviderNodePoolResourceName)
+	if database.IsNotFoundError(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, utils.TrackError(fmt.Errorf("failed to get ServiceProviderNodePool: %w", err))
+	}
+
+	if len(spnp.Status.MaestroReadonlyBundles) > 0 {
+		logger.Info("waiting for nodepool-scoped Maestro readonly bundles to be deleted before removing Cosmos entry",
+			"serviceProviderNodePoolResourceID", spnp.ResourceID.String(), "remainingBundles", len(spnp.Status.MaestroReadonlyBundles))
+		return false, nil
+	}
+	return true, nil
+}

--- a/backend/pkg/controllers/nodepooldeletion/node_pool_child_resources_cleanup_controller_test.go
+++ b/backend/pkg/controllers/nodepooldeletion/node_pool_child_resources_cleanup_controller_test.go
@@ -94,7 +94,7 @@ func TestNodePoolChildResourcesCleanupController_SyncOnce(t *testing.T) {
 	}{
 		{
 			name:             "when no DeletionTimestamp, no ClusterServiceDeletionTimestamp are set and ClusterServiceID is set performs a no-op",
-			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, nil),
+			existingNodePool: newTestNodePool(t, nil),
 			childResources:   []any{newTestManagementClusterContent(t, "untouched-mcc")},
 			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				mccCRUD := db.HCPClusters(testSubscriptionID, testResourceGroupName).
@@ -105,7 +105,7 @@ func TestNodePoolChildResourcesCleanupController_SyncOnce(t *testing.T) {
 		},
 		{
 			name: "when no ClusterServiceDeletionTimestamp is set performs a no-op",
-			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+			existingNodePool: newTestNodePool(t, func(np *api.HCPOpenShiftClusterNodePool) {
 				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-time.Hour)}
 				np.ServiceProviderProperties.ClusterServiceDeletionTimestamp = nil
 				np.ServiceProviderProperties.ClusterServiceID = nil
@@ -120,7 +120,7 @@ func TestNodePoolChildResourcesCleanupController_SyncOnce(t *testing.T) {
 		},
 		{
 			name: "when ClusterServiceID is set performs a no-op",
-			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+			existingNodePool: newTestNodePool(t, func(np *api.HCPOpenShiftClusterNodePool) {
 				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-time.Hour)}
 				np.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-30 * time.Minute)}
 			}),
@@ -134,11 +134,11 @@ func TestNodePoolChildResourcesCleanupController_SyncOnce(t *testing.T) {
 		},
 		{
 			name:             "when all conditions met and there are no children performs a no-op",
-			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			existingNodePool: newTestNodePool(t, readyToDeleteNodePoolOptsFunc),
 		},
 		{
 			name:             "when there is a children resource it deletes it",
-			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			existingNodePool: newTestNodePool(t, readyToDeleteNodePoolOptsFunc),
 			childResources:   []any{newTestManagementClusterContent(t, "test-mcc")},
 			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				nodePoolResourceID := testKey.GetResourceID()
@@ -157,7 +157,7 @@ func TestNodePoolChildResourcesCleanupController_SyncOnce(t *testing.T) {
 		},
 		{
 			name:             "deletion of node pool controllers is skipped",
-			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			existingNodePool: newTestNodePool(t, readyToDeleteNodePoolOptsFunc),
 			childResources:   []any{newTestNodePoolController(t, "test-controller")},
 			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				nodePoolResourceID := testKey.GetResourceID()
@@ -178,7 +178,7 @@ func TestNodePoolChildResourcesCleanupController_SyncOnce(t *testing.T) {
 		},
 		{
 			name:             "when there are nodepool controller and non nodepool controller children it deletes the non nodepool controller children",
-			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			existingNodePool: newTestNodePool(t, readyToDeleteNodePoolOptsFunc),
 			childResources:   []any{newTestManagementClusterContent(t, "test-mcc"), newTestNodePoolController(t, "test-controller")},
 			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				nodePoolResourceID := testKey.GetResourceID()
@@ -205,7 +205,7 @@ func TestNodePoolChildResourcesCleanupController_SyncOnce(t *testing.T) {
 		},
 		{
 			name:             "when there is a child ServiceProviderNodePool and it does not have Maestro bundle references it deletes it",
-			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			existingNodePool: newTestNodePool(t, readyToDeleteNodePoolOptsFunc),
 			childResources:   []any{newTestSPNP(t, nil)},
 			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				spnpCRUD := db.ServiceProviderNodePools(
@@ -216,7 +216,7 @@ func TestNodePoolChildResourcesCleanupController_SyncOnce(t *testing.T) {
 		},
 		{
 			name:             "when there is a child ServiceProviderNodePool and it has Maestro bundle references it does not delete it",
-			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			existingNodePool: newTestNodePool(t, readyToDeleteNodePoolOptsFunc),
 			childResources: []any{newTestSPNP(t, api.MaestroBundleReferenceList{
 				{Name: "bundle-a", MaestroAPIMaestroBundleName: "name-a", MaestroAPIMaestroBundleID: "id-a"},
 			})},
@@ -229,7 +229,7 @@ func TestNodePoolChildResourcesCleanupController_SyncOnce(t *testing.T) {
 		},
 		{
 			name:             "when there are child resources including a ServiceProviderNodePool with Maestro bundle references it deletes them excluding it",
-			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			existingNodePool: newTestNodePool(t, readyToDeleteNodePoolOptsFunc),
 			childResources: []any{
 				newTestManagementClusterContent(t, "gate-mcc"),
 				newTestSPNP(t, api.MaestroBundleReferenceList{
@@ -241,22 +241,6 @@ func TestNodePoolChildResourcesCleanupController_SyncOnce(t *testing.T) {
 					NodePools(testClusterName).ManagementClusterContents(testNodePoolName)
 				_, err := mccCRUD.Get(ctx, "gate-mcc")
 				require.True(t, database.IsNotFoundError(err), "expected MCC gate-mcc to be deleted")
-
-				spnpCRUD := db.ServiceProviderNodePools(
-					testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName)
-				_, err = spnpCRUD.Get(ctx, api.ServiceProviderNodePoolResourceName)
-				require.NoError(t, err, "expected SPNP to still exist")
-			},
-		},
-		{
-			name:             "UsesNewNodePoolDeletionApproach false -- no-op even when all cleanup conditions met and children exist",
-			existingNodePool: newTestNodePoolWithOldDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
-			childResources:   []any{newTestManagementClusterContent(t, "untouched-mcc"), newTestSPNP(t, nil)},
-			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
-				mccCRUD := db.HCPClusters(testSubscriptionID, testResourceGroupName).
-					NodePools(testClusterName).ManagementClusterContents(testNodePoolName)
-				_, err := mccCRUD.Get(ctx, "untouched-mcc")
-				require.NoError(t, err, "expected child resource to still exist")
 
 				spnpCRUD := db.ServiceProviderNodePools(
 					testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName)

--- a/backend/pkg/controllers/nodepooldeletion/node_pool_child_resources_cleanup_controller_test.go
+++ b/backend/pkg/controllers/nodepooldeletion/node_pool_child_resources_cleanup_controller_test.go
@@ -1,0 +1,304 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodepooldeletion
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+func newTestManagementClusterContent(t *testing.T, name string) *api.ManagementClusterContent {
+	t.Helper()
+	resourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+			"/nodePools/" + testNodePoolName +
+			"/managementClusterContents/" + name))
+	return &api.ManagementClusterContent{
+		CosmosMetadata: api.CosmosMetadata{ResourceID: resourceID},
+	}
+}
+
+func newTestNodePoolController(t *testing.T, name string) *api.Controller {
+	t.Helper()
+	resourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+			"/nodePools/" + testNodePoolName +
+			"/hcpOpenShiftControllers/" + name))
+	return &api.Controller{
+		CosmosMetadata: api.CosmosMetadata{ResourceID: resourceID},
+		ExternalID: api.Must(azcorearm.ParseResourceID(
+			"/subscriptions/" + testSubscriptionID +
+				"/resourceGroups/" + testResourceGroupName +
+				"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+				"/nodePools/" + testNodePoolName)),
+		Status: api.ControllerStatus{
+			Conditions: []metav1.Condition{},
+		},
+	}
+}
+
+func TestNodePoolChildResourcesCleanupController_SyncOnce(t *testing.T) {
+	fixedNow := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	readyToDeleteNodePoolOptsFunc := func(np *api.HCPOpenShiftClusterNodePool) {
+		np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-time.Hour)}
+		np.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-30 * time.Minute)}
+		np.ServiceProviderProperties.ClusterServiceID = nil
+	}
+
+	testKey := controllerutils.HCPNodePoolKey{
+		SubscriptionID:    testSubscriptionID,
+		ResourceGroupName: testResourceGroupName,
+		HCPClusterName:    testClusterName,
+		HCPNodePoolName:   testNodePoolName,
+	}
+
+	testCases := []struct {
+		name             string
+		existingNodePool *api.HCPOpenShiftClusterNodePool
+		childResources   []any
+		wantErr          bool
+		verifyDB         func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient)
+	}{
+		{
+			name:             "when no DeletionTimestamp, no ClusterServiceDeletionTimestamp are set and ClusterServiceID is set performs a no-op",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, nil),
+			childResources:   []any{newTestManagementClusterContent(t, "untouched-mcc")},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				mccCRUD := db.HCPClusters(testSubscriptionID, testResourceGroupName).
+					NodePools(testClusterName).ManagementClusterContents(testNodePoolName)
+				_, err := mccCRUD.Get(ctx, "untouched-mcc")
+				require.NoError(t, err, "expected child resource to still exist")
+			},
+		},
+		{
+			name: "when no ClusterServiceDeletionTimestamp is set performs a no-op",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-time.Hour)}
+				np.ServiceProviderProperties.ClusterServiceDeletionTimestamp = nil
+				np.ServiceProviderProperties.ClusterServiceID = nil
+			}),
+			childResources: []any{newTestManagementClusterContent(t, "untouched-mcc")},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				mccCRUD := db.HCPClusters(testSubscriptionID, testResourceGroupName).
+					NodePools(testClusterName).ManagementClusterContents(testNodePoolName)
+				_, err := mccCRUD.Get(ctx, "untouched-mcc")
+				require.NoError(t, err, "expected child resource to still exist")
+			},
+		},
+		{
+			name: "when ClusterServiceID is set performs a no-op",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-time.Hour)}
+				np.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-30 * time.Minute)}
+			}),
+			childResources: []any{newTestManagementClusterContent(t, "untouched-mcc")},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				mccCRUD := db.HCPClusters(testSubscriptionID, testResourceGroupName).
+					NodePools(testClusterName).ManagementClusterContents(testNodePoolName)
+				_, err := mccCRUD.Get(ctx, "untouched-mcc")
+				require.NoError(t, err, "expected child resource to still exist")
+			},
+		},
+		{
+			name:             "when all conditions met and there are no children performs a no-op",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+		},
+		{
+			name:             "when there is a children resource it deletes it",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			childResources:   []any{newTestManagementClusterContent(t, "test-mcc")},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				nodePoolResourceID := testKey.GetResourceID()
+				untypedCRUD, err := db.UntypedCRUD(*nodePoolResourceID)
+				require.NoError(t, err)
+				childIterator, err := untypedCRUD.ListRecursive(ctx, nil)
+				require.NoError(t, err)
+
+				var remainingCount int
+				for range childIterator.Items(ctx) {
+					remainingCount++
+				}
+				require.NoError(t, childIterator.GetError())
+				assert.Equal(t, 0, remainingCount, "expected no children to remain")
+			},
+		},
+		{
+			name:             "deletion of node pool controllers is skipped",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			childResources:   []any{newTestNodePoolController(t, "test-controller")},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				nodePoolResourceID := testKey.GetResourceID()
+				untypedCRUD, err := db.UntypedCRUD(*nodePoolResourceID)
+				require.NoError(t, err)
+				childIterator, err := untypedCRUD.ListRecursive(ctx, nil)
+				require.NoError(t, err)
+
+				var controllerCount int
+				for _, child := range childIterator.Items(ctx) {
+					if strings.EqualFold(child.ResourceType, api.NodePoolControllerResourceType.String()) {
+						controllerCount++
+					}
+				}
+				require.NoError(t, childIterator.GetError())
+				assert.Equal(t, 1, controllerCount, "expected controller child to remain")
+			},
+		},
+		{
+			name:             "when there are nodepool controller and non nodepool controller children it deletes the non nodepool controller children",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			childResources:   []any{newTestManagementClusterContent(t, "test-mcc"), newTestNodePoolController(t, "test-controller")},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				nodePoolResourceID := testKey.GetResourceID()
+				untypedCRUD, err := db.UntypedCRUD(*nodePoolResourceID)
+				require.NoError(t, err)
+				childIterator, err := untypedCRUD.ListRecursive(ctx, nil)
+				require.NoError(t, err)
+
+				var remainingCount int
+				var controllerCount int
+				for _, child := range childIterator.Items(ctx) {
+					remainingCount++
+					if strings.EqualFold(child.ResourceType, api.NodePoolControllerResourceType.String()) {
+						controllerCount++
+					}
+				}
+				require.NoError(t, childIterator.GetError())
+				assert.Equal(t, 1, remainingCount, "expected only controller child to remain")
+				assert.Equal(t, 1, controllerCount, "expected the remaining child to be a controller")
+			},
+		},
+		{
+			name: "when the node pool is not found performs a no-op",
+		},
+		{
+			name:             "when there is a child ServiceProviderNodePool and it does not have Maestro bundle references it deletes it",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			childResources:   []any{newTestSPNP(t, nil)},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				spnpCRUD := db.ServiceProviderNodePools(
+					testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName)
+				_, err := spnpCRUD.Get(ctx, api.ServiceProviderNodePoolResourceName)
+				require.True(t, database.IsNotFoundError(err), "expected SPNP to be deleted")
+			},
+		},
+		{
+			name:             "when there is a child ServiceProviderNodePool and it has Maestro bundle references it does not delete it",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			childResources: []any{newTestSPNP(t, api.MaestroBundleReferenceList{
+				{Name: "bundle-a", MaestroAPIMaestroBundleName: "name-a", MaestroAPIMaestroBundleID: "id-a"},
+			})},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				spnpCRUD := db.ServiceProviderNodePools(
+					testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName)
+				_, err := spnpCRUD.Get(ctx, api.ServiceProviderNodePoolResourceName)
+				require.NoError(t, err, "expected SPNP to still exist")
+			},
+		},
+		{
+			name:             "when there are child resources including a ServiceProviderNodePool with Maestro bundle references it deletes them excluding it",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			childResources: []any{
+				newTestManagementClusterContent(t, "gate-mcc"),
+				newTestSPNP(t, api.MaestroBundleReferenceList{
+					{Name: "bundle-a", MaestroAPIMaestroBundleName: "name-a", MaestroAPIMaestroBundleID: "id-a"},
+				}),
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				mccCRUD := db.HCPClusters(testSubscriptionID, testResourceGroupName).
+					NodePools(testClusterName).ManagementClusterContents(testNodePoolName)
+				_, err := mccCRUD.Get(ctx, "gate-mcc")
+				require.True(t, database.IsNotFoundError(err), "expected MCC gate-mcc to be deleted")
+
+				spnpCRUD := db.ServiceProviderNodePools(
+					testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName)
+				_, err = spnpCRUD.Get(ctx, api.ServiceProviderNodePoolResourceName)
+				require.NoError(t, err, "expected SPNP to still exist")
+			},
+		},
+		{
+			name:             "UsesNewNodePoolDeletionApproach false -- no-op even when all cleanup conditions met and children exist",
+			existingNodePool: newTestNodePoolWithOldDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			childResources:   []any{newTestManagementClusterContent(t, "untouched-mcc"), newTestSPNP(t, nil)},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				mccCRUD := db.HCPClusters(testSubscriptionID, testResourceGroupName).
+					NodePools(testClusterName).ManagementClusterContents(testNodePoolName)
+				_, err := mccCRUD.Get(ctx, "untouched-mcc")
+				require.NoError(t, err, "expected child resource to still exist")
+
+				spnpCRUD := db.ServiceProviderNodePools(
+					testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName)
+				_, err = spnpCRUD.Get(ctx, api.ServiceProviderNodePoolResourceName)
+				require.NoError(t, err, "expected SPNP to still exist")
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+
+			resources := []any{}
+			if tc.existingNodePool != nil {
+				resources = append(resources, tc.existingNodePool)
+			}
+			resources = append(resources, tc.childResources...)
+			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, resources)
+			require.NoError(t, err)
+
+			nodePoolsForLister := []*api.HCPOpenShiftClusterNodePool{}
+			if tc.existingNodePool != nil {
+				nodePoolsForLister = append(nodePoolsForLister, tc.existingNodePool)
+			}
+
+			syncer := &nodePoolChildResourcesCleanupController{
+				cooldownChecker:   &alwaysSyncCooldownChecker{},
+				nodePoolLister:    &listertesting.SliceNodePoolLister{NodePools: nodePoolsForLister},
+				resourcesDBClient: mockResourcesDBClient,
+			}
+
+			err = syncer.SyncOnce(ctx, testKey)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			if tc.verifyDB != nil {
+				tc.verifyDB(t, ctx, mockResourcesDBClient)
+			}
+		})
+	}
+}

--- a/backend/pkg/controllers/nodepooldeletion/node_pool_cluster_service_delete_dispatch_controller.go
+++ b/backend/pkg/controllers/nodepooldeletion/node_pool_cluster_service_delete_dispatch_controller.go
@@ -1,0 +1,219 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodepooldeletion
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilsclock "k8s.io/utils/clock"
+	"k8s.io/utils/lru"
+
+	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/internal/api"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// missingClusterServiceIDTimeout is how long we wait after first observing
+// DeletionTimestamp for the ClusterServiceID to appear before concluding
+// that the corresponding Cluster Service Node Pool was never created and we have
+// no work to do (or before treating a 404 from Cluster Service as definitive).
+const missingClusterServiceIDTimeout = 120 * time.Second
+
+// nodePoolClusterServiceDeleteDispatchSyncer issues a Cluster Service delete for any
+// NodePool whose DeletionTimestamp has been set. The frontend records the
+// timestamp on the NodePool when DeleteNodePool is invoked, this controller
+// picks it up and calls Cluster Service out-of-band so the frontend never has
+// to block on it. Once the controller has issued the delete (or given up
+// waiting for a ClusterServiceID), it stamps ClusterServiceDeletionTimestamp
+// on the NodePool to record that this step is complete and avoid re-issuing
+// the delete on subsequent syncs.
+// The controller also caches the time the controller has first seen the
+// serviceProviderProperties.deletionTimestamp being set for a nodepool. This
+// is used to avoid immediately triggering deletion in scenarios where the
+// nodepool was marked for deletion but the controllers were not available for
+// some reason until some time afterwards.
+type nodePoolClusterServiceDeleteDispatchSyncer struct {
+	clock                utilsclock.PassiveClock
+	cooldownChecker      controllerutil.CooldownChecker
+	nodePoolLister       listers.NodePoolLister
+	resourcesDBClient    database.ResourcesDBClient
+	clusterServiceClient ocm.ClusterServiceClientSpec
+	// firstSeenDeletionTimestampCache is a cache that contains the time the controller
+	// has first seen the serviceProviderProperties.deletionTimestamp being set
+	// for a nodepool. The cache key is the lowercased node pool's resource ID and
+	// the value is a time.Time in UTC indicating the first seen deletion timestamp.
+	firstSeenDeletionTimestampCache *lru.Cache
+}
+
+var _ controllerutils.NodePoolSyncer = (*nodePoolClusterServiceDeleteDispatchSyncer)(nil)
+
+func NewNodePoolClusterServiceDeleteDispatchController(
+	clock utilsclock.PassiveClock,
+	resourcesDBClient database.ResourcesDBClient,
+	clusterServiceClient ocm.ClusterServiceClientSpec,
+	activeOperationLister listers.ActiveOperationLister,
+	informers informers.BackendInformers,
+) controllerutils.Controller {
+	_, nodePoolLister := informers.NodePools()
+	syncer := &nodePoolClusterServiceDeleteDispatchSyncer{
+		clock:                           clock,
+		cooldownChecker:                 controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		nodePoolLister:                  nodePoolLister,
+		resourcesDBClient:               resourcesDBClient,
+		clusterServiceClient:            clusterServiceClient,
+		firstSeenDeletionTimestampCache: lru.New(50000),
+	}
+
+	return controllerutils.NewNodePoolWatchingController(
+		"NodePoolClusterServiceDeleteDispatch",
+		resourcesDBClient,
+		informers,
+		time.Minute,
+		syncer,
+	)
+}
+
+func (c *nodePoolClusterServiceDeleteDispatchSyncer) CooldownChecker() controllerutil.CooldownChecker {
+	return c.cooldownChecker
+}
+
+// NeedsWork reports whether the deleter has unfinished business for the given
+// NodePool: DeletionTimestamp must be set and ClusterServiceDeletionTimestamp
+// must not yet be set.
+func (c *nodePoolClusterServiceDeleteDispatchSyncer) NeedsWork(nodePool *api.HCPOpenShiftClusterNodePool) bool {
+	// TODO temporary check to skip the new deletion approach for NodePools that were created before the new approach was implemented.
+	// This will be removed once all nodepools whose deletion was triggered before the new approach is fully rolled out have been
+	// fully deleted in all ARO-HCP permanent environments, for all regions.
+	if !nodePool.ServiceProviderProperties.UsesNewNodePoolDeletionApproach {
+		return false
+	}
+
+	return nodePool.ServiceProviderProperties.DeletionTimestamp != nil &&
+		nodePool.ServiceProviderProperties.ClusterServiceDeletionTimestamp == nil
+}
+
+// SyncOnce calls Cluster Service to delete the NodePool when its DeletionTimestamp is set.
+//
+// If the NodePool has no ClusterServiceID yet, we may have raced cluster-service NodePool
+// creation. We wait for missingClusterServiceIDTimeout from when we first observed
+// DeletionTimestamp before concluding the cluster-service NodePool was never created.
+//
+// In either terminal case - CS delete issued or wait abandoned - we stamp
+// ClusterServiceDeletionTimestamp so the next sync short-circuits.
+func (c *nodePoolClusterServiceDeleteDispatchSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPNodePoolKey) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	cachedNodePool, err := c.nodePoolLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get node pool from cache: %w", err))
+	}
+	if !c.NeedsWork(cachedNodePool) {
+		return nil
+	}
+
+	// Confirm against the live document. The cache can lag behind a write that
+	// just set DeletionTimestamp, populated ClusterServiceID, or stamped
+	// ClusterServiceDeletionTimestamp.
+	nodePoolCRUD := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).NodePools(key.HCPClusterName)
+	nodePool, err := nodePoolCRUD.Get(ctx, key.HCPNodePoolName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get node pool: %w", err))
+	}
+	if !c.NeedsWork(nodePool) {
+		return nil
+	}
+
+	// We check if we have seen the deletion marker being set for this node pool.
+	// If we don't we start tracking it in the cache.
+	nodePoolDeletionTimestamp := nodePool.ServiceProviderProperties.DeletionTimestamp.Time
+	cacheKey := strings.ToLower(nodePool.ID.String())
+	var firstSeenNodePoolDeletionTimestamp time.Time
+	firstSeenEntry, ok := c.firstSeenDeletionTimestampCache.Get(cacheKey)
+	if ok {
+		firstSeenNodePoolDeletionTimestamp = firstSeenEntry.(time.Time)
+	} else {
+		firstSeenNodePoolDeletionTimestamp = c.clock.Now().UTC()
+		c.firstSeenDeletionTimestampCache.Add(cacheKey, firstSeenNodePoolDeletionTimestamp)
+	}
+
+	csID := nodePool.ServiceProviderProperties.ClusterServiceID
+	if csID == nil || len(csID.String()) == 0 {
+		elapsed := c.clock.Since(firstSeenNodePoolDeletionTimestamp)
+		if elapsed < missingClusterServiceIDTimeout {
+			// The frontend may still be in the middle of creating the cluster-service
+			// NodePool, or the controller that does so hasn't run yet. Re-check on the
+			// next sync. The resync interval and informer change events drive retries.
+			return nil
+		}
+		logger.Info("giving up on cluster-service NodePool delete - ClusterServiceID never appeared",
+			"nodePoolDeletionTimestamp", nodePoolDeletionTimestamp, "nodePoolFirstSeenDeletionTimestamp", firstSeenNodePoolDeletionTimestamp)
+	} else if err := c.clusterServiceClient.DeleteNodePool(ctx, *csID); err != nil {
+		var ocmError *ocmerrors.Error
+
+		switch {
+		case errors.As(err, &ocmError) && ocmError.Status() == http.StatusBadRequest &&
+			strings.Contains(ocmError.Reason(), "Cannot delete node pool: its parent cluster must be in a deletable state") &&
+			strings.Contains(ocmError.Reason(), "Parent cluster state: 'uninstalling'"):
+			// If the error is indicating that the parent cluster is already being
+			// uninstalled we consider that the the nodepool is already being deleted
+			// because Cluster Service on cluster deletion will end up deleting the
+			// nodepools as well.
+			// Matching an error message is brittle, but Clusters Service
+			// returns 400 Bad Request for a wide range of errors and there
+			// is no other information in the response to distinguish them.
+			logger.Info("NodePool already being deleted by cluster-service via parent cluster deletion", "clusterServiceID", csID.String())
+		case errors.As(err, &ocmError) && ocmError.Status() == http.StatusNotFound:
+			// OCM error 404 - could be a stale CSID or a race against an in-flight CS
+			// create. Wait before treating the NodePool as definitively gone
+			elapsed := c.clock.Since(firstSeenNodePoolDeletionTimestamp)
+			if elapsed < missingClusterServiceIDTimeout {
+				return nil
+			}
+			logger.Info("cluster-service NodePool already deleted or race against in-flight CS create", "clusterServiceID", csID.String())
+		default:
+			return utils.TrackError(fmt.Errorf("failed to delete cluster-service NodePool: %w", err))
+		}
+	} else {
+		logger.Info("requested cluster-service NodePool delete", "clusterServiceID", csID.String())
+	}
+
+	nodePool.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: c.clock.Now().UTC()}
+	_, err = nodePoolCRUD.Replace(ctx, nodePool, nil)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to stamp ClusterServiceDeletionTimestamp: %w", err))
+	}
+	c.firstSeenDeletionTimestampCache.Remove(cacheKey)
+
+	return nil
+}

--- a/backend/pkg/controllers/nodepooldeletion/node_pool_cluster_service_delete_dispatch_controller.go
+++ b/backend/pkg/controllers/nodepooldeletion/node_pool_cluster_service_delete_dispatch_controller.go
@@ -106,13 +106,6 @@ func (c *nodePoolClusterServiceDeleteDispatchSyncer) CooldownChecker() controlle
 // NodePool: DeletionTimestamp must be set and ClusterServiceDeletionTimestamp
 // must not yet be set.
 func (c *nodePoolClusterServiceDeleteDispatchSyncer) NeedsWork(nodePool *api.HCPOpenShiftClusterNodePool) bool {
-	// TODO temporary check to skip the new deletion approach for NodePools that were created before the new approach was implemented.
-	// This will be removed once all nodepools whose deletion was triggered before the new approach is fully rolled out have been
-	// fully deleted in all ARO-HCP permanent environments, for all regions.
-	if !nodePool.ServiceProviderProperties.UsesNewNodePoolDeletionApproach {
-		return false
-	}
-
 	return nodePool.ServiceProviderProperties.DeletionTimestamp != nil &&
 		nodePool.ServiceProviderProperties.ClusterServiceDeletionTimestamp == nil
 }

--- a/backend/pkg/controllers/nodepooldeletion/node_pool_cluster_service_delete_dispatch_controller_test.go
+++ b/backend/pkg/controllers/nodepooldeletion/node_pool_cluster_service_delete_dispatch_controller_test.go
@@ -106,12 +106,12 @@ func TestNodePoolClusterServiceDeleteDispatchSyncer_SyncOnce(t *testing.T) {
 	}{
 		{
 			name:             "when no DeletionTimestamp no-op is performed",
-			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, nil),
+			existingNodePool: newTestNodePool(t, nil),
 			verifyDB:         verifyClusterServiceDeletionTimestampIsNil,
 		},
 		{
 			name: "when ClusterServiceDeletionTimestamp is set no-op is performed",
-			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+			existingNodePool: newTestNodePool(t, func(np *api.HCPOpenShiftClusterNodePool) {
 				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
 				np.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-30 * time.Minute)}
 			}),
@@ -126,7 +126,7 @@ func TestNodePoolClusterServiceDeleteDispatchSyncer_SyncOnce(t *testing.T) {
 		},
 		{
 			name: "when ClusterServiceID is not set and deletion is first observed then first seen is recorded and no-op is performed",
-			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+			existingNodePool: newTestNodePool(t, func(np *api.HCPOpenShiftClusterNodePool) {
 				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
 				np.ServiceProviderProperties.ClusterServiceID = nil
 			}),
@@ -134,7 +134,7 @@ func TestNodePoolClusterServiceDeleteDispatchSyncer_SyncOnce(t *testing.T) {
 		},
 		{
 			name: "when ClusterServiceID is not set and first seen within missing cluster service id is within timeout no-op is performed",
-			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+			existingNodePool: newTestNodePool(t, func(np *api.HCPOpenShiftClusterNodePool) {
 				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
 				np.ServiceProviderProperties.ClusterServiceID = nil
 			}),
@@ -143,7 +143,7 @@ func TestNodePoolClusterServiceDeleteDispatchSyncer_SyncOnce(t *testing.T) {
 		},
 		{
 			name: "when ClusterServiceID is not set and first seen older than missing cluster service id timeout then we give up and set ClusterServiceDeletionTimestamp",
-			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+			existingNodePool: newTestNodePool(t, func(np *api.HCPOpenShiftClusterNodePool) {
 				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
 				np.ServiceProviderProperties.ClusterServiceID = nil
 			}),
@@ -152,7 +152,7 @@ func TestNodePoolClusterServiceDeleteDispatchSyncer_SyncOnce(t *testing.T) {
 		},
 		{
 			name: "when ClusterServiceID is set we trigger CS nodepool deletion and set ClusterServiceDeletionTimestamp",
-			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+			existingNodePool: newTestNodePool(t, func(np *api.HCPOpenShiftClusterNodePool) {
 				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Minute)}
 			}),
 			firstSeenDeletionAt: fixedClockTime.Add(-missingClusterServiceIDTimeout / 2),
@@ -165,7 +165,7 @@ func TestNodePoolClusterServiceDeleteDispatchSyncer_SyncOnce(t *testing.T) {
 		},
 		{
 			name: "when CS nodepool deletion returns 404 and first seen is within the missing cluster service id timeout no-op is performed",
-			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+			existingNodePool: newTestNodePool(t, func(np *api.HCPOpenShiftClusterNodePool) {
 				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
 			}),
 			firstSeenDeletionAt: fixedClockTime.Add(-missingClusterServiceIDTimeout / 2),
@@ -178,7 +178,7 @@ func TestNodePoolClusterServiceDeleteDispatchSyncer_SyncOnce(t *testing.T) {
 		},
 		{
 			name: "when CS nodepool deletion returns 404 and first seen is older than the missing cluster service id timeout then we give up and set ClusterServiceDeletionTimestamp",
-			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+			existingNodePool: newTestNodePool(t, func(np *api.HCPOpenShiftClusterNodePool) {
 				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
 			}),
 			firstSeenDeletionAt: fixedClockTime.Add(-missingClusterServiceIDTimeout - time.Second),
@@ -191,7 +191,7 @@ func TestNodePoolClusterServiceDeleteDispatchSyncer_SyncOnce(t *testing.T) {
 		},
 		{
 			name: "when CS nodepool deletion returns one of the not handled errors we propagate it without setting ClusterServiceDeletionTimestamp",
-			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+			existingNodePool: newTestNodePool(t, func(np *api.HCPOpenShiftClusterNodePool) {
 				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Minute)}
 			}),
 			firstSeenDeletionAt: fixedClockTime.Add(-missingClusterServiceIDTimeout / 2),
@@ -205,7 +205,7 @@ func TestNodePoolClusterServiceDeleteDispatchSyncer_SyncOnce(t *testing.T) {
 		},
 		{
 			name: "when CS nodepool deletion returns parent cluster is uninstalling we set ClusterServiceDeletionTimestamp immediately",
-			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+			existingNodePool: newTestNodePool(t, func(np *api.HCPOpenShiftClusterNodePool) {
 				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-30 * time.Second)}
 			}),
 			firstSeenDeletionAt: fixedClockTime.Add(-missingClusterServiceIDTimeout / 2),
@@ -215,13 +215,6 @@ func TestNodePoolClusterServiceDeleteDispatchSyncer_SyncOnce(t *testing.T) {
 					Return(newFakeOCMParentClusterUninstallingError())
 			},
 			verifyDB: verifyClusterServiceDeletionTimestampStamped,
-		},
-		{
-			name: "UsesNewNodePoolDeletionApproach false -- no-op even when DeletionTimestamp is set",
-			existingNodePool: newTestNodePoolWithOldDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
-				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Minute)}
-			}),
-			verifyDB: verifyClusterServiceDeletionTimestampIsNil,
 		},
 		{
 			name: "node pool not found no-op is performed",
@@ -289,14 +282,14 @@ func TestNodePoolClusterServiceDeleteDispatchSyncer_SyncOnce_cacheShortCircuit(t
 	ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
 	ctrl := gomock.NewController(t)
 
-	nodePoolInDB := newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+	nodePoolInDB := newTestNodePool(t, func(np *api.HCPOpenShiftClusterNodePool) {
 		np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
 	})
 	mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, []any{nodePoolInDB})
 	require.NoError(t, err)
 
 	// Here the cached node pool does not have a DeletionTimestamp set, so the syncer will short-circuit.
-	cachedNodePool := newTestNodePoolWithNewDeletionApproach(t, nil)
+	cachedNodePool := newTestNodePool(t, nil)
 
 	syncer := &nodePoolClusterServiceDeleteDispatchSyncer{
 		clock:                           clocktesting.NewFakePassiveClock(fixedClockTime),
@@ -327,7 +320,7 @@ func TestNodePoolClusterServiceDeleteDispatchSyncer_SyncOnce_firstSeenDeletionCa
 	ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
 	ctrl := gomock.NewController(t)
 
-	nodePool := newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+	nodePool := newTestNodePool(t, func(np *api.HCPOpenShiftClusterNodePool) {
 		np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
 		np.ServiceProviderProperties.ClusterServiceID = nil
 	})
@@ -364,7 +357,7 @@ func TestNodePoolClusterServiceDeleteDispatchSyncer_SyncOnce_firstSeenDeletionCa
 	ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
 	ctrl := gomock.NewController(t)
 
-	nodePool := newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+	nodePool := newTestNodePool(t, func(np *api.HCPOpenShiftClusterNodePool) {
 		np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Minute)}
 	})
 	mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, []any{nodePool})
@@ -412,9 +405,7 @@ func fakeOCMNotFoundError() error {
 	return e
 }
 
-// TODO rename this to newTestNodePoolWithNewDeletionApproach and remove the newTestNodePoolWithOldDeletionApproach function once
-// the new deletion approach is fully rolled out in all ARO-HCP permanent environments, for all regions.
-func newTestNodePoolWithNewDeletionApproach(t *testing.T, opts func(*api.HCPOpenShiftClusterNodePool)) *api.HCPOpenShiftClusterNodePool {
+func newTestNodePool(t *testing.T, opts func(*api.HCPOpenShiftClusterNodePool)) *api.HCPOpenShiftClusterNodePool {
 	t.Helper()
 	resourceID := api.Must(azcorearm.ParseResourceID(
 		"/subscriptions/" + testSubscriptionID +
@@ -441,20 +432,12 @@ func newTestNodePoolWithNewDeletionApproach(t *testing.T, opts func(*api.HCPOpen
 			},
 		},
 		ServiceProviderProperties: api.HCPOpenShiftClusterNodePoolServiceProviderProperties{
-			ClusterServiceID:                nodePoolInternalID,
-			UsesNewNodePoolDeletionApproach: true,
+			ClusterServiceID: nodePoolInternalID,
 		},
 	}
 	if opts != nil {
 		opts(np)
 	}
-	return np
-}
-
-// TODO remove this once the new deletion approach is fully rolled out in all ARO-HCP permanent environments, for all regions.
-func newTestNodePoolWithOldDeletionApproach(t *testing.T, opts func(*api.HCPOpenShiftClusterNodePool)) *api.HCPOpenShiftClusterNodePool {
-	np := newTestNodePoolWithNewDeletionApproach(t, opts)
-	np.ServiceProviderProperties.UsesNewNodePoolDeletionApproach = false
 	return np
 }
 

--- a/backend/pkg/controllers/nodepooldeletion/node_pool_cluster_service_delete_dispatch_controller_test.go
+++ b/backend/pkg/controllers/nodepooldeletion/node_pool_cluster_service_delete_dispatch_controller_test.go
@@ -1,0 +1,475 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodepooldeletion
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clocktesting "k8s.io/utils/clock/testing"
+	"k8s.io/utils/lru"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+const (
+	testSubscriptionID      = "00000000-0000-0000-0000-000000000000"
+	testResourceGroupName   = "test-rg"
+	testClusterName         = "test-cluster"
+	testNodePoolName        = "test-nodepool"
+	testClusterServiceIDStr = "/api/aro_hcp/v1alpha1/clusters/abc123"
+	testNodePoolCSIDStr     = testClusterServiceIDStr + "/node_pools/" + testNodePoolName
+)
+
+type alwaysSyncCooldownChecker struct{}
+
+func (c *alwaysSyncCooldownChecker) CanSync(ctx context.Context, key any) bool {
+	return true
+}
+
+func TestNodePoolClusterServiceDeleteDispatchSyncer_SyncOnce(t *testing.T) {
+	fixedClockTime := time.Now().UTC().Truncate(time.Second)
+
+	testKey := controllerutils.HCPNodePoolKey{
+		SubscriptionID:    testSubscriptionID,
+		ResourceGroupName: testResourceGroupName,
+		HCPClusterName:    testClusterName,
+		HCPNodePoolName:   testNodePoolName,
+	}
+
+	verifyClusterServiceDeletionTimestampIsNil := func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+		t.Helper()
+		stored, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).
+			NodePools(testClusterName).Get(ctx, testNodePoolName)
+		require.NoError(t, err)
+		assert.Nil(t, stored.ServiceProviderProperties.ClusterServiceDeletionTimestamp)
+	}
+
+	verifyClusterServiceDeletionTimestampStamped := func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+		t.Helper()
+		stored, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).
+			NodePools(testClusterName).Get(ctx, testNodePoolName)
+		require.NoError(t, err)
+		require.NotNil(t, stored.ServiceProviderProperties.ClusterServiceDeletionTimestamp, "expected ClusterServiceDeletionTimestamp to be stamped")
+		assert.True(t, stored.ServiceProviderProperties.ClusterServiceDeletionTimestamp.Time.Equal(fixedClockTime),
+			"expected ClusterServiceDeletionTimestamp to equal fixedClockTime, got %v", stored.ServiceProviderProperties.ClusterServiceDeletionTimestamp.Time)
+	}
+
+	newFakeOCMParentClusterUninstallingError := func() error {
+		e, _ := ocmerrors.NewError().
+			Status(http.StatusBadRequest).
+			Reason("Cannot delete node pool: its parent cluster must be in a deletable state. Parent cluster state: 'uninstalling'").
+			Build()
+		return e
+	}
+
+	testCases := []struct {
+		name                string
+		existingNodePool    *api.HCPOpenShiftClusterNodePool
+		firstSeenDeletionAt time.Time
+		setupMockCSClient   func(mock *ocm.MockClusterServiceClientSpec)
+		wantErr             bool
+		wantErrContain      string
+		verifyDB            func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient)
+	}{
+		{
+			name:             "when no DeletionTimestamp no-op is performed",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, nil),
+			verifyDB:         verifyClusterServiceDeletionTimestampIsNil,
+		},
+		{
+			name: "when ClusterServiceDeletionTimestamp is set no-op is performed",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
+				np.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-30 * time.Minute)}
+			}),
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				stored, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).
+					NodePools(testClusterName).Get(ctx, testNodePoolName)
+				require.NoError(t, err)
+				require.NotNil(t, stored.ServiceProviderProperties.ClusterServiceDeletionTimestamp)
+				assert.True(t, stored.ServiceProviderProperties.ClusterServiceDeletionTimestamp.Time.Equal(fixedClockTime.Add(-30*time.Minute)),
+					"expected ClusterServiceDeletionTimestamp unchanged")
+			},
+		},
+		{
+			name: "when ClusterServiceID is not set and deletion is first observed then first seen is recorded and no-op is performed",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
+				np.ServiceProviderProperties.ClusterServiceID = nil
+			}),
+			verifyDB: verifyClusterServiceDeletionTimestampIsNil,
+		},
+		{
+			name: "when ClusterServiceID is not set and first seen within missing cluster service id is within timeout no-op is performed",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
+				np.ServiceProviderProperties.ClusterServiceID = nil
+			}),
+			firstSeenDeletionAt: fixedClockTime.Add(-missingClusterServiceIDTimeout / 2),
+			verifyDB:            verifyClusterServiceDeletionTimestampIsNil,
+		},
+		{
+			name: "when ClusterServiceID is not set and first seen older than missing cluster service id timeout then we give up and set ClusterServiceDeletionTimestamp",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
+				np.ServiceProviderProperties.ClusterServiceID = nil
+			}),
+			firstSeenDeletionAt: fixedClockTime.Add(-missingClusterServiceIDTimeout - time.Second),
+			verifyDB:            verifyClusterServiceDeletionTimestampStamped,
+		},
+		{
+			name: "when ClusterServiceID is set we trigger CS nodepool deletion and set ClusterServiceDeletionTimestamp",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Minute)}
+			}),
+			firstSeenDeletionAt: fixedClockTime.Add(-missingClusterServiceIDTimeout / 2),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					DeleteNodePool(gomock.Any(), api.Must(api.NewInternalID(testNodePoolCSIDStr))).
+					Return(nil)
+			},
+			verifyDB: verifyClusterServiceDeletionTimestampStamped,
+		},
+		{
+			name: "when CS nodepool deletion returns 404 and first seen is within the missing cluster service id timeout no-op is performed",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
+			}),
+			firstSeenDeletionAt: fixedClockTime.Add(-missingClusterServiceIDTimeout / 2),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					DeleteNodePool(gomock.Any(), api.Must(api.NewInternalID(testNodePoolCSIDStr))).
+					Return(fakeOCMNotFoundError())
+			},
+			verifyDB: verifyClusterServiceDeletionTimestampIsNil,
+		},
+		{
+			name: "when CS nodepool deletion returns 404 and first seen is older than the missing cluster service id timeout then we give up and set ClusterServiceDeletionTimestamp",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
+			}),
+			firstSeenDeletionAt: fixedClockTime.Add(-missingClusterServiceIDTimeout - time.Second),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					DeleteNodePool(gomock.Any(), api.Must(api.NewInternalID(testNodePoolCSIDStr))).
+					Return(fakeOCMNotFoundError())
+			},
+			verifyDB: verifyClusterServiceDeletionTimestampStamped,
+		},
+		{
+			name: "when CS nodepool deletion returns one of the not handled errors we propagate it without setting ClusterServiceDeletionTimestamp",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Minute)}
+			}),
+			firstSeenDeletionAt: fixedClockTime.Add(-missingClusterServiceIDTimeout / 2),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					DeleteNodePool(gomock.Any(), api.Must(api.NewInternalID(testNodePoolCSIDStr))).
+					Return(errors.New("boom"))
+			},
+			wantErr:        true,
+			wantErrContain: "failed to delete cluster-service NodePool",
+		},
+		{
+			name: "when CS nodepool deletion returns parent cluster is uninstalling we set ClusterServiceDeletionTimestamp immediately",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-30 * time.Second)}
+			}),
+			firstSeenDeletionAt: fixedClockTime.Add(-missingClusterServiceIDTimeout / 2),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					DeleteNodePool(gomock.Any(), api.Must(api.NewInternalID(testNodePoolCSIDStr))).
+					Return(newFakeOCMParentClusterUninstallingError())
+			},
+			verifyDB: verifyClusterServiceDeletionTimestampStamped,
+		},
+		{
+			name: "UsesNewNodePoolDeletionApproach false -- no-op even when DeletionTimestamp is set",
+			existingNodePool: newTestNodePoolWithOldDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Minute)}
+			}),
+			verifyDB: verifyClusterServiceDeletionTimestampIsNil,
+		},
+		{
+			name: "node pool not found no-op is performed",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+			ctrl := gomock.NewController(t)
+
+			resources := []any{}
+			if tc.existingNodePool != nil {
+				resources = append(resources, tc.existingNodePool)
+			}
+			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, resources)
+			require.NoError(t, err)
+
+			mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
+			if tc.setupMockCSClient != nil {
+				tc.setupMockCSClient(mockCSClient)
+			}
+
+			nodePoolsForLister := []*api.HCPOpenShiftClusterNodePool{}
+			if tc.existingNodePool != nil {
+				nodePoolsForLister = append(nodePoolsForLister, tc.existingNodePool)
+			}
+
+			firstSeenDeletionTimestampCache := lru.New(10)
+			if !tc.firstSeenDeletionAt.IsZero() {
+				firstSeenDeletionTimestampCache.Add(
+					strings.ToLower(tc.existingNodePool.ID.String()),
+					tc.firstSeenDeletionAt,
+				)
+			}
+
+			syncer := &nodePoolClusterServiceDeleteDispatchSyncer{
+				clock:                           clocktesting.NewFakePassiveClock(fixedClockTime),
+				cooldownChecker:                 &alwaysSyncCooldownChecker{},
+				nodePoolLister:                  &listertesting.SliceNodePoolLister{NodePools: nodePoolsForLister},
+				resourcesDBClient:               mockResourcesDBClient,
+				clusterServiceClient:            mockCSClient,
+				firstSeenDeletionTimestampCache: firstSeenDeletionTimestampCache,
+			}
+
+			err = syncer.SyncOnce(ctx, testKey)
+			if tc.wantErr {
+				require.Error(t, err)
+				if len(tc.wantErrContain) > 0 {
+					require.ErrorContains(t, err, tc.wantErrContain)
+				}
+				return
+			}
+			require.NoError(t, err)
+
+			if tc.verifyDB != nil {
+				tc.verifyDB(t, ctx, mockResourcesDBClient)
+			}
+		})
+	}
+}
+
+func TestNodePoolClusterServiceDeleteDispatchSyncer_SyncOnce_cacheShortCircuit(t *testing.T) {
+	fixedClockTime := time.Now().UTC().Truncate(time.Second)
+	ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+	ctrl := gomock.NewController(t)
+
+	nodePoolInDB := newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+		np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
+	})
+	mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, []any{nodePoolInDB})
+	require.NoError(t, err)
+
+	// Here the cached node pool does not have a DeletionTimestamp set, so the syncer will short-circuit.
+	cachedNodePool := newTestNodePoolWithNewDeletionApproach(t, nil)
+
+	syncer := &nodePoolClusterServiceDeleteDispatchSyncer{
+		clock:                           clocktesting.NewFakePassiveClock(fixedClockTime),
+		cooldownChecker:                 &alwaysSyncCooldownChecker{},
+		nodePoolLister:                  &listertesting.SliceNodePoolLister{NodePools: []*api.HCPOpenShiftClusterNodePool{cachedNodePool}},
+		resourcesDBClient:               mockResourcesDBClient,
+		clusterServiceClient:            ocm.NewMockClusterServiceClientSpec(ctrl),
+		firstSeenDeletionTimestampCache: lru.New(10),
+	}
+
+	key := controllerutils.HCPNodePoolKey{
+		SubscriptionID:    testSubscriptionID,
+		ResourceGroupName: testResourceGroupName,
+		HCPClusterName:    testClusterName,
+		HCPNodePoolName:   testNodePoolName,
+	}
+
+	require.NoError(t, syncer.SyncOnce(ctx, key))
+
+	stored, err := mockResourcesDBClient.HCPClusters(testSubscriptionID, testResourceGroupName).
+		NodePools(testClusterName).Get(ctx, testNodePoolName)
+	require.NoError(t, err)
+	assert.Nil(t, stored.ServiceProviderProperties.ClusterServiceDeletionTimestamp)
+}
+
+func TestNodePoolClusterServiceDeleteDispatchSyncer_SyncOnce_firstSeenDeletionCachePopulation(t *testing.T) {
+	fixedClockTime := time.Now().UTC().Truncate(time.Second)
+	ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+	ctrl := gomock.NewController(t)
+
+	nodePool := newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+		np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
+		np.ServiceProviderProperties.ClusterServiceID = nil
+	})
+	mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, []any{nodePool})
+	require.NoError(t, err)
+
+	firstSeenDeletionTimestampCache := lru.New(10)
+	syncer := &nodePoolClusterServiceDeleteDispatchSyncer{
+		clock:                           clocktesting.NewFakePassiveClock(fixedClockTime),
+		cooldownChecker:                 &alwaysSyncCooldownChecker{},
+		nodePoolLister:                  &listertesting.SliceNodePoolLister{NodePools: []*api.HCPOpenShiftClusterNodePool{nodePool}},
+		resourcesDBClient:               mockResourcesDBClient,
+		clusterServiceClient:            ocm.NewMockClusterServiceClientSpec(ctrl),
+		firstSeenDeletionTimestampCache: firstSeenDeletionTimestampCache,
+	}
+
+	key := controllerutils.HCPNodePoolKey{
+		SubscriptionID:    testSubscriptionID,
+		ResourceGroupName: testResourceGroupName,
+		HCPClusterName:    testClusterName,
+		HCPNodePoolName:   testNodePoolName,
+	}
+
+	require.NoError(t, syncer.SyncOnce(ctx, key))
+
+	cacheKey := strings.ToLower(nodePool.ID.String())
+	firstSeenEntry, ok := firstSeenDeletionTimestampCache.Get(cacheKey)
+	require.True(t, ok, "expected first seen deletion timestamp to be cached")
+	assert.True(t, firstSeenEntry.(time.Time).Equal(fixedClockTime))
+}
+
+func TestNodePoolClusterServiceDeleteDispatchSyncer_SyncOnce_firstSeenDeletionCacheCleared(t *testing.T) {
+	fixedClockTime := time.Now().UTC().Truncate(time.Second)
+	ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+	ctrl := gomock.NewController(t)
+
+	nodePool := newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+		np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Minute)}
+	})
+	mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, []any{nodePool})
+	require.NoError(t, err)
+
+	cacheKey := strings.ToLower(nodePool.ID.String())
+	firstSeenDeletionTimestampCache := lru.New(10)
+	firstSeenDeletionTimestampCache.Add(cacheKey, fixedClockTime.Add(-missingClusterServiceIDTimeout/2))
+
+	mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
+	mockCSClient.EXPECT().
+		DeleteNodePool(gomock.Any(), api.Must(api.NewInternalID(testNodePoolCSIDStr))).
+		Return(nil)
+
+	syncer := &nodePoolClusterServiceDeleteDispatchSyncer{
+		clock:                           clocktesting.NewFakePassiveClock(fixedClockTime),
+		cooldownChecker:                 &alwaysSyncCooldownChecker{},
+		nodePoolLister:                  &listertesting.SliceNodePoolLister{NodePools: []*api.HCPOpenShiftClusterNodePool{nodePool}},
+		resourcesDBClient:               mockResourcesDBClient,
+		clusterServiceClient:            mockCSClient,
+		firstSeenDeletionTimestampCache: firstSeenDeletionTimestampCache,
+	}
+
+	key := controllerutils.HCPNodePoolKey{
+		SubscriptionID:    testSubscriptionID,
+		ResourceGroupName: testResourceGroupName,
+		HCPClusterName:    testClusterName,
+		HCPNodePoolName:   testNodePoolName,
+	}
+
+	require.NoError(t, syncer.SyncOnce(ctx, key))
+
+	_, ok := firstSeenDeletionTimestampCache.Get(cacheKey)
+	assert.False(t, ok, "expected first seen deletion cache entry to be removed after terminal sync")
+
+	stored, err := mockResourcesDBClient.HCPClusters(testSubscriptionID, testResourceGroupName).
+		NodePools(testClusterName).Get(ctx, testNodePoolName)
+	require.NoError(t, err)
+	require.NotNil(t, stored.ServiceProviderProperties.ClusterServiceDeletionTimestamp)
+	assert.True(t, stored.ServiceProviderProperties.ClusterServiceDeletionTimestamp.Time.Equal(fixedClockTime))
+}
+
+func fakeOCMNotFoundError() error {
+	e, _ := ocmerrors.NewError().Status(http.StatusNotFound).Reason("not found").Build()
+	return e
+}
+
+// TODO rename this to newTestNodePoolWithNewDeletionApproach and remove the newTestNodePoolWithOldDeletionApproach function once
+// the new deletion approach is fully rolled out in all ARO-HCP permanent environments, for all regions.
+func newTestNodePoolWithNewDeletionApproach(t *testing.T, opts func(*api.HCPOpenShiftClusterNodePool)) *api.HCPOpenShiftClusterNodePool {
+	t.Helper()
+	resourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+			"/nodePools/" + testNodePoolName))
+	nodePoolInternalID := api.Ptr(api.Must(api.NewInternalID(testNodePoolCSIDStr)))
+	np := &api.HCPOpenShiftClusterNodePool{
+		TrackedResource: arm.TrackedResource{
+			Resource: arm.Resource{
+				ID:   resourceID,
+				Name: testNodePoolName,
+				Type: api.NodePoolResourceType.String(),
+			},
+			Location: "eastus",
+		},
+		CosmosMetadata: arm.CosmosMetadata{ResourceID: resourceID},
+		Properties: api.HCPOpenShiftClusterNodePoolProperties{
+			Platform: api.NodePoolPlatformProfile{
+				OSDisk: api.OSDiskProfile{
+					DiskStorageAccountType: api.DiskStorageAccountTypePremium_LRS,
+					DiskType:               api.OsDiskTypeManaged,
+				},
+			},
+		},
+		ServiceProviderProperties: api.HCPOpenShiftClusterNodePoolServiceProviderProperties{
+			ClusterServiceID:                nodePoolInternalID,
+			UsesNewNodePoolDeletionApproach: true,
+		},
+	}
+	if opts != nil {
+		opts(np)
+	}
+	return np
+}
+
+// TODO remove this once the new deletion approach is fully rolled out in all ARO-HCP permanent environments, for all regions.
+func newTestNodePoolWithOldDeletionApproach(t *testing.T, opts func(*api.HCPOpenShiftClusterNodePool)) *api.HCPOpenShiftClusterNodePool {
+	np := newTestNodePoolWithNewDeletionApproach(t, opts)
+	np.ServiceProviderProperties.UsesNewNodePoolDeletionApproach = false
+	return np
+}
+
+func newTestSPNP(t *testing.T, bundles api.MaestroBundleReferenceList) *api.ServiceProviderNodePool {
+	t.Helper()
+	spnpResourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+			"/nodePools/" + testNodePoolName +
+			"/serviceProviderNodePools/default"))
+	return &api.ServiceProviderNodePool{
+		CosmosMetadata: arm.CosmosMetadata{ResourceID: spnpResourceID},
+		Status: api.ServiceProviderNodePoolStatus{
+			MaestroReadonlyBundles: bundles,
+		},
+	}
+}

--- a/backend/pkg/controllers/nodepooldeletion/node_pool_cluster_service_id_clearer.go
+++ b/backend/pkg/controllers/nodepooldeletion/node_pool_cluster_service_id_clearer.go
@@ -1,0 +1,143 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodepooldeletion
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/internal/api"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// nodePoolClusterServiceIDClearer clears ClusterServiceID after the
+// cluster-service NodePool itself has been confirmed gone. This runs after the
+// delet dispatch controller has already issued the delete request
+// (ClusterServiceDeletionTimestamp is set). We poll cluster-service for the
+// NodePool and, on 404, zero out the stored ClusterServiceID so downstream
+// code knows the CS resource is fully gone.
+type nodePoolClusterServiceIDClearer struct {
+	cooldownChecker      controllerutil.CooldownChecker
+	nodePoolLister       listers.NodePoolLister
+	resourcesDBClient    database.ResourcesDBClient
+	clusterServiceClient ocm.ClusterServiceClientSpec
+}
+
+var _ controllerutils.NodePoolSyncer = (*nodePoolClusterServiceIDClearer)(nil)
+
+func NewNodePoolClusterServiceIDClearerController(
+	resourcesDBClient database.ResourcesDBClient,
+	clusterServiceClient ocm.ClusterServiceClientSpec,
+	activeOperationLister listers.ActiveOperationLister,
+	informers informers.BackendInformers,
+) controllerutils.Controller {
+	_, nodePoolLister := informers.NodePools()
+	syncer := &nodePoolClusterServiceIDClearer{
+		cooldownChecker:      controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		nodePoolLister:       nodePoolLister,
+		resourcesDBClient:    resourcesDBClient,
+		clusterServiceClient: clusterServiceClient,
+	}
+
+	return controllerutils.NewNodePoolWatchingController(
+		"NodePoolDeletionClusterServiceIDClearer",
+		resourcesDBClient,
+		informers,
+		time.Minute,
+		syncer,
+	)
+}
+
+func (c *nodePoolClusterServiceIDClearer) CooldownChecker() controllerutil.CooldownChecker {
+	return c.cooldownChecker
+}
+
+// NeedsWork reports whether this controller has unfinished business for the
+// given NodePool: deletion has been started (DeletionTimestamp), the deleter
+// has already issued the CS delete (ClusterServiceDeletionTimestamp), and a
+// ClusterServiceID is still recorded that needs verification before clearing.
+func (c *nodePoolClusterServiceIDClearer) NeedsWork(nodePool *api.HCPOpenShiftClusterNodePool) bool {
+	// TODO temporary check to skip the new deletion approach for NodePools that were created before the new approach was implemented.
+	// This will be removed once all nodepools whose deletion was triggered before the new approach is fully rolled out have been
+	// fully deleted in all ARO-HCP permanent environments, for all regions.
+	if !nodePool.ServiceProviderProperties.UsesNewNodePoolDeletionApproach {
+		return false
+	}
+
+	return nodePool.ServiceProviderProperties.DeletionTimestamp != nil &&
+		nodePool.ServiceProviderProperties.ClusterServiceDeletionTimestamp != nil &&
+		nodePool.ServiceProviderProperties.ClusterServiceID != nil && len(nodePool.ServiceProviderProperties.ClusterServiceID.String()) > 0
+}
+
+// SyncOnce reads the NodePool from cluster-service. If cluster-service reports
+// 404, the deletion has finished and we zero out ClusterServiceID. Any other
+// state means cluster-service is still draining the NodePool. We retry on the
+// next sync.
+func (c *nodePoolClusterServiceIDClearer) SyncOnce(ctx context.Context, key controllerutils.HCPNodePoolKey) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	cachedNodePool, err := c.nodePoolLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get node pool from cache: %w", err))
+	}
+	if !c.NeedsWork(cachedNodePool) {
+		return nil
+	}
+
+	nodePoolCRUD := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).NodePools(key.HCPClusterName)
+	nodePool, err := nodePoolCRUD.Get(ctx, key.HCPNodePoolName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get node pool: %w", err))
+	}
+	if !c.NeedsWork(nodePool) {
+		return nil
+	}
+
+	csID := nodePool.ServiceProviderProperties.ClusterServiceID
+	_, err = c.clusterServiceClient.GetNodePool(ctx, *csID)
+	if err != nil {
+		var ocmError *ocmerrors.Error
+		if !errors.As(err, &ocmError) || ocmError.Status() != http.StatusNotFound {
+			return utils.TrackError(fmt.Errorf("failed to get cluster-service NodePool: %w", err))
+		}
+		// 404 - cluster-service has finished deleting the NodePool, clear the CS ID.
+		logger.Info("cluster-service NodePool gone. Clearing ClusterServiceID", "clusterServiceID", csID.String())
+		nodePool.ServiceProviderProperties.ClusterServiceID = nil
+		if _, err := nodePoolCRUD.Replace(ctx, nodePool, nil); err != nil {
+			return utils.TrackError(fmt.Errorf("failed to clear ClusterServiceID: %w", err))
+		}
+		return nil
+	}
+
+	// NodePool still exists in cluster-service. Nothing to do yet.
+	return nil
+}

--- a/backend/pkg/controllers/nodepooldeletion/node_pool_cluster_service_id_clearer.go
+++ b/backend/pkg/controllers/nodepooldeletion/node_pool_cluster_service_id_clearer.go
@@ -80,13 +80,6 @@ func (c *nodePoolClusterServiceIDClearer) CooldownChecker() controllerutil.Coold
 // has already issued the CS delete (ClusterServiceDeletionTimestamp), and a
 // ClusterServiceID is still recorded that needs verification before clearing.
 func (c *nodePoolClusterServiceIDClearer) NeedsWork(nodePool *api.HCPOpenShiftClusterNodePool) bool {
-	// TODO temporary check to skip the new deletion approach for NodePools that were created before the new approach was implemented.
-	// This will be removed once all nodepools whose deletion was triggered before the new approach is fully rolled out have been
-	// fully deleted in all ARO-HCP permanent environments, for all regions.
-	if !nodePool.ServiceProviderProperties.UsesNewNodePoolDeletionApproach {
-		return false
-	}
-
 	return nodePool.ServiceProviderProperties.DeletionTimestamp != nil &&
 		nodePool.ServiceProviderProperties.ClusterServiceDeletionTimestamp != nil &&
 		nodePool.ServiceProviderProperties.ClusterServiceID != nil && len(nodePool.ServiceProviderProperties.ClusterServiceID.String()) > 0

--- a/backend/pkg/controllers/nodepooldeletion/node_pool_cluster_service_id_clearer_test.go
+++ b/backend/pkg/controllers/nodepooldeletion/node_pool_cluster_service_id_clearer_test.go
@@ -64,19 +64,19 @@ func TestNodePoolClusterServiceIDClearer_SyncOnce(t *testing.T) {
 	}{
 		{
 			name:             "no DeletionTimestamp -- no-op",
-			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, nil),
+			existingNodePool: newTestNodePool(t, nil),
 			verifyDB:         verifyClusterServiceIDUnchanged,
 		},
 		{
 			name: "DeletionTimestamp set but ClusterServiceDeletionTimestamp not yet -- no-op",
-			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+			existingNodePool: newTestNodePool(t, func(np *api.HCPOpenShiftClusterNodePool) {
 				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-time.Hour)}
 			}),
 			verifyDB: verifyClusterServiceIDUnchanged,
 		},
 		{
 			name: "ClusterServiceID already cleared -- no-op",
-			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+			existingNodePool: newTestNodePool(t, func(np *api.HCPOpenShiftClusterNodePool) {
 				withDeletionStampsNodePoolOptsFunc(np)
 				np.ServiceProviderProperties.ClusterServiceID = nil
 			}),
@@ -90,7 +90,7 @@ func TestNodePoolClusterServiceIDClearer_SyncOnce(t *testing.T) {
 		},
 		{
 			name: "CS NodePool still present -- wait",
-			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+			existingNodePool: newTestNodePool(t, func(np *api.HCPOpenShiftClusterNodePool) {
 				withDeletionStampsNodePoolOptsFunc(np)
 			}),
 			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
@@ -102,7 +102,7 @@ func TestNodePoolClusterServiceIDClearer_SyncOnce(t *testing.T) {
 		},
 		{
 			name: "CS returns 404 -- clear ClusterServiceID",
-			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+			existingNodePool: newTestNodePool(t, func(np *api.HCPOpenShiftClusterNodePool) {
 				withDeletionStampsNodePoolOptsFunc(np)
 			}),
 			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
@@ -120,7 +120,7 @@ func TestNodePoolClusterServiceIDClearer_SyncOnce(t *testing.T) {
 		},
 		{
 			name: "CS returns one of the not handled errors -- propagated, no clear",
-			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+			existingNodePool: newTestNodePool(t, func(np *api.HCPOpenShiftClusterNodePool) {
 				withDeletionStampsNodePoolOptsFunc(np)
 			}),
 			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
@@ -130,13 +130,6 @@ func TestNodePoolClusterServiceIDClearer_SyncOnce(t *testing.T) {
 			},
 			wantErr:        true,
 			wantErrContain: "failed to get cluster-service NodePool",
-		},
-		{
-			name: "UsesNewNodePoolDeletionApproach false -- no-op even when all clear conditions met",
-			existingNodePool: newTestNodePoolWithOldDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
-				withDeletionStampsNodePoolOptsFunc(np)
-			}),
-			verifyDB: verifyClusterServiceIDUnchanged,
 		},
 		{
 			name: "node pool not found",

--- a/backend/pkg/controllers/nodepooldeletion/node_pool_cluster_service_id_clearer_test.go
+++ b/backend/pkg/controllers/nodepooldeletion/node_pool_cluster_service_id_clearer_test.go
@@ -1,0 +1,204 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodepooldeletion
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+func TestNodePoolClusterServiceIDClearer_SyncOnce(t *testing.T) {
+	fixedNow := time.Now().UTC().Truncate(time.Second)
+	withDeletionStampsNodePoolOptsFunc := func(np *api.HCPOpenShiftClusterNodePool) {
+		np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-time.Hour)}
+		np.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-30 * time.Minute)}
+	}
+
+	verifyClusterServiceIDUnchanged := func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+		t.Helper()
+		stored, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).
+			NodePools(testClusterName).Get(ctx, testNodePoolName)
+		require.NoError(t, err)
+		require.NotNil(t, stored.ServiceProviderProperties.ClusterServiceID, "ClusterServiceID should not be nil")
+		assert.Equal(t, testNodePoolCSIDStr, stored.ServiceProviderProperties.ClusterServiceID.String(),
+			"ClusterServiceID should be unchanged")
+	}
+
+	testCases := []struct {
+		name              string
+		existingNodePool  *api.HCPOpenShiftClusterNodePool
+		setupMockCSClient func(mock *ocm.MockClusterServiceClientSpec)
+		wantErr           bool
+		wantErrContain    string
+		verifyDB          func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient)
+	}{
+		{
+			name:             "no DeletionTimestamp -- no-op",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, nil),
+			verifyDB:         verifyClusterServiceIDUnchanged,
+		},
+		{
+			name: "DeletionTimestamp set but ClusterServiceDeletionTimestamp not yet -- no-op",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-time.Hour)}
+			}),
+			verifyDB: verifyClusterServiceIDUnchanged,
+		},
+		{
+			name: "ClusterServiceID already cleared -- no-op",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				withDeletionStampsNodePoolOptsFunc(np)
+				np.ServiceProviderProperties.ClusterServiceID = nil
+			}),
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+				stored, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).
+					NodePools(testClusterName).Get(ctx, testNodePoolName)
+				require.NoError(t, err)
+				assert.Nil(t, stored.ServiceProviderProperties.ClusterServiceID, "ClusterServiceID should remain nil")
+			},
+		},
+		{
+			name: "CS NodePool still present -- wait",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				withDeletionStampsNodePoolOptsFunc(np)
+			}),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetNodePool(gomock.Any(), api.Must(api.NewInternalID(testNodePoolCSIDStr))).
+					Return(newCSNodePool(t), nil)
+			},
+			verifyDB: verifyClusterServiceIDUnchanged,
+		},
+		{
+			name: "CS returns 404 -- clear ClusterServiceID",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				withDeletionStampsNodePoolOptsFunc(np)
+			}),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetNodePool(gomock.Any(), api.Must(api.NewInternalID(testNodePoolCSIDStr))).
+					Return(nil, fakeOCMNotFoundError())
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+				stored, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).
+					NodePools(testClusterName).Get(ctx, testNodePoolName)
+				require.NoError(t, err)
+				assert.Nil(t, stored.ServiceProviderProperties.ClusterServiceID, "expected ClusterServiceID to be cleared")
+			},
+		},
+		{
+			name: "CS returns one of the not handled errors -- propagated, no clear",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				withDeletionStampsNodePoolOptsFunc(np)
+			}),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetNodePool(gomock.Any(), api.Must(api.NewInternalID(testNodePoolCSIDStr))).
+					Return(nil, errors.New("boom"))
+			},
+			wantErr:        true,
+			wantErrContain: "failed to get cluster-service NodePool",
+		},
+		{
+			name: "UsesNewNodePoolDeletionApproach false -- no-op even when all clear conditions met",
+			existingNodePool: newTestNodePoolWithOldDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				withDeletionStampsNodePoolOptsFunc(np)
+			}),
+			verifyDB: verifyClusterServiceIDUnchanged,
+		},
+		{
+			name: "node pool not found",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+			ctrl := gomock.NewController(t)
+
+			resources := []any{}
+			if tc.existingNodePool != nil {
+				resources = append(resources, tc.existingNodePool)
+			}
+			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, resources)
+			require.NoError(t, err)
+
+			mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
+			if tc.setupMockCSClient != nil {
+				tc.setupMockCSClient(mockCSClient)
+			}
+
+			nodePoolsForLister := []*api.HCPOpenShiftClusterNodePool{}
+			if tc.existingNodePool != nil {
+				nodePoolsForLister = append(nodePoolsForLister, tc.existingNodePool)
+			}
+
+			syncer := &nodePoolClusterServiceIDClearer{
+				cooldownChecker:      &alwaysSyncCooldownChecker{},
+				nodePoolLister:       &listertesting.SliceNodePoolLister{NodePools: nodePoolsForLister},
+				resourcesDBClient:    mockResourcesDBClient,
+				clusterServiceClient: mockCSClient,
+			}
+
+			key := controllerutils.HCPNodePoolKey{
+				SubscriptionID:    testSubscriptionID,
+				ResourceGroupName: testResourceGroupName,
+				HCPClusterName:    testClusterName,
+				HCPNodePoolName:   testNodePoolName,
+			}
+
+			err = syncer.SyncOnce(ctx, key)
+			if tc.wantErr {
+				require.Error(t, err)
+				if len(tc.wantErrContain) > 0 {
+					require.ErrorContains(t, err, tc.wantErrContain)
+				}
+				return
+			}
+			require.NoError(t, err)
+
+			if tc.verifyDB != nil {
+				tc.verifyDB(t, ctx, mockResourcesDBClient)
+			}
+		})
+	}
+}
+
+func newCSNodePool(t *testing.T) *arohcpv1alpha1.NodePool {
+	t.Helper()
+	np, err := arohcpv1alpha1.NewNodePool().ID(testNodePoolName).Build()
+	require.NoError(t, err)
+	return np
+}

--- a/backend/pkg/controllers/nodepooldeletion/node_pool_deletion_controller.go
+++ b/backend/pkg/controllers/nodepooldeletion/node_pool_deletion_controller.go
@@ -75,13 +75,6 @@ func (c *nodePoolDeletionController) CooldownChecker() controllerutil.CooldownCh
 // - ClusterServiceDeletionTimestamp must be set
 // - ClusterServiceID must be nil
 func (c *nodePoolDeletionController) NeedsWork(nodePool *api.HCPOpenShiftClusterNodePool) bool {
-	// TODO temporary check to skip the new deletion approach for NodePools that were created before the new approach was implemented.
-	// This will be removed once all nodepools whose deletion was triggered before the new approach is fully rolled out have been
-	// fully deleted in all ARO-HCP permanent environments, for all regions.
-	if !nodePool.ServiceProviderProperties.UsesNewNodePoolDeletionApproach {
-		return false
-	}
-
 	return nodePool.ServiceProviderProperties.DeletionTimestamp != nil &&
 		nodePool.ServiceProviderProperties.ClusterServiceDeletionTimestamp != nil &&
 		nodePool.ServiceProviderProperties.ClusterServiceID == nil

--- a/backend/pkg/controllers/nodepooldeletion/node_pool_deletion_controller.go
+++ b/backend/pkg/controllers/nodepooldeletion/node_pool_deletion_controller.go
@@ -1,0 +1,203 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodepooldeletion
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/internal/api"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// nodePoolDeletionController issues a Cosmos nodepool delete
+// for the Node Pools that have their DeletionTimestamp and ClusterServiceDeletionTimestamp set,
+// their ClusterServiceID has been cleared, and all nodepool-scoped Maestro readonly bundles
+// have been deleted from the ServiceProviderNodePool.
+type nodePoolDeletionController struct {
+	cooldownChecker               controllerutil.CooldownChecker
+	nodePoolLister                listers.NodePoolLister
+	serviceProviderNodePoolLister listers.ServiceProviderNodePoolLister
+	resourcesDBClient             database.ResourcesDBClient
+}
+
+var _ controllerutils.NodePoolSyncer = (*nodePoolDeletionController)(nil)
+
+func NewNodePoolDeletionController(
+	resourcesDBClient database.ResourcesDBClient,
+	activeOperationLister listers.ActiveOperationLister,
+	informers informers.BackendInformers,
+) controllerutils.Controller {
+	_, nodePoolLister := informers.NodePools()
+	_, serviceProviderNodePoolLister := informers.ServiceProviderNodePools()
+	syncer := &nodePoolDeletionController{
+		cooldownChecker:               controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		nodePoolLister:                nodePoolLister,
+		serviceProviderNodePoolLister: serviceProviderNodePoolLister,
+		resourcesDBClient:             resourcesDBClient,
+	}
+
+	return controllerutils.NewNodePoolWatchingController(
+		"NodePoolDeletionController",
+		resourcesDBClient,
+		informers,
+		time.Minute,
+		syncer,
+	)
+}
+
+func (c *nodePoolDeletionController) CooldownChecker() controllerutil.CooldownChecker {
+	return c.cooldownChecker
+}
+
+// NeedsWork reports whether the deleter has unfinished business for the given
+// NodePool. All the following conditions must be met:
+// - DeletionTimestamp must be set
+// - ClusterServiceDeletionTimestamp must be set
+// - ClusterServiceID must be nil
+func (c *nodePoolDeletionController) NeedsWork(nodePool *api.HCPOpenShiftClusterNodePool) bool {
+	// TODO temporary check to skip the new deletion approach for NodePools that were created before the new approach was implemented.
+	// This will be removed once all nodepools whose deletion was triggered before the new approach is fully rolled out have been
+	// fully deleted in all ARO-HCP permanent environments, for all regions.
+	if !nodePool.ServiceProviderProperties.UsesNewNodePoolDeletionApproach {
+		return false
+	}
+
+	return nodePool.ServiceProviderProperties.DeletionTimestamp != nil &&
+		nodePool.ServiceProviderProperties.ClusterServiceDeletionTimestamp != nil &&
+		nodePool.ServiceProviderProperties.ClusterServiceID == nil
+}
+
+// SyncOnce calls Cosmos to delete the NodePool when the NeedsWork condition is met and
+// all the delete preconditions are met.
+func (c *nodePoolDeletionController) SyncOnce(ctx context.Context, key controllerutils.HCPNodePoolKey) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	cachedNodePool, err := c.nodePoolLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get node pool from cache: %w", err))
+	}
+	if !c.NeedsWork(cachedNodePool) {
+		return nil
+	}
+
+	// We do a quick check to see if the ServiceProviderNodePool has any Maestro readonly bundles.
+	// If it does, we return early as we need to wait for the bundles to be deleted.
+	cachedSPNP, spnpCacheErr := c.serviceProviderNodePoolLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
+	if spnpCacheErr == nil && len(cachedSPNP.Status.MaestroReadonlyBundles) > 0 {
+		return nil
+	}
+
+	// Confirm against the live document. The cache can lag behind a write that
+	// modified one of the NeedsWork conditions.
+	nodePoolCRUD := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).NodePools(key.HCPClusterName)
+	nodePool, err := nodePoolCRUD.Get(ctx, key.HCPNodePoolName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get node pool: %w", err))
+	}
+	if !c.NeedsWork(nodePool) {
+		return nil
+	}
+
+	// We do not proceed until we know that all the maestro readonly bundles have been eliminated
+	preconditionMet, err := c.deletePreconditionAllMaestroNodePoolScopedReadonlyBundlesCleared(ctx, key)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to check precondition: %w", err))
+	}
+	if !preconditionMet {
+		return nil
+	}
+
+	// We do not proceed until we know that the cosmos child resources have been eliminated
+	preconditionMet, err = c.deletePreconditionCosmosChildResourcesDeleted(ctx, key)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to check precondition: %w", err))
+	}
+	if !preconditionMet {
+		return nil
+	}
+
+	logger.Info("deleting node pool from Cosmos")
+	err = nodePoolCRUD.Delete(ctx, key.HCPNodePoolName)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to delete node pool from Cosmos: %w", err))
+	}
+	logger.Info("node pool deleted from Cosmos")
+
+	return nil
+}
+
+// deletePreconditionAllMaestroNodePoolScopedReadonlyBundlesCleared checks if the ServiceProviderNodePool has any Maestro readonly bundles.
+// If it does, it returns false, otherwise it returns true.
+func (c *nodePoolDeletionController) deletePreconditionAllMaestroNodePoolScopedReadonlyBundlesCleared(ctx context.Context, key controllerutils.HCPNodePoolKey) (bool, error) {
+	logger := utils.LoggerFromContext(ctx)
+
+	spnpCRUD := c.resourcesDBClient.ServiceProviderNodePools(key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
+	spnp, spnpErr := spnpCRUD.Get(ctx, api.ServiceProviderNodePoolResourceName)
+	if spnpErr != nil && !database.IsNotFoundError(spnpErr) {
+		return false, utils.TrackError(fmt.Errorf("failed to get ServiceProviderNodePool: %w", spnpErr))
+	}
+	if spnp != nil && len(spnp.Status.MaestroReadonlyBundles) > 0 {
+		logger.Info("waiting for nodepool-scoped Maestro readonly bundles to be deleted before removing Cosmos entry",
+			"remainingBundles", len(spnp.Status.MaestroReadonlyBundles))
+		return false, nil
+	}
+	return true, nil
+}
+
+// deletePreconditionCosmosChildResourcesDeleted checks if the cosmos child resources have been deleted.
+// If they have, it returns true, otherwise it returns false.
+// It ignores node pool controllers here, as there might be controllers still running for the NodePool until the very
+// end of the deletion process.
+func (c *nodePoolDeletionController) deletePreconditionCosmosChildResourcesDeleted(ctx context.Context, key controllerutils.HCPNodePoolKey) (bool, error) {
+	logger := utils.LoggerFromContext(ctx)
+
+	nodePoolResourceID := key.GetResourceID()
+	untypedCRUD, err := c.resourcesDBClient.UntypedCRUD(*nodePoolResourceID)
+	if err != nil {
+		return false, utils.TrackError(fmt.Errorf("failed to create untyped CRUD for child check: %w", err))
+	}
+	childIterator, err := untypedCRUD.ListRecursive(ctx, nil)
+	if err != nil {
+		return false, utils.TrackError(fmt.Errorf("failed to list child resources: %w", err))
+	}
+	for _, childResource := range childIterator.Items(ctx) {
+		// We ignore node pool controllers here, as there might be controllers still running for the NodePool until the very
+		// end of the deletion process
+		if strings.EqualFold(childResource.ResourceType, api.NodePoolControllerResourceType.String()) {
+			continue
+		}
+		logger.Info("child resource still exists, waiting for cleanup", "childResourceID", childResource.ResourceID)
+		return false, nil
+	}
+	if err := childIterator.GetError(); err != nil {
+		return false, utils.TrackError(fmt.Errorf("error iterating child resources: %w", err))
+	}
+
+	return true, nil
+}

--- a/backend/pkg/controllers/nodepooldeletion/node_pool_deletion_controller_test.go
+++ b/backend/pkg/controllers/nodepooldeletion/node_pool_deletion_controller_test.go
@@ -64,19 +64,19 @@ func TestNodePoolDeletionController_SyncOnce(t *testing.T) {
 	}{
 		{
 			name:             "no DeletionTimestamp -- no-op",
-			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, nil),
+			existingNodePool: newTestNodePool(t, nil),
 			verifyDB:         verifyNodePoolStillExists,
 		},
 		{
 			name: "DeletionTimestamp set but ClusterServiceDeletionTimestamp not -- no-op",
-			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+			existingNodePool: newTestNodePool(t, func(np *api.HCPOpenShiftClusterNodePool) {
 				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-time.Hour)}
 			}),
 			verifyDB: verifyNodePoolStillExists,
 		},
 		{
 			name: "ClusterServiceID still set -- no-op",
-			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+			existingNodePool: newTestNodePool(t, func(np *api.HCPOpenShiftClusterNodePool) {
 				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-time.Hour)}
 				np.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-30 * time.Minute)}
 			}),
@@ -84,12 +84,12 @@ func TestNodePoolDeletionController_SyncOnce(t *testing.T) {
 		},
 		{
 			name:             "all conditions met, no children -- deletes nodepool from Cosmos",
-			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			existingNodePool: newTestNodePool(t, readyToDeleteNodePoolOptsFunc),
 			verifyDB:         verifyNodePoolDeleted,
 		},
 		{
 			name:             "all conditions met, SPNP has remaining bundles -- backs off",
-			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			existingNodePool: newTestNodePool(t, readyToDeleteNodePoolOptsFunc),
 			childResources: []any{newTestSPNP(t, api.MaestroBundleReferenceList{
 				{Name: "readonly-bundle-1"},
 			})},
@@ -97,27 +97,21 @@ func TestNodePoolDeletionController_SyncOnce(t *testing.T) {
 		},
 		{
 			name:             "all conditions met, SPNP with no bundles -- backs off until SPNP removed",
-			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			existingNodePool: newTestNodePool(t, readyToDeleteNodePoolOptsFunc),
 			childResources:   []any{newTestSPNP(t, nil)},
 			verifyDB:         verifyNodePoolStillExists,
 		},
 		{
 			name:             "all conditions met, a non node pool controller cosmos child exists -- backs off",
-			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			existingNodePool: newTestNodePool(t, readyToDeleteNodePoolOptsFunc),
 			childResources:   []any{newTestManagementClusterContent(t, "test-mcc")},
 			verifyDB:         verifyNodePoolStillExists,
 		},
 		{
 			name:             "all conditions met, only controller children -- deletes nodepool",
-			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			existingNodePool: newTestNodePool(t, readyToDeleteNodePoolOptsFunc),
 			childResources:   []any{newTestNodePoolController(t, "test-controller")},
 			verifyDB:         verifyNodePoolDeleted,
-		},
-		{
-			name:             "UsesNewNodePoolDeletionApproach false -- no-op even when all delete conditions met",
-			existingNodePool: newTestNodePoolWithOldDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
-			childResources:   []any{newTestNodePoolController(t, "test-controller")},
-			verifyDB:         verifyNodePoolStillExists,
 		},
 		{
 			name: "node pool not found -- no-op",

--- a/backend/pkg/controllers/nodepooldeletion/node_pool_deletion_controller_test.go
+++ b/backend/pkg/controllers/nodepooldeletion/node_pool_deletion_controller_test.go
@@ -1,0 +1,176 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodepooldeletion
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+func TestNodePoolDeletionController_SyncOnce(t *testing.T) {
+	fixedNow := time.Now().UTC().Truncate(time.Second)
+	readyToDeleteNodePoolOptsFunc := func(np *api.HCPOpenShiftClusterNodePool) {
+		np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-time.Hour)}
+		np.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-30 * time.Minute)}
+		np.ServiceProviderProperties.ClusterServiceID = nil
+	}
+
+	verifyNodePoolStillExists := func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+		t.Helper()
+		_, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).
+			NodePools(testClusterName).Get(ctx, testNodePoolName)
+		require.NoError(t, err, "expected nodepool to still exist in Cosmos")
+	}
+
+	verifyNodePoolDeleted := func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+		t.Helper()
+		_, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).
+			NodePools(testClusterName).Get(ctx, testNodePoolName)
+		assert.True(t, database.IsNotFoundError(err), "expected nodepool to be deleted from Cosmos")
+	}
+
+	testCases := []struct {
+		name             string
+		existingNodePool *api.HCPOpenShiftClusterNodePool
+		childResources   []any
+		wantErr          bool
+		verifyDB         func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient)
+	}{
+		{
+			name:             "no DeletionTimestamp -- no-op",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, nil),
+			verifyDB:         verifyNodePoolStillExists,
+		},
+		{
+			name: "DeletionTimestamp set but ClusterServiceDeletionTimestamp not -- no-op",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-time.Hour)}
+			}),
+			verifyDB: verifyNodePoolStillExists,
+		},
+		{
+			name: "ClusterServiceID still set -- no-op",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-time.Hour)}
+				np.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-30 * time.Minute)}
+			}),
+			verifyDB: verifyNodePoolStillExists,
+		},
+		{
+			name:             "all conditions met, no children -- deletes nodepool from Cosmos",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			verifyDB:         verifyNodePoolDeleted,
+		},
+		{
+			name:             "all conditions met, SPNP has remaining bundles -- backs off",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			childResources: []any{newTestSPNP(t, api.MaestroBundleReferenceList{
+				{Name: "readonly-bundle-1"},
+			})},
+			verifyDB: verifyNodePoolStillExists,
+		},
+		{
+			name:             "all conditions met, SPNP with no bundles -- backs off until SPNP removed",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			childResources:   []any{newTestSPNP(t, nil)},
+			verifyDB:         verifyNodePoolStillExists,
+		},
+		{
+			name:             "all conditions met, a non node pool controller cosmos child exists -- backs off",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			childResources:   []any{newTestManagementClusterContent(t, "test-mcc")},
+			verifyDB:         verifyNodePoolStillExists,
+		},
+		{
+			name:             "all conditions met, only controller children -- deletes nodepool",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			childResources:   []any{newTestNodePoolController(t, "test-controller")},
+			verifyDB:         verifyNodePoolDeleted,
+		},
+		{
+			name:             "UsesNewNodePoolDeletionApproach false -- no-op even when all delete conditions met",
+			existingNodePool: newTestNodePoolWithOldDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			childResources:   []any{newTestNodePoolController(t, "test-controller")},
+			verifyDB:         verifyNodePoolStillExists,
+		},
+		{
+			name: "node pool not found -- no-op",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+
+			resources := []any{}
+			if tc.existingNodePool != nil {
+				resources = append(resources, tc.existingNodePool)
+			}
+			resources = append(resources, tc.childResources...)
+			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, resources)
+			require.NoError(t, err)
+
+			nodePoolsForLister := []*api.HCPOpenShiftClusterNodePool{}
+			if tc.existingNodePool != nil {
+				nodePoolsForLister = append(nodePoolsForLister, tc.existingNodePool)
+			}
+			spnpForLister := []*api.ServiceProviderNodePool{}
+			for _, child := range tc.childResources {
+				if spnp, ok := child.(*api.ServiceProviderNodePool); ok {
+					spnpForLister = append(spnpForLister, spnp)
+				}
+			}
+
+			syncer := &nodePoolDeletionController{
+				cooldownChecker:               &alwaysSyncCooldownChecker{},
+				nodePoolLister:                &listertesting.SliceNodePoolLister{NodePools: nodePoolsForLister},
+				serviceProviderNodePoolLister: &listertesting.SliceServiceProviderNodePoolLister{ServiceProviderNodePools: spnpForLister},
+				resourcesDBClient:             mockResourcesDBClient,
+			}
+
+			key := controllerutils.HCPNodePoolKey{
+				SubscriptionID:    testSubscriptionID,
+				ResourceGroupName: testResourceGroupName,
+				HCPClusterName:    testClusterName,
+				HCPNodePoolName:   testNodePoolName,
+			}
+
+			err = syncer.SyncOnce(ctx, key)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			if tc.verifyDB != nil {
+				tc.verifyDB(t, ctx, mockResourcesDBClient)
+			}
+		})
+	}
+}

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_delete.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_delete.go
@@ -116,10 +116,31 @@ func (c *operationClusterDelete) SynchronizeOperation(ctx context.Context, key c
 		// TODO when we update to make clusterserice creation async, we need to handle this correctly.
 		return nil
 	}
+
 	clusterStatus, err := c.clusterServiceClient.GetClusterStatus(ctx, operation.InternalID)
 	var ocmGetClusterError *ocmerrors.Error
 	if err != nil && errors.As(err, &ocmGetClusterError) && ocmGetClusterError.Status() == http.StatusNotFound {
 		logger.Info("cluster was deleted")
+
+		// Some nodepool controllers require of the Cosmos document to do their cleanup work so we block
+		// the cluster cosmos deletion until the nodepools are gone.
+		nodePoolIterator, err := c.resourcesDBClient.HCPClusters(operation.ExternalID.SubscriptionID, operation.ExternalID.ResourceGroupName).NodePools(operation.ExternalID.Name).List(ctx, nil)
+		if err != nil {
+			return utils.TrackError(err)
+		}
+		foundAtLeastOneNodePool := false
+		for range nodePoolIterator.Items(ctx) {
+			foundAtLeastOneNodePool = true
+			break
+		}
+		err = nodePoolIterator.GetError()
+		if err != nil {
+			return utils.TrackError(err)
+		}
+		if foundAtLeastOneNodePool {
+			logger.Info("cluster still has cosmos nodepools")
+			return nil
+		}
 
 		// Update the Cosmos DB billing document with a deletion timestamp.
 		// Do this before calling setDeleteOperationAsCompleted so that in

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_delete_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_delete_test.go
@@ -29,6 +29,7 @@ import (
 	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
 	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
 
+	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/databasetesting"
@@ -42,6 +43,7 @@ func TestOperationClusterDelete_SynchronizeOperation(t *testing.T) {
 
 	tests := []struct {
 		name        string
+		nodePools   []*api.HCPOpenShiftClusterNodePool
 		setupMock   func(ctrl *gomock.Controller, fixture *clusterTestFixture) ocm.ClusterServiceClientSpec
 		expectError bool
 		verify      func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *clusterTestFixture)
@@ -66,6 +68,30 @@ func TestOperationClusterDelete_SynchronizeOperation(t *testing.T) {
 				// Verify cluster document was deleted
 				_, err = db.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
 				assert.Error(t, err, "cluster should have been deleted")
+			},
+		},
+		{
+			name: "cluster not found does not remove cluster while nodepools exist",
+			nodePools: []*api.HCPOpenShiftClusterNodePool{
+				newNodePoolTestFixture().newNodePool(),
+			},
+			setupMock: func(ctrl *gomock.Controller, fixture *clusterTestFixture) ocm.ClusterServiceClientSpec {
+				mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
+				notFoundErr, _ := ocmerrors.NewError().Status(http.StatusNotFound).Build()
+				mockCSClient.EXPECT().
+					GetClusterStatus(gomock.Any(), fixture.clusterInternalID).
+					Return(nil, notFoundErr)
+				return mockCSClient
+			},
+			expectError: false,
+			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *clusterTestFixture) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+
+				cluster, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
+				require.NoError(t, err)
+				assert.NotNil(t, cluster)
 			},
 		},
 		{
@@ -163,11 +189,16 @@ func TestOperationClusterDelete_SynchronizeOperation(t *testing.T) {
 			billingDoc.CreationTime = createdAt
 			billingDoc.Location = testAzureLocation
 			billingDoc.TenantID = testTenantID
-
-			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, []any{cluster, operation})
-			require.NoError(t, err)
 			mockBillingDBClient := databasetesting.NewMockBillingDBClient()
-			err = mockBillingDBClient.BillingDocs(fixture.clusterResourceID.SubscriptionID).Create(ctx, billingDoc)
+			err := mockBillingDBClient.BillingDocs(fixture.clusterResourceID.SubscriptionID).Create(ctx, billingDoc)
+			require.NoError(t, err)
+
+			// Mock resources DB client with cluster, operation, and node pools
+			resources := []any{cluster, operation}
+			for _, nodePool := range tt.nodePools {
+				resources = append(resources, nodePool)
+			}
+			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, resources)
 			require.NoError(t, err)
 
 			mockCSClient := tt.setupMock(ctrl, fixture)
@@ -181,7 +212,6 @@ func TestOperationClusterDelete_SynchronizeOperation(t *testing.T) {
 			}
 
 			err = controller.SynchronizeOperation(ctx, fixture.operationKey())
-
 			if tt.expectError {
 				require.Error(t, err)
 			} else {

--- a/backend/pkg/controllers/operationcontrollers/operation_node_pool_delete.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_node_pool_delete.go
@@ -102,54 +102,6 @@ func (c *operationNodePoolDelete) ShouldProcess(ctx context.Context, operation *
 	return true
 }
 
-func (c *operationNodePoolDelete) legacyShouldProcess(ctx context.Context, operation *api.Operation) bool {
-	if operation.Status.IsTerminal() {
-		return false
-	}
-	if operation.Request != database.OperationRequestDelete {
-		return false
-	}
-	if operation.ExternalID == nil || !strings.EqualFold(operation.ExternalID.ResourceType.String(), api.NodePoolResourceType.String()) {
-		return false
-	}
-	return true
-}
-
-func (c *operationNodePoolDelete) legacySynchronizeOperation(ctx context.Context, operation *api.Operation) error {
-	logger := utils.LoggerFromContext(ctx)
-
-	if !c.legacyShouldProcess(ctx, operation) {
-		return nil // no work to do
-	}
-
-	nodePoolStatus, err := c.clusterServiceClient.GetNodePoolStatus(ctx, operation.InternalID)
-	var ocmGetNodePoolError *ocmerrors.Error
-	if err != nil && errors.As(err, &ocmGetNodePoolError) && ocmGetNodePoolError.Status() == http.StatusNotFound {
-		logger.Info("node pool was deleted")
-
-		err = SetDeleteOperationAsCompleted(ctx, c.clock, c.resourcesDBClient, operation, postAsyncNotificationFn(c.notificationClient))
-		if err != nil {
-			return utils.TrackError(err)
-		}
-		return nil
-	}
-	if err != nil {
-		return utils.TrackError(err)
-	}
-
-	newOperationStatus, newOperationError, err := convertNodePoolStatus(operation, nodePoolStatus)
-	if err != nil {
-		return utils.TrackError(err)
-	}
-
-	err = UpdateOperationStatus(ctx, c.clock, c.resourcesDBClient, operation, newOperationStatus, newOperationError, postAsyncNotificationFn(c.notificationClient))
-	if err != nil {
-		return utils.TrackError(err)
-	}
-
-	return nil
-}
-
 func (c *operationNodePoolDelete) SynchronizeOperation(ctx context.Context, key controllerutils.OperationKey) error {
 	logger := utils.LoggerFromContext(ctx)
 	logger.Info("checking operation")
@@ -161,13 +113,6 @@ func (c *operationNodePoolDelete) SynchronizeOperation(ctx context.Context, key 
 	if err != nil {
 		return fmt.Errorf("failed to get active operation: %w", err)
 	}
-
-	// TODO remove this once migration of node pool deletion from frontend to backend is fully completed.
-	if !operation.UsesNewNodePoolDeletionApproach {
-		return c.legacySynchronizeOperation(ctx, operation)
-	}
-
-	// From here, we know it uses the new deletion approach.
 
 	if !c.ShouldProcess(ctx, operation) {
 		return nil // no work to do

--- a/backend/pkg/controllers/operationcontrollers/operation_node_pool_delete.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_node_pool_delete.go
@@ -45,16 +45,25 @@ type operationNodePoolDelete struct {
 // follows an asynchronous node pool deletion operation to completion and updates
 // the corresponding operation document in Cosmos DB.
 //
-// Operation documents relevant to this controller will have the following values:
-//
-//	ResourceType: Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools
-//	     Request: Delete
-//	      Status: any non-terminal value
+// The controller has the following responsibilities:
+//   - While the NodePool Cosmos document is present, it reconciles the
+//     operation and the node pool status.
+//   - When the NodePool Cosmos document is deleted (by the nodePoolDeletionController),
+//     it marks the operation as Succeeded. It also cleans up child
+//     resources. TODO Note: This last part is handled by other controllers too but
+//     because the SetDeleteOperationAsCompleted is still reused by other operations
+//     that have not been migrated to asynchronous flow yet this remains.
 //
 // Note that "to completion" does not imply success. An operation is considered
 // complete when its status field reaches what Azure defines as a terminal value;
 // any of "Succeeded", "Failed", or "Canceled". Once the operation status reaches
 // a terminal value, there will be no further updates to the operation document.
+//
+// Operation documents relevant to this controller will have the following values:
+//
+//	ResourceType: Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools
+//	     Request: Delete
+//	      Status: any non-terminal value
 func NewOperationNodePoolDeleteController(
 	clock utilsclock.PassiveClock,
 	resourcesDBClient database.ResourcesDBClient,
@@ -93,18 +102,23 @@ func (c *operationNodePoolDelete) ShouldProcess(ctx context.Context, operation *
 	return true
 }
 
-func (c *operationNodePoolDelete) SynchronizeOperation(ctx context.Context, key controllerutils.OperationKey) error {
-	logger := utils.LoggerFromContext(ctx)
-	logger.Info("checking operation")
+func (c *operationNodePoolDelete) legacyShouldProcess(ctx context.Context, operation *api.Operation) bool {
+	if operation.Status.IsTerminal() {
+		return false
+	}
+	if operation.Request != database.OperationRequestDelete {
+		return false
+	}
+	if operation.ExternalID == nil || !strings.EqualFold(operation.ExternalID.ResourceType.String(), api.NodePoolResourceType.String()) {
+		return false
+	}
+	return true
+}
 
-	operation, err := c.resourcesDBClient.Operations(key.SubscriptionID).Get(ctx, key.OperationName)
-	if database.IsNotFoundError(err) {
-		return nil // no work to do
-	}
-	if err != nil {
-		return fmt.Errorf("failed to get active operation: %w", err)
-	}
-	if !c.ShouldProcess(ctx, operation) {
+func (c *operationNodePoolDelete) legacySynchronizeOperation(ctx context.Context, operation *api.Operation) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	if !c.legacyShouldProcess(ctx, operation) {
 		return nil // no work to do
 	}
 
@@ -121,6 +135,96 @@ func (c *operationNodePoolDelete) SynchronizeOperation(ctx context.Context, key 
 	}
 	if err != nil {
 		return utils.TrackError(err)
+	}
+
+	newOperationStatus, newOperationError, err := convertNodePoolStatus(operation, nodePoolStatus)
+	if err != nil {
+		return utils.TrackError(err)
+	}
+
+	err = UpdateOperationStatus(ctx, c.clock, c.resourcesDBClient, operation, newOperationStatus, newOperationError, postAsyncNotificationFn(c.notificationClient))
+	if err != nil {
+		return utils.TrackError(err)
+	}
+
+	return nil
+}
+
+func (c *operationNodePoolDelete) SynchronizeOperation(ctx context.Context, key controllerutils.OperationKey) error {
+	logger := utils.LoggerFromContext(ctx)
+	logger.Info("checking operation")
+
+	operation, err := c.resourcesDBClient.Operations(key.SubscriptionID).Get(ctx, key.OperationName)
+	if database.IsNotFoundError(err) {
+		return nil // no work to do
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get active operation: %w", err)
+	}
+
+	// TODO remove this once migration of node pool deletion from frontend to backend is fully completed.
+	if !operation.UsesNewNodePoolDeletionApproach {
+		return c.legacySynchronizeOperation(ctx, operation)
+	}
+
+	// From here, we know it uses the new deletion approach.
+
+	if !c.ShouldProcess(ctx, operation) {
+		return nil // no work to do
+	}
+
+	nodePoolCRUD := c.resourcesDBClient.HCPClusters(operation.ExternalID.SubscriptionID, operation.ExternalID.ResourceGroupName).NodePools(operation.ExternalID.Parent.Name)
+	nodePool, err := nodePoolCRUD.Get(ctx, operation.ExternalID.Name)
+	if database.IsNotFoundError(err) {
+		logger.Info("node pool document deleted - completing operation")
+		err = SetDeleteOperationAsCompleted(ctx, c.clock, c.resourcesDBClient, operation, postAsyncNotificationFn(c.notificationClient))
+		if err != nil {
+			return utils.TrackError(err)
+		}
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get node pool: %w", err))
+	}
+
+	if !c.shouldReconcileOperationAndResourceStatus(nodePool) {
+		return nil
+	}
+	err = c.reconcileOperationAndResourceStatus(ctx, operation, nodePool)
+	if err != nil {
+		return utils.TrackError(err)
+	}
+
+	return nil
+}
+
+func (c *operationNodePoolDelete) shouldReconcileOperationAndResourceStatus(nodePool *api.HCPOpenShiftClusterNodePool) bool {
+	return nodePool.ServiceProviderProperties.DeletionTimestamp != nil &&
+		nodePool.ServiceProviderProperties.ClusterServiceDeletionTimestamp != nil &&
+		nodePool.ServiceProviderProperties.ClusterServiceID != nil
+}
+
+func (c *operationNodePoolDelete) reconcileOperationAndResourceStatus(ctx context.Context, operation *api.Operation, nodePool *api.HCPOpenShiftClusterNodePool) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	nodePoolCSID := nodePool.ServiceProviderProperties.ClusterServiceID
+
+	nodePoolStatus, err := c.clusterServiceClient.GetNodePoolStatus(ctx, *nodePoolCSID)
+	if err != nil {
+		var ocmError *ocmerrors.Error
+		if !errors.As(err, &ocmError) || ocmError.Status() != http.StatusNotFound {
+			return utils.TrackError(fmt.Errorf("failed to get cluster-service NodePool status: %w", err))
+		}
+		// 404 - CS has finished deleting. nodePoolClusterServiceIDClearer will clear the ID.
+		logger.Info("cluster-service NodePool gone - skipping operation update", "clusterServiceID", nodePoolCSID.String())
+		return nil
+	}
+
+	// If the node pool is in the Ready state from CS side, we wait until the Cosmos NodePool document is deleted, which
+	// will be picked up by a next reconciliation of this controller and we will update the operation to Succeeded.
+	if nodePoolStatus.State().NodePoolStateValue() == string(NodePoolStateReady) {
+		logger.Info("cluster-service NodePool in Ready state. Waiting until Cosmos NodePool document is deleted.")
+		return nil
 	}
 
 	newOperationStatus, newOperationError, err := convertNodePoolStatus(operation, nodePoolStatus)

--- a/backend/pkg/controllers/operationcontrollers/operation_node_pool_delete_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_node_pool_delete_test.go
@@ -18,17 +18,20 @@ import (
 	"context"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr/testr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilsclock "k8s.io/utils/clock"
 
 	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
 	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
 
+	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/databasetesting"
@@ -37,15 +40,92 @@ import (
 )
 
 func TestOperationNodePoolDelete_SynchronizeOperation(t *testing.T) {
-	tests := []struct {
-		name        string
-		setupMock   func(ctrl *gomock.Controller, fixture *nodePoolTestFixture) ocm.ClusterServiceClientSpec
-		expectError bool
-		verify      func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture)
+	fixture := newNodePoolTestFixture()
+
+	nodePoolPassingExtraReconcileGate := func() *api.HCPOpenShiftClusterNodePool {
+		now := time.Now()
+		np := fixture.newNodePool()
+		np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: now}
+		np.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: now}
+		return np
+	}
+
+	testCases := []struct {
+		name                    string
+		existingNodePool        *api.HCPOpenShiftClusterNodePool
+		wantErr                 bool
+		verifyDB                func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient)
+		usesNewDeletionApproach bool
+		setupCSMock             func(ctrl *gomock.Controller, fixture *nodePoolTestFixture) ocm.ClusterServiceClientSpec
 	}{
 		{
-			name: "node pool not found marks operation succeeded and removes node pool",
-			setupMock: func(ctrl *gomock.Controller, fixture *nodePoolTestFixture) ocm.ClusterServiceClientSpec {
+			name: "node pool document gone completes operation",
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateSucceeded, op.Status)
+			},
+			usesNewDeletionApproach: true,
+		},
+		{
+			name: "shouldReconcile gate not passed skips cluster service",
+			existingNodePool: func() *api.HCPOpenShiftClusterNodePool {
+				np := fixture.newNodePool()
+				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+				return np
+			}(),
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+			},
+			usesNewDeletionApproach: true,
+		},
+		{
+			name:             "extra reconcilegate passed and CS Ready waits without updating operation",
+			existingNodePool: nodePoolPassingExtraReconcileGate(),
+			setupCSMock: func(ctrl *gomock.Controller, fixture *nodePoolTestFixture) ocm.ClusterServiceClientSpec {
+				mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
+				nodePoolStatus, err := arohcpv1alpha1.NewNodePoolStatus().
+					State(arohcpv1alpha1.NewNodePoolState().NodePoolStateValue(string(NodePoolStateReady))).
+					Build()
+				require.NoError(t, err)
+				mockCSClient.EXPECT().
+					GetNodePoolStatus(gomock.Any(), fixture.nodePoolInternalID).
+					Return(nodePoolStatus, nil)
+				return mockCSClient
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+			},
+			usesNewDeletionApproach: true,
+		},
+		{
+			name:             "extra reconcile gate passed and CS uninstalling updates operation to deleting",
+			existingNodePool: nodePoolPassingExtraReconcileGate(),
+			setupCSMock: func(ctrl *gomock.Controller, fixture *nodePoolTestFixture) ocm.ClusterServiceClientSpec {
+				mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
+				nodePoolStatus, err := arohcpv1alpha1.NewNodePoolStatus().
+					State(arohcpv1alpha1.NewNodePoolState().NodePoolStateValue(string(NodePoolStateUninstalling))).
+					Build()
+				require.NoError(t, err)
+				mockCSClient.EXPECT().
+					GetNodePoolStatus(gomock.Any(), fixture.nodePoolInternalID).
+					Return(nodePoolStatus, nil)
+				return mockCSClient
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateDeleting, op.Status)
+			},
+			usesNewDeletionApproach: true,
+		},
+		{
+			name: "legacy approach: node pool gone in cluster service marks operation succeeded",
+			setupCSMock: func(ctrl *gomock.Controller, fixture *nodePoolTestFixture) ocm.ClusterServiceClientSpec {
 				mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
 				notFoundErr, _ := ocmerrors.NewError().Status(http.StatusNotFound).Build()
 				mockCSClient.EXPECT().
@@ -53,110 +133,57 @@ func TestOperationNodePoolDelete_SynchronizeOperation(t *testing.T) {
 					Return(nil, notFoundErr)
 				return mockCSClient
 			},
-			expectError: false,
-			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateSucceeded, op.Status)
-
-				// Verify node pool document was deleted
-				_, err = db.HCPClusters(testSubscriptionID, testResourceGroupName).NodePools(testClusterName).Get(ctx, testNodePoolName)
-				assert.Error(t, err, "node pool should have been deleted")
 			},
+			usesNewDeletionApproach: false,
 		},
 		{
-			name: "node pool uninstalling updates operation to deleting",
-			setupMock: func(ctrl *gomock.Controller, fixture *nodePoolTestFixture) ocm.ClusterServiceClientSpec {
+			name: "legacy approach: node pool still exists in cluster service keeps operation accepted",
+			setupCSMock: func(ctrl *gomock.Controller, fixture *nodePoolTestFixture) ocm.ClusterServiceClientSpec {
 				mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
-				nodePoolStatus, _ := arohcpv1alpha1.NewNodePoolStatus().
-					State(arohcpv1alpha1.NewNodePoolState().NodePoolStateValue(string(NodePoolStateUninstalling))).
-					Build()
-				mockCSClient.EXPECT().
-					GetNodePoolStatus(gomock.Any(), fixture.nodePoolInternalID).
-					Return(nodePoolStatus, nil)
-				return mockCSClient
-			},
-			expectError: false,
-			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
-				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
-				require.NoError(t, err)
-				assert.Equal(t, arm.ProvisioningStateDeleting, op.Status)
-
-				// Node pool should still exist during uninstalling
-				nodePool, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).NodePools(testClusterName).Get(ctx, testNodePoolName)
-				require.NoError(t, err)
-				assert.NotNil(t, nodePool)
-			},
-		},
-		{
-			name: "node pool ready during delete stays at current status",
-			setupMock: func(ctrl *gomock.Controller, fixture *nodePoolTestFixture) ocm.ClusterServiceClientSpec {
-				mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
-				nodePoolStatus, _ := arohcpv1alpha1.NewNodePoolStatus().
+				nodePoolStatus, err := arohcpv1alpha1.NewNodePoolStatus().
 					State(arohcpv1alpha1.NewNodePoolState().NodePoolStateValue(string(NodePoolStateReady))).
 					Build()
+				require.NoError(t, err)
 				mockCSClient.EXPECT().
 					GetNodePoolStatus(gomock.Any(), fixture.nodePoolInternalID).
 					Return(nodePoolStatus, nil)
 				return mockCSClient
 			},
-			expectError: false,
-			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
-				// When node pool is Ready during delete, operation stays at Accepted
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
-
-				// Node pool should still exist
-				nodePool, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).NodePools(testClusterName).Get(ctx, testNodePoolName)
-				require.NoError(t, err)
-				assert.NotNil(t, nodePool)
 			},
-		},
-		{
-			name: "node pool error during delete transitions to failed",
-			setupMock: func(ctrl *gomock.Controller, fixture *nodePoolTestFixture) ocm.ClusterServiceClientSpec {
-				mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
-				nodePoolStatus, _ := arohcpv1alpha1.NewNodePoolStatus().
-					State(arohcpv1alpha1.NewNodePoolState().NodePoolStateValue(string(NodePoolStateError))).
-					Message("delete failed").
-					Build()
-				mockCSClient.EXPECT().
-					GetNodePoolStatus(gomock.Any(), fixture.nodePoolInternalID).
-					Return(nodePoolStatus, nil)
-				return mockCSClient
-			},
-			expectError: false,
-			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
-				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
-				require.NoError(t, err)
-				assert.Equal(t, arm.ProvisioningStateFailed, op.Status)
-				assert.NotNil(t, op.Error)
-
-				// Node pool should still exist on failure
-				nodePool, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).NodePools(testClusterName).Get(ctx, testNodePoolName)
-				require.NoError(t, err)
-				assert.NotNil(t, nodePool)
-			},
+			usesNewDeletionApproach: false,
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
-			ctx = utils.ContextWithLogger(ctx, testr.New(t))
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
-			fixture := newNodePoolTestFixture()
-			cluster := fixture.newCluster()
-			nodePool := fixture.newNodePool()
 			operation := fixture.newOperation(database.OperationRequestDelete)
+			// TODO remove this once the new deletion approach is fully rolled out in all ARO-HCP permanent environments, for all regions.
+			operation.UsesNewNodePoolDeletionApproach = tc.usesNewDeletionApproach
 
-			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, []any{cluster, nodePool, operation})
+			resources := []any{operation}
+			if tc.existingNodePool != nil {
+				resources = append(resources, tc.existingNodePool)
+			}
+
+			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, resources)
 			require.NoError(t, err)
 
-			mockCSClient := tt.setupMock(ctrl, fixture)
+			var mockCSClient ocm.ClusterServiceClientSpec
+			if tc.setupCSMock != nil {
+				mockCSClient = tc.setupCSMock(ctrl, fixture)
+			}
 
 			controller := &operationNodePoolDelete{
 				clock:                utilsclock.RealClock{},
@@ -166,15 +193,14 @@ func TestOperationNodePoolDelete_SynchronizeOperation(t *testing.T) {
 			}
 
 			err = controller.SynchronizeOperation(ctx, fixture.operationKey())
-
-			if tt.expectError {
+			if tc.wantErr {
 				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
+				return
 			}
+			require.NoError(t, err)
 
-			if tt.verify != nil {
-				tt.verify(t, ctx, mockResourcesDBClient, fixture)
+			if tc.verifyDB != nil {
+				tc.verifyDB(t, ctx, mockResourcesDBClient)
 			}
 		})
 	}

--- a/backend/pkg/controllers/operationcontrollers/operation_node_pool_delete_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_node_pool_delete_test.go
@@ -16,7 +16,6 @@ package operationcontrollers
 
 import (
 	"context"
-	"net/http"
 	"testing"
 	"time"
 
@@ -29,7 +28,6 @@ import (
 	utilsclock "k8s.io/utils/clock"
 
 	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
-	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
 
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
@@ -51,12 +49,11 @@ func TestOperationNodePoolDelete_SynchronizeOperation(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name                    string
-		existingNodePool        *api.HCPOpenShiftClusterNodePool
-		wantErr                 bool
-		verifyDB                func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient)
-		usesNewDeletionApproach bool
-		setupCSMock             func(ctrl *gomock.Controller, fixture *nodePoolTestFixture) ocm.ClusterServiceClientSpec
+		name             string
+		existingNodePool *api.HCPOpenShiftClusterNodePool
+		wantErr          bool
+		verifyDB         func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient)
+		setupCSMock      func(ctrl *gomock.Controller, fixture *nodePoolTestFixture) ocm.ClusterServiceClientSpec
 	}{
 		{
 			name: "node pool document gone completes operation",
@@ -65,7 +62,6 @@ func TestOperationNodePoolDelete_SynchronizeOperation(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateSucceeded, op.Status)
 			},
-			usesNewDeletionApproach: true,
 		},
 		{
 			name: "shouldReconcile gate not passed skips cluster service",
@@ -79,7 +75,6 @@ func TestOperationNodePoolDelete_SynchronizeOperation(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
 			},
-			usesNewDeletionApproach: true,
 		},
 		{
 			name:             "extra reconcilegate passed and CS Ready waits without updating operation",
@@ -100,7 +95,6 @@ func TestOperationNodePoolDelete_SynchronizeOperation(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
 			},
-			usesNewDeletionApproach: true,
 		},
 		{
 			name:             "extra reconcile gate passed and CS uninstalling updates operation to deleting",
@@ -121,44 +115,6 @@ func TestOperationNodePoolDelete_SynchronizeOperation(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateDeleting, op.Status)
 			},
-			usesNewDeletionApproach: true,
-		},
-		{
-			name: "legacy approach: node pool gone in cluster service marks operation succeeded",
-			setupCSMock: func(ctrl *gomock.Controller, fixture *nodePoolTestFixture) ocm.ClusterServiceClientSpec {
-				mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
-				notFoundErr, _ := ocmerrors.NewError().Status(http.StatusNotFound).Build()
-				mockCSClient.EXPECT().
-					GetNodePoolStatus(gomock.Any(), fixture.nodePoolInternalID).
-					Return(nil, notFoundErr)
-				return mockCSClient
-			},
-			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
-				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
-				require.NoError(t, err)
-				assert.Equal(t, arm.ProvisioningStateSucceeded, op.Status)
-			},
-			usesNewDeletionApproach: false,
-		},
-		{
-			name: "legacy approach: node pool still exists in cluster service keeps operation accepted",
-			setupCSMock: func(ctrl *gomock.Controller, fixture *nodePoolTestFixture) ocm.ClusterServiceClientSpec {
-				mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
-				nodePoolStatus, err := arohcpv1alpha1.NewNodePoolStatus().
-					State(arohcpv1alpha1.NewNodePoolState().NodePoolStateValue(string(NodePoolStateReady))).
-					Build()
-				require.NoError(t, err)
-				mockCSClient.EXPECT().
-					GetNodePoolStatus(gomock.Any(), fixture.nodePoolInternalID).
-					Return(nodePoolStatus, nil)
-				return mockCSClient
-			},
-			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
-				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
-				require.NoError(t, err)
-				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
-			},
-			usesNewDeletionApproach: false,
 		},
 	}
 
@@ -169,9 +125,6 @@ func TestOperationNodePoolDelete_SynchronizeOperation(t *testing.T) {
 			defer ctrl.Finish()
 
 			operation := fixture.newOperation(database.OperationRequestDelete)
-			// TODO remove this once the new deletion approach is fully rolled out in all ARO-HCP permanent environments, for all regions.
-			operation.UsesNewNodePoolDeletionApproach = tc.usesNewDeletionApproach
-
 			resources := []any{operation}
 			if tc.existingNodePool != nil {
 				resources = append(resources, tc.existingNodePool)

--- a/backend/pkg/controllers/operationcontrollers/utils.go
+++ b/backend/pkg/controllers/operationcontrollers/utils.go
@@ -385,7 +385,6 @@ func notifyOperationOwner(ctx context.Context, resourcesDBClient database.Resour
 	}
 }
 
-// PostAsyncNotification submits an POST request with status payload to the given URL.
 func postAsyncNotificationFn(notificationClient *http.Client) PostAsyncNotificationFunc {
 	return func(ctx context.Context, operation *api.Operation) error {
 		return PostAsyncNotification(ctx, notificationClient, operation)

--- a/backend/pkg/controllers/read_and_persist_cluster_scoped_maestro_readonly_bundles_content_controller.go
+++ b/backend/pkg/controllers/read_and_persist_cluster_scoped_maestro_readonly_bundles_content_controller.go
@@ -122,7 +122,7 @@ func (c *readAndPersistClusterScopedMaestroReadonlyBundlesContentSyncer) SyncOnc
 	// This is important to avoid leaking resources when the sync is done.
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	maestroClient, err := createMaestroClientFromCSProvisionShard(ctx, c.maestroSourceEnvironmentIdentifier, c.maestroClientBuilder, clusterProvisionShard)
+	maestroClient, err := CreateMaestroClientFromCSProvisionShard(ctx, c.maestroSourceEnvironmentIdentifier, c.maestroClientBuilder, clusterProvisionShard)
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to create Maestro client: %w", err))
 	}

--- a/backend/pkg/controllers/read_and_persist_nodepool_scoped_maestro_readonly_bundles_content_controller.go
+++ b/backend/pkg/controllers/read_and_persist_nodepool_scoped_maestro_readonly_bundles_content_controller.go
@@ -121,7 +121,7 @@ func (c *readAndPersistNodePoolScopedMaestroReadonlyBundlesContentSyncer) SyncOn
 	// This is important to avoid leaking resources when the sync is done.
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	maestroClient, err := createMaestroClientFromCSProvisionShard(ctx, c.maestroSourceEnvironmentIdentifier, c.maestroClientBuilder, clusterProvisionShard)
+	maestroClient, err := CreateMaestroClientFromCSProvisionShard(ctx, c.maestroSourceEnvironmentIdentifier, c.maestroClientBuilder, clusterProvisionShard)
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to create Maestro client: %w", err))
 	}

--- a/backend/pkg/listertesting/helpers.go
+++ b/backend/pkg/listertesting/helpers.go
@@ -55,3 +55,22 @@ func managementClusterContentMatchesCluster(resourceID *azcorearm.ResourceID, cl
 	}
 	return strings.EqualFold(resourceID.Parent.Name, clusterName)
 }
+
+// serviceProviderNodePoolMatchesNodePool checks if a service provider node pool's resource ID belongs to the given node pool.
+// Service provider node pools are grandchild resources: .../nodePools/<np>/serviceProviderNodePools/default
+// so we check the parent (nodePool) name.
+func serviceProviderNodePoolMatchesNodePool(resourceID *azcorearm.ResourceID, nodePoolName string) bool {
+	if resourceID == nil || resourceID.Parent == nil {
+		return false
+	}
+	return strings.EqualFold(resourceID.Parent.Name, nodePoolName)
+}
+
+// serviceProviderNodePoolMatchesCluster checks if a service provider node pool's resource ID belongs to the given cluster.
+// The cluster name is the grandparent: .../hcpOpenShiftClusters/<cluster>/nodePools/<np>/serviceProviderNodePools/default
+func serviceProviderNodePoolMatchesCluster(resourceID *azcorearm.ResourceID, clusterName string) bool {
+	if resourceID == nil || resourceID.Parent == nil || resourceID.Parent.Parent == nil {
+		return false
+	}
+	return strings.EqualFold(resourceID.Parent.Parent.Name, clusterName)
+}

--- a/backend/pkg/listertesting/slice_listers.go
+++ b/backend/pkg/listertesting/slice_listers.go
@@ -253,6 +253,50 @@ func (l *SliceServiceProviderClusterLister) ListForCluster(ctx context.Context, 
 	return result, nil
 }
 
+// SliceServiceProviderNodePoolLister implements listers.ServiceProviderNodePoolLister backed by a slice.
+type SliceServiceProviderNodePoolLister struct {
+	ServiceProviderNodePools []*api.ServiceProviderNodePool
+}
+
+var _ listers.ServiceProviderNodePoolLister = &SliceServiceProviderNodePoolLister{}
+
+func (l *SliceServiceProviderNodePoolLister) List(ctx context.Context) ([]*api.ServiceProviderNodePool, error) {
+	return l.ServiceProviderNodePools, nil
+}
+
+func (l *SliceServiceProviderNodePoolLister) Get(ctx context.Context, subscriptionID, resourceGroupName, clusterName, nodePoolName string) (*api.ServiceProviderNodePool, error) {
+	for _, spnp := range l.ServiceProviderNodePools {
+		resourceID := spnp.GetResourceID()
+		if resourceID == nil {
+			continue
+		}
+		if strings.EqualFold(resourceID.SubscriptionID, subscriptionID) &&
+			strings.EqualFold(resourceID.ResourceGroupName, resourceGroupName) &&
+			serviceProviderNodePoolMatchesCluster(resourceID, clusterName) &&
+			serviceProviderNodePoolMatchesNodePool(resourceID, nodePoolName) {
+			return spnp, nil
+		}
+	}
+	return nil, database.NewNotFoundError()
+}
+
+func (l *SliceServiceProviderNodePoolLister) ListForNodePool(ctx context.Context, subscriptionName, resourceGroupName, clusterName, nodePoolName string) ([]*api.ServiceProviderNodePool, error) {
+	var result []*api.ServiceProviderNodePool
+	for _, spnp := range l.ServiceProviderNodePools {
+		resourceID := spnp.GetResourceID()
+		if resourceID == nil {
+			continue
+		}
+		if strings.EqualFold(resourceID.SubscriptionID, subscriptionName) &&
+			strings.EqualFold(resourceID.ResourceGroupName, resourceGroupName) &&
+			serviceProviderNodePoolMatchesCluster(resourceID, clusterName) &&
+			serviceProviderNodePoolMatchesNodePool(resourceID, nodePoolName) {
+			result = append(result, spnp)
+		}
+	}
+	return result, nil
+}
+
 // SliceManagementClusterContentLister implements listers.ManagementClusterContentLister backed by a slice.
 type SliceManagementClusterContentLister struct {
 	Contents []*api.ManagementClusterContent

--- a/frontend/pkg/frontend/node_pool.go
+++ b/frontend/pkg/frontend/node_pool.go
@@ -744,9 +744,6 @@ func (f *Frontend) addDeleteNodePoolToTransaction(ctx context.Context, writer ht
 		"",
 		"",
 		correlationData)
-	// TODO remove this once migration of the new node pool deletion from frontend to backend approach is fully completed in all ARO-HCP
-	// permanent environments, for all regions.
-	operationDoc.UsesNewNodePoolDeletionApproach = true
 	if request != nil {
 		// these are optional because when this is triggered via the subscription deletion flow, there is no
 		// deletion request containing these headers so these operations cannot be directly tracked.
@@ -768,7 +765,6 @@ func (f *Frontend) addDeleteNodePoolToTransaction(ctx context.Context, writer ht
 	if nodePool.ServiceProviderProperties.DeletionTimestamp == nil {
 		nodePool.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: time.Now().UTC()}
 	}
-	nodePool.ServiceProviderProperties.UsesNewNodePoolDeletionApproach = true
 	_, err = f.resourcesDBClient.HCPClusters(nodePool.ID.SubscriptionID, nodePool.ID.ResourceGroupName).NodePools(nodePool.ID.Parent.Name).
 		AddReplaceToTransaction(ctx, transaction, nodePool, nil)
 	if err != nil {

--- a/frontend/pkg/frontend/node_pool.go
+++ b/frontend/pkg/frontend/node_pool.go
@@ -17,7 +17,6 @@ package frontend
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"maps"
 	"net/http"
@@ -30,8 +29,6 @@ import (
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
-
-	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
 
 	"github.com/Azure/ARO-HCP/internal/admission"
 	"github.com/Azure/ARO-HCP/internal/api"
@@ -708,26 +705,6 @@ func (f *Frontend) DeleteNodePool(writer http.ResponseWriter, request *http.Requ
 		return utils.TrackError(err)
 	}
 
-	// Temporary check until creation and deletion interaction with CS is moved to the backend: if a delete arrives and the node
-	// pool has not been created in CS or the ClusterServiceID reference has not been persisted in Cosmos, return an error.
-	if nodePool.ServiceProviderProperties.ClusterServiceID == nil || len(nodePool.ServiceProviderProperties.ClusterServiceID.String()) == 0 {
-		return utils.TrackError(fmt.Errorf("serviceProviderProperties.clusterServiceID is required to delete a node pool"))
-	}
-
-	err = f.clusterServiceClient.DeleteNodePool(ctx, *nodePool.ServiceProviderProperties.ClusterServiceID)
-	var ocmError *ocmerrors.Error
-	if errors.As(err, &ocmError) && ocmError.Status() == http.StatusNotFound {
-		// StatusNotFound means we have stale data in Cosmos DB.
-		// This can happen in test environments if a user bypasses
-		// the RP to delete a resource (e.g. "ocm delete"). It can
-		// also happen if an asynchronous deletion operation fails.
-		// we will fall through and cancel all operations and go through as normal a deletion flow as we can to avoid
-		// leaking data related to the resource, like controller status.
-		logger.Info("clusterService nodepool missing, trying to clean up", "err", err)
-	} else if err != nil {
-		return utils.TrackError(err)
-	}
-
 	transaction := f.resourcesDBClient.NewTransaction(nodePool.ID.SubscriptionID)
 	if err := f.addDeleteNodePoolToTransaction(ctx, writer, request, transaction, nodePool); err != nil {
 		return utils.TrackError(err)
@@ -758,21 +735,18 @@ func (f *Frontend) addDeleteNodePoolToTransaction(ctx context.Context, writer ht
 		return utils.TrackError(err)
 	}
 
-	// Temporary check until creation and deletion interaction with CS is moved to the backend: if a delete arrives and the node pool
-	// has not been created in CS or the ClusterServiceID reference has not been persisted in Cosmos, return an error.
-	if nodePool.ServiceProviderProperties.ClusterServiceID == nil || len(nodePool.ServiceProviderProperties.ClusterServiceID.String()) == 0 {
-		return utils.TrackError(fmt.Errorf("serviceProviderProperties.clusterServiceID is required to delete a node pool"))
-	}
-
 	operationDoc := database.NewOperation(
 		database.OperationRequestDelete,
 		nodePool.ID,
-		*nodePool.ServiceProviderProperties.ClusterServiceID,
+		api.InternalID{},
 		f.azureLocation,
 		"",
 		"",
 		"",
 		correlationData)
+	// TODO remove this once migration of the new node pool deletion from frontend to backend approach is fully completed in all ARO-HCP
+	// permanent environments, for all regions.
+	operationDoc.UsesNewNodePoolDeletionApproach = true
 	if request != nil {
 		// these are optional because when this is triggered via the subscription deletion flow, there is no
 		// deletion request containing these headers so these operations cannot be directly tracked.
@@ -791,6 +765,10 @@ func (f *Frontend) addDeleteNodePoolToTransaction(ctx context.Context, writer ht
 	}
 	nodePool.ServiceProviderProperties.ActiveOperationID = operationDoc.ResourceID.Name
 	nodePool.Properties.ProvisioningState = operationDoc.Status
+	if nodePool.ServiceProviderProperties.DeletionTimestamp == nil {
+		nodePool.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: time.Now().UTC()}
+	}
+	nodePool.ServiceProviderProperties.UsesNewNodePoolDeletionApproach = true
 	_, err = f.resourcesDBClient.HCPClusters(nodePool.ID.SubscriptionID, nodePool.ID.ResourceGroupName).NodePools(nodePool.ID.Parent.Name).
 		AddReplaceToTransaction(ctx, transaction, nodePool, nil)
 	if err != nil {

--- a/internal/api/types_nodepool.go
+++ b/internal/api/types_nodepool.go
@@ -73,13 +73,6 @@ type HCPOpenShiftClusterNodePoolServiceProviderProperties struct {
 	// The timestamp is in UTC.
 	// TODO this attribute is not in use yet. Do not rely on it.
 	ClusterServiceDeletionTimestamp *metav1.Time `json:"clusterServiceDeletionTimestamp,omitempty"`
-
-	// TODO Temporary field to track whether the node pool operation is using the new deletion approach.
-	// We are migrating from the node pool cs deletion synchronous in frontend to the backend, to be fully asynchronous
-	// This boolean is true for NodePool delete operations that are created with new deletion approach.
-	// This will be removed once all nodepools whose deletion was triggered before the new approach is fully rolled out have been
-	// fully deleted in all ARO-HCP permanent environments, for all regions.
-	UsesNewNodePoolDeletionApproach bool `json:"usesNewNodePoolDeletionApproach"`
 }
 
 // NodePoolVersionProfile represents the worker node pool version.

--- a/internal/api/types_operation.go
+++ b/internal/api/types_operation.go
@@ -70,13 +70,6 @@ type Operation struct {
 	Status arm.ProvisioningState `json:"status,omitempty"`
 	// Error is an OData error, present when Status is "Failed" or "Canceled"
 	Error *arm.CloudErrorBody `json:"error,omitempty"`
-
-	// Temporary field to track whether the node pool operation is using the new deletion approach.
-	// We are migrating from the node pool cs deletion synchronous in frontend to the backend, to be fully asynchronous
-	// This boolean is true for NodePool delete operations that are created with new deletion approach.
-	// This will be removed once all nodepools whose deletion was triggered before the new approach is fully rolled out have been
-	// fully deleted in all ARO-HCP permanent environments, for all regions.
-	UsesNewNodePoolDeletionApproach bool `json:"usesNewNodePoolDeletionApproach"`
 }
 
 func (o *Operation) ComputeLogicalResourceID() *azcorearm.ResourceID {

--- a/internal/api/types_serviceprovider_cluster.go
+++ b/internal/api/types_serviceprovider_cluster.go
@@ -229,6 +229,26 @@ func (l *MaestroBundleReferenceList) Set(maestroBundleReference *MaestroBundleRe
 	return nil
 }
 
+// Remove removes the Maestro Bundle reference for a given Maestro Bundle internal name.
+// If the Maestro Bundle reference identified by name does not exist, it is a no-op.
+// If multiple Maestro Bundle references are found for the same internal name, it returns an error.
+func (l *MaestroBundleReferenceList) Remove(name MaestroBundleInternalName) error {
+	filtered := make(MaestroBundleReferenceList, 0, len(*l))
+	matched := 0
+	for _, bundle := range *l {
+		if bundle.Name == name {
+			matched++
+		} else {
+			filtered = append(filtered, bundle)
+		}
+	}
+	if matched > 1 {
+		return utils.TrackError(fmt.Errorf("multiple Maestro Bundle references found for the same internal name: %s", name))
+	}
+	*l = filtered
+	return nil
+}
+
 // MaestroBundleInternalName is a type that represents the internal name of a Maestro Bundle.
 // It is used to identify the Maestro Bundle internally and to retrieve it from the MaestroBundleReferenceList.
 type MaestroBundleInternalName string

--- a/internal/api/v20240610preview/conversion_fuzz_test.go
+++ b/internal/api/v20240610preview/conversion_fuzz_test.go
@@ -79,8 +79,6 @@ func TestRoundTripInternalExternalInternal(t *testing.T) {
 			j.ActiveOperationID = ""
 			// ClusterServiceID does not roundtrip through the external type because it is purely an internal detail
 			j.ClusterServiceID = nil
-			// UsesNewNodePoolDeletionApproach does not roundtrip through the external type because it is purely an internal detail
-			j.UsesNewNodePoolDeletionApproach = false
 		},
 		func(j *api.OSDiskProfile, c randfill.Continue) {
 			c.FillNoCustom(j)

--- a/internal/api/v20251223preview/conversion_fuzz_test.go
+++ b/internal/api/v20251223preview/conversion_fuzz_test.go
@@ -77,8 +77,6 @@ func TestRoundTripInternalExternalInternal(t *testing.T) {
 			j.ActiveOperationID = ""
 			// ClusterServiceID does not roundtrip through the external type because it is purely an internal detail
 			j.ClusterServiceID = nil
-			// UsesNewNodePoolDeletionApproach does not roundtrip through the external type because it is purely an internal detail
-			j.UsesNewNodePoolDeletionApproach = false
 		},
 		func(j *api.HCPOpenShiftClusterExternalAuthServiceProviderProperties, c randfill.Continue) {
 			c.FillNoCustom(j)

--- a/test-integration/backend/controllers/mismatches/artifacts/cluster/remove_orphaned_cluster_descendents/00-load-initial-state/nodepool-basic.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/cluster/remove_orphaned_cluster_descendents/00-load-initial-state/nodepool-basic.json
@@ -57,8 +57,7 @@
 				},
 				"serviceProviderProperties": {
 					"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
-					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"clusterServiceID": ""
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -103,8 +102,7 @@
 		},
 		"serviceProviderProperties": {
 			"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
-			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/w9xhwccbjp/node_pools/k9xp9ghzh2",
-			"usesNewNodePoolDeletionApproach": false
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/w9xhwccbjp/node_pools/k9xp9ghzh2"
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/backend/controllers/mismatches/artifacts/delete_orphaned_cosmos/all_parents_exist/00-load-initial-state/nodepool-basic.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/delete_orphaned_cosmos/all_parents_exist/00-load-initial-state/nodepool-basic.json
@@ -32,8 +32,7 @@
 				},
 				"serviceProviderProperties": {
 					"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
-					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"clusterServiceID": ""
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -58,8 +57,7 @@
 		},
 		"serviceProviderProperties": {
 			"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
-			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/w9xhwccbjp/node_pools/k9xp9ghzh2",
-			"usesNewNodePoolDeletionApproach": false
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/w9xhwccbjp/node_pools/k9xp9ghzh2"
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/backend/controllers/mismatches/artifacts/delete_orphaned_cosmos/all_parents_exist/99-cosmosCompare-end-state/nodepool-basic.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/delete_orphaned_cosmos/all_parents_exist/99-cosmosCompare-end-state/nodepool-basic.json
@@ -32,8 +32,7 @@
 				},
 				"serviceProviderProperties": {
 					"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
-					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"clusterServiceID": ""
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -58,8 +57,7 @@
 		},
 		"serviceProviderProperties": {
 			"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
-			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/w9xhwccbjp/node_pools/k9xp9ghzh2",
-			"usesNewNodePoolDeletionApproach": false
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/w9xhwccbjp/node_pools/k9xp9ghzh2"
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/backend/controllers/mismatches/artifacts/externalauth/remove_orphaned_externalauth_descendents/00-load-initial-state/nodepool-basic.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/externalauth/remove_orphaned_externalauth_descendents/00-load-initial-state/nodepool-basic.json
@@ -57,8 +57,7 @@
 				},
 				"serviceProviderProperties": {
 					"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
-					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"clusterServiceID": ""
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -103,8 +102,7 @@
 		},
 		"serviceProviderProperties": {
 			"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
-			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0/node_pools/k9xp9ghzh2",
-			"usesNewNodePoolDeletionApproach": false
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0/node_pools/k9xp9ghzh2"
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/backend/controllers/mismatches/artifacts/externalauth/remove_orphaned_externalauth_descendents/99-cosmosCompare-end-state/nodepool-basic.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/externalauth/remove_orphaned_externalauth_descendents/99-cosmosCompare-end-state/nodepool-basic.json
@@ -57,8 +57,7 @@
 				},
 				"serviceProviderProperties": {
 					"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
-					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"clusterServiceID": ""
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -103,8 +102,7 @@
 		},
 		"serviceProviderProperties": {
 			"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
-			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0/node_pools/k9xp9ghzh2",
-			"usesNewNodePoolDeletionApproach": false
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0/node_pools/k9xp9ghzh2"
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/backend/controllers/mismatches/artifacts/nodepool/present_nodepool/00-load-initial-state/nodepool-basic.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/nodepool/present_nodepool/00-load-initial-state/nodepool-basic.json
@@ -57,8 +57,7 @@
 				},
 				"serviceProviderProperties": {
 					"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
-					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"clusterServiceID": ""
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -103,8 +102,7 @@
 		},
 		"serviceProviderProperties": {
 			"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
-			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0/node_pools/k9xp9ghzh2",
-			"usesNewNodePoolDeletionApproach": false
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0/node_pools/k9xp9ghzh2"
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/backend/controllers/mismatches/artifacts/nodepool/present_nodepool/99-cosmosCompare-end-state/nodepool-basic.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/nodepool/present_nodepool/99-cosmosCompare-end-state/nodepool-basic.json
@@ -57,8 +57,7 @@
 				},
 				"serviceProviderProperties": {
 					"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
-					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"clusterServiceID": ""
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -103,8 +102,7 @@
 		},
 		"serviceProviderProperties": {
 			"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
-			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/w9xhwccbjp/node_pools/k9xp9ghzh2",
-			"usesNewNodePoolDeletionApproach": false
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/w9xhwccbjp/node_pools/k9xp9ghzh2"
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/backend/controllers/mismatches/artifacts/nodepool/remove_orphaned_nodepool_descendents/00-load-initial-state/nodepool-basic.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/nodepool/remove_orphaned_nodepool_descendents/00-load-initial-state/nodepool-basic.json
@@ -57,8 +57,7 @@
 				},
 				"serviceProviderProperties": {
 					"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
-					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"clusterServiceID": ""
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -103,8 +102,7 @@
 		},
 		"serviceProviderProperties": {
 			"activeOperationId": "a7b69c90-242b-4a85-8187-0b3bd4979155",
-			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/w9xhwccbjp/node_pools/k9xp9ghzh2",
-			"usesNewNodePoolDeletionApproach": false
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/w9xhwccbjp/node_pools/k9xp9ghzh2"
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/01-load-initial/basic-external-auth-operation-external-auth.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/01-load-initial/basic-external-auth-operation-external-auth.json
@@ -14,8 +14,7 @@
 		"request": "Create",
 		"startTime": "2025-12-05T20:30:10.966609337Z",
 		"status": "Succeeded",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceID": "/subscriptions/f52dfea2-47ee-4396-8006-4a27d47d59c5/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/01738f95-410e-414a-98ce-fe6097133ce6",
 	"resourceType": "microsoft.redhatopenshift/hcpoperationstatuses",

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/01-load-initial/create-with-tags-operation.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/01-load-initial/create-with-tags-operation.json
@@ -14,8 +14,7 @@
 		"request": "Create",
 		"startTime": "2025-12-05T20:29:59.734335781Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceID": "/subscriptions/f52dfea2-47ee-4396-8006-4a27d47d59c5/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/7c6b7caa-572f-41b6-9f18-1bb11adfbd31",
 	"resourceType": "microsoft.redhatopenshift/hcpoperationstatuses",

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/01-load-initial/immutability-np.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/01-load-initial/immutability-np.json
@@ -26,8 +26,7 @@
 					}
 				},
 				"serviceProviderProperties": {
-					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"clusterServiceID": ""
 				}
 			}
 		},

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/01-load-initial/immutability-operation-for-node-pool.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/01-load-initial/immutability-operation-for-node-pool.json
@@ -14,8 +14,7 @@
 		"request": "Create",
 		"startTime": "2025-12-05T20:30:25.067364685Z",
 		"status": "Succeeded",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceID": "/subscriptions/f52dfea2-47ee-4396-8006-4a27d47d59c5/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/37332594-70b3-4796-9af6-301a5d57d1e6",
 	"resourceType": "microsoft.redhatopenshift/hcpoperationstatuses",

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/01-load-initial/operation-3-new.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/01-load-initial/operation-3-new.json
@@ -15,8 +15,7 @@
 		"resourceId": "/subscriptions/f52dfea2-47ee-4396-8006-4a27d47d59c5/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/37332504-70b3-4796-9af6-301a5d47d127",
 		"startTime": "2025-12-05T20:30:25.067364685Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceID": "/subscriptions/f52dfea2-47ee-4396-8006-4a27d47d59c5/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/37332504-70b3-4796-9af6-301a5d47d127",
 	"resourceType": "microsoft.redhatopenshift/hcpoperationstatuses",

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/02-untypedListRecursive-immutability/immutability-np.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/02-untypedListRecursive-immutability/immutability-np.json
@@ -21,8 +21,7 @@
 					}
 				},
 				"serviceProviderProperties": {
-					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"clusterServiceID": ""
 				}
 			}
 		},

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/04-untypedListRecursive-resourcegroup/immutability-np.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/04-untypedListRecursive-resourcegroup/immutability-np.json
@@ -21,8 +21,7 @@
 					}
 				},
 				"serviceProviderProperties": {
-					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"clusterServiceID": ""
 				}
 			}
 		},

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/05-untypedListRecursive-subscription/basic-external-auth-operation-external-auth.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/05-untypedListRecursive-subscription/basic-external-auth-operation-external-auth.json
@@ -14,8 +14,7 @@
 		"request": "Create",
 		"startTime": "2025-12-05T20:30:10.966609337Z",
 		"status": "Succeeded",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceID": "/subscriptions/f52dfea2-47ee-4396-8006-4a27d47d59c5/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/01738f95-410e-414a-98ce-fe6097133ce6",
 	"resourceType": "microsoft.redhatopenshift/hcpoperationstatuses",

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/05-untypedListRecursive-subscription/create-with-tags-operation.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/05-untypedListRecursive-subscription/create-with-tags-operation.json
@@ -14,8 +14,7 @@
 		"request": "Create",
 		"startTime": "2025-12-05T20:29:59.734335781Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceID": "/subscriptions/f52dfea2-47ee-4396-8006-4a27d47d59c5/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/7c6b7caa-572f-41b6-9f18-1bb11adfbd31",
 	"resourceType": "microsoft.redhatopenshift/hcpoperationstatuses",

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/05-untypedListRecursive-subscription/immutability-np.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/05-untypedListRecursive-subscription/immutability-np.json
@@ -21,8 +21,7 @@
 					}
 				},
 				"serviceProviderProperties": {
-					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"clusterServiceID": ""
 				}
 			}
 		},

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/05-untypedListRecursive-subscription/immutability-operation-for-node-pool.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/05-untypedListRecursive-subscription/immutability-operation-for-node-pool.json
@@ -14,8 +14,7 @@
 		"request": "Create",
 		"startTime": "2025-12-05T20:30:25.067364685Z",
 		"status": "Succeeded",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceID": "/subscriptions/f52dfea2-47ee-4396-8006-4a27d47d59c5/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/37332594-70b3-4796-9af6-301a5d57d1e6",
 	"resourceType": "microsoft.redhatopenshift/hcpoperationstatuses",

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/05-untypedListRecursive-subscription/operation-3-new.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/05-untypedListRecursive-subscription/operation-3-new.json
@@ -15,8 +15,7 @@
 		"resourceId": "/subscriptions/f52dfea2-47ee-4396-8006-4a27d47d59c5/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/37332504-70b3-4796-9af6-301a5d47d127",
 		"startTime": "2025-12-05T20:30:25.067364685Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceID": "/subscriptions/f52dfea2-47ee-4396-8006-4a27d47d59c5/providers/microsoft.redhatopenshift/hcpoperationstatuses/37332504-70b3-4796-9af6-301a5d47d127",
 	"resourceType": "microsoft.redhatopenshift/hcpoperationstatuses",

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/07-untypedListRecursive-resourcegroup-via-child/immutability-np.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/07-untypedListRecursive-resourcegroup-via-child/immutability-np.json
@@ -21,8 +21,7 @@
 					}
 				},
 				"serviceProviderProperties": {
-					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"clusterServiceID": ""
 				}
 			}
 		},

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/08-untypedListRecursive-immutability-cluster/immutability-np.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/08-untypedListRecursive-immutability-cluster/immutability-np.json
@@ -21,8 +21,7 @@
 					}
 				},
 				"serviceProviderProperties": {
-					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"clusterServiceID": ""
 				}
 			}
 		},

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/09-untypedList-immutability-cluster/immutability-np.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/09-untypedList-immutability-cluster/immutability-np.json
@@ -21,8 +21,7 @@
 					}
 				},
 				"serviceProviderProperties": {
-					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"clusterServiceID": ""
 				}
 			}
 		},

--- a/test-integration/frontend/artifacts/FrontendCRUD/AdminCredentials/request/03-listActiveOperations-request-credentials/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/AdminCredentials/request/03-listActiveOperations-request-credentials/00-key.json
@@ -1,7 +1,5 @@
 {
 	"parentResourceID": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6",
-	"properties": {
-		"usesNewNodePoolDeletionApproach": false
-	},
+	"properties": {},
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses"
 }

--- a/test-integration/frontend/artifacts/FrontendCRUD/AdminCredentials/revoke/03-listActiveOperations-revoke-credentials/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/AdminCredentials/revoke/03-listActiveOperations-revoke-credentials/00-key.json
@@ -1,7 +1,5 @@
 {
 	"parentResourceID": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6",
-	"properties": {
-		"usesNewNodePoolDeletionApproach": false
-	},
+	"properties": {},
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses"
 }

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-current/02-cosmosCompare-confirm-content/operation-cluster-create-with-tags-create.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-current/02-cosmosCompare-confirm-content/operation-cluster-create-with-tags-create.json
@@ -18,8 +18,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/7a4ed07a-47a1-4efb-966a-93a6316522a0",
 		"startTime": "2025-12-19T19:59:30.714826736Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/7a4ed07a-47a1-4efb-966a-93a6316522a0",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-current/05-listActiveOperations-cluster-create/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-current/05-listActiveOperations-cluster-create/00-key.json
@@ -1,7 +1,5 @@
 {
 	"parentResourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7",
-	"properties": {
-		"usesNewNodePoolDeletionApproach": false
-	},
+	"properties": {},
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses"
 }

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-cluster-operation/03-cosmosCompare-final-state/operation-cluster-create-canceled.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-cluster-operation/03-cosmosCompare-final-state/operation-cluster-create-canceled.json
@@ -8,8 +8,7 @@
 		"externalId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/test-cluster",
 		"request": "Create",
 		"status": "Canceled",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",
 	"ttl": 604800

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-cluster-operation/03-cosmosCompare-final-state/operation-cluster-delete.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-cluster-operation/03-cosmosCompare-final-state/operation-cluster-delete.json
@@ -4,8 +4,7 @@
 		"externalId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/test-cluster",
 		"request": "Delete",
 		"status": "Deleting",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",
 	"ttl": 604800

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/nodepool-test-nodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/nodepool-test-nodepool.json
@@ -56,7 +56,7 @@
 				},
 				"serviceProviderProperties": {
 					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"usesNewNodePoolDeletionApproach": true
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -103,7 +103,7 @@
 			}
 		},
 		"serviceProviderProperties": {
-			"usesNewNodePoolDeletionApproach": false
+			"usesNewNodePoolDeletionApproach": true
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/nodepool-test-nodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/nodepool-test-nodepool.json
@@ -55,8 +55,7 @@
 					}
 				},
 				"serviceProviderProperties": {
-					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": true
+					"clusterServiceID": ""
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -102,9 +101,7 @@
 				"id": "4.20.8"
 			}
 		},
-		"serviceProviderProperties": {
-			"usesNewNodePoolDeletionApproach": true
-		},
+		"serviceProviderProperties": {},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",
 			"createdByType": "Application",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/operation-cluster-create.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/operation-cluster-create.json
@@ -4,8 +4,7 @@
 		"externalId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/test-cluster",
 		"request": "Create",
 		"status": "Succeeded",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",
 	"ttl": 604800

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/operation-cluster-delete.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/operation-cluster-delete.json
@@ -4,8 +4,7 @@
 		"externalId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/test-cluster",
 		"request": "Delete",
 		"status": "Deleting",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",
 	"ttl": 604800

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/operation-nodepool-create-canceled.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/operation-nodepool-create-canceled.json
@@ -8,8 +8,7 @@
 		"externalId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/test-cluster/nodePools/test-nodepool",
 		"request": "Create",
 		"status": "Canceled",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",
 	"ttl": 604800

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/operation-nodepool-delete.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/operation-nodepool-delete.json
@@ -3,8 +3,7 @@
 	"properties": {
 		"externalId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/test-cluster/nodePools/test-nodepool",
 		"request": "Delete",
-		"status": "Deleting",
-		"usesNewNodePoolDeletionApproach": true
+		"status": "Deleting"
 	},
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",
 	"ttl": 604800

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/operation-nodepool-delete.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/operation-nodepool-delete.json
@@ -4,7 +4,7 @@
 		"externalId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/test-cluster/nodePools/test-nodepool",
 		"request": "Delete",
 		"status": "Deleting",
-		"usesNewNodePoolDeletionApproach": false
+		"usesNewNodePoolDeletionApproach": true
 	},
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",
 	"ttl": 604800

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/read-old-data/01-load-old-data/hcpoperationstatuses_Create_90b2322c-2c26-47ca-b6f9-d9b1a8385cbc.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/read-old-data/01-load-old-data/hcpoperationstatuses_Create_90b2322c-2c26-47ca-b6f9-d9b1a8385cbc.json
@@ -18,8 +18,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/90b2322c-2c26-47ca-b6f9-d9b1a8385cbc",
 		"startTime": "2026-01-05T18:29:58.181047849Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/90b2322c-2c26-47ca-b6f9-d9b1a8385cbc",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/read-old-data/04-listActiveOperations-cluster-create/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/read-old-data/04-listActiveOperations-cluster-create/00-key.json
@@ -1,7 +1,5 @@
 {
 	"parentResourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7",
-	"properties": {
-		"usesNewNodePoolDeletionApproach": false
-	},
+	"properties": {},
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses"
 }

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/create-current/06-cosmosCompare-ending-content/operation-cluster-create-create-with-tags.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/create-current/06-cosmosCompare-ending-content/operation-cluster-create-create-with-tags.json
@@ -15,8 +15,7 @@
 		"resourceId": null,
 		"startTime": "2025-12-19T19:59:30.714826736Z",
 		"status": "Succeeded",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/7a4ed07a-47a1-4efb-966a-93a6316522a0",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/create-current/06-cosmosCompare-ending-content/operation-externalauth-create-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/create-current/06-cosmosCompare-ending-content/operation-externalauth-create-default.json
@@ -18,8 +18,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/ea807c13-7e15-43d4-b760-69ef7e31d273",
 		"startTime": "2026-01-09T18:30:03.439824696Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/ea807c13-7e15-43d4-b760-69ef7e31d273",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/01-load-old-data/operation-cluster-create-with-tags-create.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/01-load-old-data/operation-cluster-create-with-tags-create.json
@@ -18,8 +18,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/9696fbeb-0e78-4a32-a3fd-a6e987c2a015",
 		"startTime": "2026-01-09T18:32:10.15007222Z",
 		"status": "Succeeded",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/9696fbeb-0e78-4a32-a3fd-a6e987c2a015",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/01-load-old-data/operation-externalauth-create-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/01-load-old-data/operation-externalauth-create-default.json
@@ -18,8 +18,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/5dce3cac-e09b-4ef5-803c-cb8f17b3a552",
 		"startTime": "2026-01-09T18:32:10.835814057Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/5dce3cac-e09b-4ef5-803c-cb8f17b3a552",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/09-cosmosCompare-confirm-update/operation-cluster-create-create-with-tags.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/09-cosmosCompare-confirm-update/operation-cluster-create-create-with-tags.json
@@ -15,8 +15,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/9696fbeb-0e78-4a32-a3fd-a6e987c2a015",
 		"startTime": "2026-01-09T18:32:10.15007222Z",
 		"status": "Succeeded",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/9696fbeb-0e78-4a32-a3fd-a6e987c2a015",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/09-cosmosCompare-confirm-update/operation-externalauth-create-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/09-cosmosCompare-confirm-update/operation-externalauth-create-default.json
@@ -15,8 +15,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/5dce3cac-e09b-4ef5-803c-cb8f17b3a552",
 		"startTime": "2026-01-09T18:32:10.835814057Z",
 		"status": "Succeeded",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/5dce3cac-e09b-4ef5-803c-cb8f17b3a552",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/09-cosmosCompare-confirm-update/operation-externalauth-update-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/09-cosmosCompare-confirm-update/operation-externalauth-update-default.json
@@ -15,8 +15,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/4d8d4875-5233-4987-8b14-a26e177b8e20",
 		"startTime": "2026-01-09T18:44:19.757910778Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/4d8d4875-5233-4987-8b14-a26e177b8e20",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/nodepool-basic-node-pool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/nodepool-basic-node-pool.json
@@ -57,8 +57,7 @@
 				},
 				"serviceProviderProperties": {
 					"activeOperationId": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
-					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"clusterServiceID": ""
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -103,8 +102,7 @@
 		},
 		"serviceProviderProperties": {
 			"activeOperationId": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
-			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s",
-			"usesNewNodePoolDeletionApproach": false
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s"
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/nodepool-node-pool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/nodepool-node-pool-02.json
@@ -57,8 +57,7 @@
 				},
 				"serviceProviderProperties": {
 					"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
-					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"clusterServiceID": ""
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -103,8 +102,7 @@
 		},
 		"serviceProviderProperties": {
 			"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
-			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4",
-			"usesNewNodePoolDeletionApproach": false
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4"
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/operation-cluster-create-with-tags-create.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/operation-cluster-create-with-tags-create.json
@@ -15,8 +15,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/7a4ed07a-47a1-4efb-966a-93a6316522a0",
 		"startTime": "2025-12-19T19:59:30.714826736Z",
 		"status": "Succeeded",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/7a4ed07a-47a1-4efb-966a-93a6316522a0",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/operation-create-basicnodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/operation-create-basicnodepool.json
@@ -15,8 +15,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
 		"startTime": "2026-01-08T20:04:05.054190978Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/operation-create-nodepool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/operation-create-nodepool-02.json
@@ -15,8 +15,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/4067756a-fcc1-4732-a211-d785d888203c",
 		"startTime": "2026-01-08T20:04:05.330050272Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/4067756a-fcc1-4732-a211-d785d888203c",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/operation-externalauth-create-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/operation-externalauth-create-default.json
@@ -15,8 +15,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/5dce3cac-e09b-4ef5-803c-cb8f17b3a552",
 		"startTime": "2026-01-09T18:32:10.835814057Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/5dce3cac-e09b-4ef5-803c-cb8f17b3a552",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/nodepool-basic-node-pool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/nodepool-basic-node-pool.json
@@ -61,8 +61,7 @@
 				},
 				"serviceProviderProperties": {
 					"activeOperationId": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
-					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"clusterServiceID": ""
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -108,8 +107,7 @@
 		},
 		"serviceProviderProperties": {
 			"activeOperationId": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
-			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s",
-			"usesNewNodePoolDeletionApproach": false
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s"
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/nodepool-node-pool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/nodepool-node-pool-02.json
@@ -61,8 +61,7 @@
 				},
 				"serviceProviderProperties": {
 					"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
-					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"clusterServiceID": ""
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -108,8 +107,7 @@
 		},
 		"serviceProviderProperties": {
 			"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
-			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4",
-			"usesNewNodePoolDeletionApproach": false
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4"
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/operation-cluster-create-with-tags-create.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/operation-cluster-create-with-tags-create.json
@@ -15,8 +15,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/7a4ed07a-47a1-4efb-966a-93a6316522a0",
 		"startTime": "2025-12-19T19:59:30.714826736Z",
 		"status": "Succeeded",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/7a4ed07a-47a1-4efb-966a-93a6316522a0",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/operation-create-basicnodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/operation-create-basicnodepool.json
@@ -15,8 +15,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
 		"startTime": "2026-01-08T20:04:05.054190978Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/operation-create-nodepool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/operation-create-nodepool-02.json
@@ -15,8 +15,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/4067756a-fcc1-4732-a211-d785d888203c",
 		"startTime": "2026-01-08T20:04:05.330050272Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/4067756a-fcc1-4732-a211-d785d888203c",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/operation-externalauth-create-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/operation-externalauth-create-default.json
@@ -15,8 +15,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/5dce3cac-e09b-4ef5-803c-cb8f17b3a552",
 		"startTime": "2026-01-09T18:32:10.835814057Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/5dce3cac-e09b-4ef5-803c-cb8f17b3a552",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/nodepool-basic-node-pool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/nodepool-basic-node-pool.json
@@ -57,8 +57,7 @@
 				},
 				"serviceProviderProperties": {
 					"activeOperationId": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
-					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"clusterServiceID": ""
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -103,8 +102,7 @@
 		},
 		"serviceProviderProperties": {
 			"activeOperationId": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
-			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s",
-			"usesNewNodePoolDeletionApproach": false
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s"
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/nodepool-node-pool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/nodepool-node-pool-02.json
@@ -57,8 +57,7 @@
 				},
 				"serviceProviderProperties": {
 					"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
-					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"clusterServiceID": ""
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -103,8 +102,7 @@
 		},
 		"serviceProviderProperties": {
 			"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
-			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4",
-			"usesNewNodePoolDeletionApproach": false
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4"
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/operation-cluster-create-with-tags-create.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/operation-cluster-create-with-tags-create.json
@@ -15,8 +15,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/7a4ed07a-47a1-4efb-966a-93a6316522a0",
 		"startTime": "2025-12-19T19:59:30.714826736Z",
 		"status": "Succeeded",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/7a4ed07a-47a1-4efb-966a-93a6316522a0",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/operation-create-basicnodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/operation-create-basicnodepool.json
@@ -18,8 +18,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
 		"startTime": "2026-01-08T20:04:05.054190978Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/operation-create-nodepool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/operation-create-nodepool-02.json
@@ -18,8 +18,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/4067756a-fcc1-4732-a211-d785d888203c",
 		"startTime": "2026-01-08T20:04:05.330050272Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/4067756a-fcc1-4732-a211-d785d888203c",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/operation-externalauth-create-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/operation-externalauth-create-default.json
@@ -18,8 +18,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/5dce3cac-e09b-4ef5-803c-cb8f17b3a552",
 		"startTime": "2026-01-09T18:32:10.835814057Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/5dce3cac-e09b-4ef5-803c-cb8f17b3a552",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/nodepool-basic-node-pool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/nodepool-basic-node-pool.json
@@ -57,8 +57,7 @@
 				},
 				"serviceProviderProperties": {
 					"activeOperationId": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
-					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"clusterServiceID": ""
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -103,8 +102,7 @@
 		},
 		"serviceProviderProperties": {
 			"activeOperationId": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
-			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s",
-			"usesNewNodePoolDeletionApproach": false
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s"
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/nodepool-node-pool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/nodepool-node-pool-02.json
@@ -55,8 +55,7 @@
 					}
 				},
 				"serviceProviderProperties": {
-					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"clusterServiceID": ""
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -101,8 +100,7 @@
 			}
 		},
 		"serviceProviderProperties": {
-			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4",
-			"usesNewNodePoolDeletionApproach": false
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4"
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/operation-cluster-create-with-tags-create.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/operation-cluster-create-with-tags-create.json
@@ -15,8 +15,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/7a4ed07a-47a1-4efb-966a-93a6316522a0",
 		"startTime": "2025-12-19T19:59:30.714826736Z",
 		"status": "Succeeded",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/7a4ed07a-47a1-4efb-966a-93a6316522a0",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/operation-create-basicnodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/operation-create-basicnodepool.json
@@ -15,8 +15,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
 		"startTime": "2026-01-08T20:04:05.054190978Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/operation-create-nodepool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/operation-create-nodepool-02.json
@@ -15,8 +15,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/4067756a-fcc1-4732-a211-d785d888203c",
 		"startTime": "2026-01-08T20:04:05.330050272Z",
 		"status": "Succeeded",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/4067756a-fcc1-4732-a211-d785d888203c",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/operation-externalauth-create-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/operation-externalauth-create-default.json
@@ -15,8 +15,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/5dce3cac-e09b-4ef5-803c-cb8f17b3a552",
 		"startTime": "2026-01-09T18:32:10.835814057Z",
 		"status": "Succeeded",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/5dce3cac-e09b-4ef5-803c-cb8f17b3a552",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/create-current/05-listActiveOperations-cluster-create/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/create-current/05-listActiveOperations-cluster-create/00-key.json
@@ -1,7 +1,5 @@
 {
 	"parentResourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7",
-	"properties": {
-		"usesNewNodePoolDeletionApproach": false
-	},
+	"properties": {},
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses"
 }

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/create-current/06-cosmosCompare-confirm-content/nodepool-basic-node-pool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/create-current/06-cosmosCompare-confirm-content/nodepool-basic-node-pool.json
@@ -63,8 +63,7 @@
 				},
 				"serviceProviderProperties": {
 					"activeOperationId": "bf643e76-55fe-48a0-a752-f5c5a2db72ad",
-					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"clusterServiceID": ""
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -112,8 +111,7 @@
 		},
 		"serviceProviderProperties": {
 			"activeOperationId": "bf643e76-55fe-48a0-a752-f5c5a2db72ad",
-			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/dl7f9px2f2/node_pools/82npf9hxmk",
-			"usesNewNodePoolDeletionApproach": false
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/dl7f9px2f2/node_pools/82npf9hxmk"
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/create-current/06-cosmosCompare-confirm-content/nodepool-node-pool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/create-current/06-cosmosCompare-confirm-content/nodepool-node-pool-02.json
@@ -63,8 +63,7 @@
 				},
 				"serviceProviderProperties": {
 					"activeOperationId": "25e4713b-44b5-4799-9e60-894a132c6674",
-					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"clusterServiceID": ""
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -112,8 +111,7 @@
 		},
 		"serviceProviderProperties": {
 			"activeOperationId": "25e4713b-44b5-4799-9e60-894a132c6674",
-			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/dl7f9px2f2/node_pools/5zdc9grtvf",
-			"usesNewNodePoolDeletionApproach": false
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/dl7f9px2f2/node_pools/5zdc9grtvf"
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/create-current/06-cosmosCompare-confirm-content/operation-cluster-create-with-tags-create.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/create-current/06-cosmosCompare-confirm-content/operation-cluster-create-with-tags-create.json
@@ -18,8 +18,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/locations/fake-location/hcpOperationStatuses/7a4ed07a-47a1-4efb-966a-93a6316522a0",
 		"startTime": "2025-12-19T19:59:30.714826736Z",
 		"status": "Succeeded",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/7a4ed07a-47a1-4efb-966a-93a6316522a0",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/nodepool-basic-node-pool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/nodepool-basic-node-pool.json
@@ -57,8 +57,7 @@
 				},
 				"serviceProviderProperties": {
 					"activeOperationId": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
-					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"clusterServiceID": ""
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -103,8 +102,7 @@
 		},
 		"serviceProviderProperties": {
 			"activeOperationId": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
-			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s",
-			"usesNewNodePoolDeletionApproach": false
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s"
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/nodepool-node-pool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/nodepool-node-pool-02.json
@@ -57,8 +57,7 @@
 				},
 				"serviceProviderProperties": {
 					"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
-					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"clusterServiceID": ""
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -103,8 +102,7 @@
 		},
 		"serviceProviderProperties": {
 			"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
-			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4",
-			"usesNewNodePoolDeletionApproach": false
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4"
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/operation-cluster-create-with-tags-create.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/operation-cluster-create-with-tags-create.json
@@ -15,8 +15,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/7a4ed07a-47a1-4efb-966a-93a6316522a0",
 		"startTime": "2025-12-19T19:59:30.714826736Z",
 		"status": "Succeeded",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/7a4ed07a-47a1-4efb-966a-93a6316522a0",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/operation-create-basicnodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/operation-create-basicnodepool.json
@@ -18,8 +18,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
 		"startTime": "2026-01-08T20:04:05.054190978Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/operation-create-nodepool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/operation-create-nodepool-02.json
@@ -18,8 +18,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/4067756a-fcc1-4732-a211-d785d888203c",
 		"startTime": "2026-01-08T20:04:05.330050272Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/4067756a-fcc1-4732-a211-d785d888203c",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/04-listActiveOperations-node-create/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/04-listActiveOperations-node-create/00-key.json
@@ -1,7 +1,5 @@
 {
 	"parentResourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7",
-	"properties": {
-		"usesNewNodePoolDeletionApproach": false
-	},
+	"properties": {},
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses"
 }

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/nodepool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/nodepool-02.json
@@ -57,8 +57,7 @@
 				},
 				"serviceProviderProperties": {
 					"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
-					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"clusterServiceID": ""
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -103,8 +102,7 @@
 		},
 		"serviceProviderProperties": {
 			"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
-			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4",
-			"usesNewNodePoolDeletionApproach": false
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4"
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/nodepool-basic-node-pool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/nodepool-basic-node-pool.json
@@ -61,8 +61,7 @@
 				},
 				"serviceProviderProperties": {
 					"activeOperationId": "9e244879-591b-4693-823a-4412b4200f4d",
-					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"clusterServiceID": ""
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -108,8 +107,7 @@
 		},
 		"serviceProviderProperties": {
 			"activeOperationId": "9e244879-591b-4693-823a-4412b4200f4d",
-			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s",
-			"usesNewNodePoolDeletionApproach": false
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s"
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/operation-create-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/operation-create-cluster.json
@@ -15,8 +15,7 @@
 		"resourceId": null,
 		"startTime": "2025-12-19T19:59:30.714826736Z",
 		"status": "Succeeded",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/7a4ed07a-47a1-4efb-966a-93a6316522a0",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/operation-create-nodepool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/operation-create-nodepool-02.json
@@ -15,8 +15,7 @@
 		"resourceId": null,
 		"startTime": "2026-01-08T20:04:05.330050272Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/4067756a-fcc1-4732-a211-d785d888203c",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/operation-create-nodepool-basic.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/operation-create-nodepool-basic.json
@@ -15,8 +15,7 @@
 		"resourceId": null,
 		"startTime": "2026-01-08T20:04:05.054190978Z",
 		"status": "Succeeded",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/operation-update-nodepool-basic.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/operation-update-nodepool-basic.json
@@ -15,8 +15,7 @@
 		"resourceId": null,
 		"startTime": "2026-01-08T20:09:32.571015378Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/50c1a0ba-3bc4-48fb-857e-eb0974df1e1c",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/version-update/08-listActiveOperations-version-update/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/version-update/08-listActiveOperations-version-update/00-key.json
@@ -1,7 +1,5 @@
 {
 	"parentResourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7",
-	"properties": {
-		"usesNewNodePoolDeletionApproach": false
-	},
+	"properties": {},
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses"
 }

--- a/test-integration/frontend/artifacts/FrontendCRUD/Operations/read-new-data/01-load-new-data/operation.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Operations/read-new-data/01-load-new-data/operation.json
@@ -16,8 +16,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/ab5d298a-2267-432a-ad71-313bbdae0349",
 		"startTime": "2026-01-08T19:02:35.73640117Z",
 		"status": "Succeeded",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewNodePoolDeletionApproach": false
+		"tenantId": "00000000-0000-0000-0000-000000000000"
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/ab5d298a-2267-432a-ad71-313bbdae0349",
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",


### PR DESCRIPTION
Remove the temporary migration flag and legacy deletion logic now that the
backend-driven async node pool deletion flow is fully rolled out and all
nodepool deletions cleanup process is managed by backend.

This PR builds on top of https://github.com/Azure/ARO-HCP/pull/5444