### PR TITLE
observability: add Node Pool Management SLO Grafana dashboard (ARO-25967)

### DIFF
--- a/observability/grafana-dashboards/sre/user-journey/nodepool-slo.json
+++ b/observability/grafana-dashboards/sre/user-journey/nodepool-slo.json
@@ -727,7 +727,7 @@
         "options": [],
         "query": "prometheus",
         "refresh": 1,
-        "regex": "^Managed_Prometheus_hcps-.*$",
+        "regex": "^Managed_Prometheus_services-.*$",
         "type": "datasource"
       }
     ]

--- a/observability/grafana-dashboards/sre/user-journey/nodepool-slo.json
+++ b/observability/grafana-dashboards/sre/user-journey/nodepool-slo.json
@@ -422,7 +422,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "backend_resource_operation_last_transition_time_seconds{resource_type=~\".*nodepools\", phase=~\"succeeded|failed|canceled\"} - backend_resource_operation_start_time_seconds{resource_type=~\".*nodepools\", phase=~\"succeeded|failed|canceled\"}",
+          "expr": "backend_resource_operation_last_transition_time_seconds{resource_type=~\".*nodepools\", operation_type=~\"update|delete\", phase=~\"succeeded|failed\"} - backend_resource_operation_start_time_seconds{resource_type=~\".*nodepools\", operation_type=~\"update|delete\", phase=~\"succeeded|failed\"}",
           "legendFormat": "{{ operation_type }} - {{ phase }}",
           "refId": "A"
         }
@@ -524,7 +524,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "count by (operation_type, phase) (backend_resource_operation_phase_info{resource_type=~\".*nodepools\", phase=~\"succeeded|failed|canceled\"})",
+          "expr": "count by (operation_type, phase) (backend_resource_operation_phase_info{resource_type=~\".*nodepools\", operation_type=~\"update|delete\", phase=~\"succeeded|failed\"})",
           "legendFormat": "{{ operation_type }} - {{ phase }}",
           "refId": "A"
         }

--- a/observability/grafana-dashboards/sre/user-journey/nodepool-slo.json
+++ b/observability/grafana-dashboards/sre/user-journey/nodepool-slo.json
@@ -68,7 +68,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "(\n  count(backend_resource_operation_phase_info{resource_type=~\".*nodepools\", phase=\"succeeded\"})\n  /\n  count(backend_resource_operation_phase_info{resource_type=~\".*nodepools\", phase=~\"succeeded|failed\"})\n) * 100",
+          "expr": "(\n  (count(backend_resource_operation_phase_info{resource_type=~\".*nodepools\", phase=\"succeeded\"}) or vector(0))\n  /\n  (count(backend_resource_operation_phase_info{resource_type=~\".*nodepools\", phase=~\"succeeded|failed|canceled\"}) > 0 or vector(1))\n) * 100",
           "instant": true,
           "legendFormat": "Success Rate",
           "refId": "A"
@@ -246,7 +246,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "(\n  count(backend_resource_operation_phase_info{resource_type=~\".*nodepools\", phase=\"succeeded\"})\n  /\n  count(backend_resource_operation_phase_info{resource_type=~\".*nodepools\", phase=~\"succeeded|failed\"})\n) * 100",
+          "expr": "(\n  (count(backend_resource_operation_phase_info{resource_type=~\".*nodepools\", phase=\"succeeded\"}) or vector(0))\n  /\n  (count(backend_resource_operation_phase_info{resource_type=~\".*nodepools\", phase=~\"succeeded|failed|canceled\"}) > 0 or vector(1))\n) * 100",
           "legendFormat": "Success Rate %",
           "refId": "A"
         }
@@ -406,7 +406,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "backend_resource_operation_last_transition_time_seconds{resource_type=~\".*nodepools\", phase=~\"succeeded|failed\"} - backend_resource_operation_start_time_seconds{resource_type=~\".*nodepools\", phase=~\"succeeded|failed\"}",
+          "expr": "backend_resource_operation_last_transition_time_seconds{resource_type=~\".*nodepools\", phase=~\"succeeded|failed|canceled\"} - backend_resource_operation_start_time_seconds{resource_type=~\".*nodepools\", phase=~\"succeeded|failed|canceled\"}",
           "legendFormat": "{{ operation_type }} - {{ phase }}",
           "refId": "A"
         }
@@ -508,7 +508,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "count by (operation_type, phase) (backend_resource_operation_phase_info{resource_type=~\".*nodepools\", phase=~\"succeeded|failed\"})",
+          "expr": "count by (operation_type, phase) (backend_resource_operation_phase_info{resource_type=~\".*nodepools\", phase=~\"succeeded|failed|canceled\"})",
           "legendFormat": "{{ operation_type }} - {{ phase }}",
           "refId": "A"
         }

--- a/observability/grafana-dashboards/sre/user-journey/nodepool-slo.json
+++ b/observability/grafana-dashboards/sre/user-journey/nodepool-slo.json
@@ -1,0 +1,744 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "gridPos": { "h": 4, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "code": { "language": "plaintext", "showLineNumbers": false, "showMiniMap": false },
+        "content": "### Node Pool Management SLO Dashboard\n\nMonitors node pool operation health against defined SLOs.\n\n**SLO Targets (Proposed — pending baseline):**\n- Operation success rate: 95% over 7-day rolling window\n- Operation latency: 95% within 600s\n- Resource health: 99.5% non-failed provisioning state\n\n**Metrics Source:** `backend_resource_operation_phase_info`, `backend_nodepool_provision_state` (Cosmos DB-backed)\n\n**Jira:** [ARO-25967](https://redhat.atlassian.net/browse/ARO-25967) | **TSG:** [Node Pool Management TSG](https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/troubleshooting/node-pool-management-tsg.html)",
+        "mode": "markdown"
+      },
+      "pluginVersion": "11.6.9",
+      "title": "Dashboard Info",
+      "type": "text"
+    },
+    {
+      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
+      "description": "Current operation success rate — fraction of terminal operations in succeeded state. SLO target: 95%.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red" },
+              { "color": "yellow", "value": 90 },
+              { "color": "green", "value": 95 }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 4 },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "editorMode": "code",
+          "expr": "(\n  count(backend_resource_operation_phase_info{resource_type=~\".*nodepools\", phase=\"succeeded\"})\n  /\n  count(backend_resource_operation_phase_info{resource_type=~\".*nodepools\", phase=~\"succeeded|failed\"})\n) * 100",
+          "instant": true,
+          "legendFormat": "Success Rate",
+          "refId": "A"
+        }
+      ],
+      "title": "Operation Success Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
+      "description": "Current count of node pool operations in failed terminal state.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green" },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 5 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 4 },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "editorMode": "code",
+          "expr": "count(backend_resource_operation_phase_info{resource_type=~\".*nodepools\", phase=\"failed\"}) or vector(0)",
+          "instant": true,
+          "legendFormat": "Failed Operations",
+          "refId": "A"
+        }
+      ],
+      "title": "Failed Operations",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
+      "description": "Number of operations stuck in updating or deleting for over 1 hour.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green" },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 12, "y": 4 },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "editorMode": "code",
+          "expr": "count((time() - backend_resource_operation_start_time_seconds{resource_type=~\".*nodepools\", phase=~\"updating|deleting\"}) > 3600) or vector(0)",
+          "instant": true,
+          "legendFormat": "Stuck Operations",
+          "refId": "A"
+        }
+      ],
+      "title": "Stuck Operations (>1h)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
+      "description": "Total node pools tracked by the backend.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "blue" }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 18, "y": 4 },
+      "id": 5,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "editorMode": "code",
+          "expr": "count(backend_nodepool_provision_state) or vector(0)",
+          "instant": true,
+          "legendFormat": "Total Node Pools",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Node Pools",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
+      "description": "Operation success rate over time. The green line marks the 95% SLO target.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "thresholdsStyle": { "mode": "line" }
+          },
+          "decimals": 1,
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red" },
+              { "color": "green", "value": 95 }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 10 },
+      "id": 6,
+      "options": {
+        "legend": { "calcs": ["mean", "lastNotNull", "min"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "editorMode": "code",
+          "expr": "(\n  count(backend_resource_operation_phase_info{resource_type=~\".*nodepools\", phase=\"succeeded\"})\n  /\n  count(backend_resource_operation_phase_info{resource_type=~\".*nodepools\", phase=~\"succeeded|failed\"})\n) * 100",
+          "legendFormat": "Success Rate %",
+          "refId": "A"
+        }
+      ],
+      "title": "Operation Success Rate Over Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
+      "description": "Distribution of node pool provisioning states over time.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "none",
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "stacking": { "group": "A", "mode": "normal" }
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "failed" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "succeeded" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "updating" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "yellow", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "deleting" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 10 },
+      "id": 7,
+      "options": {
+        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "editorMode": "code",
+          "expr": "count by (phase) (backend_nodepool_provision_state)",
+          "legendFormat": "{{ phase }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Node Pool Provisioning State Distribution",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
+      "description": "Duration of in-flight operations (time since start for operations in non-terminal phases).",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "Duration",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never"
+          },
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green" },
+              { "color": "yellow", "value": 600 },
+              { "color": "red", "value": 3600 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 18 },
+      "id": 8,
+      "options": {
+        "legend": { "calcs": ["max"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "editorMode": "code",
+          "expr": "time() - backend_resource_operation_start_time_seconds{resource_type=~\".*nodepools\", phase=~\"updating|deleting\"}",
+          "legendFormat": "{{ resource_id }} ({{ phase }})",
+          "refId": "A"
+        }
+      ],
+      "title": "In-Flight Operation Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
+      "description": "Duration of completed operations (succeeded and failed).",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "Duration",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "points",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "lineWidth": 1,
+            "pointSize": 8,
+            "showPoints": "always"
+          },
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green" },
+              { "color": "yellow", "value": 600 },
+              { "color": "red", "value": 1200 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 18 },
+      "id": 9,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "editorMode": "code",
+          "expr": "backend_resource_operation_last_transition_time_seconds{resource_type=~\".*nodepools\", phase=~\"succeeded|failed\"} - backend_resource_operation_start_time_seconds{resource_type=~\".*nodepools\", phase=~\"succeeded|failed\"}",
+          "legendFormat": "{{ operation_type }} - {{ phase }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Completed Operation Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
+      "description": "Operation phase breakdown over time — count of operations in each phase.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "stacking": { "group": "A", "mode": "normal" }
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "failed" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "succeeded" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "updating" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "yellow", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "deleting" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 26 },
+      "id": 10,
+      "options": {
+        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "editorMode": "code",
+          "expr": "count by (phase) (backend_resource_operation_phase_info{resource_type=~\".*nodepools\"})",
+          "legendFormat": "{{ phase }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Operation Phase Distribution",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
+      "description": "Operations by type (update vs delete) in terminal states.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 26 },
+      "id": 11,
+      "options": {
+        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "editorMode": "code",
+          "expr": "count by (operation_type, phase) (backend_resource_operation_phase_info{resource_type=~\".*nodepools\", phase=~\"succeeded|failed\"})",
+          "legendFormat": "{{ operation_type }} - {{ phase }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Operations by Type and Outcome",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 34 },
+      "id": 20,
+      "title": "Component Health — Workqueue",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
+      "description": "Node pool controller workqueue depth. Alert threshold: > 10 for 5 minutes.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "Queue Depth",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "thresholdsStyle": { "mode": "line" }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green" },
+              { "color": "red", "value": 10 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 35 },
+      "id": 21,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "editorMode": "code",
+          "expr": "max by (name, cluster) (max without(prometheus_replica) (workqueue_depth{namespace=\"aro-hcp\", name=~\".*nodepool.*\"}))",
+          "legendFormat": "{{ name }} ({{ cluster }})",
+          "refId": "A"
+        }
+      ],
+      "title": "Workqueue Depth",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
+      "description": "Ratio of retries to total adds. Alert threshold: > 50% for 10 minutes.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "Retry Ratio",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "thresholdsStyle": { "mode": "line" }
+          },
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green" },
+              { "color": "red", "value": 0.5 }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 35 },
+      "id": 22,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "editorMode": "code",
+          "expr": "sum by (name, cluster) (max without(prometheus_replica) (rate(workqueue_retries_total{namespace=\"aro-hcp\", name=~\".*nodepool.*\"}[10m]))) / sum by (name, cluster) (max without(prometheus_replica) (rate(workqueue_adds_total{namespace=\"aro-hcp\", name=~\".*nodepool.*\"}[10m])))",
+          "legendFormat": "{{ name }} ({{ cluster }})",
+          "refId": "A"
+        }
+      ],
+      "title": "Workqueue Retry Ratio",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
+      "description": "Rate of items being added to node pool workqueues.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "Items/sec",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 43 },
+      "id": 23,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "editorMode": "code",
+          "expr": "sum by (name, cluster) (max without(prometheus_replica) (rate(workqueue_adds_total{namespace=\"aro-hcp\", name=~\".*nodepool.*\"}[5m])))",
+          "legendFormat": "{{ name }} ({{ cluster }})",
+          "refId": "A"
+        }
+      ],
+      "title": "Workqueue Add Rate (Traffic)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
+      "description": "Table of currently failed node pool operations with resource details.",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 43 },
+      "id": 24,
+      "options": {
+        "showHeader": true,
+        "sortBy": [{ "desc": true, "displayName": "subscription_id" }]
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "editorMode": "code",
+          "expr": "backend_resource_operation_phase_info{resource_type=~\".*nodepools\", phase=\"failed\"} == 1",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Failed Operations Detail",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": { "Time": true, "Value": true, "__name__": true },
+            "renameByName": {
+              "resource_id": "Resource ID",
+              "subscription_id": "Subscription",
+              "operation_type": "Operation",
+              "phase": "Phase",
+              "resource_type": "Resource Type"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["aro-hcp", "node-pool", "slo", "user-journey"],
+  "templating": {
+    "list": [
+      {
+        "allowCustomValue": false,
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "includeAll": true,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "^Managed_Prometheus_hcps-.*$",
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-7d",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Node Pool Management SLO",
+  "uid": "nodepool-slo",
+  "version": 1
+}

--- a/observability/grafana-dashboards/sre/user-journey/nodepool-slo.json
+++ b/observability/grafana-dashboards/sre/user-journey/nodepool-slo.json
@@ -68,13 +68,17 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "(\n  (count(backend_resource_operation_phase_info{resource_type=~\".*nodepools\", phase=\"succeeded\"}) or vector(0))\n  /\n  (count(backend_resource_operation_phase_info{resource_type=~\".*nodepools\", phase=~\"succeeded|failed|canceled\"}) > 0 or vector(1))\n) * 100",
+          "expr": "(\n  (count(backend_resource_operation_phase_info{resource_type=~\".*nodepools\", operation_type=~\"update|delete\", phase=\"succeeded\"}) or vector(0))\n  /\n  (count(backend_resource_operation_phase_info{resource_type=~\".*nodepools\", operation_type=~\"update|delete\", phase=~\"succeeded|failed\"}) > 0 or vector(1))\n) * 100",
           "instant": true,
           "legendFormat": "Success Rate",
           "refId": "A"
         }
       ],
       "title": "Operation Success Rate",
+      "transformations": [
+        { "id": "seriesToRows", "options": {} },
+        { "id": "merge", "options": {} }
+      ],
       "type": "stat"
     },
     {
@@ -117,6 +121,10 @@
         }
       ],
       "title": "Failed Operations",
+      "transformations": [
+        { "id": "seriesToRows", "options": {} },
+        { "id": "merge", "options": {} }
+      ],
       "type": "stat"
     },
     {
@@ -158,6 +166,10 @@
         }
       ],
       "title": "Stuck Operations (>1h)",
+      "transformations": [
+        { "id": "seriesToRows", "options": {} },
+        { "id": "merge", "options": {} }
+      ],
       "type": "stat"
     },
     {
@@ -191,13 +203,17 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "count(backend_nodepool_provision_state) or vector(0)",
+          "expr": "count(backend_nodepool_provision_state == 1) or vector(0)",
           "instant": true,
           "legendFormat": "Total Node Pools",
           "refId": "A"
         }
       ],
       "title": "Total Node Pools",
+      "transformations": [
+        { "id": "seriesToRows", "options": {} },
+        { "id": "merge", "options": {} }
+      ],
       "type": "stat"
     },
     {
@@ -246,7 +262,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "(\n  (count(backend_resource_operation_phase_info{resource_type=~\".*nodepools\", phase=\"succeeded\"}) or vector(0))\n  /\n  (count(backend_resource_operation_phase_info{resource_type=~\".*nodepools\", phase=~\"succeeded|failed|canceled\"}) > 0 or vector(1))\n) * 100",
+          "expr": "(\n  (count(backend_resource_operation_phase_info{resource_type=~\".*nodepools\", operation_type=~\"update|delete\", phase=\"succeeded\"}) or vector(0))\n  /\n  (count(backend_resource_operation_phase_info{resource_type=~\".*nodepools\", operation_type=~\"update|delete\", phase=~\"succeeded|failed\"}) > 0 or vector(1))\n) * 100",
           "legendFormat": "Success Rate %",
           "refId": "A"
         }
@@ -306,7 +322,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "count by (phase) (backend_nodepool_provision_state)",
+          "expr": "count by (phase) (backend_nodepool_provision_state == 1)",
           "legendFormat": "{{ phase }}",
           "refId": "A"
         }
@@ -695,6 +711,8 @@
       ],
       "title": "Failed Operations Detail",
       "transformations": [
+        { "id": "seriesToRows", "options": {} },
+        { "id": "merge", "options": {} },
         {
           "id": "organize",
           "options": {

--- a/observability/grafana-dashboards/sre/user-journey/nodepool-slo.json
+++ b/observability/grafana-dashboards/sre/user-journey/nodepool-slo.json
@@ -422,7 +422,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "backend_resource_operation_last_transition_time_seconds{resource_type=~\".*nodepools\", operation_type=~\"update|delete\", phase=~\"succeeded|failed\"} - backend_resource_operation_start_time_seconds{resource_type=~\".*nodepools\", operation_type=~\"update|delete\", phase=~\"succeeded|failed\"}",
+          "expr": "backend_resource_operation_last_transition_time_seconds{resource_type=~\".*nodepools\", phase=~\"succeeded|failed|canceled\"} - backend_resource_operation_start_time_seconds{resource_type=~\".*nodepools\", phase=~\"succeeded|failed|canceled\"}",
           "legendFormat": "{{ operation_type }} - {{ phase }}",
           "refId": "A"
         }
@@ -524,7 +524,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "count by (operation_type, phase) (backend_resource_operation_phase_info{resource_type=~\".*nodepools\", operation_type=~\"update|delete\", phase=~\"succeeded|failed\"})",
+          "expr": "count by (operation_type, phase) (backend_resource_operation_phase_info{resource_type=~\".*nodepools\", phase=~\"succeeded|failed|canceled\"})",
           "legendFormat": "{{ operation_type }} - {{ phase }}",
           "refId": "A"
         }

--- a/observability/grafana-dashboards/sre/user-journey/nodepool-slo.json
+++ b/observability/grafana-dashboards/sre/user-journey/nodepool-slo.json
@@ -565,7 +565,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "max by (name, cluster) (max without(prometheus_replica) (workqueue_depth{namespace=\"aro-hcp\", name=~\".*nodepool.*\"}))",
+          "expr": "max by (name, cluster) (max without(prometheus_replica) (workqueue_depth{namespace=\"aro-hcp\", name=~\".*NodePool.*\"}))",
           "legendFormat": "{{ name }} ({{ cluster }})",
           "refId": "A"
         }
@@ -618,7 +618,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "sum by (name, cluster) (max without(prometheus_replica) (rate(workqueue_retries_total{namespace=\"aro-hcp\", name=~\".*nodepool.*\"}[10m]))) / sum by (name, cluster) (max without(prometheus_replica) (rate(workqueue_adds_total{namespace=\"aro-hcp\", name=~\".*nodepool.*\"}[10m])))",
+          "expr": "sum by (name, cluster) (max without(prometheus_replica) (rate(workqueue_retries_total{namespace=\"aro-hcp\", name=~\".*NodePool.*\"}[10m]))) / sum by (name, cluster) (max without(prometheus_replica) (rate(workqueue_adds_total{namespace=\"aro-hcp\", name=~\".*NodePool.*\"}[10m])))",
           "legendFormat": "{{ name }} ({{ cluster }})",
           "refId": "A"
         }
@@ -660,7 +660,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "sum by (name, cluster) (max without(prometheus_replica) (rate(workqueue_adds_total{namespace=\"aro-hcp\", name=~\".*nodepool.*\"}[5m])))",
+          "expr": "sum by (name, cluster) (max without(prometheus_replica) (rate(workqueue_adds_total{namespace=\"aro-hcp\", name=~\".*NodePool.*\"}[5m])))",
           "legendFormat": "{{ name }} ({{ cluster }})",
           "refId": "A"
         }


### PR DESCRIPTION
## Summary
Adds a Grafana dashboard for Node Pool Management SLO monitoring.

**Stacked on:** #5112 (alerting rules) - merge that first.

**Panels:** Operation Success Rate, Failed Operations, Stuck Operations, Provisioning State Distribution, Workqueue Health, etc.

**Datasource:** Managed_Prometheus_services-* (fixed per reviewer feedback)

## Related
- Jira: [ARO-25967](https://redhat.atlassian.net/browse/ARO-25967)
- Alerting PR: #5112
