### PR TITLE
fix(recreate-system-pool): skip forced-evidence on large NRP-KVS window; align AKS version to 1.35.4

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -468,7 +468,7 @@ defaults:
       vnetAddressPrefix: "10.128.0.0/14"
       subnetPrefix: "10.128.8.0/21"
       podSubnetPrefix: "10.128.64.0/18"
-      kubernetesVersion: 1.35.1
+      kubernetesVersion: 1.35.4
       networkDataplane: "cilium"
       networkPolicy: "cilium"
       systemAgentPool:
@@ -594,7 +594,7 @@ defaults:
       vnetAddressPrefix: "10.128.0.0/14"
       subnetPrefix: "10.128.8.0/21"
       podSubnetPrefix: "10.128.64.0/18"
-      kubernetesVersion: 1.35.1
+      kubernetesVersion: 1.35.4
       networkDataplane: "azure"
       networkPolicy: "azure"
       etcd:

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -596,7 +596,7 @@ mgmt:
       vmSize: Standard_D4ds_v6
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.35.1
+    kubernetesVersion: 1.35.4
     name: ci01-j7654321-mgmt-1
     networkDataplane: azure
     networkPolicy: azure
@@ -921,7 +921,7 @@ svc:
       vmSize: Standard_D4ds_v6
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.35.1
+    kubernetesVersion: 1.35.4
     name: ci01-j7654321-svc
     networkDataplane: cilium
     networkPolicy: cilium

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -596,7 +596,7 @@ mgmt:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.35.1
+    kubernetesVersion: 1.35.4
     name: cspr-westus3-mgmt-1
     networkDataplane: azure
     networkPolicy: azure
@@ -919,7 +919,7 @@ svc:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.35.1
+    kubernetesVersion: 1.35.4
     name: cspr-westus3-svc-1
     networkDataplane: cilium
     networkPolicy: cilium

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -596,7 +596,7 @@ mgmt:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.35.1
+    kubernetesVersion: 1.35.4
     name: dev-westus3-mgmt-1
     networkDataplane: azure
     networkPolicy: azure
@@ -919,7 +919,7 @@ svc:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.35.1
+    kubernetesVersion: 1.35.4
     name: dev-westus3-svc-1
     networkDataplane: cilium
     networkPolicy: cilium

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -596,7 +596,7 @@ mgmt:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.35.1
+    kubernetesVersion: 1.35.4
     name: perf-usw3ptest-mgmt-1
     networkDataplane: azure
     networkPolicy: azure
@@ -919,7 +919,7 @@ svc:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.35.1
+    kubernetesVersion: 1.35.4
     name: perf-usw3ptest-svc
     networkDataplane: cilium
     networkPolicy: cilium

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -596,7 +596,7 @@ mgmt:
       vmSize: Standard_D4s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.35.1
+    kubernetesVersion: 1.35.4
     name: pers-usw3test-mgmt-1
     networkDataplane: azure
     networkPolicy: azure
@@ -921,7 +921,7 @@ svc:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.35.1
+    kubernetesVersion: 1.35.4
     name: pers-usw3test-svc
     networkDataplane: cilium
     networkPolicy: cilium

--- a/config/rendered/dev/prow/centralus.yaml
+++ b/config/rendered/dev/prow/centralus.yaml
@@ -596,7 +596,7 @@ mgmt:
       vmSize: Standard_D4ds_v6
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.35.1
+    kubernetesVersion: 1.35.4
     name: prow-j7654321-mgmt-1
     networkDataplane: azure
     networkPolicy: azure
@@ -921,7 +921,7 @@ svc:
       vmSize: Standard_D4ds_v6
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.35.1
+    kubernetesVersion: 1.35.4
     name: prow-j7654321-svc
     networkDataplane: cilium
     networkPolicy: cilium

--- a/dev-infrastructure/scripts/recreate-system-pool/main.go
+++ b/dev-infrastructure/scripts/recreate-system-pool/main.go
@@ -260,9 +260,13 @@ func runWith(ctx context.Context, cfg *config, orch orchestrator) error {
 		return fmt.Errorf("detection: %w", err)
 	}
 	if !act && !cfg.skipGuards && !cfg.dryRun && reasonIsNRPStormFail(reason) {
-		act, reason, err = forcedEvidencePath(ctx, cfg, orch, reason)
-		if err != nil {
-			return err
+		if shouldTriggerForcedEvidence(cfg.windowMin) {
+			act, reason, err = forcedEvidencePath(ctx, cfg, orch, reason)
+			if err != nil {
+				return err
+			}
+		} else {
+			logf("skipping forced-evidence: initial window (%dm) >= forced window (%dm) with zero hits; no active wedge. Exiting no-op.", cfg.windowMin, triggerEvidenceWindowMin)
 		}
 	}
 	if !act && !cfg.skipGuards {
@@ -369,6 +373,18 @@ func runWith(ctx context.Context, cfg *config, orch orchestrator) error {
 		logf("WARN: post-flight dump partial: %v", err)
 	}
 	return nil
+}
+
+// shouldTriggerForcedEvidence reports whether the forced-evidence path
+// is worth running given the initial NRP-KVS lookback window. It only
+// helps when that initial window was shorter than the forced poll window
+// (triggerEvidenceWindowMin): if we already looked back >= the forced
+// window and saw zero hits, an active wedge — which the AKS RP retries
+// roughly every 3 min — would already be visible, so a forced reconcile
+// plus a fresh poll cannot add signal and only risks bouncing a healthy
+// control plane.
+func shouldTriggerForcedEvidence(windowMin int) bool {
+	return windowMin < triggerEvidenceWindowMin
 }
 
 // forcedEvidencePath triggers a no-op reconcile on the live system

--- a/dev-infrastructure/scripts/recreate-system-pool/main_test.go
+++ b/dev-infrastructure/scripts/recreate-system-pool/main_test.go
@@ -226,6 +226,27 @@ func TestEvalNRPStorm(t *testing.T) {
 	}
 }
 
+func TestShouldTriggerForcedEvidence(t *testing.T) {
+	cases := []struct {
+		name      string
+		windowMin int
+		want      bool
+	}{
+		{"default_window_triggers", defaultWindowMin, true},
+		{"zero_window_triggers", 0, true},
+		{"just_below_forced_window", triggerEvidenceWindowMin - 1, true},
+		{"equal_forced_window_skips", triggerEvidenceWindowMin, false},
+		{"prod_window_360_skips", 360, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldTriggerForcedEvidence(tc.windowMin); got != tc.want {
+				t.Errorf("shouldTriggerForcedEvidence(%d)=%t want %t", tc.windowMin, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestEvalClusterState(t *testing.T) {
 	cases := []struct {
 		name  string
@@ -1531,6 +1552,16 @@ func TestRunWith(t *testing.T) {
 		{
 			name: "guard1_fail_dry_run_skips_forced_evidence",
 			cfg:  &config{clusterName: "c", resourceGroup: "rg", subscriptionID: "sub", cpVersion: "1.30.0", dryRun: true},
+			setup: func(m *mockOrchestrator) {
+				m.detectFn = func(_ context.Context, _ int) (bool, string, error) {
+					return false, "NRP-KVS storm FAIL: only 0 NRP failures < 10", nil
+				}
+			},
+			wantCalls: []string{"ensureCluster", "dumpPreflight", "detect:1"},
+		},
+		{
+			name: "guard1_fail_large_window_skips_forced_evidence",
+			cfg:  &config{clusterName: "c", resourceGroup: "rg", subscriptionID: "sub", cpVersion: "1.30.0", threshold: 10, windowMin: triggerEvidenceWindowMin},
 			setup: func(m *mockOrchestrator) {
 				m.detectFn = func(_ context.Context, _ int) (bool, string, error) {
 					return false, "NRP-KVS storm FAIL: only 0 NRP failures < 10", nil


### PR DESCRIPTION
## What

Two related changes addressing a false-positive forced-evidence trigger and the cosmetic Kubernetes version drift behind it.

### 1. `recreate-system-pool`: guard the forced-evidence path
- Added `shouldTriggerForcedEvidence(windowMin)` which returns `false` when the initial NRP-KVS lookback window is already `>= triggerEvidenceWindowMin` (60m).
- Gated the `forcedEvidencePath` call in `runWith` so the tool no longer triggers a reconcile + 60m poll when the initial window already covered enough time to surface an active wedge (the AKS RP retries a wedged VMSS write roughly every 3 minutes, so a long zero-hit window already proves there is no active storm).
- This prevents an unnecessary `CreateOrUpdate` against an already-mitigated system pool whose ARM state is still stale `Failed`.

### 2. Config: align AKS `kubernetesVersion` to `1.35.4`
- Bumped both svc and mgmt `aks.kubernetesVersion` defaults from `1.35.1` to `1.35.4` to match the version AKS has already patched control planes to out-of-band, removing the desired-vs-current drift. AKS never downgrades, so the config default is the source of the gap.

## Tests
- `TestShouldTriggerForcedEvidence` — table-driven coverage including the large-window skip case.
- New `runWith` case `guard1_fail_large_window_skips_forced_evidence` asserting execution stops after detection with no reconcile/poll calls.
- Verified locally: `ok ... recreate-system-pool`.

## Notes
- The window guard is a targeted stopgap. A follow-up should add a dataplane-health guard (skip forced-evidence when system nodes are Ready/schedulable) so the behavior is correct independent of the configured lookback window.
- Do not hand-edit rendered region config for the version bump; the default in `config/config.yaml` is the source of truth and propagates to all regions.