### PR TITLE
fix(observability): increase KubeVersionMismatch alert threshold to 90m (AROSLSRE-961)

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedHCPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedHCPPrometheusAlertingRules.bicep
@@ -858,7 +858,7 @@ resource kubernetesSystem 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-
           title: 'Different semantic versions of Kubernetes components running.'
         }
         expression: 'count by (cluster) (count by (git_version, cluster) (label_replace(kubernetes_build_info{job!~"kube-dns|coredns"},"git_version","$1","git_version","(v[0-9]*.[0-9]*).*"))) > 1'
-        for: 'PT15M'
+        for: 'PT1H30M'
         severity: 3
       }
       {

--- a/observability/Makefile
+++ b/observability/Makefile
@@ -2,13 +2,13 @@ deploy:
 	make -C ./tracing deploy
 .PHONY: deploy
 
-kubernetesControlPlane-prometheusRule:
-	PROMETHEUS_OPERATOR_REF=$(shell yq -r '.prometheusRules.prometheusOperatorVersion' observability.yaml) && \
+sync-upstream:
+	PROMETHEUS_OPERATOR_REF=$$(yq -r '.prometheusRules.prometheusOperatorVersion' observability.yaml) && \
 	wget --quiet --output-document=alerts/kubernetesControlPlane-prometheusRule.yaml \
 	https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/$${PROMETHEUS_OPERATOR_REF}/manifests/kubernetesControlPlane-prometheusRule.yaml
-.PHONY: kubernetesControlPlane-prometheusRule
+.PHONY: sync-upstream
 
-alerts: kubernetesControlPlane-prometheusRule
+alerts:
 	EXTRA_FLAGS=$(GENERATOR_FLAGS) make -C ../tooling/prometheus-rules run
 	az bicep format -f $$(yq '.prometheusRules.outputBicep' observability.yaml)
 	EXTRA_FLAGS=$(GENERATOR_FLAGS) make -C ../tooling/prometheus-rules run-hcp

--- a/observability/alerts/kubernetesControlPlane-prometheusRule.yaml
+++ b/observability/alerts/kubernetesControlPlane-prometheusRule.yaml
@@ -463,7 +463,7 @@ spec:
         summary: Different semantic versions of Kubernetes components running.
       expr: |
         count by (cluster) (count by (git_version, cluster) (label_replace(kubernetes_build_info{job!~"kube-dns|coredns"},"git_version","$1","git_version","(v[0-9]*.[0-9]*).*"))) > 1
-      for: 15m
+      for: 90m
       labels:
         severity: warning
     - alert: KubeClientErrors


### PR DESCRIPTION
## Summary
- Increase KubeVersionMismatch alert `for:` duration from 15 minutes to 90 minutes
- KubeVersionMismatch fires on HCP updates, which take much longer than 15 minutes. At this point 90 minutes is a good threshold as the vast majority of upgrades, even delayed ones, should fit within this period.
- Regenerated bicep alert rules (HCP + Msft)
- Split `make sync-upstream` from `make alerts` in `observability/Makefile` so that `make alerts` no longer re-downloads the upstream YAML, allowing local `for:` overrides to persist. The `observability-prometheus` CI step runs `make alerts` and previously would always overwrite local changes. The upstream pin (`prometheusOperatorVersion`) has not been bumped since it was introduced (Apr 2025) — when it is, run `make sync-upstream`, review the diff, restore any local overrides, then `make alerts`.

Jira: https://redhat.atlassian.net/browse/AROSLSRE-961

🤖 Generated with [Claude Code](https://claude.com/claude-code)