### PR TITLE
chore: rename prow fallback deploy environment to ci00

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1536,7 +1536,7 @@ clouds:
           westus3:
             monitoring:
               alertsEnabled: true
-      prow:
+      ci00:
         defaults:
           kusto:
             manageInstance: false

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -33,7 +33,7 @@ adminApi:
     connectSocket: false
   cert:
     issuer: Self
-    name: admin-api-cert-prow-j7654321
+    name: admin-api-cert-ci00-j7654321
   image:
     digest: sha256:6f7cd7e77ae5ca7cf9231b9479211a0430a071c763d9540d769a2f40d9d78c57
     registry: arohcpsvcdev.azurecr.io
@@ -88,9 +88,9 @@ auditLogsEventHub:
   authRuleName: SendRule
   enabled: false
   kustoConsumerGroupName: AuditLogsToKusto
-  kustoDataConnectionName: prow-centralus-auditlogs
+  kustoDataConnectionName: ci00-centralus-auditlogs
   name: aks-auditlogs
-  namespace: hcp-prow-centralus-auditlogs-eh
+  namespace: hcp-ci00-centralus-auditlogs-eh
   rg: centralus-shared-resources
 automationDryRun: false
 azureGeoShortId: us
@@ -117,7 +117,7 @@ backend:
     serviceAccountName: backend
   logVerbosity: 4
   maestro:
-    sourceEnvironmentIdentifier: arohcpprow
+    sourceEnvironmentIdentifier: arohcpci00
   managedIdentityName: backend
   tracing:
     address: http://ingest.observability:4318
@@ -162,7 +162,7 @@ clustersService:
   batchProcessesDryRun: true
   denyAssignments: disabled
   deployDebugJobs: false
-  environment: arohcpprow
+  environment: arohcpci00
   image:
     digest: sha256:31fe1839cc3bd62fad4d9f5848f1269f3083c33686c328904a182a5011b4e4ff
     registry: quay.io
@@ -192,7 +192,7 @@ clustersService:
     enhancedMetricsEnabled: true
     geoRedundantBackup: false
     minTLSVersion: TLSV1.2
-    name: arohcp-prow-dbcs-j7654321
+    name: arohcp-ci00-dbcs-j7654321
     password: TheBlurstOfTimes
     private: false
     serverSku: Standard_D8s_v3
@@ -221,7 +221,7 @@ customExporter:
     serviceAccountName: aro-hcp-exporter
   managedIdentityName: aro-hcp-exporter
 cxKeyVault:
-  name: ah-prow-cx-j7654321-1
+  name: ah-ci00-cx-j7654321-1
   private: false
   softDelete: false
   tagKey: aroHCPPurpose
@@ -240,7 +240,7 @@ e2e:
     gatePromotion: true
     prowJobName: ""
 entraAppOwnerIds: d8837611-f550-4f0a-af48-575a7178adfb,16ea1e12-7ef3-4613-bea4-3d4a20cbc38c,770ce6b0-5afe-472d-ac0d-1fae72acc4e4
-environmentName: prow
+environmentName: ci00
 ev2:
   assistedId:
     applicationId: ""
@@ -274,13 +274,13 @@ frontend:
     connectSocket: false
   cert:
     issuer: Self
-    name: frontend-cert-prow-j7654321
+    name: frontend-cert-ci00-j7654321
   cosmosDB:
     billingContainerMaxScale: 4000
     disableLocalAuth: true
     fleetContainerMaxScale: 4000
     locksContainerMaxScale: 4000
-    name: arohcpprow-rp-j7654321
+    name: arohcpci00-rp-j7654321
     private: false
     resourceContainerMaxScale: 4000
     zoneRedundantMode: Disabled
@@ -368,7 +368,7 @@ global:
   billing:
     digest: placeholder
     rg: placeholder
-    subscriptionKey: hcp-billng-prow
+    subscriptionKey: hcp-billng-ci00
   globalMSIName: global-rollout-identity
   groupQuota:
     displayName: empty-sentinel
@@ -389,7 +389,7 @@ global:
   rg: global
   safeDnsIntAppObjectId: ""
   subscription:
-    displayName: Azure Red Hat OpenShift HCP - prow - Global
+    displayName: Azure Red Hat OpenShift HCP - ci00 - Global
     key: ARO Hosted Control Planes (EA Subscription 1)
     providers:
       Microsoft.Compute:
@@ -533,7 +533,7 @@ maestro:
   certIssuer: Self
   eventGrid:
     maxClientSessionsPerAuthName: 6
-    name: arohcp-prow-maestro-j7654321
+    name: arohcp-ci00-maestro-j7654321
     private: false
   image:
     digest: sha256:f6c0ac7154b13cbbd46c3f759c12a3e480bc9f7394bfa55f4bc6d4e30161a9e0
@@ -549,7 +549,7 @@ maestro:
     enhancedMetricsEnabled: true
     geoRedundantBackup: false
     minTLSVersion: TLSV1.2
-    name: arohcp-prow-dbmaestro-j7654321
+    name: arohcp-ci00-dbmaestro-j7654321
     password: TheBlurstOfTimes
     private: false
     serverSku: Standard_D2s_v3
@@ -580,7 +580,7 @@ mgmt:
     enableSwiftV2Nodepools: true
     enableSwiftV2Vnet: true
     etcd:
-      name: ah-prow-me-j7654321-1
+      name: ah-ci00-me-j7654321-1
       private: true
       softDelete: false
       tagKey: aroHCPPurpose
@@ -595,7 +595,7 @@ mgmt:
       zoneRedundantMode: Auto
       zones: ""
     kubernetesVersion: "1.35"
-    name: prow-j7654321-mgmt-1
+    name: ci00-j7654321-mgmt-1
     networkDataplane: azure
     networkPolicy: azure
     podSubnetPrefix: 10.128.64.0/18
@@ -624,7 +624,7 @@ mgmt:
   defaultStorageClassSkuName: PremiumV2_LRS
   hcpBackups:
     storageAccount:
-      name: oadpprowj76543211
+      name: oadpci00j76543211
       public: false
       zoneRedundantMode: Auto
     storageAccountContainerName: backups
@@ -677,7 +677,7 @@ mgmt:
         repository: thanos/thanos
         sha: cf3e9b292e4302ad4a4955b56379703aea39516607d382a57604a3d003c35d10
         tag: v0.41.0
-  rg: hcp-underlay-prow-j7654321-mgmt-1
+  rg: hcp-underlay-ci00-j7654321-mgmt-1
   subscription:
     certificateDomains:
     - '*.hcp.osadev.cloud'
@@ -718,7 +718,7 @@ mgmtAgent:
     serviceAccountName: mgmt-agent
   managedIdentityName: mgmt-agent
 mgmtKeyVault:
-  name: ah-prow-mg-j7654321-1
+  name: ah-ci00-mg-j7654321-1
   private: false
   softDelete: false
   tagKey: aroHCPPurpose
@@ -728,7 +728,7 @@ miMockClientId: e8723db7-9b9e-46a4-9f7d-64d75c3534f0
 miMockPrincipalId: d6b62dfa-87f5-49b3-bbcb-4a687c4faa96
 miMockTenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
 mise:
-  applicationName: arohcp-mise-prow
+  applicationName: arohcp-mise-ci00
   arm:
     applicationId: e2c2ff5c-e5b4-4e79-8c3e-1da8c48461e7
     audienceFQDN: management.azure.com
@@ -812,7 +812,7 @@ msiCredentialsRefresher:
     serviceAccountName: msi-credential-refresher
   managedIdentityName: msi-credential-refresher
 msiKeyVault:
-  name: ah-prow-mi-j7654321-1
+  name: ah-ci00-mi-j7654321-1
   private: false
   softDelete: false
   tagKey: aroHCPPurpose
@@ -822,7 +822,7 @@ msiRp:
 oidc:
   frontdoor:
     keyVault:
-      name: ah-prow-afd
+      name: ah-ci00-afd
       private: false
       softDelete: true
       tagKey: aroHCPPurpose
@@ -834,7 +834,7 @@ oidc:
     subdomain: oic
     useManagedCertificates: true
   storageAccount:
-    name: arohcpprowoidcj7654321
+    name: arohcpci00oidcj7654321
     privateLinkLocation: centralus
     public: true
     zoneRedundantMode: Auto
@@ -845,10 +845,10 @@ quotaizer:
     repository: empty-sentinel
   managedIdentityName: aro-quotaizer
   quotaGroup:
-    displayName: HCP - prow centralus
-    id: aro-prow-centralus
+    displayName: HCP - ci00 centralus
+    id: aro-ci00-centralus
 region: centralus
-regionRG: hcp-underlay-prow-j7654321
+regionRG: hcp-underlay-ci00-j7654321
 secretSyncController:
   image:
     digest: sha256:0b4799815b77c2c5c8e6375b86072e514cdc447ef1c59a5754939c32ba4147a9
@@ -882,7 +882,7 @@ serviceKeyVault:
 sessiongate:
   cert:
     issuer: Self
-    name: sessiongate-cert-prow-j7654321
+    name: sessiongate-cert-ci00-j7654321
   image:
     digest: sha256:df780df7ce54fbf58824258c44fdb1d135687c24f232440355f4e317c3af3cde
     registry: arohcpsvcdev.azurecr.io
@@ -896,7 +896,7 @@ svc:
   aks:
     clusterOutboundIPAddressIPTags: ""
     etcd:
-      name: ah-prow-se-j7654321-1
+      name: ah-ci00-se-j7654321-1
       private: true
       softDelete: false
       tagKey: aroHCPPurpose
@@ -911,7 +911,7 @@ svc:
       zoneRedundantMode: Auto
       zones: ""
     kubernetesVersion: "1.35"
-    name: prow-j7654321-svc
+    name: ci00-j7654321-svc
     networkDataplane: cilium
     networkPolicy: cilium
     podSubnetPrefix: 10.128.64.0/18
@@ -996,7 +996,7 @@ svc:
         repository: thanos/thanos
         sha: cf3e9b292e4302ad4a4955b56379703aea39516607d382a57604a3d003c35d10
         tag: v0.41.0
-  rg: hcp-underlay-prow-j7654321-svc
+  rg: hcp-underlay-ci00-j7654321-svc
   subscription:
     certificateDomains:
     - '*.hcpsvc.osadev.cloud'

--- a/test/cmd/aro-hcp-tests/slot-manager/acquire.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/acquire.go
@@ -84,7 +84,7 @@ func splitSelectorValues(raw string) []string {
 
 func BindAcquireOptions(opts *RawAcquireOptions, cmd *cobra.Command) error {
 	cmd.Flags().StringVar(&opts.ClusterProfileDir, "cluster-profile-dir", opts.ClusterProfileDir, "Path to CLUSTER_PROFILE_DIR")
-	cmd.Flags().StringVar(&opts.DeployEnv, "deploy-env", opts.DeployEnv, "Deploy environment name (prow, ci01, int, stg, prod)")
+	cmd.Flags().StringVar(&opts.DeployEnv, "deploy-env", opts.DeployEnv, "Deploy environment name (ci00, ci01, int, stg, prod)")
 	cmd.Flags().StringSliceVar(&opts.AllowedSubscriptions, "allowed-subscriptions", opts.AllowedSubscriptions, "Optional catalog subscription_name values allowed for candidate pool selection.")
 	cmd.Flags().StringSliceVar(&opts.AllowedLocations, "allowed-locations", opts.AllowedLocations, "Optional Azure regions allowed for fixed-mode candidate pool selection.")
 	cmd.Flags().StringVar(&opts.SharedDir, "shared-dir", opts.SharedDir, "Path to SHARED_DIR")

--- a/test/cmd/aro-hcp-tests/slot-manager/acquire_test.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/acquire_test.go
@@ -297,7 +297,7 @@ func TestAcquireRunFixedModeFallsBackWithinRequestedRegion(t *testing.T) {
 	catalogPath := writeAcquireTestCatalogFromYAML(t, `version: 1
 environments:
   dev:
-    deploy_envs: [prow, ci01]
+    deploy_envs: [ci00, ci01]
     pools:
       - subscription_name: dev-sub-a
         region: centralus
@@ -940,7 +940,7 @@ func writeAcquireTestCatalog(t *testing.T, regionMode, region string) string {
 	return writeAcquireTestCatalogFromYAML(t, fmt.Sprintf(`version: 1
 environments:
   dev:
-    deploy_envs: [prow, ci01]
+    deploy_envs: [ci00, ci01]
     pools:
       - subscription_name: "ARO HCP E2E Hosted Clusters (EA Subscription)"
         region: %s

--- a/test/cmd/aro-hcp-tests/slot-manager/identity-pool/pools_test.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/identity-pool/pools_test.go
@@ -41,7 +41,7 @@ func TestLoadIdentityPools(t *testing.T) {
 environments:
   dev:
     deploy_envs:
-      - prow
+      - ci00
     pools:
       - subscription_name: dev-sub-1
         region: westus3
@@ -106,7 +106,7 @@ func TestLoadIdentityPoolsResolutionFailure(t *testing.T) {
 environments:
   dev:
     deploy_envs:
-      - prow
+      - ci00
     pools:
       - subscription_name: unknown-sub
         region: westus3
@@ -137,7 +137,7 @@ func TestLoadIdentityPoolsDeduplicatesResolution(t *testing.T) {
 environments:
   dev:
     deploy_envs:
-      - prow
+      - ci00
     pools:
       - subscription_name: shared-sub
         region: westus3

--- a/test/cmd/aro-hcp-tests/slot-manager/slots/catalog_test.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/slots/catalog_test.go
@@ -25,7 +25,7 @@ import (
 const syntheticCatalogYAML = `version: 1
 environments:
   dev:
-    deploy_envs: [prow, ci01]
+    deploy_envs: [ci00, ci01]
     pools:
       - subscription_name: dev-shard-0
         region: westus3

--- a/test/cmd/aro-hcp-tests/slot-manager/slots/generate_boskos_test.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/slots/generate_boskos_test.go
@@ -30,7 +30,7 @@ func TestRewriteGenerateBoskosAndValidateBoskosConfig(t *testing.T) {
 		Version: 1,
 		Environments: map[string]Environment{
 			"dev": {
-				DeployEnvs: []string{"prow", "ci01"},
+				DeployEnvs: []string{"ci00", "ci01"},
 				Pools: []Pool{
 					{
 						SubscriptionName:        "dev",

--- a/test/e2e-config/e2e-slots.yaml
+++ b/test/e2e-config/e2e-slots.yaml
@@ -2,7 +2,7 @@ version: 1
 environments:
   dev:
     deploy_envs:
-    - prow
+    - ci00
     - ci01
     pools:
     # shard1: additional dev capacity for multi-subscription testing.

--- a/test/e2e/mise_routing.go
+++ b/test/e2e/mise_routing.go
@@ -66,7 +66,7 @@ func (p *miseVersionValidator) Do(req *policy.Request) (*http.Response, error) {
 
 // Tests the VirtualService routes to the correct frontend instance based on request headers
 // by creating and deleting a full HCP cluster, validating every response header.
-// In INT and above, this exercises MISE-backed routing. In dev/prow environments, the same
+// In INT and above, this exercises MISE-backed routing. In dev/CI environments, the same
 // VirtualService is deployed but fronts non-MISE frontend instances. PR checks connect
 // through the Istio ingress gateway (not port-forwarded), so the VirtualService routing
 // rules are always evaluated.

--- a/test/util/verifiers/must_gather_cli.go
+++ b/test/util/verifiers/must_gather_cli.go
@@ -199,7 +199,7 @@ func infraClusterNames() (svcCluster, mgmtCluster string) {
 
 	deployEnv := os.Getenv("DEPLOY_ENV")
 	if deployEnv == "" {
-		deployEnv = "prow"
+		deployEnv = "ci00"
 	}
 
 	suffix := buildID

--- a/tooling/cleanup-sweeper/resourcegroups.policy.yaml
+++ b/tooling/cleanup-sweeper/resourcegroups.policy.yaml
@@ -2,8 +2,8 @@
 # - excludedResourceGroups: never candidates (global, hcp-kusto-us, westus3-shared-resources).
 # - Skip managed RGs (managedBy set).
 # - hcp-underlay-pers-*: delete after 15d if persist=true; after 2d if persist is absent or not "true".
-# - hcp-underlay-prow-*: delete after 6h.
-# - Name prefix hcp-underlay-ci*: delete after 6h (covers ci01, etc.).
+# - hcp-underlay-prow-*: delete after 6h (transitional, remove after rename rollout).
+# - Name prefix hcp-underlay-ci*: delete after 6h (covers ci00, ci01, etc.).
 # - Skip any RG with persist=true (after pers-* and CI rules).
 # - Default: delete any other RG after 2d.
 # Delete rules need a parseable tags.createdAt; see docs/cleanup.md and scripts/ for Azure Policy.
@@ -39,6 +39,8 @@ rgOrdered:
         tagsNotEq:
           persist: "true"
       olderThan: "48h"
+    # TODO(ARO-27234): remove this rule once all hcp-underlay-prow-* RGs have
+    # aged out after the prow→ci00 rename rollout is complete.
     - name: prow-delete-after-6h
       action: delete
       match:

--- a/tooling/templatize/settings.yaml
+++ b/tooling/templatize/settings.yaml
@@ -28,7 +28,7 @@ environments:
     ev2Cloud: public
     cxStamp: 1
     regionShortSuffix: "${USER:0:4}"
-- name: prow
+- name: ci00
   description: |
     CI infra shard0 - PR end-to-end tests (fallback).
   defaults:


### PR DESCRIPTION
[ARO-27234](https://redhat.atlassian.net/browse/ARO-27234)

### What

Rename the `prow` fallback deploy environment to `ci00`, aligning it with the existing `ci01` naming convention.

### Why

The `prow` environment name is a legacy artifact from when there was only one CI shard. Now that we have `ci01`, the fallback shard should follow the same `ciNN` pattern. This rename is a prerequisite for retiring legacy Vault keys ([ARO-27235](https://redhat.atlassian.net/browse/ARO-27235)) and is part of the broader CI infrastructure re-architecture ([ARO-25833](https://redhat.atlassian.net/browse/ARO-25833)).

### Testing

No new tests needed — this is a pure naming change. Existing test fixtures and test data have been updated to use `ci00` in place of `prow` (slot-manager tests, Boskos generation, identity pool tests, catalog tests). All tests pass unchanged since they validate behavior, not the specific environment name string.

### Special notes for your reviewer

- The rendered config (`config/rendered/dev/prow/` → `ci00/`) was re-materialized via `make -C config render`. The large diff there is all derived from the environment name change — no manual edits.
- The cleanup-sweeper retains a transitional `prow-delete-after-6h` rule with a `TODO([ARO-27234](https://redhat.atlassian.net/browse/ARO-27234))` to remove it once existing `hcp-underlay-prow-*` resource groups age out.
- All remaining `prow` references in the repo are intentional — they refer to Prow the CI system (tokens, directory paths, snapshot tooling, documentation), not the deploy environment name.
- **Companion PR needed in openshift/release** to update `DEPLOY_ENV` / `ARO_HCP_DEPLOY_ENV` defaults from `prow` to `ci00`. Merge order: this PR first, then openshift/release.
- A new Vault key `infra-ci00-subscription-id` needs to be created (copied from `infra-prow-subscription-id`) in the `cluster-secrets-aro-hcp-dev` credential via the OpenShift CI self-service Vault portal.

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes) — N/A
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented — N/A (no logic changes)
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merged