### PR TITLE
ARO-27438: log "deleting resource" on delete handlers

### DIFF
--- a/frontend/pkg/frontend/cluster.go
+++ b/frontend/pkg/frontend/cluster.go
@@ -705,6 +705,8 @@ func (f *Frontend) DeleteCluster(writer http.ResponseWriter, request *http.Reque
 		return utils.TrackError(err)
 	}
 
+	logger.Info(fmt.Sprintf("deleting resource %s", cluster.ID))
+
 	transaction := f.resourcesDBClient.NewTransaction(cluster.ID.SubscriptionID)
 	if err := f.addDeleteClusterToTransaction(ctx, writer, request, transaction, cluster); err != nil {
 		return utils.TrackError(err)

--- a/frontend/pkg/frontend/external_auth.go
+++ b/frontend/pkg/frontend/external_auth.go
@@ -578,6 +578,8 @@ func (f *Frontend) DeleteExternalAuth(writer http.ResponseWriter, request *http.
 		return utils.TrackError(err)
 	}
 
+	logger.Info(fmt.Sprintf("deleting resource %s", externalAuth.ID))
+
 	// Temporary check until creation and deletion interaction with CS is moved to the backend: if a delete arrives and the external
 	// auth has not been created in CS or the ClusterServiceID reference has not been persisted in Cosmos, return an error.
 	if externalAuth.ServiceProviderProperties.ClusterServiceID == nil || len(externalAuth.ServiceProviderProperties.ClusterServiceID.String()) == 0 {

--- a/frontend/pkg/frontend/node_pool.go
+++ b/frontend/pkg/frontend/node_pool.go
@@ -708,6 +708,8 @@ func (f *Frontend) DeleteNodePool(writer http.ResponseWriter, request *http.Requ
 		return utils.TrackError(err)
 	}
 
+	logger.Info(fmt.Sprintf("deleting resource %s", nodePool.ID))
+
 	// We retrieve all node pools for the cluster, including the one we are attempting to
 	// delete, and we pass them to the delete admission validation.
 	// TODO once OCPBUGS-86702 is resolved, we should remove this retrieval and the check of last nodepool being


### PR DESCRIPTION
[ARO-27438](https://redhat.atlassian.net/browse/ARO-27438)

### What

Emit a structured `deleting resource <id>` log line when a cluster, node pool, or external auth delete request is accepted, in `DeleteCluster`, `DeleteNodePool`, and `DeleteExternalAuth`. This mirrors the existing `creating resource <id>` and `updating resource <id>` lines (see `cluster.go`, `node_pool.go`, `external_auth.go`).

The line is placed right after the provisioning-state conflict check passes, so it fires once per accepted delete and carries the full resource path. The ARM 404 fast-path (resource already gone) intentionally does not log.

### Why

Today the frontend logs create and update with the resource path, but there is no equivalent for delete. Fleet/observability tooling can therefore count delete outcomes (succeeded/failed from backend events) but has no delete-attempt signal. Without a delete denominator we cannot compute a delete success rate, and we cannot detect a delete that hangs without ever reaching a terminal event ("stuck in deleting").

This adds the missing signal with no behavior, schema, or API change. It is purely observability.

### Testing

No new tests. This is a single structured log statement per handler with no control-flow change; existing `frontend/pkg/frontend` unit tests pass and the frontend builds/vets clean. The new lines reuse the same `logger` and resource `.ID` already in scope, identical to the create/update log pattern.

### Special notes for your reviewer

- Placement is symmetric across all three handlers: immediately after `checkForProvisioningStateConflict(... OperationRequestDelete ...)`.
- Consumers should treat this as a delete-attempt marker (one per accepted request), not a success indicator.

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows Conventional Commits format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Commit history is clean (rebased/squashed)
