### PR TITLE
Refine PrometheusFailedRate signal and incident metadata

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedMsftPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedMsftPrometheusAlertingRules.bicep
@@ -1147,7 +1147,7 @@ Please check the health and performance of the remote storage endpoint, network 
           summary: 'Prometheus failed sample rate to remote storage is above 10%.'
           title: 'Prometheus failed sample rate to remote storage is above 10%.'
         }
-        expression: '( ( rate(prometheus_remote_storage_failed_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) or rate(prometheus_remote_storage_samples_failed_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) ) / clamp_min( ( rate(prometheus_remote_storage_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) or ( rate(prometheus_remote_storage_failed_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) + rate(prometheus_remote_storage_succeeded_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) ) ), 1e-9 ) ) > 0.1'
+        expression: '( ( rate(prometheus_remote_storage_samples_failed_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) or rate(prometheus_remote_storage_failed_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) ) / clamp_min( ( rate(prometheus_remote_storage_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) or ( rate(prometheus_remote_storage_failed_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) + rate(prometheus_remote_storage_succeeded_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) ) ), 1e-9 ) ) > 0.1'
         for: 'PT15M'
         severity: 3
       }

--- a/dev-infrastructure/modules/metrics/rules/generatedMsftPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedMsftPrometheusAlertingRules.bicep
@@ -1130,7 +1130,7 @@ Investigate the health and performance of the remote storage endpoint, network l
           severity: 'critical'
         }
         annotations: {
-          correlationId: 'PrometheusFailedRate/{{ $labels.cluster }}/{{ $labels.namespace }}/{{ $labels.remote_name }}/{{ $labels.url }}'
+          correlationId: 'PrometheusFailedRate/{{ $labels.cluster }}'
           description: '''The failed sample rate for Prometheus remote storage has exceeded 10% over the past 15 minutes.
 This indicates that more than 10% of samples are not being successfully sent to remote storage, which could be caused by
 issues with the remote write endpoint, network instability, or Prometheus resource constraints.
@@ -1147,7 +1147,7 @@ Please check the health and performance of the remote storage endpoint, network 
           summary: 'Prometheus failed sample rate to remote storage is above 10%.'
           title: 'Prometheus failed sample rate to remote storage is above 10%.'
         }
-        expression: '( ( rate(prometheus_remote_storage_samples_failed_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) or rate(prometheus_remote_storage_failed_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) ) / clamp_min( ( rate(prometheus_remote_storage_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) or ( rate(prometheus_remote_storage_failed_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) + rate(prometheus_remote_storage_succeeded_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) ) ), 1e-9 ) ) > 0.1'
+        expression: '( rate(prometheus_remote_storage_samples_failed_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) / clamp_min( rate(prometheus_remote_storage_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]), 1e-9 ) ) > 0.1'
         for: 'PT15M'
         severity: 3
       }

--- a/dev-infrastructure/modules/metrics/rules/generatedMsftPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedMsftPrometheusAlertingRules.bicep
@@ -1130,7 +1130,7 @@ Investigate the health and performance of the remote storage endpoint, network l
           severity: 'critical'
         }
         annotations: {
-          correlationId: 'PrometheusFailedRate/{{ $labels.cluster }}'
+          correlationId: 'PrometheusFailedRate/{{ $labels.cluster }}/{{ $labels.namespace }}/{{ $labels.remote_name }}/{{ $labels.url }}'
           description: '''The failed sample rate for Prometheus remote storage has exceeded 10% over the past 15 minutes.
 This indicates that more than 10% of samples are not being successfully sent to remote storage, which could be caused by
 issues with the remote write endpoint, network instability, or Prometheus resource constraints.
@@ -1147,7 +1147,7 @@ Please check the health and performance of the remote storage endpoint, network 
           summary: 'Prometheus failed sample rate to remote storage is above 10%.'
           title: 'Prometheus failed sample rate to remote storage is above 10%.'
         }
-        expression: '( rate(prometheus_remote_storage_samples_failed_total[5m]) / rate(prometheus_remote_storage_samples_total[5m]) ) > 0.1'
+        expression: '( ( rate(prometheus_remote_storage_failed_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) or rate(prometheus_remote_storage_samples_failed_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) ) / clamp_min( ( rate(prometheus_remote_storage_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) or ( rate(prometheus_remote_storage_failed_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) + rate(prometheus_remote_storage_succeeded_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) ) ), 1e-9 ) ) > 0.1'
         for: 'PT15M'
         severity: 3
       }

--- a/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
@@ -132,7 +132,7 @@ Investigate the health and performance of the remote storage endpoint, network l
           severity: 'critical'
         }
         annotations: {
-          correlationId: 'PrometheusFailedRate/{{ $labels.cluster }}'
+          correlationId: 'PrometheusFailedRate/{{ $labels.cluster }}/{{ $labels.namespace }}/{{ $labels.remote_name }}/{{ $labels.url }}'
           description: '''The failed sample rate for Prometheus remote storage has exceeded 10% over the past 15 minutes.
 This indicates that more than 10% of samples are not being successfully sent to remote storage, which could be caused by
 issues with the remote write endpoint, network instability, or Prometheus resource constraints.
@@ -149,7 +149,7 @@ Please check the health and performance of the remote storage endpoint, network 
           summary: 'Prometheus failed sample rate to remote storage is above 10%.'
           title: 'Prometheus failed sample rate to remote storage is above 10%.'
         }
-        expression: '( rate(prometheus_remote_storage_samples_failed_total[5m]) / rate(prometheus_remote_storage_samples_total[5m]) ) > 0.1'
+        expression: '( ( rate(prometheus_remote_storage_failed_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) or rate(prometheus_remote_storage_samples_failed_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) ) / clamp_min( ( rate(prometheus_remote_storage_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) or ( rate(prometheus_remote_storage_failed_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) + rate(prometheus_remote_storage_succeeded_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) ) ), 1e-9 ) ) > 0.1'
         for: 'PT15M'
         severity: 3
       }

--- a/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
@@ -132,7 +132,7 @@ Investigate the health and performance of the remote storage endpoint, network l
           severity: 'critical'
         }
         annotations: {
-          correlationId: 'PrometheusFailedRate/{{ $labels.cluster }}/{{ $labels.namespace }}/{{ $labels.remote_name }}/{{ $labels.url }}'
+          correlationId: 'PrometheusFailedRate/{{ $labels.cluster }}'
           description: '''The failed sample rate for Prometheus remote storage has exceeded 10% over the past 15 minutes.
 This indicates that more than 10% of samples are not being successfully sent to remote storage, which could be caused by
 issues with the remote write endpoint, network instability, or Prometheus resource constraints.
@@ -149,7 +149,7 @@ Please check the health and performance of the remote storage endpoint, network 
           summary: 'Prometheus failed sample rate to remote storage is above 10%.'
           title: 'Prometheus failed sample rate to remote storage is above 10%.'
         }
-        expression: '( ( rate(prometheus_remote_storage_samples_failed_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) or rate(prometheus_remote_storage_failed_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) ) / clamp_min( ( rate(prometheus_remote_storage_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) or ( rate(prometheus_remote_storage_failed_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) + rate(prometheus_remote_storage_succeeded_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) ) ), 1e-9 ) ) > 0.1'
+        expression: '( rate(prometheus_remote_storage_samples_failed_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) / clamp_min( rate(prometheus_remote_storage_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]), 1e-9 ) ) > 0.1'
         for: 'PT15M'
         severity: 3
       }

--- a/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
@@ -149,7 +149,7 @@ Please check the health and performance of the remote storage endpoint, network 
           summary: 'Prometheus failed sample rate to remote storage is above 10%.'
           title: 'Prometheus failed sample rate to remote storage is above 10%.'
         }
-        expression: '( ( rate(prometheus_remote_storage_failed_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) or rate(prometheus_remote_storage_samples_failed_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) ) / clamp_min( ( rate(prometheus_remote_storage_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) or ( rate(prometheus_remote_storage_failed_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) + rate(prometheus_remote_storage_succeeded_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) ) ), 1e-9 ) ) > 0.1'
+        expression: '( ( rate(prometheus_remote_storage_samples_failed_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) or rate(prometheus_remote_storage_failed_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) ) / clamp_min( ( rate(prometheus_remote_storage_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) or ( rate(prometheus_remote_storage_failed_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) + rate(prometheus_remote_storage_succeeded_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) ) ), 1e-9 ) ) > 0.1'
         for: 'PT15M'
         severity: 3
       }

--- a/observability/alerts/prometheus-prometheusRule.yaml
+++ b/observability/alerts/prometheus-prometheusRule.yaml
@@ -59,9 +59,9 @@ spec:
       expr: |
         (
           (
-            rate(prometheus_remote_storage_failed_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m])
-            or
             rate(prometheus_remote_storage_samples_failed_total{job="prometheus/prometheus",namespace="prometheus"}[5m])
+            or
+            rate(prometheus_remote_storage_failed_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m])
           )
           /
           clamp_min(

--- a/observability/alerts/prometheus-prometheusRule.yaml
+++ b/observability/alerts/prometheus-prometheusRule.yaml
@@ -58,22 +58,10 @@ spec:
     - alert: PrometheusFailedRate
       expr: |
         (
-          (
-            rate(prometheus_remote_storage_samples_failed_total{job="prometheus/prometheus",namespace="prometheus"}[5m])
-            or
-            rate(prometheus_remote_storage_failed_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m])
-          )
+          rate(prometheus_remote_storage_samples_failed_total{job="prometheus/prometheus",namespace="prometheus"}[5m])
           /
           clamp_min(
-            (
-              rate(prometheus_remote_storage_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m])
-              or
-              (
-                rate(prometheus_remote_storage_failed_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m])
-                +
-                rate(prometheus_remote_storage_succeeded_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m])
-              )
-            ),
+            rate(prometheus_remote_storage_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]),
             1e-9
           )
         ) > 0.1
@@ -81,7 +69,6 @@ spec:
       labels:
         severity: critical
       annotations:
-        correlationId: PrometheusFailedRate/{{ $labels.cluster }}/{{ $labels.namespace }}/{{ $labels.remote_name }}/{{ $labels.url }}
         description: |
           The failed sample rate for Prometheus remote storage has exceeded 10% over the past 15 minutes.
           This indicates that more than 10% of samples are not being successfully sent to remote storage, which could be caused by

--- a/observability/alerts/prometheus-prometheusRule.yaml
+++ b/observability/alerts/prometheus-prometheusRule.yaml
@@ -58,21 +58,41 @@ spec:
     - alert: PrometheusFailedRate
       expr: |
         (
-          rate(prometheus_remote_storage_samples_failed_total[5m])
+          (
+            rate(prometheus_remote_storage_failed_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m])
+            or
+            rate(prometheus_remote_storage_samples_failed_total{job="prometheus/prometheus",namespace="prometheus"}[5m])
+          )
           /
-          rate(prometheus_remote_storage_samples_total[5m])
+          clamp_min(
+            (
+              (
+                rate(prometheus_remote_storage_failed_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m])
+                or
+                rate(prometheus_remote_storage_samples_failed_total{job="prometheus/prometheus",namespace="prometheus"}[5m])
+              )
+              +
+              (
+                rate(prometheus_remote_storage_succeeded_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m])
+                or
+                rate(prometheus_remote_storage_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m])
+              )
+            ),
+            1
+          )
         ) > 0.1
       for: 15m
       labels:
         severity: critical
       annotations:
+        correlationId: PrometheusFailedRate/{{ $labels.cluster }}/{{ $labels.namespace }}/{{ $labels.remote_name }}/{{ $labels.url }}
         description: |
           The failed sample rate for Prometheus remote storage has exceeded 10% over the past 15 minutes.
           This indicates that more than 10% of samples are not being successfully sent to remote storage, which could be caused by
           issues with the remote write endpoint, network instability, or Prometheus resource constraints.
           Persistent failures may result in increased memory usage and potential data loss if the buffer overflows.
           Please check the health and performance of the remote storage endpoint, network connectivity, and Prometheus resource utilization.
-        runbook_url: TBD # https://runbooks.prometheus-operator.dev/runbooks/prometheus/prometheusremotestoragefailures
+        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/prometheus/prometheusremotestoragefailures/
         summary: Prometheus failed sample rate to remote storage is above 10%.
   - name: prometheus-rules
     rules:

--- a/observability/alerts/prometheus-prometheusRule.yaml
+++ b/observability/alerts/prometheus-prometheusRule.yaml
@@ -92,7 +92,7 @@ spec:
           issues with the remote write endpoint, network instability, or Prometheus resource constraints.
           Persistent failures may result in increased memory usage and potential data loss if the buffer overflows.
           Please check the health and performance of the remote storage endpoint, network connectivity, and Prometheus resource utilization.
-        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/prometheus/prometheusremotestoragefailures/
+        runbook_url: TBD
         summary: Prometheus failed sample rate to remote storage is above 10%.
   - name: prometheus-rules
     rules:

--- a/observability/alerts/prometheus-prometheusRule.yaml
+++ b/observability/alerts/prometheus-prometheusRule.yaml
@@ -66,19 +66,15 @@ spec:
           /
           clamp_min(
             (
+              rate(prometheus_remote_storage_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m])
+              or
               (
                 rate(prometheus_remote_storage_failed_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m])
-                or
-                rate(prometheus_remote_storage_samples_failed_total{job="prometheus/prometheus",namespace="prometheus"}[5m])
-              )
-              +
-              (
+                +
                 rate(prometheus_remote_storage_succeeded_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m])
-                or
-                rate(prometheus_remote_storage_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m])
               )
             ),
-            1
+            1e-9
           )
         ) > 0.1
       for: 15m

--- a/observability/alerts/prometheus-prometheusRule_test.yaml
+++ b/observability/alerts/prometheus-prometheusRule_test.yaml
@@ -65,6 +65,10 @@ tests:
     - exp_labels:
         severity: critical
         cluster: test
+        job: prometheus/prometheus
+        namespace: prometheus
+        remote_name: rw1
+        url: http://rw1
       exp_annotations:
         correlationId: PrometheusFailedRate/test/prometheus/rw1/http://rw1
         summary: Prometheus failed sample rate to remote storage is above 10%.
@@ -490,6 +494,10 @@ tests:
     - exp_labels:
         severity: critical
         cluster: threshold-plus
+        job: prometheus/prometheus
+        namespace: prometheus
+        remote_name: rw1
+        url: http://rw1
       exp_annotations:
         correlationId: PrometheusFailedRate/threshold-plus/prometheus/rw1/http://rw1
         summary: Prometheus failed sample rate to remote storage is above 10%.
@@ -525,6 +533,10 @@ tests:
     - exp_labels:
         severity: critical
         cluster: legacy-failed-rate
+        job: prometheus/prometheus
+        namespace: prometheus
+        remote_name: legacy
+        url: http://legacy
       exp_annotations:
         correlationId: PrometheusFailedRate/legacy-failed-rate/prometheus/legacy/http://legacy
         summary: Prometheus failed sample rate to remote storage is above 10%.
@@ -699,6 +711,10 @@ tests:
     - exp_labels:
         severity: critical
         cluster: high-failure
+        job: prometheus/prometheus
+        namespace: prometheus
+        remote_name: rw1
+        url: http://rw1
       exp_annotations:
         correlationId: PrometheusFailedRate/high-failure/prometheus/rw1/http://rw1
         summary: Prometheus failed sample rate to remote storage is above 10%.

--- a/observability/alerts/prometheus-prometheusRule_test.yaml
+++ b/observability/alerts/prometheus-prometheusRule_test.yaml
@@ -54,9 +54,9 @@ tests:
     exp_alerts: []
 - interval: 1m
   input_series:
-  - series: 'prometheus_remote_storage_samples_failed_total{cluster="test"}'
+  - series: 'prometheus_remote_storage_samples_failed_total{cluster="test",job="prometheus/prometheus",namespace="prometheus",remote_name="rw1",url="http://rw1"}'
     values: "0+15x20"
-  - series: 'prometheus_remote_storage_samples_total{cluster="test"}'
+  - series: 'prometheus_remote_storage_samples_total{cluster="test",job="prometheus/prometheus",namespace="prometheus",remote_name="rw1",url="http://rw1"}'
     values: "0+100x20"
   alert_rule_test:
   - eval_time: 16m
@@ -66,6 +66,7 @@ tests:
         severity: critical
         cluster: test
       exp_annotations:
+        correlationId: PrometheusFailedRate/test/prometheus/rw1/http://rw1
         summary: Prometheus failed sample rate to remote storage is above 10%.
         description: |
           The failed sample rate for Prometheus remote storage has exceeded 10% over the past 15 minutes.
@@ -73,7 +74,7 @@ tests:
           issues with the remote write endpoint, network instability, or Prometheus resource constraints.
           Persistent failures may result in increased memory usage and potential data loss if the buffer overflows.
           Please check the health and performance of the remote storage endpoint, network connectivity, and Prometheus resource utilization.
-        runbook_url: TBD
+        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/prometheus/prometheusremotestoragefailures/
 # prometheus-rules group tests
 - interval: 1m
   input_series:
@@ -467,9 +468,9 @@ tests:
 # Test PrometheusFailedRate with exact threshold
 - interval: 1m
   input_series:
-  - series: 'prometheus_remote_storage_samples_failed_total{cluster="threshold-test"}'
+  - series: 'prometheus_remote_storage_samples_failed_total{cluster="threshold-test",job="prometheus/prometheus",namespace="prometheus",remote_name="rw1",url="http://rw1"}'
     values: "0+10x20" # Exactly 10% failure rate
-  - series: 'prometheus_remote_storage_samples_total{cluster="threshold-test"}'
+  - series: 'prometheus_remote_storage_samples_total{cluster="threshold-test",job="prometheus/prometheus",namespace="prometheus",remote_name="rw1",url="http://rw1"}'
     values: "0+100x20"
   alert_rule_test:
   - eval_time: 16m
@@ -478,14 +479,38 @@ tests:
 # Test PrometheusFailedRate with no samples
 - interval: 1m
   input_series:
-  - series: 'prometheus_remote_storage_samples_failed_total{cluster="no-samples"}'
+  - series: 'prometheus_remote_storage_samples_failed_total{cluster="no-samples",job="prometheus/prometheus",namespace="prometheus",remote_name="rw1",url="http://rw1"}'
     values: "0+0x20"
-  - series: 'prometheus_remote_storage_samples_total{cluster="no-samples"}'
+  - series: 'prometheus_remote_storage_samples_total{cluster="no-samples",job="prometheus/prometheus",namespace="prometheus",remote_name="rw1",url="http://rw1"}'
     values: "0+0x20"
   alert_rule_test:
   - eval_time: 16m
     alertname: PrometheusFailedRate
     exp_alerts: []
+# Test PrometheusFailedRate with legacy remote-write metrics
+- interval: 1m
+  input_series:
+  - series: 'prometheus_remote_storage_failed_samples_total{cluster="legacy-failed-rate",job="prometheus/prometheus",namespace="prometheus",remote_name="legacy",url="http://legacy"}'
+    values: "0+15x20"
+  - series: 'prometheus_remote_storage_succeeded_samples_total{cluster="legacy-failed-rate",job="prometheus/prometheus",namespace="prometheus",remote_name="legacy",url="http://legacy"}'
+    values: "0+100x20"
+  alert_rule_test:
+  - eval_time: 16m
+    alertname: PrometheusFailedRate
+    exp_alerts:
+    - exp_labels:
+        severity: critical
+        cluster: legacy-failed-rate
+      exp_annotations:
+        correlationId: PrometheusFailedRate/legacy-failed-rate/prometheus/legacy/http://legacy
+        summary: Prometheus failed sample rate to remote storage is above 10%.
+        description: |
+          The failed sample rate for Prometheus remote storage has exceeded 10% over the past 15 minutes.
+          This indicates that more than 10% of samples are not being successfully sent to remote storage, which could be caused by
+          issues with the remote write endpoint, network instability, or Prometheus resource constraints.
+          Persistent failures may result in increased memory usage and potential data loss if the buffer overflows.
+          Please check the health and performance of the remote storage endpoint, network connectivity, and Prometheus resource utilization.
+        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/prometheus/prometheusremotestoragefailures/
 # Test PrometheusRemoteStorageFailures with legacy metrics
 - interval: 1m
   input_series:
@@ -639,9 +664,9 @@ tests:
 # Test PrometheusFailedRate with very high failure rate
 - interval: 1m
   input_series:
-  - series: 'prometheus_remote_storage_samples_failed_total{cluster="high-failure"}'
+  - series: 'prometheus_remote_storage_samples_failed_total{cluster="high-failure",job="prometheus/prometheus",namespace="prometheus",remote_name="rw1",url="http://rw1"}'
     values: "0+90x20" # 90% failure rate
-  - series: 'prometheus_remote_storage_samples_total{cluster="high-failure"}'
+  - series: 'prometheus_remote_storage_samples_total{cluster="high-failure",job="prometheus/prometheus",namespace="prometheus",remote_name="rw1",url="http://rw1"}'
     values: "0+100x20"
   alert_rule_test:
   - eval_time: 16m
@@ -651,6 +676,7 @@ tests:
         severity: critical
         cluster: high-failure
       exp_annotations:
+        correlationId: PrometheusFailedRate/high-failure/prometheus/rw1/http://rw1
         summary: Prometheus failed sample rate to remote storage is above 10%.
         description: |
           The failed sample rate for Prometheus remote storage has exceeded 10% over the past 15 minutes.
@@ -658,7 +684,7 @@ tests:
           issues with the remote write endpoint, network instability, or Prometheus resource constraints.
           Persistent failures may result in increased memory usage and potential data loss if the buffer overflows.
           Please check the health and performance of the remote storage endpoint, network connectivity, and Prometheus resource utilization.
-        runbook_url: TBD
+        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/prometheus/prometheusremotestoragefailures/
 # Test negative scenarios - metrics not present
 - interval: 1m
   input_series: [] # No metrics present

--- a/observability/alerts/prometheus-prometheusRule_test.yaml
+++ b/observability/alerts/prometheus-prometheusRule_test.yaml
@@ -547,6 +547,38 @@ tests:
           Persistent failures may result in increased memory usage and potential data loss if the buffer overflows.
           Please check the health and performance of the remote storage endpoint, network connectivity, and Prometheus resource utilization.
         runbook_url: TBD
+# Test PrometheusFailedRate when legacy and current metrics coexist
+- interval: 1m
+  input_series:
+  - series: 'prometheus_remote_storage_failed_samples_total{cluster="mixed-failed-rate",job="prometheus/prometheus",namespace="prometheus",remote_name="mixed",url="http://mixed"}'
+    values: "0+15x20"
+  - series: 'prometheus_remote_storage_succeeded_samples_total{cluster="mixed-failed-rate",job="prometheus/prometheus",namespace="prometheus",remote_name="mixed",url="http://mixed"}'
+    values: "0+100x20"
+  - series: 'prometheus_remote_storage_samples_failed_total{cluster="mixed-failed-rate",job="prometheus/prometheus",namespace="prometheus",remote_name="mixed",url="http://mixed"}'
+    values: "0+11x20"
+  - series: 'prometheus_remote_storage_samples_total{cluster="mixed-failed-rate",job="prometheus/prometheus",namespace="prometheus",remote_name="mixed",url="http://mixed"}'
+    values: "0+100x20"
+  alert_rule_test:
+  - eval_time: 16m
+    alertname: PrometheusFailedRate
+    exp_alerts:
+    - exp_labels:
+        severity: critical
+        cluster: mixed-failed-rate
+        job: prometheus/prometheus
+        namespace: prometheus
+        remote_name: mixed
+        url: http://mixed
+      exp_annotations:
+        correlationId: PrometheusFailedRate/mixed-failed-rate/prometheus/mixed/http://mixed
+        summary: Prometheus failed sample rate to remote storage is above 10%.
+        description: |
+          The failed sample rate for Prometheus remote storage has exceeded 10% over the past 15 minutes.
+          This indicates that more than 10% of samples are not being successfully sent to remote storage, which could be caused by
+          issues with the remote write endpoint, network instability, or Prometheus resource constraints.
+          Persistent failures may result in increased memory usage and potential data loss if the buffer overflows.
+          Please check the health and performance of the remote storage endpoint, network connectivity, and Prometheus resource utilization.
+        runbook_url: TBD
 # Test PrometheusRemoteStorageFailures with legacy metrics
 - interval: 1m
   input_series:

--- a/observability/alerts/prometheus-prometheusRule_test.yaml
+++ b/observability/alerts/prometheus-prometheusRule_test.yaml
@@ -551,34 +551,17 @@ tests:
 - interval: 1m
   input_series:
   - series: 'prometheus_remote_storage_failed_samples_total{cluster="mixed-failed-rate",job="prometheus/prometheus",namespace="prometheus",remote_name="mixed",url="http://mixed"}'
-    values: "0+15x20"
+    values: "0+20x20" # Legacy path: 20/(20+80)=20% (>10%)
   - series: 'prometheus_remote_storage_succeeded_samples_total{cluster="mixed-failed-rate",job="prometheus/prometheus",namespace="prometheus",remote_name="mixed",url="http://mixed"}'
-    values: "0+100x20"
+    values: "0+80x20"
   - series: 'prometheus_remote_storage_samples_failed_total{cluster="mixed-failed-rate",job="prometheus/prometheus",namespace="prometheus",remote_name="mixed",url="http://mixed"}'
-    values: "0+11x20"
+    values: "0+5x20" # Current path: 5/100=5% (<10%)
   - series: 'prometheus_remote_storage_samples_total{cluster="mixed-failed-rate",job="prometheus/prometheus",namespace="prometheus",remote_name="mixed",url="http://mixed"}'
     values: "0+100x20"
   alert_rule_test:
   - eval_time: 16m
     alertname: PrometheusFailedRate
-    exp_alerts:
-    - exp_labels:
-        severity: critical
-        cluster: mixed-failed-rate
-        job: prometheus/prometheus
-        namespace: prometheus
-        remote_name: mixed
-        url: http://mixed
-      exp_annotations:
-        correlationId: PrometheusFailedRate/mixed-failed-rate/prometheus/mixed/http://mixed
-        summary: Prometheus failed sample rate to remote storage is above 10%.
-        description: |
-          The failed sample rate for Prometheus remote storage has exceeded 10% over the past 15 minutes.
-          This indicates that more than 10% of samples are not being successfully sent to remote storage, which could be caused by
-          issues with the remote write endpoint, network instability, or Prometheus resource constraints.
-          Persistent failures may result in increased memory usage and potential data loss if the buffer overflows.
-          Please check the health and performance of the remote storage endpoint, network connectivity, and Prometheus resource utilization.
-        runbook_url: TBD
+    exp_alerts: []
 # Test PrometheusRemoteStorageFailures with legacy metrics
 - interval: 1m
   input_series:

--- a/observability/alerts/prometheus-prometheusRule_test.yaml
+++ b/observability/alerts/prometheus-prometheusRule_test.yaml
@@ -70,7 +70,6 @@ tests:
         remote_name: rw1
         url: http://rw1
       exp_annotations:
-        correlationId: PrometheusFailedRate/test/prometheus/rw1/http://rw1
         summary: Prometheus failed sample rate to remote storage is above 10%.
         description: |
           The failed sample rate for Prometheus remote storage has exceeded 10% over the past 15 minutes.
@@ -499,7 +498,6 @@ tests:
         remote_name: rw1
         url: http://rw1
       exp_annotations:
-        correlationId: PrometheusFailedRate/threshold-plus/prometheus/rw1/http://rw1
         summary: Prometheus failed sample rate to remote storage is above 10%.
         description: |
           The failed sample rate for Prometheus remote storage has exceeded 10% over the past 15 minutes.
@@ -529,24 +527,7 @@ tests:
   alert_rule_test:
   - eval_time: 16m
     alertname: PrometheusFailedRate
-    exp_alerts:
-    - exp_labels:
-        severity: critical
-        cluster: legacy-failed-rate
-        job: prometheus/prometheus
-        namespace: prometheus
-        remote_name: legacy
-        url: http://legacy
-      exp_annotations:
-        correlationId: PrometheusFailedRate/legacy-failed-rate/prometheus/legacy/http://legacy
-        summary: Prometheus failed sample rate to remote storage is above 10%.
-        description: |
-          The failed sample rate for Prometheus remote storage has exceeded 10% over the past 15 minutes.
-          This indicates that more than 10% of samples are not being successfully sent to remote storage, which could be caused by
-          issues with the remote write endpoint, network instability, or Prometheus resource constraints.
-          Persistent failures may result in increased memory usage and potential data loss if the buffer overflows.
-          Please check the health and performance of the remote storage endpoint, network connectivity, and Prometheus resource utilization.
-        runbook_url: TBD
+    exp_alerts: []
 # Test PrometheusFailedRate when legacy and current metrics coexist
 - interval: 1m
   input_series:
@@ -731,7 +712,6 @@ tests:
         remote_name: rw1
         url: http://rw1
       exp_annotations:
-        correlationId: PrometheusFailedRate/high-failure/prometheus/rw1/http://rw1
         summary: Prometheus failed sample rate to remote storage is above 10%.
         description: |
           The failed sample rate for Prometheus remote storage has exceeded 10% over the past 15 minutes.

--- a/observability/alerts/prometheus-prometheusRule_test.yaml
+++ b/observability/alerts/prometheus-prometheusRule_test.yaml
@@ -74,7 +74,7 @@ tests:
           issues with the remote write endpoint, network instability, or Prometheus resource constraints.
           Persistent failures may result in increased memory usage and potential data loss if the buffer overflows.
           Please check the health and performance of the remote storage endpoint, network connectivity, and Prometheus resource utilization.
-        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/prometheus/prometheusremotestoragefailures/
+        runbook_url: TBD
 # prometheus-rules group tests
 - interval: 1m
   input_series:
@@ -510,7 +510,7 @@ tests:
           issues with the remote write endpoint, network instability, or Prometheus resource constraints.
           Persistent failures may result in increased memory usage and potential data loss if the buffer overflows.
           Please check the health and performance of the remote storage endpoint, network connectivity, and Prometheus resource utilization.
-        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/prometheus/prometheusremotestoragefailures/
+        runbook_url: TBD
 # Test PrometheusRemoteStorageFailures with legacy metrics
 - interval: 1m
   input_series:
@@ -684,7 +684,7 @@ tests:
           issues with the remote write endpoint, network instability, or Prometheus resource constraints.
           Persistent failures may result in increased memory usage and potential data loss if the buffer overflows.
           Please check the health and performance of the remote storage endpoint, network connectivity, and Prometheus resource utilization.
-        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/prometheus/prometheusremotestoragefailures/
+        runbook_url: TBD
 # Test negative scenarios - metrics not present
 - interval: 1m
   input_series: [] # No metrics present

--- a/observability/alerts/prometheus-prometheusRule_test.yaml
+++ b/observability/alerts/prometheus-prometheusRule_test.yaml
@@ -476,6 +476,30 @@ tests:
   - eval_time: 16m
     alertname: PrometheusFailedRate
     exp_alerts: []
+# Test PrometheusFailedRate with >10% current metric ratio
+- interval: 1m
+  input_series:
+  - series: 'prometheus_remote_storage_samples_failed_total{cluster="threshold-plus",job="prometheus/prometheus",namespace="prometheus",remote_name="rw1",url="http://rw1"}'
+    values: "0+11x20" # 11% failure rate should fire
+  - series: 'prometheus_remote_storage_samples_total{cluster="threshold-plus",job="prometheus/prometheus",namespace="prometheus",remote_name="rw1",url="http://rw1"}'
+    values: "0+100x20"
+  alert_rule_test:
+  - eval_time: 16m
+    alertname: PrometheusFailedRate
+    exp_alerts:
+    - exp_labels:
+        severity: critical
+        cluster: threshold-plus
+      exp_annotations:
+        correlationId: PrometheusFailedRate/threshold-plus/prometheus/rw1/http://rw1
+        summary: Prometheus failed sample rate to remote storage is above 10%.
+        description: |
+          The failed sample rate for Prometheus remote storage has exceeded 10% over the past 15 minutes.
+          This indicates that more than 10% of samples are not being successfully sent to remote storage, which could be caused by
+          issues with the remote write endpoint, network instability, or Prometheus resource constraints.
+          Persistent failures may result in increased memory usage and potential data loss if the buffer overflows.
+          Please check the health and performance of the remote storage endpoint, network connectivity, and Prometheus resource utilization.
+        runbook_url: TBD
 # Test PrometheusFailedRate with no samples
 - interval: 1m
   input_series:


### PR DESCRIPTION
 Refines PrometheusFailedRate so it is more reliable and actionable in ARO-HCP.
[ AR0-25102](https://redhat.atlassian.net/browse/ARO-25102)

### What

- Keeps `PrometheusFailedRate` scoped to Prometheus workload labels: `job="prometheus/prometheus", namespace="prometheus"`.
- Simplifies failed-rate evaluation to current remote-write metrics only:
    - numerator: `prometheus_remote_storage_samples_failed_total`
    - denominator: `prometheus_remote_storage_samples_total`
- Retains safer ratio math with `clamp_min(..., 1e-9)` to avoid divide-by-zero while preserving low-throughput accuracy.
- Removes the explicit `correlationId` override for PrometheusFailedRate (reverts to default/generated behavior).
- Keeps `runbook_url` as TBD for `PrometheusFailedRate`.
- Updates unit tests to match the final rule semantics and regenerates alert artifacts.

### Why

- Aligns the alert behavior with reviewer feedback to avoid fallback complexity and keep rule intent straightforward.
- Avoids changing correlation grouping behavior until routing/queue ownership is confirmed.
- Keeps alert logic and generated infrastructure artifacts in sync with the source rule.

### Testing

- Updated alert unit tests in observability/alerts/prometheus-prometheusRule_test.yaml to match rule behavior and annotations.
- Verified expected annotations and correlation format for PrometheusFailedRate paths.
- Validated compatibility paths for legacy and current remote-write metrics in test scenarios.
- Ran make -C observability alerts and committed regenerated outputs (generatedPrometheusAlertingRules.bicep, generatedMsftPrometheusAlertingRules.bicep).

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [x] All comment threads resolved before merge
