### PR TITLE
feat: prepare internal api attributes related to async externalauth deletion trigger in backend

### DIFF
--- a/frontend/pkg/frontend/external_auth.go
+++ b/frontend/pkg/frontend/external_auth.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
@@ -656,6 +657,9 @@ func (f *Frontend) addDeleteExternalAuthToTransaction(ctx context.Context, write
 		return utils.TrackError(err)
 	}
 
+	if externalAuth.ServiceProviderProperties.DeletionTimestamp == nil {
+		externalAuth.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: time.Now().UTC()}
+	}
 	externalAuth.ServiceProviderProperties.ActiveOperationID = operationDoc.ResourceID.Name
 	externalAuth.Properties.ProvisioningState = operationDoc.Status
 	_, err = f.resourcesDBClient.HCPClusters(externalAuth.ID.SubscriptionID, externalAuth.ID.ResourceGroupName).ExternalAuth(externalAuth.ID.Parent.Name).

--- a/internal/api/types_externalauth.go
+++ b/internal/api/types_externalauth.go
@@ -17,6 +17,8 @@ package api
 import (
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
 	"github.com/Azure/ARO-HCP/internal/api/arm"
@@ -62,6 +64,30 @@ type HCPOpenShiftClusterExternalAuthProperties struct {
 type HCPOpenShiftClusterExternalAuthServiceProviderProperties struct {
 	ClusterServiceID  *InternalID `json:"clusterServiceID,omitempty"`
 	ActiveOperationID string      `json:"activeOperationId,omitempty"`
+	// DeletionTimestamp is the timestamp at which the ExternalAuth deletion was requested.
+	// The timestamp is in UTC.
+	// A nil value indicates that the ExternalAuth deletion has not been requested.
+	DeletionTimestamp *metav1.Time `json:"deletionTimestamp,omitempty"`
+	// ClusterServiceDeletionTimestamp is written when a dispatch of a Cluster
+	// Service Delete ExternalAuth request against Cluster Service for this
+	// external auth has been handled. It is set after a successful
+	// DeleteExternalAuth call to Cluster Service, but also when it's
+	// determined that no delete call is needed but we consider we should
+	// behave as if the delete call was successfully issued (for example, if
+	// the parent cluster of the external auth is already being uninstalled,
+	// because cluster-service will already take care of deleting the
+	// external auth as part of the cluster teardown).
+	// A nil value indicates that the Cluster Service Deletion has not been requested.
+	// The timestamp is in UTC.
+	// TODO this attribute is not in use yet. Do not rely on it.
+	ClusterServiceDeletionTimestamp *metav1.Time `json:"clusterServiceDeletionTimestamp,omitempty"`
+
+	// TODO Temporary field to track whether the external auth operation is using the new deletion approach.
+	// We are migrating from the external auth CS deletion synchronous in frontend to the backend, to be fully asynchronous.
+	// This boolean is true for ExternalAuth delete operations that are created with new deletion approach.
+	// This will be removed once all external auths whose deletion was triggered before the new approach is fully rolled out have been
+	// fully deleted in all ARO-HCP permanent environments, for all regions.
+	UsesNewExternalAuthDeletionApproach bool `json:"usesNewExternalAuthDeletionApproach"`
 }
 
 // Condition defines an observation of the external auth state.

--- a/internal/api/types_operation.go
+++ b/internal/api/types_operation.go
@@ -77,6 +77,13 @@ type Operation struct {
 	// This will be removed once all nodepools whose deletion was triggered before the new approach is fully rolled out have been
 	// fully deleted in all ARO-HCP permanent environments, for all regions.
 	UsesNewNodePoolDeletionApproach bool `json:"usesNewNodePoolDeletionApproach"`
+
+	// TODO Temporary field to track whether the external auth operation is using the new deletion approach.
+	// We are migrating from the external auth CS deletion synchronous in frontend to the backend, to be fully asynchronous.
+	// This boolean is true for ExternalAuth delete operations that are created with new deletion approach.
+	// This will be removed once all external auths whose deletion was triggered before the new approach is fully rolled out have been
+	// fully deleted in all ARO-HCP permanent environments, for all regions.
+	UsesNewExternalAuthDeletionApproach bool `json:"usesNewExternalAuthDeletionApproach"`
 }
 
 func (o *Operation) ComputeLogicalResourceID() *azcorearm.ResourceID {

--- a/internal/api/v20240610preview/conversion_fuzz_test.go
+++ b/internal/api/v20240610preview/conversion_fuzz_test.go
@@ -95,6 +95,8 @@ func TestRoundTripInternalExternalInternal(t *testing.T) {
 			j.ActiveOperationID = ""
 			// ClusterServiceID does not roundtrip through the external type because it is purely an internal detail
 			j.ClusterServiceID = nil
+			// UsesNewExternalAuthDeletionApproach does not roundtrip through the external type because it is purely an internal detail
+			j.UsesNewExternalAuthDeletionApproach = false
 		},
 		func(j *api.CustomerPlatformProfile, c randfill.Continue) {
 			c.FillNoCustom(j)

--- a/internal/api/v20251223preview/conversion_fuzz_test.go
+++ b/internal/api/v20251223preview/conversion_fuzz_test.go
@@ -86,6 +86,8 @@ func TestRoundTripInternalExternalInternal(t *testing.T) {
 			j.ActiveOperationID = ""
 			// ClusterServiceID does not roundtrip through the external type because it is purely an internal detail
 			j.ClusterServiceID = nil
+			// UsesNewExternalAuthDeletionApproach does not roundtrip through the external type because it is purely an internal detail
+			j.UsesNewExternalAuthDeletionApproach = false
 		},
 		func(j *api.CustomerManagedEncryptionProfile, c randfill.Continue) {
 			c.FillNoCustom(j)

--- a/internal/api/zz_generated.deepcopy.go
+++ b/internal/api/zz_generated.deepcopy.go
@@ -599,6 +599,14 @@ func (in *HCPOpenShiftClusterExternalAuthServiceProviderProperties) DeepCopyInto
 		*out = new(InternalID)
 		**out = **in
 	}
+	if in.DeletionTimestamp != nil {
+		in, out := &in.DeletionTimestamp, &out.DeletionTimestamp
+		*out = (*in).DeepCopy()
+	}
+	if in.ClusterServiceDeletionTimestamp != nil {
+		in, out := &in.ClusterServiceDeletionTimestamp, &out.ClusterServiceDeletionTimestamp
+		*out = (*in).DeepCopy()
+	}
 	return
 }
 

--- a/test-integration/backend/controllers/mismatches/artifacts/cluster/remove_orphaned_cluster_descendents/00-load-initial-state/externalauth-default.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/cluster/remove_orphaned_cluster_descendents/00-load-initial-state/externalauth-default.json
@@ -70,7 +70,8 @@
 				},
 				"serviceProviderProperties": {
 					"activeOperationId": "ea807c13-7e15-43d4-b760-69ef7e31d273",
-					"clusterServiceID": ""
+					"clusterServiceID": "",
+					"usesNewExternalAuthDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -128,7 +129,8 @@
 		},
 		"serviceProviderProperties": {
 			"activeOperationId": "ea807c13-7e15-43d4-b760-69ef7e31d273",
-			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/swzpxg6nxn/external_auth_config/external_auths/5fghjjqxvd"
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/swzpxg6nxn/external_auth_config/external_auths/5fghjjqxvd",
+			"usesNewExternalAuthDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/backend/controllers/mismatches/artifacts/externalauth/present_externalauth/00-load-initial-state/externalauth-default.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/externalauth/present_externalauth/00-load-initial-state/externalauth-default.json
@@ -70,7 +70,8 @@
 				},
 				"serviceProviderProperties": {
 					"activeOperationId": "ea807c13-7e15-43d4-b760-69ef7e31d273",
-					"clusterServiceID": ""
+					"clusterServiceID": "",
+					"usesNewExternalAuthDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -128,7 +129,8 @@
 		},
 		"serviceProviderProperties": {
 			"activeOperationId": "ea807c13-7e15-43d4-b760-69ef7e31d273",
-			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0/external_auth_config/external_auths/5fghjjqxvd"
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0/external_auth_config/external_auths/5fghjjqxvd",
+			"usesNewExternalAuthDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/backend/controllers/mismatches/artifacts/externalauth/present_externalauth/99-cosmosCompare-end-state/externalauth-default.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/externalauth/present_externalauth/99-cosmosCompare-end-state/externalauth-default.json
@@ -70,7 +70,8 @@
 				},
 				"serviceProviderProperties": {
 					"activeOperationId": "ea807c13-7e15-43d4-b760-69ef7e31d273",
-					"clusterServiceID": ""
+					"clusterServiceID": "",
+					"usesNewExternalAuthDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -128,7 +129,8 @@
 		},
 		"serviceProviderProperties": {
 			"activeOperationId": "ea807c13-7e15-43d4-b760-69ef7e31d273",
-			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0/external_auth_config/external_auths/5fghjjqxvd"
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0/external_auth_config/external_auths/5fghjjqxvd",
+			"usesNewExternalAuthDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/backend/controllers/mismatches/artifacts/externalauth/remove_orphaned_externalauth_descendents/00-load-initial-state/externalauth-default.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/externalauth/remove_orphaned_externalauth_descendents/00-load-initial-state/externalauth-default.json
@@ -70,7 +70,8 @@
 				},
 				"serviceProviderProperties": {
 					"activeOperationId": "ea807c13-7e15-43d4-b760-69ef7e31d273",
-					"clusterServiceID": ""
+					"clusterServiceID": "",
+					"usesNewExternalAuthDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -128,7 +129,8 @@
 		},
 		"serviceProviderProperties": {
 			"activeOperationId": "ea807c13-7e15-43d4-b760-69ef7e31d273",
-			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0/external_auth_config/external_auths/5fghjjqxvd"
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/1243e9e9-d150-4ef1-9735-2bbc3cabc7d0/external_auth_config/external_auths/5fghjjqxvd",
+			"usesNewExternalAuthDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/backend/controllers/mismatches/artifacts/nodepool/remove_orphaned_nodepool_descendents/00-load-initial-state/externalauth-default.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/nodepool/remove_orphaned_nodepool_descendents/00-load-initial-state/externalauth-default.json
@@ -70,7 +70,8 @@
 				},
 				"serviceProviderProperties": {
 					"activeOperationId": "ea807c13-7e15-43d4-b760-69ef7e31d273",
-					"clusterServiceID": ""
+					"clusterServiceID": "",
+					"usesNewExternalAuthDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -128,7 +129,8 @@
 		},
 		"serviceProviderProperties": {
 			"activeOperationId": "ea807c13-7e15-43d4-b760-69ef7e31d273",
-			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/swzpxg6nxn/external_auth_config/external_auths/5fghjjqxvd"
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/swzpxg6nxn/external_auth_config/external_auths/5fghjjqxvd",
+			"usesNewExternalAuthDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/backend/controllers/mismatches/artifacts/nodepool/remove_orphaned_nodepool_descendents/99-cosmosCompare-end-state/externalauth-default.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/nodepool/remove_orphaned_nodepool_descendents/99-cosmosCompare-end-state/externalauth-default.json
@@ -70,7 +70,8 @@
 				},
 				"serviceProviderProperties": {
 					"activeOperationId": "ea807c13-7e15-43d4-b760-69ef7e31d273",
-					"clusterServiceID": ""
+					"clusterServiceID": "",
+					"usesNewExternalAuthDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -128,7 +129,8 @@
 		},
 		"serviceProviderProperties": {
 			"activeOperationId": "ea807c13-7e15-43d4-b760-69ef7e31d273",
-			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/swzpxg6nxn/external_auth_config/external_auths/5fghjjqxvd"
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/swzpxg6nxn/external_auth_config/external_auths/5fghjjqxvd",
+			"usesNewExternalAuthDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/01-load-initial/basic-external-auth-auth.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/01-load-initial/basic-external-auth-auth.json
@@ -55,7 +55,8 @@
 					"provisioningState": ""
 				},
 				"serviceProviderProperties": {
-					"clusterServiceID": ""
+					"clusterServiceID": "",
+					"usesNewExternalAuthDeletionApproach": false
 				}
 			}
 		},

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/01-load-initial/basic-external-auth-operation-external-auth.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/01-load-initial/basic-external-auth-operation-external-auth.json
@@ -15,6 +15,7 @@
 		"startTime": "2025-12-05T20:30:10.966609337Z",
 		"status": "Succeeded",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceID": "/subscriptions/f52dfea2-47ee-4396-8006-4a27d47d59c5/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/01738f95-410e-414a-98ce-fe6097133ce6",

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/01-load-initial/create-with-tags-operation.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/01-load-initial/create-with-tags-operation.json
@@ -15,6 +15,7 @@
 		"startTime": "2025-12-05T20:29:59.734335781Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceID": "/subscriptions/f52dfea2-47ee-4396-8006-4a27d47d59c5/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/7c6b7caa-572f-41b6-9f18-1bb11adfbd31",

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/01-load-initial/immutability-operation-for-node-pool.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/01-load-initial/immutability-operation-for-node-pool.json
@@ -15,6 +15,7 @@
 		"startTime": "2025-12-05T20:30:25.067364685Z",
 		"status": "Succeeded",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceID": "/subscriptions/f52dfea2-47ee-4396-8006-4a27d47d59c5/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/37332594-70b3-4796-9af6-301a5d57d1e6",

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/01-load-initial/operation-3-new.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/01-load-initial/operation-3-new.json
@@ -16,6 +16,7 @@
 		"startTime": "2025-12-05T20:30:25.067364685Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceID": "/subscriptions/f52dfea2-47ee-4396-8006-4a27d47d59c5/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/37332504-70b3-4796-9af6-301a5d47d127",

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/04-untypedListRecursive-resourcegroup/basic-external-auth-auth.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/04-untypedListRecursive-resourcegroup/basic-external-auth-auth.json
@@ -55,7 +55,8 @@
 					"provisioningState": ""
 				},
 				"serviceProviderProperties": {
-					"clusterServiceID": ""
+					"clusterServiceID": "",
+					"usesNewExternalAuthDeletionApproach": false
 				}
 			}
 		},

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/05-untypedListRecursive-subscription/basic-external-auth-auth.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/05-untypedListRecursive-subscription/basic-external-auth-auth.json
@@ -55,7 +55,8 @@
 					"provisioningState": ""
 				},
 				"serviceProviderProperties": {
-					"clusterServiceID": ""
+					"clusterServiceID": "",
+					"usesNewExternalAuthDeletionApproach": false
 				}
 			}
 		},

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/05-untypedListRecursive-subscription/basic-external-auth-operation-external-auth.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/05-untypedListRecursive-subscription/basic-external-auth-operation-external-auth.json
@@ -15,6 +15,7 @@
 		"startTime": "2025-12-05T20:30:10.966609337Z",
 		"status": "Succeeded",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceID": "/subscriptions/f52dfea2-47ee-4396-8006-4a27d47d59c5/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/01738f95-410e-414a-98ce-fe6097133ce6",

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/05-untypedListRecursive-subscription/create-with-tags-operation.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/05-untypedListRecursive-subscription/create-with-tags-operation.json
@@ -15,6 +15,7 @@
 		"startTime": "2025-12-05T20:29:59.734335781Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceID": "/subscriptions/f52dfea2-47ee-4396-8006-4a27d47d59c5/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/7c6b7caa-572f-41b6-9f18-1bb11adfbd31",

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/05-untypedListRecursive-subscription/immutability-operation-for-node-pool.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/05-untypedListRecursive-subscription/immutability-operation-for-node-pool.json
@@ -15,6 +15,7 @@
 		"startTime": "2025-12-05T20:30:25.067364685Z",
 		"status": "Succeeded",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceID": "/subscriptions/f52dfea2-47ee-4396-8006-4a27d47d59c5/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/37332594-70b3-4796-9af6-301a5d57d1e6",

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/05-untypedListRecursive-subscription/operation-3-new.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/05-untypedListRecursive-subscription/operation-3-new.json
@@ -16,6 +16,7 @@
 		"startTime": "2025-12-05T20:30:25.067364685Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceID": "/subscriptions/f52dfea2-47ee-4396-8006-4a27d47d59c5/providers/microsoft.redhatopenshift/hcpoperationstatuses/37332504-70b3-4796-9af6-301a5d47d127",

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/07-untypedListRecursive-resourcegroup-via-child/basic-external-auth-auth.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/07-untypedListRecursive-resourcegroup-via-child/basic-external-auth-auth.json
@@ -55,7 +55,8 @@
 					"provisioningState": ""
 				},
 				"serviceProviderProperties": {
-					"clusterServiceID": ""
+					"clusterServiceID": "",
+					"usesNewExternalAuthDeletionApproach": false
 				}
 			}
 		},

--- a/test-integration/frontend/artifacts/FrontendCRUD/AdminCredentials/request/03-listActiveOperations-request-credentials/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/AdminCredentials/request/03-listActiveOperations-request-credentials/00-key.json
@@ -1,6 +1,7 @@
 {
 	"parentResourceID": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6",
 	"properties": {
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses"

--- a/test-integration/frontend/artifacts/FrontendCRUD/AdminCredentials/revoke/03-listActiveOperations-revoke-credentials/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/AdminCredentials/revoke/03-listActiveOperations-revoke-credentials/00-key.json
@@ -1,6 +1,7 @@
 {
 	"parentResourceID": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6",
 	"properties": {
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses"

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-current/02-cosmosCompare-confirm-content/operation-cluster-create-with-tags-create.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-current/02-cosmosCompare-confirm-content/operation-cluster-create-with-tags-create.json
@@ -19,6 +19,7 @@
 		"startTime": "2025-12-19T19:59:30.714826736Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/7a4ed07a-47a1-4efb-966a-93a6316522a0",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-current/05-listActiveOperations-cluster-create/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-current/05-listActiveOperations-cluster-create/00-key.json
@@ -1,6 +1,7 @@
 {
 	"parentResourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7",
 	"properties": {
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses"

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-cluster-operation/03-cosmosCompare-final-state/operation-cluster-create-canceled.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-cluster-operation/03-cosmosCompare-final-state/operation-cluster-create-canceled.json
@@ -9,6 +9,7 @@
 		"request": "Create",
 		"status": "Canceled",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-cluster-operation/03-cosmosCompare-final-state/operation-cluster-delete.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-cluster-operation/03-cosmosCompare-final-state/operation-cluster-delete.json
@@ -5,6 +5,7 @@
 		"request": "Delete",
 		"status": "Deleting",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/operation-cluster-create.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/operation-cluster-create.json
@@ -5,6 +5,7 @@
 		"request": "Create",
 		"status": "Succeeded",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/operation-cluster-delete.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/operation-cluster-delete.json
@@ -5,6 +5,7 @@
 		"request": "Delete",
 		"status": "Deleting",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/operation-nodepool-create-canceled.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/operation-nodepool-create-canceled.json
@@ -9,6 +9,7 @@
 		"request": "Create",
 		"status": "Canceled",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/operation-nodepool-delete.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/operation-nodepool-delete.json
@@ -4,6 +4,7 @@
 		"externalId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/test-cluster/nodePools/test-nodepool",
 		"request": "Delete",
 		"status": "Deleting",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/read-old-data/01-load-old-data/hcpoperationstatuses_Create_90b2322c-2c26-47ca-b6f9-d9b1a8385cbc.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/read-old-data/01-load-old-data/hcpoperationstatuses_Create_90b2322c-2c26-47ca-b6f9-d9b1a8385cbc.json
@@ -19,6 +19,7 @@
 		"startTime": "2026-01-05T18:29:58.181047849Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/90b2322c-2c26-47ca-b6f9-d9b1a8385cbc",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/read-old-data/04-listActiveOperations-cluster-create/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/read-old-data/04-listActiveOperations-cluster-create/00-key.json
@@ -1,6 +1,7 @@
 {
 	"parentResourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7",
 	"properties": {
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses"

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/create-current/06-cosmosCompare-ending-content/externalauth-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/create-current/06-cosmosCompare-ending-content/externalauth-default.json
@@ -73,7 +73,8 @@
 				},
 				"serviceProviderProperties": {
 					"activeOperationId": "60df392c-42ba-4384-95b4-5e4601df2f3e",
-					"clusterServiceID": ""
+					"clusterServiceID": "",
+					"usesNewExternalAuthDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -131,7 +132,8 @@
 		},
 		"serviceProviderProperties": {
 			"activeOperationId": "60df392c-42ba-4384-95b4-5e4601df2f3e",
-			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/tqqtpctbpj/external_auth_config/external_auths/88m6lb2bbv"
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/tqqtpctbpj/external_auth_config/external_auths/88m6lb2bbv",
+			"usesNewExternalAuthDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/create-current/06-cosmosCompare-ending-content/operation-cluster-create-create-with-tags.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/create-current/06-cosmosCompare-ending-content/operation-cluster-create-create-with-tags.json
@@ -16,6 +16,7 @@
 		"startTime": "2025-12-19T19:59:30.714826736Z",
 		"status": "Succeeded",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/7a4ed07a-47a1-4efb-966a-93a6316522a0",

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/create-current/06-cosmosCompare-ending-content/operation-externalauth-create-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/create-current/06-cosmosCompare-ending-content/operation-externalauth-create-default.json
@@ -19,6 +19,7 @@
 		"startTime": "2026-01-09T18:30:03.439824696Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/ea807c13-7e15-43d4-b760-69ef7e31d273",

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/01-load-old-data/externalauth-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/01-load-old-data/externalauth-default.json
@@ -70,7 +70,8 @@
 				},
 				"serviceProviderProperties": {
 					"activeOperationId": "5dce3cac-e09b-4ef5-803c-cb8f17b3a552",
-					"clusterServiceID": ""
+					"clusterServiceID": "",
+					"usesNewExternalAuthDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -128,7 +129,8 @@
 		},
 		"serviceProviderProperties": {
 			"activeOperationId": "5dce3cac-e09b-4ef5-803c-cb8f17b3a552",
-			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/m6bpjxtlqf/external_auth_config/external_auths/zt59xrx22b"
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/m6bpjxtlqf/external_auth_config/external_auths/zt59xrx22b",
+			"usesNewExternalAuthDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/01-load-old-data/operation-cluster-create-with-tags-create.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/01-load-old-data/operation-cluster-create-with-tags-create.json
@@ -19,6 +19,7 @@
 		"startTime": "2026-01-09T18:32:10.15007222Z",
 		"status": "Succeeded",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/9696fbeb-0e78-4a32-a3fd-a6e987c2a015",

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/01-load-old-data/operation-externalauth-create-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/01-load-old-data/operation-externalauth-create-default.json
@@ -19,6 +19,7 @@
 		"startTime": "2026-01-09T18:32:10.835814057Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/5dce3cac-e09b-4ef5-803c-cb8f17b3a552",

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/09-cosmosCompare-confirm-update/externalauth-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/09-cosmosCompare-confirm-update/externalauth-default.json
@@ -73,7 +73,8 @@
 				},
 				"serviceProviderProperties": {
 					"activeOperationId": "d99a71e0-9237-4ae2-8617-e76035e2bcd4",
-					"clusterServiceID": ""
+					"clusterServiceID": "",
+					"usesNewExternalAuthDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -131,7 +132,8 @@
 		},
 		"serviceProviderProperties": {
 			"activeOperationId": "d99a71e0-9237-4ae2-8617-e76035e2bcd4",
-			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/m6bpjxtlqf/external_auth_config/external_auths/zt59xrx22b"
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/m6bpjxtlqf/external_auth_config/external_auths/zt59xrx22b",
+			"usesNewExternalAuthDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/09-cosmosCompare-confirm-update/operation-cluster-create-create-with-tags.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/09-cosmosCompare-confirm-update/operation-cluster-create-create-with-tags.json
@@ -16,6 +16,7 @@
 		"startTime": "2026-01-09T18:32:10.15007222Z",
 		"status": "Succeeded",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/9696fbeb-0e78-4a32-a3fd-a6e987c2a015",

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/09-cosmosCompare-confirm-update/operation-externalauth-create-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/09-cosmosCompare-confirm-update/operation-externalauth-create-default.json
@@ -16,6 +16,7 @@
 		"startTime": "2026-01-09T18:32:10.835814057Z",
 		"status": "Succeeded",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/5dce3cac-e09b-4ef5-803c-cb8f17b3a552",

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/09-cosmosCompare-confirm-update/operation-externalauth-update-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/09-cosmosCompare-confirm-update/operation-externalauth-update-default.json
@@ -16,6 +16,7 @@
 		"startTime": "2026-01-09T18:44:19.757910778Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/4d8d4875-5233-4987-8b14-a26e177b8e20",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/externalauth-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/externalauth-default.json
@@ -70,7 +70,8 @@
 				},
 				"serviceProviderProperties": {
 					"activeOperationId": "5dce3cac-e09b-4ef5-803c-cb8f17b3a552",
-					"clusterServiceID": ""
+					"clusterServiceID": "",
+					"usesNewExternalAuthDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -128,7 +129,8 @@
 		},
 		"serviceProviderProperties": {
 			"activeOperationId": "5dce3cac-e09b-4ef5-803c-cb8f17b3a552",
-			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/m6bpjxtlqf/external_auth_config/external_auths/zt59xrx22b"
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/m6bpjxtlqf/external_auth_config/external_auths/zt59xrx22b",
+			"usesNewExternalAuthDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/operation-cluster-create-with-tags-create.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/operation-cluster-create-with-tags-create.json
@@ -16,6 +16,7 @@
 		"startTime": "2025-12-19T19:59:30.714826736Z",
 		"status": "Succeeded",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/7a4ed07a-47a1-4efb-966a-93a6316522a0",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/operation-create-basicnodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/operation-create-basicnodepool.json
@@ -16,6 +16,7 @@
 		"startTime": "2026-01-08T20:04:05.054190978Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/operation-create-nodepool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/operation-create-nodepool-02.json
@@ -16,6 +16,7 @@
 		"startTime": "2026-01-08T20:04:05.330050272Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/4067756a-fcc1-4732-a211-d785d888203c",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/operation-externalauth-create-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/operation-externalauth-create-default.json
@@ -16,6 +16,7 @@
 		"startTime": "2026-01-09T18:32:10.835814057Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/5dce3cac-e09b-4ef5-803c-cb8f17b3a552",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/externalauth-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/externalauth-default.json
@@ -73,7 +73,8 @@
 				},
 				"serviceProviderProperties": {
 					"activeOperationId": "5dce3cac-e09b-4ef5-803c-cb8f17b3a552",
-					"clusterServiceID": ""
+					"clusterServiceID": "",
+					"usesNewExternalAuthDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -131,7 +132,8 @@
 		},
 		"serviceProviderProperties": {
 			"activeOperationId": "5dce3cac-e09b-4ef5-803c-cb8f17b3a552",
-			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/m6bpjxtlqf/external_auth_config/external_auths/zt59xrx22b"
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/m6bpjxtlqf/external_auth_config/external_auths/zt59xrx22b",
+			"usesNewExternalAuthDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/operation-cluster-create-with-tags-create.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/operation-cluster-create-with-tags-create.json
@@ -16,6 +16,7 @@
 		"startTime": "2025-12-19T19:59:30.714826736Z",
 		"status": "Succeeded",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/7a4ed07a-47a1-4efb-966a-93a6316522a0",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/operation-create-basicnodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/operation-create-basicnodepool.json
@@ -16,6 +16,7 @@
 		"startTime": "2026-01-08T20:04:05.054190978Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/operation-create-nodepool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/operation-create-nodepool-02.json
@@ -16,6 +16,7 @@
 		"startTime": "2026-01-08T20:04:05.330050272Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/4067756a-fcc1-4732-a211-d785d888203c",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/operation-externalauth-create-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/operation-externalauth-create-default.json
@@ -16,6 +16,7 @@
 		"startTime": "2026-01-09T18:32:10.835814057Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/5dce3cac-e09b-4ef5-803c-cb8f17b3a552",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/externalauth-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/externalauth-default.json
@@ -70,7 +70,8 @@
 				},
 				"serviceProviderProperties": {
 					"activeOperationId": "5dce3cac-e09b-4ef5-803c-cb8f17b3a552",
-					"clusterServiceID": ""
+					"clusterServiceID": "",
+					"usesNewExternalAuthDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -128,7 +129,8 @@
 		},
 		"serviceProviderProperties": {
 			"activeOperationId": "5dce3cac-e09b-4ef5-803c-cb8f17b3a552",
-			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/external_auth_config/external_auths/zt59xrx22b"
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/external_auth_config/external_auths/zt59xrx22b",
+			"usesNewExternalAuthDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/operation-cluster-create-with-tags-create.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/operation-cluster-create-with-tags-create.json
@@ -16,6 +16,7 @@
 		"startTime": "2025-12-19T19:59:30.714826736Z",
 		"status": "Succeeded",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/7a4ed07a-47a1-4efb-966a-93a6316522a0",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/operation-create-basicnodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/operation-create-basicnodepool.json
@@ -19,6 +19,7 @@
 		"startTime": "2026-01-08T20:04:05.054190978Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/operation-create-nodepool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/operation-create-nodepool-02.json
@@ -19,6 +19,7 @@
 		"startTime": "2026-01-08T20:04:05.330050272Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/4067756a-fcc1-4732-a211-d785d888203c",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/operation-externalauth-create-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/operation-externalauth-create-default.json
@@ -19,6 +19,7 @@
 		"startTime": "2026-01-09T18:32:10.835814057Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/5dce3cac-e09b-4ef5-803c-cb8f17b3a552",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/externalauth-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/externalauth-default.json
@@ -69,7 +69,8 @@
 				},
 				"serviceProviderProperties": {
 					"activeOperationId": "117a9956-c10f-493d-a435-fcc43ab90896",
-					"clusterServiceID": ""
+					"clusterServiceID": "",
+					"usesNewExternalAuthDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -127,7 +128,8 @@
 		},
 		"serviceProviderProperties": {
 			"activeOperationId": "117a9956-c10f-493d-a435-fcc43ab90896",
-			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/external_auth_config/external_auths/zt59xrx22b"
+			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/external_auth_config/external_auths/zt59xrx22b",
+			"usesNewExternalAuthDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/operation-cluster-create-with-tags-create.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/operation-cluster-create-with-tags-create.json
@@ -16,6 +16,7 @@
 		"startTime": "2025-12-19T19:59:30.714826736Z",
 		"status": "Succeeded",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/7a4ed07a-47a1-4efb-966a-93a6316522a0",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/operation-create-basicnodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/operation-create-basicnodepool.json
@@ -16,6 +16,7 @@
 		"startTime": "2026-01-08T20:04:05.054190978Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/operation-create-nodepool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/operation-create-nodepool-02.json
@@ -16,6 +16,7 @@
 		"startTime": "2026-01-08T20:04:05.330050272Z",
 		"status": "Succeeded",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/4067756a-fcc1-4732-a211-d785d888203c",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/operation-externalauth-create-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/operation-externalauth-create-default.json
@@ -16,6 +16,7 @@
 		"startTime": "2026-01-09T18:32:10.835814057Z",
 		"status": "Succeeded",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/5dce3cac-e09b-4ef5-803c-cb8f17b3a552",

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/create-current/06-cosmosCompare-confirm-content/operation-cluster-create-with-tags-create.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/create-current/06-cosmosCompare-confirm-content/operation-cluster-create-with-tags-create.json
@@ -19,6 +19,7 @@
 		"startTime": "2025-12-19T19:59:30.714826736Z",
 		"status": "Succeeded",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/7a4ed07a-47a1-4efb-966a-93a6316522a0",

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/operation-cluster-create-with-tags-create.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/operation-cluster-create-with-tags-create.json
@@ -16,6 +16,7 @@
 		"startTime": "2025-12-19T19:59:30.714826736Z",
 		"status": "Succeeded",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/7a4ed07a-47a1-4efb-966a-93a6316522a0",

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/operation-create-basicnodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/operation-create-basicnodepool.json
@@ -19,6 +19,7 @@
 		"startTime": "2026-01-08T20:04:05.054190978Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/operation-create-nodepool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/operation-create-nodepool-02.json
@@ -19,6 +19,7 @@
 		"startTime": "2026-01-08T20:04:05.330050272Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/4067756a-fcc1-4732-a211-d785d888203c",

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/operation-create-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/operation-create-cluster.json
@@ -16,6 +16,7 @@
 		"startTime": "2025-12-19T19:59:30.714826736Z",
 		"status": "Succeeded",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/7a4ed07a-47a1-4efb-966a-93a6316522a0",

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/operation-create-nodepool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/operation-create-nodepool-02.json
@@ -16,6 +16,7 @@
 		"startTime": "2026-01-08T20:04:05.330050272Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/4067756a-fcc1-4732-a211-d785d888203c",

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/operation-create-nodepool-basic.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/operation-create-nodepool-basic.json
@@ -16,6 +16,7 @@
 		"startTime": "2026-01-08T20:04:05.054190978Z",
 		"status": "Succeeded",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/operation-update-nodepool-basic.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/operation-update-nodepool-basic.json
@@ -16,6 +16,7 @@
 		"startTime": "2026-01-08T20:09:32.571015378Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/50c1a0ba-3bc4-48fb-857e-eb0974df1e1c",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Operations/read-new-data/01-load-new-data/operation.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Operations/read-new-data/01-load-new-data/operation.json
@@ -17,6 +17,7 @@
 		"startTime": "2026-01-08T19:02:35.73640117Z",
 		"status": "Succeeded",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},
 	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/ab5d298a-2267-432a-ad71-313bbdae0349",


### PR DESCRIPTION
This commit adds the DeletionTimestamp and ClusterServiceDeletionTimestamp in the ExternalAuth
internal API type.

DeletionTimestamp is the the timestamp at which the ExternalAuth deletion
was requested. A nil value indicates that the ExternalAuth deletion has not been requested.

ClusterServiceDeletionTimestamp is written when a dispatch of a Cluster
Service Delete ExternalAuth request against Cluster Service for this
external auth has been handled. It is set after a successful DeleteExternalAuth call
to Cluster Service, but also when it's determined that no delete call is
needed but we consider we should behave as if the delete call was successfully
issued (for example, if the parent cluster of the externalauth is already being
uninstalled, because cluster-service will already take care of deleting the
externalauth as part of the cluster teardown).
A nil value indicates that the Cluster Service Deletion has not been requested.

These two attributes are not used on the backend side yet.

This commit also adds the UsesNewExternalAuthDeletionApproach attribute for both
ExternalAuth and Operation internal api types. This will be used as a gate when we de

<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

### Why

<!-- Briefly explain why this change is needed -->

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
