### PR TITLE
test(e2e): improve z-stream test cases and observability

### DIFF
--- a/test/e2e/control_plane_automated_z_stream_upgrade.go
+++ b/test/e2e/control_plane_automated_z_stream_upgrade.go
@@ -32,6 +32,15 @@ import (
 )
 
 var _ = Describe("Service Provider", func() {
+	// basic flow for z-stream upgrade:
+	// 1. Every 5min, NewControlPlaneDesiredVersionController checks Cincinnati to see if there is a more up-to-date z-stream (patch) version
+	// 2. If z-stream update is available, Cincinnati responds with the updated version. This value is stored in existingServiceProviderCluster.Spec.ControlPlaneVersion.DesiredVersion
+	// 3. Every 5min, NewTriggerControlPlaneUpgradeController compares the current version (at ServiceProviderCluster.Status.ControlPlaneVersion.ActiveVersions[]) to the value at existingServiceProviderCluster.Spec.ControlPlaneVersion.DesiredVersion
+	// 4. If the versions are not equal, an upgrade policy is POSTed to the Cluster Service API.
+	// 5. Cluster Service publishes the policy to Maestro which forwards the update request to the management cluster at HostedCluster.Spec.Release.
+	// 6. Hypershift detects the Spec.Release change, applies the changes to the control plane/components, and updates version history.
+	// 7. The ClusterVersion Operator in the Guest cluster tracks the upgrade, including the state of the upgrade (Partial or Completed)
+	// 8. Every 5min, NewControlPlaneActiveVersionController checks the version history array and syncs it back to ServiceProviderCluster.Status.ControlPlaneVersion.ActiveVersions[], thus closing the loop.
 	DescribeTable("should upgrade the control plane z-stream automatically on behalf of the customer",
 		func(ctx context.Context, minorVersion string, baseInstallVersion string) {
 			const (
@@ -124,6 +133,12 @@ var _ = Describe("Service Provider", func() {
 				By("skipping z-stream upgrade verification: no upgrade path (cluster installed at latest)")
 				return
 			}
+
+			By("waiting for z-stream upgrade to trigger")
+			Eventually(func() error {
+				return verifiers.VerifyHCPCluster(ctx, adminRESTConfig, verifiers.VerifyHostedControlPlaneZStreamUpgradeTriggered(installVersion))
+			}, framework.HCPClusterVersionUpgradeTriggeredTimeout, 1*time.Minute).Should(Succeed())
+			GinkgoLogr.Info("z-stream upgrade has been triggered", "installVersion", installVersion)
 
 			By("verifying that only a z-stream upgrade was performed")
 			Eventually(func() error {

--- a/test/util/framework/constants.go
+++ b/test/util/framework/constants.go
@@ -34,10 +34,11 @@ const (
 
 // Resource Update timeouts
 const (
-	HCPClusterVersionUpgradeTimeout = 45 * time.Minute
-	NodePoolVersionUpgradeTimeout   = 45 * time.Minute
-	NodePoolScalingTimeout          = 20 * time.Minute
-	UpdateHCPClusterTimeout         = 10 * time.Minute
+	HCPClusterVersionUpgradeTriggeredTimeout = 15 * time.Minute
+	HCPClusterVersionUpgradeTimeout          = 45 * time.Minute
+	NodePoolVersionUpgradeTimeout            = 45 * time.Minute
+	NodePoolScalingTimeout                   = 20 * time.Minute
+	UpdateHCPClusterTimeout                  = 10 * time.Minute
 )
 
 // Identity assignment

--- a/test/util/verifiers/hosted_control_plane_version.go
+++ b/test/util/verifiers/hosted_control_plane_version.go
@@ -38,11 +38,13 @@ import (
 func GetClusterVersion(ctx context.Context, adminRESTConfig *rest.Config) *configv1.ClusterVersion {
 	configClient, err := configv1client.NewForConfig(adminRESTConfig)
 	if err != nil {
+		ginkgo.GinkgoLogr.Error(err, "failed to create config client")
 		ginkgo.Fail("failed to create config client")
 	}
 
 	clusterVersion, err := configClient.ClusterVersions().Get(ctx, "version", metav1.GetOptions{})
 	if err != nil {
+		ginkgo.GinkgoLogr.Error(err, "failed to get clusterversion from context")
 		ginkgo.Fail("failed to get clusterversion from context")
 	}
 
@@ -58,6 +60,7 @@ func InitZStreamTest(ctx context.Context, adminRESTConfig *rest.Config, initialV
 
 	initialSemver, err := semver.ParseTolerant(initialVersion)
 	if err != nil {
+		ginkgo.GinkgoLogr.Error(err, "unable to parse initial version")
 		ginkgo.Fail("unable to parse initial version")
 	}
 

--- a/test/util/verifiers/hosted_control_plane_version.go
+++ b/test/util/verifiers/hosted_control_plane_version.go
@@ -44,8 +44,8 @@ func GetClusterVersion(ctx context.Context, adminRESTConfig *rest.Config) *confi
 
 	clusterVersion, err := configClient.ClusterVersions().Get(ctx, "version", metav1.GetOptions{})
 	if err != nil {
-		ginkgo.GinkgoLogr.Error(err, "failed to get clusterversion from context")
-		ginkgo.Fail("failed to get clusterversion from context")
+		ginkgo.GinkgoLogr.Error(err, "failed to GET clusterversions/version")
+		ginkgo.Fail("failed to GET clusterversions/version")
 	}
 
 	return clusterVersion

--- a/test/util/verifiers/hosted_control_plane_version.go
+++ b/test/util/verifiers/hosted_control_plane_version.go
@@ -173,7 +173,7 @@ func (v verifyHostedControlPlaneZStreamUpgradeOnly) Verify(ctx context.Context, 
 		}
 
 		if historyEntrySemver.GT(initialSemver) {
-			if historyEntry.State == "Partial" {
+			if historyEntry.State == configv1.PartialUpdate {
 				ginkgo.GinkgoLogr.Info("z-stream upgrade in progress",
 					"initialVersion", initialSemver.String(),
 					"upgradeVersion", historyEntrySemver.String(),
@@ -181,7 +181,7 @@ func (v verifyHostedControlPlaneZStreamUpgradeOnly) Verify(ctx context.Context, 
 				return fmt.Errorf("z-stream upgrade in progress")
 			}
 
-			if historyEntry.State == "Completed" {
+			if historyEntry.State == configv1.CompletedUpdate {
 				var totalUpgradeTime time.Duration
 				if historyEntry.CompletionTime != nil {
 					totalUpgradeTime = historyEntry.CompletionTime.Sub(historyEntry.StartedTime.Time)

--- a/test/util/verifiers/hosted_control_plane_version.go
+++ b/test/util/verifiers/hosted_control_plane_version.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"time"
 
 	"github.com/blang/semver/v4"
 	"github.com/onsi/ginkgo/v2"
@@ -27,11 +28,98 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
+	v1 "github.com/openshift/api/config/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/test/util/framework"
 )
+
+func GetClusterVersion(ctx context.Context, adminRESTConfig *rest.Config) *v1.ClusterVersion {
+	configClient, err := configv1client.NewForConfig(adminRESTConfig)
+	if err != nil {
+		ginkgo.Fail("failed to create config client")
+	}
+
+	clusterVersion, err := configClient.ClusterVersions().Get(ctx, "version", metav1.GetOptions{})
+	if err != nil {
+		ginkgo.Fail("failed to get clusterversion from context")
+	}
+
+	return clusterVersion
+}
+
+func InitZStreamTest(ctx context.Context, adminRESTConfig *rest.Config, initialVersion string) ([]v1.UpdateHistory, semver.Version) {
+	clusterVersion := GetClusterVersion(ctx, adminRESTConfig)
+
+	ginkgo.GinkgoLogr.Info("Initial version state",
+		"initialVersion", initialVersion,
+		"history", framework.SummarizeClusterVersionHistory(clusterVersion.Status.History))
+
+	initialSemver, err := semver.ParseTolerant(initialVersion)
+	if err != nil {
+		ginkgo.Fail("unable to parse initial version")
+	}
+
+	return clusterVersion.Status.History, initialSemver
+}
+
+func GetHistorySemver(version, initialVersion string, history []v1.UpdateHistory) semver.Version {
+	if len(version) == 0 {
+		ginkgo.Fail(fmt.Sprintf("UpdateHistory version found with length 0. initialVersion: %s, history: %v",
+			initialVersion,
+			framework.SummarizeClusterVersionHistory(history)))
+	}
+
+	historyVersion, err := semver.ParseTolerant(version)
+	if err != nil {
+		ginkgo.GinkgoLogr.Error(err, "unable to parse version to semver",
+			"version", version)
+		ginkgo.Fail("unable to parse version to semver")
+	}
+
+	return historyVersion
+}
+
+type verifyHostedControlPlaneZStreamUpgradeTriggered struct {
+	initialVersion string
+}
+
+func (v verifyHostedControlPlaneZStreamUpgradeTriggered) Name() string {
+	return fmt.Sprintf("VerifyHostedControlPlaneZStreamUpgradeTriggered(initial=%s)", v.initialVersion)
+}
+
+func (v verifyHostedControlPlaneZStreamUpgradeTriggered) Verify(ctx context.Context, adminRESTConfig *rest.Config) error {
+	ginkgo.GinkgoLogr.Info("Checking if z-stream upgrade has been triggered")
+
+	history, initialSemver := InitZStreamTest(ctx, adminRESTConfig, v.initialVersion)
+
+	if len(history) == 0 {
+		ginkgo.Fail("Version history is empty. Cluster may not be properly initialized.")
+	}
+	if len(history) == 1 {
+		return fmt.Errorf("z-stream upgrade has not yet been triggered. initial version: %q. History: %v",
+			v.initialVersion,
+			framework.SummarizeClusterVersionHistory(history))
+	}
+
+	// quickly validate the newest version, then return. The VerifyHostedControlPlaneZStreamUpgradeOnly test will more thoroughly vet each version history entry.
+	latestHistoryEntrySemver := GetHistorySemver(history[0].Version, v.initialVersion, history)
+	if !latestHistoryEntrySemver.GT(initialSemver) {
+		ginkgo.Fail(fmt.Sprintf("Unexpected upgrade path occurred. initial version: %q. upgrade version: %q. History: %v",
+			v.initialVersion,
+			latestHistoryEntrySemver,
+			framework.SummarizeClusterVersionHistory(history)))
+	}
+
+	return nil
+}
+
+// VerifyHostedControlPlaneZStreamUpgradeTriggered returns a verifier that checks if a z-stream
+// upgrade has been triggered (but not necessarily completed).
+func VerifyHostedControlPlaneZStreamUpgradeTriggered(initialVersion string) HostedClusterVerifier {
+	return verifyHostedControlPlaneZStreamUpgradeTriggered{initialVersion: initialVersion}
+}
 
 type verifyHostedControlPlaneZStreamUpgradeOnly struct {
 	initialVersion string
@@ -42,51 +130,78 @@ func (v verifyHostedControlPlaneZStreamUpgradeOnly) Name() string {
 }
 
 func (v verifyHostedControlPlaneZStreamUpgradeOnly) Verify(ctx context.Context, adminRESTConfig *rest.Config) error {
-	initialSemver, err := semver.ParseTolerant(v.initialVersion)
-	if err != nil {
-		return fmt.Errorf("parse initial version %q: %w", v.initialVersion, err)
+	ginkgo.GinkgoLogr.Info("Checking if z-stream upgrade has completed")
+
+	history, initialSemver := InitZStreamTest(ctx, adminRESTConfig, v.initialVersion)
+
+	if len(history) < 2 {
+		ginkgo.Fail("z-stream upgrade not yet triggered. Cannot check if update has completed. " +
+			"Ensure VerifyHostedControlPlaneZStreamUpgradeTriggered runs successfully before calling this test.")
 	}
 
-	configClient, err := configv1client.NewForConfig(adminRESTConfig)
-	if err != nil {
-		return fmt.Errorf("failed to create config client: %w", err)
+	initialSemverCount := 0
+	for _, historyEntry := range history {
+		historyEntrySemver := GetHistorySemver(historyEntry.Version, v.initialVersion, history)
+
+		if historyEntrySemver.EQ(initialSemver) {
+			initialSemverCount++
+			if initialSemverCount > 1 {
+				ginkgo.Fail(fmt.Sprintf("more than 1 of the initial version was found in the version history. initial version: %q. History: %v",
+					v.initialVersion,
+					framework.SummarizeClusterVersionHistory(history)))
+			}
+
+			continue
+		}
+
+		if historyEntrySemver.Major != initialSemver.Major ||
+			historyEntrySemver.Minor != initialSemver.Minor {
+			ginkgo.Fail(fmt.Sprintf("version %q in clusterversion history has different major.minor than initial %q (expected %d.%d.x)",
+				historyEntrySemver.String(),
+				v.initialVersion,
+				initialSemver.Major,
+				initialSemver.Minor))
+		}
+
+		if historyEntrySemver.LT(initialSemver) {
+			ginkgo.Fail(fmt.Sprintf("downgrade unexpected: version %q is less than initial %q",
+				historyEntrySemver.String(),
+				initialSemver.String()))
+		}
+
+		if historyEntrySemver.GT(initialSemver) {
+			if historyEntry.State == "Partial" {
+				ginkgo.GinkgoLogr.Info("z-stream upgrade in progress",
+					"initialVersion", initialSemver.String(),
+					"upgradeVersion", historyEntrySemver.String(),
+					"startedTime", historyEntry.StartedTime)
+				return fmt.Errorf("z-stream upgrade in progress")
+			}
+
+			if historyEntry.State == "Completed" {
+				var totalUpgradeTime time.Duration
+				if historyEntry.CompletionTime != nil {
+					totalUpgradeTime = historyEntry.CompletionTime.Sub(historyEntry.StartedTime.Time)
+				}
+
+				ginkgo.GinkgoLogr.Info("z-stream was upgraded successfully",
+					"initialVersion", initialSemver.String(),
+					"upgradeVersion", historyEntrySemver.String(),
+					"startedTime", historyEntry.StartedTime,
+					"completionTime", historyEntry.CompletionTime,
+					"totalUpgradeTime", totalUpgradeTime)
+
+				return nil
+			}
+		}
 	}
 
-	clusterVersion, err := configClient.ClusterVersions().Get(ctx, "version", metav1.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to get clusterversion %q: %w", "version", err)
-	}
-
-	ginkgo.GinkgoLogr.Info("Retrieved openshift cluster version history",
-		"history", framework.SummarizeClusterVersionHistory(clusterVersion.Status.History))
-
-	var sawUpgrade bool
-	for _, history := range clusterVersion.Status.History {
-		historyVersion, err := semver.ParseTolerant(history.Version)
-		if err != nil {
-			return fmt.Errorf("parse version %q in history: %w", history.Version, err)
-		}
-		if historyVersion.Major != initialSemver.Major || historyVersion.Minor != initialSemver.Minor {
-			return fmt.Errorf("version %q in clusterversion history has different major.minor than initial %q (expected %d.%d.x)",
-				historyVersion.String(), v.initialVersion, initialSemver.Major, initialSemver.Minor)
-		}
-		if historyVersion.GT(initialSemver) {
-			sawUpgrade = true
-		}
-		if historyVersion.LT(initialSemver) {
-			return fmt.Errorf("downgrade unexpected: version %q is less than initial %q", historyVersion.String(), initialSemver.String())
-		}
-	}
-	if !sawUpgrade {
-		return fmt.Errorf("no version in clusterversion/version status.history is greater than initial %q", v.initialVersion)
-	}
-	return nil
+	ginkgo.Fail("unexpected failure: no partial or completed z-stream upgrade found when validating version history array")
+	return fmt.Errorf("unexpected failure: no partial or completed z-stream upgrade found when validating version history array") // make compiler happy
 }
 
-// VerifyHostedControlPlaneZStreamUpgradeOnly returns a verifier that the HCP control plane has
-// performed only a z-stream upgrade from the initial version: at least one entry in
-// ClusterVersion status.history is greater than initialVersion, and every entry has the same
-// major.minor as initialVersion.
+// VerifyHostedControlPlaneZStreamUpgradeOnly returns a verifier that checks if a z-stream
+// upgrade has been completed, and that only the z-stream has been modified.
 func VerifyHostedControlPlaneZStreamUpgradeOnly(initialVersion string) HostedClusterVerifier {
 	return verifyHostedControlPlaneZStreamUpgradeOnly{initialVersion: initialVersion}
 }
@@ -101,15 +216,7 @@ func (v verifyHostedControlPlaneYStreamUpgrade) Name() string {
 }
 
 func (v verifyHostedControlPlaneYStreamUpgrade) Verify(ctx context.Context, adminRESTConfig *rest.Config) error {
-	configClient, err := configv1client.NewForConfig(adminRESTConfig)
-	if err != nil {
-		return fmt.Errorf("failed to create config client: %w", err)
-	}
-
-	clusterVersion, err := configClient.ClusterVersions().Get(ctx, "version", metav1.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to get clusterversion %q: %w", "version", err)
-	}
+	clusterVersion := GetClusterVersion(ctx, adminRESTConfig)
 
 	ginkgo.GinkgoLogr.Info("clusterversion status after y-stream upgrade",
 		"history", framework.SummarizeClusterVersionHistory(clusterVersion.Status.History))

--- a/test/util/verifiers/hosted_control_plane_version.go
+++ b/test/util/verifiers/hosted_control_plane_version.go
@@ -28,14 +28,14 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
-	v1 "github.com/openshift/api/config/v1"
+	configv1 "github.com/openshift/api/config/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/test/util/framework"
 )
 
-func GetClusterVersion(ctx context.Context, adminRESTConfig *rest.Config) *v1.ClusterVersion {
+func GetClusterVersion(ctx context.Context, adminRESTConfig *rest.Config) *configv1.ClusterVersion {
 	configClient, err := configv1client.NewForConfig(adminRESTConfig)
 	if err != nil {
 		ginkgo.Fail("failed to create config client")
@@ -49,7 +49,7 @@ func GetClusterVersion(ctx context.Context, adminRESTConfig *rest.Config) *v1.Cl
 	return clusterVersion
 }
 
-func InitZStreamTest(ctx context.Context, adminRESTConfig *rest.Config, initialVersion string) ([]v1.UpdateHistory, semver.Version) {
+func InitZStreamTest(ctx context.Context, adminRESTConfig *rest.Config, initialVersion string) ([]configv1.UpdateHistory, semver.Version) {
 	clusterVersion := GetClusterVersion(ctx, adminRESTConfig)
 
 	ginkgo.GinkgoLogr.Info("Initial version state",
@@ -64,7 +64,7 @@ func InitZStreamTest(ctx context.Context, adminRESTConfig *rest.Config, initialV
 	return clusterVersion.Status.History, initialSemver
 }
 
-func GetHistorySemver(version, initialVersion string, history []v1.UpdateHistory) semver.Version {
+func GetHistorySemver(version, initialVersion string, history []configv1.UpdateHistory) semver.Version {
 	if len(version) == 0 {
 		ginkgo.Fail(fmt.Sprintf("UpdateHistory version found with length 0. initialVersion: %s, history: %v",
 			initialVersion,


### PR DESCRIPTION
Jira: https://redhat.atlassian.net/browse/ARO-27283

### What

- split the z-stream e2e test into an "upgrade has triggered" phase and an "upgrade has completed" phase in order to more easily tell where errors/timeouts are occurring at a glance.
- **important: added check to verify that the z-stream upgrade has actually completed successfully**. This will likely cause the test to take more time, however note that a +15min allowance was added to the test to give the z-stream upgrade time to trigger (that is, recognize that an update is available and consequently kick off the upgrade), while the original 45min timeout is now solely allotted for the test to go through the upgrade process successfully.
- improved logging to help pinpoint where errors/timeouts occur.
- added fast failures so that the full 45min time allotment isn't spent spinning on unrecoverable errors. 

### Why

The z-stream e2e test was occasionally running into timeouts at 40min on the INT environment with next to no telemetry explaining why. This PR may not solve the issue at its source, but it should help pinpoint future errors.