### PR TITLE
Add Kusto ingestion latency alerts

### DIFF
--- a/dev-infrastructure/configurations/kusto-monitoring.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/kusto-monitoring.tmpl.bicepparam
@@ -3,5 +3,5 @@ using '../templates/kusto-monitoring.bicep'
 param kustoClusterId = '__kustoClusterId__'
 param kustoRegion = '__kustoRegion__'
 param regionLocation = '{{ .region }}'
-param actionGroups = ['__actionGroupSL__']
+param actionGroupSL = '__actionGroupSL__'
 param alertsEnabled = {{ .monitoring.alertsEnabled }}

--- a/dev-infrastructure/configurations/kusto-monitoring.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/kusto-monitoring.tmpl.bicepparam
@@ -1,0 +1,7 @@
+using '../templates/kusto-monitoring.bicep'
+
+param kustoClusterId = '__kustoClusterId__'
+param kustoRegion = '__kustoRegion__'
+param regionLocation = '{{ .region }}'
+param actionGroups = ['__actionGroupSL__']
+param alertsEnabled = {{ .monitoring.alertsEnabled }}

--- a/dev-infrastructure/configurations/monitoring.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/monitoring.tmpl.bicepparam
@@ -2,8 +2,6 @@ using '../templates/monitoring.bicep'
 
 param azureMonitoringWorkspaceId = '__azureMonitoringWorkspaceId__'
 param hcpAzureMonitoringWorkspaceId = '__hcpAzureMonitoringWorkspaceId__'
-param kustoClusterId = '__kustoClusterId__'
-param kustoRegion = '__kustoRegion__'
 
 param manageConnection = {{ .monitoring.icm.manageConnection }}
 param alertsEnabled = {{ .monitoring.alertsEnabled }}

--- a/dev-infrastructure/configurations/monitoring.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/monitoring.tmpl.bicepparam
@@ -2,6 +2,8 @@ using '../templates/monitoring.bicep'
 
 param azureMonitoringWorkspaceId = '__azureMonitoringWorkspaceId__'
 param hcpAzureMonitoringWorkspaceId = '__hcpAzureMonitoringWorkspaceId__'
+param kustoClusterId = '__kustoClusterId__'
+param kustoRegion = '__kustoRegion__'
 
 param manageConnection = {{ .monitoring.icm.manageConnection }}
 param alertsEnabled = {{ .monitoring.alertsEnabled }}

--- a/dev-infrastructure/modules/metrics/kusto-alerts.bicep
+++ b/dev-infrastructure/modules/metrics/kusto-alerts.bicep
@@ -23,7 +23,7 @@ resource ingestionLatencyAboveAverage 'Microsoft.Insights/metricAlerts@2018-03-0
     evaluationFrequency: 'PT5M'
     windowSize: 'PT30M'
     criteria: {
-      'odata.type': 'Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria'
+      'odata.type': 'Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria'
       allOf: [
         {
           name: 'IngestionLatencyCriteria'

--- a/dev-infrastructure/modules/metrics/kusto-alerts.bicep
+++ b/dev-infrastructure/modules/metrics/kusto-alerts.bicep
@@ -1,0 +1,82 @@
+@description('Resource ID of the Kusto cluster to monitor')
+param kustoClusterId string
+
+@description('Action group resource IDs to notify when alerts fire')
+param actionGroups array
+
+@description('Whether alerts are enabled')
+param enabled bool
+
+var kustoName = last(split(kustoClusterId, '/'))
+
+resource ingestionLatencyAboveAverage 'Microsoft.Insights/metricAlerts@2018-03-01' = {
+  name: 'Kusto Ingestion Latency Above Average - ${kustoName}'
+  location: 'global'
+  properties: {
+    description: 'Kusto ingestion latency is above its dynamic baseline. Investigate the ingestion pipeline for slowdowns. https://learn.microsoft.com/azure/data-explorer/monitor-batching-ingestion'
+    severity: 3
+    enabled: enabled
+    autoMitigate: true
+    scopes: [
+      kustoClusterId
+    ]
+    evaluationFrequency: 'PT5M'
+    windowSize: 'PT30M'
+    criteria: {
+      'odata.type': 'Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria'
+      allOf: [
+        {
+          name: 'IngestionLatencyCriteria'
+          metricName: 'IngestionLatencyInSeconds'
+          operator: 'GreaterThan'
+          timeAggregation: 'Average'
+          criterionType: 'DynamicThresholdCriterion'
+          alertSensitivity: 'Medium'
+          failingPeriods: {
+            numberOfEvaluationPeriods: 4
+            minFailingPeriodsToAlert: 3
+          }
+        }
+      ]
+    }
+    actions: [
+      for g in actionGroups: {
+        actionGroupId: g
+      }
+    ]
+  }
+}
+
+resource ingestionLatencyHigh 'Microsoft.Insights/metricAlerts@2018-03-01' = {
+  name: 'Kusto Ingestion Latency High - ${kustoName}'
+  location: 'global'
+  properties: {
+    description: 'Kusto ingestion latency exceeds 15 minutes. This indicates a serious ingestion pipeline issue. https://learn.microsoft.com/azure/data-explorer/monitor-batching-ingestion'
+    severity: 2
+    enabled: enabled
+    autoMitigate: true
+    scopes: [
+      kustoClusterId
+    ]
+    evaluationFrequency: 'PT5M'
+    windowSize: 'PT30M'
+    criteria: {
+      'odata.type': 'Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria'
+      allOf: [
+        {
+          threshold: 900
+          name: 'IngestionLatencyHighCriteria'
+          metricName: 'IngestionLatencyInSeconds'
+          operator: 'GreaterThan'
+          timeAggregation: 'Average'
+          criterionType: 'StaticThresholdCriterion'
+        }
+      ]
+    }
+    actions: [
+      for g in actionGroups: {
+        actionGroupId: g
+      }
+    ]
+  }
+}

--- a/dev-infrastructure/modules/metrics/kusto-alerts.bicep
+++ b/dev-infrastructure/modules/metrics/kusto-alerts.bicep
@@ -52,7 +52,7 @@ resource ingestionLatencyHigh 'Microsoft.Insights/metricAlerts@2018-03-01' = {
   location: 'global'
   properties: {
     description: 'Kusto ingestion latency exceeds 15 minutes. This indicates a serious ingestion pipeline issue. https://learn.microsoft.com/azure/data-explorer/monitor-batching-ingestion'
-    severity: 2
+    severity: 3
     enabled: enabled
     autoMitigate: true
     scopes: [

--- a/dev-infrastructure/monitoring-pipeline.yaml
+++ b/dev-infrastructure/monitoring-pipeline.yaml
@@ -9,16 +9,6 @@ $schema: "pipeline.schema.v1"
 serviceGroup: Microsoft.Azure.ARO.HCP.Monitoring
 rolloutName: Monitoring Rollout
 resourceGroups:
-- name: kusto
-  resourceGroup: '{{ .kusto.rg }}'
-  subscription: '{{ .global.subscription.key }}'
-  steps:
-  - name: output
-    action: ARM
-    template: templates/kusto-lookup.bicep
-    parameters: configurations/kusto-lookup.tmpl.bicepparam
-    deploymentLevel: ResourceGroup
-    outputOnly: true
 - name: regional
   resourceGroup: '{{ .regionRG }}'
   subscription: '{{ .svc.subscription.key }}'
@@ -47,6 +37,22 @@ resourceGroups:
         resourceGroup: regional
         step: output
         name: hcpAzureMonitoringWorkspaceId
+- name: kusto
+  resourceGroup: '{{ .kusto.rg }}'
+  subscription: '{{ .global.subscription.key }}'
+  steps:
+  - name: output
+    action: ARM
+    template: templates/kusto-lookup.bicep
+    parameters: configurations/kusto-lookup.tmpl.bicepparam
+    deploymentLevel: ResourceGroup
+    outputOnly: true
+  - name: kusto-monitoring
+    action: ARM
+    template: templates/kusto-monitoring.bicep
+    parameters: configurations/kusto-monitoring.tmpl.bicepparam
+    deploymentLevel: ResourceGroup
+    variables:
     - name: kustoClusterId
       input:
         resourceGroup: kusto
@@ -57,3 +63,8 @@ resourceGroups:
         resourceGroup: kusto
         step: output
         name: kustoRegion
+    - name: actionGroupSL
+      input:
+        resourceGroup: regional
+        step: monitoring
+        name: actionGroupSL

--- a/dev-infrastructure/monitoring-pipeline.yaml
+++ b/dev-infrastructure/monitoring-pipeline.yaml
@@ -9,6 +9,16 @@ $schema: "pipeline.schema.v1"
 serviceGroup: Microsoft.Azure.ARO.HCP.Monitoring
 rolloutName: Monitoring Rollout
 resourceGroups:
+- name: kusto
+  resourceGroup: '{{ .kusto.rg }}'
+  subscription: '{{ .global.subscription.key }}'
+  steps:
+  - name: output
+    action: ARM
+    template: templates/kusto-lookup.bicep
+    parameters: configurations/kusto-lookup.tmpl.bicepparam
+    deploymentLevel: ResourceGroup
+    outputOnly: true
 - name: regional
   resourceGroup: '{{ .regionRG }}'
   subscription: '{{ .svc.subscription.key }}'
@@ -37,3 +47,13 @@ resourceGroups:
         resourceGroup: regional
         step: output
         name: hcpAzureMonitoringWorkspaceId
+    - name: kustoClusterId
+      input:
+        resourceGroup: kusto
+        step: output
+        name: kustoResourceId
+    - name: kustoRegion
+      input:
+        resourceGroup: kusto
+        step: output
+        name: kustoRegion

--- a/dev-infrastructure/monitoring-pipeline.yaml
+++ b/dev-infrastructure/monitoring-pipeline.yaml
@@ -48,10 +48,12 @@ resourceGroups:
     deploymentLevel: ResourceGroup
     outputOnly: true
   - name: kusto-monitoring
-    action: ARM
+    action: ARMStack
     template: templates/kusto-monitoring.bicep
     parameters: configurations/kusto-monitoring.tmpl.bicepparam
     deploymentLevel: ResourceGroup
+    actionOnUnmanage: delete
+    bypassStackOutOfSyncError: false
     variables:
     - name: kustoClusterId
       input:

--- a/dev-infrastructure/templates/kusto-monitoring.bicep
+++ b/dev-infrastructure/templates/kusto-monitoring.bicep
@@ -17,7 +17,7 @@ module kustoAlerts '../modules/metrics/kusto-alerts.bicep' = if (kustoClusterId 
   name: 'kustoAlerts'
   params: {
     kustoClusterId: kustoClusterId
-    actionGroups: [actionGroupSL]
+    actionGroups: actionGroupSL != '' ? [actionGroupSL] : []
     enabled: alertsEnabled
   }
 }

--- a/dev-infrastructure/templates/kusto-monitoring.bicep
+++ b/dev-infrastructure/templates/kusto-monitoring.bicep
@@ -1,0 +1,23 @@
+@description('Resource ID of the Kusto cluster')
+param kustoClusterId string
+
+@description('Action group resource IDs to notify when alerts fire')
+param actionGroups array
+
+@description('Whether alerts are enabled')
+param alertsEnabled bool
+
+@description('Region of the Kusto cluster (empty string when Kusto is disabled)')
+param kustoRegion string
+
+@description('Region of the monitoring deployment')
+param regionLocation string
+
+module kustoAlerts '../modules/metrics/kusto-alerts.bicep' = if (kustoClusterId != '' && kustoRegion == regionLocation) {
+  name: 'kustoAlerts'
+  params: {
+    kustoClusterId: kustoClusterId
+    actionGroups: actionGroups
+    enabled: alertsEnabled
+  }
+}

--- a/dev-infrastructure/templates/kusto-monitoring.bicep
+++ b/dev-infrastructure/templates/kusto-monitoring.bicep
@@ -1,8 +1,8 @@
 @description('Resource ID of the Kusto cluster')
 param kustoClusterId string
 
-@description('Action group resource IDs to notify when alerts fire')
-param actionGroups array
+@description('SL action group resource ID, injected from monitoring step output')
+param actionGroupSL string
 
 @description('Whether alerts are enabled')
 param alertsEnabled bool
@@ -17,7 +17,7 @@ module kustoAlerts '../modules/metrics/kusto-alerts.bicep' = if (kustoClusterId 
   name: 'kustoAlerts'
   params: {
     kustoClusterId: kustoClusterId
-    actionGroups: actionGroups
+    actionGroups: [actionGroupSL]
     enabled: alertsEnabled
   }
 }

--- a/dev-infrastructure/templates/monitoring.bicep
+++ b/dev-infrastructure/templates/monitoring.bicep
@@ -67,12 +67,6 @@ param manageConnection bool
 @description('Whether ICM alerting is enabled for this region')
 param alertsEnabled bool
 
-@description('Resource ID of the Kusto cluster (empty string when Kusto is disabled)')
-param kustoClusterId string
-
-@description('Region of the Kusto cluster (empty string when Kusto is disabled)')
-param kustoRegion string
-
 module actionGroups '../modules/metrics/actiongroups.bicep' = if (manageConnection) {
   name: 'actionGroups'
   params: {
@@ -156,12 +150,4 @@ module hcpIngestionAlerts '../modules/metrics/amw-ingestion-alerts.bicep' = {
   }
 }
 
-// Since we deploy Kusto only once per Geography, only deploy alerts if the Kusto cluster is in the same region as the current resource group.
-module kustoAlerts '../modules/metrics/kusto-alerts.bicep' = if (kustoClusterId != '' && kustoRegion == resourceGroup().location) {
-  name: 'kustoAlerts'
-  params: {
-    kustoClusterId: kustoClusterId
-    actionGroups: sreActionGroups
-    enabled: alertsEnabled
-  }
-}
+output actionGroupSL string = manageConnection ? actionGroups.outputs.actionGroupsSL : ''

--- a/dev-infrastructure/templates/monitoring.bicep
+++ b/dev-infrastructure/templates/monitoring.bicep
@@ -67,6 +67,12 @@ param manageConnection bool
 @description('Whether ICM alerting is enabled for this region')
 param alertsEnabled bool
 
+@description('Resource ID of the Kusto cluster (empty string when Kusto is disabled)')
+param kustoClusterId string
+
+@description('Region of the Kusto cluster (empty string when Kusto is disabled)')
+param kustoRegion string
+
 module actionGroups '../modules/metrics/actiongroups.bicep' = if (manageConnection) {
   name: 'actionGroups'
   params: {
@@ -145,6 +151,16 @@ module hcpIngestionAlerts '../modules/metrics/amw-ingestion-alerts.bicep' = {
   params: {
     azureMonitorWorkspaceId: hcpAzureMonitoringWorkspaceId
     workspaceLabel: 'hcp'
+    actionGroups: sreActionGroups
+    enabled: alertsEnabled
+  }
+}
+
+// Since we deploy Kusto only once per Geography, only deploy alerts if the Kusto cluster is in the same region as the current resource group.
+module kustoAlerts '../modules/metrics/kusto-alerts.bicep' = if (kustoClusterId != '' && kustoRegion == resourceGroup().location) {
+  name: 'kustoAlerts'
+  params: {
+    kustoClusterId: kustoClusterId
     actionGroups: sreActionGroups
     enabled: alertsEnabled
   }


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-956
<!-- Link to Jira issue -->

### What
Add two metric alerts for Kusto clusters to detect ingestion pipeline slowdowns:

1. Dynamic threshold alert (Severity 3 - Warning): Uses Azure's machine-learning baseline to detect when ingestion latency deviates above its learned average. Evaluated every 5 minutes over a 30-minute window. Fires when 3 of the last 4 evaluation periods breach the dynamic baseline (i.e. sustained for ~15 minutes). A single transient spike won't trigger it, but a flicker that recovers within one period is tolerated.

2. Static threshold alert (Severity 2 - Error): Hard ceiling at 900 seconds (15 minutes). Catches slow latency creep that the dynamic alert would adapt to over time as its baseline shifts upward.

Alerts are gated on Kusto being enabled and the Kusto cluster region matching the monitoring stack region, since Kusto is deployed once per geography.
