### PR TITLE
fix(hypershift): revert shared ingress haproxy image (AROSLSRE-978)

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -326,7 +326,10 @@ defaults:
     sharedIngressImage:
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
-      digest: sha256:4eea8f361b3fcb99722b1bf436fc78b999a3ad762bd3162d9566fd6ad156d2f6 # 3779a6ac9ca489bae813319a28ce84768c5b255a (2026-05-21 07:18)
+      # This image is rendered into dataplane worker HAProxy static pods through
+      # IMAGE_SHARED_INGRESS_HAPROXY. Keep it manually pinned: digest bumps change
+      # the NodePool MachineConfig hash and roll workers.
+      digest: sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678 # pinned, see AROSLSRE-978
     limitClusterSizes: false
   # Log settings
   logs:

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -432,7 +432,7 @@ hypershift:
   namespace: hypershift
   sharedIngressIPTag: ""
   sharedIngressImage:
-    digest: sha256:4eea8f361b3fcb99722b1bf436fc78b999a3ad762bd3162d9566fd6ad156d2f6
+    digest: sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678
     registry: quay.io
     repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
 imageRegistryPolicy:

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -432,7 +432,7 @@ hypershift:
   namespace: hypershift
   sharedIngressIPTag: ""
   sharedIngressImage:
-    digest: sha256:4eea8f361b3fcb99722b1bf436fc78b999a3ad762bd3162d9566fd6ad156d2f6
+    digest: sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678
     registry: quay.io
     repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
 imageRegistryPolicy:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -432,7 +432,7 @@ hypershift:
   namespace: hypershift
   sharedIngressIPTag: ""
   sharedIngressImage:
-    digest: sha256:4eea8f361b3fcb99722b1bf436fc78b999a3ad762bd3162d9566fd6ad156d2f6
+    digest: sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678
     registry: quay.io
     repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
 imageRegistryPolicy:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -432,7 +432,7 @@ hypershift:
   namespace: hypershift
   sharedIngressIPTag: ""
   sharedIngressImage:
-    digest: sha256:4eea8f361b3fcb99722b1bf436fc78b999a3ad762bd3162d9566fd6ad156d2f6
+    digest: sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678
     registry: quay.io
     repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
 imageRegistryPolicy:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -432,7 +432,7 @@ hypershift:
   namespace: hypershift
   sharedIngressIPTag: ""
   sharedIngressImage:
-    digest: sha256:4eea8f361b3fcb99722b1bf436fc78b999a3ad762bd3162d9566fd6ad156d2f6
+    digest: sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678
     registry: quay.io
     repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
 imageRegistryPolicy:

--- a/config/rendered/dev/prow/centralus.yaml
+++ b/config/rendered/dev/prow/centralus.yaml
@@ -432,7 +432,7 @@ hypershift:
   namespace: hypershift
   sharedIngressIPTag: ""
   sharedIngressImage:
-    digest: sha256:4eea8f361b3fcb99722b1bf436fc78b999a3ad762bd3162d9566fd6ad156d2f6
+    digest: sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678
     registry: quay.io
     repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
 imageRegistryPolicy:

--- a/tooling/image-updater/config.yaml
+++ b/tooling/image-updater/config.yaml
@@ -37,7 +37,7 @@ images:
     group: hypershift-stack
     source:
       image: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
-      tagPattern: "^[a-f0-9]{40}$"
+      tag: "0903f6b78a608541892ecbe8005899a91bda9ad5"
       multiArch: true
     targets:
     - jsonPath: defaults.hypershift.sharedIngressImage.digest


### PR DESCRIPTION
<!-- Link to Jira issue -->

- Parent incident: https://redhat.atlassian.net/browse/AROSLSRE-978
- Pin shared ingress HAProxy image bumper input: https://redhat.atlassian.net/browse/AROSLSRE-983
- Revert global shared ingress HAProxy digest: https://redhat.atlassian.net/browse/AROSLSRE-984

### What

Reverts `defaults.hypershift.sharedIngressImage.digest` from the newer shared ingress HAProxy digest back to the old known-safe digest, and pins the image-updater entry to the matching old tag so bumper runs do not move it again.

```text
old safe: sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678
old tag:  0903f6b78a608541892ecbe8005899a91bda9ad5
newer:    sha256:4eea8f361b3fcb99722b1bf436fc78b999a3ad762bd3162d9566fd6ad156d2f6
```

### Why

`IMAGE_SHARED_INGRESS_HAPROXY` is rendered into the dataplane worker `kube-apiserver-proxy` HAProxy static pod. Digest changes alter `haproxyRawConfig -> mcoRawConfig -> HashWithoutVersion()` and can trigger a full NodePool rollout.

### Testing

- `make -C config materialize`
- `make -C tooling/image-updater test`
- `PATH=/tmp/go125/bin:$PATH make yamlfmt`
- `git diff --check`
- `crane digest quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main:0903f6b78a608541892ecbe8005899a91bda9ad5`

### Special notes for your reviewer

This intentionally pins both the rendered config digest and the bumper source tag. Prod UK South already rendered the newer digest, so it needs a separate sdp-pipelines region override before this revert is promoted there (tracked under AROSLSRE-985, with follow-up cleanup in [AROSLSRE-994](https://redhat.atlassian.net/browse/AROSLSRE-994)).

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [x] All comment threads resolved before merge
