### PR TITLE
feat: introduce asynchronous external auth deletion in backend in a disabled state

### DIFF
--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -40,6 +40,7 @@ import (
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/clusterpropertiescontroller"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/datadumpcontrollers"
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/externalauthdeletion"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/managementclustercontrollers"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/metricscontrollers"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/mismatchcontrollers"
@@ -654,6 +655,30 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		backendInformers,
 	)
 
+	externalAuthDeletionClusterServiceDeleteDispatchController := externalauthdeletion.NewExternalAuthClusterServiceDeleteDispatchController(
+		utilsclock.RealClock{},
+		b.options.ResourcesDBClient,
+		b.options.ClustersServiceClient,
+		activeOperationLister,
+		backendInformers,
+	)
+	externalAuthClusterServiceIDClearerController := externalauthdeletion.NewExternalAuthClusterServiceIDClearerController(
+		b.options.ResourcesDBClient,
+		b.options.ClustersServiceClient,
+		activeOperationLister,
+		backendInformers,
+	)
+	externalAuthChildResourcesCleanupController := externalauthdeletion.NewExternalAuthChildResourcesCleanupController(
+		b.options.ResourcesDBClient,
+		activeOperationLister,
+		backendInformers,
+	)
+	externalAuthDeletionController := externalauthdeletion.NewExternalAuthDeletionController(
+		b.options.ResourcesDBClient,
+		activeOperationLister,
+		backendInformers,
+	)
+
 	le, err := leaderelection.NewLeaderElector(leaderelection.LeaderElectionConfig{
 		Lock:          b.options.LeaderElectionLock,
 		LeaseDuration: leaderElectionLeaseDuration,
@@ -717,6 +742,10 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 				go nodePoolClusterServiceIDClearerController.Run(ctx, 20)
 				go nodePoolChildResourcesCleanupController.Run(ctx, 20)
 				go nodePoolDeletionController.Run(ctx, 20)
+				go externalAuthDeletionClusterServiceDeleteDispatchController.Run(ctx, 20)
+				go externalAuthClusterServiceIDClearerController.Run(ctx, 20)
+				go externalAuthChildResourcesCleanupController.Run(ctx, 20)
+				go externalAuthDeletionController.Run(ctx, 20)
 				go operationPhaseMetricsController.Run(ctx, 1)
 				go clusterMetricsController.Run(ctx, 1)
 				go nodePoolMetricsController.Run(ctx, 1)

--- a/backend/pkg/controllers/externalauthdeletion/external_auth_child_resources_cleanup_controller.go
+++ b/backend/pkg/controllers/externalauthdeletion/external_auth_child_resources_cleanup_controller.go
@@ -1,0 +1,156 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package externalauthdeletion
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/internal/api"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// externalAuthChildResourcesCleanupController deletes child resources
+// scoped under an ExternalAuth recursively once the ExternalAuth is
+// marked for deletion and Cluster Service has confirmed the delete on
+// its side. Controller status documents
+// (ExternalAuthControllerResourceType) are left alone. The orphan
+// scraper handles those after the ExternalAuth document itself is
+// removed.
+type externalAuthChildResourcesCleanupController struct {
+	cooldownChecker    controllerutil.CooldownChecker
+	externalAuthLister listers.ExternalAuthLister
+	resourcesDBClient  database.ResourcesDBClient
+}
+
+var _ controllerutils.ExternalAuthSyncer = (*externalAuthChildResourcesCleanupController)(nil)
+
+func NewExternalAuthChildResourcesCleanupController(
+	resourcesDBClient database.ResourcesDBClient,
+	activeOperationLister listers.ActiveOperationLister,
+	informers informers.BackendInformers,
+) controllerutils.Controller {
+	_, externalAuthLister := informers.ExternalAuths()
+	syncer := &externalAuthChildResourcesCleanupController{
+		cooldownChecker:    controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		externalAuthLister: externalAuthLister,
+		resourcesDBClient:  resourcesDBClient,
+	}
+
+	return controllerutils.NewExternalAuthWatchingController(
+		"ExternalAuthChildResourcesCleanupController",
+		resourcesDBClient,
+		informers,
+		time.Minute,
+		syncer,
+	)
+}
+
+func (c *externalAuthChildResourcesCleanupController) CooldownChecker() controllerutil.CooldownChecker {
+	return c.cooldownChecker
+}
+
+func (c *externalAuthChildResourcesCleanupController) NeedsWork(externalAuth *api.HCPOpenShiftClusterExternalAuth) bool {
+	// TODO temporary check to skip the new deletion approach for ExternalAuths that were created before the new approach was implemented.
+	// This will be removed once all externalauths whose deletion was triggered before the new approach is fully rolled out have been
+	// fully deleted in all ARO-HCP permanent environments, for all regions.
+	if !externalAuth.ServiceProviderProperties.UsesNewExternalAuthDeletionApproach {
+		return false
+	}
+
+	return externalAuth.ServiceProviderProperties.DeletionTimestamp != nil &&
+		externalAuth.ServiceProviderProperties.ClusterServiceDeletionTimestamp != nil &&
+		externalAuth.ServiceProviderProperties.ClusterServiceID == nil
+}
+
+func (c *externalAuthChildResourcesCleanupController) SyncOnce(ctx context.Context, key controllerutils.HCPExternalAuthKey) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	cachedExternalAuth, err := c.externalAuthLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPExternalAuthName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get external auth from cache: %w", err))
+	}
+	if !c.NeedsWork(cachedExternalAuth) {
+		return nil
+	}
+
+	externalAuthCRUD := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).ExternalAuth(key.HCPClusterName)
+	externalAuth, err := externalAuthCRUD.Get(ctx, key.HCPExternalAuthName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get external auth: %w", err))
+	}
+	if !c.NeedsWork(externalAuth) {
+		return nil
+	}
+
+	externalAuthResourceID := key.GetResourceID()
+	untypedCRUD, err := c.resourcesDBClient.UntypedCRUD(*externalAuthResourceID)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to create untyped CRUD for external auth children: %w", err))
+	}
+
+	// extraDeleteGates determines which child resource types should be skipped during cleanup.
+	// We never delete external auth controllers here, as there might be controllers still
+	// running for the ExternalAuth until the very end of the deletion process.
+	extraDeleteGates := map[string]func(ctx context.Context, resourceID *azcorearm.ResourceID) (bool, error){
+		strings.ToLower(api.ExternalAuthControllerResourceType.String()): func(ctx context.Context, resourceID *azcorearm.ResourceID) (bool, error) { return false, nil },
+	}
+
+	childIterator, err := untypedCRUD.ListRecursive(ctx, nil)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to list external auth child resources: %w", err))
+	}
+	for _, childResource := range childIterator.Items(ctx) {
+		if childResource.ResourceID == nil {
+			return utils.TrackError(fmt.Errorf("child resource at cosmosID %q has no resourceID; refusing to delete", childResource.ID))
+		}
+
+		extraDeleteGate, ok := extraDeleteGates[strings.ToLower(childResource.ResourceType)]
+		if ok {
+			shouldDelete, err := extraDeleteGate(ctx, childResource.ResourceID)
+			if err != nil {
+				return utils.TrackError(err)
+			}
+			if !shouldDelete {
+				continue
+			}
+		}
+
+		logger.Info("deleting child resource", "childResourceID", childResource.ResourceID)
+		if err := untypedCRUD.Delete(ctx, childResource.ResourceID); err != nil {
+			return utils.TrackError(err)
+		}
+	}
+	if err := childIterator.GetError(); err != nil {
+		return utils.TrackError(err)
+	}
+
+	return nil
+}

--- a/backend/pkg/controllers/externalauthdeletion/external_auth_child_resources_cleanup_controller_test.go
+++ b/backend/pkg/controllers/externalauthdeletion/external_auth_child_resources_cleanup_controller_test.go
@@ -1,0 +1,278 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package externalauthdeletion
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+func newTestExternalAuthController(t *testing.T, name string) *api.Controller {
+	t.Helper()
+	resourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+			"/externalAuths/" + testExternalAuthName +
+			"/hcpOpenShiftControllers/" + name))
+	return &api.Controller{
+		CosmosMetadata: api.CosmosMetadata{ResourceID: resourceID},
+		ExternalID: api.Must(azcorearm.ParseResourceID(
+			"/subscriptions/" + testSubscriptionID +
+				"/resourceGroups/" + testResourceGroupName +
+				"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+				"/externalAuths/" + testExternalAuthName)),
+		Status: api.ControllerStatus{
+			Conditions: []metav1.Condition{},
+		},
+	}
+}
+
+func TestExternalAuthChildResourcesCleanupController_SyncOnce(t *testing.T) {
+	fixedNow := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	readyToDeleteExternalAuthOptsFunc := func(ea *api.HCPOpenShiftClusterExternalAuth) {
+		ea.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-time.Hour)}
+		ea.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-30 * time.Minute)}
+		ea.ServiceProviderProperties.ClusterServiceID = nil
+	}
+
+	// storeNonControllerChild inserts a synthetic non-controller child document
+	// under the external auth resource path. At the moment of writing this (2026-06-02) auth has no typed
+	// non-controller children, so we store a raw TypedDocument directly.
+	storeNonControllerChild := func(t *testing.T, db *databasetesting.MockResourcesDBClient, name string) {
+		t.Helper()
+		resourceID := api.Must(azcorearm.ParseResourceID(
+			"/subscriptions/" + testSubscriptionID +
+				"/resourceGroups/" + testResourceGroupName +
+				"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+				"/externalAuths/" + testExternalAuthName +
+				"/nonControllerChildType/" + name))
+		cosmosID, err := arm.ResourceIDToCosmosID(resourceID)
+		require.NoError(t, err)
+		doc := database.TypedDocument{
+			BaseDocument: database.BaseDocument{ID: cosmosID},
+			ResourceID:   resourceID,
+			ResourceType: "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/externalAuths/nonControllerChildType",
+		}
+		data, err := json.Marshal(doc)
+		require.NoError(t, err)
+		db.StoreDocument(cosmosID, data)
+	}
+
+	testKey := controllerutils.HCPExternalAuthKey{
+		SubscriptionID:      testSubscriptionID,
+		ResourceGroupName:   testResourceGroupName,
+		HCPClusterName:      testClusterName,
+		HCPExternalAuthName: testExternalAuthName,
+	}
+
+	testCases := []struct {
+		name                    string
+		existingExternalAuth    *api.HCPOpenShiftClusterExternalAuth
+		childResources          []any
+		extraSetupDBTestingMock func(t *testing.T, db *databasetesting.MockResourcesDBClient)
+		wantErr                 bool
+		verifyDB                func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient)
+	}{
+		{
+			name:                 "when no DeletionTimestamp, no ClusterServiceDeletionTimestamp are set and ClusterServiceID is set performs a no-op",
+			existingExternalAuth: newTestExternalAuthWithNewDeletionApproach(t, nil),
+			childResources:       []any{newTestExternalAuthController(t, "untouched-controller")},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				controllerCRUD := db.HCPClusters(testSubscriptionID, testResourceGroupName).
+					ExternalAuth(testClusterName).Controllers(testExternalAuthName)
+				_, err := controllerCRUD.Get(ctx, "untouched-controller")
+				require.NoError(t, err, "expected child resource to still exist")
+			},
+		},
+		{
+			name: "when no ClusterServiceDeletionTimestamp is set performs a no-op",
+			existingExternalAuth: newTestExternalAuthWithNewDeletionApproach(t, func(ea *api.HCPOpenShiftClusterExternalAuth) {
+				ea.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-time.Hour)}
+				ea.ServiceProviderProperties.ClusterServiceDeletionTimestamp = nil
+				ea.ServiceProviderProperties.ClusterServiceID = nil
+			}),
+			childResources: []any{newTestExternalAuthController(t, "untouched-controller")},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				controllerCRUD := db.HCPClusters(testSubscriptionID, testResourceGroupName).
+					ExternalAuth(testClusterName).Controllers(testExternalAuthName)
+				_, err := controllerCRUD.Get(ctx, "untouched-controller")
+				require.NoError(t, err, "expected child resource to still exist")
+			},
+		},
+		{
+			name: "when ClusterServiceID is set performs a no-op",
+			existingExternalAuth: newTestExternalAuthWithNewDeletionApproach(t, func(ea *api.HCPOpenShiftClusterExternalAuth) {
+				ea.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-time.Hour)}
+				ea.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-30 * time.Minute)}
+			}),
+			childResources: []any{newTestExternalAuthController(t, "untouched-controller")},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				controllerCRUD := db.HCPClusters(testSubscriptionID, testResourceGroupName).
+					ExternalAuth(testClusterName).Controllers(testExternalAuthName)
+				_, err := controllerCRUD.Get(ctx, "untouched-controller")
+				require.NoError(t, err, "expected child resource to still exist")
+			},
+		},
+		{
+			name:                 "when all conditions met and there are no children performs a no-op",
+			existingExternalAuth: newTestExternalAuthWithNewDeletionApproach(t, readyToDeleteExternalAuthOptsFunc),
+		},
+		{
+			name:                 "when there is a children resource it deletes it",
+			existingExternalAuth: newTestExternalAuthWithNewDeletionApproach(t, readyToDeleteExternalAuthOptsFunc),
+			extraSetupDBTestingMock: func(t *testing.T, db *databasetesting.MockResourcesDBClient) {
+				storeNonControllerChild(t, db, "test-mcc")
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				externalAuthResourceID := testKey.GetResourceID()
+				untypedCRUD, err := db.UntypedCRUD(*externalAuthResourceID)
+				require.NoError(t, err)
+				childIterator, err := untypedCRUD.ListRecursive(ctx, nil)
+				require.NoError(t, err)
+
+				var remainingCount int
+				for range childIterator.Items(ctx) {
+					remainingCount++
+				}
+				require.NoError(t, childIterator.GetError())
+				assert.Equal(t, 0, remainingCount, "expected no children to remain")
+			},
+		},
+		{
+			name:                 "deletion of external auth controllers is skipped",
+			existingExternalAuth: newTestExternalAuthWithNewDeletionApproach(t, readyToDeleteExternalAuthOptsFunc),
+			childResources:       []any{newTestExternalAuthController(t, "test-controller")},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				externalAuthResourceID := testKey.GetResourceID()
+				untypedCRUD, err := db.UntypedCRUD(*externalAuthResourceID)
+				require.NoError(t, err)
+				childIterator, err := untypedCRUD.ListRecursive(ctx, nil)
+				require.NoError(t, err)
+
+				var controllerCount int
+				for _, child := range childIterator.Items(ctx) {
+					if strings.EqualFold(child.ResourceType, api.ExternalAuthControllerResourceType.String()) {
+						controllerCount++
+					}
+				}
+				require.NoError(t, childIterator.GetError())
+				assert.Equal(t, 1, controllerCount, "expected controller child to remain")
+			},
+		},
+		{
+			name:                 "when there are external auth controller and non controller children it deletes the non controller children",
+			existingExternalAuth: newTestExternalAuthWithNewDeletionApproach(t, readyToDeleteExternalAuthOptsFunc),
+			childResources:       []any{newTestExternalAuthController(t, "test-controller")},
+			extraSetupDBTestingMock: func(t *testing.T, db *databasetesting.MockResourcesDBClient) {
+				storeNonControllerChild(t, db, "test-mcc")
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				externalAuthResourceID := testKey.GetResourceID()
+				untypedCRUD, err := db.UntypedCRUD(*externalAuthResourceID)
+				require.NoError(t, err)
+				childIterator, err := untypedCRUD.ListRecursive(ctx, nil)
+				require.NoError(t, err)
+
+				var remainingCount int
+				var controllerCount int
+				for _, child := range childIterator.Items(ctx) {
+					remainingCount++
+					if strings.EqualFold(child.ResourceType, api.ExternalAuthControllerResourceType.String()) {
+						controllerCount++
+					}
+				}
+				require.NoError(t, childIterator.GetError())
+				assert.Equal(t, 1, remainingCount, "expected only controller child to remain")
+				assert.Equal(t, 1, controllerCount, "expected the remaining child to be a controller")
+			},
+		},
+
+		{
+			name:                 "when the external auth is not found performs a no-op",
+			existingExternalAuth: nil,
+		},
+		{
+			name:                 "UsesNewExternalAuthDeletionApproach false -- no-op even when all cleanup conditions met and children exist",
+			existingExternalAuth: newTestExternalAuthWithOldDeletionApproach(t, readyToDeleteExternalAuthOptsFunc),
+			childResources:       []any{newTestExternalAuthController(t, "untouched-controller")},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				controllerCRUD := db.HCPClusters(testSubscriptionID, testResourceGroupName).
+					ExternalAuth(testClusterName).Controllers(testExternalAuthName)
+				_, err := controllerCRUD.Get(ctx, "untouched-controller")
+				require.NoError(t, err, "expected child resource to still exist")
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+
+			resources := []any{}
+			if tc.existingExternalAuth != nil {
+				resources = append(resources, tc.existingExternalAuth)
+			}
+			resources = append(resources, tc.childResources...)
+			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, resources)
+			require.NoError(t, err)
+
+			if tc.extraSetupDBTestingMock != nil {
+				tc.extraSetupDBTestingMock(t, mockResourcesDBClient)
+			}
+
+			externalAuthsForLister := []*api.HCPOpenShiftClusterExternalAuth{}
+			if tc.existingExternalAuth != nil {
+				externalAuthsForLister = append(externalAuthsForLister, tc.existingExternalAuth)
+			}
+
+			syncer := &externalAuthChildResourcesCleanupController{
+				cooldownChecker:    &alwaysSyncCooldownChecker{},
+				externalAuthLister: &listertesting.SliceExternalAuthLister{ExternalAuths: externalAuthsForLister},
+				resourcesDBClient:  mockResourcesDBClient,
+			}
+
+			err = syncer.SyncOnce(ctx, testKey)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			if tc.verifyDB != nil {
+				tc.verifyDB(t, ctx, mockResourcesDBClient)
+			}
+		})
+	}
+}

--- a/backend/pkg/controllers/externalauthdeletion/external_auth_cluster_service_delete_dispatch_controller.go
+++ b/backend/pkg/controllers/externalauthdeletion/external_auth_cluster_service_delete_dispatch_controller.go
@@ -1,0 +1,213 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package externalauthdeletion
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilsclock "k8s.io/utils/clock"
+	"k8s.io/utils/lru"
+
+	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/internal/api"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// missingClusterServiceIDTimeout is how long we wait after first observing
+// DeletionTimestamp for the ClusterServiceID to appear before concluding
+// that the corresponding Cluster Service ExternalAuth was never created and we
+// have no work to do (or before treating a 404 from Cluster Service as definitive).
+const missingClusterServiceIDTimeout = 120 * time.Second
+
+// externalAuthClusterServiceDeleteDispatchSyncer issues a Cluster Service
+// delete for any ExternalAuth whose DeletionTimestamp has been set. The
+// frontend records the timestamp on the ExternalAuth when
+// DeleteExternalAuth is invoked, this controller picks it up and calls
+// Cluster Service out-of-band so the frontend never has to block on it.
+// Once the controller has issued the delete (or given up waiting for a
+// ClusterServiceID), it stamps ClusterServiceDeletionTimestamp on the
+// ExternalAuth to record that this step is complete and avoid re-issuing
+// the delete on subsequent syncs.
+type externalAuthClusterServiceDeleteDispatchSyncer struct {
+	clock                utilsclock.PassiveClock
+	cooldownChecker      controllerutil.CooldownChecker
+	externalAuthLister   listers.ExternalAuthLister
+	resourcesDBClient    database.ResourcesDBClient
+	clusterServiceClient ocm.ClusterServiceClientSpec
+	// firstSeenDeletionTimestampCache contains the time the controller
+	// first saw the serviceProviderProperties.deletionTimestamp being set
+	// for an external auth. The cache key is the lowercased external
+	// auth's resource ID and the value is a time.Time in UTC.
+	firstSeenDeletionTimestampCache *lru.Cache
+}
+
+var _ controllerutils.ExternalAuthSyncer = (*externalAuthClusterServiceDeleteDispatchSyncer)(nil)
+
+func NewExternalAuthClusterServiceDeleteDispatchController(
+	clock utilsclock.PassiveClock,
+	resourcesDBClient database.ResourcesDBClient,
+	clusterServiceClient ocm.ClusterServiceClientSpec,
+	activeOperationLister listers.ActiveOperationLister,
+	informers informers.BackendInformers,
+) controllerutils.Controller {
+	_, externalAuthLister := informers.ExternalAuths()
+	syncer := &externalAuthClusterServiceDeleteDispatchSyncer{
+		clock:                           clock,
+		cooldownChecker:                 controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		externalAuthLister:              externalAuthLister,
+		resourcesDBClient:               resourcesDBClient,
+		clusterServiceClient:            clusterServiceClient,
+		firstSeenDeletionTimestampCache: lru.New(50000),
+	}
+
+	return controllerutils.NewExternalAuthWatchingController(
+		"ExternalAuthClusterServiceDeleteDispatch",
+		resourcesDBClient,
+		informers,
+		time.Minute,
+		syncer,
+	)
+}
+
+func (c *externalAuthClusterServiceDeleteDispatchSyncer) CooldownChecker() controllerutil.CooldownChecker {
+	return c.cooldownChecker
+}
+
+// NeedsWork reports whether the deleter has unfinished business for the given
+// ExternalAuth: DeletionTimestamp must be set and ClusterServiceDeletionTimestamp
+// must not yet be set.
+func (c *externalAuthClusterServiceDeleteDispatchSyncer) NeedsWork(externalAuth *api.HCPOpenShiftClusterExternalAuth) bool {
+	// TODO temporary check to skip the new deletion approach for ExternalAuths that were created before the new approach was implemented.
+	// This will be removed once all externalauths whose deletion was triggered before the new approach is fully rolled out have been
+	// fully deleted in all ARO-HCP permanent environments, for all regions.
+	if !externalAuth.ServiceProviderProperties.UsesNewExternalAuthDeletionApproach {
+		return false
+	}
+
+	return externalAuth.ServiceProviderProperties.DeletionTimestamp != nil &&
+		externalAuth.ServiceProviderProperties.ClusterServiceDeletionTimestamp == nil
+}
+
+// SyncOnce calls Cluster Service to delete the ExternalAuth when its
+// DeletionTimestamp is set.
+//
+// If the ExternalAuth has no ClusterServiceID yet, we may have raced
+// cluster-service ExternalAuth creation. We wait for
+// missingClusterServiceIDTimeout from when we first observed
+// DeletionTimestamp before concluding the cluster-service ExternalAuth
+// was never created.
+//
+// In either terminal case -- CS delete issued or wait abandoned -- we
+// stamp ClusterServiceDeletionTimestamp so the next sync short-circuits.
+func (c *externalAuthClusterServiceDeleteDispatchSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPExternalAuthKey) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	cachedExternalAuth, err := c.externalAuthLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPExternalAuthName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get external auth from cache: %w", err))
+	}
+	if !c.NeedsWork(cachedExternalAuth) {
+		return nil
+	}
+
+	externalAuthCRUD := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).ExternalAuth(key.HCPClusterName)
+	externalAuth, err := externalAuthCRUD.Get(ctx, key.HCPExternalAuthName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get external auth: %w", err))
+	}
+	if !c.NeedsWork(externalAuth) {
+		return nil
+	}
+
+	externalAuthDeletionTimestamp := externalAuth.ServiceProviderProperties.DeletionTimestamp.Time
+	cacheKey := strings.ToLower(externalAuth.ID.String())
+	var firstSeenExternalAuthDeletionTimestamp time.Time
+	firstSeenEntry, ok := c.firstSeenDeletionTimestampCache.Get(cacheKey)
+	if ok {
+		firstSeenExternalAuthDeletionTimestamp = firstSeenEntry.(time.Time)
+	} else {
+		firstSeenExternalAuthDeletionTimestamp = c.clock.Now().UTC()
+		c.firstSeenDeletionTimestampCache.Add(cacheKey, firstSeenExternalAuthDeletionTimestamp)
+	}
+
+	csID := externalAuth.ServiceProviderProperties.ClusterServiceID
+	if csID == nil || len(csID.String()) == 0 {
+		elapsed := c.clock.Since(firstSeenExternalAuthDeletionTimestamp)
+		if elapsed < missingClusterServiceIDTimeout {
+			// The frontend may still be in the middle of creating the cluster-service
+			// ExternalAuth, or the controller that does so hasn't run yet. Re-check on the
+			// next sync. The resync interval and informer change events drive retries.
+			return nil
+		}
+		logger.Info("giving up on cluster-service ExternalAuth delete - ClusterServiceID never appeared",
+			"externalAuthDeletionTimestamp", externalAuthDeletionTimestamp, "externalAuthFirstSeenDeletionTimestamp", firstSeenExternalAuthDeletionTimestamp)
+	} else if err := c.clusterServiceClient.DeleteExternalAuth(ctx, *csID); err != nil {
+		var ocmError *ocmerrors.Error
+
+		switch {
+		case errors.As(err, &ocmError) && ocmError.Status() == http.StatusBadRequest &&
+			strings.Contains(ocmError.Reason(), "Cannot delete ExternalAuth: its parent cluster must be in deletable state") &&
+			strings.Contains(ocmError.Reason(), "Parent cluster state: 'uninstalling'"):
+			// If the error is indicating that the parent cluster is already being
+			// uninstalled we consider that the external auth is already being deleted
+			// because Cluster Service on cluster deletion will end up deleting the
+			// externalauths as well.
+			// Matching an error message is brittle, but Clusters Service
+			// returns 400 Bad Request for a wide range of errors and there
+			// is no other information in the response to distinguish them.
+			logger.Info("ExternalAuth already being deleted by cluster-service via parent cluster deletion", "clusterServiceID", csID.String())
+		case errors.As(err, &ocmError) && ocmError.Status() == http.StatusNotFound:
+			// OCM error 404 - could be a stale CSID or a race against an in-flight CS
+			// create. Wait before treating the ExternalAuth as definitively gone.
+			elapsed := c.clock.Since(firstSeenExternalAuthDeletionTimestamp)
+			if elapsed < missingClusterServiceIDTimeout {
+				return nil
+			}
+			logger.Info("cluster-service ExternalAuth already deleted or race against in-flight CS create", "clusterServiceID", csID.String())
+		default:
+			return utils.TrackError(fmt.Errorf("failed to delete cluster-service ExternalAuth: %w", err))
+		}
+	} else {
+		logger.Info("requested cluster-service ExternalAuth delete", "clusterServiceID", csID.String())
+	}
+
+	externalAuth.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: c.clock.Now().UTC()}
+	_, err = externalAuthCRUD.Replace(ctx, externalAuth, nil)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to stamp ClusterServiceDeletionTimestamp: %w", err))
+	}
+	c.firstSeenDeletionTimestampCache.Remove(cacheKey)
+
+	return nil
+}

--- a/backend/pkg/controllers/externalauthdeletion/external_auth_cluster_service_delete_dispatch_controller_test.go
+++ b/backend/pkg/controllers/externalauthdeletion/external_auth_cluster_service_delete_dispatch_controller_test.go
@@ -1,0 +1,464 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package externalauthdeletion
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clocktesting "k8s.io/utils/clock/testing"
+	"k8s.io/utils/lru"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+const (
+	testSubscriptionID      = "00000000-0000-0000-0000-000000000000"
+	testResourceGroupName   = "test-rg"
+	testClusterName         = "test-cluster"
+	testExternalAuthName    = "test-externalauth"
+	testClusterServiceIDStr = "/api/aro_hcp/v1alpha1/clusters/abc123"
+	testExternalAuthCSIDStr = testClusterServiceIDStr + "/external_auth_config/external_auths/" + testExternalAuthName
+)
+
+type alwaysSyncCooldownChecker struct{}
+
+func (c *alwaysSyncCooldownChecker) CanSync(ctx context.Context, key any) bool {
+	return true
+}
+
+func TestExternalAuthClusterServiceDeleteDispatchSyncer_SyncOnce(t *testing.T) {
+	fixedClockTime := time.Now().UTC().Truncate(time.Second)
+
+	testKey := controllerutils.HCPExternalAuthKey{
+		SubscriptionID:      testSubscriptionID,
+		ResourceGroupName:   testResourceGroupName,
+		HCPClusterName:      testClusterName,
+		HCPExternalAuthName: testExternalAuthName,
+	}
+
+	verifyClusterServiceDeletionTimestampIsNil := func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+		t.Helper()
+		stored, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).
+			ExternalAuth(testClusterName).Get(ctx, testExternalAuthName)
+		require.NoError(t, err)
+		assert.Nil(t, stored.ServiceProviderProperties.ClusterServiceDeletionTimestamp)
+	}
+
+	verifyClusterServiceDeletionTimestampStamped := func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+		t.Helper()
+		stored, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).
+			ExternalAuth(testClusterName).Get(ctx, testExternalAuthName)
+		require.NoError(t, err)
+		require.NotNil(t, stored.ServiceProviderProperties.ClusterServiceDeletionTimestamp, "expected ClusterServiceDeletionTimestamp to be stamped")
+		assert.True(t, stored.ServiceProviderProperties.ClusterServiceDeletionTimestamp.Time.Equal(fixedClockTime),
+			"expected ClusterServiceDeletionTimestamp to equal fixedClockTime, got %v", stored.ServiceProviderProperties.ClusterServiceDeletionTimestamp.Time)
+	}
+
+	testCases := []struct {
+		name                 string
+		existingExternalAuth *api.HCPOpenShiftClusterExternalAuth
+		firstSeenDeletionAt  time.Time
+		setupMockCSClient    func(mock *ocm.MockClusterServiceClientSpec)
+		wantErr              bool
+		wantErrContain       string
+		verifyDB             func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient)
+	}{
+		{
+			name:                 "when no DeletionTimestamp no-op is performed",
+			existingExternalAuth: newTestExternalAuthWithNewDeletionApproach(t, nil),
+			verifyDB:             verifyClusterServiceDeletionTimestampIsNil,
+		},
+		{
+			name: "when ClusterServiceDeletionTimestamp is set no-op is performed",
+			existingExternalAuth: newTestExternalAuthWithNewDeletionApproach(t, func(ea *api.HCPOpenShiftClusterExternalAuth) {
+				ea.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
+				ea.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-30 * time.Minute)}
+			}),
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				stored, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).
+					ExternalAuth(testClusterName).Get(ctx, testExternalAuthName)
+				require.NoError(t, err)
+				require.NotNil(t, stored.ServiceProviderProperties.ClusterServiceDeletionTimestamp)
+				assert.True(t, stored.ServiceProviderProperties.ClusterServiceDeletionTimestamp.Time.Equal(fixedClockTime.Add(-30*time.Minute)),
+					"expected ClusterServiceDeletionTimestamp unchanged")
+			},
+		},
+		{
+			name: "when ClusterServiceID is not set and deletion is first observed then first seen is recorded and no-op is performed",
+			existingExternalAuth: newTestExternalAuthWithNewDeletionApproach(t, func(ea *api.HCPOpenShiftClusterExternalAuth) {
+				ea.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
+				ea.ServiceProviderProperties.ClusterServiceID = nil
+			}),
+			verifyDB: verifyClusterServiceDeletionTimestampIsNil,
+		},
+		{
+			name: "when ClusterServiceID is not set and first seen within missing cluster service id is within timeout no-op is performed",
+			existingExternalAuth: newTestExternalAuthWithNewDeletionApproach(t, func(ea *api.HCPOpenShiftClusterExternalAuth) {
+				ea.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
+				ea.ServiceProviderProperties.ClusterServiceID = nil
+			}),
+			firstSeenDeletionAt: fixedClockTime.Add(-missingClusterServiceIDTimeout / 2),
+			verifyDB:            verifyClusterServiceDeletionTimestampIsNil,
+		},
+		{
+			name: "when ClusterServiceID is not set and first seen older than missing cluster service id timeout then we give up and set ClusterServiceDeletionTimestamp",
+			existingExternalAuth: newTestExternalAuthWithNewDeletionApproach(t, func(ea *api.HCPOpenShiftClusterExternalAuth) {
+				ea.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
+				ea.ServiceProviderProperties.ClusterServiceID = nil
+			}),
+			firstSeenDeletionAt: fixedClockTime.Add(-missingClusterServiceIDTimeout - time.Second),
+			verifyDB:            verifyClusterServiceDeletionTimestampStamped,
+		},
+		{
+			name: "when ClusterServiceID is set we trigger CS external auth deletion and set ClusterServiceDeletionTimestamp",
+			existingExternalAuth: newTestExternalAuthWithNewDeletionApproach(t, func(ea *api.HCPOpenShiftClusterExternalAuth) {
+				ea.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Minute)}
+			}),
+			firstSeenDeletionAt: fixedClockTime.Add(-missingClusterServiceIDTimeout / 2),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					DeleteExternalAuth(gomock.Any(), api.Must(api.NewInternalID(testExternalAuthCSIDStr))).
+					Return(nil)
+			},
+			verifyDB: verifyClusterServiceDeletionTimestampStamped,
+		},
+		{
+			name: "when CS external auth deletion returns 404 and first seen is within the missing cluster service id timeout no-op is performed",
+			existingExternalAuth: newTestExternalAuthWithNewDeletionApproach(t, func(ea *api.HCPOpenShiftClusterExternalAuth) {
+				ea.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
+			}),
+			firstSeenDeletionAt: fixedClockTime.Add(-missingClusterServiceIDTimeout / 2),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					DeleteExternalAuth(gomock.Any(), api.Must(api.NewInternalID(testExternalAuthCSIDStr))).
+					Return(fakeOCMNotFoundError())
+			},
+			verifyDB: verifyClusterServiceDeletionTimestampIsNil,
+		},
+		{
+			name: "when CS external auth deletion returns 404 and first seen is older than the missing cluster service id timeout then we give up and set ClusterServiceDeletionTimestamp",
+			existingExternalAuth: newTestExternalAuthWithNewDeletionApproach(t, func(ea *api.HCPOpenShiftClusterExternalAuth) {
+				ea.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
+			}),
+			firstSeenDeletionAt: fixedClockTime.Add(-missingClusterServiceIDTimeout - time.Second),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					DeleteExternalAuth(gomock.Any(), api.Must(api.NewInternalID(testExternalAuthCSIDStr))).
+					Return(fakeOCMNotFoundError())
+			},
+			verifyDB: verifyClusterServiceDeletionTimestampStamped,
+		},
+		{
+			name: "when CS external auth deletion returns one of the not handled errors we propagate it without setting ClusterServiceDeletionTimestamp",
+			existingExternalAuth: newTestExternalAuthWithNewDeletionApproach(t, func(ea *api.HCPOpenShiftClusterExternalAuth) {
+				ea.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Minute)}
+			}),
+			firstSeenDeletionAt: fixedClockTime.Add(-missingClusterServiceIDTimeout / 2),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					DeleteExternalAuth(gomock.Any(), api.Must(api.NewInternalID(testExternalAuthCSIDStr))).
+					Return(errors.New("boom"))
+			},
+			wantErr:        true,
+			wantErrContain: "failed to delete cluster-service ExternalAuth",
+		},
+		{
+			name: "when CS external auth deletion returns parent cluster is uninstalling we set ClusterServiceDeletionTimestamp immediately",
+			existingExternalAuth: newTestExternalAuthWithNewDeletionApproach(t, func(ea *api.HCPOpenShiftClusterExternalAuth) {
+				ea.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-30 * time.Second)}
+			}),
+			firstSeenDeletionAt: fixedClockTime.Add(-missingClusterServiceIDTimeout / 2),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				parentClusterUninstallingErr, _ := ocmerrors.NewError().
+					Status(http.StatusBadRequest).
+					Reason("Cannot delete ExternalAuth: its parent cluster must be in deletable state. Parent cluster state: 'uninstalling'").
+					Build()
+				mock.EXPECT().
+					DeleteExternalAuth(gomock.Any(), api.Must(api.NewInternalID(testExternalAuthCSIDStr))).
+					Return(parentClusterUninstallingErr)
+			},
+			verifyDB: verifyClusterServiceDeletionTimestampStamped,
+		},
+		{
+			name: "UsesNewExternalAuthDeletionApproach false -- no-op even when DeletionTimestamp is set",
+			existingExternalAuth: newTestExternalAuthWithOldDeletionApproach(t, func(ea *api.HCPOpenShiftClusterExternalAuth) {
+				ea.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Minute)}
+			}),
+			verifyDB: verifyClusterServiceDeletionTimestampIsNil,
+		},
+		{
+			name: "external auth not found no-op is performed",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+			ctrl := gomock.NewController(t)
+
+			resources := []any{}
+			if tc.existingExternalAuth != nil {
+				resources = append(resources, tc.existingExternalAuth)
+			}
+			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, resources)
+			require.NoError(t, err)
+
+			mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
+			if tc.setupMockCSClient != nil {
+				tc.setupMockCSClient(mockCSClient)
+			}
+
+			externalAuthsForLister := []*api.HCPOpenShiftClusterExternalAuth{}
+			if tc.existingExternalAuth != nil {
+				externalAuthsForLister = append(externalAuthsForLister, tc.existingExternalAuth)
+			}
+
+			firstSeenDeletionTimestampCache := lru.New(10)
+			if !tc.firstSeenDeletionAt.IsZero() {
+				firstSeenDeletionTimestampCache.Add(
+					strings.ToLower(tc.existingExternalAuth.ID.String()),
+					tc.firstSeenDeletionAt,
+				)
+			}
+
+			syncer := &externalAuthClusterServiceDeleteDispatchSyncer{
+				clock:                           clocktesting.NewFakePassiveClock(fixedClockTime),
+				cooldownChecker:                 &alwaysSyncCooldownChecker{},
+				externalAuthLister:              &listertesting.SliceExternalAuthLister{ExternalAuths: externalAuthsForLister},
+				resourcesDBClient:               mockResourcesDBClient,
+				clusterServiceClient:            mockCSClient,
+				firstSeenDeletionTimestampCache: firstSeenDeletionTimestampCache,
+			}
+
+			err = syncer.SyncOnce(ctx, testKey)
+			if tc.wantErr {
+				require.Error(t, err)
+				if len(tc.wantErrContain) > 0 {
+					require.ErrorContains(t, err, tc.wantErrContain)
+				}
+				return
+			}
+			require.NoError(t, err)
+
+			if tc.verifyDB != nil {
+				tc.verifyDB(t, ctx, mockResourcesDBClient)
+			}
+		})
+	}
+}
+
+func TestExternalAuthClusterServiceDeleteDispatchSyncer_SyncOnce_cacheShortCircuit(t *testing.T) {
+	fixedClockTime := time.Now().UTC().Truncate(time.Second)
+	ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+	ctrl := gomock.NewController(t)
+
+	externalAuthInDB := newTestExternalAuthWithNewDeletionApproach(t, func(ea *api.HCPOpenShiftClusterExternalAuth) {
+		ea.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
+	})
+	mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, []any{externalAuthInDB})
+	require.NoError(t, err)
+
+	// Here the cached external auth does not have a DeletionTimestamp set, so the syncer will short-circuit.
+	cachedExternalAuth := newTestExternalAuthWithNewDeletionApproach(t, nil)
+
+	syncer := &externalAuthClusterServiceDeleteDispatchSyncer{
+		clock:                           clocktesting.NewFakePassiveClock(fixedClockTime),
+		cooldownChecker:                 &alwaysSyncCooldownChecker{},
+		externalAuthLister:              &listertesting.SliceExternalAuthLister{ExternalAuths: []*api.HCPOpenShiftClusterExternalAuth{cachedExternalAuth}},
+		resourcesDBClient:               mockResourcesDBClient,
+		clusterServiceClient:            ocm.NewMockClusterServiceClientSpec(ctrl),
+		firstSeenDeletionTimestampCache: lru.New(10),
+	}
+
+	key := controllerutils.HCPExternalAuthKey{
+		SubscriptionID:      testSubscriptionID,
+		ResourceGroupName:   testResourceGroupName,
+		HCPClusterName:      testClusterName,
+		HCPExternalAuthName: testExternalAuthName,
+	}
+
+	require.NoError(t, syncer.SyncOnce(ctx, key))
+
+	stored, err := mockResourcesDBClient.HCPClusters(testSubscriptionID, testResourceGroupName).
+		ExternalAuth(testClusterName).Get(ctx, testExternalAuthName)
+	require.NoError(t, err)
+	assert.Nil(t, stored.ServiceProviderProperties.ClusterServiceDeletionTimestamp)
+}
+
+func TestExternalAuthClusterServiceDeleteDispatchSyncer_SyncOnce_firstSeenDeletionCachePopulation(t *testing.T) {
+	fixedClockTime := time.Now().UTC().Truncate(time.Second)
+	ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+	ctrl := gomock.NewController(t)
+
+	externalAuth := newTestExternalAuthWithNewDeletionApproach(t, func(ea *api.HCPOpenShiftClusterExternalAuth) {
+		ea.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
+		ea.ServiceProviderProperties.ClusterServiceID = nil
+	})
+	mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, []any{externalAuth})
+	require.NoError(t, err)
+
+	firstSeenDeletionTimestampCache := lru.New(10)
+	syncer := &externalAuthClusterServiceDeleteDispatchSyncer{
+		clock:                           clocktesting.NewFakePassiveClock(fixedClockTime),
+		cooldownChecker:                 &alwaysSyncCooldownChecker{},
+		externalAuthLister:              &listertesting.SliceExternalAuthLister{ExternalAuths: []*api.HCPOpenShiftClusterExternalAuth{externalAuth}},
+		resourcesDBClient:               mockResourcesDBClient,
+		clusterServiceClient:            ocm.NewMockClusterServiceClientSpec(ctrl),
+		firstSeenDeletionTimestampCache: firstSeenDeletionTimestampCache,
+	}
+
+	key := controllerutils.HCPExternalAuthKey{
+		SubscriptionID:      testSubscriptionID,
+		ResourceGroupName:   testResourceGroupName,
+		HCPClusterName:      testClusterName,
+		HCPExternalAuthName: testExternalAuthName,
+	}
+
+	require.NoError(t, syncer.SyncOnce(ctx, key))
+
+	cacheKey := strings.ToLower(externalAuth.ID.String())
+	firstSeenEntry, ok := firstSeenDeletionTimestampCache.Get(cacheKey)
+	require.True(t, ok, "expected first seen deletion timestamp to be cached")
+	assert.True(t, firstSeenEntry.(time.Time).Equal(fixedClockTime))
+}
+
+func TestExternalAuthClusterServiceDeleteDispatchSyncer_SyncOnce_firstSeenDeletionCacheCleared(t *testing.T) {
+	fixedClockTime := time.Now().UTC().Truncate(time.Second)
+	ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+	ctrl := gomock.NewController(t)
+
+	externalAuth := newTestExternalAuthWithNewDeletionApproach(t, func(ea *api.HCPOpenShiftClusterExternalAuth) {
+		ea.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Minute)}
+	})
+	mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, []any{externalAuth})
+	require.NoError(t, err)
+
+	cacheKey := strings.ToLower(externalAuth.ID.String())
+	firstSeenDeletionTimestampCache := lru.New(10)
+	firstSeenDeletionTimestampCache.Add(cacheKey, fixedClockTime.Add(-missingClusterServiceIDTimeout/2))
+
+	mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
+	mockCSClient.EXPECT().
+		DeleteExternalAuth(gomock.Any(), api.Must(api.NewInternalID(testExternalAuthCSIDStr))).
+		Return(nil)
+
+	syncer := &externalAuthClusterServiceDeleteDispatchSyncer{
+		clock:                           clocktesting.NewFakePassiveClock(fixedClockTime),
+		cooldownChecker:                 &alwaysSyncCooldownChecker{},
+		externalAuthLister:              &listertesting.SliceExternalAuthLister{ExternalAuths: []*api.HCPOpenShiftClusterExternalAuth{externalAuth}},
+		resourcesDBClient:               mockResourcesDBClient,
+		clusterServiceClient:            mockCSClient,
+		firstSeenDeletionTimestampCache: firstSeenDeletionTimestampCache,
+	}
+
+	key := controllerutils.HCPExternalAuthKey{
+		SubscriptionID:      testSubscriptionID,
+		ResourceGroupName:   testResourceGroupName,
+		HCPClusterName:      testClusterName,
+		HCPExternalAuthName: testExternalAuthName,
+	}
+
+	require.NoError(t, syncer.SyncOnce(ctx, key))
+
+	_, ok := firstSeenDeletionTimestampCache.Get(cacheKey)
+	assert.False(t, ok, "expected first seen deletion cache entry to be removed after terminal sync")
+
+	stored, err := mockResourcesDBClient.HCPClusters(testSubscriptionID, testResourceGroupName).
+		ExternalAuth(testClusterName).Get(ctx, testExternalAuthName)
+	require.NoError(t, err)
+	require.NotNil(t, stored.ServiceProviderProperties.ClusterServiceDeletionTimestamp)
+	assert.True(t, stored.ServiceProviderProperties.ClusterServiceDeletionTimestamp.Time.Equal(fixedClockTime))
+}
+
+// newTestExternalAuthWithNewDeletionApproach creates a test external auth with the new
+// deletion approach enabled. The ClusterServiceID uses the external_auth_config/external_auths
+// path format required by Cluster Service.
+//
+// TODO rename this and remove the newTestExternalAuthWithOldDeletionApproach function once
+// the new deletion approach is fully rolled out in all ARO-HCP permanent environments, for all regions.
+func newTestExternalAuthWithNewDeletionApproach(t *testing.T, opts func(*api.HCPOpenShiftClusterExternalAuth)) *api.HCPOpenShiftClusterExternalAuth {
+	t.Helper()
+	resourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+			"/externalAuths/" + testExternalAuthName))
+	externalAuthInternalID := api.Ptr(api.Must(api.NewInternalID(testExternalAuthCSIDStr)))
+	ea := &api.HCPOpenShiftClusterExternalAuth{
+		ProxyResource: arm.ProxyResource{
+			Resource: arm.Resource{
+				ID:   resourceID,
+				Name: testExternalAuthName,
+				Type: api.ExternalAuthResourceType.String(),
+			},
+		},
+		CosmosMetadata: arm.CosmosMetadata{ResourceID: resourceID},
+		Properties: api.HCPOpenShiftClusterExternalAuthProperties{
+			Issuer: api.TokenIssuerProfile{
+				URL:       "https://example.com",
+				Audiences: []string{"audience1"},
+			},
+			Claim: api.ExternalAuthClaimProfile{
+				Mappings: api.TokenClaimMappingsProfile{
+					Username: api.UsernameClaimProfile{
+						Claim:        "sub",
+						PrefixPolicy: api.UsernameClaimPrefixPolicyNone,
+					},
+				},
+			},
+		},
+		ServiceProviderProperties: api.HCPOpenShiftClusterExternalAuthServiceProviderProperties{
+			ClusterServiceID:                    externalAuthInternalID,
+			UsesNewExternalAuthDeletionApproach: true,
+		},
+	}
+	if opts != nil {
+		opts(ea)
+	}
+	return ea
+}
+
+// TODO remove this once the new deletion approach is fully rolled out in all ARO-HCP permanent environments, for all regions.
+func newTestExternalAuthWithOldDeletionApproach(t *testing.T, opts func(*api.HCPOpenShiftClusterExternalAuth)) *api.HCPOpenShiftClusterExternalAuth {
+	ea := newTestExternalAuthWithNewDeletionApproach(t, opts)
+	ea.ServiceProviderProperties.UsesNewExternalAuthDeletionApproach = false
+	return ea
+}
+
+func fakeOCMNotFoundError() error {
+	e, _ := ocmerrors.NewError().Status(http.StatusNotFound).Reason("not found").Build()
+	return e
+}

--- a/backend/pkg/controllers/externalauthdeletion/external_auth_cluster_service_id_clearer.go
+++ b/backend/pkg/controllers/externalauthdeletion/external_auth_cluster_service_id_clearer.go
@@ -1,0 +1,143 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package externalauthdeletion
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/internal/api"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// externalAuthClusterServiceIDClearer clears ClusterServiceID after the
+// cluster-service ExternalAuth itself has been confirmed gone. This runs
+// after the delete dispatch controller has already issued the delete
+// request (ClusterServiceDeletionTimestamp is set). We poll
+// cluster-service for the ExternalAuth and, on 404, zero out the stored
+// ClusterServiceID so downstream code knows the CS resource is fully gone.
+type externalAuthClusterServiceIDClearer struct {
+	cooldownChecker      controllerutil.CooldownChecker
+	externalAuthLister   listers.ExternalAuthLister
+	resourcesDBClient    database.ResourcesDBClient
+	clusterServiceClient ocm.ClusterServiceClientSpec
+}
+
+var _ controllerutils.ExternalAuthSyncer = (*externalAuthClusterServiceIDClearer)(nil)
+
+func NewExternalAuthClusterServiceIDClearerController(
+	resourcesDBClient database.ResourcesDBClient,
+	clusterServiceClient ocm.ClusterServiceClientSpec,
+	activeOperationLister listers.ActiveOperationLister,
+	informers informers.BackendInformers,
+) controllerutils.Controller {
+	_, externalAuthLister := informers.ExternalAuths()
+	syncer := &externalAuthClusterServiceIDClearer{
+		cooldownChecker:      controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		externalAuthLister:   externalAuthLister,
+		resourcesDBClient:    resourcesDBClient,
+		clusterServiceClient: clusterServiceClient,
+	}
+
+	return controllerutils.NewExternalAuthWatchingController(
+		"ExternalAuthDeletionClusterServiceIDClearer",
+		resourcesDBClient,
+		informers,
+		time.Minute,
+		syncer,
+	)
+}
+
+func (c *externalAuthClusterServiceIDClearer) CooldownChecker() controllerutil.CooldownChecker {
+	return c.cooldownChecker
+}
+
+// NeedsWork reports whether this controller has unfinished business for the
+// given ExternalAuth: deletion has been started (DeletionTimestamp), the deleter
+// has already issued the CS delete (ClusterServiceDeletionTimestamp), and a
+// ClusterServiceID is still recorded that needs verification before clearing.
+func (c *externalAuthClusterServiceIDClearer) NeedsWork(externalAuth *api.HCPOpenShiftClusterExternalAuth) bool {
+	// TODO temporary check to skip the new deletion approach for ExternalAuths that were created before the new approach was implemented.
+	// This will be removed once all externalauths whose deletion was triggered before the new approach is fully rolled out have been
+	// fully deleted in all ARO-HCP permanent environments, for all regions.
+	if !externalAuth.ServiceProviderProperties.UsesNewExternalAuthDeletionApproach {
+		return false
+	}
+
+	return externalAuth.ServiceProviderProperties.DeletionTimestamp != nil &&
+		externalAuth.ServiceProviderProperties.ClusterServiceDeletionTimestamp != nil &&
+		externalAuth.ServiceProviderProperties.ClusterServiceID != nil && len(externalAuth.ServiceProviderProperties.ClusterServiceID.String()) > 0
+}
+
+// SyncOnce reads the ExternalAuth from cluster-service. If
+// cluster-service reports 404, the deletion has finished and we zero out
+// ClusterServiceID. Any other state means cluster-service is still
+// processing the deletion. We retry on the next sync.
+func (c *externalAuthClusterServiceIDClearer) SyncOnce(ctx context.Context, key controllerutils.HCPExternalAuthKey) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	cachedExternalAuth, err := c.externalAuthLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPExternalAuthName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get external auth from cache: %w", err))
+	}
+	if !c.NeedsWork(cachedExternalAuth) {
+		return nil
+	}
+
+	externalAuthCRUD := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).ExternalAuth(key.HCPClusterName)
+	externalAuth, err := externalAuthCRUD.Get(ctx, key.HCPExternalAuthName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get external auth: %w", err))
+	}
+	if !c.NeedsWork(externalAuth) {
+		return nil
+	}
+
+	csID := externalAuth.ServiceProviderProperties.ClusterServiceID
+	_, err = c.clusterServiceClient.GetExternalAuth(ctx, *csID)
+	if err != nil {
+		var ocmError *ocmerrors.Error
+		if !errors.As(err, &ocmError) || ocmError.Status() != http.StatusNotFound {
+			return utils.TrackError(fmt.Errorf("failed to get cluster-service ExternalAuth: %w", err))
+		}
+		// 404 - cluster-service has finished deleting the ExternalAuth, clear the CS ID.
+		logger.Info("cluster-service ExternalAuth gone. Clearing ClusterServiceID", "clusterServiceID", csID.String())
+		externalAuth.ServiceProviderProperties.ClusterServiceID = nil
+		if _, err := externalAuthCRUD.Replace(ctx, externalAuth, nil); err != nil {
+			return utils.TrackError(fmt.Errorf("failed to clear ClusterServiceID: %w", err))
+		}
+		return nil
+	}
+
+	// ExternalAuth still exists in cluster-service. Nothing to do yet.
+	return nil
+}

--- a/backend/pkg/controllers/externalauthdeletion/external_auth_cluster_service_id_clearer_test.go
+++ b/backend/pkg/controllers/externalauthdeletion/external_auth_cluster_service_id_clearer_test.go
@@ -1,0 +1,204 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package externalauthdeletion
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+func TestExternalAuthClusterServiceIDClearer_SyncOnce(t *testing.T) {
+	fixedNow := time.Now().UTC().Truncate(time.Second)
+	withDeletionStampsExternalAuthOptsFunc := func(ea *api.HCPOpenShiftClusterExternalAuth) {
+		ea.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-time.Hour)}
+		ea.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-30 * time.Minute)}
+	}
+
+	verifyClusterServiceIDUnchanged := func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+		t.Helper()
+		stored, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).
+			ExternalAuth(testClusterName).Get(ctx, testExternalAuthName)
+		require.NoError(t, err)
+		require.NotNil(t, stored.ServiceProviderProperties.ClusterServiceID, "ClusterServiceID should not be nil")
+		assert.Equal(t, testExternalAuthCSIDStr, stored.ServiceProviderProperties.ClusterServiceID.String(),
+			"ClusterServiceID should be unchanged")
+	}
+
+	testCases := []struct {
+		name                 string
+		existingExternalAuth *api.HCPOpenShiftClusterExternalAuth
+		setupMockCSClient    func(mock *ocm.MockClusterServiceClientSpec)
+		wantErr              bool
+		wantErrContain       string
+		verifyDB             func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient)
+	}{
+		{
+			name:                 "no DeletionTimestamp -- no-op",
+			existingExternalAuth: newTestExternalAuthWithNewDeletionApproach(t, nil),
+			verifyDB:             verifyClusterServiceIDUnchanged,
+		},
+		{
+			name: "DeletionTimestamp set but ClusterServiceDeletionTimestamp not yet -- no-op",
+			existingExternalAuth: newTestExternalAuthWithNewDeletionApproach(t, func(ea *api.HCPOpenShiftClusterExternalAuth) {
+				ea.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-time.Hour)}
+			}),
+			verifyDB: verifyClusterServiceIDUnchanged,
+		},
+		{
+			name: "ClusterServiceID already cleared -- no-op",
+			existingExternalAuth: newTestExternalAuthWithNewDeletionApproach(t, func(ea *api.HCPOpenShiftClusterExternalAuth) {
+				withDeletionStampsExternalAuthOptsFunc(ea)
+				ea.ServiceProviderProperties.ClusterServiceID = nil
+			}),
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+				stored, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).
+					ExternalAuth(testClusterName).Get(ctx, testExternalAuthName)
+				require.NoError(t, err)
+				assert.Nil(t, stored.ServiceProviderProperties.ClusterServiceID, "ClusterServiceID should remain nil")
+			},
+		},
+		{
+			name: "CS ExternalAuth still present -- wait",
+			existingExternalAuth: newTestExternalAuthWithNewDeletionApproach(t, func(ea *api.HCPOpenShiftClusterExternalAuth) {
+				withDeletionStampsExternalAuthOptsFunc(ea)
+			}),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetExternalAuth(gomock.Any(), api.Must(api.NewInternalID(testExternalAuthCSIDStr))).
+					Return(newCSExternalAuth(t), nil)
+			},
+			verifyDB: verifyClusterServiceIDUnchanged,
+		},
+		{
+			name: "CS returns 404 -- clear ClusterServiceID",
+			existingExternalAuth: newTestExternalAuthWithNewDeletionApproach(t, func(ea *api.HCPOpenShiftClusterExternalAuth) {
+				withDeletionStampsExternalAuthOptsFunc(ea)
+			}),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetExternalAuth(gomock.Any(), api.Must(api.NewInternalID(testExternalAuthCSIDStr))).
+					Return(nil, fakeOCMNotFoundError())
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+				stored, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).
+					ExternalAuth(testClusterName).Get(ctx, testExternalAuthName)
+				require.NoError(t, err)
+				assert.Nil(t, stored.ServiceProviderProperties.ClusterServiceID, "expected ClusterServiceID to be cleared")
+			},
+		},
+		{
+			name: "CS returns one of the not handled errors -- propagated, no clear",
+			existingExternalAuth: newTestExternalAuthWithNewDeletionApproach(t, func(ea *api.HCPOpenShiftClusterExternalAuth) {
+				withDeletionStampsExternalAuthOptsFunc(ea)
+			}),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetExternalAuth(gomock.Any(), api.Must(api.NewInternalID(testExternalAuthCSIDStr))).
+					Return(nil, errors.New("boom"))
+			},
+			wantErr:        true,
+			wantErrContain: "failed to get cluster-service ExternalAuth",
+		},
+		{
+			name: "UsesNewExternalAuthDeletionApproach false -- no-op even when all clear conditions met",
+			existingExternalAuth: newTestExternalAuthWithOldDeletionApproach(t, func(ea *api.HCPOpenShiftClusterExternalAuth) {
+				withDeletionStampsExternalAuthOptsFunc(ea)
+			}),
+			verifyDB: verifyClusterServiceIDUnchanged,
+		},
+		{
+			name: "external auth not found",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+			ctrl := gomock.NewController(t)
+
+			resources := []any{}
+			if tc.existingExternalAuth != nil {
+				resources = append(resources, tc.existingExternalAuth)
+			}
+			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, resources)
+			require.NoError(t, err)
+
+			mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
+			if tc.setupMockCSClient != nil {
+				tc.setupMockCSClient(mockCSClient)
+			}
+
+			externalAuthsForLister := []*api.HCPOpenShiftClusterExternalAuth{}
+			if tc.existingExternalAuth != nil {
+				externalAuthsForLister = append(externalAuthsForLister, tc.existingExternalAuth)
+			}
+
+			syncer := &externalAuthClusterServiceIDClearer{
+				cooldownChecker:      &alwaysSyncCooldownChecker{},
+				externalAuthLister:   &listertesting.SliceExternalAuthLister{ExternalAuths: externalAuthsForLister},
+				resourcesDBClient:    mockResourcesDBClient,
+				clusterServiceClient: mockCSClient,
+			}
+
+			key := controllerutils.HCPExternalAuthKey{
+				SubscriptionID:      testSubscriptionID,
+				ResourceGroupName:   testResourceGroupName,
+				HCPClusterName:      testClusterName,
+				HCPExternalAuthName: testExternalAuthName,
+			}
+
+			err = syncer.SyncOnce(ctx, key)
+			if tc.wantErr {
+				require.Error(t, err)
+				if len(tc.wantErrContain) > 0 {
+					require.ErrorContains(t, err, tc.wantErrContain)
+				}
+				return
+			}
+			require.NoError(t, err)
+
+			if tc.verifyDB != nil {
+				tc.verifyDB(t, ctx, mockResourcesDBClient)
+			}
+		})
+	}
+}
+
+func newCSExternalAuth(t *testing.T) *arohcpv1alpha1.ExternalAuth {
+	t.Helper()
+	ea, err := arohcpv1alpha1.NewExternalAuth().ID(testExternalAuthName).Build()
+	require.NoError(t, err)
+	return ea
+}

--- a/backend/pkg/controllers/externalauthdeletion/external_auth_deletion_controller.go
+++ b/backend/pkg/controllers/externalauthdeletion/external_auth_deletion_controller.go
@@ -1,0 +1,163 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package externalauthdeletion
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/internal/api"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// externalAuthDeletionController issues a Cosmos external auth delete
+// for ExternalAuths that have their DeletionTimestamp and
+// ClusterServiceDeletionTimestamp set and their ClusterServiceID
+// cleared, once all child resources have been cleaned up.
+type externalAuthDeletionController struct {
+	cooldownChecker    controllerutil.CooldownChecker
+	externalAuthLister listers.ExternalAuthLister
+	resourcesDBClient  database.ResourcesDBClient
+}
+
+var _ controllerutils.ExternalAuthSyncer = (*externalAuthDeletionController)(nil)
+
+func NewExternalAuthDeletionController(
+	resourcesDBClient database.ResourcesDBClient,
+	activeOperationLister listers.ActiveOperationLister,
+	informers informers.BackendInformers,
+) controllerutils.Controller {
+	_, externalAuthLister := informers.ExternalAuths()
+	syncer := &externalAuthDeletionController{
+		cooldownChecker:    controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		externalAuthLister: externalAuthLister,
+		resourcesDBClient:  resourcesDBClient,
+	}
+
+	return controllerutils.NewExternalAuthWatchingController(
+		"ExternalAuthDeletionController",
+		resourcesDBClient,
+		informers,
+		time.Minute,
+		syncer,
+	)
+}
+
+func (c *externalAuthDeletionController) CooldownChecker() controllerutil.CooldownChecker {
+	return c.cooldownChecker
+}
+
+// NeedsWork reports whether the deleter has unfinished business for the
+// given ExternalAuth. All the following conditions must be met:
+// - DeletionTimestamp must be set
+// - ClusterServiceDeletionTimestamp must be set
+// - ClusterServiceID must be nil
+func (c *externalAuthDeletionController) NeedsWork(externalAuth *api.HCPOpenShiftClusterExternalAuth) bool {
+	// TODO temporary check to skip the new deletion approach for ExternalAuths that were created before the new approach was implemented.
+	// This will be removed once all externalauths whose deletion was triggered before the new approach is fully rolled out have been
+	// fully deleted in all ARO-HCP permanent environments, for all regions.
+	if !externalAuth.ServiceProviderProperties.UsesNewExternalAuthDeletionApproach {
+		return false
+	}
+
+	return externalAuth.ServiceProviderProperties.DeletionTimestamp != nil &&
+		externalAuth.ServiceProviderProperties.ClusterServiceDeletionTimestamp != nil &&
+		externalAuth.ServiceProviderProperties.ClusterServiceID == nil
+}
+
+// SyncOnce calls Cosmos to delete the ExternalAuth when the NeedsWork
+// condition is met and all the delete preconditions are met.
+func (c *externalAuthDeletionController) SyncOnce(ctx context.Context, key controllerutils.HCPExternalAuthKey) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	cachedExternalAuth, err := c.externalAuthLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPExternalAuthName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get external auth from cache: %w", err))
+	}
+	if !c.NeedsWork(cachedExternalAuth) {
+		return nil
+	}
+
+	externalAuthCRUD := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).ExternalAuth(key.HCPClusterName)
+	externalAuth, err := externalAuthCRUD.Get(ctx, key.HCPExternalAuthName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get external auth: %w", err))
+	}
+	if !c.NeedsWork(externalAuth) {
+		return nil
+	}
+
+	preconditionMet, err := c.deletePreconditionCosmosChildResourcesDeleted(ctx, key)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to check precondition: %w", err))
+	}
+	if !preconditionMet {
+		return nil
+	}
+
+	logger.Info("deleting external auth from Cosmos")
+	err = externalAuthCRUD.Delete(ctx, key.HCPExternalAuthName)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to delete external auth from Cosmos: %w", err))
+	}
+	logger.Info("external auth deleted from Cosmos")
+
+	return nil
+}
+
+// deletePreconditionCosmosChildResourcesDeleted checks if the cosmos
+// child resources have been deleted. It ignores external auth
+// controllers, as there might be controllers still running for the
+// ExternalAuth until the very end of the deletion process.
+func (c *externalAuthDeletionController) deletePreconditionCosmosChildResourcesDeleted(ctx context.Context, key controllerutils.HCPExternalAuthKey) (bool, error) {
+	logger := utils.LoggerFromContext(ctx)
+
+	externalAuthResourceID := key.GetResourceID()
+	untypedCRUD, err := c.resourcesDBClient.UntypedCRUD(*externalAuthResourceID)
+	if err != nil {
+		return false, utils.TrackError(fmt.Errorf("failed to create untyped CRUD for child check: %w", err))
+	}
+	childIterator, err := untypedCRUD.ListRecursive(ctx, nil)
+	if err != nil {
+		return false, utils.TrackError(fmt.Errorf("failed to list child resources: %w", err))
+	}
+	for _, childResource := range childIterator.Items(ctx) {
+		// We ignore external auth controllers here, as there might be controllers still running for the ExternalAuth until the very
+		// end of the deletion process
+		if strings.EqualFold(childResource.ResourceType, api.ExternalAuthControllerResourceType.String()) {
+			continue
+		}
+		logger.Info("child resource still exists, waiting for cleanup", "childResourceID", childResource.ResourceID)
+		return false, nil
+	}
+	if err := childIterator.GetError(); err != nil {
+		return false, utils.TrackError(fmt.Errorf("error iterating child resources: %w", err))
+	}
+
+	return true, nil
+}

--- a/backend/pkg/controllers/externalauthdeletion/external_auth_deletion_controller_test.go
+++ b/backend/pkg/controllers/externalauthdeletion/external_auth_deletion_controller_test.go
@@ -1,0 +1,150 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package externalauthdeletion
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+func TestExternalAuthDeletionController_SyncOnce(t *testing.T) {
+	fixedNow := time.Now().UTC().Truncate(time.Second)
+	readyToDeleteExternalAuthOptsFunc := func(ea *api.HCPOpenShiftClusterExternalAuth) {
+		ea.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-time.Hour)}
+		ea.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-30 * time.Minute)}
+		ea.ServiceProviderProperties.ClusterServiceID = nil
+	}
+
+	verifyExternalAuthStillExists := func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+		t.Helper()
+		_, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).
+			ExternalAuth(testClusterName).Get(ctx, testExternalAuthName)
+		require.NoError(t, err, "expected external auth to still exist in Cosmos")
+	}
+
+	verifyExternalAuthDeleted := func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+		t.Helper()
+		_, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).
+			ExternalAuth(testClusterName).Get(ctx, testExternalAuthName)
+		assert.True(t, database.IsNotFoundError(err), "expected external auth to be deleted from Cosmos")
+	}
+
+	testCases := []struct {
+		name                 string
+		existingExternalAuth *api.HCPOpenShiftClusterExternalAuth
+		childResources       []any
+		wantErr              bool
+		verifyDB             func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient)
+	}{
+		{
+			name:                 "no DeletionTimestamp -- no-op",
+			existingExternalAuth: newTestExternalAuthWithNewDeletionApproach(t, nil),
+			verifyDB:             verifyExternalAuthStillExists,
+		},
+		{
+			name: "DeletionTimestamp set but ClusterServiceDeletionTimestamp not -- no-op",
+			existingExternalAuth: newTestExternalAuthWithNewDeletionApproach(t, func(ea *api.HCPOpenShiftClusterExternalAuth) {
+				ea.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-time.Hour)}
+			}),
+			verifyDB: verifyExternalAuthStillExists,
+		},
+		{
+			name: "ClusterServiceID still set -- no-op",
+			existingExternalAuth: newTestExternalAuthWithNewDeletionApproach(t, func(ea *api.HCPOpenShiftClusterExternalAuth) {
+				ea.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-time.Hour)}
+				ea.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-30 * time.Minute)}
+			}),
+			verifyDB: verifyExternalAuthStillExists,
+		},
+		{
+			name:                 "all conditions met, no children -- deletes external auth from Cosmos",
+			existingExternalAuth: newTestExternalAuthWithNewDeletionApproach(t, readyToDeleteExternalAuthOptsFunc),
+			verifyDB:             verifyExternalAuthDeleted,
+		},
+		{
+			name:                 "all conditions met, only controller children -- deletes external auth",
+			existingExternalAuth: newTestExternalAuthWithNewDeletionApproach(t, readyToDeleteExternalAuthOptsFunc),
+			childResources:       []any{newTestExternalAuthController(t, "test-controller")},
+			verifyDB:             verifyExternalAuthDeleted,
+		},
+		{
+			name:                 "UsesNewExternalAuthDeletionApproach false -- no-op even when all delete conditions met",
+			existingExternalAuth: newTestExternalAuthWithOldDeletionApproach(t, readyToDeleteExternalAuthOptsFunc),
+			childResources:       []any{newTestExternalAuthController(t, "test-controller")},
+			verifyDB:             verifyExternalAuthStillExists,
+		},
+		{
+			name:                 "external auth not found -- no-op",
+			existingExternalAuth: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+
+			resources := []any{}
+			if tc.existingExternalAuth != nil {
+				resources = append(resources, tc.existingExternalAuth)
+			}
+			resources = append(resources, tc.childResources...)
+			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, resources)
+			require.NoError(t, err)
+
+			externalAuthsForLister := []*api.HCPOpenShiftClusterExternalAuth{}
+			if tc.existingExternalAuth != nil {
+				externalAuthsForLister = append(externalAuthsForLister, tc.existingExternalAuth)
+			}
+
+			syncer := &externalAuthDeletionController{
+				cooldownChecker:    &alwaysSyncCooldownChecker{},
+				externalAuthLister: &listertesting.SliceExternalAuthLister{ExternalAuths: externalAuthsForLister},
+				resourcesDBClient:  mockResourcesDBClient,
+			}
+
+			key := controllerutils.HCPExternalAuthKey{
+				SubscriptionID:      testSubscriptionID,
+				ResourceGroupName:   testResourceGroupName,
+				HCPClusterName:      testClusterName,
+				HCPExternalAuthName: testExternalAuthName,
+			}
+
+			err = syncer.SyncOnce(ctx, key)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			if tc.verifyDB != nil {
+				tc.verifyDB(t, ctx, mockResourcesDBClient)
+			}
+		})
+	}
+}

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_delete.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_delete.go
@@ -142,6 +142,26 @@ func (c *operationClusterDelete) SynchronizeOperation(ctx context.Context, key c
 			return nil
 		}
 
+		// Some external auth controllers require the Cosmos document to do their cleanup work, so we block
+		// the cluster cosmos deletion until the external auths are gone.
+		externalAuthIterator, err := c.resourcesDBClient.HCPClusters(operation.ExternalID.SubscriptionID, operation.ExternalID.ResourceGroupName).ExternalAuth(operation.ExternalID.Name).List(ctx, nil)
+		if err != nil {
+			return utils.TrackError(err)
+		}
+		foundAtLeastOneExternalAuth := false
+		for range externalAuthIterator.Items(ctx) {
+			foundAtLeastOneExternalAuth = true
+			break
+		}
+		err = externalAuthIterator.GetError()
+		if err != nil {
+			return utils.TrackError(err)
+		}
+		if foundAtLeastOneExternalAuth {
+			logger.Info("cluster still has cosmos externalauths")
+			return nil
+		}
+
 		// Update the Cosmos DB billing document with a deletion timestamp.
 		// Do this before calling setDeleteOperationAsCompleted so that in
 		// case of error the backend will retry by virtue of the operation

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_delete_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_delete_test.go
@@ -42,11 +42,12 @@ func TestOperationClusterDelete_SynchronizeOperation(t *testing.T) {
 	createdAt := mustParseTime("2025-01-15T10:30:00Z")
 
 	tests := []struct {
-		name        string
-		nodePools   []*api.HCPOpenShiftClusterNodePool
-		setupMock   func(ctrl *gomock.Controller, fixture *clusterTestFixture) ocm.ClusterServiceClientSpec
-		expectError bool
-		verify      func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *clusterTestFixture)
+		name          string
+		nodePools     []*api.HCPOpenShiftClusterNodePool
+		externalAuths []*api.HCPOpenShiftClusterExternalAuth
+		setupMock     func(ctrl *gomock.Controller, fixture *clusterTestFixture) ocm.ClusterServiceClientSpec
+		expectError   bool
+		verify        func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *clusterTestFixture)
 	}{
 		{
 			name: "cluster not found marks billing as deleted and removes cluster",
@@ -72,9 +73,6 @@ func TestOperationClusterDelete_SynchronizeOperation(t *testing.T) {
 		},
 		{
 			name: "cluster not found does not remove cluster while nodepools exist",
-			nodePools: []*api.HCPOpenShiftClusterNodePool{
-				newNodePoolTestFixture().newNodePool(),
-			},
 			setupMock: func(ctrl *gomock.Controller, fixture *clusterTestFixture) ocm.ClusterServiceClientSpec {
 				mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
 				notFoundErr, _ := ocmerrors.NewError().Status(http.StatusNotFound).Build()
@@ -84,11 +82,42 @@ func TestOperationClusterDelete_SynchronizeOperation(t *testing.T) {
 				return mockCSClient
 			},
 			expectError: false,
+			nodePools: []*api.HCPOpenShiftClusterNodePool{
+				newNodePoolTestFixture().newNodePool(),
+			},
 			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *clusterTestFixture) {
+				// Operation should remain non-terminal since nodepools still exist
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
 
+				// Cluster should still exist
+				cluster, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
+				require.NoError(t, err)
+				assert.NotNil(t, cluster)
+			},
+		},
+		{
+			name: "cluster not found does not remove cluster while external auths exist",
+			setupMock: func(ctrl *gomock.Controller, fixture *clusterTestFixture) ocm.ClusterServiceClientSpec {
+				mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
+				notFoundErr, _ := ocmerrors.NewError().Status(http.StatusNotFound).Build()
+				mockCSClient.EXPECT().
+					GetClusterStatus(gomock.Any(), fixture.clusterInternalID).
+					Return(nil, notFoundErr)
+				return mockCSClient
+			},
+			expectError: false,
+			externalAuths: []*api.HCPOpenShiftClusterExternalAuth{
+				newExternalAuthTestFixture().newExternalAuth(),
+			},
+			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *clusterTestFixture) {
+				// Operation should remain non-terminal since external auths still exist
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+
+				// Cluster should still exist
 				cluster, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
 				require.NoError(t, err)
 				assert.NotNil(t, cluster)
@@ -193,10 +222,13 @@ func TestOperationClusterDelete_SynchronizeOperation(t *testing.T) {
 			err := mockBillingDBClient.BillingDocs(fixture.clusterResourceID.SubscriptionID).Create(ctx, billingDoc)
 			require.NoError(t, err)
 
-			// Mock resources DB client with cluster, operation, and node pools
+			// Mock resources DB client with cluster, operation, node pools and external auths
 			resources := []any{cluster, operation}
 			for _, nodePool := range tt.nodePools {
 				resources = append(resources, nodePool)
+			}
+			for _, externalAuth := range tt.externalAuths {
+				resources = append(resources, externalAuth)
 			}
 			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, resources)
 			require.NoError(t, err)

--- a/backend/pkg/controllers/operationcontrollers/operation_external_auth_delete.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_external_auth_delete.go
@@ -45,16 +45,26 @@ type operationExternalAuthDelete struct {
 // follows an asynchronous external auth deletion operation to completion and updates
 // the corresponding operation document in Cosmos DB.
 //
-// Operation documents relevant to this controller will have the following values:
-//
-//	ResourceType: Microsoft.RedHatOpenShift/hcpOpenShiftClusters/externalAuths
-//	     Request: Delete
-//	      Status: any non-terminal value
+// The controller has the following responsibilities:
+//   - For legacy operations (UsesNewExternalAuthDeletionApproach == false):
+//     it polls Cluster Service until the external auth is gone (404), then
+//     marks the operation as Succeeded and cleans up the Cosmos document.
+//   - For new-approach operations (UsesNewExternalAuthDeletionApproach == true):
+//     while the ExternalAuth Cosmos document is present, it reconciles the
+//     operation status. When the ExternalAuth Cosmos document is deleted
+//     (by the externalAuthDeletionController), it marks the operation as
+//     Succeeded.
 //
 // Note that "to completion" does not imply success. An operation is considered
 // complete when its status field reaches what Azure defines as a terminal value;
 // any of "Succeeded", "Failed", or "Canceled". Once the operation status reaches
 // a terminal value, there will be no further updates to the operation document.
+//
+// Operation documents relevant to this controller will have the following values:
+//
+//	ResourceType: Microsoft.RedHatOpenShift/hcpOpenShiftClusters/externalAuths
+//	     Request: Delete
+//	      Status: any non-terminal value
 func NewOperationExternalAuthDeleteController(
 	clock utilsclock.PassiveClock,
 	resourcesDBClient database.ResourcesDBClient,
@@ -104,21 +114,80 @@ func (c *operationExternalAuthDelete) SynchronizeOperation(ctx context.Context, 
 	if err != nil {
 		return fmt.Errorf("failed to get active operation: %w", err)
 	}
+
+	// TODO remove this once migration of external auth deletion from frontend to backend is fully completed.
+	if !operation.UsesNewExternalAuthDeletionApproach {
+		return c.legacySynchronizeOperation(ctx, operation)
+	}
+
+	// From here, we know it uses the new deletion approach.
+
 	if !c.ShouldProcess(ctx, operation) {
 		return nil // no work to do
 	}
 
-	_, err = c.clusterServiceClient.GetExternalAuth(ctx, operation.InternalID)
-	var ocmGetExternalAuthError *ocmerrors.Error
-	if err != nil && errors.As(err, &ocmGetExternalAuthError) && ocmGetExternalAuthError.Status() == http.StatusNotFound {
-		logger.Info("external auth was deleted")
-
+	externalAuthCRUD := c.resourcesDBClient.HCPClusters(operation.ExternalID.SubscriptionID, operation.ExternalID.ResourceGroupName).ExternalAuth(operation.ExternalID.Parent.Name)
+	externalAuth, err := externalAuthCRUD.Get(ctx, operation.ExternalID.Name)
+	if database.IsNotFoundError(err) {
+		logger.Info("external auth document deleted - completing operation")
 		err = SetDeleteOperationAsCompleted(ctx, c.clock, c.resourcesDBClient, operation, postAsyncNotificationFn(c.notificationClient))
 		if err != nil {
 			return utils.TrackError(err)
 		}
 		return nil
 	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get external auth: %w", err))
+	}
+
+	if !c.shouldReconcileOperationAndResourceStatus(externalAuth) {
+		return nil
+	}
+	err = c.reconcileOperationAndResourceStatus(ctx, operation, externalAuth)
+	if err != nil {
+		return utils.TrackError(err)
+	}
+
+	return nil
+}
+
+func (c *operationExternalAuthDelete) shouldReconcileOperationAndResourceStatus(externalAuth *api.HCPOpenShiftClusterExternalAuth) bool {
+	return externalAuth.ServiceProviderProperties.DeletionTimestamp != nil &&
+		externalAuth.ServiceProviderProperties.ClusterServiceDeletionTimestamp != nil &&
+		externalAuth.ServiceProviderProperties.ClusterServiceID != nil
+}
+
+func (c *operationExternalAuthDelete) reconcileOperationAndResourceStatus(ctx context.Context, operation *api.Operation, externalAuth *api.HCPOpenShiftClusterExternalAuth) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	csID := externalAuth.ServiceProviderProperties.ClusterServiceID
+
+	csExternalAuth, err := c.clusterServiceClient.GetExternalAuth(ctx, *csID)
+	if err != nil {
+		var ocmError *ocmerrors.Error
+		if !errors.As(err, &ocmError) || ocmError.Status() != http.StatusNotFound {
+			return utils.TrackError(fmt.Errorf("failed to get cluster-service ExternalAuth: %w", err))
+		}
+		// 404 - CS has finished deleting. externalAuthClusterServiceIDClearer will clear the ID.
+		logger.Info("cluster-service ExternalAuth gone - skipping operation update", "clusterServiceID", csID.String())
+		return nil
+	}
+
+	csExternalAuthStatus := csExternalAuth.Status()
+
+	// If the external auth is in the Ready state from CS side, we wait until the Cosmos ExternalAuth document is deleted, which
+	// will be picked up by a next reconciliation of this controller and we will update the operation to Succeeded.
+	if csExternalAuthStatus.State().Value() == string(ExternalAuthStateReady) {
+		logger.Info("cluster-service ExternalAuth in Ready state. Waiting until Cosmos ExternalAuth document is deleted.")
+		return nil
+	}
+
+	newOperationStatus, newOperationError, err := convertExternalAuthStatus(operation, csExternalAuthStatus)
+	if err != nil {
+		return utils.TrackError(err)
+	}
+
+	err = UpdateOperationStatus(ctx, c.clock, c.resourcesDBClient, operation, newOperationStatus, newOperationError, postAsyncNotificationFn(c.notificationClient))
 	if err != nil {
 		return utils.TrackError(err)
 	}

--- a/backend/pkg/controllers/operationcontrollers/operation_external_auth_delete_legacy.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_external_auth_delete_legacy.go
@@ -1,0 +1,66 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operationcontrollers
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+
+	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+func (c *operationExternalAuthDelete) legacyShouldProcess(ctx context.Context, operation *api.Operation) bool {
+	if operation.Status.IsTerminal() {
+		return false
+	}
+	if operation.Request != database.OperationRequestDelete {
+		return false
+	}
+	if operation.ExternalID == nil || !strings.EqualFold(operation.ExternalID.ResourceType.String(), api.ExternalAuthResourceType.String()) {
+		return false
+	}
+	return true
+}
+
+func (c *operationExternalAuthDelete) legacySynchronizeOperation(ctx context.Context, operation *api.Operation) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	if !c.legacyShouldProcess(ctx, operation) {
+		return nil // no work to do
+	}
+
+	_, err := c.clusterServiceClient.GetExternalAuth(ctx, operation.InternalID)
+	var ocmGetExternalAuthError *ocmerrors.Error
+	if err != nil && errors.As(err, &ocmGetExternalAuthError) && ocmGetExternalAuthError.Status() == http.StatusNotFound {
+		logger.Info("external auth was deleted")
+
+		err = SetDeleteOperationAsCompleted(ctx, c.clock, c.resourcesDBClient, operation, postAsyncNotificationFn(c.notificationClient))
+		if err != nil {
+			return utils.TrackError(err)
+		}
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(err)
+	}
+
+	return nil
+}

--- a/backend/pkg/controllers/operationcontrollers/operation_external_auth_delete_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_external_auth_delete_test.go
@@ -18,17 +18,20 @@ import (
 	"context"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr/testr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilsclock "k8s.io/utils/clock"
 
 	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
 	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
 
+	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/databasetesting"
@@ -37,15 +40,140 @@ import (
 )
 
 func TestOperationExternalAuthDelete_SynchronizeOperation(t *testing.T) {
-	tests := []struct {
-		name        string
-		setupMock   func(ctrl *gomock.Controller, fixture *externalAuthTestFixture) ocm.ClusterServiceClientSpec
-		expectError bool
-		verify      func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *externalAuthTestFixture)
+	fixture := newExternalAuthTestFixture()
+
+	externalAuthPassingExtraReconcileGate := func() *api.HCPOpenShiftClusterExternalAuth {
+		now := time.Now()
+		ea := fixture.newExternalAuth()
+		ea.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: now}
+		ea.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: now}
+		return ea
+	}
+
+	testCases := []struct {
+		name                                string
+		existingExternalAuth                *api.HCPOpenShiftClusterExternalAuth
+		wantErr                             bool
+		verifyDB                            func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient)
+		usesNewExternalAuthDeletionApproach bool
+		setupCSMock                         func(ctrl *gomock.Controller, fixture *externalAuthTestFixture) ocm.ClusterServiceClientSpec
 	}{
 		{
-			name: "external auth not found marks operation succeeded and removes external auth",
-			setupMock: func(ctrl *gomock.Controller, fixture *externalAuthTestFixture) ocm.ClusterServiceClientSpec {
+			name:                                "external auth document gone completes operation",
+			usesNewExternalAuthDeletionApproach: true,
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateSucceeded, op.Status)
+			},
+		},
+		{
+			name: "shouldReconcile gate not passed skips cluster service",
+			existingExternalAuth: func() *api.HCPOpenShiftClusterExternalAuth {
+				ea := fixture.newExternalAuth()
+				ea.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+				return ea
+			}(),
+			usesNewExternalAuthDeletionApproach: true,
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+			},
+		},
+		{
+			name: "shouldReconcile gate not passed when ClusterServiceID is nil",
+			existingExternalAuth: func() *api.HCPOpenShiftClusterExternalAuth {
+				ea := fixture.newExternalAuth()
+				ea.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+				ea.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: time.Now()}
+				ea.ServiceProviderProperties.ClusterServiceID = nil
+				return ea
+			}(),
+			usesNewExternalAuthDeletionApproach: true,
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+			},
+		},
+		{
+			name:                                "extra reconcile gate passed and CS ready waits without updating operation",
+			existingExternalAuth:                externalAuthPassingExtraReconcileGate(),
+			usesNewExternalAuthDeletionApproach: true,
+			setupCSMock: func(ctrl *gomock.Controller, fixture *externalAuthTestFixture) ocm.ClusterServiceClientSpec {
+				mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
+				csEA, _ := arohcpv1alpha1.NewExternalAuth().
+					ID(testExternalAuthIDStr).
+					Status(arohcpv1alpha1.NewExternalAuthStatus().
+						State(arohcpv1alpha1.NewExternalAuthState().
+							Value(string(ExternalAuthStateReady)))).
+					Build()
+				mockCSClient.EXPECT().
+					GetExternalAuth(gomock.Any(), fixture.externalAuthInternalID).
+					Return(csEA, nil)
+				return mockCSClient
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+			},
+		},
+		{
+			name:                                "extra reconcile gate passed and CS uninstalling updates operation to deleting",
+			existingExternalAuth:                externalAuthPassingExtraReconcileGate(),
+			usesNewExternalAuthDeletionApproach: true,
+			setupCSMock: func(ctrl *gomock.Controller, fixture *externalAuthTestFixture) ocm.ClusterServiceClientSpec {
+				mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
+				csEA, _ := arohcpv1alpha1.NewExternalAuth().
+					ID(testExternalAuthIDStr).
+					Status(arohcpv1alpha1.NewExternalAuthStatus().
+						State(arohcpv1alpha1.NewExternalAuthState().
+							Value(string(ExternalAuthStateUninstalling)))).
+					Build()
+				mockCSClient.EXPECT().
+					GetExternalAuth(gomock.Any(), fixture.externalAuthInternalID).
+					Return(csEA, nil)
+				return mockCSClient
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateDeleting, op.Status)
+			},
+		},
+		{
+			name:                                "extra reconcile gate passed and CS error marks operation failed",
+			existingExternalAuth:                externalAuthPassingExtraReconcileGate(),
+			usesNewExternalAuthDeletionApproach: true,
+			setupCSMock: func(ctrl *gomock.Controller, fixture *externalAuthTestFixture) ocm.ClusterServiceClientSpec {
+				mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
+				csEA, _ := arohcpv1alpha1.NewExternalAuth().
+					ID(testExternalAuthIDStr).
+					Status(arohcpv1alpha1.NewExternalAuthStatus().
+						State(arohcpv1alpha1.NewExternalAuthState().
+							Value(string(ExternalAuthStateError))).
+						Message("something went wrong")).
+					Build()
+				mockCSClient.EXPECT().
+					GetExternalAuth(gomock.Any(), fixture.externalAuthInternalID).
+					Return(csEA, nil)
+				return mockCSClient
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateFailed, op.Status)
+				assert.NotNil(t, op.Error)
+				assert.Equal(t, "something went wrong", op.Error.Message)
+			},
+		},
+		{
+			name:                                "extra reconcile gate passed and CS returns 404 waits for ID clearer",
+			existingExternalAuth:                externalAuthPassingExtraReconcileGate(),
+			usesNewExternalAuthDeletionApproach: true,
+			setupCSMock: func(ctrl *gomock.Controller, fixture *externalAuthTestFixture) ocm.ClusterServiceClientSpec {
 				mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
 				notFoundErr, _ := ocmerrors.NewError().Status(http.StatusNotFound).Build()
 				mockCSClient.EXPECT().
@@ -53,20 +181,36 @@ func TestOperationExternalAuthDelete_SynchronizeOperation(t *testing.T) {
 					Return(nil, notFoundErr)
 				return mockCSClient
 			},
-			expectError: false,
-			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *externalAuthTestFixture) {
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+			},
+		},
+		{
+			name:                 "legacy approach: external auth gone in cluster service marks operation succeeded",
+			existingExternalAuth: fixture.newExternalAuth(),
+			setupCSMock: func(ctrl *gomock.Controller, fixture *externalAuthTestFixture) ocm.ClusterServiceClientSpec {
+				mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
+				notFoundErr, _ := ocmerrors.NewError().Status(http.StatusNotFound).Build()
+				mockCSClient.EXPECT().
+					GetExternalAuth(gomock.Any(), fixture.externalAuthInternalID).
+					Return(nil, notFoundErr)
+				return mockCSClient
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateSucceeded, op.Status)
 
-				// Verify external auth document was deleted
 				_, err = db.HCPClusters(testSubscriptionID, testResourceGroupName).ExternalAuth(testClusterName).Get(ctx, testExternalAuthName)
 				assert.Error(t, err, "external auth should have been deleted")
 			},
 		},
 		{
-			name: "external auth still exists keeps operation pending",
-			setupMock: func(ctrl *gomock.Controller, fixture *externalAuthTestFixture) ocm.ClusterServiceClientSpec {
+			name:                 "legacy approach: external auth still exists in cluster service keeps operation accepted",
+			existingExternalAuth: fixture.newExternalAuth(),
+			setupCSMock: func(ctrl *gomock.Controller, fixture *externalAuthTestFixture) ocm.ClusterServiceClientSpec {
 				mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
 				externalAuth, _ := arohcpv1alpha1.NewExternalAuth().
 					ID(testExternalAuthIDStr).
@@ -76,37 +220,36 @@ func TestOperationExternalAuthDelete_SynchronizeOperation(t *testing.T) {
 					Return(externalAuth, nil)
 				return mockCSClient
 			},
-			expectError: false,
-			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *externalAuthTestFixture) {
-				// When external auth still exists, operation stays at Accepted
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
-
-				// External auth should still exist
-				externalAuth, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).ExternalAuth(testClusterName).Get(ctx, testExternalAuthName)
-				require.NoError(t, err)
-				assert.NotNil(t, externalAuth)
 			},
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
-			ctx = utils.ContextWithLogger(ctx, testr.New(t))
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
-			fixture := newExternalAuthTestFixture()
-			cluster := fixture.newCluster()
-			externalAuth := fixture.newExternalAuth()
 			operation := fixture.newOperation(database.OperationRequestDelete)
+			// TODO remove this once the new deletion approach is fully rolled out in all ARO-HCP permanent environments, for all regions.
+			operation.UsesNewExternalAuthDeletionApproach = tc.usesNewExternalAuthDeletionApproach
 
-			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, []any{cluster, externalAuth, operation})
+			resources := []any{fixture.newCluster(), operation}
+			if tc.existingExternalAuth != nil {
+				resources = append(resources, tc.existingExternalAuth)
+			}
+
+			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, resources)
 			require.NoError(t, err)
 
-			mockCSClient := tt.setupMock(ctrl, fixture)
+			var mockCSClient ocm.ClusterServiceClientSpec
+			if tc.setupCSMock != nil {
+				mockCSClient = tc.setupCSMock(ctrl, fixture)
+			}
 
 			controller := &operationExternalAuthDelete{
 				clock:                utilsclock.RealClock{},
@@ -116,15 +259,14 @@ func TestOperationExternalAuthDelete_SynchronizeOperation(t *testing.T) {
 			}
 
 			err = controller.SynchronizeOperation(ctx, fixture.operationKey())
-
-			if tt.expectError {
+			if tc.wantErr {
 				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
+				return
 			}
+			require.NoError(t, err)
 
-			if tt.verify != nil {
-				tt.verify(t, ctx, mockResourcesDBClient, fixture)
+			if tc.verifyDB != nil {
+				tc.verifyDB(t, ctx, mockResourcesDBClient)
 			}
 		})
 	}

--- a/backend/pkg/controllers/operationcontrollers/utils.go
+++ b/backend/pkg/controllers/operationcontrollers/utils.go
@@ -61,6 +61,16 @@ const (
 	NodePoolStateError            NodePoolStateValue = "error"
 )
 
+// Copied from uhc-clusters-service, because the
+// OCM SDK does not define this for some reason.
+type ExternalAuthStateValue string
+
+const (
+	ExternalAuthStateReady        ExternalAuthStateValue = "ready"
+	ExternalAuthStateUninstalling ExternalAuthStateValue = "uninstalling"
+	ExternalAuthStateError        ExternalAuthStateValue = "error"
+)
+
 // UpdateOperationStatus updates Cosmos DB to reflect an updated resource status.
 // If the operation has an associated resource, both documents are updated
 // atomically using a transactional batch to prevent a window where the
@@ -556,6 +566,32 @@ func convertNodePoolStatus(operation *api.Operation, nodePoolStatus *arohcpv1alp
 		err = fmt.Errorf("unhandled NodePoolState '%s'", state)
 	}
 
+	return newOperationStatus, opError, err
+}
+
+func convertExternalAuthStatus(operation *api.Operation, externalAuthStatus *arohcpv1alpha1.ExternalAuthStatus) (arm.ProvisioningState, *arm.CloudErrorBody, error) {
+	var newOperationStatus = operation.Status
+	var opError *arm.CloudErrorBody
+	var err error
+
+	switch state := ExternalAuthStateValue(externalAuthStatus.State().Value()); state {
+	case ExternalAuthStateReady:
+		if operation.Request != database.OperationRequestDelete {
+			newOperationStatus = arm.ProvisioningStateSucceeded
+		}
+	case ExternalAuthStateError:
+		// XXX OCM SDK offers no error code or message for failed externalauth
+		//     operations so "Internal Server Error" is all we can do for now.
+		newOperationStatus = arm.ProvisioningStateFailed
+		opError = arm.NewInternalServerError().CloudErrorBody
+		if msg, ok := externalAuthStatus.GetMessage(); ok {
+			opError.Message = msg
+		}
+	case ExternalAuthStateUninstalling:
+		newOperationStatus = arm.ProvisioningStateDeleting
+	default:
+		err = fmt.Errorf("unhandled ExternalAuthState '%s'", state)
+	}
 	return newOperationStatus, opError, err
 }
 


### PR DESCRIPTION
The backend logic to perform asynchronous external auth deletion is disabled for now: all new controllers and the updated external auth delete operation controller branch on UsesNewExternalAuthDeletionApproach, which is not set by the frontend yet. Legacy synchronous deletion behavior is preserved via legacySynchronizeOperation in operation_externa_auth_delete.

Changes:
- Add ExternalAuthClusterServiceDeleteDispatchController to call Cluster Service DeleteExternalAuth after DeletionTimestamp is set. It also stamps ClusterServiceDeletionTimestamp
- Add ExternalAuthClusterServiceIDClearerController to clear ClusterServiceID once from the ExternalAuth's serviceProviderProperties when Cluster Service reports the external auth is gone
- Add ExternalAuthChildResourcesCleanupController to recursively delete Cosmos child resources under the external auth, and ignoring controllers documents
- Add ExternalAuthDeletionController to delete the External Auth Cosmos document once CS cleanup and child resources cleanup are completed
- Update OperationExternalAuthDeleteController to complete operations when the ExternalAuth Cosmos document is removed (new path), as well as keep CS polling to update the externalauth delete operation and the externalauth delete status from CS state. The controller also keeps the legacy external auth delete operation controller behavior by branching depending on UsesNewExternalAuthDeletionApproach
- Block cluster Cosmos deletion in OperationClusterDeleteController until all external auth documents are removed

<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

### Why

<!-- Briefly explain why this change is needed -->

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
