### PR TITLE
fix(ops): target worker node pools for recreate-broken-pools (AROSLSRE-1003)

### DIFF
--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -283,7 +283,7 @@ resourceGroups:
         step: subscription-output
         name: subscriptionId
     - name: NODEPOOL_TAG
-      value: 'user'
+      value: 'worker'
     - name: NRP_FAIL_THRESHOLD
       value: '10'
     - name: NRP_FAIL_WINDOW_MIN


### PR DESCRIPTION
[AROSLSRE-1003](https://issues.redhat.com/browse/AROSLSRE-1003)

### What

Changes the `recreate-broken-user-nodepools` pipeline step to pass `NODEPOOL_TAG=worker`.

### Why

The INT run showed the script was included and launched, but exited no-op because no node pools had `aro-hcp.azure.com/role=user`:

```text
NODEPOOL_TAG=user
no selected node pools confirmed broken: no node pools found with aro-hcp.azure.com/role="user". Exiting no-op.
```

Live user workload pools are labeled `aro-hcp.azure.com/role=worker`, so the step must target `worker` to select `userswft*` pools.

### Testing

```text
go test ./dev-infrastructure/scripts/recreate-broken-pools -count=1
```

### Special notes for your reviewer

This is intentionally scoped to the selector fix. The separate leftover temp-pool adoption follow-up remains in https://github.com/Azure/ARO-HCP/pull/5480.

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [x] All comment threads resolved before merge