### PR TITLE
run node pool verifiers in parallel

### DIFF
--- a/test/e2e/nodepool_ephemeral_osdisk.go
+++ b/test/e2e/nodepool_ephemeral_osdisk.go
@@ -170,13 +170,9 @@ var _ = Describe("Nodepool Ephemeral OS Disk", func() {
 			)
 			Expect(err).NotTo(HaveOccurred(), "failed to get admin REST config for cluster %s", customerClusterName)
 
-			By("ensuring the cluster is viable")
-			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig)
-			Expect(err).NotTo(HaveOccurred(), "failed to verify HCP cluster %s is viable", customerClusterName)
-
-			By("verifying count and ready status of nodes from the ephemeral nodepool")
-			Expect(verifiers.VerifyNodeCount(customerClusterName, int(nodePoolParams.Replicas)).Verify(ctx, adminRESTConfig)).To(Succeed(), "failed to verify node count matches expected replicas %d", nodePoolParams.Replicas)
-			Expect(verifiers.VerifyNodesReady().Verify(ctx, adminRESTConfig)).To(Succeed(), "failed to verify all nodes are ready")
+			By("verifying cluster and count and ready status of nodes from the ephemeral nodepool")
+			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig, verifiers.VerifyNodeCount(customerClusterName, int(nodePoolParams.Replicas)), verifiers.VerifyNodesReady())
+			Expect(err).NotTo(HaveOccurred(), "failed to verify node count of %d and ready status for ephemeral nodepool", nodePoolParams.Replicas)
 
 			By("verifying Azure VMs actually have ephemeral OS disks")
 			computeFactory := tc.GetARMComputeClientFactoryOrDie(ctx)

--- a/test/e2e/nodepool_update_nodes.go
+++ b/test/e2e/nodepool_update_nodes.go
@@ -132,8 +132,8 @@ var _ = Describe("Customer", func() {
 
 			By("verifying nodes count and ready status")
 			totalNodeCount := mainNodeCount + oneNodeCount
-			Expect(verifiers.VerifyNodeCount(customerClusterName, totalNodeCount).Verify(ctx, adminRESTConfig)).To(Succeed(), "failed to verify initial node count of %d", totalNodeCount)
-			Expect(verifiers.VerifyNodesReady().Verify(ctx, adminRESTConfig)).To(Succeed(), "failed to verify all nodes are ready after initial creation")
+			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig, verifiers.VerifyNodeCount(customerClusterName, totalNodeCount), verifiers.VerifyNodesReady())
+			Expect(err).NotTo(HaveOccurred(), "failed to verify node count of %d and ready status after initial creation", totalNodeCount)
 
 			By("scaling up the nodepool replicas from 2 to 3 replicas")
 			mainNodeCount = 3
@@ -157,8 +157,8 @@ var _ = Describe("Customer", func() {
 
 			By("verifying nodes count and ready status")
 			totalNodeCount = mainNodeCount + oneNodeCount
-			Expect(verifiers.VerifyNodeCount(customerClusterName, totalNodeCount).Verify(ctx, adminRESTConfig)).To(Succeed(), "failed to verify node count of %d after scale up", totalNodeCount)
-			Expect(verifiers.VerifyNodesReady().Verify(ctx, adminRESTConfig)).To(Succeed(), "failed to verify all nodes are ready after scale up")
+			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig, verifiers.VerifyNodeCount(customerClusterName, totalNodeCount), verifiers.VerifyNodesReady())
+			Expect(err).NotTo(HaveOccurred(), "failed to verify node count of %d and ready status after scale up", totalNodeCount)
 
 			nodePoolsClient := tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient()
 
@@ -184,8 +184,8 @@ var _ = Describe("Customer", func() {
 
 			By("verifying nodes count and ready status")
 			totalNodeCount = mainNodeCount + oneNodeCount
-			Expect(verifiers.VerifyNodeCount(customerClusterName, totalNodeCount).Verify(ctx, adminRESTConfig)).To(Succeed(), "failed to verify node count of %d after scale down", totalNodeCount)
-			Expect(verifiers.VerifyNodesReady().Verify(ctx, adminRESTConfig)).To(Succeed(), "failed to verify all nodes are ready after scale down")
+			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig, verifiers.VerifyNodeCount(customerClusterName, totalNodeCount), verifiers.VerifyNodesReady())
+			Expect(err).NotTo(HaveOccurred(), "failed to verify node count of %d and ready status after scale down", totalNodeCount)
 
 			By("updating the one-replica nodepool replicas to 0 and enabling autoscaling with a PATCH")
 			update = hcpsdk20240610preview.NodePoolUpdate{
@@ -216,7 +216,7 @@ var _ = Describe("Customer", func() {
 			By("verifying nodes count and ready status")
 			oneNodeCount = 2
 			totalNodeCount = mainNodeCount + oneNodeCount
-			Expect(verifiers.VerifyNodeCount(customerClusterName, totalNodeCount).Verify(ctx, adminRESTConfig)).To(Succeed(), "failed to verify node count of %d after enabling autoscaling", totalNodeCount)
-			Expect(verifiers.VerifyNodesReady().Verify(ctx, adminRESTConfig)).To(Succeed(), "failed to verify all nodes are ready after enabling autoscaling")
+			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig, verifiers.VerifyNodeCount(customerClusterName, totalNodeCount), verifiers.VerifyNodesReady())
+			Expect(err).NotTo(HaveOccurred(), "failed to verify node count of %d and ready status after enabling autoscaling", totalNodeCount)
 		})
 })

--- a/test/e2e/oidc_issuer_workload_identity.go
+++ b/test/e2e/oidc_issuer_workload_identity.go
@@ -259,8 +259,8 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create node pool %s", customerNodePoolName)
 
 			By("verifying nodes count and ready status")
-			Expect(verifiers.VerifyNodeCount(customerClusterName, int(nodePoolParams.Replicas)).Verify(ctx, adminRESTConfig)).To(Succeed(), "failed to verify node count matches expected replicas %d", nodePoolParams.Replicas)
-			Expect(verifiers.VerifyNodesReady().Verify(ctx, adminRESTConfig)).To(Succeed(), "failed to verify all nodes are ready")
+			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig, verifiers.VerifyNodeCount(customerClusterName, int(nodePoolParams.Replicas)), verifiers.VerifyNodesReady())
+			Expect(err).NotTo(HaveOccurred(), "failed to verify node count of %d and ready status", nodePoolParams.Replicas)
 
 			By("creating a user-assigned managed identity for the test")
 			subscriptionID, err := tc.SubscriptionID(ctx)


### PR DESCRIPTION
### What

Few E2E test cases call multiple verifiers one by one, eg.:

```
Expect(verifiers.VerifyNodeCount(customerClusterName, totalNodeCount).Verify(ctx, adminRESTConfig)).To(Succeed())
Expect(verifiers.VerifyNodesReady().Verify(ctx, adminRESTConfig)).To(Succeed())
```

When we can run them in parallel via `VerifyHCPCluster`:

```
err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig, verifiers.VerifyNodeCount(customerClusterName, totalNodeCount), verifiers.VerifyNodesReady())
Expect(err).NotTo(HaveOccurred())
```

Obviously there are cases when we actually want to run some verifiers first before going on with other checks, but checking number and status of nodes in a node pool is not that case.

### Why

- in case of failure, we are get more evidence about the issue (results for all verifiers are provided, not just the first one which failed)
- running multiple verifiers in parallel will (hopefully) speed up the test runtime (the effect is small though)
- we run core verifiers in these cases, increasing coverage a bit by making sure that the cluster is still fully healthy

### Testing

- rerunning the e2e-parallel job multiple times

### Special notes for your reviewer

Work in progress (addressing feedback): will create new functions to run verifiers:

- general function to just run verifiers it receives without having any defaults (unlike VerifyHCPCluster)
- consider one for node pool verification (may not be needed)

### PR Checklist

- [X] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [X] Summary explains the "Why" behind the change
- [ ] ~Linked to relevant ticket/issue~ (not applicable)
- [ ] ~Screenshots included~ (not applicable)
- [X] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [X] Draft PR used for WIP (if applicable)
- [X] Commit history is clean (rebased/squashed)
- [X] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
