### PR TITLE
fix(ops): adopt leftover temp pools before detection (AROSLSRE-1003)

### DIFF
--- a/dev-infrastructure/scripts/recreate-broken-pools/main.go
+++ b/dev-infrastructure/scripts/recreate-broken-pools/main.go
@@ -310,6 +310,7 @@ type orchestrator interface {
 	detect(ctx context.Context) ([]nodePoolTarget, string, error)
 	dumpPreflight(ctx context.Context) error
 	dumpPostflight(ctx context.Context) error
+	adoptLeftoverTempPools(ctx context.Context) error
 	adoptLeftoverTempPool(ctx context.Context, target nodePoolTarget) error
 	snapshotPool(ctx context.Context, poolName string) (*armcs.AgentPool, error)
 	maybeAbortLRO(ctx context.Context) (bool, error)
@@ -358,6 +359,13 @@ func runWith(ctx context.Context, cfg *config, orch orchestrator) error {
 	logBanner("PRE-FLIGHT ARM STATE")
 	if err := orch.dumpPreflight(ctx); err != nil {
 		logf("WARN: pre-flight dump partial: %v", err)
+	}
+
+	if !cfg.dryRun {
+		logBanner("LEFTOVER TEMP POOL ADOPTION")
+		if err := orch.adoptLeftoverTempPools(ctx); err != nil {
+			return fmt.Errorf("adopt leftover temp pools: %w", err)
+		}
 	}
 
 	logBanner("DETECTION GUARDS")
@@ -1197,6 +1205,39 @@ func tempPoolSourceID(p *armcs.AgentPool) string {
 	return *v
 }
 
+// targetFromLeftoverTempPool validates a temp pool discovered during the
+// pre-detection adoption scan and returns the source pool target that owns it.
+// Non-temp pools and temp pools for other NODEPOOL_TAG values are ignored.
+// Malformed temp pools for this run fail closed so the operator can inspect
+// them before normal detection exits no-op and hides the leftover.
+func targetFromLeftoverTempPool(p *armcs.AgentPool, nodePoolTag string) (*nodePoolTarget, bool, error) {
+	if p == nil || p.Name == nil || p.Properties == nil {
+		return nil, false, nil
+	}
+	if !isTempPool(p) {
+		return nil, false, nil
+	}
+	if role := poolRoleTag(p); role != nodePoolTag {
+		logf("adopt pre-scan: ignoring temp pool %q with %s=%q while this run targets %q", *p.Name, nodePoolRoleLabel, role, nodePoolTag)
+		return nil, false, nil
+	}
+
+	srcID := tempPoolSourceID(p)
+	if srcID == "" {
+		return nil, true, fmt.Errorf("leftover temp pool %q has no %q tag", *p.Name, tempPoolSourceTag)
+	}
+	srcName, err := poolNameFromARMID(srcID)
+	if err != nil {
+		return nil, true, fmt.Errorf("leftover temp pool %q has malformed %q tag %q: %w", *p.Name, tempPoolSourceTag, srcID, err)
+	}
+	expectedName := tempPoolName(srcName)
+	if *p.Name != expectedName {
+		return nil, true, fmt.Errorf("leftover temp pool %q source tag points to %q, whose deterministic temp name is %q", *p.Name, srcName, expectedName)
+	}
+
+	return &nodePoolTarget{name: srcName, vmssPrefix: poolVMSSPrefix(srcName)}, true, nil
+}
+
 // poolNameFromARMID parses the trailing agent-pool name segment from
 // an AKS agent pool ARM resource ID, e.g.
 //
@@ -1221,6 +1262,33 @@ func poolNameFromARMID(id string) (string, error) {
 		return "", fmt.Errorf("trailing pool name segment %q contains a path separator", name)
 	}
 	return name, nil
+}
+
+// adoptLeftoverTempPools scans all agent pools before detection can exit
+// no-op. This makes the Succeeded-source and missing-source adoption paths
+// reachable even when no source pool is currently wedge-compatible.
+func (c *clients) adoptLeftoverTempPools(ctx context.Context) error {
+	pager := c.pools.NewListPager(c.cfg.resourceGroup, c.cfg.clusterName, nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return fmt.Errorf("adopt pre-scan: list pools: %w", err)
+		}
+		for _, p := range page.Value {
+			target, ok, err := targetFromLeftoverTempPool(p, c.cfg.nodePoolTag)
+			if err != nil {
+				return fmt.Errorf("adopt pre-scan: %w", err)
+			}
+			if !ok {
+				continue
+			}
+			logf("adopt pre-scan: found leftover temp pool %q for source %q", strDeref(p.Name), target.name)
+			if err := c.adoptLeftoverTempPool(ctx, *target); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 // adoptLeftoverTempPool handles a leftover temp pool from a previous

--- a/dev-infrastructure/scripts/recreate-broken-pools/main_test.go
+++ b/dev-infrastructure/scripts/recreate-broken-pools/main_test.go
@@ -974,6 +974,84 @@ func TestTempPoolSourceID(t *testing.T) {
 	}
 }
 
+func mkLeftoverTempPool(name, source, role string) *armcs.AgentPool {
+	return &armcs.AgentPool{
+		Name: ptr(name),
+		Properties: &armcs.ManagedClusterAgentPoolProfileProperties{
+			NodeLabels: map[string]*string{
+				nodePoolRoleLabel: ptr(role),
+			},
+			Tags: map[string]*string{
+				tempPoolPurposeTag: ptr(tempPoolPurposeValue),
+				tempPoolSourceTag:  ptr(source),
+			},
+		},
+	}
+}
+
+func TestTargetFromLeftoverTempPool(t *testing.T) {
+	source := "/subscriptions/x/resourceGroups/y/providers/Microsoft.ContainerService/managedClusters/c/agentPools/userswft3"
+	temp := mkLeftoverTempPool(tempPoolName("userswft3"), source, "user")
+
+	target, ok, err := targetFromLeftoverTempPool(temp, "user")
+	if err != nil {
+		t.Fatalf("targetFromLeftoverTempPool() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("targetFromLeftoverTempPool() skipped matching temp pool")
+	}
+	if target.name != "userswft3" || target.vmssPrefix != poolVMSSPrefix("userswft3") {
+		t.Fatalf("target = %#v", target)
+	}
+}
+
+func TestTargetFromLeftoverTempPoolIgnoresOtherRoles(t *testing.T) {
+	source := "/subscriptions/x/resourceGroups/y/providers/Microsoft.ContainerService/managedClusters/c/agentPools/system"
+	temp := mkLeftoverTempPool(tempPoolName("system"), source, "system")
+
+	target, ok, err := targetFromLeftoverTempPool(temp, "user")
+	if err != nil {
+		t.Fatalf("targetFromLeftoverTempPool() error = %v", err)
+	}
+	if ok || target != nil {
+		t.Fatalf("targetFromLeftoverTempPool() = %#v, %t; want skip", target, ok)
+	}
+}
+
+func TestTargetFromLeftoverTempPoolMalformedForTargetRoleFailsClosed(t *testing.T) {
+	cases := []struct {
+		name string
+		pool *armcs.AgentPool
+	}{
+		{
+			name: "missing source tag",
+			pool: &armcs.AgentPool{
+				Name: ptr(tempPoolName("userswft3")),
+				Properties: &armcs.ManagedClusterAgentPoolProfileProperties{
+					NodeLabels: map[string]*string{nodePoolRoleLabel: ptr("user")},
+					Tags:       map[string]*string{tempPoolPurposeTag: ptr(tempPoolPurposeValue)},
+				},
+			},
+		},
+		{
+			name: "malformed source tag",
+			pool: mkLeftoverTempPool(tempPoolName("userswft3"), "not-an-agent-pool-id", "user"),
+		},
+		{
+			name: "name does not match deterministic source name",
+			pool: mkLeftoverTempPool(tempPoolName("otherpool"), "/subscriptions/x/resourceGroups/y/providers/Microsoft.ContainerService/managedClusters/c/agentPools/userswft3", "user"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, _, err := targetFromLeftoverTempPool(tc.pool, "user"); err == nil {
+				t.Fatal("expected fail-closed error")
+			}
+		})
+	}
+}
+
 func TestBuildTempAgentPool_NilProperties(t *testing.T) {
 	if _, err := buildTempAgentPool(&armcs.AgentPool{}, "1.35.4"); err == nil {
 		t.Fatal("expected error for nil properties")
@@ -1590,6 +1668,7 @@ type mockOrchestrator struct {
 	ensureClusterFn          func(ctx context.Context) (armcs.ManagedCluster, bool, error)
 	bootstrapKubeFn          func(ctx context.Context, mc armcs.ManagedCluster) error
 	detectFn                 func(ctx context.Context, n int) (bool, string, error)
+	adoptLeftoverTempPoolsFn func(ctx context.Context) error
 	adoptLeftoverTempPoolFn  func(ctx context.Context, target nodePoolTarget) error
 	snapshotSystemFn         func(ctx context.Context) (*armcs.AgentPool, error)
 	maybeAbortLROFn          func(ctx context.Context) (bool, error)
@@ -1648,6 +1727,14 @@ func (m *mockOrchestrator) dumpPreflight(ctx context.Context) error {
 func (m *mockOrchestrator) dumpPostflight(ctx context.Context) error {
 	m.record("dumpPostflight")
 	return nil
+}
+
+func (m *mockOrchestrator) adoptLeftoverTempPools(ctx context.Context) error {
+	if m.adoptLeftoverTempPoolsFn == nil {
+		return nil
+	}
+	m.record("adoptLeftoverTempPools")
+	return m.adoptLeftoverTempPoolsFn(ctx)
 }
 
 func (m *mockOrchestrator) adoptLeftoverTempPool(ctx context.Context, target nodePoolTarget) error {
@@ -1816,9 +1903,32 @@ func TestRunWith(t *testing.T) {
 			wantCalls: []string{"ensureCluster", "dumpPreflight", "detect:1"},
 		},
 		{
+			name: "pre_scan_adopts_leftover_before_detection_noop",
+			cfg:  &config{clusterName: "c", resourceGroup: "rg", subscriptionID: "sub", cpVersion: "1.30.0"},
+			setup: func(m *mockOrchestrator) {
+				m.adoptLeftoverTempPoolsFn = func(context.Context) error { return nil }
+				m.detectFn = func(_ context.Context, _ int) (bool, string, error) {
+					return false, "no selected node pools with role user", nil
+				}
+			},
+			wantCalls: []string{"ensureCluster", "dumpPreflight", "adoptLeftoverTempPools", "detect:1"},
+		},
+		{
+			name: "pre_scan_error_stops_before_detection",
+			cfg:  &config{clusterName: "c", resourceGroup: "rg", subscriptionID: "sub", cpVersion: "1.30.0"},
+			setup: func(m *mockOrchestrator) {
+				m.adoptLeftoverTempPoolsFn = func(context.Context) error { return dummyErr }
+			},
+			wantErr:   "adopt leftover temp pools:",
+			wantCalls: []string{"ensureCluster", "dumpPreflight", "adoptLeftoverTempPools"},
+		},
+		{
 			name: "guard1_fail_dry_run_skips_forced_evidence",
 			cfg:  &config{clusterName: "c", resourceGroup: "rg", subscriptionID: "sub", cpVersion: "1.30.0", dryRun: true},
 			setup: func(m *mockOrchestrator) {
+				m.adoptLeftoverTempPoolsFn = func(context.Context) error {
+					return errors.New("dry run must not adopt temp pools")
+				}
 				m.detectFn = func(_ context.Context, _ int) (bool, string, error) {
 					return false, "NRP-KVS storm FAIL: only 0 NRP failures < 10", nil
 				}


### PR DESCRIPTION
[AROSLSRE-1003](https://issues.redhat.com/browse/AROSLSRE-1003)

### What

Adds a pre-detection leftover temp-pool adoption scan to `recreate-broken-pools`.

The scan finds temp pools created by the binary for the current `NODEPOOL_TAG`, validates their source metadata, and routes them through the existing single-target adoption state machine before normal detection can exit no-op.

### Why

The original per-target adoption only ran after detection selected a currently wedged source pool. That left two documented adoption outcomes unreachable: deleting a stale temp pool after the source had already been recreated successfully, and failing closed when a previous run deleted the source pool but crashed before recreating it.

### Testing

```text
go test ./dev-infrastructure/scripts/recreate-broken-pools -count=1
```

### Special notes for your reviewer

This keeps dry-run non-mutating and preserves the existing per-target adoption call before remediation as a second safety check.

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [x] All comment threads resolved before merge