### PR TITLE
Add an lower bound alert on AMW ingestion

### DIFF
--- a/dev-infrastructure/modules/metrics/amw-ingestion-alerts.bicep
+++ b/dev-infrastructure/modules/metrics/amw-ingestion-alerts.bicep
@@ -10,6 +10,9 @@ param actionGroups array
 @description('Whether alerts are enabled')
 param enabled bool
 
+@description('Threshold (percent) below which the low event ingestion alert fires')
+param lowEventIngestionThreshold int
+
 @description('Runbook URL for Prometheus metrics absent alert')
 param prometheusRunbookUrl string = 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/troubleshooting/prometheus.html'
 
@@ -178,6 +181,40 @@ resource highRiskEventIngestion 'Microsoft.Insights/metricAlerts@2018-03-01' = {
           name: 'EventsPerMinuteCriteria'
           metricName: 'EventsPerMinuteIngestedPercentUtilization'
           operator: 'GreaterThan'
+          timeAggregation: 'Average'
+          criterionType: 'StaticThresholdCriterion'
+        }
+      ]
+    }
+    actions: [
+      for g in actionGroups: {
+        actionGroupId: g
+      }
+    ]
+  }
+}
+
+resource lowEventIngestion 'Microsoft.Insights/metricAlerts@2018-03-01' = {
+  name: 'AMW Low Event Ingestion Utilization - ${workspaceLabel} - ${amwName}'
+  location: 'global'
+  properties: {
+    description: 'Events Per Minute utilization is below ${lowEventIngestionThreshold}%. This may indicate that Prometheus remote write is broken or that very few metrics are being ingested. Investigate the ingestion pipeline. https://learn.microsoft.com/azure/azure-monitor/metrics/azure-monitor-workspace-monitor-ingest-limits'
+    severity: 3
+    enabled: enabled
+    autoMitigate: true
+    scopes: [
+      azureMonitorWorkspaceId
+    ]
+    evaluationFrequency: 'PT5M'
+    windowSize: 'PT30M'
+    criteria: {
+      'odata.type': 'Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria'
+      allOf: [
+        {
+          threshold: lowEventIngestionThreshold
+          name: 'EventsPerMinuteCriteria'
+          metricName: 'EventsPerMinuteIngestedPercentUtilization'
+          operator: 'LessThan'
           timeAggregation: 'Average'
           criterionType: 'StaticThresholdCriterion'
         }

--- a/dev-infrastructure/modules/metrics/amw-ingestion-alerts.bicep
+++ b/dev-infrastructure/modules/metrics/amw-ingestion-alerts.bicep
@@ -198,7 +198,7 @@ resource lowEventIngestion 'Microsoft.Insights/metricAlerts@2018-03-01' = {
   name: 'AMW Low Event Ingestion Utilization - ${workspaceLabel} - ${amwName}'
   location: 'global'
   properties: {
-    description: 'Events Per Minute utilization is below ${lowEventIngestionThreshold}%. This may indicate that Prometheus remote write is broken or that very few metrics are being ingested. Investigate the ingestion pipeline. https://learn.microsoft.com/azure/azure-monitor/metrics/azure-monitor-workspace-monitor-ingest-limits'
+    description: 'Events Per Minute utilization is below limit. This may indicate that Prometheus remote write is broken or that very few metrics are being ingested. Investigate the ingestion pipeline. https://learn.microsoft.com/azure/azure-monitor/metrics/azure-monitor-workspace-monitor-ingest-limits'
     severity: 3
     enabled: enabled
     autoMitigate: true

--- a/dev-infrastructure/templates/monitoring.bicep
+++ b/dev-infrastructure/templates/monitoring.bicep
@@ -137,6 +137,7 @@ module svcIngestionAlerts '../modules/metrics/amw-ingestion-alerts.bicep' = {
     workspaceLabel: 'svc'
     actionGroups: sreActionGroups
     enabled: alertsEnabled
+    lowEventIngestionThreshold: 1
   }
 }
 
@@ -147,5 +148,6 @@ module hcpIngestionAlerts '../modules/metrics/amw-ingestion-alerts.bicep' = {
     workspaceLabel: 'hcp'
     actionGroups: sreActionGroups
     enabled: alertsEnabled
+    lowEventIngestionThreshold: 5
   }
 }


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-982

<!-- Link to Jira issue -->

### What/Why

Added a new lowEventIngestionThreshold parameter and a lowEventIngestion metric alert that fires when EventsPerMinuteIngestedPercentUtilization drops below the threshold (using LessThan  operator, severity 3).

dev-infrastructure/templates/monitoring.bicep — Passes the threshold to both call sites:
 - svc: lowEventIngestionThreshold: 1 (alerts below 1%)
 - hcp: lowEventIngestionThreshold: 5 (alerts below 5%)

