### PR TITLE
feat: expand nodepool recreate script to include user and infra nodepools

### DIFF
--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -205,8 +205,10 @@ resourceGroups:
   # KVS corruption (AROSLSRE-924 / ICM 798003653). Checks all pools
   # (system, user/swft, infra). Runs BEFORE the cluster ARM step so
   # the cluster PUT does not get stuck behind a wedged VMSS update.
-  # The Go binary exits 0 (no-op) if the cluster does not exist yet
-  # (greenfield rollout), or if no pools are in a wedge-compatible state.
+  # Exits 0 (no-op) when: cluster does not exist (greenfield), cluster
+  # state is not recoverable, no pools are wedge-compatible, or NRP-KVS
+  # evidence does not reach threshold (including after forced-evidence
+  # probing). Exits non-zero when pools are skipped due to time budget.
   - name: pipeline-msi-reader-permissions
     action: ARM
     template: templates/pipeline-msi-reader-permissions.bicep
@@ -238,9 +240,9 @@ resourceGroups:
         step: subscription-output
         name: subscriptionId
     - name: NRP_FAIL_THRESHOLD
-      value: '10'
+      value: '5'
     - name: NRP_FAIL_WINDOW_MIN
-      value: '360'
+      value: '15'
     dependsOn:
     - resourceGroup: management
       step: cx-oncert-public-kv-issuer

--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -224,6 +224,7 @@ resourceGroups:
     action: Shell
     command: ./scripts/recreate-system-pool/recreate-system-pool
     workingDir: .
+    timeout: 120m
     shellIdentity:
       input:
         resourceGroup: global

--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -201,12 +201,12 @@ resourceGroups:
         name: mgmtKeyVaultUrl
     issuer:
       value: OneCertV2-PublicCA
-  # Detect and self-heal the AKS system pool when NRP KVS corruption
-  # has wedged it (AROSLSRE-924 / ICM 798003653). Runs BEFORE the cluster
-  # ARM step so the cluster PUT does not get stuck behind a wedged
-  # VMSS update. The Go binary checks cluster existence first and exits
-  # 0 (no-op) if the cluster has not been created yet (greenfield
-  # rollout), or if any of the four detection guards fail.
+  # Detect and self-heal any AKS nodepool whose VMSS is wedged by NRP
+  # KVS corruption (AROSLSRE-924 / ICM 798003653). Checks all pools
+  # (system, user/swft, infra). Runs BEFORE the cluster ARM step so
+  # the cluster PUT does not get stuck behind a wedged VMSS update.
+  # The Go binary exits 0 (no-op) if the cluster does not exist yet
+  # (greenfield rollout), or if no pools are in a wedge-compatible state.
   - name: pipeline-msi-reader-permissions
     action: ARM
     template: templates/pipeline-msi-reader-permissions.bicep

--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -224,7 +224,6 @@ resourceGroups:
     action: Shell
     command: ./scripts/recreate-system-pool/recreate-system-pool
     workingDir: .
-    timeout: 120m
     shellIdentity:
       input:
         resourceGroup: global

--- a/dev-infrastructure/scripts/recreate-system-pool/main.go
+++ b/dev-infrastructure/scripts/recreate-system-pool/main.go
@@ -256,7 +256,7 @@ type orchestrator interface {
 	deletePool(ctx context.Context, pool string) error
 	recreatePool(ctx context.Context, poolName string, live *armcs.AgentPool) error
 	reconcileTagPut(ctx context.Context) error
-	triggerPoolReconcile(ctx context.Context, poolName string, live *armcs.AgentPool) error
+	triggerPoolScaleUp(ctx context.Context, poolName string, live *armcs.AgentPool) error
 	pollForNRPEvidence(ctx context.Context, poolName string, vmssPrefix string, timeout time.Duration, pollInterval time.Duration, windowMin int, threshold int) (int, error)
 	abortPoolReconcile(ctx context.Context, poolName string) error
 }
@@ -527,10 +527,12 @@ func remediateNonSystemPool(ctx context.Context, orch orchestrator, wp wedgedPoo
 	return nil
 }
 
-// forcedEvidenceForPool triggers a no-op reconcile on the given pool
-// so the AKS RP attempts a fresh VMSS write. It then polls the
-// activity log for NRP-KVS Failed events and aborts the LRO it started
-// once threshold-many hits are observed or the timeout elapses.
+// forcedEvidenceForPool triggers a scale-up (+1 node) on the given pool
+// to force a VMSS write. A no-op reconcile may not trigger a VMSS write
+// for user pools, but a scale-up always does because it creates a new VM
+// instance. It then polls the activity log for NRP-KVS Failed events and
+// aborts the LRO once threshold-many hits are observed or the timeout
+// elapses.
 //
 // Returns a *wedgedPool if evidence reached the threshold and the caller
 // should proceed with the remediate flow. Returns nil with no error if
@@ -544,12 +546,12 @@ func forcedEvidenceForPool(ctx context.Context, cfg *config, orch orchestrator, 
 		return nil, fmt.Errorf("forced evidence snapshot %s: %w", sp.name, err)
 	}
 
-	if err := orch.triggerPoolReconcile(ctx, sp.name, live); err != nil {
-		logf("WARN: triggerPoolReconcile for %s failed: %v; treating as no-op", sp.name, err)
+	if err := orch.triggerPoolScaleUp(ctx, sp.name, live); err != nil {
+		logf("WARN: triggerPoolScaleUp for %s failed: %v; treating as no-op", sp.name, err)
 		return nil, nil
 	}
 
-	logf("triggered pool %s reconcile; polling activity log every %ds for up to %dm",
+	logf("triggered pool %s scale-up; polling activity log every %ds for up to %dm",
 		sp.name, triggerEvidencePollIntervalSec, triggerEvidenceTimeoutMin)
 	hits, pollErr := orch.pollForNRPEvidence(
 		ctx,
@@ -561,6 +563,7 @@ func forcedEvidenceForPool(ctx context.Context, cfg *config, orch orchestrator, 
 		cfg.threshold,
 	)
 
+	// Abort the scale-up LRO and restore the original pool spec.
 	abortCtx, abortCancel := context.WithTimeout(context.Background(), abortTriggerTimeoutMin*time.Minute)
 	defer abortCancel()
 	if abortErr := orch.abortPoolReconcile(abortCtx, sp.name); abortErr != nil {
@@ -1515,14 +1518,22 @@ func (c *clients) reconcileTagPut(ctx context.Context) error {
 // by issuing a sanitized CreateOrUpdate with the snapshot spec.
 // It does not wait for the LRO to finish — the caller polls the activity
 // log for NRP-KVS evidence in parallel and aborts the LRO when done.
-func (c *clients) triggerPoolReconcile(ctx context.Context, poolName string, live *armcs.AgentPool) error {
+func (c *clients) triggerPoolScaleUp(ctx context.Context, poolName string, live *armcs.AgentPool) error {
 	body, err := agentPoolForCreate(live, c.cfg.cpVersion)
 	if err != nil {
-		return fmt.Errorf("triggerPoolReconcile %s: %w", poolName, err)
+		return fmt.Errorf("triggerPoolScaleUp %s: %w", poolName, err)
 	}
-	logf("triggering AgentPool CreateOrUpdate on %q (no-op reconcile with live spec)", poolName)
+	if body.Properties.Count != nil {
+		*body.Properties.Count++
+	} else {
+		body.Properties.Count = ptr(int32(2))
+	}
+	if body.Properties.EnableAutoScaling != nil && *body.Properties.EnableAutoScaling && body.Properties.MinCount != nil {
+		*body.Properties.MinCount++
+	}
+	logf("triggering scale-up on %q (count=%d) to force VMSS write", poolName, *body.Properties.Count)
 	if _, err := c.pools.BeginCreateOrUpdate(ctx, c.cfg.resourceGroup, c.cfg.clusterName, poolName, *body, nil); err != nil {
-		return fmt.Errorf("begin trigger pool reconcile %s: %w", poolName, err)
+		return fmt.Errorf("begin trigger pool scale-up %s: %w", poolName, err)
 	}
 	return nil
 }

--- a/dev-infrastructure/scripts/recreate-system-pool/main.go
+++ b/dev-infrastructure/scripts/recreate-system-pool/main.go
@@ -219,6 +219,9 @@ func tmpPoolName(poolName string) string {
 	if poolName == systemPoolName {
 		return systmpPoolName
 	}
+	if len(poolName) >= 12 {
+		return poolName[:11] + tmpPoolSuffix
+	}
 	return poolName + tmpPoolSuffix
 }
 

--- a/dev-infrastructure/scripts/recreate-system-pool/main.go
+++ b/dev-infrastructure/scripts/recreate-system-pool/main.go
@@ -38,7 +38,7 @@
 //   CLUSTER_NAME              AKS cluster name (e.g. int-uksouth-mgmt-1)
 //   RESOURCE_GROUP            Resource group containing the AKS cluster
 //   SUBSCRIPTION_ID           Azure subscription ID containing the AKS cluster
-//   NRP_FAIL_THRESHOLD        Failed-event count threshold (default 10)
+//   NRP_FAIL_THRESHOLD        Failed-event count threshold (default 5)
 //   NRP_FAIL_WINDOW_MIN       Activity-log lookback window in min (default 15)
 //   DRY_RUN                   "true" to print intended actions but make no writes
 //
@@ -132,6 +132,7 @@ import (
 const (
 	systemPoolName    = "system"
 	systmpPoolName    = "systmp"
+	tmpPoolSuffix     = "t"
 	defaultThreshold  = 5
 	defaultWindowMin  = 15
 	lroAbortAgeMin    = 30
@@ -140,7 +141,7 @@ const (
 	poolReadyTOMin    = 10
 	pollIntervalSec   = 30
 	overallTimeoutMin = 55
-	minPoolBudgetMin  = 5
+	minPoolBudgetMin  = 20
 
 	// The NRP-KVS storm check requires this error code so other failure
 	// modes (quota / capacity / policy / etc) cannot trip the threshold.
@@ -158,7 +159,7 @@ const (
 	// to produce fresh evidence (or to prove the wedge is not NRP-KVS).
 	// Times are short relative to the AKS RP retry cadence (~3 min) so
 	// threshold-many retries can accumulate during the wait window.
-	triggerEvidenceTimeoutMin      = 10 // wait at most this long for evidence
+	triggerEvidenceTimeoutMin      = 20 // wait at most this long for evidence
 	triggerEvidencePollIntervalSec = 60 // re-query activity log every poll
 	triggerEvidenceWindowMin       = 60 // activity-log lookback for the wait loop
 
@@ -208,6 +209,17 @@ func poolVMSSPrefix(poolName string) string {
 	return "aks-" + poolName + "-"
 }
 
+func tmpPoolName(poolName string) string {
+	if poolName == systemPoolName {
+		return systmpPoolName
+	}
+	return poolName + tmpPoolSuffix
+}
+
+func isTmpPool(name string) bool {
+	return name == systmpPoolName || strings.HasSuffix(name, tmpPoolSuffix)
+}
+
 func classifyPool(p *armcs.AgentPool) poolCategory {
 	if p.Properties != nil && p.Properties.Mode != nil && *p.Properties.Mode == armcs.AgentPoolModeSystem {
 		return poolCategorySystem
@@ -251,12 +263,13 @@ type orchestrator interface {
 	preflightChecks(ctx context.Context, pools []wedgedPool) error
 	snapshotPool(ctx context.Context, poolName string) (*armcs.AgentPool, error)
 	maybeAbortLRO(ctx context.Context) (bool, error)
-	addSystmp(ctx context.Context, live *armcs.AgentPool) error
+	addTmpPool(ctx context.Context, tmpName string, live *armcs.AgentPool) error
 	drainPool(ctx context.Context, pool string, timeout time.Duration) error
 	deletePool(ctx context.Context, pool string) error
 	recreatePool(ctx context.Context, poolName string, live *armcs.AgentPool) error
 	reconcileTagPut(ctx context.Context) error
 	triggerPoolScaleUp(ctx context.Context, poolName string, live *armcs.AgentPool) error
+	restorePoolSpec(ctx context.Context, poolName string, live *armcs.AgentPool) error
 	pollForNRPEvidence(ctx context.Context, poolName string, vmssPrefix string, timeout time.Duration, pollInterval time.Duration, windowMin int, threshold int) (int, error)
 	abortPoolReconcile(ctx context.Context, poolName string) error
 }
@@ -447,24 +460,18 @@ func runWith(ctx context.Context, cfg *config, orch orchestrator) error {
 			return fmt.Errorf("snapshot pool %s: %w", wp.name, err)
 		}
 
-		if wp.category == poolCategorySystem {
-			if err := remediateSystemPool(ctx, orch, wp, live); err != nil {
-				return err
-			}
-		} else {
-			if err := remediateNonSystemPool(ctx, orch, wp, live); err != nil {
-				return err
-			}
+		if err := remediatePool(ctx, orch, wp, live); err != nil {
+			return err
 		}
+	}
+
+	if skipped > 0 {
+		return fmt.Errorf("%d wedged pool(s) skipped due to insufficient time budget", skipped)
 	}
 
 	logBanner("TAG RECONCILE")
 	if err := orch.reconcileTagPut(ctx); err != nil {
 		return fmt.Errorf("tag reconcile: %w", err)
-	}
-
-	if skipped > 0 {
-		return fmt.Errorf("%d wedged pool(s) skipped due to insufficient time budget", skipped)
 	}
 
 	logBanner("DONE")
@@ -474,12 +481,12 @@ func runWith(ctx context.Context, cfg *config, orch orchestrator) error {
 	return nil
 }
 
-func remediateSystemPool(ctx context.Context, orch orchestrator, wp wedgedPool, live *armcs.AgentPool) error {
-	logf("system pool requires systmp dance")
+func remediatePool(ctx context.Context, orch orchestrator, wp wedgedPool, live *armcs.AgentPool) error {
+	tmp := tmpPoolName(wp.name)
 
-	logf(">>> adding throwaway systmp pool")
-	if err := orch.addSystmp(ctx, live); err != nil {
-		return fmt.Errorf("add systmp for %s: %w", wp.name, err)
+	logf(">>> adding throwaway pool %s", tmp)
+	if err := orch.addTmpPool(ctx, tmp, live); err != nil {
+		return fmt.Errorf("add tmp pool %s for %s: %w", tmp, wp.name, err)
 	}
 
 	logf(">>> draining pool %s", wp.name)
@@ -497,31 +504,12 @@ func remediateSystemPool(ctx context.Context, orch orchestrator, wp wedgedPool, 
 		return fmt.Errorf("recreate %s: %w", wp.name, err)
 	}
 
-	logf(">>> cleaning up systmp")
-	if err := orch.drainPool(ctx, systmpPoolName, 5*time.Minute); err != nil {
-		logf("WARN: systmp drain returned: %v (continuing to delete)", err)
+	logf(">>> cleaning up tmp pool %s", tmp)
+	if err := orch.drainPool(ctx, tmp, 5*time.Minute); err != nil {
+		logf("WARN: %s drain returned: %v (continuing to delete)", tmp, err)
 	}
-	if err := orch.deletePool(ctx, systmpPoolName); err != nil {
-		return fmt.Errorf("delete systmp: %w", err)
-	}
-
-	return nil
-}
-
-func remediateNonSystemPool(ctx context.Context, orch orchestrator, wp wedgedPool, live *armcs.AgentPool) error {
-	logf(">>> draining pool %s", wp.name)
-	if err := orch.drainPool(ctx, wp.name, 10*time.Minute); err != nil {
-		return fmt.Errorf("drain %s: %w", wp.name, err)
-	}
-
-	logf(">>> deleting pool %s", wp.name)
-	if err := orch.deletePool(ctx, wp.name); err != nil {
-		return fmt.Errorf("delete %s: %w", wp.name, err)
-	}
-
-	logf(">>> recreating pool %s", wp.name)
-	if err := orch.recreatePool(ctx, wp.name, live); err != nil {
-		return fmt.Errorf("recreate %s: %w", wp.name, err)
+	if err := orch.deletePool(ctx, tmp); err != nil {
+		return fmt.Errorf("delete %s: %w", tmp, err)
 	}
 
 	return nil
@@ -564,10 +552,16 @@ func forcedEvidenceForPool(ctx context.Context, cfg *config, orch orchestrator, 
 	)
 
 	// Abort the scale-up LRO and restore the original pool spec.
+	// If the scale-up completed before abort, the pool has an extra
+	// node and bumped min/maxCount. Restoring the original spec via
+	// CreateOrUpdate reverts that.
 	abortCtx, abortCancel := context.WithTimeout(context.Background(), abortTriggerTimeoutMin*time.Minute)
 	defer abortCancel()
 	if abortErr := orch.abortPoolReconcile(abortCtx, sp.name); abortErr != nil {
 		logf("WARN: abortPoolReconcile for %s failed: %v", sp.name, abortErr)
+	}
+	if restoreErr := orch.restorePoolSpec(abortCtx, sp.name, live); restoreErr != nil {
+		logf("WARN: restorePoolSpec for %s failed: %v", sp.name, restoreErr)
 	}
 
 	if pollErr != nil {
@@ -973,10 +967,7 @@ func evalClusterSafety(pools []*armcs.AgentPool) (bool, string) {
 		if p == nil || p.Name == nil || p.Properties == nil {
 			continue
 		}
-		if classifyPool(p) == poolCategorySystem {
-			continue
-		}
-		if *p.Name == systmpPoolName {
+		if classifyPool(p) == poolCategorySystem || isTmpPool(*p.Name) {
 			continue
 		}
 		cnt := int32(0)
@@ -1070,7 +1061,7 @@ func (c *clients) detect(ctx context.Context) ([]wedgedPool, string, error) {
 				continue
 			}
 			name := *p.Name
-			if name == systmpPoolName {
+			if isTmpPool(name) {
 				continue
 			}
 			cat := classifyPool(p)
@@ -1101,7 +1092,7 @@ func (c *clients) detect(ctx context.Context) ([]wedgedPool, string, error) {
 			continue
 		}
 		name := *p.Name
-		if name == systmpPoolName {
+		if isTmpPool(name) {
 			continue
 		}
 
@@ -1157,26 +1148,19 @@ func (c *clients) detect(ctx context.Context) ([]wedgedPool, string, error) {
 // would let us create a duplicate systmp on top of an existing one,
 // which would fail with a less actionable error later.
 func (c *clients) preflightChecks(ctx context.Context, pools []wedgedPool) error {
-	systemInList := false
 	for _, wp := range pools {
-		if wp.category == poolCategorySystem {
-			systemInList = true
-			break
+		tmp := tmpPoolName(wp.name)
+		_, err := c.pools.Get(ctx, c.cfg.resourceGroup, c.cfg.clusterName, tmp, nil)
+		switch {
+		case err == nil:
+			return fmt.Errorf("leftover tmp pool %q present from previous run; clean it up then re-run", tmp)
+		case isNotFoundErr(err):
+			continue
+		default:
+			return fmt.Errorf("preflight Get %s: %w", tmp, err)
 		}
 	}
-	if !systemInList {
-		return nil
-	}
-
-	_, err := c.pools.Get(ctx, c.cfg.resourceGroup, c.cfg.clusterName, systmpPoolName, nil)
-	switch {
-	case err == nil:
-		return fmt.Errorf("leftover 'systmp' pool present from previous run; clean it up then re-run")
-	case isNotFoundErr(err):
-		return nil
-	default:
-		return fmt.Errorf("preflight Get systmp: %w", err)
-	}
+	return nil
 }
 
 // ---------------------------------------------------------------------------
@@ -1333,23 +1317,21 @@ func (c *clients) maybeAbortLRO(ctx context.Context) (bool, error) {
 // across environments). The temporary pool overrides Count=1 and adds
 // an obviously-temporary purpose tag while otherwise relying on the
 // sanitized live-pool clone for node labels, taints and VMSS tags.
-func buildSystmpAgentPool(live *armcs.AgentPool, cpVersion string) (*armcs.AgentPool, error) {
+func buildTmpAgentPool(live *armcs.AgentPool, cpVersion string) (*armcs.AgentPool, error) {
 	body, err := agentPoolForCreate(live, cpVersion)
 	if err != nil {
-		return nil, fmt.Errorf("buildSystmpAgentPool: %w", err)
+		return nil, fmt.Errorf("buildTmpAgentPool: %w", err)
 	}
 	if body.Properties.VMSize == nil || *body.Properties.VMSize == "" {
-		return nil, errors.New("buildSystmpAgentPool: live snapshot has no VMSize")
+		return nil, errors.New("buildTmpAgentPool: live snapshot has no VMSize")
 	}
 	if body.Properties.OSDiskSizeGB == nil || *body.Properties.OSDiskSizeGB <= 0 {
-		return nil, errors.New("buildSystmpAgentPool: live snapshot has no OSDiskSizeGB")
+		return nil, errors.New("buildTmpAgentPool: live snapshot has no OSDiskSizeGB")
 	}
 	if cpVersion == "" {
-		return nil, errors.New("buildSystmpAgentPool: empty cpVersion")
+		return nil, errors.New("buildTmpAgentPool: empty cpVersion")
 	}
-	mode := armcs.AgentPoolModeSystem
 	cnt := int32(1)
-	body.Properties.Mode = &mode
 	body.Properties.Count = &cnt
 	body.Properties.MinCount = nil
 	body.Properties.MaxCount = nil
@@ -1357,25 +1339,25 @@ func buildSystmpAgentPool(live *armcs.AgentPool, cpVersion string) (*armcs.Agent
 	if body.Properties.Tags == nil {
 		body.Properties.Tags = map[string]*string{}
 	}
-	body.Properties.Tags["purpose"] = ptr("temp-system-aroslsre-924")
+	body.Properties.Tags["purpose"] = ptr("temp-aroslsre-924")
 	return body, nil
 }
 
-func (c *clients) addSystmp(ctx context.Context, live *armcs.AgentPool) error {
-	body, err := buildSystmpAgentPool(live, c.cfg.cpVersion)
+func (c *clients) addTmpPool(ctx context.Context, tmpName string, live *armcs.AgentPool) error {
+	body, err := buildTmpAgentPool(live, c.cfg.cpVersion)
 	if err != nil {
 		return err
 	}
-	logf("creating systmp (vmSize=%s, 1 node, k8s=%s, inherited taints)", strDeref(live.Properties.VMSize), c.cfg.cpVersion)
-	poller, err := c.pools.BeginCreateOrUpdate(ctx, c.cfg.resourceGroup, c.cfg.clusterName, systmpPoolName, *body, nil)
+	logf("creating tmp pool %s (vmSize=%s, 1 node, k8s=%s, inherited taints)", tmpName, strDeref(live.Properties.VMSize), c.cfg.cpVersion)
+	poller, err := c.pools.BeginCreateOrUpdate(ctx, c.cfg.resourceGroup, c.cfg.clusterName, tmpName, *body, nil)
 	if err != nil {
-		return fmt.Errorf("begin create systmp: %w", err)
+		return fmt.Errorf("begin create %s: %w", tmpName, err)
 	}
 	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
-		return fmt.Errorf("poll create systmp: %w", err)
+		return fmt.Errorf("poll create %s: %w", tmpName, err)
 	}
-	logf("systmp pool created; waiting for k8s node Ready")
-	return c.waitForReadyNodes(ctx, systmpPoolName, 1, systmpReadyTOMin*time.Minute)
+	logf("tmp pool %s created; waiting for k8s node Ready", tmpName)
+	return c.waitForReadyNodes(ctx, tmpName, 1, systmpReadyTOMin*time.Minute)
 }
 
 // ---------------------------------------------------------------------------
@@ -1530,6 +1512,9 @@ func (c *clients) triggerPoolScaleUp(ctx context.Context, poolName string, live 
 	}
 	if body.Properties.EnableAutoScaling != nil && *body.Properties.EnableAutoScaling && body.Properties.MinCount != nil {
 		*body.Properties.MinCount++
+		if body.Properties.MaxCount != nil && *body.Properties.MinCount > *body.Properties.MaxCount {
+			*body.Properties.MaxCount = *body.Properties.MinCount
+		}
 	}
 	logf("triggering scale-up on %q (count=%d) to force VMSS write", poolName, *body.Properties.Count)
 	if _, err := c.pools.BeginCreateOrUpdate(ctx, c.cfg.resourceGroup, c.cfg.clusterName, poolName, *body, nil); err != nil {
@@ -1597,6 +1582,22 @@ func (c *clients) abortPoolReconcile(ctx context.Context, poolName string) error
 	}
 	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
 		return fmt.Errorf("poll abort pool reconcile %s: %w", poolName, err)
+	}
+	return nil
+}
+
+func (c *clients) restorePoolSpec(ctx context.Context, poolName string, live *armcs.AgentPool) error {
+	body, err := agentPoolForCreate(live, c.cfg.cpVersion)
+	if err != nil {
+		return fmt.Errorf("restorePoolSpec %s: %w", poolName, err)
+	}
+	logf("restoring original spec for pool %s", poolName)
+	poller, err := c.pools.BeginCreateOrUpdate(ctx, c.cfg.resourceGroup, c.cfg.clusterName, poolName, *body, nil)
+	if err != nil {
+		return fmt.Errorf("begin restore pool spec %s: %w", poolName, err)
+	}
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		return fmt.Errorf("poll restore pool spec %s: %w", poolName, err)
 	}
 	return nil
 }

--- a/dev-infrastructure/scripts/recreate-system-pool/main.go
+++ b/dev-infrastructure/scripts/recreate-system-pool/main.go
@@ -13,11 +13,11 @@
 // limitations under the License.
 //
 // recreate-system-pool: detection-gated self-healing for the NRP KVS
-// corruption that breaks the AKS `system` pool VMSS.
+// corruption that breaks any AKS management cluster nodepool's VMSS.
 //
 // Background
 // ----------
-// A corrupted NRP KVS entity for the `system` pool's VMSS causes every
+// A corrupted NRP KVS entity for a nodepool's VMSS causes every
 // Microsoft.Compute/virtualMachineScaleSets/write to fail with
 // NetworkingInternalOperationError on a continuous retry chain. Fresh
 // VM instances come up but never get a Swift NIC, so kubelet never
@@ -42,12 +42,13 @@
 //   NRP_FAIL_WINDOW_MIN       Activity-log lookback window in min (default 15)
 //   DRY_RUN                   "true" to print intended actions but make no writes
 //
-// Detection checks (ALL must pass; otherwise exit 0 no-op)
-// --------------------------------------------------------
+// Detection checks (ALL must pass per pool; otherwise skip that pool)
+// -------------------------------------------------------------------
 // Names below are the check labels used in log lines and reason
 // strings throughout this binary. Checks run in the order listed
-// (cluster state -> non-system pools -> system wedge -> NRP-KVS storm)
-// so the cheap ARM checks short-circuit before we query Activity Log.
+// (cluster state -> cluster safety -> per-pool wedge -> per-pool
+// NRP-KVS storm) so the cheap ARM checks short-circuit before we
+// query Activity Log.
 //
 //   [cluster state]      cluster provisioningState is recoverable:
 //                        Succeeded, Canceled, Failed (settled) OR
@@ -56,8 +57,8 @@
 //                        whether to abort the LRO). Creating and
 //                        Deleting are rejected; unknown states are
 //                        rejected conservatively.
-//   [non-system pools]   every non-system pool has count > 0.
-//   [system wedge]       system pool provisioningState is NOT
+//   [cluster safety]     at least one non-system pool has count > 0.
+//   [pool wedge]         per-pool provisioningState is NOT
 //                        Succeeded — positive confirmation that this
 //                        specific pool is wedged. Accepts Failed,
 //                        Canceled, Updating, Upgrading (an NRP-KVS
@@ -68,7 +69,7 @@
 //                        Rejects Succeeded (no wedge) and
 //                        Creating/Deleting/unknown.
 //   [NRP-KVS storm]      >= NRP_FAIL_THRESHOLD Failed VMSS-write
-//                        events on the system pool's VMSS in the
+//                        events on the wedged pool's VMSS in the
 //                        last NRP_FAIL_WINDOW_MIN whose inner error
 //                        code is NetworkingInternalOperationError.
 //                        Other failure modes — quota/capacity/policy
@@ -77,23 +78,26 @@
 //                        pool recreation that would not address their
 //                        actual root cause.
 //
-// Action (only when all guards pass)
-// ----------------------------------
-//   1. Snapshot the system pool ARM JSON (raw).
-//   2. Abort cluster LRO if one is active and older than 30 min. The
-//      AROSLSRE-880 / NRP-KVS incident at INT (2026-05-16..18) left the
-//      cluster stuck in Updating for days because the parent upgrade
-//      LRO retried forever; aborting frees the cluster to accept fresh
-//      PUTs. Aborts move the cluster from Updating to Canceled. If the
-//      latest LRO is younger than 30 min, we no-op exit 0 instead of
-//      racing a potentially-healthy in-progress operation.
-//   3. Add throwaway `systmp` System pool (same vmSize + taint + label).
-//   4. Cordon + drain existing system nodes (client-go drain helper).
-//   5. Delete the broken `system` pool.
-//   6. Re-create `system` via SDK CreateOrUpdate with the sanitized
+// Action (only when all guards pass for a pool)
+// ----------------------------------------------
+// For system pools:
+//   1. Snapshot the pool ARM JSON (raw).
+//   2. Add throwaway `systmp` System pool (same vmSize + taint + label).
+//   3. Cordon + drain existing system nodes (client-go drain helper).
+//   4. Delete the broken `system` pool.
+//   5. Re-create `system` via SDK CreateOrUpdate with the sanitized
 //      AgentPool struct from the snapshot.
-//   7. Cordon + drain + delete `systmp`.
-//   8. No-op reconcile via tag update (kicks cluster back to Succeeded).
+//   6. Cordon + drain + delete `systmp`.
+//
+// For non-system pools (user, infra):
+//   1. Snapshot the pool ARM JSON (raw).
+//   2. Cordon + drain existing pool nodes.
+//   3. Delete the broken pool.
+//   4. Re-create the pool via SDK CreateOrUpdate with the sanitized
+//      AgentPool struct from the snapshot.
+//
+// After all pools are remediated:
+//   - No-op reconcile via tag update (kicks cluster back to Succeeded).
 
 package main
 
@@ -106,6 +110,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -132,29 +137,22 @@ const (
 	lroAbortAgeMin    = 30
 	lroLookupWindow   = "14d"
 	systmpReadyTOMin  = 10
-	systemReadyTOMin  = 10
+	poolReadyTOMin    = 10
 	pollIntervalSec   = 30
-	overallTimeoutMin = 60
+	overallTimeoutMin = 150
+	minPoolBudgetMin  = 20
 
 	// The NRP-KVS storm check requires this error code so other failure
 	// modes (quota / capacity / policy / etc) cannot trip the threshold.
 	nrpKVSErrorCode    = "NetworkingInternalOperationError"
 	vmssWriteOperation = "Microsoft.Compute/virtualMachineScaleSets/write"
 
-	// systemVMSSPrefix is the activity-log filter for VMSS-write events
-	// scoped to the system pool's VMSS. AKS names node-pool VMSS using
-	// the convention "aks-<poolName>-<random>-vmss"; this constant is
-	// derived from systemPoolName so the two stay in sync if the system
-	// pool is ever renamed. Stable across all AKS API versions we run
-	// today (2024-10-01, 2025-07-02-preview).
-	systemVMSSPrefix = "aks-" + systemPoolName + "-"
-
 	activityLogAuthRetryTimeoutMin = 5
 	activityLogAuthRetryInitialSec = 10
 	activityLogAuthRetryMaxSec     = 60
 
-	// triggerEvidence forces an AKS RP reconcile of the system pool when
-	// the cluster-state / non-system-pools / system-wedge checks PASS
+	// triggerEvidence forces an AKS RP reconcile of the wedged pool when
+	// the cluster-state / cluster-safety / pool-wedge checks PASS
 	// but the NRP-KVS-storm check has no recent NRP-KVS events in the
 	// configured lookback window. The trigger gives the wedge a chance
 	// to produce fresh evidence (or to prove the wedge is not NRP-KVS).
@@ -173,6 +171,54 @@ const (
 	// skip the abort and leave the AKS RP retrying the wedged write.
 	abortTriggerTimeoutMin = 5
 )
+
+// ---------------------------------------------------------------------------
+// pool classification
+// ---------------------------------------------------------------------------
+
+type poolCategory int
+
+const (
+	poolCategorySystem poolCategory = iota
+	poolCategoryUser
+	poolCategoryInfra
+)
+
+func (c poolCategory) String() string {
+	switch c {
+	case poolCategorySystem:
+		return "system"
+	case poolCategoryUser:
+		return "user"
+	case poolCategoryInfra:
+		return "infra"
+	}
+	return "unknown"
+}
+
+type wedgedPool struct {
+	name        string
+	category    poolCategory
+	vmssPrefix  string
+	nrpFailures int
+	suspected   bool // wedge state passed but NRP storm check failed
+}
+
+func poolVMSSPrefix(poolName string) string {
+	return "aks-" + poolName + "-"
+}
+
+func classifyPool(p *armcs.AgentPool) poolCategory {
+	if p.Properties != nil && p.Properties.Mode != nil && *p.Properties.Mode == armcs.AgentPoolModeSystem {
+		return poolCategorySystem
+	}
+	if p.Properties != nil && p.Properties.NodeLabels != nil {
+		if role := p.Properties.NodeLabels["aro-hcp.azure.com/role"]; role != nil && *role == "infra" {
+			return poolCategoryInfra
+		}
+	}
+	return poolCategoryUser
+}
 
 func main() {
 	// JSON logs to stderr so the Geneva collector ships them to Kusto in
@@ -199,20 +245,20 @@ func main() {
 type orchestrator interface {
 	ensureCluster(ctx context.Context) (armcs.ManagedCluster, bool, error)
 	bootstrapKube(ctx context.Context, mc armcs.ManagedCluster) error
-	detect(ctx context.Context) (bool, string, error)
+	detect(ctx context.Context) ([]wedgedPool, string, error)
 	dumpPreflight(ctx context.Context) error
 	dumpPostflight(ctx context.Context) error
-	preflightChecks(ctx context.Context) error
-	snapshotSystem(ctx context.Context) (*armcs.AgentPool, error)
+	preflightChecks(ctx context.Context, pools []wedgedPool) error
+	snapshotPool(ctx context.Context, poolName string) (*armcs.AgentPool, error)
 	maybeAbortLRO(ctx context.Context) (bool, error)
 	addSystmp(ctx context.Context, live *armcs.AgentPool) error
 	drainPool(ctx context.Context, pool string, timeout time.Duration) error
 	deletePool(ctx context.Context, pool string) error
-	recreateSystem(ctx context.Context, live *armcs.AgentPool) error
+	recreatePool(ctx context.Context, poolName string, live *armcs.AgentPool) error
 	reconcileTagPut(ctx context.Context) error
-	triggerSystemReconcile(ctx context.Context, live *armcs.AgentPool) error
-	pollForNRPEvidence(ctx context.Context, timeout time.Duration, pollInterval time.Duration, windowMin int, threshold int) (int, error)
-	abortSystemReconcile(ctx context.Context) error
+	triggerPoolReconcile(ctx context.Context, poolName string, live *armcs.AgentPool) error
+	pollForNRPEvidence(ctx context.Context, poolName string, vmssPrefix string, timeout time.Duration, pollInterval time.Duration, windowMin int, threshold int) (int, error)
+	abortPoolReconcile(ctx context.Context, poolName string) error
 }
 
 func run() error {
@@ -251,32 +297,59 @@ func runWith(ctx context.Context, cfg *config, orch orchestrator) error {
 		logf("WARN: pre-flight dump partial: %v", err)
 	}
 
-	logBanner("DETECTION GUARDS")
+	logBanner("DETECTION")
 	if cfg.skipGuards {
 		logf("SKIP_GUARDS=true — bypassing detection guards")
 	}
-	act, reason, err := orch.detect(ctx)
+	allWedged, reason, err := orch.detect(ctx)
 	if err != nil {
 		return fmt.Errorf("detection: %w", err)
 	}
-	if !act && !cfg.skipGuards && !cfg.dryRun && reasonIsNRPStormFail(reason) {
-		act, reason, err = forcedEvidencePath(ctx, cfg, orch, reason)
-		if err != nil {
-			return err
+
+	// Separate confirmed (NRP evidence present) from suspected (wedge state only)
+	var confirmed, suspected []wedgedPool
+	for _, wp := range allWedged {
+		if wp.suspected {
+			suspected = append(suspected, wp)
+		} else {
+			confirmed = append(confirmed, wp)
 		}
 	}
-	if !act && !cfg.skipGuards {
-		logf("guards did not fire: %s. Exiting no-op.", reason)
+
+	// Run forced evidence for suspected pools
+	if len(confirmed) == 0 && len(suspected) > 0 && !cfg.skipGuards && !cfg.dryRun {
+		for _, sp := range suspected {
+			logBanner(fmt.Sprintf("FORCED EVIDENCE :: pool %s (%s)", sp.name, sp.category))
+			wp, err := forcedEvidenceForPool(ctx, cfg, orch, sp)
+			if err != nil {
+				return err
+			}
+			if wp != nil {
+				confirmed = append(confirmed, *wp)
+			}
+		}
+		sort.Slice(confirmed, func(i, j int) bool {
+			return confirmed[i].category < confirmed[j].category
+		})
+	}
+
+	wedgedPools := confirmed
+
+	if len(wedgedPools) == 0 && !cfg.skipGuards {
+		logf("no wedged pools detected: %s. Exiting no-op.", reason)
 		return nil
 	}
-	if act {
-		logf("ALL GUARDS PASSED — proceeding with recreate")
+	if len(wedgedPools) > 0 {
+		logf("WEDGED POOLS: %d pool(s) confirmed", len(wedgedPools))
+		for _, wp := range wedgedPools {
+			logf("  pool=%s category=%s nrpFailures=%d", wp.name, wp.category, wp.nrpFailures)
+		}
 	} else {
-		logf("guards did not fire (%s) but SKIP_GUARDS=true — forcing recreate", reason)
+		logf("no wedged pools detected (%s) but SKIP_GUARDS=true", reason)
 	}
 
 	if cfg.dryRun {
-		logf("DRY_RUN=true — guards passed; would proceed with recreate. Exiting no-op.")
+		logf("DRY_RUN=true — would remediate %d pool(s). Exiting no-op.", len(wedgedPools))
 		return nil
 	}
 	if cfg.cpVersion == "" {
@@ -293,16 +366,11 @@ func runWith(ctx context.Context, cfg *config, orch orchestrator) error {
 		logf("WARN: pre-action dump partial: %v", err)
 	}
 
-	if err := orch.preflightChecks(ctx); err != nil {
+	if err := orch.preflightChecks(ctx, wedgedPools); err != nil {
 		return err
 	}
 
-	logBanner("STEP 1 :: snapshot system pool")
-	if _, err := orch.snapshotSystem(ctx); err != nil {
-		return fmt.Errorf("snapshot: %w", err)
-	}
-
-	logBanner("STEP 2 :: abort long-stuck cluster LRO if any")
+	logBanner("ABORT CLUSTER LRO IF ANY")
 	proceed, err := orch.maybeAbortLRO(ctx)
 	if err != nil {
 		return fmt.Errorf("abort LRO: %w", err)
@@ -312,54 +380,59 @@ func runWith(ctx context.Context, cfg *config, orch orchestrator) error {
 		return nil
 	}
 
-	logBanner("STEP 2b :: re-check detection guards after LRO handling")
-	act, reason, err = orch.detect(ctx)
+	logBanner("RE-CHECK DETECTION AFTER LRO HANDLING")
+	allWedged, reason, err = orch.detect(ctx)
 	if err != nil {
 		return fmt.Errorf("post-LRO detection: %w", err)
 	}
-	if !act && !cfg.skipGuards {
-		logf("guards no longer fire after LRO handling: %s. Exiting no-op.", reason)
+	// Re-separate confirmed from suspected after LRO handling
+	confirmed = nil
+	for _, wp := range allWedged {
+		if !wp.suspected {
+			confirmed = append(confirmed, wp)
+		}
+	}
+	wedgedPools = confirmed
+	if len(wedgedPools) == 0 && !cfg.skipGuards {
+		logf("no wedged pools after LRO handling: %s. Exiting no-op.", reason)
 		return nil
 	}
-	if act {
-		logf("guards still pass after LRO handling")
+	if len(wedgedPools) > 0 {
+		logf("wedged pools still present after LRO handling: %d", len(wedgedPools))
 	} else {
-		logf("guards no longer fire (%s) but SKIP_GUARDS=true — continuing", reason)
-	}
-	live, err := orch.snapshotSystem(ctx)
-	if err != nil {
-		return fmt.Errorf("post-LRO snapshot: %w", err)
+		logf("no wedged pools after LRO handling (%s) but SKIP_GUARDS=true — continuing", reason)
 	}
 
-	logBanner("STEP 3 :: add throwaway 'systmp' System pool")
-	if err := orch.addSystmp(ctx, live); err != nil {
-		return fmt.Errorf("add systmp: %w", err)
+	deadline, hasDeadline := ctx.Deadline()
+	for i, wp := range wedgedPools {
+		if hasDeadline {
+			remaining := time.Until(deadline)
+			if remaining < minPoolBudgetMin*time.Minute {
+				logf("WARN: only %s remaining; skipping pool %s and %d remaining pool(s)",
+					remaining.Round(time.Minute), wp.name, len(wedgedPools)-i)
+				break
+			}
+		}
+
+		logBanner(fmt.Sprintf("REMEDIATE POOL %d/%d :: %s (%s)", i+1, len(wedgedPools), wp.name, wp.category))
+
+		live, err := orch.snapshotPool(ctx, wp.name)
+		if err != nil {
+			return fmt.Errorf("snapshot pool %s: %w", wp.name, err)
+		}
+
+		if wp.category == poolCategorySystem {
+			if err := remediateSystemPool(ctx, orch, wp, live); err != nil {
+				return err
+			}
+		} else {
+			if err := remediateNonSystemPool(ctx, orch, wp, live); err != nil {
+				return err
+			}
+		}
 	}
 
-	logBanner("STEP 4 :: cordon + drain existing system nodes")
-	if err := orch.drainPool(ctx, systemPoolName, 10*time.Minute); err != nil {
-		return fmt.Errorf("drain system: %w", err)
-	}
-
-	logBanner("STEP 5 :: delete the broken 'system' pool")
-	if err := orch.deletePool(ctx, systemPoolName); err != nil {
-		return fmt.Errorf("delete system: %w", err)
-	}
-
-	logBanner("STEP 6 :: re-create 'system' via SDK CreateOrUpdate")
-	if err := orch.recreateSystem(ctx, live); err != nil {
-		return fmt.Errorf("recreate system: %w", err)
-	}
-
-	logBanner("STEP 7 :: drain + delete throwaway 'systmp' pool")
-	if err := orch.drainPool(ctx, systmpPoolName, 5*time.Minute); err != nil {
-		logf("WARN: systmp drain returned: %v (continuing to delete)", err)
-	}
-	if err := orch.deletePool(ctx, systmpPoolName); err != nil {
-		return fmt.Errorf("delete systmp: %w", err)
-	}
-
-	logBanner("STEP 8 :: no-op reconcile via tag update")
+	logBanner("TAG RECONCILE")
 	if err := orch.reconcileTagPut(ctx); err != nil {
 		return fmt.Errorf("tag reconcile: %w", err)
 	}
@@ -371,62 +444,112 @@ func runWith(ctx context.Context, cfg *config, orch orchestrator) error {
 	return nil
 }
 
-// forcedEvidencePath triggers a no-op reconcile on the live system
-// pool so the AKS RP attempts a fresh VMSS write. It then polls the
+func remediateSystemPool(ctx context.Context, orch orchestrator, wp wedgedPool, live *armcs.AgentPool) error {
+	logf("system pool requires systmp dance")
+
+	logf(">>> adding throwaway systmp pool")
+	if err := orch.addSystmp(ctx, live); err != nil {
+		return fmt.Errorf("add systmp for %s: %w", wp.name, err)
+	}
+
+	logf(">>> draining pool %s", wp.name)
+	if err := orch.drainPool(ctx, wp.name, 10*time.Minute); err != nil {
+		return fmt.Errorf("drain %s: %w", wp.name, err)
+	}
+
+	logf(">>> deleting pool %s", wp.name)
+	if err := orch.deletePool(ctx, wp.name); err != nil {
+		return fmt.Errorf("delete %s: %w", wp.name, err)
+	}
+
+	logf(">>> recreating pool %s", wp.name)
+	if err := orch.recreatePool(ctx, wp.name, live); err != nil {
+		return fmt.Errorf("recreate %s: %w", wp.name, err)
+	}
+
+	logf(">>> cleaning up systmp")
+	if err := orch.drainPool(ctx, systmpPoolName, 5*time.Minute); err != nil {
+		logf("WARN: systmp drain returned: %v (continuing to delete)", err)
+	}
+	if err := orch.deletePool(ctx, systmpPoolName); err != nil {
+		return fmt.Errorf("delete systmp: %w", err)
+	}
+
+	return nil
+}
+
+func remediateNonSystemPool(ctx context.Context, orch orchestrator, wp wedgedPool, live *armcs.AgentPool) error {
+	logf(">>> draining pool %s", wp.name)
+	if err := orch.drainPool(ctx, wp.name, 10*time.Minute); err != nil {
+		return fmt.Errorf("drain %s: %w", wp.name, err)
+	}
+
+	logf(">>> deleting pool %s", wp.name)
+	if err := orch.deletePool(ctx, wp.name); err != nil {
+		return fmt.Errorf("delete %s: %w", wp.name, err)
+	}
+
+	logf(">>> recreating pool %s", wp.name)
+	if err := orch.recreatePool(ctx, wp.name, live); err != nil {
+		return fmt.Errorf("recreate %s: %w", wp.name, err)
+	}
+
+	return nil
+}
+
+// forcedEvidenceForPool triggers a no-op reconcile on the given pool
+// so the AKS RP attempts a fresh VMSS write. It then polls the
 // activity log for NRP-KVS Failed events and aborts the LRO it started
 // once threshold-many hits are observed or the timeout elapses.
 //
-// Returns (act, reason, error). act=true means evidence reached the
-// threshold and the caller should proceed with the recreate flow.
-// act=false with no error means the trigger was inconclusive (the
-// cluster is wedged for a different reason) and the caller should
-// exit no-op.
-func forcedEvidencePath(ctx context.Context, cfg *config, orch orchestrator, initialReason string) (bool, string, error) {
-	logBanner("FORCED EVIDENCE :: triggering reconcile to verify NRP-KVS signature")
-	logf("initial NRP-KVS storm check saw no evidence in last %dm: %s", cfg.windowMin, initialReason)
+// Returns a *wedgedPool if evidence reached the threshold and the caller
+// should proceed with the remediate flow. Returns nil with no error if
+// the trigger was inconclusive (the pool is wedged for a different
+// reason) and the caller should skip it.
+func forcedEvidenceForPool(ctx context.Context, cfg *config, orch orchestrator, sp wedgedPool) (*wedgedPool, error) {
+	logf("initial NRP-KVS storm check saw no evidence for pool %s in last %dm", sp.name, cfg.windowMin)
 
-	live, err := orch.snapshotSystem(ctx)
+	live, err := orch.snapshotPool(ctx, sp.name)
 	if err != nil {
-		return false, initialReason, fmt.Errorf("forced evidence snapshot: %w", err)
+		return nil, fmt.Errorf("forced evidence snapshot %s: %w", sp.name, err)
 	}
 
-	if err := orch.triggerSystemReconcile(ctx, live); err != nil {
-		logf("WARN: triggerSystemReconcile failed: %v; treating as no-op", err)
-		return false, initialReason, nil
+	if err := orch.triggerPoolReconcile(ctx, sp.name, live); err != nil {
+		logf("WARN: triggerPoolReconcile for %s failed: %v; treating as no-op", sp.name, err)
+		return nil, nil
 	}
 
-	logf("triggered system pool reconcile; polling activity log every %ds for up to %dm",
-		triggerEvidencePollIntervalSec, triggerEvidenceTimeoutMin)
+	logf("triggered pool %s reconcile; polling activity log every %ds for up to %dm",
+		sp.name, triggerEvidencePollIntervalSec, triggerEvidenceTimeoutMin)
 	hits, pollErr := orch.pollForNRPEvidence(
 		ctx,
+		sp.name,
+		sp.vmssPrefix,
 		triggerEvidenceTimeoutMin*time.Minute,
 		triggerEvidencePollIntervalSec*time.Second,
 		triggerEvidenceWindowMin,
 		cfg.threshold,
 	)
 
-	// Always best-effort abort the LRO we started so the cluster doesn't
-	// keep retrying the wedged write after we're done observing. Use a
-	// fresh context.Background-rooted context so the abort still runs
-	// when the parent ctx is already cancelled (overall script timeout
-	// or pollForNRPEvidence consuming its full budget) — the LRO we
-	// triggered here is our responsibility to tear down.
 	abortCtx, abortCancel := context.WithTimeout(context.Background(), abortTriggerTimeoutMin*time.Minute)
 	defer abortCancel()
-	if abortErr := orch.abortSystemReconcile(abortCtx); abortErr != nil {
-		logf("WARN: abortSystemReconcile failed: %v", abortErr)
+	if abortErr := orch.abortPoolReconcile(abortCtx, sp.name); abortErr != nil {
+		logf("WARN: abortPoolReconcile for %s failed: %v", sp.name, abortErr)
 	}
 
 	if pollErr != nil {
-		return false, initialReason, fmt.Errorf("poll for NRP evidence: %w", pollErr)
+		return nil, fmt.Errorf("poll for NRP evidence on %s: %w", sp.name, pollErr)
 	}
 	if hits < cfg.threshold {
-		reason := fmt.Sprintf("forced evidence inconclusive: only %d NRP failures < %d after %dm", hits, cfg.threshold, triggerEvidenceTimeoutMin)
-		logf("%s. Exiting no-op.", reason)
-		return false, reason, nil
+		logf("forced evidence inconclusive for %s: only %d NRP failures < %d after %dm",
+			sp.name, hits, cfg.threshold, triggerEvidenceTimeoutMin)
+		return nil, nil
 	}
-	logf("forced evidence confirmed NRP-KVS (%d hits >= threshold %d) — proceeding with recreate", hits, cfg.threshold)
-	return true, "", nil
+	logf("forced evidence confirmed NRP-KVS for %s (%d hits >= threshold %d)", sp.name, hits, cfg.threshold)
+	wp := sp
+	wp.nrpFailures = hits
+	wp.suspected = false
+	return &wp, nil
 }
 
 // ---------------------------------------------------------------------------
@@ -808,48 +931,36 @@ func evalClusterState(provisioningState string) (bool, string) {
 	return false, fmt.Sprintf("cluster state FAIL: provisioningState=%q is not a recognized recoverable state", provisioningState)
 }
 
-// evalNonSystemPools reports whether all non-system pools have count > 0
-// and a system pool exists. Also reports the system pool's minCount
-// and provisioningState back to the caller so the latter can be fed
-// into evalSystemWedge without a second list-pools API call.
-//
-// Returns (pass, systemMin, systemProvState, reason).
-func evalNonSystemPools(pools []*armcs.AgentPool) (bool, int32, string, string) {
-	var systemMin int32
-	var systemProvState string
-	systemFound := false
+// evalClusterSafety reports whether the cluster has at least one
+// non-system pool with count > 0, ensuring we never operate on a
+// cluster where all workload capacity has disappeared.
+func evalClusterSafety(pools []*armcs.AgentPool) (bool, string) {
+	hasNonSystemWithCount := false
 	for _, p := range pools {
 		if p == nil || p.Name == nil || p.Properties == nil {
 			continue
 		}
-		name := *p.Name
-		if name == systemPoolName {
-			systemFound = true
-			if p.Properties.MinCount != nil {
-				systemMin = *p.Properties.MinCount
-			}
-			if p.Properties.ProvisioningState != nil {
-				systemProvState = *p.Properties.ProvisioningState
-			}
+		if *p.Name == systemPoolName || *p.Name == systmpPoolName {
 			continue
 		}
 		cnt := int32(0)
 		if p.Properties.Count != nil {
 			cnt = *p.Properties.Count
 		}
-		if cnt == 0 {
-			return false, 0, "", fmt.Sprintf("non-system pools FAIL: pool %q has count=0", name)
+		if cnt > 0 {
+			hasNonSystemWithCount = true
+			break
 		}
 	}
-	if !systemFound {
-		return false, 0, "", "non-system pools FAIL: no system pool found"
+	if !hasNonSystemWithCount {
+		return false, "cluster safety FAIL: no non-system pool has count > 0"
 	}
-	return true, systemMin, systemProvState, ""
+	return true, ""
 }
 
-// evalSystemWedge reports whether the system pool itself is in a
-// wedge-compatible state. Refines the NRP-KVS storm check with a
-// positive signal scoped to this exact agent-pool resource.
+// evalPoolWedged reports whether a pool is in a wedge-compatible state.
+// Refines the NRP-KVS storm check with a positive signal scoped to
+// this exact agent-pool resource.
 //
 // Accepts:
 //   - Failed   — RP gave up retrying the VMSS write chain.
@@ -865,86 +976,162 @@ func evalNonSystemPools(pools []*armcs.AgentPool) (bool, int32, string, string) 
 //   - Creating  — pool not fully created yet; do not interfere.
 //   - Deleting  — pool being torn down; do not interfere.
 //   - empty / unknown — fail conservatively.
-func evalSystemWedge(systemProvState string) (bool, string) {
-	switch systemProvState {
+func evalPoolWedged(provState string) (bool, string) {
+	switch provState {
 	case "Failed", "Canceled", "Updating", "Upgrading":
 		return true, ""
 	case "Succeeded":
-		return false, "system wedge FAIL: provisioningState=\"Succeeded\" (no wedge)"
+		return false, "pool wedge FAIL: provisioningState=\"Succeeded\" (no wedge)"
 	case "Creating":
-		return false, "system wedge FAIL: provisioningState=\"Creating\" (not fully created)"
+		return false, "pool wedge FAIL: provisioningState=\"Creating\" (not fully created)"
 	case "Deleting":
-		return false, "system wedge FAIL: provisioningState=\"Deleting\" (being torn down)"
+		return false, "pool wedge FAIL: provisioningState=\"Deleting\" (being torn down)"
 	case "":
-		return false, "system wedge FAIL: provisioningState is empty"
+		return false, "pool wedge FAIL: provisioningState is empty"
 	}
-	return false, fmt.Sprintf("system wedge FAIL: provisioningState=%q is not a recognized wedge-compatible state", systemProvState)
+	return false, fmt.Sprintf("pool wedge FAIL: provisioningState=%q is not a recognized wedge-compatible state", provState)
 }
 
-func (c *clients) detect(ctx context.Context) (bool, string, error) {
+func (c *clients) detect(ctx context.Context) ([]wedgedPool, string, error) {
 	// Cluster state check
 	mc, err := c.cluster.Get(ctx, c.cfg.resourceGroup, c.cfg.clusterName, nil)
 	if err != nil {
-		return false, "", fmt.Errorf("cluster state get: %w", err)
+		return nil, "", fmt.Errorf("cluster state get: %w", err)
 	}
 	cs := ""
 	if mc.Properties != nil && mc.Properties.ProvisioningState != nil {
 		cs = *mc.Properties.ProvisioningState
 	}
-	logf("cluster state :: provisioningState=%s (accept: Succeeded/Canceled/Failed/Updating/Upgrading; reject: Creating/Deleting/unknown)", cs)
+	logf("cluster state :: provisioningState=%s", cs)
 	if pass, reason := evalClusterState(cs); !pass {
-		return false, reason, nil
+		return nil, reason, nil
 	}
 	logf("cluster state PASS")
 
-	// Non-system pools check (also discovers system minCount and state).
+	// List all pools
 	pager := c.pools.NewListPager(c.cfg.resourceGroup, c.cfg.clusterName, nil)
 	var allPools []*armcs.AgentPool
 	for pager.More() {
 		page, err := pager.NextPage(ctx)
 		if err != nil {
-			return false, "", fmt.Errorf("non-system pools list: %w", err)
+			return nil, "", fmt.Errorf("list pools: %w", err)
 		}
 		allPools = append(allPools, page.Value...)
 	}
-	pass, systemMin, systemProvState, reason := evalNonSystemPools(allPools)
-	if !pass {
-		return false, reason, nil
-	}
-	logf("non-system pools PASS (system minCount=%d systemProvState=%q)", systemMin, systemProvState)
 
-	// System wedge check (system pool itself is in a wedge-compatible state).
-	if pass, reason := evalSystemWedge(systemProvState); !pass {
-		return false, reason, nil
+	// Safety: at least one non-system pool has count > 0
+	if pass, reason := evalClusterSafety(allPools); !pass {
+		return nil, reason, nil
 	}
-	logf("system wedge PASS (system pool provisioningState=%q)", systemProvState)
+	logf("cluster safety PASS")
 
-	// NRP-KVS storm check (activity log on aks-system-* VMSS)
+	// SKIP_GUARDS: return all pools as confirmed wedged regardless of state.
+	if c.cfg.skipGuards {
+		logf("SKIP_GUARDS=true — marking all pools as confirmed wedged")
+		var wedged []wedgedPool
+		for _, p := range allPools {
+			if p == nil || p.Name == nil || p.Properties == nil {
+				continue
+			}
+			name := *p.Name
+			if name == systmpPoolName {
+				continue
+			}
+			cat := classifyPool(p)
+			logf("pool %s: category=%s — force-marking as wedged (SKIP_GUARDS)", name, cat)
+			wedged = append(wedged, wedgedPool{
+				name:       name,
+				category:   cat,
+				vmssPrefix: poolVMSSPrefix(name),
+			})
+		}
+		sort.Slice(wedged, func(i, j int) bool {
+			return wedged[i].category < wedged[j].category
+		})
+		return wedged, "", nil
+	}
+
+	// Query activity log once for all pools
 	logf("NRP-KVS storm :: checking activity log on %s for last %d min", c.cfg.nodeRG, c.cfg.windowMin)
 	out, err := c.activityLogJSON(ctx, c.cfg.nodeRG, fmt.Sprintf("%dm", c.cfg.windowMin))
 	if err != nil {
-		return false, "", fmt.Errorf("NRP-KVS storm activity-log query failed: %w", err)
+		return nil, "", fmt.Errorf("NRP-KVS storm activity-log query failed: %w", err)
 	}
-	hits, err := countNRPFailures(out, systemVMSSPrefix)
-	if err != nil {
-		return false, "", fmt.Errorf("NRP-KVS storm activity-log parse failed: %w", err)
-	}
-	logf("NRP-KVS storm :: NRP-KVS (%s) Failed events on aks-system-* in window: %d (threshold %d)",
-		nrpKVSErrorCode, hits, c.cfg.threshold)
-	if pass, reason := evalNRPStorm(hits, c.cfg.threshold); !pass {
-		return false, reason, nil
-	}
-	logf("NRP-KVS storm PASS")
 
-	return true, "", nil
+	// Check each pool for wedge state and NRP evidence
+	var wedged []wedgedPool
+	for _, p := range allPools {
+		if p == nil || p.Name == nil || p.Properties == nil {
+			continue
+		}
+		name := *p.Name
+		if name == systmpPoolName {
+			continue
+		}
+
+		provState := strDeref(p.Properties.ProvisioningState)
+		if pass, _ := evalPoolWedged(provState); !pass {
+			continue
+		}
+		logf("pool %s: provisioningState=%s — wedge-compatible", name, provState)
+
+		vmssPrefix := poolVMSSPrefix(name)
+		hits, err := countNRPFailures(out, vmssPrefix)
+		if err != nil {
+			return nil, "", fmt.Errorf("NRP failure count for pool %s: %w", name, err)
+		}
+		logf("pool %s: NRP-KVS failures on %s*: %d (threshold %d)", name, vmssPrefix, hits, c.cfg.threshold)
+
+		cat := classifyPool(p)
+		if hits >= c.cfg.threshold {
+			logf("pool %s: NRP-KVS storm CONFIRMED", name)
+			wedged = append(wedged, wedgedPool{
+				name:        name,
+				category:    cat,
+				vmssPrefix:  vmssPrefix,
+				nrpFailures: hits,
+			})
+		} else {
+			logf("pool %s: NRP storm threshold not met — marking as suspected", name)
+			wedged = append(wedged, wedgedPool{
+				name:        name,
+				category:    cat,
+				vmssPrefix:  vmssPrefix,
+				nrpFailures: hits,
+				suspected:   true,
+			})
+		}
+	}
+
+	// Sort: system first, then user, then infra
+	sort.Slice(wedged, func(i, j int) bool {
+		return wedged[i].category < wedged[j].category
+	})
+
+	if len(wedged) == 0 {
+		return nil, "no pools are in wedge-compatible state", nil
+	}
+	return wedged, "", nil
 }
 
-// preflightChecks fails CLOSED: if the AKS Get for systmp returns
-// anything other than HTTP 404 we must not proceed. Treating
-// auth/throttling/transient errors as "pool does not exist" would let
-// us create a duplicate systmp on top of an existing one, which would
-// fail with a less actionable error later.
-func (c *clients) preflightChecks(ctx context.Context) error {
+// preflightChecks fails CLOSED: if a system pool is in the wedged list,
+// verify that no leftover 'systmp' pool exists. If the AKS Get for
+// systmp returns anything other than HTTP 404 we must not proceed.
+// Treating auth/throttling/transient errors as "pool does not exist"
+// would let us create a duplicate systmp on top of an existing one,
+// which would fail with a less actionable error later.
+func (c *clients) preflightChecks(ctx context.Context, pools []wedgedPool) error {
+	systemInList := false
+	for _, wp := range pools {
+		if wp.category == poolCategorySystem {
+			systemInList = true
+			break
+		}
+	}
+	if !systemInList {
+		return nil
+	}
+
 	_, err := c.pools.Get(ctx, c.cfg.resourceGroup, c.cfg.clusterName, systmpPoolName, nil)
 	switch {
 	case err == nil:
@@ -957,27 +1144,26 @@ func (c *clients) preflightChecks(ctx context.Context) error {
 }
 
 // ---------------------------------------------------------------------------
-// step 1 :: snapshot
+// snapshot
 // ---------------------------------------------------------------------------
 
-func (c *clients) snapshotSystem(ctx context.Context) (*armcs.AgentPool, error) {
-	resp, err := c.pools.Get(ctx, c.cfg.resourceGroup, c.cfg.clusterName, systemPoolName, nil)
+func (c *clients) snapshotPool(ctx context.Context, poolName string) (*armcs.AgentPool, error) {
+	resp, err := c.pools.Get(ctx, c.cfg.resourceGroup, c.cfg.clusterName, poolName, nil)
 	if err != nil {
-		return nil, fmt.Errorf("get system pool: %w", err)
+		return nil, fmt.Errorf("get pool %s: %w", poolName, err)
 	}
 	live := resp.AgentPool
-	// Audit-friendly stdout dump.
 	if b, err := json.MarshalIndent(live, "", "  "); err == nil {
-		logf("--- live system pool (raw) ---\n%s", string(b))
+		logf("--- live pool %s (raw) ---\n%s", poolName, string(b))
 	}
 	if live.Properties == nil {
-		return nil, errors.New("system pool has no properties")
+		return nil, fmt.Errorf("pool %s has no properties", poolName)
 	}
 	if live.Properties.VMSize == nil || *live.Properties.VMSize == "" {
-		return nil, errors.New("system pool has no VMSize; refusing to act")
+		return nil, fmt.Errorf("pool %s has no VMSize; refusing to act", poolName)
 	}
 	if live.Properties.VnetSubnetID == nil || *live.Properties.VnetSubnetID == "" {
-		return nil, errors.New("system pool has no VnetSubnetID; refusing to act")
+		return nil, fmt.Errorf("pool %s has no VnetSubnetID; refusing to act", poolName)
 	}
 	return &live, nil
 }
@@ -1036,7 +1222,7 @@ func agentPoolForCreate(live *armcs.AgentPool, cpVersion string) (*armcs.AgentPo
 }
 
 // ---------------------------------------------------------------------------
-// step 2 :: maybe abort LRO
+// maybe abort LRO
 // ---------------------------------------------------------------------------
 
 func isActiveClusterState(state string) bool {
@@ -1098,7 +1284,7 @@ func (c *clients) maybeAbortLRO(ctx context.Context) (bool, error) {
 }
 
 // ---------------------------------------------------------------------------
-// step 3 :: systmp
+// systmp
 // ---------------------------------------------------------------------------
 
 // buildSystmpAgentPool constructs the throwaway System pool body from a
@@ -1157,7 +1343,7 @@ func (c *clients) addSystmp(ctx context.Context, live *armcs.AgentPool) error {
 }
 
 // ---------------------------------------------------------------------------
-// step 4/7 :: drain (client-go drain helper)
+// drain (client-go drain helper)
 // ---------------------------------------------------------------------------
 
 // drainPool cordons each node before inspecting/deleting pods. Cordon failure is fatal:
@@ -1216,7 +1402,7 @@ func (c *clients) drainPool(ctx context.Context, pool string, timeout time.Durat
 }
 
 // ---------------------------------------------------------------------------
-// step 5 :: delete pool
+// delete pool
 // ---------------------------------------------------------------------------
 
 func (c *clients) deletePool(ctx context.Context, pool string) error {
@@ -1233,24 +1419,24 @@ func (c *clients) deletePool(ctx context.Context, pool string) error {
 }
 
 // ---------------------------------------------------------------------------
-// step 6 :: re-create system via SDK CreateOrUpdate
+// re-create pool via SDK CreateOrUpdate
 // ---------------------------------------------------------------------------
 
-func (c *clients) recreateSystem(ctx context.Context, live *armcs.AgentPool) error {
+func (c *clients) recreatePool(ctx context.Context, poolName string, live *armcs.AgentPool) error {
 	body, err := agentPoolForCreate(live, c.cfg.cpVersion)
 	if err != nil {
-		return fmt.Errorf("agent pool clone: %w", err)
+		return fmt.Errorf("agent pool clone for %s: %w", poolName, err)
 	}
 	if b, err := json.MarshalIndent(body, "", "  "); err == nil {
-		logf("--- sanitized PUT body ---\n%s", string(b))
+		logf("--- sanitized PUT body for %s ---\n%s", poolName, string(b))
 	}
-	logf("BeginCreateOrUpdate system pool")
-	poller, err := c.pools.BeginCreateOrUpdate(ctx, c.cfg.resourceGroup, c.cfg.clusterName, systemPoolName, *body, nil)
+	logf("BeginCreateOrUpdate pool %s", poolName)
+	poller, err := c.pools.BeginCreateOrUpdate(ctx, c.cfg.resourceGroup, c.cfg.clusterName, poolName, *body, nil)
 	if err != nil {
-		return fmt.Errorf("begin recreate system: %w", err)
+		return fmt.Errorf("begin recreate %s: %w", poolName, err)
 	}
 	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
-		return fmt.Errorf("poll recreate system: %w", err)
+		return fmt.Errorf("poll recreate %s: %w", poolName, err)
 	}
 	expected := int32(1)
 	if body.Properties != nil {
@@ -1260,12 +1446,12 @@ func (c *clients) recreateSystem(ctx context.Context, live *armcs.AgentPool) err
 			expected = *body.Properties.Count
 		}
 	}
-	logf("system pool ARM-Succeeded; waiting for %d Ready k8s node(s)", expected)
-	return c.waitForReadyNodes(ctx, systemPoolName, int(expected), systemReadyTOMin*time.Minute)
+	logf("pool %s ARM-Succeeded; waiting for %d Ready k8s node(s)", poolName, expected)
+	return c.waitForReadyNodes(ctx, poolName, int(expected), poolReadyTOMin*time.Minute)
 }
 
 // ---------------------------------------------------------------------------
-// step 8 :: no-op tag reconcile via SDK tag PATCH
+// no-op tag reconcile via SDK tag PATCH
 // ---------------------------------------------------------------------------
 
 func (c *clients) reconcileTagPut(ctx context.Context) error {
@@ -1287,23 +1473,23 @@ func (c *clients) reconcileTagPut(ctx context.Context) error {
 }
 
 // ---------------------------------------------------------------------------
-// forced-evidence trigger (used only when cluster-state, non-system-pools,
-// and system-wedge checks PASS and the NRP-KVS-storm check FAILs
+// forced-evidence trigger (used only when cluster-state, cluster-safety,
+// and pool-wedge checks PASS and the NRP-KVS-storm check FAILs
 // because the activity log has no recent NRP-KVS events)
 // ---------------------------------------------------------------------------
 
-// triggerSystemReconcile starts an AKS RP reconcile of the live system
-// pool by issuing a sanitized CreateOrUpdate with the snapshot spec.
+// triggerPoolReconcile starts an AKS RP reconcile of the given pool
+// by issuing a sanitized CreateOrUpdate with the snapshot spec.
 // It does not wait for the LRO to finish — the caller polls the activity
 // log for NRP-KVS evidence in parallel and aborts the LRO when done.
-func (c *clients) triggerSystemReconcile(ctx context.Context, live *armcs.AgentPool) error {
+func (c *clients) triggerPoolReconcile(ctx context.Context, poolName string, live *armcs.AgentPool) error {
 	body, err := agentPoolForCreate(live, c.cfg.cpVersion)
 	if err != nil {
-		return fmt.Errorf("triggerSystemReconcile: %w", err)
+		return fmt.Errorf("triggerPoolReconcile %s: %w", poolName, err)
 	}
-	logf("triggering AgentPool CreateOrUpdate on %q (no-op reconcile with live spec)", systemPoolName)
-	if _, err := c.pools.BeginCreateOrUpdate(ctx, c.cfg.resourceGroup, c.cfg.clusterName, systemPoolName, *body, nil); err != nil {
-		return fmt.Errorf("begin trigger system reconcile: %w", err)
+	logf("triggering AgentPool CreateOrUpdate on %q (no-op reconcile with live spec)", poolName)
+	if _, err := c.pools.BeginCreateOrUpdate(ctx, c.cfg.resourceGroup, c.cfg.clusterName, poolName, *body, nil); err != nil {
+		return fmt.Errorf("begin trigger pool reconcile %s: %w", poolName, err)
 	}
 	return nil
 }
@@ -1313,31 +1499,31 @@ func (c *clients) triggerSystemReconcile(ctx context.Context, live *armcs.AgentP
 // elapses. windowMin controls how far back each poll looks (a window
 // equal to the timeout makes every poll see all events since the
 // trigger).
-func (c *clients) pollForNRPEvidence(ctx context.Context, timeout time.Duration, pollInterval time.Duration, windowMin int, threshold int) (int, error) {
+func (c *clients) pollForNRPEvidence(ctx context.Context, poolName string, vmssPrefix string, timeout time.Duration, pollInterval time.Duration, windowMin int, threshold int) (int, error) {
 	if pollInterval <= 0 {
 		pollInterval = 60 * time.Second
 	}
 	deadline := time.Now().Add(timeout)
 	last := 0
 	for {
-		resp, err := c.pools.Get(ctx, c.cfg.resourceGroup, c.cfg.clusterName, systemPoolName, nil)
+		resp, err := c.pools.Get(ctx, c.cfg.resourceGroup, c.cfg.clusterName, poolName, nil)
 		if err != nil {
-			logf("WARN: forced-evidence pool state check failed: %v (continuing)", err)
+			logf("WARN: forced-evidence pool state check for %s failed: %v (continuing)", poolName, err)
 		} else if resp.Properties != nil && resp.Properties.ProvisioningState != nil && *resp.Properties.ProvisioningState == "Succeeded" {
-			logf("forced evidence: system pool provisioningState=Succeeded; wedge resolved, returning early")
+			logf("forced evidence: pool %s provisioningState=Succeeded; wedge resolved, returning early", poolName)
 			return 0, nil
 		}
 
 		out, err := c.activityLogJSON(ctx, c.cfg.nodeRG, fmt.Sprintf("%dm", windowMin))
 		if err != nil {
-			return last, fmt.Errorf("forced-evidence activity-log query: %w", err)
+			return last, fmt.Errorf("forced-evidence activity-log query for %s: %w", poolName, err)
 		}
-		hits, parseErr := countNRPFailures(out, systemVMSSPrefix)
+		hits, parseErr := countNRPFailures(out, vmssPrefix)
 		if parseErr != nil {
-			return last, fmt.Errorf("forced-evidence activity-log parse: %w", parseErr)
+			return last, fmt.Errorf("forced-evidence activity-log parse for %s: %w", poolName, parseErr)
 		}
 		last = hits
-		logf("forced evidence poll: NRP-KVS hits=%d threshold=%d (window=%dm)", hits, threshold, windowMin)
+		logf("forced evidence poll for %s: NRP-KVS hits=%d threshold=%d (window=%dm)", poolName, hits, threshold, windowMin)
 		if hits >= threshold {
 			return hits, nil
 		}
@@ -1356,17 +1542,17 @@ func (c *clients) pollForNRPEvidence(ctx context.Context, timeout time.Duration,
 	}
 }
 
-// abortSystemReconcile aborts the latest LRO on the system pool, which
+// abortPoolReconcile aborts the latest LRO on the given pool, which
 // (when the forced-evidence trigger started one) cancels the in-flight
 // CreateOrUpdate. Best-effort: failures here are logged by the caller
 // but not propagated.
-func (c *clients) abortSystemReconcile(ctx context.Context) error {
-	poller, err := c.pools.BeginAbortLatestOperation(ctx, c.cfg.resourceGroup, c.cfg.clusterName, systemPoolName, nil)
+func (c *clients) abortPoolReconcile(ctx context.Context, poolName string) error {
+	poller, err := c.pools.BeginAbortLatestOperation(ctx, c.cfg.resourceGroup, c.cfg.clusterName, poolName, nil)
 	if err != nil {
-		return fmt.Errorf("begin abort system reconcile: %w", err)
+		return fmt.Errorf("begin abort pool reconcile %s: %w", poolName, err)
 	}
 	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
-		return fmt.Errorf("poll abort system reconcile: %w", err)
+		return fmt.Errorf("poll abort pool reconcile %s: %w", poolName, err)
 	}
 	return nil
 }
@@ -1432,18 +1618,6 @@ func isNodeSchedulableReady(n *corev1.Node) bool {
 		return false
 	}
 	return n.DeletionTimestamp == nil
-}
-
-// reasonIsNRPStormFail reports whether a detect() reason string
-// indicates that the cluster-state, non-system-pools, and system-wedge
-// checks all PASSed and only the NRP-KVS-storm check FAILed.
-// Used to gate the forced-evidence trigger path: the cluster is in a
-// wedge-compatible state, but the activity log has no recent NRP-KVS
-// events in the configured lookback window. The forced-evidence path
-// triggers a no-op reconcile on the live system pool to give AKS a
-// chance to re-attempt the failing VMSS write before deciding to act.
-func reasonIsNRPStormFail(reason string) bool {
-	return strings.HasPrefix(strings.TrimSpace(reason), "NRP-KVS storm FAIL")
 }
 
 // activityLogJSON returns Activity Log events in the compact JSON shape used

--- a/dev-infrastructure/scripts/recreate-system-pool/main.go
+++ b/dev-infrastructure/scripts/recreate-system-pool/main.go
@@ -952,7 +952,10 @@ func evalClusterSafety(pools []*armcs.AgentPool) (bool, string) {
 		if p == nil || p.Name == nil || p.Properties == nil {
 			continue
 		}
-		if *p.Name == systemPoolName || *p.Name == systmpPoolName {
+		if classifyPool(p) == poolCategorySystem {
+			continue
+		}
+		if *p.Name == systmpPoolName {
 			continue
 		}
 		cnt := int32(0)

--- a/dev-infrastructure/scripts/recreate-system-pool/main.go
+++ b/dev-infrastructure/scripts/recreate-system-pool/main.go
@@ -387,24 +387,42 @@ func runWith(ctx context.Context, cfg *config, orch orchestrator) error {
 	}
 
 	logBanner("RE-CHECK DETECTION AFTER LRO HANDLING")
+	priorConfirmed := wedgedPools
 	allWedged, reason, err = orch.detect(ctx)
 	if err != nil {
 		return fmt.Errorf("post-LRO detection: %w", err)
 	}
-	// Re-separate confirmed from suspected after LRO handling
-	confirmed = nil
+	// Merge: keep pools that are still confirmed, and carry forward any
+	// pool that was confirmed in phase 1 but came back as suspected
+	// (e.g. the activity-log window rolled past the forced-evidence trigger).
+	// Pools that disappeared from allWedged entirely (recovered to Succeeded)
+	// are NOT carried forward.
+	reconfirmed := make(map[string]bool)
+	suspectedNames := make(map[string]bool)
+	wedgedPools = nil
 	for _, wp := range allWedged {
 		if !wp.suspected {
-			confirmed = append(confirmed, wp)
+			wedgedPools = append(wedgedPools, wp)
+			reconfirmed[wp.name] = true
+		} else {
+			suspectedNames[wp.name] = true
 		}
 	}
-	wedgedPools = confirmed
+	for _, wp := range priorConfirmed {
+		if !reconfirmed[wp.name] && suspectedNames[wp.name] {
+			logf("pool %s: was confirmed in phase 1 but re-detect classified as suspected; carrying forward", wp.name)
+			wedgedPools = append(wedgedPools, wp)
+		}
+	}
+	sort.Slice(wedgedPools, func(i, j int) bool {
+		return wedgedPools[i].category < wedgedPools[j].category
+	})
 	if len(wedgedPools) == 0 && !cfg.skipGuards {
 		logf("no wedged pools after LRO handling: %s. Exiting no-op.", reason)
 		return nil
 	}
 	if len(wedgedPools) > 0 {
-		logf("wedged pools still present after LRO handling: %d", len(wedgedPools))
+		logf("wedged pools to remediate after LRO handling: %d", len(wedgedPools))
 	} else {
 		logf("no wedged pools after LRO handling (%s) but SKIP_GUARDS=true — continuing", reason)
 	}
@@ -440,13 +458,13 @@ func runWith(ctx context.Context, cfg *config, orch orchestrator) error {
 		}
 	}
 
-	if skipped > 0 {
-		return fmt.Errorf("%d wedged pool(s) skipped due to insufficient time budget", skipped)
-	}
-
 	logBanner("TAG RECONCILE")
 	if err := orch.reconcileTagPut(ctx); err != nil {
 		return fmt.Errorf("tag reconcile: %w", err)
+	}
+
+	if skipped > 0 {
+		return fmt.Errorf("%d wedged pool(s) skipped due to insufficient time budget", skipped)
 	}
 
 	logBanner("DONE")

--- a/dev-infrastructure/scripts/recreate-system-pool/main.go
+++ b/dev-infrastructure/scripts/recreate-system-pool/main.go
@@ -139,8 +139,8 @@ const (
 	systmpReadyTOMin  = 10
 	poolReadyTOMin    = 10
 	pollIntervalSec   = 30
-	overallTimeoutMin = 150
-	minPoolBudgetMin  = 20
+	overallTimeoutMin = 55
+	minPoolBudgetMin  = 5
 
 	// The NRP-KVS storm check requires this error code so other failure
 	// modes (quota / capacity / policy / etc) cannot trip the threshold.
@@ -158,7 +158,7 @@ const (
 	// to produce fresh evidence (or to prove the wedge is not NRP-KVS).
 	// Times are short relative to the AKS RP retry cadence (~3 min) so
 	// threshold-many retries can accumulate during the wait window.
-	triggerEvidenceTimeoutMin      = 30 // wait at most this long for evidence
+	triggerEvidenceTimeoutMin      = 10 // wait at most this long for evidence
 	triggerEvidencePollIntervalSec = 60 // re-query activity log every poll
 	triggerEvidenceWindowMin       = 60 // activity-log lookback for the wait loop
 
@@ -299,7 +299,7 @@ func runWith(ctx context.Context, cfg *config, orch orchestrator) error {
 
 	logBanner("DETECTION")
 	if cfg.skipGuards {
-		logf("SKIP_GUARDS=true — bypassing detection guards")
+		logf("SKIP_GUARDS=true — bypassing per-pool wedge and NRP-KVS checks (cluster-state and safety checks still apply)")
 	}
 	allWedged, reason, err := orch.detect(ctx)
 	if err != nil {
@@ -404,12 +404,14 @@ func runWith(ctx context.Context, cfg *config, orch orchestrator) error {
 	}
 
 	deadline, hasDeadline := ctx.Deadline()
+	skipped := 0
 	for i, wp := range wedgedPools {
 		if hasDeadline {
 			remaining := time.Until(deadline)
 			if remaining < minPoolBudgetMin*time.Minute {
+				skipped = len(wedgedPools) - i
 				logf("WARN: only %s remaining; skipping pool %s and %d remaining pool(s)",
-					remaining.Round(time.Minute), wp.name, len(wedgedPools)-i)
+					remaining.Round(time.Minute), wp.name, skipped)
 				break
 			}
 		}
@@ -430,6 +432,10 @@ func runWith(ctx context.Context, cfg *config, orch orchestrator) error {
 				return err
 			}
 		}
+	}
+
+	if skipped > 0 {
+		return fmt.Errorf("%d wedged pool(s) skipped due to insufficient time budget", skipped)
 	}
 
 	logBanner("TAG RECONCILE")

--- a/dev-infrastructure/scripts/recreate-system-pool/main.go
+++ b/dev-infrastructure/scripts/recreate-system-pool/main.go
@@ -140,7 +140,7 @@ const (
 	systmpReadyTOMin  = 10
 	poolReadyTOMin    = 10
 	pollIntervalSec   = 30
-	overallTimeoutMin = 55
+	overallTimeoutMin = 110
 	minPoolBudgetMin  = 20
 
 	// The NRP-KVS storm check requires this error code so other failure

--- a/dev-infrastructure/scripts/recreate-system-pool/main.go
+++ b/dev-infrastructure/scripts/recreate-system-pool/main.go
@@ -152,13 +152,19 @@ const (
 	activityLogAuthRetryInitialSec = 10
 	activityLogAuthRetryMaxSec     = 60
 
-	// triggerEvidence forces an AKS RP reconcile of the wedged pool when
-	// the cluster-state / cluster-safety / pool-wedge checks PASS
-	// but the NRP-KVS-storm check has no recent NRP-KVS events in the
-	// configured lookback window. The trigger gives the wedge a chance
-	// to produce fresh evidence (or to prove the wedge is not NRP-KVS).
-	// Times are short relative to the AKS RP retry cadence (~3 min) so
-	// threshold-many retries can accumulate during the wait window.
+	// triggerEvidence forces a scale-up on the wedged pool when the
+	// cluster-state / cluster-safety / pool-wedge checks PASS but the
+	// NRP-KVS-storm check has no recent NRP-KVS events in the configured
+	// lookback window (NRP_FAIL_WINDOW_MIN). The scale-up forces a VMSS
+	// write, giving the wedge a chance to produce fresh evidence.
+	//
+	// These constants are independent of NRP_FAIL_WINDOW_MIN: initial
+	// detection uses NRP_FAIL_WINDOW_MIN (env var, default 15 min) to
+	// check for existing evidence. Forced evidence uses its own wider
+	// window (triggerEvidenceWindowMin=60) since it needs to capture
+	// events it just triggered, and polls for up to
+	// triggerEvidenceTimeoutMin. The same NRP_FAIL_THRESHOLD applies
+	// to both paths.
 	triggerEvidenceTimeoutMin      = 20 // wait at most this long for evidence
 	triggerEvidencePollIntervalSec = 60 // re-query activity log every poll
 	triggerEvidenceWindowMin       = 60 // activity-log lookback for the wait loop

--- a/dev-infrastructure/scripts/recreate-system-pool/main.go
+++ b/dev-infrastructure/scripts/recreate-system-pool/main.go
@@ -316,9 +316,15 @@ func runWith(ctx context.Context, cfg *config, orch orchestrator) error {
 		}
 	}
 
-	// Run forced evidence for suspected pools
+	// Run forced evidence for suspected SwiftV2 pools (system, user).
+	// Infra pools are not SwiftV2 and cannot have NRP-KVS corruption,
+	// so probing them wastes ~10 min each with no possible result.
 	if len(confirmed) == 0 && len(suspected) > 0 && !cfg.skipGuards && !cfg.dryRun {
 		for _, sp := range suspected {
+			if sp.category == poolCategoryInfra {
+				logf("skipping forced evidence for infra pool %s (not SwiftV2)", sp.name)
+				continue
+			}
 			logBanner(fmt.Sprintf("FORCED EVIDENCE :: pool %s (%s)", sp.name, sp.category))
 			wp, err := forcedEvidenceForPool(ctx, cfg, orch, sp)
 			if err != nil {

--- a/dev-infrastructure/scripts/recreate-system-pool/main_test.go
+++ b/dev-infrastructure/scripts/recreate-system-pool/main_test.go
@@ -1403,20 +1403,20 @@ type mockOrchestrator struct {
 	calls       []string
 	detectCount int
 
-	ensureClusterFn        func(ctx context.Context) (armcs.ManagedCluster, bool, error)
-	bootstrapKubeFn        func(ctx context.Context, mc armcs.ManagedCluster) error
-	detectFn               func(ctx context.Context, n int) ([]wedgedPool, string, error)
-	preflightChecksFn      func(ctx context.Context, pools []wedgedPool) error
-	snapshotPoolFn         func(ctx context.Context, poolName string) (*armcs.AgentPool, error)
-	maybeAbortLROFn        func(ctx context.Context) (bool, error)
-	addSystmpFn            func(ctx context.Context, live *armcs.AgentPool) error
-	drainPoolFn            func(ctx context.Context, pool string, timeout time.Duration) error
-	deletePoolFn           func(ctx context.Context, pool string) error
-	recreatePoolFn         func(ctx context.Context, poolName string, live *armcs.AgentPool) error
-	reconcileTagPutFn      func(ctx context.Context) error
-	triggerPoolReconcileFn func(ctx context.Context, poolName string, live *armcs.AgentPool) error
-	pollForNRPEvidenceFn   func(ctx context.Context, poolName string, vmssPrefix string, timeout time.Duration, pollInterval time.Duration, windowMin int, threshold int) (int, error)
-	abortPoolReconcileFn   func(ctx context.Context, poolName string) error
+	ensureClusterFn      func(ctx context.Context) (armcs.ManagedCluster, bool, error)
+	bootstrapKubeFn      func(ctx context.Context, mc armcs.ManagedCluster) error
+	detectFn             func(ctx context.Context, n int) ([]wedgedPool, string, error)
+	preflightChecksFn    func(ctx context.Context, pools []wedgedPool) error
+	snapshotPoolFn       func(ctx context.Context, poolName string) (*armcs.AgentPool, error)
+	maybeAbortLROFn      func(ctx context.Context) (bool, error)
+	addSystmpFn          func(ctx context.Context, live *armcs.AgentPool) error
+	drainPoolFn          func(ctx context.Context, pool string, timeout time.Duration) error
+	deletePoolFn         func(ctx context.Context, pool string) error
+	recreatePoolFn       func(ctx context.Context, poolName string, live *armcs.AgentPool) error
+	reconcileTagPutFn    func(ctx context.Context) error
+	triggerPoolScaleUpFn func(ctx context.Context, poolName string, live *armcs.AgentPool) error
+	pollForNRPEvidenceFn func(ctx context.Context, poolName string, vmssPrefix string, timeout time.Duration, pollInterval time.Duration, windowMin int, threshold int) (int, error)
+	abortPoolReconcileFn func(ctx context.Context, poolName string) error
 }
 
 func (m *mockOrchestrator) record(name string) { m.calls = append(m.calls, name) }
@@ -1520,10 +1520,10 @@ func (m *mockOrchestrator) reconcileTagPut(ctx context.Context) error {
 	return nil
 }
 
-func (m *mockOrchestrator) triggerPoolReconcile(ctx context.Context, poolName string, live *armcs.AgentPool) error {
-	m.record("triggerPoolReconcile:" + poolName)
-	if m.triggerPoolReconcileFn != nil {
-		return m.triggerPoolReconcileFn(ctx, poolName, live)
+func (m *mockOrchestrator) triggerPoolScaleUp(ctx context.Context, poolName string, live *armcs.AgentPool) error {
+	m.record("triggerPoolScaleUp:" + poolName)
+	if m.triggerPoolScaleUpFn != nil {
+		return m.triggerPoolScaleUpFn(ctx, poolName, live)
 	}
 	return nil
 }
@@ -1622,7 +1622,7 @@ func TestRunWith(t *testing.T) {
 			},
 			wantCalls: []string{
 				"ensureCluster", "dumpPreflight", "detect:1",
-				"snapshotPool:system", "triggerPoolReconcile:system", "pollForNRPEvidence:system", "abortPoolReconcile:system",
+				"snapshotPool:system", "triggerPoolScaleUp:system", "pollForNRPEvidence:system", "abortPoolReconcile:system",
 			},
 		},
 		{
@@ -1641,7 +1641,7 @@ func TestRunWith(t *testing.T) {
 			},
 			wantCalls: []string{
 				"ensureCluster", "dumpPreflight", "detect:1",
-				"snapshotPool:system", "triggerPoolReconcile:system", "pollForNRPEvidence:system", "abortPoolReconcile:system",
+				"snapshotPool:system", "triggerPoolScaleUp:system", "pollForNRPEvidence:system", "abortPoolReconcile:system",
 				"bootstrapKube", "dumpPreflight", "preflightChecks",
 				"maybeAbortLRO", "detect:2", "snapshotPool:system",
 				"addSystmp",
@@ -1658,13 +1658,13 @@ func TestRunWith(t *testing.T) {
 				m.detectFn = func(_ context.Context, _ int) ([]wedgedPool, string, error) {
 					return []wedgedPool{suspectedSystemPool}, "", nil
 				}
-				m.triggerPoolReconcileFn = func(_ context.Context, _ string, _ *armcs.AgentPool) error {
+				m.triggerPoolScaleUpFn = func(_ context.Context, _ string, _ *armcs.AgentPool) error {
 					return errors.New("conflict")
 				}
 			},
 			wantCalls: []string{
 				"ensureCluster", "dumpPreflight", "detect:1",
-				"snapshotPool:system", "triggerPoolReconcile:system",
+				"snapshotPool:system", "triggerPoolScaleUp:system",
 			},
 		},
 		{

--- a/dev-infrastructure/scripts/recreate-system-pool/main_test.go
+++ b/dev-infrastructure/scripts/recreate-system-pool/main_test.go
@@ -506,9 +506,9 @@ func TestClassifyPool(t *testing.T) {
 
 func TestPoolVMSSPrefix(t *testing.T) {
 	cases := []struct {
-		name   string
-		pool   string
-		want   string
+		name string
+		pool string
+		want string
 	}{
 		{"system", "system", "aks-system-"},
 		{"user", "userswft3", "aks-userswft3-"},
@@ -1398,20 +1398,20 @@ type mockOrchestrator struct {
 	calls       []string
 	detectCount int
 
-	ensureClusterFn      func(ctx context.Context) (armcs.ManagedCluster, bool, error)
-	bootstrapKubeFn      func(ctx context.Context, mc armcs.ManagedCluster) error
-	detectFn             func(ctx context.Context, n int) ([]wedgedPool, string, error)
-	preflightChecksFn    func(ctx context.Context, pools []wedgedPool) error
-	snapshotPoolFn       func(ctx context.Context, poolName string) (*armcs.AgentPool, error)
-	maybeAbortLROFn      func(ctx context.Context) (bool, error)
-	addSystmpFn          func(ctx context.Context, live *armcs.AgentPool) error
-	drainPoolFn          func(ctx context.Context, pool string, timeout time.Duration) error
-	deletePoolFn         func(ctx context.Context, pool string) error
-	recreatePoolFn       func(ctx context.Context, poolName string, live *armcs.AgentPool) error
-	reconcileTagPutFn    func(ctx context.Context) error
+	ensureClusterFn        func(ctx context.Context) (armcs.ManagedCluster, bool, error)
+	bootstrapKubeFn        func(ctx context.Context, mc armcs.ManagedCluster) error
+	detectFn               func(ctx context.Context, n int) ([]wedgedPool, string, error)
+	preflightChecksFn      func(ctx context.Context, pools []wedgedPool) error
+	snapshotPoolFn         func(ctx context.Context, poolName string) (*armcs.AgentPool, error)
+	maybeAbortLROFn        func(ctx context.Context) (bool, error)
+	addSystmpFn            func(ctx context.Context, live *armcs.AgentPool) error
+	drainPoolFn            func(ctx context.Context, pool string, timeout time.Duration) error
+	deletePoolFn           func(ctx context.Context, pool string) error
+	recreatePoolFn         func(ctx context.Context, poolName string, live *armcs.AgentPool) error
+	reconcileTagPutFn      func(ctx context.Context) error
 	triggerPoolReconcileFn func(ctx context.Context, poolName string, live *armcs.AgentPool) error
-	pollForNRPEvidenceFn func(ctx context.Context, poolName string, vmssPrefix string, timeout time.Duration, pollInterval time.Duration, windowMin int, threshold int) (int, error)
-	abortPoolReconcileFn func(ctx context.Context, poolName string) error
+	pollForNRPEvidenceFn   func(ctx context.Context, poolName string, vmssPrefix string, timeout time.Duration, pollInterval time.Duration, windowMin int, threshold int) (int, error)
+	abortPoolReconcileFn   func(ctx context.Context, poolName string) error
 }
 
 func (m *mockOrchestrator) record(name string) { m.calls = append(m.calls, name) }

--- a/dev-infrastructure/scripts/recreate-system-pool/main_test.go
+++ b/dev-infrastructure/scripts/recreate-system-pool/main_test.go
@@ -771,12 +771,12 @@ func TestAgentPoolForCreate_NilProperties(t *testing.T) {
 }
 
 // =============================================================================
-// buildSystmpAgentPool
+// buildTmpAgentPool
 // =============================================================================
 
 func TestBuildSystmpAgentPool_ValidInputs(t *testing.T) {
 	live := mkLiveSystemPool()
-	body, err := buildSystmpAgentPool(live, "1.35.4")
+	body, err := buildTmpAgentPool(live, "1.35.4")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -817,7 +817,7 @@ func TestBuildSystmpAgentPool_ValidInputs(t *testing.T) {
 	if p.Tags["delegate-ip-allocation-for-nics-without-subnet"] == nil || *p.Tags["delegate-ip-allocation-for-nics-without-subnet"] != "true" {
 		t.Errorf("Swift tag not inherited: %v", p.Tags)
 	}
-	if p.Tags["purpose"] == nil || *p.Tags["purpose"] != "temp-system-aroslsre-924" {
+	if p.Tags["purpose"] == nil || *p.Tags["purpose"] != "temp-aroslsre-924" {
 		t.Errorf("temporary purpose tag missing: %v", p.Tags)
 	}
 	if _, ok := p.Tags["aks-managed-foo"]; ok {
@@ -826,13 +826,13 @@ func TestBuildSystmpAgentPool_ValidInputs(t *testing.T) {
 }
 
 func TestBuildSystmpAgentPool_NilLive(t *testing.T) {
-	if _, err := buildSystmpAgentPool(nil, "1.35.4"); err == nil {
+	if _, err := buildTmpAgentPool(nil, "1.35.4"); err == nil {
 		t.Fatal("expected error for nil live")
 	}
 }
 
 func TestBuildSystmpAgentPool_NilProperties(t *testing.T) {
-	if _, err := buildSystmpAgentPool(&armcs.AgentPool{}, "1.35.4"); err == nil {
+	if _, err := buildTmpAgentPool(&armcs.AgentPool{}, "1.35.4"); err == nil {
 		t.Fatal("expected error for nil properties")
 	}
 }
@@ -840,18 +840,18 @@ func TestBuildSystmpAgentPool_NilProperties(t *testing.T) {
 func TestBuildSystmpAgentPool_MissingVMSize(t *testing.T) {
 	live := mkLiveSystemPool()
 	live.Properties.VMSize = nil
-	if _, err := buildSystmpAgentPool(live, "1.35.4"); err == nil {
+	if _, err := buildTmpAgentPool(live, "1.35.4"); err == nil {
 		t.Fatal("expected error for missing VMSize")
 	}
 	live.Properties.VMSize = ptr("")
-	if _, err := buildSystmpAgentPool(live, "1.35.4"); err == nil {
+	if _, err := buildTmpAgentPool(live, "1.35.4"); err == nil {
 		t.Fatal("expected error for empty VMSize")
 	}
 }
 
 func TestBuildSystmpAgentPool_MissingCPVersion(t *testing.T) {
 	live := mkLiveSystemPool()
-	if _, err := buildSystmpAgentPool(live, ""); err == nil {
+	if _, err := buildTmpAgentPool(live, ""); err == nil {
 		t.Fatal("expected error for empty cpVersion")
 	}
 }
@@ -859,7 +859,7 @@ func TestBuildSystmpAgentPool_MissingCPVersion(t *testing.T) {
 func TestBuildSystmpAgentPool_NoPodSubnet(t *testing.T) {
 	live := mkLiveSystemPool()
 	live.Properties.PodSubnetID = nil
-	body, err := buildSystmpAgentPool(live, "1.35.4")
+	body, err := buildTmpAgentPool(live, "1.35.4")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -871,7 +871,7 @@ func TestBuildSystmpAgentPool_NoPodSubnet(t *testing.T) {
 func TestBuildSystmpAgentPool_DoesNotShareTaintPointer(t *testing.T) {
 	// Mutating the live snapshot's taints must not affect the systmp body.
 	live := mkLiveSystemPool()
-	body, _ := buildSystmpAgentPool(live, "1.35.4")
+	body, _ := buildTmpAgentPool(live, "1.35.4")
 	*live.Properties.NodeTaints[0] = "hacked"
 	if *body.Properties.NodeTaints[0] != "CriticalAddonsOnly=true:NoSchedule" {
 		t.Errorf("systmp NodeTaints share state with live: %v", body.Properties.NodeTaints)
@@ -880,7 +880,7 @@ func TestBuildSystmpAgentPool_DoesNotShareTaintPointer(t *testing.T) {
 
 func TestBuildSystmpAgentPool_DoesNotShareInheritedMapsOrSlices(t *testing.T) {
 	live := mkLiveSystemPool()
-	body, err := buildSystmpAgentPool(live, "1.35.4")
+	body, err := buildTmpAgentPool(live, "1.35.4")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -901,12 +901,12 @@ func TestBuildSystmpAgentPool_DoesNotShareInheritedMapsOrSlices(t *testing.T) {
 func TestBuildSystmpAgentPool_MissingOSDiskSizeGB(t *testing.T) {
 	live := mkLiveSystemPool()
 	live.Properties.OSDiskSizeGB = nil
-	if _, err := buildSystmpAgentPool(live, "1.35.4"); err == nil {
+	if _, err := buildTmpAgentPool(live, "1.35.4"); err == nil {
 		t.Fatal("expected error for missing OSDiskSizeGB")
 	}
 	zero := int32(0)
 	live.Properties.OSDiskSizeGB = &zero
-	if _, err := buildSystmpAgentPool(live, "1.35.4"); err == nil {
+	if _, err := buildTmpAgentPool(live, "1.35.4"); err == nil {
 		t.Fatal("expected error for OSDiskSizeGB == 0")
 	}
 }
@@ -915,7 +915,7 @@ func TestBuildSystmpAgentPool_InheritsDiskSizeAndOSType(t *testing.T) {
 	live := mkLiveSystemPool()
 	custom := int32(64)
 	live.Properties.OSDiskSizeGB = &custom
-	body, err := buildSystmpAgentPool(live, "1.35.4")
+	body, err := buildTmpAgentPool(live, "1.35.4")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1409,7 +1409,7 @@ type mockOrchestrator struct {
 	preflightChecksFn    func(ctx context.Context, pools []wedgedPool) error
 	snapshotPoolFn       func(ctx context.Context, poolName string) (*armcs.AgentPool, error)
 	maybeAbortLROFn      func(ctx context.Context) (bool, error)
-	addSystmpFn          func(ctx context.Context, live *armcs.AgentPool) error
+	addTmpPoolFn         func(ctx context.Context, tmpName string, live *armcs.AgentPool) error
 	drainPoolFn          func(ctx context.Context, pool string, timeout time.Duration) error
 	deletePoolFn         func(ctx context.Context, pool string) error
 	recreatePoolFn       func(ctx context.Context, poolName string, live *armcs.AgentPool) error
@@ -1417,6 +1417,7 @@ type mockOrchestrator struct {
 	triggerPoolScaleUpFn func(ctx context.Context, poolName string, live *armcs.AgentPool) error
 	pollForNRPEvidenceFn func(ctx context.Context, poolName string, vmssPrefix string, timeout time.Duration, pollInterval time.Duration, windowMin int, threshold int) (int, error)
 	abortPoolReconcileFn func(ctx context.Context, poolName string) error
+	restorePoolSpecFn    func(ctx context.Context, poolName string, live *armcs.AgentPool) error
 }
 
 func (m *mockOrchestrator) record(name string) { m.calls = append(m.calls, name) }
@@ -1480,10 +1481,10 @@ func (m *mockOrchestrator) maybeAbortLRO(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
-func (m *mockOrchestrator) addSystmp(ctx context.Context, live *armcs.AgentPool) error {
-	m.record("addSystmp")
-	if m.addSystmpFn != nil {
-		return m.addSystmpFn(ctx, live)
+func (m *mockOrchestrator) addTmpPool(ctx context.Context, tmpName string, live *armcs.AgentPool) error {
+	m.record("addTmpPool:" + tmpName)
+	if m.addTmpPoolFn != nil {
+		return m.addTmpPoolFn(ctx, tmpName, live)
 	}
 	return nil
 }
@@ -1544,6 +1545,14 @@ func (m *mockOrchestrator) abortPoolReconcile(ctx context.Context, poolName stri
 	return nil
 }
 
+func (m *mockOrchestrator) restorePoolSpec(ctx context.Context, poolName string, live *armcs.AgentPool) error {
+	m.record("restorePoolSpec:" + poolName)
+	if m.restorePoolSpecFn != nil {
+		return m.restorePoolSpecFn(ctx, poolName, live)
+	}
+	return nil
+}
+
 func TestRunWith(t *testing.T) {
 	dummyErr := errors.New("boom")
 
@@ -1554,7 +1563,7 @@ func TestRunWith(t *testing.T) {
 		"ensureCluster", "dumpPreflight", "detect:1",
 		"bootstrapKube", "dumpPreflight", "preflightChecks",
 		"maybeAbortLRO", "detect:2", "snapshotPool:system",
-		"addSystmp",
+		"addTmpPool:systmp",
 		"drainPool:system", "deletePool:system",
 		"recreatePool:system",
 		"drainPool:systmp", "deletePool:systmp",
@@ -1622,7 +1631,7 @@ func TestRunWith(t *testing.T) {
 			},
 			wantCalls: []string{
 				"ensureCluster", "dumpPreflight", "detect:1",
-				"snapshotPool:system", "triggerPoolScaleUp:system", "pollForNRPEvidence:system", "abortPoolReconcile:system",
+				"snapshotPool:system", "triggerPoolScaleUp:system", "pollForNRPEvidence:system", "abortPoolReconcile:system", "restorePoolSpec:system",
 			},
 		},
 		{
@@ -1641,10 +1650,10 @@ func TestRunWith(t *testing.T) {
 			},
 			wantCalls: []string{
 				"ensureCluster", "dumpPreflight", "detect:1",
-				"snapshotPool:system", "triggerPoolScaleUp:system", "pollForNRPEvidence:system", "abortPoolReconcile:system",
+				"snapshotPool:system", "triggerPoolScaleUp:system", "pollForNRPEvidence:system", "abortPoolReconcile:system", "restorePoolSpec:system",
 				"bootstrapKube", "dumpPreflight", "preflightChecks",
 				"maybeAbortLRO", "detect:2", "snapshotPool:system",
-				"addSystmp",
+				"addTmpPool:systmp",
 				"drainPool:system", "deletePool:system",
 				"recreatePool:system",
 				"drainPool:systmp", "deletePool:systmp",
@@ -1731,17 +1740,17 @@ func TestRunWith(t *testing.T) {
 			wantCalls: fullHappyPath,
 		},
 		{
-			name: "addSystmp_error",
+			name: "addTmpPool_error",
 			cfg:  &config{clusterName: "c", resourceGroup: "rg", subscriptionID: "sub", cpVersion: "1.30.0"},
 			setup: func(m *mockOrchestrator) {
-				m.addSystmpFn = func(context.Context, *armcs.AgentPool) error { return dummyErr }
+				m.addTmpPoolFn = func(context.Context, string, *armcs.AgentPool) error { return dummyErr }
 			},
-			wantErr: "add systmp",
+			wantErr: "add tmp pool",
 			wantCalls: []string{
 				"ensureCluster", "dumpPreflight", "detect:1",
 				"bootstrapKube", "dumpPreflight", "preflightChecks",
 				"maybeAbortLRO", "detect:2", "snapshotPool:system",
-				"addSystmp",
+				"addTmpPool:systmp",
 			},
 		},
 		{
@@ -1760,7 +1769,7 @@ func TestRunWith(t *testing.T) {
 				"ensureCluster", "dumpPreflight", "detect:1",
 				"bootstrapKube", "dumpPreflight", "preflightChecks",
 				"maybeAbortLRO", "detect:2", "snapshotPool:system",
-				"addSystmp", "drainPool:system",
+				"addTmpPool:systmp", "drainPool:system",
 			},
 		},
 		{
@@ -1831,8 +1840,10 @@ func TestRunWith(t *testing.T) {
 				"ensureCluster", "dumpPreflight", "detect:1",
 				"bootstrapKube", "dumpPreflight", "preflightChecks",
 				"maybeAbortLRO", "detect:2", "snapshotPool:userswft3",
+				"addTmpPool:userswft3t",
 				"drainPool:userswft3", "deletePool:userswft3",
 				"recreatePool:userswft3",
+				"drainPool:userswft3t", "deletePool:userswft3t",
 				"reconcileTagPut", "dumpPostflight",
 			},
 		},
@@ -1854,14 +1865,16 @@ func TestRunWith(t *testing.T) {
 				"maybeAbortLRO", "detect:2",
 				// system pool (with systmp dance)
 				"snapshotPool:system",
-				"addSystmp",
+				"addTmpPool:systmp",
 				"drainPool:system", "deletePool:system",
 				"recreatePool:system",
 				"drainPool:systmp", "deletePool:systmp",
-				// user pool (no systmp)
+				// user pool (with tmp dance)
 				"snapshotPool:userswft3",
+				"addTmpPool:userswft3t",
 				"drainPool:userswft3", "deletePool:userswft3",
 				"recreatePool:userswft3",
+				"drainPool:userswft3t", "deletePool:userswft3t",
 				// finish
 				"reconcileTagPut", "dumpPostflight",
 			},

--- a/dev-infrastructure/scripts/recreate-system-pool/main_test.go
+++ b/dev-infrastructure/scripts/recreate-system-pool/main_test.go
@@ -197,7 +197,7 @@ func TestParseEnvConfig_DryRunFlag(t *testing.T) {
 }
 
 // =============================================================================
-// evalNRPStorm..4
+// evalNRPStorm, evalClusterState, evalClusterSafety, evalPoolWedged
 // =============================================================================
 
 func TestEvalNRPStorm(t *testing.T) {
@@ -280,7 +280,7 @@ func mkPool(name string, count, minCount *int32) *armcs.AgentPool {
 }
 
 // mkPoolWithState builds a pool with provisioning state set, used for
-// guard 4/5 interactions.
+// guard interactions.
 func mkPoolWithState(name string, count, minCount *int32, provState string) *armcs.AgentPool {
 	p := mkPool(name, count, minCount)
 	if provState != "" {
@@ -290,134 +290,235 @@ func mkPoolWithState(name string, count, minCount *int32, provState string) *arm
 	return p
 }
 
-func TestEvalNonSystemPools_AllHealthy(t *testing.T) {
-	pools := []*armcs.AgentPool{
-		mkPoolWithState("system", ptr(int32(2)), ptr(int32(2)), "Succeeded"),
-		mkPool("userswft3", ptr(int32(4)), ptr(int32(4))),
-	}
-	pass, sysMin, sysState, reason := evalNonSystemPools(pools)
-	if !pass {
-		t.Fatalf("expected pass, got fail: %s", reason)
-	}
-	if sysMin != 2 {
-		t.Errorf("systemMin=%d want 2", sysMin)
-	}
-	if sysState != "Succeeded" {
-		t.Errorf("sysState=%q want Succeeded", sysState)
+// mkPoolWithMode builds a pool with mode set.
+func mkPoolWithMode(name string, mode armcs.AgentPoolMode) *armcs.AgentPool {
+	return &armcs.AgentPool{
+		Name: ptr(name),
+		Properties: &armcs.ManagedClusterAgentPoolProfileProperties{
+			Count: ptr(int32(1)),
+			Mode:  &mode,
+		},
 	}
 }
 
-func TestEvalNonSystemPools_NonSystemPoolEmpty(t *testing.T) {
-	pools := []*armcs.AgentPool{
-		mkPool("system", ptr(int32(2)), ptr(int32(2))),
-		mkPool("userswft3", ptr(int32(0)), ptr(int32(0))),
-	}
-	pass, _, _, reason := evalNonSystemPools(pools)
-	if pass {
-		t.Fatal("expected fail when non-system pool has count=0")
-	}
-	if !strings.Contains(reason, "userswft3") {
-		t.Errorf("reason should mention failing pool, got %q", reason)
+// mkPoolWithLabel builds a pool with a label set.
+func mkPoolWithLabel(name string, labelKey, labelValue string) *armcs.AgentPool {
+	return &armcs.AgentPool{
+		Name: ptr(name),
+		Properties: &armcs.ManagedClusterAgentPoolProfileProperties{
+			Count:      ptr(int32(1)),
+			NodeLabels: map[string]*string{labelKey: ptr(labelValue)},
+		},
 	}
 }
 
-func TestEvalNonSystemPools_NoSystemPool(t *testing.T) {
-	pools := []*armcs.AgentPool{
-		mkPool("userswft3", ptr(int32(4)), ptr(int32(4))),
-	}
-	pass, _, _, reason := evalNonSystemPools(pools)
-	if pass {
-		t.Fatal("expected fail when no system pool")
-	}
-	if !strings.Contains(reason, "system pool") {
-		t.Errorf("reason should mention missing system pool, got %q", reason)
-	}
-}
-
-func TestEvalNonSystemPools_SystemPoolWithZeroCount_OK(t *testing.T) {
-	// System pool itself can have count=0 (that's the whole point of this script).
-	pools := []*armcs.AgentPool{
-		mkPool("system", ptr(int32(0)), ptr(int32(2))),
-		mkPool("userswft3", ptr(int32(4)), ptr(int32(4))),
-	}
-	pass, sysMin, _, reason := evalNonSystemPools(pools)
-	if !pass {
-		t.Fatalf("system pool with count=0 should not fail guard 4: %s", reason)
-	}
-	if sysMin != 2 {
-		t.Errorf("systemMin=%d want 2", sysMin)
-	}
-}
-
-func TestEvalNonSystemPools_NilPoolsSkipped(t *testing.T) {
-	pools := []*armcs.AgentPool{
-		nil,
-		mkPool("system", ptr(int32(2)), ptr(int32(2))),
-		nil,
-		mkPool("userswft3", ptr(int32(4)), ptr(int32(4))),
-	}
-	pass, _, _, reason := evalNonSystemPools(pools)
-	if !pass {
-		t.Fatalf("nil pools should be skipped: %s", reason)
-	}
-}
-
-func TestEvalNonSystemPools_PoolMissingFieldsSkipped(t *testing.T) {
-	pools := []*armcs.AgentPool{
-		{Name: ptr("orphan")}, // no properties
-		{Properties: &armcs.ManagedClusterAgentPoolProfileProperties{Count: ptr(int32(3))}}, // no name
-		mkPool("system", ptr(int32(1)), ptr(int32(2))),
-		mkPool("userswft3", ptr(int32(4)), ptr(int32(4))),
-	}
-	pass, _, _, reason := evalNonSystemPools(pools)
-	if !pass {
-		t.Fatalf("malformed pool entries should be skipped: %s", reason)
-	}
-}
-
-func TestEvalNonSystemPools_SystemMissingMinCount_DefaultsZero(t *testing.T) {
-	pools := []*armcs.AgentPool{
-		mkPool("system", ptr(int32(1)), nil),
-		mkPool("userswft3", ptr(int32(4)), ptr(int32(4))),
-	}
-	pass, sysMin, _, _ := evalNonSystemPools(pools)
-	if !pass || sysMin != 0 {
-		t.Errorf("systemMin=%d pass=%t (want 0/true)", sysMin, pass)
-	}
-}
-
-func TestEvalNonSystemPools_EmptyList(t *testing.T) {
-	pass, _, _, reason := evalNonSystemPools(nil)
-	if pass {
-		t.Fatal("empty pool list must fail")
-	}
-	if reason == "" {
-		t.Errorf("empty list fail must have a reason")
-	}
-}
-
-func TestEvalNonSystemPools_ExtractsSystemProvState(t *testing.T) {
+func TestEvalClusterSafety(t *testing.T) {
 	cases := []struct {
-		name  string
-		state string
+		name     string
+		pools    []*armcs.AgentPool
+		wantPass bool
 	}{
-		{"Succeeded", "Succeeded"},
-		{"Failed", "Failed"},
-		{"Updating", "Updating"},
-		{"Canceled", "Canceled"},
+		{
+			name: "has_non_system_pool_with_count",
+			pools: []*armcs.AgentPool{
+				mkPoolWithState("system", ptr(int32(2)), ptr(int32(2)), "Succeeded"),
+				mkPool("userswft3", ptr(int32(4)), ptr(int32(4))),
+			},
+			wantPass: true,
+		},
+		{
+			name: "non_system_pool_has_zero_count",
+			pools: []*armcs.AgentPool{
+				mkPool("system", ptr(int32(2)), ptr(int32(2))),
+				mkPool("userswft3", ptr(int32(0)), ptr(int32(0))),
+			},
+			wantPass: false,
+		},
+		{
+			name: "only_system_pool",
+			pools: []*armcs.AgentPool{
+				mkPool("system", ptr(int32(2)), ptr(int32(2))),
+			},
+			wantPass: false,
+		},
+		{
+			name: "system_pool_zero_count_but_user_pool_ok",
+			pools: []*armcs.AgentPool{
+				mkPool("system", ptr(int32(0)), ptr(int32(2))),
+				mkPool("userswft3", ptr(int32(4)), ptr(int32(4))),
+			},
+			wantPass: true,
+		},
+		{
+			name: "nil_pools_skipped",
+			pools: []*armcs.AgentPool{
+				nil,
+				mkPool("system", ptr(int32(2)), ptr(int32(2))),
+				nil,
+				mkPool("userswft3", ptr(int32(4)), ptr(int32(4))),
+			},
+			wantPass: true,
+		},
+		{
+			name: "pools_missing_fields_skipped",
+			pools: []*armcs.AgentPool{
+				{Name: ptr("orphan")}, // no properties
+				{Properties: &armcs.ManagedClusterAgentPoolProfileProperties{Count: ptr(int32(3))}}, // no name
+				mkPool("system", ptr(int32(1)), ptr(int32(2))),
+				mkPool("userswft3", ptr(int32(4)), ptr(int32(4))),
+			},
+			wantPass: true,
+		},
+		{
+			name:     "empty_list",
+			pools:    nil,
+			wantPass: false,
+		},
+		{
+			name: "systmp_pool_excluded",
+			pools: []*armcs.AgentPool{
+				mkPool("system", ptr(int32(2)), ptr(int32(2))),
+				mkPool("systmp", ptr(int32(1)), ptr(int32(1))),
+			},
+			wantPass: false,
+		},
+		{
+			name: "multiple_non_system_one_with_count",
+			pools: []*armcs.AgentPool{
+				mkPool("system", ptr(int32(2)), ptr(int32(2))),
+				mkPool("user1", ptr(int32(0)), nil),
+				mkPool("user2", ptr(int32(3)), nil),
+			},
+			wantPass: true,
+		},
+		{
+			name: "non_system_nil_count_treated_as_zero",
+			pools: []*armcs.AgentPool{
+				mkPool("system", ptr(int32(2)), ptr(int32(2))),
+				mkPool("userswft3", nil, nil),
+			},
+			wantPass: false,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			pools := []*armcs.AgentPool{
-				mkPoolWithState("system", ptr(int32(0)), ptr(int32(2)), tc.state),
-				mkPool("userswft3", ptr(int32(4)), ptr(int32(4))),
+			pass, reason := evalClusterSafety(tc.pools)
+			if pass != tc.wantPass {
+				t.Errorf("pass=%t want %t (%s)", pass, tc.wantPass, reason)
 			}
-			pass, _, gotState, _ := evalNonSystemPools(pools)
-			if !pass {
-				t.Fatal("expected pass")
+			if !pass && reason == "" {
+				t.Errorf("non-pass result must have a reason")
 			}
-			if gotState != tc.state {
-				t.Errorf("systemProvState=%q want %q", gotState, tc.state)
+		})
+	}
+}
+
+// =============================================================================
+// evalPoolWedged
+// =============================================================================
+
+func TestEvalPoolWedged(t *testing.T) {
+	cases := []struct {
+		name  string
+		state string
+		want  bool
+	}{
+		// Wedge-compatible states.
+		{"failed", "Failed", true},
+		{"canceled", "Canceled", true},
+		{"updating", "Updating", true}, // AROSLSRE-880 wedge signature
+		{"upgrading", "Upgrading", true},
+		// Healthy: explicitly reject.
+		{"succeeded", "Succeeded", false},
+		// Transitional: explicitly reject.
+		{"creating", "Creating", false},
+		{"deleting", "Deleting", false},
+		// Defensive rejects.
+		{"empty", "", false},
+		{"lowercase_failed", "failed", false}, // case-sensitive on purpose
+		{"unknown", "SomethingFuture", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pass, reason := evalPoolWedged(tc.state)
+			if pass != tc.want {
+				t.Errorf("state=%q: pass=%t want %t (%s)", tc.state, pass, tc.want, reason)
+			}
+			if !pass && reason == "" {
+				t.Errorf("non-pass result must have a reason")
+			}
+			if !pass && !strings.Contains(reason, "pool wedge FAIL:") {
+				t.Errorf("reason should contain 'pool wedge FAIL:', got %q", reason)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// classifyPool
+// =============================================================================
+
+func TestClassifyPool(t *testing.T) {
+	cases := []struct {
+		name string
+		pool *armcs.AgentPool
+		want poolCategory
+	}{
+		{
+			name: "system_pool",
+			pool: mkPoolWithMode("system", armcs.AgentPoolModeSystem),
+			want: poolCategorySystem,
+		},
+		{
+			name: "user_pool_explicit",
+			pool: mkPoolWithMode("userswft3", armcs.AgentPoolModeUser),
+			want: poolCategoryUser,
+		},
+		{
+			name: "infra_pool",
+			pool: mkPoolWithLabel("infra", "aro-hcp.azure.com/role", "infra"),
+			want: poolCategoryInfra,
+		},
+		{
+			name: "user_pool_no_mode",
+			pool: mkPool("somepool", ptr(int32(1)), nil),
+			want: poolCategoryUser,
+		},
+		{
+			name: "user_pool_with_other_label",
+			pool: mkPoolWithLabel("labeled", "aro-hcp.azure.com/role", "worker"),
+			want: poolCategoryUser,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyPool(tc.pool)
+			if got != tc.want {
+				t.Errorf("classifyPool(%s)=%v want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// poolVMSSPrefix
+// =============================================================================
+
+func TestPoolVMSSPrefix(t *testing.T) {
+	cases := []struct {
+		name   string
+		pool   string
+		want   string
+	}{
+		{"system", "system", "aks-system-"},
+		{"user", "userswft3", "aks-userswft3-"},
+		{"infra", "infra", "aks-infra-"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := poolVMSSPrefix(tc.pool)
+			if got != tc.want {
+				t.Errorf("poolVMSSPrefix(%q)=%q want %q", tc.pool, got, tc.want)
 			}
 		})
 	}
@@ -1290,44 +1391,6 @@ func TestIsActivityLogAuthorizationError(t *testing.T) {
 }
 
 // =============================================================================
-// evalSystemWedge  (system pool provisioningState == "Failed")
-// =============================================================================
-
-func TestEvalSystemWedge(t *testing.T) {
-	cases := []struct {
-		name  string
-		state string
-		want  bool
-	}{
-		// Wedge-compatible states.
-		{"failed", "Failed", true},
-		{"canceled", "Canceled", true},
-		{"updating", "Updating", true}, // AROSLSRE-880 wedge signature
-		{"upgrading", "Upgrading", true},
-		// Healthy: explicitly reject.
-		{"succeeded", "Succeeded", false},
-		// Transitional: explicitly reject.
-		{"creating", "Creating", false},
-		{"deleting", "Deleting", false},
-		// Defensive rejects.
-		{"empty", "", false},
-		{"lowercase_failed", "failed", false}, // case-sensitive on purpose
-		{"unknown", "SomethingFuture", false},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			pass, reason := evalSystemWedge(tc.state)
-			if pass != tc.want {
-				t.Errorf("state=%q: pass=%t want %t (%s)", tc.state, pass, tc.want, reason)
-			}
-			if !pass && reason == "" {
-				t.Errorf("non-pass result must have a reason")
-			}
-		})
-	}
-}
-
-// =============================================================================
 // runWith orchestration integration tests
 // =============================================================================
 
@@ -1335,20 +1398,20 @@ type mockOrchestrator struct {
 	calls       []string
 	detectCount int
 
-	ensureClusterFn          func(ctx context.Context) (armcs.ManagedCluster, bool, error)
-	bootstrapKubeFn          func(ctx context.Context, mc armcs.ManagedCluster) error
-	detectFn                 func(ctx context.Context, n int) (bool, string, error)
-	preflightChecksFn        func(ctx context.Context) error
-	snapshotSystemFn         func(ctx context.Context) (*armcs.AgentPool, error)
-	maybeAbortLROFn          func(ctx context.Context) (bool, error)
-	addSystmpFn              func(ctx context.Context, live *armcs.AgentPool) error
-	drainPoolFn              func(ctx context.Context, pool string, timeout time.Duration) error
-	deletePoolFn             func(ctx context.Context, pool string) error
-	recreateSystemFn         func(ctx context.Context, live *armcs.AgentPool) error
-	reconcileTagPutFn        func(ctx context.Context) error
-	triggerSystemReconcileFn func(ctx context.Context, live *armcs.AgentPool) error
-	pollForNRPEvidenceFn     func(ctx context.Context, timeout time.Duration, pollInterval time.Duration, windowMin int, threshold int) (int, error)
-	abortSystemReconcileFn   func(ctx context.Context) error
+	ensureClusterFn      func(ctx context.Context) (armcs.ManagedCluster, bool, error)
+	bootstrapKubeFn      func(ctx context.Context, mc armcs.ManagedCluster) error
+	detectFn             func(ctx context.Context, n int) ([]wedgedPool, string, error)
+	preflightChecksFn    func(ctx context.Context, pools []wedgedPool) error
+	snapshotPoolFn       func(ctx context.Context, poolName string) (*armcs.AgentPool, error)
+	maybeAbortLROFn      func(ctx context.Context) (bool, error)
+	addSystmpFn          func(ctx context.Context, live *armcs.AgentPool) error
+	drainPoolFn          func(ctx context.Context, pool string, timeout time.Duration) error
+	deletePoolFn         func(ctx context.Context, pool string) error
+	recreatePoolFn       func(ctx context.Context, poolName string, live *armcs.AgentPool) error
+	reconcileTagPutFn    func(ctx context.Context) error
+	triggerPoolReconcileFn func(ctx context.Context, poolName string, live *armcs.AgentPool) error
+	pollForNRPEvidenceFn func(ctx context.Context, poolName string, vmssPrefix string, timeout time.Duration, pollInterval time.Duration, windowMin int, threshold int) (int, error)
+	abortPoolReconcileFn func(ctx context.Context, poolName string) error
 }
 
 func (m *mockOrchestrator) record(name string) { m.calls = append(m.calls, name) }
@@ -1369,13 +1432,13 @@ func (m *mockOrchestrator) bootstrapKube(ctx context.Context, mc armcs.ManagedCl
 	return nil
 }
 
-func (m *mockOrchestrator) detect(ctx context.Context) (bool, string, error) {
+func (m *mockOrchestrator) detect(ctx context.Context) ([]wedgedPool, string, error) {
 	m.detectCount++
 	m.record(fmt.Sprintf("detect:%d", m.detectCount))
 	if m.detectFn != nil {
 		return m.detectFn(ctx, m.detectCount)
 	}
-	return true, "", nil
+	return []wedgedPool{{name: "system", category: poolCategorySystem, vmssPrefix: "aks-system-"}}, "", nil
 }
 
 func (m *mockOrchestrator) dumpPreflight(ctx context.Context) error {
@@ -1388,18 +1451,18 @@ func (m *mockOrchestrator) dumpPostflight(ctx context.Context) error {
 	return nil
 }
 
-func (m *mockOrchestrator) preflightChecks(ctx context.Context) error {
+func (m *mockOrchestrator) preflightChecks(ctx context.Context, pools []wedgedPool) error {
 	m.record("preflightChecks")
 	if m.preflightChecksFn != nil {
-		return m.preflightChecksFn(ctx)
+		return m.preflightChecksFn(ctx, pools)
 	}
 	return nil
 }
 
-func (m *mockOrchestrator) snapshotSystem(ctx context.Context) (*armcs.AgentPool, error) {
-	m.record("snapshotSystem")
-	if m.snapshotSystemFn != nil {
-		return m.snapshotSystemFn(ctx)
+func (m *mockOrchestrator) snapshotPool(ctx context.Context, poolName string) (*armcs.AgentPool, error) {
+	m.record("snapshotPool:" + poolName)
+	if m.snapshotPoolFn != nil {
+		return m.snapshotPoolFn(ctx, poolName)
 	}
 	return &armcs.AgentPool{}, nil
 }
@@ -1436,10 +1499,10 @@ func (m *mockOrchestrator) deletePool(ctx context.Context, pool string) error {
 	return nil
 }
 
-func (m *mockOrchestrator) recreateSystem(ctx context.Context, live *armcs.AgentPool) error {
-	m.record("recreateSystem")
-	if m.recreateSystemFn != nil {
-		return m.recreateSystemFn(ctx, live)
+func (m *mockOrchestrator) recreatePool(ctx context.Context, poolName string, live *armcs.AgentPool) error {
+	m.record("recreatePool:" + poolName)
+	if m.recreatePoolFn != nil {
+		return m.recreatePoolFn(ctx, poolName, live)
 	}
 	return nil
 }
@@ -1452,26 +1515,26 @@ func (m *mockOrchestrator) reconcileTagPut(ctx context.Context) error {
 	return nil
 }
 
-func (m *mockOrchestrator) triggerSystemReconcile(ctx context.Context, live *armcs.AgentPool) error {
-	m.record("triggerSystemReconcile")
-	if m.triggerSystemReconcileFn != nil {
-		return m.triggerSystemReconcileFn(ctx, live)
+func (m *mockOrchestrator) triggerPoolReconcile(ctx context.Context, poolName string, live *armcs.AgentPool) error {
+	m.record("triggerPoolReconcile:" + poolName)
+	if m.triggerPoolReconcileFn != nil {
+		return m.triggerPoolReconcileFn(ctx, poolName, live)
 	}
 	return nil
 }
 
-func (m *mockOrchestrator) pollForNRPEvidence(ctx context.Context, timeout time.Duration, pollInterval time.Duration, windowMin int, threshold int) (int, error) {
-	m.record("pollForNRPEvidence")
+func (m *mockOrchestrator) pollForNRPEvidence(ctx context.Context, poolName string, vmssPrefix string, timeout time.Duration, pollInterval time.Duration, windowMin int, threshold int) (int, error) {
+	m.record("pollForNRPEvidence:" + poolName)
 	if m.pollForNRPEvidenceFn != nil {
-		return m.pollForNRPEvidenceFn(ctx, timeout, pollInterval, windowMin, threshold)
+		return m.pollForNRPEvidenceFn(ctx, poolName, vmssPrefix, timeout, pollInterval, windowMin, threshold)
 	}
 	return threshold, nil
 }
 
-func (m *mockOrchestrator) abortSystemReconcile(ctx context.Context) error {
-	m.record("abortSystemReconcile")
-	if m.abortSystemReconcileFn != nil {
-		return m.abortSystemReconcileFn(ctx)
+func (m *mockOrchestrator) abortPoolReconcile(ctx context.Context, poolName string) error {
+	m.record("abortPoolReconcile:" + poolName)
+	if m.abortPoolReconcileFn != nil {
+		return m.abortPoolReconcileFn(ctx, poolName)
 	}
 	return nil
 }
@@ -1479,13 +1542,16 @@ func (m *mockOrchestrator) abortSystemReconcile(ctx context.Context) error {
 func TestRunWith(t *testing.T) {
 	dummyErr := errors.New("boom")
 
+	systemPool := wedgedPool{name: "system", category: poolCategorySystem, vmssPrefix: "aks-system-"}
+	suspectedSystemPool := wedgedPool{name: "system", category: poolCategorySystem, vmssPrefix: "aks-system-", suspected: true}
+
 	fullHappyPath := []string{
 		"ensureCluster", "dumpPreflight", "detect:1",
 		"bootstrapKube", "dumpPreflight", "preflightChecks",
-		"snapshotSystem", "maybeAbortLRO", "detect:2", "snapshotSystem",
+		"maybeAbortLRO", "detect:2", "snapshotPool:system",
 		"addSystmp",
 		"drainPool:system", "deletePool:system",
-		"recreateSystem",
+		"recreatePool:system",
 		"drainPool:systmp", "deletePool:systmp",
 		"reconcileTagPut", "dumpPostflight",
 	}
@@ -1519,97 +1585,102 @@ func TestRunWith(t *testing.T) {
 			wantCalls: []string{"ensureCluster"},
 		},
 		{
-			name: "guards_do_not_fire_non_guard1",
+			name: "guards_do_not_fire",
 			cfg:  &config{clusterName: "c", resourceGroup: "rg", subscriptionID: "sub", cpVersion: "1.30.0"},
 			setup: func(m *mockOrchestrator) {
-				m.detectFn = func(_ context.Context, _ int) (bool, string, error) {
-					return false, "cluster state FAIL: not recoverable", nil
+				m.detectFn = func(_ context.Context, _ int) ([]wedgedPool, string, error) {
+					return nil, "cluster state FAIL: not recoverable", nil
 				}
 			},
 			wantCalls: []string{"ensureCluster", "dumpPreflight", "detect:1"},
 		},
 		{
-			name: "guard1_fail_dry_run_skips_forced_evidence",
+			name: "suspected_pool_dry_run_skips_forced_evidence",
 			cfg:  &config{clusterName: "c", resourceGroup: "rg", subscriptionID: "sub", cpVersion: "1.30.0", dryRun: true},
 			setup: func(m *mockOrchestrator) {
-				m.detectFn = func(_ context.Context, _ int) (bool, string, error) {
-					return false, "NRP-KVS storm FAIL: only 0 NRP failures < 10", nil
+				m.detectFn = func(_ context.Context, _ int) ([]wedgedPool, string, error) {
+					return []wedgedPool{suspectedSystemPool}, "", nil
 				}
 			},
 			wantCalls: []string{"ensureCluster", "dumpPreflight", "detect:1"},
 		},
 		{
-			name: "guard1_fail_forced_evidence_inconclusive",
+			name: "suspected_pool_forced_evidence_inconclusive",
 			cfg:  &config{clusterName: "c", resourceGroup: "rg", subscriptionID: "sub", cpVersion: "1.30.0", threshold: 10},
 			setup: func(m *mockOrchestrator) {
-				m.detectFn = func(_ context.Context, _ int) (bool, string, error) {
-					return false, "NRP-KVS storm FAIL: only 0 NRP failures < 10", nil
+				m.detectFn = func(_ context.Context, _ int) ([]wedgedPool, string, error) {
+					return []wedgedPool{suspectedSystemPool}, "", nil
 				}
-				m.pollForNRPEvidenceFn = func(context.Context, time.Duration, time.Duration, int, int) (int, error) {
+				m.pollForNRPEvidenceFn = func(_ context.Context, _ string, _ string, _ time.Duration, _ time.Duration, _ int, _ int) (int, error) {
 					return 3, nil
 				}
 			},
 			wantCalls: []string{
 				"ensureCluster", "dumpPreflight", "detect:1",
-				"snapshotSystem", "triggerSystemReconcile", "pollForNRPEvidence", "abortSystemReconcile",
+				"snapshotPool:system", "triggerPoolReconcile:system", "pollForNRPEvidence:system", "abortPoolReconcile:system",
 			},
 		},
 		{
-			name: "guard1_fail_forced_evidence_confirms_nrp",
+			name: "suspected_pool_forced_evidence_confirms_nrp",
 			cfg:  &config{clusterName: "c", resourceGroup: "rg", subscriptionID: "sub", cpVersion: "1.30.0", threshold: 10},
 			setup: func(m *mockOrchestrator) {
-				m.detectFn = func(_ context.Context, n int) (bool, string, error) {
+				m.detectFn = func(_ context.Context, n int) ([]wedgedPool, string, error) {
 					if n == 1 {
-						return false, "NRP-KVS storm FAIL: only 0 NRP failures < 10", nil
+						return []wedgedPool{suspectedSystemPool}, "", nil
 					}
-					return true, "", nil
+					return []wedgedPool{systemPool}, "", nil
 				}
-				m.pollForNRPEvidenceFn = func(context.Context, time.Duration, time.Duration, int, int) (int, error) {
+				m.pollForNRPEvidenceFn = func(_ context.Context, _ string, _ string, _ time.Duration, _ time.Duration, _ int, _ int) (int, error) {
 					return 12, nil
 				}
 			},
 			wantCalls: []string{
 				"ensureCluster", "dumpPreflight", "detect:1",
-				"snapshotSystem", "triggerSystemReconcile", "pollForNRPEvidence", "abortSystemReconcile",
+				"snapshotPool:system", "triggerPoolReconcile:system", "pollForNRPEvidence:system", "abortPoolReconcile:system",
 				"bootstrapKube", "dumpPreflight", "preflightChecks",
-				"snapshotSystem", "maybeAbortLRO", "detect:2", "snapshotSystem",
+				"maybeAbortLRO", "detect:2", "snapshotPool:system",
 				"addSystmp",
 				"drainPool:system", "deletePool:system",
-				"recreateSystem",
+				"recreatePool:system",
 				"drainPool:systmp", "deletePool:systmp",
 				"reconcileTagPut", "dumpPostflight",
 			},
 		},
 		{
-			name: "guard1_fail_trigger_failure_exits_noop",
+			name: "suspected_pool_trigger_failure_exits_noop",
 			cfg:  &config{clusterName: "c", resourceGroup: "rg", subscriptionID: "sub", cpVersion: "1.30.0", threshold: 10},
 			setup: func(m *mockOrchestrator) {
-				m.detectFn = func(_ context.Context, _ int) (bool, string, error) {
-					return false, "NRP-KVS storm FAIL: only 0 NRP failures < 10", nil
+				m.detectFn = func(_ context.Context, _ int) ([]wedgedPool, string, error) {
+					return []wedgedPool{suspectedSystemPool}, "", nil
 				}
-				m.triggerSystemReconcileFn = func(context.Context, *armcs.AgentPool) error {
+				m.triggerPoolReconcileFn = func(_ context.Context, _ string, _ *armcs.AgentPool) error {
 					return errors.New("conflict")
 				}
 			},
 			wantCalls: []string{
 				"ensureCluster", "dumpPreflight", "detect:1",
-				"snapshotSystem", "triggerSystemReconcile",
+				"snapshotPool:system", "triggerPoolReconcile:system",
 			},
 		},
 		{
 			name: "detect_error",
 			cfg:  &config{clusterName: "c", resourceGroup: "rg", subscriptionID: "sub", cpVersion: "1.30.0"},
 			setup: func(m *mockOrchestrator) {
-				m.detectFn = func(_ context.Context, _ int) (bool, string, error) {
-					return false, "", dummyErr
+				m.detectFn = func(_ context.Context, _ int) ([]wedgedPool, string, error) {
+					return nil, "", dummyErr
 				}
 			},
 			wantErr:   "detection:",
 			wantCalls: []string{"ensureCluster", "dumpPreflight", "detect:1"},
 		},
 		{
-			name:      "dry_run_exits_after_guards",
-			cfg:       &config{clusterName: "c", resourceGroup: "rg", subscriptionID: "sub", cpVersion: "1.30.0", dryRun: true},
+			name: "dry_run_exits_after_guards",
+			cfg:  &config{clusterName: "c", resourceGroup: "rg", subscriptionID: "sub", cpVersion: "1.30.0", dryRun: true},
+			setup: func(m *mockOrchestrator) {
+				m.detectFn = func(_ context.Context, _ int) ([]wedgedPool, string, error) {
+					return []wedgedPool{systemPool}, "", nil
+				}
+			},
 			wantCalls: []string{"ensureCluster", "dumpPreflight", "detect:1"},
 		},
 		{
@@ -1629,24 +1700,24 @@ func TestRunWith(t *testing.T) {
 			wantCalls: []string{
 				"ensureCluster", "dumpPreflight", "detect:1",
 				"bootstrapKube", "dumpPreflight", "preflightChecks",
-				"snapshotSystem", "maybeAbortLRO",
+				"maybeAbortLRO",
 			},
 		},
 		{
 			name: "guards_fail_after_lro_abort",
 			cfg:  &config{clusterName: "c", resourceGroup: "rg", subscriptionID: "sub", cpVersion: "1.30.0"},
 			setup: func(m *mockOrchestrator) {
-				m.detectFn = func(_ context.Context, n int) (bool, string, error) {
+				m.detectFn = func(_ context.Context, n int) ([]wedgedPool, string, error) {
 					if n == 1 {
-						return true, "", nil
+						return []wedgedPool{systemPool}, "", nil
 					}
-					return false, "system wedge FAIL after LRO", nil
+					return nil, "pool wedge FAIL after LRO", nil
 				}
 			},
 			wantCalls: []string{
 				"ensureCluster", "dumpPreflight", "detect:1",
 				"bootstrapKube", "dumpPreflight", "preflightChecks",
-				"snapshotSystem", "maybeAbortLRO", "detect:2",
+				"maybeAbortLRO", "detect:2",
 			},
 		},
 		{
@@ -1660,11 +1731,11 @@ func TestRunWith(t *testing.T) {
 			setup: func(m *mockOrchestrator) {
 				m.addSystmpFn = func(context.Context, *armcs.AgentPool) error { return dummyErr }
 			},
-			wantErr: "add systmp:",
+			wantErr: "add systmp",
 			wantCalls: []string{
 				"ensureCluster", "dumpPreflight", "detect:1",
 				"bootstrapKube", "dumpPreflight", "preflightChecks",
-				"snapshotSystem", "maybeAbortLRO", "detect:2", "snapshotSystem",
+				"maybeAbortLRO", "detect:2", "snapshotPool:system",
 				"addSystmp",
 			},
 		},
@@ -1683,7 +1754,7 @@ func TestRunWith(t *testing.T) {
 			wantCalls: []string{
 				"ensureCluster", "dumpPreflight", "detect:1",
 				"bootstrapKube", "dumpPreflight", "preflightChecks",
-				"snapshotSystem", "maybeAbortLRO", "detect:2", "snapshotSystem",
+				"maybeAbortLRO", "detect:2", "snapshotPool:system",
 				"addSystmp", "drainPool:system",
 			},
 		},
@@ -1704,7 +1775,7 @@ func TestRunWith(t *testing.T) {
 			name: "recreate_system_error",
 			cfg:  &config{clusterName: "c", resourceGroup: "rg", subscriptionID: "sub", cpVersion: "1.30.0"},
 			setup: func(m *mockOrchestrator) {
-				m.recreateSystemFn = func(context.Context, *armcs.AgentPool) error { return dummyErr }
+				m.recreatePoolFn = func(_ context.Context, _ string, _ *armcs.AgentPool) error { return dummyErr }
 			},
 			wantErr: "recreate system:",
 		},
@@ -1741,6 +1812,54 @@ func TestRunWith(t *testing.T) {
 				m.reconcileTagPutFn = func(context.Context) error { return dummyErr }
 			},
 			wantErr: "tag reconcile:",
+		},
+		{
+			name: "user_pool_only_remediation",
+			cfg:  &config{clusterName: "c", resourceGroup: "rg", subscriptionID: "sub", cpVersion: "1.30.0"},
+			setup: func(m *mockOrchestrator) {
+				userPool := wedgedPool{name: "userswft3", category: poolCategoryUser, vmssPrefix: "aks-userswft3-"}
+				m.detectFn = func(_ context.Context, _ int) ([]wedgedPool, string, error) {
+					return []wedgedPool{userPool}, "", nil
+				}
+			},
+			wantCalls: []string{
+				"ensureCluster", "dumpPreflight", "detect:1",
+				"bootstrapKube", "dumpPreflight", "preflightChecks",
+				"maybeAbortLRO", "detect:2", "snapshotPool:userswft3",
+				"drainPool:userswft3", "deletePool:userswft3",
+				"recreatePool:userswft3",
+				"reconcileTagPut", "dumpPostflight",
+			},
+		},
+		{
+			name: "multi_pool_system_and_user",
+			cfg:  &config{clusterName: "c", resourceGroup: "rg", subscriptionID: "sub", cpVersion: "1.30.0"},
+			setup: func(m *mockOrchestrator) {
+				pools := []wedgedPool{
+					{name: "system", category: poolCategorySystem, vmssPrefix: "aks-system-"},
+					{name: "userswft3", category: poolCategoryUser, vmssPrefix: "aks-userswft3-"},
+				}
+				m.detectFn = func(_ context.Context, _ int) ([]wedgedPool, string, error) {
+					return pools, "", nil
+				}
+			},
+			wantCalls: []string{
+				"ensureCluster", "dumpPreflight", "detect:1",
+				"bootstrapKube", "dumpPreflight", "preflightChecks",
+				"maybeAbortLRO", "detect:2",
+				// system pool (with systmp dance)
+				"snapshotPool:system",
+				"addSystmp",
+				"drainPool:system", "deletePool:system",
+				"recreatePool:system",
+				"drainPool:systmp", "deletePool:systmp",
+				// user pool (no systmp)
+				"snapshotPool:userswft3",
+				"drainPool:userswft3", "deletePool:userswft3",
+				"recreatePool:userswft3",
+				// finish
+				"reconcileTagPut", "dumpPostflight",
+			},
 		},
 	}
 

--- a/dev-infrastructure/scripts/recreate-system-pool/main_test.go
+++ b/dev-infrastructure/scripts/recreate-system-pool/main_test.go
@@ -270,13 +270,18 @@ func TestEvalClusterState(t *testing.T) {
 }
 
 func mkPool(name string, count, minCount *int32) *armcs.AgentPool {
-	return &armcs.AgentPool{
+	p := &armcs.AgentPool{
 		Name: ptr(name),
 		Properties: &armcs.ManagedClusterAgentPoolProfileProperties{
 			Count:    count,
 			MinCount: minCount,
 		},
 	}
+	if name == systemPoolName || name == systmpPoolName {
+		mode := armcs.AgentPoolModeSystem
+		p.Properties.Mode = &mode
+	}
+	return p
 }
 
 // mkPoolWithState builds a pool with provisioning state set, used for


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Extends recreate-system-pool from handling only the AKS system nodepool to detecting and remediating all management cluster nodepools — system, user (swft), and infra. The NRP-KVS corruption is bound to a VMSS ARM resource ID and can affect any SwiftV2 pool, not just the system pool. The tool is also now generalizable for other issues requiring nodepool recreation.

  Detection — detect() now iterates all pools and returns a []wedgedPool list instead of a single bool. Each pool is checked independently for wedge-compatible provisioningState and NRP-KVS evidence on its own VMSS prefix (aks-<poolName>-). Activity log is queried once and filtered per-pool. Pools are classified as
  system/user/infra using AKS Mode field + aro-hcp.azure.com/role node label.

  Remediation — Pools are processed sequentially, system first:
  - System pool: existing systmp dance (AKS requires at least one System-mode pool)
  - User/infra pools: direct drain → delete → recreate (no temporary pool needed)

  Forced evidence — Now per-pool: triggers a reconcile on the specific wedged pool, watches its VMSS prefix for NRP-KVS errors, aborts the triggered LRO.  If there are 0 confirmed nodepools, SKIPS reconcile on infra nodepools since they cannot have this failure state, and we only have 1 hour for this step to run.

  Safety — evalClusterSafety replaces evalNonSystemPools (checks at least one non-system pool has count > 0). Per-pool time budget check (5 min minimum) prevents timeout overrun when multiple pools are wedged. 

  SKIP_GUARDS — Returns all pools as confirmed wedged for testing against healthy clusters.

  - dev-infrastructure/scripts/recreate-system-pool/main.go — multi-pool detection, remediation, forced evidence
  - dev-infrastructure/scripts/recreate-system-pool/main_test.go — updated mock orchestrator, new test cases
  - dev-infrastructure/mgmt-pipeline.yaml — updated step comment

### Why

The NRP-KVS corruption (ICM 798003653) that wedged the system pool in INT and Stage can hit any SwiftV2 pool's VMSS. User pools (userswft1-3) are SwiftV2-enabled in all production environments. Having the self-healing tool only cover the system pool leaves user pool wedges as a manual firefight.

### Testing
 
 - 342 unit test runs pass, including new cases for classifyPool, evalClusterSafety, evalPoolWedged, user-pool-only remediation, and multi-pool ordering
  - Full multi-pool recreation validated on personal dev env (pers-usw3scla-mgmt-1, 6 pools):
  All 6 pools Succeeded after completion. PDB eviction retries during system pool drain resolved within the 10 min drain window.

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
