### PR TITLE
feat: prepare internal api attributes related to async cluster deletion trigger in backend

### DIFF
--- a/frontend/pkg/frontend/cluster.go
+++ b/frontend/pkg/frontend/cluster.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/operation"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
 
@@ -784,6 +785,9 @@ func (f *Frontend) addDeleteClusterToTransaction(ctx context.Context, writer htt
 		return utils.TrackError(err)
 	}
 
+	if cluster.ServiceProviderProperties.DeletionTimestamp == nil {
+		cluster.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: time.Now().UTC()}
+	}
 	cluster.ServiceProviderProperties.ActiveOperationID = operationDoc.ResourceID.Name
 	cluster.ServiceProviderProperties.ProvisioningState = operationDoc.Status
 	_, err = f.resourcesDBClient.HCPClusters(cluster.ID.SubscriptionID, cluster.ID.ResourceGroupName).

--- a/internal/api/types_cluster.go
+++ b/internal/api/types_cluster.go
@@ -15,6 +15,8 @@
 package api
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
 	"github.com/Azure/ARO-HCP/internal/api/arm"
@@ -76,6 +78,27 @@ type HCPOpenShiftClusterServiceProviderProperties struct {
 	// associated with this cluster. It is set when the billing document is created
 	// and used to avoid redundant creation attempts.
 	BillingDocumentCosmosID string `json:"billingDocumentCosmosID,omitempty"`
+	// DeletionTimestamp is the timestamp at which the Cluster deletion was requested.
+	// The timestamp is in UTC.
+	// A nil value indicates that the Cluster deletion has not been requested.
+	DeletionTimestamp *metav1.Time `json:"deletionTimestamp,omitempty"`
+	// ClusterServiceDeletionTimestamp is written when a dispatch of a Cluster
+	// Service Delete Cluster request against Cluster Service for this cluster
+	// has been handled. It is set after a successful DeleteCluster call to
+	// Cluster Service, but also when it's determined that no delete call is
+	// needed but we consider we should behave as if the delete call was
+	// successfully issued.
+	// A nil value indicates that the Cluster Service Deletion has not been requested.
+	// The timestamp is in UTC.
+	// TODO this attribute is not in use yet. Do not rely on it.
+	ClusterServiceDeletionTimestamp *metav1.Time `json:"clusterServiceDeletionTimestamp,omitempty"`
+
+	// TODO Temporary field to track whether the cluster operation is using the new deletion approach.
+	// We are migrating from the cluster CS deletion synchronous in frontend to the backend, to be fully asynchronous.
+	// This boolean is true for Cluster delete operations that are created with new deletion approach.
+	// This will be removed once all clusters whose deletion was triggered before the new approach is fully rolled out have been
+	// fully deleted in all ARO-HCP permanent environments, for all regions.
+	UsesNewClusterDeletionApproach bool `json:"usesNewClusterDeletionApproach"`
 }
 
 // VersionProfile represents the cluster control plane version.

--- a/internal/api/types_operation.go
+++ b/internal/api/types_operation.go
@@ -84,6 +84,13 @@ type Operation struct {
 	// This will be removed once all external auths whose deletion was triggered before the new approach is fully rolled out have been
 	// fully deleted in all ARO-HCP permanent environments, for all regions.
 	UsesNewExternalAuthDeletionApproach bool `json:"usesNewExternalAuthDeletionApproach"`
+
+	// TODO Temporary field to track whether the cluster operation is using the new deletion approach.
+	// We are migrating from the cluster CS deletion synchronous in frontend to the backend, to be fully asynchronous.
+	// This boolean is true for Cluster delete operations that are created with new deletion approach.
+	// This will be removed once all clusters whose deletion was triggered before the new approach is fully rolled out have been
+	// fully deleted in all ARO-HCP permanent environments, for all regions.
+	UsesNewClusterDeletionApproach bool `json:"usesNewClusterDeletionApproach"`
 }
 
 func (o *Operation) ComputeLogicalResourceID() *azcorearm.ResourceID {

--- a/internal/api/v20240610preview/conversion_fuzz_test.go
+++ b/internal/api/v20240610preview/conversion_fuzz_test.go
@@ -72,6 +72,8 @@ func TestRoundTripInternalExternalInternal(t *testing.T) {
 			j.ClusterUID = ""
 			// BillingDocumentCosmosID does not roundtrip through the external type because it is purely an internal detail
 			j.BillingDocumentCosmosID = ""
+			// UsesNewClusterDeletionApproach does not roundtrip through the external type because it is purely an internal detail
+			j.UsesNewClusterDeletionApproach = false
 		},
 		func(j *api.HCPOpenShiftClusterNodePoolServiceProviderProperties, c randfill.Continue) {
 			c.FillNoCustom(j)

--- a/internal/api/v20251223preview/conversion_fuzz_test.go
+++ b/internal/api/v20251223preview/conversion_fuzz_test.go
@@ -70,6 +70,8 @@ func TestRoundTripInternalExternalInternal(t *testing.T) {
 			j.ClusterUID = ""
 			// BillingDocumentCosmosID does not roundtrip through the external type because it is purely an internal detail
 			j.BillingDocumentCosmosID = ""
+			// UsesNewClusterDeletionApproach does not roundtrip through the external type because it is purely an internal detail
+			j.UsesNewClusterDeletionApproach = false
 		},
 		func(j *api.HCPOpenShiftClusterNodePoolServiceProviderProperties, c randfill.Continue) {
 			c.FillNoCustom(j)

--- a/internal/api/zz_generated.deepcopy.go
+++ b/internal/api/zz_generated.deepcopy.go
@@ -801,6 +801,14 @@ func (in *HCPOpenShiftClusterServiceProviderProperties) DeepCopyInto(out *HCPOpe
 	out.API = in.API
 	out.Platform = in.Platform
 	out.ExperimentalFeatures = in.ExperimentalFeatures
+	if in.DeletionTimestamp != nil {
+		in, out := &in.DeletionTimestamp, &out.DeletionTimestamp
+		*out = (*in).DeepCopy()
+	}
+	if in.ClusterServiceDeletionTimestamp != nil {
+		in, out := &in.ClusterServiceDeletionTimestamp, &out.ClusterServiceDeletionTimestamp
+		*out = (*in).DeepCopy()
+	}
 	return
 }
 

--- a/test-integration/admin/artifacts/AdminCRUD/HCP/breakglass/00-load-initial-cosmos-state/01-cluster.json
+++ b/test-integration/admin/artifacts/AdminCRUD/HCP/breakglass/00-load-initial-cosmos-state/01-cluster.json
@@ -31,7 +31,8 @@
 				"name": "some-hcp-cluster",
 				"serviceProviderProperties": {
 					"clusterServiceID": "/api/aro_hcp/v1alpha1/clusters/fixed-value",
-					"provisioningState": "Succeeded"
+					"provisioningState": "Succeeded",
+					"usesNewClusterDeletionApproach": false
 				},
 				"tags": {
 					"foo": "bar"
@@ -43,7 +44,8 @@
 		"name": "some-hcp-cluster",
 		"serviceProviderProperties": {
 			"clusterServiceID": "/api/aro_hcp/v1alpha1/clusters/fixed-value",
-			"provisioningState": "Succeeded"
+			"provisioningState": "Succeeded",
+			"usesNewClusterDeletionApproach": false
 		},
 		"tags": {
 			"foo": "bar"

--- a/test-integration/admin/artifacts/AdminCRUD/HCP/cosmosdump/00-load-initial-cosmos-state/01-cluster.json
+++ b/test-integration/admin/artifacts/AdminCRUD/HCP/cosmosdump/00-load-initial-cosmos-state/01-cluster.json
@@ -36,7 +36,8 @@
 				"name": "some-hcp-cluster",
 				"serviceProviderProperties": {
 					"clusterServiceID": "/api/aro_hcp/v1alpha1/clusters/fixed-value",
-					"provisioningState": "Succeeded"
+					"provisioningState": "Succeeded",
+					"usesNewClusterDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -54,7 +55,8 @@
 		"name": "some-hcp-cluster",
 		"serviceProviderProperties": {
 			"clusterServiceID": "/api/aro_hcp/v1alpha1/clusters/fixed-value",
-			"provisioningState": "Succeeded"
+			"provisioningState": "Succeeded",
+			"usesNewClusterDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/admin/artifacts/AdminCRUD/HCP/hello-world/00-load-initial-cosmos-state/01-cluster.json
+++ b/test-integration/admin/artifacts/AdminCRUD/HCP/hello-world/00-load-initial-cosmos-state/01-cluster.json
@@ -36,7 +36,8 @@
 				"name": "some-hcp-cluster",
 				"serviceProviderProperties": {
 					"clusterServiceID": "/api/aro_hcp/v1alpha1/clusters/fixed-value",
-					"provisioningState": "Succeeded"
+					"provisioningState": "Succeeded",
+					"usesNewClusterDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -54,7 +55,8 @@
 		"name": "some-hcp-cluster",
 		"serviceProviderProperties": {
 			"clusterServiceID": "/api/aro_hcp/v1alpha1/clusters/fixed-value",
-			"provisioningState": "Succeeded"
+			"provisioningState": "Succeeded",
+			"usesNewClusterDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/admin/artifacts/AdminCRUD/HCP/lowercase-middleware/00-load-initial-cosmos-state/01-cluster.json
+++ b/test-integration/admin/artifacts/AdminCRUD/HCP/lowercase-middleware/00-load-initial-cosmos-state/01-cluster.json
@@ -36,7 +36,8 @@
 				"name": "some-hcp-cluster",
 				"serviceProviderProperties": {
 					"clusterServiceID": "/api/aro_hcp/v1alpha1/clusters/fixed-value",
-					"provisioningState": "Succeeded"
+					"provisioningState": "Succeeded",
+					"usesNewClusterDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -54,7 +55,8 @@
 		"name": "some-hcp-cluster",
 		"serviceProviderProperties": {
 			"clusterServiceID": "/api/aro_hcp/v1alpha1/clusters/fixed-value",
-			"provisioningState": "Succeeded"
+			"provisioningState": "Succeeded",
+			"usesNewClusterDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/backend/controllers/do_nothing/artifacts/sync_cluster/00-load-initial-state/cluster.json
+++ b/test-integration/backend/controllers/do_nothing/artifacts/sync_cluster/00-load-initial-state/cluster.json
@@ -139,7 +139,8 @@
 					"console": {},
 					"dns": {},
 					"platform": {},
-					"provisioningState": "Accepted"
+					"provisioningState": "Accepted",
+					"usesNewClusterDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -159,7 +160,8 @@
 			"console": {},
 			"dns": {},
 			"platform": {},
-			"provisioningState": "Accepted"
+			"provisioningState": "Accepted",
+			"usesNewClusterDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/backend/controllers/mismatches/artifacts/cluster/present_cluster/00-load-initial-state/cluster.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/cluster/present_cluster/00-load-initial-state/cluster.json
@@ -139,7 +139,8 @@
 					"console": {},
 					"dns": {},
 					"platform": {},
-					"provisioningState": "Accepted"
+					"provisioningState": "Accepted",
+					"usesNewClusterDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -159,7 +160,8 @@
 			"console": {},
 			"dns": {},
 			"platform": {},
-			"provisioningState": "Accepted"
+			"provisioningState": "Accepted",
+			"usesNewClusterDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/backend/controllers/mismatches/artifacts/cluster/present_cluster/99-cosmosCompare-end-state/cluster.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/cluster/present_cluster/99-cosmosCompare-end-state/cluster.json
@@ -139,7 +139,8 @@
 					"console": {},
 					"dns": {},
 					"platform": {},
-					"provisioningState": "Accepted"
+					"provisioningState": "Accepted",
+					"usesNewClusterDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -159,7 +160,8 @@
 			"console": {},
 			"dns": {},
 			"platform": {},
-			"provisioningState": "Accepted"
+			"provisioningState": "Accepted",
+			"usesNewClusterDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/backend/controllers/mismatches/artifacts/cluster/remove_orphaned_cluster_descendents/00-load-initial-state/cluster-safe.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/cluster/remove_orphaned_cluster_descendents/00-load-initial-state/cluster-safe.json
@@ -139,7 +139,8 @@
 					"console": {},
 					"dns": {},
 					"platform": {},
-					"provisioningState": "Accepted"
+					"provisioningState": "Accepted",
+					"usesNewClusterDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -159,7 +160,8 @@
 			"console": {},
 			"dns": {},
 			"platform": {},
-			"provisioningState": "Accepted"
+			"provisioningState": "Accepted",
+			"usesNewClusterDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/backend/controllers/mismatches/artifacts/cluster/remove_orphaned_cluster_descendents/00-load-initial-state/cluster.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/cluster/remove_orphaned_cluster_descendents/00-load-initial-state/cluster.json
@@ -139,7 +139,8 @@
 					"console": {},
 					"dns": {},
 					"platform": {},
-					"provisioningState": "Accepted"
+					"provisioningState": "Accepted",
+					"usesNewClusterDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -159,7 +160,8 @@
 			"console": {},
 			"dns": {},
 			"platform": {},
-			"provisioningState": "Accepted"
+			"provisioningState": "Accepted",
+			"usesNewClusterDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/backend/controllers/mismatches/artifacts/cluster/remove_orphaned_cluster_descendents/99-cosmosCompare-end-state/cluster-safe.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/cluster/remove_orphaned_cluster_descendents/99-cosmosCompare-end-state/cluster-safe.json
@@ -139,7 +139,8 @@
 					"console": {},
 					"dns": {},
 					"platform": {},
-					"provisioningState": "Accepted"
+					"provisioningState": "Accepted",
+					"usesNewClusterDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -159,7 +160,8 @@
 			"console": {},
 			"dns": {},
 			"platform": {},
-			"provisioningState": "Accepted"
+			"provisioningState": "Accepted",
+			"usesNewClusterDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/backend/controllers/mismatches/artifacts/delete_orphaned_cosmos/all_parents_exist/00-load-initial-state/cluster.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/delete_orphaned_cosmos/all_parents_exist/00-load-initial-state/cluster.json
@@ -79,7 +79,8 @@
 					"console": {},
 					"dns": {},
 					"platform": {},
-					"provisioningState": "Accepted"
+					"provisioningState": "Accepted",
+					"usesNewClusterDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -99,7 +100,8 @@
 			"console": {},
 			"dns": {},
 			"platform": {},
-			"provisioningState": "Accepted"
+			"provisioningState": "Accepted",
+			"usesNewClusterDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/backend/controllers/mismatches/artifacts/delete_orphaned_cosmos/all_parents_exist/99-cosmosCompare-end-state/cluster.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/delete_orphaned_cosmos/all_parents_exist/99-cosmosCompare-end-state/cluster.json
@@ -79,7 +79,8 @@
 					"console": {},
 					"dns": {},
 					"platform": {},
-					"provisioningState": "Accepted"
+					"provisioningState": "Accepted",
+					"usesNewClusterDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -99,7 +100,8 @@
 			"console": {},
 			"dns": {},
 			"platform": {},
-			"provisioningState": "Accepted"
+			"provisioningState": "Accepted",
+			"usesNewClusterDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/backend/controllers/mismatches/artifacts/delete_orphaned_cosmos/controller_under_missing_nodepool_deleted/00-load-initial-state/cluster.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/delete_orphaned_cosmos/controller_under_missing_nodepool_deleted/00-load-initial-state/cluster.json
@@ -79,7 +79,8 @@
 					"console": {},
 					"dns": {},
 					"platform": {},
-					"provisioningState": "Accepted"
+					"provisioningState": "Accepted",
+					"usesNewClusterDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -99,7 +100,8 @@
 			"console": {},
 			"dns": {},
 			"platform": {},
-			"provisioningState": "Accepted"
+			"provisioningState": "Accepted",
+			"usesNewClusterDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/backend/controllers/mismatches/artifacts/delete_orphaned_cosmos/controller_under_missing_nodepool_deleted/99-cosmosCompare-end-state/cluster.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/delete_orphaned_cosmos/controller_under_missing_nodepool_deleted/99-cosmosCompare-end-state/cluster.json
@@ -79,7 +79,8 @@
 					"console": {},
 					"dns": {},
 					"platform": {},
-					"provisioningState": "Accepted"
+					"provisioningState": "Accepted",
+					"usesNewClusterDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -99,7 +100,8 @@
 			"console": {},
 			"dns": {},
 			"platform": {},
-			"provisioningState": "Accepted"
+			"provisioningState": "Accepted",
+			"usesNewClusterDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/backend/controllers/mismatches/artifacts/externalauth/present_externalauth/00-load-initial-state/cluster.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/externalauth/present_externalauth/00-load-initial-state/cluster.json
@@ -139,7 +139,8 @@
 					"console": {},
 					"dns": {},
 					"platform": {},
-					"provisioningState": "Accepted"
+					"provisioningState": "Accepted",
+					"usesNewClusterDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -159,7 +160,8 @@
 			"console": {},
 			"dns": {},
 			"platform": {},
-			"provisioningState": "Accepted"
+			"provisioningState": "Accepted",
+			"usesNewClusterDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/backend/controllers/mismatches/artifacts/externalauth/present_externalauth/99-cosmosCompare-end-state/cluster.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/externalauth/present_externalauth/99-cosmosCompare-end-state/cluster.json
@@ -139,7 +139,8 @@
 					"console": {},
 					"dns": {},
 					"platform": {},
-					"provisioningState": "Accepted"
+					"provisioningState": "Accepted",
+					"usesNewClusterDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -159,7 +160,8 @@
 			"console": {},
 			"dns": {},
 			"platform": {},
-			"provisioningState": "Accepted"
+			"provisioningState": "Accepted",
+			"usesNewClusterDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/backend/controllers/mismatches/artifacts/externalauth/remove_orphaned_externalauth_descendents/00-load-initial-state/cluster.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/externalauth/remove_orphaned_externalauth_descendents/00-load-initial-state/cluster.json
@@ -139,7 +139,8 @@
 					"console": {},
 					"dns": {},
 					"platform": {},
-					"provisioningState": "Accepted"
+					"provisioningState": "Accepted",
+					"usesNewClusterDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -159,7 +160,8 @@
 			"console": {},
 			"dns": {},
 			"platform": {},
-			"provisioningState": "Accepted"
+			"provisioningState": "Accepted",
+			"usesNewClusterDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/backend/controllers/mismatches/artifacts/externalauth/remove_orphaned_externalauth_descendents/99-cosmosCompare-end-state/cluster.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/externalauth/remove_orphaned_externalauth_descendents/99-cosmosCompare-end-state/cluster.json
@@ -139,7 +139,8 @@
 					"console": {},
 					"dns": {},
 					"platform": {},
-					"provisioningState": "Accepted"
+					"provisioningState": "Accepted",
+					"usesNewClusterDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -159,7 +160,8 @@
 			"console": {},
 			"dns": {},
 			"platform": {},
-			"provisioningState": "Accepted"
+			"provisioningState": "Accepted",
+			"usesNewClusterDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/backend/controllers/mismatches/artifacts/nodepool/present_nodepool/00-load-initial-state/cluster.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/nodepool/present_nodepool/00-load-initial-state/cluster.json
@@ -139,7 +139,8 @@
 					"console": {},
 					"dns": {},
 					"platform": {},
-					"provisioningState": "Accepted"
+					"provisioningState": "Accepted",
+					"usesNewClusterDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -159,7 +160,8 @@
 			"console": {},
 			"dns": {},
 			"platform": {},
-			"provisioningState": "Accepted"
+			"provisioningState": "Accepted",
+			"usesNewClusterDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/backend/controllers/mismatches/artifacts/nodepool/present_nodepool/99-cosmosCompare-end-state/cluster.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/nodepool/present_nodepool/99-cosmosCompare-end-state/cluster.json
@@ -139,7 +139,8 @@
 					"console": {},
 					"dns": {},
 					"platform": {},
-					"provisioningState": "Accepted"
+					"provisioningState": "Accepted",
+					"usesNewClusterDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -159,7 +160,8 @@
 			"console": {},
 			"dns": {},
 			"platform": {},
-			"provisioningState": "Accepted"
+			"provisioningState": "Accepted",
+			"usesNewClusterDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/backend/controllers/mismatches/artifacts/nodepool/remove_orphaned_nodepool_descendents/00-load-initial-state/cluster.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/nodepool/remove_orphaned_nodepool_descendents/00-load-initial-state/cluster.json
@@ -139,7 +139,8 @@
 					"console": {},
 					"dns": {},
 					"platform": {},
-					"provisioningState": "Accepted"
+					"provisioningState": "Accepted",
+					"usesNewClusterDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -159,7 +160,8 @@
 			"console": {},
 			"dns": {},
 			"platform": {},
-			"provisioningState": "Accepted"
+			"provisioningState": "Accepted",
+			"usesNewClusterDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/backend/controllers/mismatches/artifacts/nodepool/remove_orphaned_nodepool_descendents/99-cosmosCompare-end-state/cluster.json
+++ b/test-integration/backend/controllers/mismatches/artifacts/nodepool/remove_orphaned_nodepool_descendents/99-cosmosCompare-end-state/cluster.json
@@ -139,7 +139,8 @@
 					"console": {},
 					"dns": {},
 					"platform": {},
-					"provisioningState": "Accepted"
+					"provisioningState": "Accepted",
+					"usesNewClusterDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -159,7 +160,8 @@
 			"console": {},
 			"dns": {},
 			"platform": {},
-			"provisioningState": "Accepted"
+			"provisioningState": "Accepted",
+			"usesNewClusterDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/01-load-initial/basic-external-auth-operation-external-auth.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/01-load-initial/basic-external-auth-operation-external-auth.json
@@ -15,6 +15,7 @@
 		"startTime": "2025-12-05T20:30:10.966609337Z",
 		"status": "Succeeded",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/01-load-initial/create-with-tags-cluster.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/01-load-initial/create-with-tags-cluster.json
@@ -124,7 +124,8 @@
 					"api": {},
 					"console": {},
 					"dns": {},
-					"platform": {}
+					"platform": {},
+					"usesNewClusterDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -146,7 +147,8 @@
 			"api": {},
 			"console": {},
 			"dns": {},
-			"platform": {}
+			"platform": {},
+			"usesNewClusterDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/01-load-initial/create-with-tags-operation.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/01-load-initial/create-with-tags-operation.json
@@ -15,6 +15,7 @@
 		"startTime": "2025-12-05T20:29:59.734335781Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/01-load-initial/immutability-operation-for-node-pool.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/01-load-initial/immutability-operation-for-node-pool.json
@@ -15,6 +15,7 @@
 		"startTime": "2025-12-05T20:30:25.067364685Z",
 		"status": "Succeeded",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/01-load-initial/operation-3-new.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/01-load-initial/operation-3-new.json
@@ -16,6 +16,7 @@
 		"startTime": "2025-12-05T20:30:25.067364685Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/04-untypedListRecursive-resourcegroup/create-with-tags-cluster.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/04-untypedListRecursive-resourcegroup/create-with-tags-cluster.json
@@ -124,7 +124,8 @@
 					"api": {},
 					"console": {},
 					"dns": {},
-					"platform": {}
+					"platform": {},
+					"usesNewClusterDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -146,7 +147,8 @@
 			"api": {},
 			"console": {},
 			"dns": {},
-			"platform": {}
+			"platform": {},
+			"usesNewClusterDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/05-untypedListRecursive-subscription/basic-external-auth-operation-external-auth.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/05-untypedListRecursive-subscription/basic-external-auth-operation-external-auth.json
@@ -15,6 +15,7 @@
 		"startTime": "2025-12-05T20:30:10.966609337Z",
 		"status": "Succeeded",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/05-untypedListRecursive-subscription/create-with-tags-cluster.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/05-untypedListRecursive-subscription/create-with-tags-cluster.json
@@ -124,7 +124,8 @@
 					"api": {},
 					"console": {},
 					"dns": {},
-					"platform": {}
+					"platform": {},
+					"usesNewClusterDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -146,7 +147,8 @@
 			"api": {},
 			"console": {},
 			"dns": {},
-			"platform": {}
+			"platform": {},
+			"usesNewClusterDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/05-untypedListRecursive-subscription/create-with-tags-operation.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/05-untypedListRecursive-subscription/create-with-tags-operation.json
@@ -15,6 +15,7 @@
 		"startTime": "2025-12-05T20:29:59.734335781Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/05-untypedListRecursive-subscription/immutability-operation-for-node-pool.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/05-untypedListRecursive-subscription/immutability-operation-for-node-pool.json
@@ -15,6 +15,7 @@
 		"startTime": "2025-12-05T20:30:25.067364685Z",
 		"status": "Succeeded",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/05-untypedListRecursive-subscription/operation-3-new.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/05-untypedListRecursive-subscription/operation-3-new.json
@@ -16,6 +16,7 @@
 		"startTime": "2025-12-05T20:30:25.067364685Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/07-untypedListRecursive-resourcegroup-via-child/create-with-tags-cluster.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/07-untypedListRecursive-resourcegroup-via-child/create-with-tags-cluster.json
@@ -124,7 +124,8 @@
 					"api": {},
 					"console": {},
 					"dns": {},
-					"platform": {}
+					"platform": {},
+					"usesNewClusterDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -146,7 +147,8 @@
 			"api": {},
 			"console": {},
 			"dns": {},
-			"platform": {}
+			"platform": {},
+			"usesNewClusterDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/10-untypedList-resourcegroup/create-with-tags-cluster.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/10-untypedList-resourcegroup/create-with-tags-cluster.json
@@ -124,7 +124,8 @@
 					"api": {},
 					"console": {},
 					"dns": {},
-					"platform": {}
+					"platform": {},
+					"usesNewClusterDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -146,7 +147,8 @@
 			"api": {},
 			"console": {},
 			"dns": {},
-			"platform": {}
+			"platform": {},
+			"usesNewClusterDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/12-untypedList-resourcegroup/create-with-tags-cluster.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/12-untypedList-resourcegroup/create-with-tags-cluster.json
@@ -124,7 +124,8 @@
 					"api": {},
 					"console": {},
 					"dns": {},
-					"platform": {}
+					"platform": {},
+					"usesNewClusterDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -146,7 +147,8 @@
 			"api": {},
 			"console": {},
 			"dns": {},
-			"platform": {}
+			"platform": {},
+			"usesNewClusterDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/FrontendCRUD/AdminCredentials/request-provisioning-conflict/01-load-initial-cosmos-state/01-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/AdminCredentials/request-provisioning-conflict/01-load-initial-cosmos-state/01-cluster.json
@@ -13,7 +13,8 @@
 		},
 		"serviceProviderProperties": {
 			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/fixed-value",
-			"provisioningState": "Provisioning"
+			"provisioningState": "Provisioning",
+			"usesNewClusterDeletionApproach": false
 		}
 	},
 	"resourceID": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/some-hcp-cluster",

--- a/test-integration/frontend/artifacts/FrontendCRUD/AdminCredentials/request/01-load-initial-cosmos-state/01-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/AdminCredentials/request/01-load-initial-cosmos-state/01-cluster.json
@@ -13,7 +13,8 @@
 		},
 		"serviceProviderProperties": {
 			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/fixed-value",
-			"provisioningState": "Succeeded"
+			"provisioningState": "Succeeded",
+			"usesNewClusterDeletionApproach": false
 		}
 	},
 	"resourceID": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/some-hcp-cluster",

--- a/test-integration/frontend/artifacts/FrontendCRUD/AdminCredentials/request/03-listActiveOperations-request-credentials/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/AdminCredentials/request/03-listActiveOperations-request-credentials/00-key.json
@@ -1,6 +1,7 @@
 {
 	"parentResourceID": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6",
 	"properties": {
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/AdminCredentials/revoke-forbidden-afec-missing/01-load-initial-cosmos-state/01-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/AdminCredentials/revoke-forbidden-afec-missing/01-load-initial-cosmos-state/01-cluster.json
@@ -16,7 +16,8 @@
 		},
 		"serviceProviderProperties": {
 			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/fixed-value",
-			"provisioningState": "Succeeded"
+			"provisioningState": "Succeeded",
+			"usesNewClusterDeletionApproach": false
 		}
 	},
 	"resourceID": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/some-hcp-cluster",

--- a/test-integration/frontend/artifacts/FrontendCRUD/AdminCredentials/revoke-forbidden-afec-pending/01-load-initial-cosmos-state/01-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/AdminCredentials/revoke-forbidden-afec-pending/01-load-initial-cosmos-state/01-cluster.json
@@ -16,7 +16,8 @@
 		},
 		"serviceProviderProperties": {
 			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/fixed-value",
-			"provisioningState": "Succeeded"
+			"provisioningState": "Succeeded",
+			"usesNewClusterDeletionApproach": false
 		}
 	},
 	"resourceID": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/some-hcp-cluster",

--- a/test-integration/frontend/artifacts/FrontendCRUD/AdminCredentials/revoke-provisioning-conflict/01-load-initial-cosmos-state/01-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/AdminCredentials/revoke-provisioning-conflict/01-load-initial-cosmos-state/01-cluster.json
@@ -36,7 +36,8 @@
 				"name": "some-hcp-cluster",
 				"serviceProviderProperties": {
 					"clusterServiceID": "/api/clusters_mgmt/v1/clusters/fixed-value",
-					"provisioningState": "Provisioning"
+					"provisioningState": "Provisioning",
+					"usesNewClusterDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -54,7 +55,8 @@
 		"name": "some-hcp-cluster",
 		"serviceProviderProperties": {
 			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/fixed-value",
-			"provisioningState": "Provisioning"
+			"provisioningState": "Provisioning",
+			"usesNewClusterDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/FrontendCRUD/AdminCredentials/revoke/01-load-initial-cosmos-state/01-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/AdminCredentials/revoke/01-load-initial-cosmos-state/01-cluster.json
@@ -16,7 +16,8 @@
 		},
 		"serviceProviderProperties": {
 			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/fixed-value",
-			"provisioningState": "Succeeded"
+			"provisioningState": "Succeeded",
+			"usesNewClusterDeletionApproach": false
 		}
 	},
 	"resourceID": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/some-hcp-cluster",

--- a/test-integration/frontend/artifacts/FrontendCRUD/AdminCredentials/revoke/03-listActiveOperations-revoke-credentials/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/AdminCredentials/revoke/03-listActiveOperations-revoke-credentials/00-key.json
@@ -1,6 +1,7 @@
 {
 	"parentResourceID": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6",
 	"properties": {
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-current/02-cosmosCompare-confirm-content/cluster-create-with-tags.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-current/02-cosmosCompare-confirm-content/cluster-create-with-tags.json
@@ -148,7 +148,8 @@
 					"dns": {},
 					"managedIdentitiesDataPlaneIdentityURL": "https://dummyhost.identity.azure.net/otherinformation?aqueryarg=somevalue",
 					"platform": {},
-					"provisioningState": "Accepted"
+					"provisioningState": "Accepted",
+					"usesNewClusterDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -172,7 +173,8 @@
 			"dns": {},
 			"managedIdentitiesDataPlaneIdentityURL": "https://dummyhost.identity.azure.net/otherinformation?aqueryarg=somevalue",
 			"platform": {},
-			"provisioningState": "Accepted"
+			"provisioningState": "Accepted",
+			"usesNewClusterDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-current/02-cosmosCompare-confirm-content/operation-cluster-create-with-tags-create.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-current/02-cosmosCompare-confirm-content/operation-cluster-create-with-tags-create.json
@@ -19,6 +19,7 @@
 		"startTime": "2025-12-19T19:59:30.714826736Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-current/05-listActiveOperations-cluster-create/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-current/05-listActiveOperations-cluster-create/00-key.json
@@ -1,6 +1,7 @@
 {
 	"parentResourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7",
 	"properties": {
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-current/09-cosmosCompare-confirm-update/cluster-create-with-tags.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-current/09-cosmosCompare-confirm-update/cluster-create-with-tags.json
@@ -149,7 +149,8 @@
 					"dns": {},
 					"managedIdentitiesDataPlaneIdentityURL": "https://dummyhost.identity.azure.net/otherinformation?aqueryarg=somevalue",
 					"platform": {},
-					"provisioningState": "Accepted"
+					"provisioningState": "Accepted",
+					"usesNewClusterDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -174,7 +175,8 @@
 			"dns": {},
 			"managedIdentitiesDataPlaneIdentityURL": "https://dummyhost.identity.azure.net/otherinformation?aqueryarg=somevalue",
 			"platform": {},
-			"provisioningState": "Accepted"
+			"provisioningState": "Accepted",
+			"usesNewClusterDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-cluster-operation/03-cosmosCompare-final-state/cluster-test-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-cluster-operation/03-cosmosCompare-final-state/cluster-test-cluster.json
@@ -136,7 +136,8 @@
 					"dns": {},
 					"managedIdentitiesDataPlaneIdentityURL": "https://dummyhost.identity.azure.net/otherinformation?aqueryarg=somevalue",
 					"platform": {},
-					"provisioningState": "Deleting"
+					"provisioningState": "Deleting",
+					"usesNewClusterDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -155,7 +156,8 @@
 			"dns": {},
 			"managedIdentitiesDataPlaneIdentityURL": "https://dummyhost.identity.azure.net/otherinformation?aqueryarg=somevalue",
 			"platform": {},
-			"provisioningState": "Deleting"
+			"provisioningState": "Deleting",
+			"usesNewClusterDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-cluster-operation/03-cosmosCompare-final-state/operation-cluster-create-canceled.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-cluster-operation/03-cosmosCompare-final-state/operation-cluster-create-canceled.json
@@ -9,6 +9,7 @@
 		"request": "Create",
 		"status": "Canceled",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-cluster-operation/03-cosmosCompare-final-state/operation-cluster-delete.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-cluster-operation/03-cosmosCompare-final-state/operation-cluster-delete.json
@@ -5,6 +5,7 @@
 		"request": "Delete",
 		"status": "Deleting",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/cluster-test-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/cluster-test-cluster.json
@@ -136,7 +136,8 @@
 					"dns": {},
 					"managedIdentitiesDataPlaneIdentityURL": "https://dummyhost.identity.azure.net/otherinformation?aqueryarg=somevalue",
 					"platform": {},
-					"provisioningState": "Deleting"
+					"provisioningState": "Deleting",
+					"usesNewClusterDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -155,7 +156,8 @@
 			"dns": {},
 			"managedIdentitiesDataPlaneIdentityURL": "https://dummyhost.identity.azure.net/otherinformation?aqueryarg=somevalue",
 			"platform": {},
-			"provisioningState": "Deleting"
+			"provisioningState": "Deleting",
+			"usesNewClusterDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/operation-cluster-create.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/operation-cluster-create.json
@@ -5,6 +5,7 @@
 		"request": "Create",
 		"status": "Succeeded",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/operation-cluster-delete.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/operation-cluster-delete.json
@@ -5,6 +5,7 @@
 		"request": "Delete",
 		"status": "Deleting",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/operation-nodepool-create-canceled.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/operation-nodepool-create-canceled.json
@@ -9,6 +9,7 @@
 		"request": "Create",
 		"status": "Canceled",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/operation-nodepool-delete.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/operation-nodepool-delete.json
@@ -4,6 +4,7 @@
 		"externalId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/test-cluster/nodePools/test-nodepool",
 		"request": "Delete",
 		"status": "Deleting",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/read-old-data/01-load-old-data/create-with-tags.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/read-old-data/01-load-old-data/create-with-tags.json
@@ -144,7 +144,8 @@
 					"dns": {},
 					"managedIdentitiesDataPlaneIdentityURL": "https://dummyhost.identity.azure.net/otherinformation?aqueryarg=somevalue",
 					"platform": {},
-					"provisioningState": "Accepted"
+					"provisioningState": "Accepted",
+					"usesNewClusterDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -168,7 +169,8 @@
 			"dns": {},
 			"managedIdentitiesDataPlaneIdentityURL": "https://dummyhost.identity.azure.net/otherinformation?aqueryarg=somevalue",
 			"platform": {},
-			"provisioningState": "Accepted"
+			"provisioningState": "Accepted",
+			"usesNewClusterDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/read-old-data/01-load-old-data/hcpoperationstatuses_Create_90b2322c-2c26-47ca-b6f9-d9b1a8385cbc.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/read-old-data/01-load-old-data/hcpoperationstatuses_Create_90b2322c-2c26-47ca-b6f9-d9b1a8385cbc.json
@@ -19,6 +19,7 @@
 		"startTime": "2026-01-05T18:29:58.181047849Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/read-old-data/04-listActiveOperations-cluster-create/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/read-old-data/04-listActiveOperations-cluster-create/00-key.json
@@ -1,6 +1,7 @@
 {
 	"parentResourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7",
 	"properties": {
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/read-old-data/09-cosmosCompare-confirm-update/cluster-create-with-tags.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/read-old-data/09-cosmosCompare-confirm-update/cluster-create-with-tags.json
@@ -147,7 +147,8 @@
 					"dns": {},
 					"managedIdentitiesDataPlaneIdentityURL": "https://dummyhost.identity.azure.net/otherinformation?aqueryarg=somevalue",
 					"platform": {},
-					"provisioningState": "Accepted"
+					"provisioningState": "Accepted",
+					"usesNewClusterDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -172,7 +173,8 @@
 			"dns": {},
 			"managedIdentitiesDataPlaneIdentityURL": "https://dummyhost.identity.azure.net/otherinformation?aqueryarg=somevalue",
 			"platform": {},
-			"provisioningState": "Accepted"
+			"provisioningState": "Accepted",
+			"usesNewClusterDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/cluster-creating/02-loadCosmos-cluster/cosmos-01-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/cluster-creating/02-loadCosmos-cluster/cosmos-01-cluster.json
@@ -22,7 +22,8 @@
 		},
 		"serviceProviderProperties": {
 			"clusterServiceID": "/api/aro_hcp/v1alpha1/clusters/cs-cluster-creating",
-			"provisioningState": "Provisioning"
+			"provisioningState": "Provisioning",
+			"usesNewClusterDeletionApproach": false
 		},
 		"serviceProviderState": null
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/cluster-deleting/02-loadCosmos-cluster/cosmos-01-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/cluster-deleting/02-loadCosmos-cluster/cosmos-01-cluster.json
@@ -22,7 +22,8 @@
 		},
 		"serviceProviderProperties": {
 			"clusterServiceID": "/api/aro_hcp/v1alpha1/clusters/cs-cluster-deleting",
-			"provisioningState": "Deleting"
+			"provisioningState": "Deleting",
+			"usesNewClusterDeletionApproach": false
 		},
 		"serviceProviderState": null
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/create-current/06-cosmosCompare-ending-content/cluster-create-with-tags.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/create-current/06-cosmosCompare-ending-content/cluster-create-with-tags.json
@@ -146,7 +146,8 @@
 					"dns": {},
 					"managedIdentitiesDataPlaneIdentityURL": "https://dummyhost.identity.azure.net/otherinformation?aqueryarg=somevalue",
 					"platform": {},
-					"provisioningState": "Succeeded"
+					"provisioningState": "Succeeded",
+					"usesNewClusterDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -169,7 +170,8 @@
 			"dns": {},
 			"managedIdentitiesDataPlaneIdentityURL": "https://dummyhost.identity.azure.net/otherinformation?aqueryarg=somevalue",
 			"platform": {},
-			"provisioningState": "Succeeded"
+			"provisioningState": "Succeeded",
+			"usesNewClusterDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/create-current/06-cosmosCompare-ending-content/operation-cluster-create-create-with-tags.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/create-current/06-cosmosCompare-ending-content/operation-cluster-create-create-with-tags.json
@@ -16,6 +16,7 @@
 		"startTime": "2025-12-19T19:59:30.714826736Z",
 		"status": "Succeeded",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/create-current/06-cosmosCompare-ending-content/operation-externalauth-create-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/create-current/06-cosmosCompare-ending-content/operation-externalauth-create-default.json
@@ -19,6 +19,7 @@
 		"startTime": "2026-01-09T18:30:03.439824696Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/01-load-old-data/cluster-create-with-tags.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/01-load-old-data/cluster-create-with-tags.json
@@ -142,7 +142,8 @@
 					"dns": {},
 					"managedIdentitiesDataPlaneIdentityURL": "https://dummyhost.identity.azure.net/otherinformation?aqueryarg=somevalue",
 					"platform": {},
-					"provisioningState": "Succeeded"
+					"provisioningState": "Succeeded",
+					"usesNewClusterDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -165,7 +166,8 @@
 			"dns": {},
 			"managedIdentitiesDataPlaneIdentityURL": "https://dummyhost.identity.azure.net/otherinformation?aqueryarg=somevalue",
 			"platform": {},
-			"provisioningState": "Succeeded"
+			"provisioningState": "Succeeded",
+			"usesNewClusterDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/01-load-old-data/operation-cluster-create-with-tags-create.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/01-load-old-data/operation-cluster-create-with-tags-create.json
@@ -19,6 +19,7 @@
 		"startTime": "2026-01-09T18:32:10.15007222Z",
 		"status": "Succeeded",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/01-load-old-data/operation-externalauth-create-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/01-load-old-data/operation-externalauth-create-default.json
@@ -19,6 +19,7 @@
 		"startTime": "2026-01-09T18:32:10.835814057Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/09-cosmosCompare-confirm-update/cluster-create-with-tags.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/09-cosmosCompare-confirm-update/cluster-create-with-tags.json
@@ -142,7 +142,8 @@
 					"dns": {},
 					"managedIdentitiesDataPlaneIdentityURL": "https://dummyhost.identity.azure.net/otherinformation?aqueryarg=somevalue",
 					"platform": {},
-					"provisioningState": "Succeeded"
+					"provisioningState": "Succeeded",
+					"usesNewClusterDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -165,7 +166,8 @@
 			"dns": {},
 			"managedIdentitiesDataPlaneIdentityURL": "https://dummyhost.identity.azure.net/otherinformation?aqueryarg=somevalue",
 			"platform": {},
-			"provisioningState": "Succeeded"
+			"provisioningState": "Succeeded",
+			"usesNewClusterDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/09-cosmosCompare-confirm-update/operation-cluster-create-create-with-tags.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/09-cosmosCompare-confirm-update/operation-cluster-create-create-with-tags.json
@@ -16,6 +16,7 @@
 		"startTime": "2026-01-09T18:32:10.15007222Z",
 		"status": "Succeeded",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/09-cosmosCompare-confirm-update/operation-externalauth-create-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/09-cosmosCompare-confirm-update/operation-externalauth-create-default.json
@@ -16,6 +16,7 @@
 		"startTime": "2026-01-09T18:32:10.835814057Z",
 		"status": "Succeeded",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/09-cosmosCompare-confirm-update/operation-externalauth-update-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/09-cosmosCompare-confirm-update/operation-externalauth-update-default.json
@@ -16,6 +16,7 @@
 		"startTime": "2026-01-09T18:44:19.757910778Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/cluster-create-with-tags.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/cluster-create-with-tags.json
@@ -144,7 +144,8 @@
 					"dns": {},
 					"managedIdentitiesDataPlaneIdentityURL": "https://dummyhost.identity.azure.net/otherinformation?aqueryarg=somevalue",
 					"platform": {},
-					"provisioningState": "Succeeded"
+					"provisioningState": "Succeeded",
+					"usesNewClusterDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -168,7 +169,8 @@
 			"dns": {},
 			"managedIdentitiesDataPlaneIdentityURL": "https://dummyhost.identity.azure.net/otherinformation?aqueryarg=somevalue",
 			"platform": {},
-			"provisioningState": "Succeeded"
+			"provisioningState": "Succeeded",
+			"usesNewClusterDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/operation-cluster-create-with-tags-create.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/operation-cluster-create-with-tags-create.json
@@ -16,6 +16,7 @@
 		"startTime": "2025-12-19T19:59:30.714826736Z",
 		"status": "Succeeded",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/operation-create-basicnodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/operation-create-basicnodepool.json
@@ -16,6 +16,7 @@
 		"startTime": "2026-01-08T20:04:05.054190978Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/operation-create-nodepool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/operation-create-nodepool-02.json
@@ -16,6 +16,7 @@
 		"startTime": "2026-01-08T20:04:05.330050272Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/operation-externalauth-create-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/operation-externalauth-create-default.json
@@ -16,6 +16,7 @@
 		"startTime": "2026-01-09T18:32:10.835814057Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/cluster-create-with-tags.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/cluster-create-with-tags.json
@@ -146,7 +146,8 @@
 					"dns": {},
 					"managedIdentitiesDataPlaneIdentityURL": "https://dummyhost.identity.azure.net/otherinformation?aqueryarg=somevalue",
 					"platform": {},
-					"provisioningState": "Succeeded"
+					"provisioningState": "Succeeded",
+					"usesNewClusterDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -170,7 +171,8 @@
 			"dns": {},
 			"managedIdentitiesDataPlaneIdentityURL": "https://dummyhost.identity.azure.net/otherinformation?aqueryarg=somevalue",
 			"platform": {},
-			"provisioningState": "Succeeded"
+			"provisioningState": "Succeeded",
+			"usesNewClusterDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/operation-cluster-create-with-tags-create.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/operation-cluster-create-with-tags-create.json
@@ -16,6 +16,7 @@
 		"startTime": "2025-12-19T19:59:30.714826736Z",
 		"status": "Succeeded",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/operation-create-basicnodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/operation-create-basicnodepool.json
@@ -16,6 +16,7 @@
 		"startTime": "2026-01-08T20:04:05.054190978Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/operation-create-nodepool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/operation-create-nodepool-02.json
@@ -16,6 +16,7 @@
 		"startTime": "2026-01-08T20:04:05.330050272Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/operation-externalauth-create-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/operation-externalauth-create-default.json
@@ -16,6 +16,7 @@
 		"startTime": "2026-01-09T18:32:10.835814057Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/cluster-create-with-tags.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/cluster-create-with-tags.json
@@ -143,7 +143,8 @@
 					"console": {},
 					"dns": {},
 					"platform": {},
-					"provisioningState": "Succeeded"
+					"provisioningState": "Succeeded",
+					"usesNewClusterDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -166,7 +167,8 @@
 			"console": {},
 			"dns": {},
 			"platform": {},
-			"provisioningState": "Succeeded"
+			"provisioningState": "Succeeded",
+			"usesNewClusterDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/operation-cluster-create-with-tags-create.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/operation-cluster-create-with-tags-create.json
@@ -16,6 +16,7 @@
 		"startTime": "2025-12-19T19:59:30.714826736Z",
 		"status": "Succeeded",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/operation-create-basicnodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/operation-create-basicnodepool.json
@@ -19,6 +19,7 @@
 		"startTime": "2026-01-08T20:04:05.054190978Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/operation-create-nodepool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/operation-create-nodepool-02.json
@@ -19,6 +19,7 @@
 		"startTime": "2026-01-08T20:04:05.330050272Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/operation-externalauth-create-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/operation-externalauth-create-default.json
@@ -19,6 +19,7 @@
 		"startTime": "2026-01-09T18:32:10.835814057Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/cluster-create-with-tags.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/cluster-create-with-tags.json
@@ -143,7 +143,8 @@
 					"console": {},
 					"dns": {},
 					"platform": {},
-					"provisioningState": "Succeeded"
+					"provisioningState": "Succeeded",
+					"usesNewClusterDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -166,7 +167,8 @@
 			"console": {},
 			"dns": {},
 			"platform": {},
-			"provisioningState": "Succeeded"
+			"provisioningState": "Succeeded",
+			"usesNewClusterDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/operation-cluster-create-with-tags-create.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/operation-cluster-create-with-tags-create.json
@@ -16,6 +16,7 @@
 		"startTime": "2025-12-19T19:59:30.714826736Z",
 		"status": "Succeeded",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/operation-create-basicnodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/operation-create-basicnodepool.json
@@ -16,6 +16,7 @@
 		"startTime": "2026-01-08T20:04:05.054190978Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/operation-create-nodepool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/operation-create-nodepool-02.json
@@ -16,6 +16,7 @@
 		"startTime": "2026-01-08T20:04:05.330050272Z",
 		"status": "Succeeded",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/operation-externalauth-create-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/operation-externalauth-create-default.json
@@ -16,6 +16,7 @@
 		"startTime": "2026-01-09T18:32:10.835814057Z",
 		"status": "Succeeded",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/cluster-creating/02-loadCosmos-cluster/cosmos-01-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/cluster-creating/02-loadCosmos-cluster/cosmos-01-cluster.json
@@ -36,7 +36,8 @@
 		},
 		"serviceProviderProperties": {
 			"clusterServiceID": "/api/aro_hcp/v1alpha1/clusters/cs-cluster-creating",
-			"provisioningState": "Provisioning"
+			"provisioningState": "Provisioning",
+			"usesNewClusterDeletionApproach": false
 		}
 	},
 	"resourceID": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster-creating",

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/cluster-deleting/02-loadCosmos-cluster/cosmos-01-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/cluster-deleting/02-loadCosmos-cluster/cosmos-01-cluster.json
@@ -36,7 +36,8 @@
 		},
 		"serviceProviderProperties": {
 			"clusterServiceID": "/api/aro_hcp/v1alpha1/clusters/cs-cluster-deleting",
-			"provisioningState": "Deleting"
+			"provisioningState": "Deleting",
+			"usesNewClusterDeletionApproach": false
 		}
 	},
 	"resourceID": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster-deleting",

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/create-current/06-cosmosCompare-confirm-content/cluster-create-with-tags.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/create-current/06-cosmosCompare-confirm-content/cluster-create-with-tags.json
@@ -146,7 +146,8 @@
 					"dns": {},
 					"managedIdentitiesDataPlaneIdentityURL": "https://dummyhost.identity.azure.net/otherinformation?aqueryarg=somevalue",
 					"platform": {},
-					"provisioningState": "Succeeded"
+					"provisioningState": "Succeeded",
+					"usesNewClusterDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -169,7 +170,8 @@
 			"dns": {},
 			"managedIdentitiesDataPlaneIdentityURL": "https://dummyhost.identity.azure.net/otherinformation?aqueryarg=somevalue",
 			"platform": {},
-			"provisioningState": "Succeeded"
+			"provisioningState": "Succeeded",
+			"usesNewClusterDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/create-current/06-cosmosCompare-confirm-content/operation-cluster-create-with-tags-create.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/create-current/06-cosmosCompare-confirm-content/operation-cluster-create-with-tags-create.json
@@ -19,6 +19,7 @@
 		"startTime": "2025-12-19T19:59:30.714826736Z",
 		"status": "Succeeded",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/cluster-create-with-tags.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/cluster-create-with-tags.json
@@ -144,7 +144,8 @@
 					"dns": {},
 					"managedIdentitiesDataPlaneIdentityURL": "https://dummyhost.identity.azure.net/otherinformation?aqueryarg=somevalue",
 					"platform": {},
-					"provisioningState": "Succeeded"
+					"provisioningState": "Succeeded",
+					"usesNewClusterDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -168,7 +169,8 @@
 			"dns": {},
 			"managedIdentitiesDataPlaneIdentityURL": "https://dummyhost.identity.azure.net/otherinformation?aqueryarg=somevalue",
 			"platform": {},
-			"provisioningState": "Succeeded"
+			"provisioningState": "Succeeded",
+			"usesNewClusterDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/operation-cluster-create-with-tags-create.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/operation-cluster-create-with-tags-create.json
@@ -16,6 +16,7 @@
 		"startTime": "2025-12-19T19:59:30.714826736Z",
 		"status": "Succeeded",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/operation-create-basicnodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/operation-create-basicnodepool.json
@@ -19,6 +19,7 @@
 		"startTime": "2026-01-08T20:04:05.054190978Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/operation-create-nodepool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/operation-create-nodepool-02.json
@@ -19,6 +19,7 @@
 		"startTime": "2026-01-08T20:04:05.330050272Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/cluster-create-with-tags.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/cluster-create-with-tags.json
@@ -144,7 +144,8 @@
 					"dns": {},
 					"managedIdentitiesDataPlaneIdentityURL": "https://dummyhost.identity.azure.net/otherinformation?aqueryarg=somevalue",
 					"platform": {},
-					"provisioningState": "Succeeded"
+					"provisioningState": "Succeeded",
+					"usesNewClusterDeletionApproach": false
 				},
 				"systemData": {
 					"createdBy": "Unknown-ARO-HCP-frontend",
@@ -168,7 +169,8 @@
 			"dns": {},
 			"managedIdentitiesDataPlaneIdentityURL": "https://dummyhost.identity.azure.net/otherinformation?aqueryarg=somevalue",
 			"platform": {},
-			"provisioningState": "Succeeded"
+			"provisioningState": "Succeeded",
+			"usesNewClusterDeletionApproach": false
 		},
 		"systemData": {
 			"createdBy": "Unknown-ARO-HCP-frontend",

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/operation-create-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/operation-create-cluster.json
@@ -16,6 +16,7 @@
 		"startTime": "2025-12-19T19:59:30.714826736Z",
 		"status": "Succeeded",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/operation-create-nodepool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/operation-create-nodepool-02.json
@@ -16,6 +16,7 @@
 		"startTime": "2026-01-08T20:04:05.330050272Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/operation-create-nodepool-basic.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/operation-create-nodepool-basic.json
@@ -16,6 +16,7 @@
 		"startTime": "2026-01-08T20:04:05.054190978Z",
 		"status": "Succeeded",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/operation-update-nodepool-basic.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/operation-update-nodepool-basic.json
@@ -16,6 +16,7 @@
 		"startTime": "2026-01-08T20:09:32.571015378Z",
 		"status": "Accepted",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/Operations/read-new-data/01-load-new-data/operation.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Operations/read-new-data/01-load-new-data/operation.json
@@ -17,6 +17,7 @@
 		"startTime": "2026-01-08T19:02:35.73640117Z",
 		"status": "Succeeded",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},


### PR DESCRIPTION
This commit adds the DeletionTimestamp and ClusterServiceDeletionTimestamp in the Cluster internal API type.

DeletionTimestamp is the the timestamp at which the Cluster deletion was requested. A nil value indicates that the Cluster deletion has not been requested.

ClusterServiceDeletionTimestamp is written when a dispatch of a Cluster Service Delete Cluster request against Cluster Service for this cluster has been handled. It is set after a successful DeleteCluster call to Cluster Service, but also when it's determined that no delete call is needed but we consider we should behave as if the delete call was successfully issued (for example, if the parent cluster of the cluster is already being uninstalled, because cluster-service will already take care of deleting the cluster as part of the cluster teardown).
A nil value indicates that the Cluster Service Deletion has not been requested.

These two attributes are not used on the backend side yet.

This commit also adds the UsesNewClusterDeletionApproach attribute for both Cluster and Operation internal api types. This will be used as a gate when we decide to switch cluster deletion to be with async deletion trigger in backend.

<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

### Why

<!-- Briefly explain why this change is needed -->

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
