### PR TITLE
Map Prometheus critical severity to IcM sev 2

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedHCPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedHCPPrometheusAlertingRules.bicep
@@ -711,7 +711,7 @@ resource kubernetesStorage 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
         }
         expression: '( kubelet_volume_stats_available_bytes{job="kubelet", metrics_path="/metrics"} / kubelet_volume_stats_capacity_bytes{job="kubelet", metrics_path="/metrics"} ) < 0.03 and kubelet_volume_stats_used_bytes{job="kubelet", metrics_path="/metrics"} > 0 unless on(cluster, namespace, persistentvolumeclaim) kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1 unless on(cluster, namespace, persistentvolumeclaim) kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"} == 1'
         for: 'PT1M'
-        severity: 3
+        severity: 2
       }
       {
         actions: [
@@ -765,7 +765,7 @@ resource kubernetesStorage 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
         }
         expression: '( kubelet_volume_stats_inodes_free{job="kubelet", metrics_path="/metrics"} / kubelet_volume_stats_inodes{job="kubelet", metrics_path="/metrics"} ) < 0.03 and kubelet_volume_stats_inodes_used{job="kubelet", metrics_path="/metrics"} > 0 unless on(cluster, namespace, persistentvolumeclaim) kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1 unless on(cluster, namespace, persistentvolumeclaim) kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"} == 1'
         for: 'PT1M'
-        severity: 3
+        severity: 2
       }
       {
         actions: [
@@ -819,7 +819,7 @@ resource kubernetesStorage 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
         }
         expression: 'kube_persistentvolume_status_phase{phase=~"Failed|Pending",job="kube-state-metrics"} > 0'
         for: 'PT5M'
-        severity: 3
+        severity: 2
       }
     ]
     scopes: [
@@ -928,7 +928,7 @@ resource kubeApiserverSlos 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
         }
         expression: 'sum(apiserver_request:burnrate1h) > (14.40 * 0.01000) and sum(apiserver_request:burnrate5m) > (14.40 * 0.01000)'
         for: 'PT2M'
-        severity: 3
+        severity: 2
       }
       {
         actions: [
@@ -957,7 +957,7 @@ resource kubeApiserverSlos 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
         }
         expression: 'sum(apiserver_request:burnrate6h) > (6.00 * 0.01000) and sum(apiserver_request:burnrate30m) > (6.00 * 0.01000)'
         for: 'PT15M'
-        severity: 3
+        severity: 2
       }
       {
         actions: [
@@ -1082,7 +1082,7 @@ resource kubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRuleGro
         }
         expression: 'apiserver_client_certificate_expiration_seconds_count{job="controlplane-apiserver"} > 0 and on(job) histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="controlplane-apiserver"}[5m]))) < 86400'
         for: 'PT5M'
-        severity: 3
+        severity: 2
       }
       {
         actions: [
@@ -1162,7 +1162,7 @@ resource kubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRuleGro
         }
         expression: 'count by (cluster) (up{job="controlplane-apiserver"} == 1) == 0'
         for: 'PT15M'
-        severity: 3
+        severity: 2
       }
       {
         actions: [
@@ -1416,7 +1416,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
           title: 'Kubelet client certificate is about to expire.'
         }
         expression: 'kubelet_certificate_manager_client_ttl_seconds < 86400'
-        severity: 3
+        severity: 2
       }
       {
         actions: [
@@ -1468,7 +1468,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
           title: 'Kubelet server certificate is about to expire.'
         }
         expression: 'kubelet_certificate_manager_server_ttl_seconds < 86400'
-        severity: 3
+        severity: 2
       }
       {
         actions: [
@@ -1549,7 +1549,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
         }
         expression: 'count by (cluster) (up{job="kubelet", metrics_path="/metrics"} == 1) == 0'
         for: 'PT15M'
-        severity: 3
+        severity: 2
       }
     ]
     scopes: [
@@ -1589,7 +1589,7 @@ resource kubernetesSystemScheduler 'Microsoft.AlertsManagement/prometheusRuleGro
         }
         expression: 'count by (cluster) (up{job="controlplane-kube-scheduler"} == 1) == 0'
         for: 'PT15M'
-        severity: 3
+        severity: 2
       }
     ]
     scopes: [
@@ -1629,7 +1629,7 @@ resource kubernetesSystemControllerManager 'Microsoft.AlertsManagement/prometheu
         }
         expression: 'count by (cluster) (up{job="controlplane-kube-controller-manager"} == 1) == 0'
         for: 'PT15M'
-        severity: 3
+        severity: 2
       }
     ]
     scopes: [

--- a/dev-infrastructure/modules/metrics/rules/generatedMsftPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedMsftPrometheusAlertingRules.bicep
@@ -213,7 +213,7 @@ resource msftKubernetesStorage 'Microsoft.AlertsManagement/prometheusRuleGroups@
         }
         expression: 'kube_persistentvolume_status_phase{phase=~"Failed|Pending",job="kube-state-metrics"} > 0'
         for: 'PT5M'
-        severity: 3
+        severity: 2
       }
     ]
     scopes: [
@@ -295,7 +295,7 @@ resource msftKubeApiserverSlos 'Microsoft.AlertsManagement/prometheusRuleGroups@
         }
         expression: 'sum(apiserver_request:burnrate1h) > (14.40 * 0.01000) and sum(apiserver_request:burnrate5m) > (14.40 * 0.01000)'
         for: 'PT2M'
-        severity: 3
+        severity: 2
       }
       {
         actions: [
@@ -324,7 +324,7 @@ resource msftKubeApiserverSlos 'Microsoft.AlertsManagement/prometheusRuleGroups@
         }
         expression: 'sum(apiserver_request:burnrate6h) > (6.00 * 0.01000) and sum(apiserver_request:burnrate30m) > (6.00 * 0.01000)'
         for: 'PT15M'
-        severity: 3
+        severity: 2
       }
       {
         actions: [
@@ -449,7 +449,7 @@ resource msftKubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRul
         }
         expression: 'apiserver_client_certificate_expiration_seconds_count{job="controlplane-apiserver"} > 0 and on(job) histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="controlplane-apiserver"}[5m]))) < 86400'
         for: 'PT5M'
-        severity: 3
+        severity: 2
       }
       {
         actions: [
@@ -529,7 +529,7 @@ resource msftKubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRul
         }
         expression: 'count by (cluster) (up{job="controlplane-apiserver"} == 1) == 0'
         for: 'PT15M'
-        severity: 3
+        severity: 2
       }
       {
         actions: [
@@ -783,7 +783,7 @@ resource msftKubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleG
           title: 'Kubelet client certificate is about to expire.'
         }
         expression: 'kubelet_certificate_manager_client_ttl_seconds < 86400'
-        severity: 3
+        severity: 2
       }
       {
         actions: [
@@ -835,7 +835,7 @@ resource msftKubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleG
           title: 'Kubelet server certificate is about to expire.'
         }
         expression: 'kubelet_certificate_manager_server_ttl_seconds < 86400'
-        severity: 3
+        severity: 2
       }
       {
         actions: [
@@ -916,7 +916,7 @@ resource msftKubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleG
         }
         expression: 'count by (cluster) (up{job="kubelet", metrics_path="/metrics"} == 1) == 0'
         for: 'PT15M'
-        severity: 3
+        severity: 2
       }
     ]
     scopes: [
@@ -956,7 +956,7 @@ resource msftKubernetesSystemScheduler 'Microsoft.AlertsManagement/prometheusRul
         }
         expression: 'count by (cluster) (up{job="controlplane-kube-scheduler"} == 1) == 0'
         for: 'PT15M'
-        severity: 3
+        severity: 2
       }
     ]
     scopes: [
@@ -996,7 +996,7 @@ resource msftKubernetesSystemControllerManager 'Microsoft.AlertsManagement/prome
         }
         expression: 'count by (cluster) (up{job="controlplane-kube-controller-manager"} == 1) == 0'
         for: 'PT15M'
-        severity: 3
+        severity: 2
       }
     ]
     scopes: [
@@ -1042,7 +1042,7 @@ Check the status of the Prometheus pods, service endpoints, and network connecti
         }
         expression: 'group by (cluster) (up{job="kube-state-metrics"}) unless on(cluster) group by (cluster) (up{job="prometheus/prometheus",namespace="prometheus"} == 1)'
         for: 'PT10M'
-        severity: 3
+        severity: 2
       }
       {
         actions: [
@@ -1075,7 +1075,7 @@ Please check the status of the Prometheus pods, service endpoints, and network c
         }
         expression: 'avg by (job, namespace, cluster) (avg_over_time(up{job="prometheus/prometheus",namespace="prometheus"}[1d])) < 0.95'
         for: 'PT10M'
-        severity: 3
+        severity: 2
       }
       {
         actions: [
@@ -1112,7 +1112,7 @@ Investigate the health and performance of the remote storage endpoint, network l
         }
         expression: '( prometheus_remote_storage_samples_pending / prometheus_remote_storage_samples_in_flight ) > 0.4'
         for: 'PT15M'
-        severity: 3
+        severity: 2
       }
       {
         actions: [
@@ -1149,7 +1149,7 @@ Please check the health and performance of the remote storage endpoint, network 
         }
         expression: '( rate(prometheus_remote_storage_samples_failed_total[5m]) / rate(prometheus_remote_storage_samples_total[5m]) ) > 0.1'
         for: 'PT15M'
-        severity: 3
+        severity: 2
       }
     ]
     scopes: [
@@ -1189,7 +1189,7 @@ resource msftPrometheusRules 'Microsoft.AlertsManagement/prometheusRuleGroups@20
         }
         expression: '((rate(prometheus_remote_storage_failed_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) or rate(prometheus_remote_storage_samples_failed_total{job="prometheus/prometheus",namespace="prometheus"}[5m])) / ((rate(prometheus_remote_storage_failed_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) or rate(prometheus_remote_storage_samples_failed_total{job="prometheus/prometheus",namespace="prometheus"}[5m])) + (rate(prometheus_remote_storage_succeeded_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) or rate(prometheus_remote_storage_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m])))) * 100 > 1'
         for: 'PT15M'
-        severity: 3
+        severity: 2
       }
       {
         actions: [
@@ -1243,7 +1243,7 @@ resource msftPrometheusRules 'Microsoft.AlertsManagement/prometheusRuleGroups@20
         }
         expression: 'max_over_time(prometheus_config_last_reload_successful{job="prometheus/prometheus",namespace="prometheus"}[5m]) == 0'
         for: 'PT10M'
-        severity: 3
+        severity: 2
       }
       {
         actions: [
@@ -1390,7 +1390,7 @@ resource msftMsiCredentialRefresher 'Microsoft.AlertsManagement/prometheusRuleGr
         }
         expression: 'sum by (cluster) (increase(credential_refresher_days_until_msi_credential_expiration_bucket{le="30"}[30m])) - sum by (cluster) (increase(credential_refresher_days_until_msi_credential_expiration_bucket{le="0"}[30m])) > 0'
         for: 'PT5M'
-        severity: 3
+        severity: 2
       }
       {
         actions: [
@@ -1417,7 +1417,7 @@ resource msftMsiCredentialRefresher 'Microsoft.AlertsManagement/prometheusRuleGr
         }
         expression: 'sum by (cluster) (increase(credential_refresher_days_until_msi_credential_expiration_bucket{le="0"}[30m])) - sum by (cluster) (increase(credential_refresher_days_until_msi_credential_expiration_bucket{le="-90"}[30m])) > 0'
         for: 'PT5M'
-        severity: 3
+        severity: 2
       }
       {
         actions: [
@@ -1444,7 +1444,7 @@ resource msftMsiCredentialRefresher 'Microsoft.AlertsManagement/prometheusRuleGr
         }
         expression: 'sum by (cluster) (increase(credential_refresher_days_until_msi_credential_expiration_bucket{le="-90"}[30m])) > 0'
         for: 'PT5M'
-        severity: 3
+        severity: 2
       }
     ]
     scopes: [

--- a/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
@@ -44,7 +44,7 @@ Check the status of the Prometheus pods, service endpoints, and network connecti
         }
         expression: 'group by (cluster) (up{job="kube-state-metrics"}) unless on(cluster) group by (cluster) (up{job="prometheus/prometheus",namespace="prometheus"} == 1)'
         for: 'PT10M'
-        severity: 3
+        severity: 2
       }
       {
         actions: [
@@ -77,7 +77,7 @@ Please check the status of the Prometheus pods, service endpoints, and network c
         }
         expression: 'avg by (job, namespace, cluster) (avg_over_time(up{job="prometheus/prometheus",namespace="prometheus"}[1d])) < 0.95'
         for: 'PT10M'
-        severity: 3
+        severity: 2
       }
       {
         actions: [
@@ -114,7 +114,7 @@ Investigate the health and performance of the remote storage endpoint, network l
         }
         expression: '( prometheus_remote_storage_samples_pending / prometheus_remote_storage_samples_in_flight ) > 0.4'
         for: 'PT15M'
-        severity: 3
+        severity: 2
       }
       {
         actions: [
@@ -151,7 +151,7 @@ Please check the health and performance of the remote storage endpoint, network 
         }
         expression: '( rate(prometheus_remote_storage_samples_failed_total[5m]) / rate(prometheus_remote_storage_samples_total[5m]) ) > 0.1'
         for: 'PT15M'
-        severity: 3
+        severity: 2
       }
     ]
     scopes: [
@@ -191,7 +191,7 @@ resource prometheusRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
         }
         expression: '((rate(prometheus_remote_storage_failed_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) or rate(prometheus_remote_storage_samples_failed_total{job="prometheus/prometheus",namespace="prometheus"}[5m])) / ((rate(prometheus_remote_storage_failed_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) or rate(prometheus_remote_storage_samples_failed_total{job="prometheus/prometheus",namespace="prometheus"}[5m])) + (rate(prometheus_remote_storage_succeeded_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) or rate(prometheus_remote_storage_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m])))) * 100 > 1'
         for: 'PT15M'
-        severity: 3
+        severity: 2
       }
       {
         actions: [
@@ -245,7 +245,7 @@ resource prometheusRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
         }
         expression: 'max_over_time(prometheus_config_last_reload_successful{job="prometheus/prometheus",namespace="prometheus"}[5m]) == 0'
         for: 'PT10M'
-        severity: 3
+        severity: 2
       }
       {
         actions: [

--- a/tooling/prometheus-rules/internal/generator.go
+++ b/tooling/prometheus-rules/internal/generator.go
@@ -54,7 +54,6 @@ type GroupAlerts struct {
 }
 
 type Options struct {
-	forceInfoSeverity       bool
 	promtoolPath            string
 	outputBicep             string
 	includedAlerts          map[string][]string
@@ -101,9 +100,7 @@ func readRulesFile(filename string) (*monitoringv1.PrometheusRule, error) {
 	return &rules, nil
 }
 
-func (o *Options) Complete(configFilePath string, forceInfoSeverity bool, promtoolPath string) error {
-
-	o.forceInfoSeverity = forceInfoSeverity
+func (o *Options) Complete(configFilePath string, promtoolPath string) error {
 	if promtoolPath == "" {
 		return fmt.Errorf("promtoolPath cannot be an empty string")
 	}
@@ -412,7 +409,7 @@ param location string = resourceGroup().location
 								whitespaceMatcher.ReplaceAllString(rule.Expr.String(), " "),
 							),
 						),
-						Severity: severityFor(labels, o.forceInfoSeverity),
+						Severity: severityFor(labels),
 					})
 				} else if rule.Record != "" && isRecordingRulesFile {
 					armGroup.Properties.Rules = append(armGroup.Properties.Rules, &armprometheusrulegroups.PrometheusRule{
@@ -605,12 +602,7 @@ func parseToAzureDurationString(d *monitoringv1.Duration) *string {
 	return ptr.To("PT" + strings.ToUpper(parsedDuration.String()))
 }
 
-func severityFor(labels map[string]*string, forceInfoSeverity bool) *int32 {
-	if forceInfoSeverity {
-		logrus.Warnf("Ignoring severity label due to --force-info-severity flag; severity set to 'info'")
-		return ptr.To(int32(3))
-	}
-
+func severityFor(labels map[string]*string) *int32 {
 	severity, ok := labels["severity"]
 	if !ok || severity == nil {
 		return nil

--- a/tooling/prometheus-rules/internal/generator.go
+++ b/tooling/prometheus-rules/internal/generator.go
@@ -621,11 +621,7 @@ func severityFor(labels map[string]*string, forceInfoSeverity bool) *int32 {
 
 	switch *severity {
 	case "critical":
-		// return ptr.To(int32(2)) // SEV 2: Single service SLA impact.
-		// @jboll
-		// Does it really make sense to have generated SEV2 Alerts?
-		// Consider adding such an alert manually, ensuring it has right quality.
-		return ptr.To(int32(3))
+		return ptr.To(int32(2)) // SEV 2: Single service SLA impact.
 	case "warning":
 		return ptr.To(int32(3)) // SEV 3: Urgent/high business impact, no SLA impact.
 	case "info":

--- a/tooling/prometheus-rules/internal/generator_test.go
+++ b/tooling/prometheus-rules/internal/generator_test.go
@@ -353,7 +353,7 @@ spec:
 			}
 
 			opts := NewOptions()
-			err := opts.Complete(configPath, false, "promtool")
+			err := opts.Complete(configPath, "promtool")
 
 			if tt.expectError {
 				assert.Error(t, err)
@@ -647,27 +647,20 @@ func TestParseToAzureDurationString(t *testing.T) {
 
 func TestSeverityFor(t *testing.T) {
 	tests := []struct {
-		labels            map[string]*string
-		forceInfoSeverity bool
-		expected          *int32
+		labels   map[string]*string
+		expected *int32
 	}{
-		{map[string]*string{"severity": ptr.To("critical")}, false, ptr.To(int32(2))},
-		{map[string]*string{"severity": ptr.To("warning")}, false, ptr.To(int32(3))},
-		{map[string]*string{"severity": ptr.To("info")}, false, ptr.To(int32(4))},
-		{map[string]*string{"severity": ptr.To("unknown")}, false, ptr.To(int32(4))},
-		{map[string]*string{}, false, nil},
-		{map[string]*string{"other": ptr.To("value")}, false, nil},
-		{map[string]*string{"severity": ptr.To("critical")}, true, ptr.To(int32(3))},
-		{map[string]*string{"severity": ptr.To("warning")}, true, ptr.To(int32(3))},
-		{map[string]*string{"severity": ptr.To("info")}, true, ptr.To(int32(3))},
-		{map[string]*string{"severity": ptr.To("unknown")}, true, ptr.To(int32(3))},
-		{map[string]*string{}, true, ptr.To(int32(3))},
-		{map[string]*string{"other": ptr.To("value")}, true, ptr.To(int32(3))},
+		{map[string]*string{"severity": ptr.To("critical")}, ptr.To(int32(2))},
+		{map[string]*string{"severity": ptr.To("warning")}, ptr.To(int32(3))},
+		{map[string]*string{"severity": ptr.To("info")}, ptr.To(int32(4))},
+		{map[string]*string{"severity": ptr.To("unknown")}, ptr.To(int32(4))},
+		{map[string]*string{}, nil},
+		{map[string]*string{"other": ptr.To("value")}, nil},
 	}
 
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("labels_%v", tt.labels), func(t *testing.T) {
-			result := severityFor(tt.labels, tt.forceInfoSeverity)
+			result := severityFor(tt.labels)
 			if tt.expected == nil {
 				assert.Nil(t, result)
 			} else {

--- a/tooling/prometheus-rules/internal/generator_test.go
+++ b/tooling/prometheus-rules/internal/generator_test.go
@@ -464,7 +464,7 @@ func TestOptionsGenerate(t *testing.T) {
 		assert.Contains(t, generated, "param actionGroups array")
 		assert.Contains(t, generated, "Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01")
 		assert.Contains(t, generated, "alert: 'TestAlert'")
-		assert.Contains(t, generated, "severity: 3")
+		assert.Contains(t, generated, "severity: 2")
 	})
 
 	t.Run("with included alerts", func(t *testing.T) {
@@ -651,7 +651,7 @@ func TestSeverityFor(t *testing.T) {
 		forceInfoSeverity bool
 		expected          *int32
 	}{
-		{map[string]*string{"severity": ptr.To("critical")}, false, ptr.To(int32(3))},
+		{map[string]*string{"severity": ptr.To("critical")}, false, ptr.To(int32(2))},
 		{map[string]*string{"severity": ptr.To("warning")}, false, ptr.To(int32(3))},
 		{map[string]*string{"severity": ptr.To("info")}, false, ptr.To(int32(4))},
 		{map[string]*string{"severity": ptr.To("unknown")}, false, ptr.To(int32(4))},

--- a/tooling/prometheus-rules/main.go
+++ b/tooling/prometheus-rules/main.go
@@ -28,11 +28,9 @@ func main() {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
 	var configFilePath string
-	var forceInfoSeverity bool
 	var promtoolPath string
 
 	flag.CommandLine.StringVar(&configFilePath, "config-file", "", "Path to configuration")
-	flag.CommandLine.BoolVar(&forceInfoSeverity, "force-info-severity", false, "Force all rule severities to info")
 	flag.CommandLine.StringVar(&promtoolPath, "promtool-path", "promtool", "Path to promtool binary ")
 	flag.Parse()
 
@@ -40,7 +38,7 @@ func main() {
 		logrus.WithError(err).Fatal("invalid options")
 	}
 
-	if err := prometheusrules.GenerateFromConfig(configFilePath, forceInfoSeverity, promtoolPath); err != nil {
+	if err := prometheusrules.GenerateFromConfig(configFilePath, promtoolPath); err != nil {
 		logrus.WithError(err).Fatal("error running generator")
 	}
 

--- a/tooling/prometheus-rules/main_test.go
+++ b/tooling/prometheus-rules/main_test.go
@@ -72,7 +72,7 @@ func TestPrometheusRules(t *testing.T) {
 			} {
 				require.NoError(t, copyFile(testfile, filepath.Join(tmpDir, "alerts")))
 			}
-			err := prometheusrules.GenerateFromConfig(filepath.Join(tmpDir, "config.yaml"), false, "promtool")
+			err := prometheusrules.GenerateFromConfig(filepath.Join(tmpDir, "config.yaml"), "promtool")
 			require.NoError(t, err)
 
 			generatedFile, err := os.ReadFile(filepath.Join(tmpDir, "zzz_generated_AlertingRules.bicep"))
@@ -100,7 +100,7 @@ func TestPrometheusRulesMissingTest(t *testing.T) {
 	} {
 		require.NoError(t, copyFile(testfile, filepath.Join(tmpDir, "alerts")))
 	}
-	err := prometheusrules.GenerateFromConfig(filepath.Join(tmpDir, "config.yaml"), false, "promtool")
+	err := prometheusrules.GenerateFromConfig(filepath.Join(tmpDir, "config.yaml"), "promtool")
 	require.ErrorContains(t, err, "missing testfile")
 }
 
@@ -139,7 +139,7 @@ tests: []
 
 	// Run the generator - it should handle mixed rules based on file type
 	// Since we're using AlertingRules filename, it should process only alerts
-	err = prometheusrules.GenerateFromConfig(filepath.Join(tmpDir, "config.yaml"), false, "promtool")
+	err = prometheusrules.GenerateFromConfig(filepath.Join(tmpDir, "config.yaml"), "promtool")
 	require.NoError(t, err)
 
 	// Verify the generated file exists and contains only alert rules

--- a/tooling/prometheus-rules/pkg/prometheusrules/prometheusrules.go
+++ b/tooling/prometheus-rules/pkg/prometheusrules/prometheusrules.go
@@ -36,10 +36,10 @@ func Validate(args []string, configFilePath, promtoolPath string) error {
 }
 
 // GenerateFromConfig validates and renders rule files into Bicep output.
-func GenerateFromConfig(configFilePath string, forceInfoSeverity bool, promtoolPath string) error {
+func GenerateFromConfig(configFilePath string, promtoolPath string) error {
 	o := internal.NewOptions()
 
-	if err := o.Complete(configFilePath, forceInfoSeverity, promtoolPath); err != nil {
+	if err := o.Complete(configFilePath, promtoolPath); err != nil {
 		return fmt.Errorf("could not complete options, %w", err)
 	}
 	if err := o.RunTests(); err != nil {

--- a/tooling/prometheus-rules/testdata/generated.bicep
+++ b/tooling/prometheus-rules/testdata/generated.bicep
@@ -34,7 +34,7 @@ resource InstancesDownV1 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
           title: 'All instances of the App are down'
         }
         expression: 'sum(up{job="app"}) == 0'
-        severity: 3
+        severity: 2
       }
       {
         actions: [for g in actionGroups: {

--- a/tooling/prometheus-rules/testdata/generated_5m.bicep
+++ b/tooling/prometheus-rules/testdata/generated_5m.bicep
@@ -34,7 +34,7 @@ resource InstancesDownV1 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
           title: 'All instances of the App are down'
         }
         expression: 'sum(up{job="app"}) == 0'
-        severity: 3
+        severity: 2
       }
       {
         actions: [for g in actionGroups: {


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-988

## Summary
- The `severityFor()` function in the prometheus-rules generator previously mapped `critical` alerts to Azure Monitor severity 3 (same as `warning`), with a commented-out sev 2 return
- This change enables the sev 2 mapping so that critical alerts are properly distinguished from warnings at the IcM level
- Regenerated all bicep alerting rule files to reflect the new severity mapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)