### PR TITLE
removing venkateshsredhat from test/OWNERS file

### DIFF
--- a/test/OWNERS
+++ b/test/OWNERS
@@ -1,7 +1,6 @@
 approvers:
 - deads2k
 - bennerv
-- venkateshsredhat
 - patriksuba
 - miquelsi
 - mgahagan73


### PR DESCRIPTION
Removing [venkateshsredhat](https://github.com/venkateshsredhat) from test/OWNERS file to keep OWNERS file up to date.