### PR TITLE
fix: enable audit logging for ci01 env and disable for prow

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1100,6 +1100,7 @@ clouds:
       cloudEnvironmentName: "AzurePublicCloud"
       kusto:
         kustoName: "hcp-dev-us-2"
+        location: eastus2
         manageInstance: true
         sku: "Standard_E8ads_v5"
         tier: "Standard"
@@ -1647,7 +1648,6 @@ clouds:
           auditLogsEventHub:
             enabled: true
           kusto:
-            location: eastus2
             manageInstance: false
           # Service Key Vault
           serviceKeyVault:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1646,6 +1646,9 @@ clouds:
         defaults:
           auditLogsEventHub:
             enabled: true
+          kusto:
+            location: eastus2
+            manageInstance: false
           # Service Key Vault
           serviceKeyVault:
             assignNSP: false

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1551,8 +1551,6 @@ clouds:
         defaults:
           kusto:
             manageInstance: false
-          auditLogsEventHub:
-            enabled: true
           # Service Key Vault
           serviceKeyVault:
             assignNSP: false
@@ -1646,6 +1644,8 @@ clouds:
       ci01:
         # prow infra shard1 - deploys into "ARO HCP E2E Infrastructure" subscription
         defaults:
+          auditLogsEventHub:
+            enabled: true
           # Service Key Vault
           serviceKeyVault:
             assignNSP: false

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -86,7 +86,7 @@ arobit:
       repository: geneva/distroless/mdsd
 auditLogsEventHub:
   authRuleName: SendRule
-  enabled: false
+  enabled: true
   kustoConsumerGroupName: AuditLogsToKusto
   kustoDataConnectionName: ci01-centralus-auditlogs
   name: aks-auditlogs

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -496,8 +496,8 @@ kusto:
   enableAutoScale: true
   hostedControlPlaneLogsDatabase: HostedControlPlaneLogs
   kustoName: hcp-dev-us-2
-  location: centralus
-  manageInstance: true
+  location: eastus2
+  manageInstance: false
   rg: hcp-kusto-us
   serviceLogsDatabase: ServiceLogs
   sku: Standard_E8ads_v5

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -496,7 +496,7 @@ kusto:
   enableAutoScale: true
   hostedControlPlaneLogsDatabase: HostedControlPlaneLogs
   kustoName: hcp-dev-us-2
-  location: westus3
+  location: eastus2
   manageInstance: false
   rg: hcp-kusto-us
   serviceLogsDatabase: ServiceLogs

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -496,7 +496,7 @@ kusto:
   enableAutoScale: true
   hostedControlPlaneLogsDatabase: HostedControlPlaneLogs
   kustoName: hcp-dev-us-2
-  location: westus3
+  location: eastus2
   manageInstance: true
   rg: hcp-kusto-us
   serviceLogsDatabase: ServiceLogs

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -496,7 +496,7 @@ kusto:
   enableAutoScale: true
   hostedControlPlaneLogsDatabase: HostedControlPlaneLogs
   kustoName: hcp-dev-us-2
-  location: westus3
+  location: eastus2
   manageInstance: false
   rg: hcp-kusto-us
   serviceLogsDatabase: ServiceLogs

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -496,7 +496,7 @@ kusto:
   enableAutoScale: true
   hostedControlPlaneLogsDatabase: HostedControlPlaneLogs
   kustoName: hcp-dev-us-2
-  location: westus3
+  location: eastus2
   manageInstance: false
   rg: hcp-kusto-us
   serviceLogsDatabase: ServiceLogs

--- a/config/rendered/dev/prow/centralus.yaml
+++ b/config/rendered/dev/prow/centralus.yaml
@@ -86,7 +86,7 @@ arobit:
       repository: geneva/distroless/mdsd
 auditLogsEventHub:
   authRuleName: SendRule
-  enabled: true
+  enabled: false
   kustoConsumerGroupName: AuditLogsToKusto
   kustoDataConnectionName: prow-centralus-auditlogs
   name: aks-auditlogs

--- a/config/rendered/dev/prow/centralus.yaml
+++ b/config/rendered/dev/prow/centralus.yaml
@@ -496,7 +496,7 @@ kusto:
   enableAutoScale: true
   hostedControlPlaneLogsDatabase: HostedControlPlaneLogs
   kustoName: hcp-dev-us-2
-  location: centralus
+  location: eastus2
   manageInstance: false
   rg: hcp-kusto-us
   serviceLogsDatabase: ServiceLogs


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Enables audit logging for ci01 e2e clusters, overrides default kusto location (kusto is in eastus2) and sets manageInstance to false (as it was previously).

### Why

Audit logging was previously enabled for e2e clusters, but when e2e clusters were moved from prow to ci01 the setting wasn't carried over.

### Testing

e2e

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
