### PR TITLE
test: remove timebomb from private keyvault e2e test

### DIFF
--- a/test/e2e/cluster_create_private_kv.go
+++ b/test/e2e/cluster_create_private_kv.go
@@ -16,7 +16,6 @@ package e2e
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -31,10 +30,6 @@ import (
 )
 
 var _ = Describe("Create HCPOpenShiftCluster with Private KeyVault", func() {
-	// Set deadline to a reasonable date after which we expect the private keyvault
-	// feature to be fully ready. Adjust as needed based on rollout schedule.
-	timeBombDeadline := mustParseDate("2026-04-01")
-
 	BeforeEach(func() {
 		// do nothing. per test initialization usually ages better than shared.
 	})
@@ -99,12 +94,6 @@ var _ = Describe("Create HCPOpenShiftCluster with Private KeyVault", func() {
 				clusterResource,
 				framework.ClusterCreationTimeout,
 			)
-			if isAPINotDeployedError(err) {
-				if time.Now().Before(timeBombDeadline) {
-					Skip(fmt.Sprintf("v20251223preview API not yet deployed; skipping until %s", timeBombDeadline.Format(time.RFC3339)))
-				}
-				Fail(fmt.Sprintf("v20251223preview API still not deployed as of %s deadline", timeBombDeadline.Format(time.RFC3339)))
-			}
 			Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster %q with private keyvault", customerClusterName)
 
 			By("verifying cluster was created with private keyvault visibility")
@@ -122,13 +111,7 @@ var _ = Describe("Create HCPOpenShiftCluster with Private KeyVault", func() {
 			Expect(cluster.Properties.Etcd.DataEncryption.CustomerManaged).ToNot(BeNil(), "cluster %q Properties.Etcd.DataEncryption.CustomerManaged was nil", customerClusterName)
 			Expect(cluster.Properties.Etcd.DataEncryption.CustomerManaged.Kms).ToNot(BeNil(), "cluster %q Properties.Etcd.DataEncryption.CustomerManaged.Kms was nil", customerClusterName)
 
-			visibilityNotPresent := cluster.Properties.Etcd.DataEncryption.CustomerManaged.Kms.Visibility == nil
-			if visibilityNotPresent {
-				if time.Now().Before(timeBombDeadline) {
-					Skip("v20251223preview deployed but Visibility field not present in cluster response; skipping until rollout completes")
-				}
-				Fail(fmt.Sprintf("Visibility field still not present in v20251223preview cluster response as of %s deadline", timeBombDeadline.Format(time.RFC3339)))
-			}
+			Expect(cluster.Properties.Etcd.DataEncryption.CustomerManaged.Kms.Visibility).ToNot(BeNil(), "cluster %q Visibility field was nil", customerClusterName)
 			Expect(*cluster.Properties.Etcd.DataEncryption.CustomerManaged.Kms.Visibility).To(Equal(hcpsdk20251223preview.KeyVaultVisibilityPrivate), "cluster etcd encryption key vault visibility should be Private")
 
 			GinkgoLogr.Info("Cluster created successfully with private keyvault",


### PR DESCRIPTION
<!-- No Jira issue -->

### What

Remove the timebomb and skip logic from the private KeyVault cluster creation e2e test.

### Why

The `v20251223preview` API is now fully deployed and the timebomb deadline has passed. The conditional skip/fail guards are no longer needed and the test should run unconditionally.

### Testing

Existing e2e test — this change removes temporary skip logic and replaces it with standard Gomega assertions. No new tests needed.

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [ ] ~~Linked to relevant ticket/issue~~ N/A
- [ ] ~~Screenshots included (if graph/UI/metrics changes)~~ N/A
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Commit history is clean (rebased/squashed)
- [ ] ~~Tricky code blocks are commented~~ N/A
- [ ] Specific reviewers tagged
- [x] All comment threads resolved before merge