### PR TITLE
fix(backend): remove redundant API URL gate from create operation

### DIFF
--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_create.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_create.go
@@ -285,9 +285,36 @@ func (c *operationClusterCreate) hostedClusterOperationStatus(ctx context.Contex
 		return newOperationState(arm.ProvisioningStateProvisioning, "hosted cluster has no control plane endpoint port"), nil
 	}
 
-	// if we got here,
-	// 1. the hosted cluster is available via condition
-	// 2. the hosted cluster has successfully installed at least one version
-	// 3. the hosted cluster has a control plane endpoint host and port
+	// Ensure the API URL is populated in the Cosmos cluster document before
+	// the create operation transitions to Succeeded. The cluster_properties_sync
+	// controller copies this from Cluster Service on a 5-minute cycle; writing
+	// it here from the HostedCluster's ControlPlaneEndpoint avoids a delay
+	// where the operation succeeds but the user sees an empty API URL.
+	if err := c.ensureAPIURL(ctx, operation, hostedCluster); err != nil {
+		return nil, utils.TrackError(err)
+	}
+
 	return newOperationState(arm.ProvisioningStateSucceeded, ""), nil
+}
+
+func (c *operationClusterCreate) ensureAPIURL(ctx context.Context, operation *api.Operation, hostedCluster *v1beta1.HostedCluster) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	clusterCRUD := c.resourcesDBClient.HCPClusters(operation.ExternalID.SubscriptionID, operation.ExternalID.ResourceGroupName)
+	cluster, err := clusterCRUD.Get(ctx, operation.ExternalID.Name)
+	if err != nil {
+		return fmt.Errorf("failed to get cluster for API URL check: %w", err)
+	}
+
+	if len(cluster.ServiceProviderProperties.API.URL) > 0 {
+		return nil
+	}
+
+	apiURL := fmt.Sprintf("https://%s:%d", hostedCluster.Status.ControlPlaneEndpoint.Host, hostedCluster.Status.ControlPlaneEndpoint.Port)
+	cluster.ServiceProviderProperties.API.URL = apiURL
+	if _, err := clusterCRUD.Replace(ctx, cluster, nil); err != nil {
+		return fmt.Errorf("failed to write API URL to cluster: %w", err)
+	}
+	logger.Info("Populated API URL from HostedCluster ControlPlaneEndpoint", "apiURL", apiURL)
+	return nil
 }

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_create.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_create.go
@@ -151,9 +151,9 @@ func (c *operationClusterCreate) SynchronizeOperation(ctx context.Context, key c
 	logger.Info("new status via cluster-service", "newStatus", newOperationStatus, "newOperationError", opError)
 
 	if newOperationStatus == arm.ProvisioningStateSucceeded && cosmosNewOperationState.provisioningState != arm.ProvisioningStateSucceeded {
-		// we want to require that the cosmos view of cluster creation is also complete before we mark it.  This ensures (among other things)
-		// that our ability to read maestro is successful.
-		// Once we have confidence in our ability to determine that cluster is functional, we'll stop checking cluster-service at all.
+		// Require the cosmos view (HostedCluster ControlPlaneEndpoint via ReadDesire) to also
+		// confirm readiness before marking the operation Succeeded. This ensures Maestro
+		// observability is functional independently of Cluster Service's status.
 		return fmt.Errorf("cosmos operation status is %q, but cluster-service operation status is %q", cosmosNewOperationState.provisioningState, newOperationStatus)
 	}
 

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_create.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_create.go
@@ -48,7 +48,6 @@ import (
 
 type operationClusterCreate struct {
 	clock                                 utilsclock.PassiveClock
-	clusterLister                         listers.ClusterLister
 	clusterManagementClusterContentLister listers.ManagementClusterContentLister
 	readDesireLister                      dblisters.ReadDesireLister
 	resourcesDBClient                     database.ResourcesDBClient
@@ -79,11 +78,9 @@ func NewOperationClusterCreateController(
 	informers informers.BackendInformers,
 	readDesireLister dblisters.ReadDesireLister,
 ) controllerutils.Controller {
-	_, clusterLister := informers.Clusters()
 	_, clusterManagementClusterContentLister := informers.ManagementClusterContents()
 	syncer := &operationClusterCreate{
 		clock:                                 clock,
-		clusterLister:                         clusterLister,
 		clusterManagementClusterContentLister: clusterManagementClusterContentLister,
 		readDesireLister:                      readDesireLister,
 		resourcesDBClient:                     resourcesDBClient,
@@ -180,11 +177,6 @@ func (c *operationClusterCreate) determineOperationStatus(ctx context.Context, o
 	} else {
 		operationStates = append(operationStates, currState)
 	}
-	if currState, err := c.clusterOperationStatus(ctx, operation); err != nil {
-		errs = append(errs, utils.TrackError(err))
-	} else {
-		operationStates = append(operationStates, currState)
-	}
 
 	if err := errors.Join(errs...); err != nil {
 		return nil, err
@@ -206,20 +198,6 @@ func (c *operationClusterCreate) determineOperationStatus(ctx context.Context, o
 	}
 	logger.Info("picked cluster create operation status", "provisioningState", picked.provisioningState, "message", picked.message)
 	return picked, nil
-}
-
-func (c *operationClusterCreate) clusterOperationStatus(ctx context.Context, operation *api.Operation) (*operationState, error) {
-	cluster, err := c.clusterLister.Get(ctx, operation.ExternalID.SubscriptionID, operation.ExternalID.ResourceGroupName, operation.ExternalID.Name)
-	if err != nil {
-		return nil, utils.TrackError(err)
-	}
-
-	if len(cluster.ServiceProviderProperties.API.URL) == 0 {
-		message := ".api.url is empty"
-		return newOperationState(arm.ProvisioningStateProvisioning, message), nil
-	}
-
-	return newOperationState(arm.ProvisioningStateSucceeded, ""), nil
 }
 
 // minVersionsWithValidSuccessCondition maps from <major>.<micro> to the first z-stream version that includes the fix for

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_create.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_create.go
@@ -217,7 +217,7 @@ func (c *operationClusterCreate) hostedClusterOperationStatus(ctx context.Contex
 	// don't need to know which management cluster the HostedCluster is on.
 	readDesire, err := c.readDesireLister.GetForCluster(ctx, operation.ExternalID.SubscriptionID, operation.ExternalID.ResourceGroupName, operation.ExternalID.Name, maestrohelpers.ReadDesireNameReadonlyHostedCluster)
 	if database.IsNotFoundError(err) {
-		return newOperationState(arm.ProvisioningStateProvisioning, ""), nil
+		return newOperationState(arm.ProvisioningStateProvisioning, "ReadDesire not yet created for cluster"), nil
 	}
 	if err != nil {
 		return nil, utils.TrackError(err)

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_create_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_create_test.go
@@ -245,6 +245,7 @@ func TestDetermineOperationStatus(t *testing.T) {
 			name:             "hosted cluster not found → Provisioning",
 			readDesireLister: &internallistertesting.SliceReadDesireLister{},
 			expectedState:    arm.ProvisioningStateProvisioning,
+			expectedMessage:  "ReadDesire not yet created for cluster",
 		},
 		{
 			name:             "read desire lister non-404 error → error propagated",

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_create_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_create_test.go
@@ -36,8 +36,6 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/hypershift/api/hypershift/v1beta1"
 
-	"github.com/Azure/ARO-HCP/backend/pkg/listers"
-	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
 	"github.com/Azure/ARO-HCP/backend/pkg/maestrohelpers"
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
@@ -132,9 +130,6 @@ func TestOperationClusterCreate_SynchronizeOperation(t *testing.T) {
 				resourcesDBClient:    mockResourcesDBClient,
 				clusterServiceClient: mockCSClient,
 				notificationClient:   nil,
-				clusterLister: &listertesting.SliceClusterLister{
-					Clusters: []*api.HCPOpenShiftCluster{newClusterWithAPIURL("https://api.example.com")},
-				},
 				readDesireLister: &internallistertesting.SliceReadDesireLister{
 					Desires: []*kubeapplier.ReadDesire{succeededDesire},
 				},
@@ -153,21 +148,6 @@ func TestOperationClusterCreate_SynchronizeOperation(t *testing.T) {
 			}
 		})
 	}
-}
-
-// errorClusterLister always returns the configured error.
-type errorClusterLister struct {
-	err error
-}
-
-func (l *errorClusterLister) List(_ context.Context) ([]*api.HCPOpenShiftCluster, error) {
-	return nil, l.err
-}
-func (l *errorClusterLister) Get(_ context.Context, _, _, _ string) (*api.HCPOpenShiftCluster, error) {
-	return nil, l.err
-}
-func (l *errorClusterLister) ListForResourceGroup(_ context.Context, _, _ string) ([]*api.HCPOpenShiftCluster, error) {
-	return nil, l.err
 }
 
 // errorReadDesireLister always returns the configured error.
@@ -224,20 +204,12 @@ func newHostedClusterReadDesire(t *testing.T, hostedCluster *v1beta1.HostedClust
 	}
 }
 
-func newClusterWithAPIURL(url string) *api.HCPOpenShiftCluster {
-	fixture := newClusterTestFixture()
-	cluster := fixture.newCluster(nil)
-	cluster.ServiceProviderProperties.API = api.ServiceProviderAPIProfile{URL: url}
-	return cluster
-}
-
 func TestDetermineOperationStatus(t *testing.T) {
 	fixture := newClusterTestFixture()
 	operation := fixture.newOperation(database.OperationRequestCreate)
 
 	tests := []struct {
 		name             string
-		clusterLister    listers.ClusterLister
 		readDesireLister dblisters.ReadDesireLister
 		expectedState    arm.ProvisioningState
 		expectedMessage  string
@@ -245,10 +217,7 @@ func TestDetermineOperationStatus(t *testing.T) {
 		errContains      string
 	}{
 		{
-			name: "both checks succeed → Succeeded",
-			clusterLister: &listertesting.SliceClusterLister{
-				Clusters: []*api.HCPOpenShiftCluster{newClusterWithAPIURL("https://api.example.com")},
-			},
+			name: "hosted cluster ready → Succeeded",
 			readDesireLister: &internallistertesting.SliceReadDesireLister{
 				Desires: []*kubeapplier.ReadDesire{
 					newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
@@ -273,88 +242,18 @@ func TestDetermineOperationStatus(t *testing.T) {
 			expectedMessage: "",
 		},
 		{
-			name: "cluster API URL empty → Provisioning (lowest priority wins)",
-			clusterLister: &listertesting.SliceClusterLister{
-				Clusters: []*api.HCPOpenShiftCluster{newClusterWithAPIURL("")},
-			},
-			readDesireLister: &internallistertesting.SliceReadDesireLister{
-				Desires: []*kubeapplier.ReadDesire{
-					newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
-						Status: v1beta1.HostedClusterStatus{
-							Conditions: []metav1.Condition{
-								{Type: string(v1beta1.HostedClusterAvailable), Status: metav1.ConditionTrue},
-							},
-							ControlPlaneVersion: v1beta1.ControlPlaneVersionStatus{
-								History: []v1beta1.ControlPlaneUpdateHistory{
-									{Version: "4.17.3", State: configv1.CompletedUpdate},
-								},
-							},
-							ControlPlaneEndpoint: v1beta1.APIEndpoint{
-								Host: "api.example.com",
-								Port: 6443,
-							},
-						},
-					}),
-				},
-			},
-			expectedState:   arm.ProvisioningStateProvisioning,
-			expectedMessage: ".api.url is empty",
-		},
-		{
-			name: "hosted cluster not found → Provisioning",
-			clusterLister: &listertesting.SliceClusterLister{
-				Clusters: []*api.HCPOpenShiftCluster{newClusterWithAPIURL("https://api.example.com")},
-			},
+			name:             "hosted cluster not found → Provisioning",
 			readDesireLister: &internallistertesting.SliceReadDesireLister{},
 			expectedState:    arm.ProvisioningStateProvisioning,
 		},
 		{
-			name:          "cluster lister error → error propagated",
-			clusterLister: &errorClusterLister{err: fmt.Errorf("cosmos error")},
-			readDesireLister: &internallistertesting.SliceReadDesireLister{
-				Desires: []*kubeapplier.ReadDesire{
-					newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
-						Status: v1beta1.HostedClusterStatus{
-							Conditions: []metav1.Condition{
-								{Type: string(v1beta1.HostedClusterAvailable), Status: metav1.ConditionTrue},
-							},
-							ControlPlaneVersion: v1beta1.ControlPlaneVersionStatus{
-								History: []v1beta1.ControlPlaneUpdateHistory{
-									{Version: "4.17.3", State: configv1.CompletedUpdate},
-								},
-							},
-							ControlPlaneEndpoint: v1beta1.APIEndpoint{
-								Host: "api.example.com",
-								Port: 6443,
-							},
-						},
-					}),
-				},
-			},
-			expectError: true,
-			errContains: "cosmos error",
-		},
-		{
-			name: "read desire lister non-404 error → error propagated",
-			clusterLister: &listertesting.SliceClusterLister{
-				Clusters: []*api.HCPOpenShiftCluster{newClusterWithAPIURL("https://api.example.com")},
-			},
+			name:             "read desire lister non-404 error → error propagated",
 			readDesireLister: &errorReadDesireLister{err: fmt.Errorf("maestro error")},
 			expectError:      true,
 			errContains:      "maestro error",
 		},
 		{
-			name:             "both errors → joined error",
-			clusterLister:    &errorClusterLister{err: fmt.Errorf("cluster error")},
-			readDesireLister: &errorReadDesireLister{err: fmt.Errorf("content error")},
-			expectError:      true,
-			errContains:      "cluster error",
-		},
-		{
 			name: "read desire not yet successful → Provisioning",
-			clusterLister: &listertesting.SliceClusterLister{
-				Clusters: []*api.HCPOpenShiftCluster{newClusterWithAPIURL("https://api.example.com")},
-			},
 			readDesireLister: &internallistertesting.SliceReadDesireLister{
 				Desires: []*kubeapplier.ReadDesire{
 					newHostedClusterReadDesire(t, &v1beta1.HostedCluster{},
@@ -366,9 +265,6 @@ func TestDetermineOperationStatus(t *testing.T) {
 		},
 		{
 			name: "hosted cluster not available → Provisioning",
-			clusterLister: &listertesting.SliceClusterLister{
-				Clusters: []*api.HCPOpenShiftCluster{newClusterWithAPIURL("https://api.example.com")},
-			},
 			readDesireLister: &internallistertesting.SliceReadDesireLister{
 				Desires: []*kubeapplier.ReadDesire{
 					newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
@@ -390,9 +286,6 @@ func TestDetermineOperationStatus(t *testing.T) {
 		},
 		{
 			name: "no control plane endpoint host → Provisioning",
-			clusterLister: &listertesting.SliceClusterLister{
-				Clusters: []*api.HCPOpenShiftCluster{newClusterWithAPIURL("https://api.example.com")},
-			},
 			readDesireLister: &internallistertesting.SliceReadDesireLister{
 				Desires: []*kubeapplier.ReadDesire{
 					newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
@@ -414,9 +307,6 @@ func TestDetermineOperationStatus(t *testing.T) {
 		},
 		{
 			name: "no control plane endpoint port → Provisioning",
-			clusterLister: &listertesting.SliceClusterLister{
-				Clusters: []*api.HCPOpenShiftCluster{newClusterWithAPIURL("https://api.example.com")},
-			},
 			readDesireLister: &internallistertesting.SliceReadDesireLister{
 				Desires: []*kubeapplier.ReadDesire{
 					newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
@@ -441,9 +331,6 @@ func TestDetermineOperationStatus(t *testing.T) {
 		},
 		{
 			name: "version with valid success condition but not installed → Provisioning",
-			clusterLister: &listertesting.SliceClusterLister{
-				Clusters: []*api.HCPOpenShiftCluster{newClusterWithAPIURL("https://api.example.com")},
-			},
 			readDesireLister: &internallistertesting.SliceReadDesireLister{
 				Desires: []*kubeapplier.ReadDesire{
 					newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
@@ -474,7 +361,6 @@ func TestDetermineOperationStatus(t *testing.T) {
 			ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
 
 			controller := &operationClusterCreate{
-				clusterLister:    tt.clusterLister,
 				readDesireLister: tt.readDesireLister,
 			}
 

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_create_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_create_test.go
@@ -67,6 +67,10 @@ func TestOperationClusterCreate_SynchronizeOperation(t *testing.T) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateSucceeded, op.Status)
+
+				cluster, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
+				require.NoError(t, err)
+				assert.Equal(t, "https://api.example.com:6443", cluster.ServiceProviderProperties.API.URL, "API URL should be populated from ControlPlaneEndpoint")
 			},
 		},
 		{
@@ -209,15 +213,24 @@ func TestDetermineOperationStatus(t *testing.T) {
 	operation := fixture.newOperation(database.OperationRequestCreate)
 
 	tests := []struct {
-		name             string
-		readDesireLister dblisters.ReadDesireLister
-		expectedState    arm.ProvisioningState
-		expectedMessage  string
-		expectError      bool
-		errContains      string
+		name              string
+		readDesireLister  dblisters.ReadDesireLister
+		resourcesDBClient database.ResourcesDBClient
+		expectedState     arm.ProvisioningState
+		expectedMessage   string
+		expectError       bool
+		errContains       string
 	}{
 		{
 			name: "hosted cluster ready → Succeeded",
+			resourcesDBClient: func() database.ResourcesDBClient {
+				db, err := databasetesting.NewMockResourcesDBClientWithResources(
+					utils.ContextWithLogger(context.Background(), testr.New(t)),
+					[]any{fixture.newCluster(nil)},
+				)
+				require.NoError(t, err)
+				return db
+			}(),
 			readDesireLister: &internallistertesting.SliceReadDesireLister{
 				Desires: []*kubeapplier.ReadDesire{
 					newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
@@ -362,7 +375,8 @@ func TestDetermineOperationStatus(t *testing.T) {
 			ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
 
 			controller := &operationClusterCreate{
-				readDesireLister: tt.readDesireLister,
+				readDesireLister:  tt.readDesireLister,
+				resourcesDBClient: tt.resourcesDBClient,
 			}
 
 			result, err := controller.determineOperationStatus(ctx, operation)

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_active_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_active_version_controller.go
@@ -149,7 +149,7 @@ func (c *controlPlaneActiveVersionSyncer) getHostedClusterActiveVersions(ctx con
 			parsedVersion, err := semver.Parse(historyEntry.Version)
 			if err != nil {
 				if historyEntry.Version == "" && historyEntry.State != configv1.CompletedUpdate {
-					logger.Info("Skipping HostedCluster controlPlaneVersion history entry with empty version (expected during rollout)", "state", historyEntry.State)
+					logger.Info("Skipping HostedCluster controlPlaneVersion history entry with empty version (expected during rollout)", "history", historyEntry)
 				} else {
 					logger.Error(err, "Skipping HostedCluster controlPlaneVersion history entry with unparseable version", "history", historyEntry)
 				}
@@ -170,7 +170,7 @@ func (c *controlPlaneActiveVersionSyncer) getHostedClusterActiveVersions(ctx con
 		parsedVersion, err := semver.Parse(historyEntry.Version)
 		if err != nil {
 			if historyEntry.Version == "" && historyEntry.State != configv1.CompletedUpdate {
-				logger.Info("Skipping HostedCluster version history entry with empty version (expected during rollout)", "state", historyEntry.State)
+				logger.Info("Skipping HostedCluster version history entry with empty version (expected during rollout)", "history", historyEntry)
 			} else {
 				logger.Error(err, "Skipping HostedCluster version history entry with unparseable version", "history", historyEntry)
 			}

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_active_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_active_version_controller.go
@@ -146,13 +146,17 @@ func (c *controlPlaneActiveVersionSyncer) getHostedClusterActiveVersions(ctx con
 	// This is available on 4.22+ clusters,  older clusters once Hypershift backports it.
 	if len(hostedCluster.Status.ControlPlaneVersion.History) > 0 {
 		for _, historyEntry := range hostedCluster.Status.ControlPlaneVersion.History {
-			parsedVersion, err := semver.Parse(historyEntry.Version)
-			if err != nil {
-				if historyEntry.Version == "" && historyEntry.State != configv1.CompletedUpdate {
+			if historyEntry.Version == "" {
+				if historyEntry.State != configv1.CompletedUpdate {
 					logger.Info("Skipping HostedCluster controlPlaneVersion history entry with empty version (expected during rollout)", "history", historyEntry)
 				} else {
-					logger.Error(err, "Skipping HostedCluster controlPlaneVersion history entry with unparseable version", "history", historyEntry)
+					logger.Error(fmt.Errorf("empty version in completed entry"), "Skipping HostedCluster controlPlaneVersion history entry with empty version", "history", historyEntry)
 				}
+				continue
+			}
+			parsedVersion, err := semver.Parse(historyEntry.Version)
+			if err != nil {
+				logger.Error(err, "Skipping HostedCluster controlPlaneVersion history entry with unparseable version", "history", historyEntry)
 				continue
 			}
 			activeVersions = append(activeVersions, api.HCPClusterActiveVersion{Version: &parsedVersion, State: historyEntry.State})
@@ -167,13 +171,17 @@ func (c *controlPlaneActiveVersionSyncer) getHostedClusterActiveVersions(ctx con
 	}
 	// Pre-4.22 clusters: fall back to status.version.history.
 	for _, historyEntry := range hostedCluster.Status.Version.History {
-		parsedVersion, err := semver.Parse(historyEntry.Version)
-		if err != nil {
-			if historyEntry.Version == "" && historyEntry.State != configv1.CompletedUpdate {
+		if historyEntry.Version == "" {
+			if historyEntry.State != configv1.CompletedUpdate {
 				logger.Info("Skipping HostedCluster version history entry with empty version (expected during rollout)", "history", historyEntry)
 			} else {
-				logger.Error(err, "Skipping HostedCluster version history entry with unparseable version", "history", historyEntry)
+				logger.Error(fmt.Errorf("empty version in completed entry"), "Skipping HostedCluster version history entry with empty version", "history", historyEntry)
 			}
+			continue
+		}
+		parsedVersion, err := semver.Parse(historyEntry.Version)
+		if err != nil {
+			logger.Error(err, "Skipping HostedCluster version history entry with unparseable version", "history", historyEntry)
 			continue
 		}
 		activeVersions = append(activeVersions, api.HCPClusterActiveVersion{Version: &parsedVersion, State: historyEntry.State})

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_active_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_active_version_controller.go
@@ -148,7 +148,11 @@ func (c *controlPlaneActiveVersionSyncer) getHostedClusterActiveVersions(ctx con
 		for _, historyEntry := range hostedCluster.Status.ControlPlaneVersion.History {
 			parsedVersion, err := semver.Parse(historyEntry.Version)
 			if err != nil {
-				logger.Error(err, "Skipping HostedCluster controlPlaneVersion history entry with unparseable version", "history", historyEntry)
+				if historyEntry.Version == "" && historyEntry.State != configv1.CompletedUpdate {
+					logger.Info("Skipping HostedCluster controlPlaneVersion history entry with empty version (expected during rollout)", "state", historyEntry.State)
+				} else {
+					logger.Error(err, "Skipping HostedCluster controlPlaneVersion history entry with unparseable version", "history", historyEntry)
+				}
 				continue
 			}
 			activeVersions = append(activeVersions, api.HCPClusterActiveVersion{Version: &parsedVersion, State: historyEntry.State})
@@ -165,7 +169,11 @@ func (c *controlPlaneActiveVersionSyncer) getHostedClusterActiveVersions(ctx con
 	for _, historyEntry := range hostedCluster.Status.Version.History {
 		parsedVersion, err := semver.Parse(historyEntry.Version)
 		if err != nil {
-			logger.Error(err, "Skipping HostedCluster version history entry with unparseable version", "history", historyEntry)
+			if historyEntry.Version == "" && historyEntry.State != configv1.CompletedUpdate {
+				logger.Info("Skipping HostedCluster version history entry with empty version (expected during rollout)", "state", historyEntry.State)
+			} else {
+				logger.Error(err, "Skipping HostedCluster version history entry with unparseable version", "history", historyEntry)
+			}
 			continue
 		}
 		activeVersions = append(activeVersions, api.HCPClusterActiveVersion{Version: &parsedVersion, State: historyEntry.State})


### PR DESCRIPTION
## Summary
- Remove the separate `clusterOperationStatus` gate from the create operation controller. This check required `ServiceProviderProperties.API.URL` in the Cosmos cluster document to be non-empty, but depended on `cluster_properties_sync` (5-minute cycle) to copy the URL from Cluster Service — introducing up to a 5-minute propagation delay that caused cluster creation timeouts.
- Instead, populate the API URL directly from the HostedCluster's `ControlPlaneEndpoint` (already verified by `hostedClusterOperationStatus`) before transitioning to Succeeded. This guarantees the user sees a usable API server URL immediately, with no sync delay. If `cluster_properties_sync` runs later, it finds the field already set and skips the write.
- Add a descriptive status message (`"ReadDesire not yet created for cluster"`) when the ReadDesire is missing, replacing the previous empty string that made stuck clusters hard to diagnose.
- Graduate log levels for empty version strings in the ActiveVersions controller: empty `Version` with `PartialUpdate` state (expected during rollout) now logs at Info instead of Error, reducing hundreds of spurious error lines per cluster creation. Empty version strings are short-circuited before `semver.Parse` to avoid unnecessary error generation.

Fixes: [ARO-27430](https://redhat.atlassian.net/browse/ARO-27430)

## Test plan
- [x] `make all` (test + lint) passes
- [x] `TestDetermineOperationStatus` updated: removed clusterLister-specific test cases, verified remaining HostedCluster-based gates
- [x] `TestOperationClusterCreate_SynchronizeOperation` verifies API URL is populated from ControlPlaneEndpoint (`https://api.example.com:6443`)
- [x] `TestControlPlaneActiveVersionSyncer_SyncOnce` passes with graduated log level changes (skip behavior unchanged)
- [x] API URL format (`https://host:port`) matches `cluster_properties_sync` test expectations
- [ ] Verify in CSPR/stg that cluster creation no longer times out waiting for API URL propagation

🤖 Generated with [Claude Code](https://claude.com/claude-code)