### PR TITLE
chore(image-updater): add service-lifecycle-approvers to OWNERS (AROSLSRE-979)

### DIFF
--- a/tooling/image-updater/OWNERS
+++ b/tooling/image-updater/OWNERS
@@ -1,4 +1,4 @@
 approvers:
 - raelga
 - tony-schndr
-- tony-schndr
+- service-lifecycle-approvers

--- a/tooling/image-updater/OWNERS
+++ b/tooling/image-updater/OWNERS
@@ -1,4 +1,3 @@
 approvers:
-- raelga
 - tony-schndr
 - service-lifecycle-approvers


### PR DESCRIPTION
### What

Make `tooling/image-updater/OWNERS` use the shared `service-lifecycle-approvers` alias instead of a hand-maintained list, and clean up the existing duplicate entry.

```diff
 approvers:
-- raelga
-- tony-schndr
 - tony-schndr
+- service-lifecycle-approvers
```

Resulting file:

```yaml
approvers:
- tony-schndr
- service-lifecycle-approvers
```

`raelga` is dropped as a named entry because he is already a member of the `service-lifecycle-approvers` alias. `tony-schndr` is kept because he is **not** part of the alias.

### Why

Previously `tooling/image-updater/OWNERS` only listed two named approvers (and `tony-schndr` was duplicated), so SL SRE team members could not `/approve` image-updater config PRs. This blocked #5418 (`/approve` from @sclarkso was rejected by prow because she is not in the file).

The `service-lifecycle-approvers` alias is already defined in `OWNERS_ALIASES` at the repo root and is the convention used by every sibling area: `acm/`, `config/`, `docs/`, `observability/`, and `dev-infrastructure/`. `tooling/image-updater/` was the only outlier.

Tracked in [AROSLSRE-979](https://redhat.atlassian.net/browse/AROSLSRE-979) / [AROSLSRE-980](https://redhat.atlassian.net/browse/AROSLSRE-980).

### Testing

- `prow/verify-owners` runs automatically on any OWNERS change and validates that the alias resolves.
- After merge, a follow-up image-updater PR `/approve`'d by any SL SRE member not previously named (e.g. @hbhushan3, @sclarkso, @avollmer-redhat) is the functional smoke test.

### Special notes for your reviewer

Bootstrap quirk: **this** PR still needs approval from one of `raelga` or `tony-schndr`, because the wider alias only takes effect after this change is merged.

### PR Checklist

- [x] Title follows Conventional Commits format with Jira key
- [x] Linked to Jira ([AROSLSRE-979](https://redhat.atlassian.net/browse/AROSLSRE-979))
- [x] No code, config, or rendered files affected — pure ownership policy change
