### PR TITLE
fix(hypershift): pin shared ingress image updater (AROSLSRE-978)

### DIFF
--- a/tooling/image-updater/config.yaml
+++ b/tooling/image-updater/config.yaml
@@ -33,11 +33,15 @@ images:
     - jsonPath: defaults.hypershift.image.digest
       filePath: ../../config/config.yaml
   # HyperShift shared ingress HAProxy image
+  #
+  # This image is also rendered into dataplane worker HAProxy static pods via
+  # IMAGE_SHARED_INGRESS_HAPROXY. Keep it pinned to a known-good tag: changing
+  # this digest changes mcoRawConfig and can roll NodePools. See AROSLSRE-978.
   hypershift-shared-ingress:
     group: hypershift-stack
     source:
       image: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
-      tagPattern: "^[a-f0-9]{40}$"
+      tag: "0903f6b78a608541892ecbe8005899a91bda9ad5"
       multiArch: true
     targets:
     - jsonPath: defaults.hypershift.sharedIngressImage.digest


### PR DESCRIPTION
<!-- Link to Jira issue -->

https://redhat.atlassian.net/browse/AROSLSRE-978

### What

Pins the `hypershift-shared-ingress` image-updater component to the exact known-good tag instead of tracking every 40-character tag through `tagPattern`.

### Why

`IMAGE_SHARED_INGRESS_HAPROXY` is rendered into the dataplane worker `kube-apiserver-proxy` HAProxy static pod. Digest changes therefore alter `haproxyRawConfig -> mcoRawConfig -> HashWithoutVersion()` and can trigger a full NodePool rollout.

### Testing

- `make -C tooling/image-updater test`
- `PATH=/tmp/go125/bin:$PATH make yamlfmt`
- `git diff --check`

I also attempted an image-updater dry-run for `hypershift-shared-ingress`; Quay returned HTTP 504 for the exact pinned tag during both updater and direct `oras` manifest lookup, so the config path was validated locally while external registry resolution was unavailable.

### Special notes for your reviewer

This PR only pins the image-updater/bumper config. A separate PR reverts `defaults.hypershift.sharedIngressImage.digest` in `config/config.yaml` to the old safe digest.

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [x] All comment threads resolved before merge
