### PR TITLE
fix: resolve cross-subscription ARM deployment diagnostics (ARO-27236)

### DIFF
--- a/test/util/framework/deployment_operations.go
+++ b/test/util/framework/deployment_operations.go
@@ -24,9 +24,18 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 
 	"github.com/Azure/ARO-HCP/test/util/timing"
+	"github.com/Azure/ARO-HCP/tooling/templatize/pkg/pipeline"
 )
 
-func fetchOperationsFor(ctx context.Context, client *armresources.DeploymentOperationsClient, resourceGroup, deploymentName string) ([]timing.Operation, error) {
+// fetchOperationsFor retrieves ARM deployment operations, handling both resource-group-scoped
+// and subscription-scoped deployments. Recursively fetches child deployment operations,
+// resolving the correct subscription client when a nested deployment crosses subscriptions.
+func fetchOperationsFor(ctx context.Context, getClient pipeline.OperationsClientGetter, subscriptionID, resourceGroup, deploymentName string) ([]timing.Operation, error) {
+	client, err := getClient(subscriptionID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get operations client for subscription: %w", err)
+	}
+
 	var operations []timing.Operation
 
 	var deploymentOperations []*armresources.DeploymentOperation
@@ -62,12 +71,18 @@ func fetchOperationsFor(ctx context.Context, client *armresources.DeploymentOper
 		}
 	}
 
+	// Recurse into nested deployments, which may target a different subscription
 	for i, op := range operations {
 		if op.Resource == nil {
 			continue
 		}
 		if strings.EqualFold(op.Resource.ResourceType, "Microsoft.Resources/deployments") {
-			children, err := fetchOperationsFor(ctx, client, op.Resource.ResourceGroup, op.Resource.Name)
+			// Use the child's subscription if available, otherwise inherit the parent's
+			childSub := subscriptionID
+			if op.Resource.SubscriptionID != "" {
+				childSub = op.Resource.SubscriptionID
+			}
+			children, err := fetchOperationsFor(ctx, getClient, childSub, op.Resource.ResourceGroup, op.Resource.Name)
 			if err != nil {
 				return []timing.Operation{}, fmt.Errorf("failed to fetch operations for child deployment %s/%s: %w", op.Resource.ResourceGroup, op.Resource.Name, err)
 			}
@@ -88,9 +103,10 @@ func operationFor(item *armresources.DeploymentOperation) (*timing.Operation, er
 			return nil, fmt.Errorf("failed to parse resource id: %w", err)
 		}
 		resource = &timing.Resource{
-			ResourceType:  resourceId.ResourceType.String(),
-			ResourceGroup: resourceId.ResourceGroupName,
-			Name:          resourceId.Name,
+			ResourceType:   resourceId.ResourceType.String(),
+			SubscriptionID: resourceId.SubscriptionID,
+			ResourceGroup:  resourceId.ResourceGroupName,
+			Name:           resourceId.Name,
 		}
 	}
 

--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -55,6 +55,7 @@ import (
 	hcpsdk20240610preview "github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
 	hcpsdk20251223preview "github.com/Azure/ARO-HCP/test/sdk/v20251223preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
 	"github.com/Azure/ARO-HCP/test/util/timing"
+	"github.com/Azure/ARO-HCP/tooling/templatize/pkg/pipeline"
 )
 
 type perItOrDescribeTestContext struct {
@@ -1269,11 +1270,25 @@ func (tc *perItOrDescribeTestContext) commitTimingMetadata(ctx context.Context) 
 	if err != nil {
 		ginkgo.Fail(fmt.Sprintf("Failed to get ARM resource client factory: %v", err))
 	}
+	subscriptionID, err := tc.getSubscriptionIDUnlocked(ctx)
+	if err != nil {
+		ginkgo.Fail(fmt.Sprintf("Failed to get subscription ID: %v", err))
+	}
+	creds, err := tc.perBinaryInvocationTestContext.getAzureCredentials()
+	if err != nil {
+		ginkgo.Fail(fmt.Sprintf("Failed to get Azure credentials: %v", err))
+	}
 	operationsClient := factory.NewDeploymentOperationsClient()
+	getOperationsClient := pipeline.NewCachedOperationsClientGetter(
+		subscriptionID,
+		operationsClient,
+		creds,
+		tc.perBinaryInvocationTestContext.getClientFactoryOptions(),
+	)
 	for _, info := range tc.knownDeployments {
 		resourceGroupName, deploymentName := info.resourceGroupName, info.deploymentName
 		ginkgo.GinkgoLogr.Info("Dumping deployment operations.", "deployment", deploymentName, "resourceGroup", resourceGroupName)
-		operations, err := fetchOperationsFor(ctx, operationsClient, resourceGroupName, deploymentName)
+		operations, err := fetchOperationsFor(ctx, getOperationsClient, subscriptionID, resourceGroupName, deploymentName)
 		if err != nil {
 			ginkgo.GinkgoLogr.Error(err, "failed to fetch operations for deployment", "deployment", deploymentName, "resourceGroup", resourceGroupName)
 			continue

--- a/tooling/templatize/pkg/pipeline/arm.go
+++ b/tooling/templatize/pkg/pipeline/arm.go
@@ -41,9 +41,11 @@ import (
 type armClient struct {
 	bicepClient *bicep.LSPClient
 
-	deploymentClient        *armresources.DeploymentsClient
-	operationsClient        *armresources.DeploymentOperationsClient
-	resourceGroupClient     *armresources.ResourceGroupsClient
+	subscriptionID      string
+	deploymentClient    *armresources.DeploymentsClient
+	getOperationsClient OperationsClientGetter
+	resourceGroupClient *armresources.ResourceGroupsClient
+
 	deploymentRetryWaitTime int
 
 	Region        string
@@ -67,10 +69,12 @@ func newArmClient(subscriptionID, region string, bicepClient *bicep.LSPClient) (
 	if err != nil {
 		return nil, fmt.Errorf("failed to create resource group client: %w", err)
 	}
+	getOperationsClient := NewCachedOperationsClientGetter(subscriptionID, operationsClient, cred, nil)
 	return &armClient{
 		bicepClient:             bicepClient,
+		subscriptionID:          subscriptionID,
 		deploymentClient:        deploymentClient,
-		operationsClient:        operationsClient,
+		getOperationsClient:     getOperationsClient,
 		deploymentRetryWaitTime: 15,
 		resourceGroupClient:     resourceGroupClient,
 		Region:                  region,
@@ -87,7 +91,7 @@ func (a *armClient) runArmStep(ctx context.Context, options *StepRunOptions, rgN
 		return nil, nil, fmt.Errorf("failed to ensure resource group exists: %w", err)
 	}
 
-	return doWaitForDeployment(ctx, a.bicepClient, a.deploymentClient, a.operationsClient, id.ServiceGroup, rgName, step, options.PipelineDirectory, options.StepCacheDir, options.Configuration, options.DeploymentTimeoutSeconds, options.RetryAttempt, state)
+	return doWaitForDeployment(ctx, a.bicepClient, a.deploymentClient, a.getOperationsClient, a.subscriptionID, id.ServiceGroup, rgName, step, options.PipelineDirectory, options.StepCacheDir, options.Configuration, options.DeploymentTimeoutSeconds, options.RetryAttempt, state)
 }
 
 func createError(errors armresources.ErrorResponse) error {
@@ -141,7 +145,7 @@ func armOutputFromOutputs(outputs any) ArmOutput {
 	return nil
 }
 
-func doWaitForDeployment(ctx context.Context, bicepClient *bicep.LSPClient, client *armresources.DeploymentsClient, operationsClient *armresources.DeploymentOperationsClient, sgName, rgName string, step *types.ARMStep, pipelineWorkingDir, stepCacheDir string, cfg configtypes.Configuration, timeoutSeconds int, retryAttempt int, state *ExecutionState) (Output, DetailsProducer, error) {
+func doWaitForDeployment(ctx context.Context, bicepClient *bicep.LSPClient, client *armresources.DeploymentsClient, getOperationsClient OperationsClientGetter, subscriptionID, sgName, rgName string, step *types.ARMStep, pipelineWorkingDir, stepCacheDir string, cfg configtypes.Configuration, timeoutSeconds int, retryAttempt int, state *ExecutionState) (Output, DetailsProducer, error) {
 	logger := logr.FromContextOrDiscard(ctx)
 
 	state.RLock()
@@ -188,7 +192,7 @@ func doWaitForDeployment(ctx context.Context, bicepClient *bicep.LSPClient, clie
 
 	var output ArmOutput
 	var details DetailsProducer
-	exists, output, details, err := pollAndGetOutputFromExistingDeployment(ctx, client, operationsClient, timeoutSeconds, step.DeploymentLevel, rgName, deploymentName)
+	exists, output, details, err := pollAndGetOutputFromExistingDeployment(ctx, client, getOperationsClient, subscriptionID, timeoutSeconds, step.DeploymentLevel, rgName, deploymentName)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to poll previously-existing deployment: %w", err)
 	}
@@ -199,7 +203,7 @@ func doWaitForDeployment(ctx context.Context, bicepClient *bicep.LSPClient, clie
 	logger.V(2).Info("Starting ARM deployment")
 	var pollErr error
 	if step.DeploymentLevel == "Subscription" {
-		details = DetermineOperationsForSubscriptionDeployment(operationsClient, deploymentName)
+		details = DetermineOperationsForSubscriptionDeployment(getOperationsClient, subscriptionID, deploymentName)
 		// Hardcode until schema is adapted
 		deployment.Location = to.Ptr("eastus2")
 		poller, err := client.BeginCreateOrUpdateAtSubscriptionScope(ctx, deploymentName, deployment, nil)
@@ -210,7 +214,7 @@ func doWaitForDeployment(ctx context.Context, bicepClient *bicep.LSPClient, clie
 
 		output, pollErr = pollAndGetOutput(ctx, poller)
 	} else {
-		details = DetermineOperationsForResourceGroupDeployment(operationsClient, rgName, deploymentName)
+		details = DetermineOperationsForResourceGroupDeployment(getOperationsClient, subscriptionID, rgName, deploymentName)
 		poller, err := client.BeginCreateOrUpdate(ctx, rgName, deploymentName, deployment, nil)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to create deployment: %w", err)
@@ -228,7 +232,7 @@ func doWaitForDeployment(ctx context.Context, bicepClient *bicep.LSPClient, clie
 
 // pollAndGetOutputFromExistingDeployment papers over the unfortunate reality that armresources.DeploymentClient has
 // no mechanism to create a poller for an existing deployment - relegating us to a manual polling loop.
-func pollAndGetOutputFromExistingDeployment(ctx context.Context, client *armresources.DeploymentsClient, operationsClient *armresources.DeploymentOperationsClient, timeoutSeconds int, deploymentLevel, resourceGroup, deploymentName string) (bool, ArmOutput, DetailsProducer, error) {
+func pollAndGetOutputFromExistingDeployment(ctx context.Context, client *armresources.DeploymentsClient, getOperationsClient OperationsClientGetter, subscriptionID string, timeoutSeconds int, deploymentLevel, resourceGroup, deploymentName string) (bool, ArmOutput, DetailsProducer, error) {
 	logger, err := logr.FromContext(ctx)
 	if err != nil {
 		return false, nil, nil, err
@@ -238,13 +242,13 @@ func pollAndGetOutputFromExistingDeployment(ctx context.Context, client *armreso
 	var details DetailsProducer
 	var get func(ctx context.Context) (output *armresources.DeploymentPropertiesExtended, err error)
 	if deploymentLevel == "Subscription" {
-		details = DetermineOperationsForSubscriptionDeployment(operationsClient, deploymentName)
+		details = DetermineOperationsForSubscriptionDeployment(getOperationsClient, subscriptionID, deploymentName)
 		get = func(ctx context.Context) (output *armresources.DeploymentPropertiesExtended, err error) {
 			response, err := client.GetAtSubscriptionScope(ctx, deploymentName, nil)
 			return response.Properties, err
 		}
 	} else {
-		details = DetermineOperationsForResourceGroupDeployment(operationsClient, resourceGroup, deploymentName)
+		details = DetermineOperationsForResourceGroupDeployment(getOperationsClient, subscriptionID, resourceGroup, deploymentName)
 		get = func(ctx context.Context) (output *armresources.DeploymentPropertiesExtended, err error) {
 			response, err := client.Get(ctx, resourceGroup, deploymentName, nil)
 			return response.Properties, err

--- a/tooling/templatize/pkg/pipeline/arm_operations.go
+++ b/tooling/templatize/pkg/pipeline/arm_operations.go
@@ -18,8 +18,10 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 )
@@ -44,15 +46,47 @@ type Operation struct {
 type Resource struct {
 	// ResourceType is the resource provider and resource name, like "Microsoft.KeyVault/vaults".
 	ResourceType string `json:"resourceType"`
+	// SubscriptionID is the Azure subscription in which the resource exists.
+	// Not serialized to avoid leaking sensitive identifiers into published artifacts.
+	SubscriptionID string `json:"-"`
 	// ResourceGroup is the Azure resource group in which the resource exists.
 	ResourceGroup string `json:"resourceGroup"`
 	// Name is the name of the resource.
 	Name string `json:"name"`
 }
 
-func DetermineOperationsForResourceGroupDeployment(client *armresources.DeploymentOperationsClient, resourceGroup, deploymentName string) DetailsProducer {
+// OperationsClientGetter returns a DeploymentOperationsClient for the given subscription ID.
+// Implementations should cache clients to avoid redundant authentication.
+type OperationsClientGetter func(subscriptionID string) (*armresources.DeploymentOperationsClient, error)
+
+// NewCachedOperationsClientGetter creates an OperationsClientGetter that caches clients per subscription.
+// The provided defaultClient is used for the given subscriptionID; clients for other subscriptions
+// are created lazily using the provided credential.
+func NewCachedOperationsClientGetter(subscriptionID string, defaultClient *armresources.DeploymentOperationsClient, cred azcore.TokenCredential, opts *azcorearm.ClientOptions) OperationsClientGetter {
+	// mu guards the clients map, which may be accessed concurrently if
+	// multiple deployment operations are fetched in parallel.
+	var mu sync.Mutex
+	clients := map[string]*armresources.DeploymentOperationsClient{
+		subscriptionID: defaultClient,
+	}
+	return func(subID string) (*armresources.DeploymentOperationsClient, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		if c, ok := clients[subID]; ok {
+			return c, nil
+		}
+		c, err := armresources.NewDeploymentOperationsClient(subID, cred, opts)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create operations client for subscription: %w", err)
+		}
+		clients[subID] = c
+		return c, nil
+	}
+}
+
+func DetermineOperationsForResourceGroupDeployment(getClient OperationsClientGetter, subscriptionID, resourceGroup, deploymentName string) DetailsProducer {
 	return func(ctx context.Context) (*ExecutionDetails, error) {
-		ops, err := fetchOperationsFor(ctx, client, resourceGroup, deploymentName)
+		ops, err := fetchOperationsFor(ctx, getClient, subscriptionID, resourceGroup, deploymentName)
 		if err != nil {
 			return nil, err
 		}
@@ -60,9 +94,9 @@ func DetermineOperationsForResourceGroupDeployment(client *armresources.Deployme
 	}
 }
 
-func DetermineOperationsForSubscriptionDeployment(client *armresources.DeploymentOperationsClient, deploymentName string) DetailsProducer {
+func DetermineOperationsForSubscriptionDeployment(getClient OperationsClientGetter, subscriptionID, deploymentName string) DetailsProducer {
 	return func(ctx context.Context) (*ExecutionDetails, error) {
-		ops, err := fetchSubscriptionScopedOperationsFor(ctx, client, deploymentName)
+		ops, err := fetchSubscriptionScopedOperationsFor(ctx, getClient, subscriptionID, deploymentName)
 		if err != nil {
 			return nil, err
 		}
@@ -72,31 +106,64 @@ func DetermineOperationsForSubscriptionDeployment(client *armresources.Deploymen
 
 // n.b. the Azure SDK for Go has unique types for the different types of pagers and no type constraint can be written to scope for pages of things containing lists of ops, so just copy-paste this instead of being clever
 
-func fetchOperationsFor(ctx context.Context, client *armresources.DeploymentOperationsClient, resourceGroup, deploymentName string) ([]Operation, error) {
+// fetchOperationsFor retrieves ARM deployment operations, handling both resource-group-scoped
+// and subscription-scoped deployments. Recursively fetches child deployment operations,
+// resolving the correct subscription client when a nested deployment crosses subscriptions.
+func fetchOperationsFor(ctx context.Context, getClient OperationsClientGetter, subscriptionID, resourceGroup, deploymentName string) ([]Operation, error) {
+	client, err := getClient(subscriptionID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get operations client for subscription: %w", err)
+	}
+
 	var operations []Operation
-	pager := client.NewListPager(resourceGroup, deploymentName, nil)
-	for pager.More() {
-		page, err := pager.NextPage(ctx)
-		if err != nil {
-			return []Operation{}, fmt.Errorf("failed to fetch operations: %w", err)
-		}
-		for _, item := range page.Value {
-			op, err := operationFor(item)
+	if resourceGroup != "" {
+		pager := client.NewListPager(resourceGroup, deploymentName, nil)
+		for pager.More() {
+			page, err := pager.NextPage(ctx)
 			if err != nil {
-				return []Operation{}, err
+				return []Operation{}, fmt.Errorf("failed to fetch operations: %w", err)
 			}
-			if op != nil {
-				operations = append(operations, *op)
+			for _, item := range page.Value {
+				op, err := operationFor(item)
+				if err != nil {
+					return []Operation{}, err
+				}
+				if op != nil {
+					operations = append(operations, *op)
+				}
+			}
+		}
+	} else {
+		pager := client.NewListAtSubscriptionScopePager(deploymentName, nil)
+		for pager.More() {
+			page, err := pager.NextPage(ctx)
+			if err != nil {
+				return []Operation{}, fmt.Errorf("failed to fetch operations: %w", err)
+			}
+			for _, item := range page.Value {
+				op, err := operationFor(item)
+				if err != nil {
+					return []Operation{}, err
+				}
+				if op != nil {
+					operations = append(operations, *op)
+				}
 			}
 		}
 	}
 
+	// Recurse into nested deployments, which may target a different subscription
 	for i, op := range operations {
 		if op.Resource == nil {
 			continue
 		}
 		if strings.EqualFold(op.Resource.ResourceType, "Microsoft.Resources/deployments") {
-			children, err := fetchOperationsFor(ctx, client, op.Resource.ResourceGroup, op.Resource.Name)
+			// Use the child's subscription if available, otherwise inherit the parent's
+			childSub := subscriptionID
+			if op.Resource.SubscriptionID != "" {
+				childSub = op.Resource.SubscriptionID
+			}
+			children, err := fetchOperationsFor(ctx, getClient, childSub, op.Resource.ResourceGroup, op.Resource.Name)
 			if err != nil {
 				return []Operation{}, fmt.Errorf("failed to fetch operations for child deployment %s/%s: %w", op.Resource.ResourceGroup, op.Resource.Name, err)
 			}
@@ -106,6 +173,8 @@ func fetchOperationsFor(ctx context.Context, client *armresources.DeploymentOper
 	return operations, nil
 }
 
+// operationFor converts an ARM DeploymentOperation into our internal Operation type.
+// Extracts subscription ID from the resource's ARM ID to enable cross-subscription traversal.
 func operationFor(item *armresources.DeploymentOperation) (*Operation, error) {
 	if item == nil || item.Properties == nil {
 		return nil, nil
@@ -117,9 +186,10 @@ func operationFor(item *armresources.DeploymentOperation) (*Operation, error) {
 			return nil, fmt.Errorf("failed to parse resource id: %w", err)
 		}
 		resource = &Resource{
-			ResourceType:  resourceId.ResourceType.String(),
-			ResourceGroup: resourceId.ResourceGroupName,
-			Name:          resourceId.Name,
+			ResourceType:   resourceId.ResourceType.String(),
+			SubscriptionID: resourceId.SubscriptionID,
+			ResourceGroup:  resourceId.ResourceGroupName,
+			Name:           resourceId.Name,
 		}
 	}
 
@@ -131,36 +201,8 @@ func operationFor(item *armresources.DeploymentOperation) (*Operation, error) {
 	}, nil
 }
 
-func fetchSubscriptionScopedOperationsFor(ctx context.Context, client *armresources.DeploymentOperationsClient, deploymentName string) ([]Operation, error) {
-	var operations []Operation
-	pager := client.NewListAtSubscriptionScopePager(deploymentName, nil)
-	for pager.More() {
-		page, err := pager.NextPage(ctx)
-		if err != nil {
-			return []Operation{}, fmt.Errorf("failed to fetch operations: %w", err)
-		}
-		for _, item := range page.Value {
-			op, err := operationFor(item)
-			if err != nil {
-				return []Operation{}, err
-			}
-			if op != nil {
-				operations = append(operations, *op)
-			}
-		}
-	}
-
-	for i, op := range operations {
-		if op.Resource == nil {
-			continue
-		}
-		if strings.EqualFold(op.Resource.ResourceType, "Microsoft.Resources/deployments") {
-			children, err := fetchSubscriptionScopedOperationsFor(ctx, client, op.Resource.Name)
-			if err != nil {
-				return []Operation{}, fmt.Errorf("failed to fetch operations for child deployment %s/%s: %w", op.Resource.ResourceGroup, op.Resource.Name, err)
-			}
-			operations[i].Children = children
-		}
-	}
-	return operations, nil
+// fetchSubscriptionScopedOperationsFor is a convenience entry point for subscription-scoped
+// deployments (no resource group). Delegates to fetchOperationsFor with an empty resource group.
+func fetchSubscriptionScopedOperationsFor(ctx context.Context, getClient OperationsClientGetter, subscriptionID, deploymentName string) ([]Operation, error) {
+	return fetchOperationsFor(ctx, getClient, subscriptionID, "", deploymentName)
 }

--- a/tooling/templatize/pkg/pipeline/arm_operations_test.go
+++ b/tooling/templatize/pkg/pipeline/arm_operations_test.go
@@ -1,0 +1,294 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipeline
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+)
+
+// fakeTransport returns canned HTTP responses keyed by subscription ID extracted from the request URL.
+// If interceptor is set, it takes precedence over the static responses map.
+type fakeTransport struct {
+	responses   map[string]string
+	interceptor func(req *http.Request) (*http.Response, error)
+}
+
+func (f *fakeTransport) Do(req *http.Request) (*http.Response, error) {
+	if f.interceptor != nil {
+		return f.interceptor(req)
+	}
+	for sub, body := range f.responses {
+		if strings.Contains(req.URL.Path, "/subscriptions/"+sub+"/") {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(body)),
+			}, nil
+		}
+	}
+	return nil, fmt.Errorf("unexpected request: %s", req.URL.Path)
+}
+
+type fakeCredential struct{}
+
+func (f *fakeCredential) GetToken(_ context.Context, _ policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return azcore.AccessToken{Token: "fake", ExpiresOn: time.Now().Add(time.Hour)}, nil
+}
+
+func mustMarshal(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(b)
+}
+
+func fakeOperationsResponse(t *testing.T, ops ...armresources.DeploymentOperation) string {
+	t.Helper()
+	ptrs := make([]*armresources.DeploymentOperation, len(ops))
+	for i := range ops {
+		ptrs[i] = &ops[i]
+	}
+	return mustMarshal(t, armresources.DeploymentOperationsListResult{Value: ptrs})
+}
+
+func fakeDeploymentOp(provOp, duration string, resourceID *string) armresources.DeploymentOperation {
+	ts := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	props := armresources.DeploymentOperationProperties{
+		ProvisioningOperation: to.Ptr(armresources.ProvisioningOperation(provOp)),
+		Timestamp:             to.Ptr(ts),
+		Duration:              to.Ptr(duration),
+	}
+	if resourceID != nil {
+		props.TargetResource = &armresources.TargetResource{ID: resourceID}
+	}
+	return armresources.DeploymentOperation{Properties: &props}
+}
+
+func TestOperationFor(t *testing.T) {
+	tests := []struct {
+		name     string
+		item     *armresources.DeploymentOperation
+		wantNil  bool
+		wantErr  bool
+		validate func(t *testing.T, op *Operation)
+	}{
+		{
+			name:    "nil item",
+			item:    nil,
+			wantNil: true,
+		},
+		{
+			name:    "nil properties",
+			item:    &armresources.DeploymentOperation{},
+			wantNil: true,
+		},
+		{
+			name: "operation without target resource",
+			item: &armresources.DeploymentOperation{
+				Properties: &armresources.DeploymentOperationProperties{
+					ProvisioningOperation: to.Ptr(armresources.ProvisioningOperation("Create")),
+					Timestamp:             to.Ptr(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)),
+					Duration:              to.Ptr("PT1M"),
+				},
+			},
+			validate: func(t *testing.T, op *Operation) {
+				assert.Equal(t, "Create", op.OperationType)
+				assert.Nil(t, op.Resource)
+			},
+		},
+		{
+			name: "operation with target resource parses subscription ID",
+			item: &armresources.DeploymentOperation{
+				Properties: &armresources.DeploymentOperationProperties{
+					ProvisioningOperation: to.Ptr(armresources.ProvisioningOperation("Create")),
+					Timestamp:             to.Ptr(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)),
+					Duration:              to.Ptr("PT1M"),
+					TargetResource: &armresources.TargetResource{
+						ID: to.Ptr("/subscriptions/sub-123/resourceGroups/rg-1/providers/Microsoft.KeyVault/vaults/my-vault"),
+					},
+				},
+			},
+			validate: func(t *testing.T, op *Operation) {
+				require.NotNil(t, op.Resource)
+				assert.Equal(t, "sub-123", op.Resource.SubscriptionID)
+				assert.Equal(t, "rg-1", op.Resource.ResourceGroup)
+				assert.Equal(t, "my-vault", op.Resource.Name)
+				assert.Equal(t, "Microsoft.KeyVault/vaults", op.Resource.ResourceType)
+			},
+		},
+		{
+			name: "nested deployment resource parses cross-subscription ID",
+			item: &armresources.DeploymentOperation{
+				Properties: &armresources.DeploymentOperationProperties{
+					ProvisioningOperation: to.Ptr(armresources.ProvisioningOperation("Create")),
+					Timestamp:             to.Ptr(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)),
+					Duration:              to.Ptr("PT2M"),
+					TargetResource: &armresources.TargetResource{
+						ID: to.Ptr("/subscriptions/other-sub-456/resourceGroups/other-rg/providers/Microsoft.Resources/deployments/nested-deploy"),
+					},
+				},
+			},
+			validate: func(t *testing.T, op *Operation) {
+				require.NotNil(t, op.Resource)
+				assert.Equal(t, "other-sub-456", op.Resource.SubscriptionID)
+				assert.Equal(t, "other-rg", op.Resource.ResourceGroup)
+				assert.Equal(t, "nested-deploy", op.Resource.Name)
+				assert.Equal(t, "Microsoft.Resources/deployments", op.Resource.ResourceType)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			op, err := operationFor(tt.item)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			if tt.wantNil {
+				assert.Nil(t, op)
+				return
+			}
+			require.NotNil(t, op)
+			if tt.validate != nil {
+				tt.validate(t, op)
+			}
+		})
+	}
+}
+
+func TestNewCachedOperationsClientGetter(t *testing.T) {
+	t.Run("returns default client for default subscription", func(t *testing.T) {
+		defaultClient := &armresources.DeploymentOperationsClient{}
+		getter := NewCachedOperationsClientGetter("sub-1", defaultClient, nil, nil)
+
+		client, err := getter("sub-1")
+		require.NoError(t, err)
+		assert.Same(t, defaultClient, client)
+	})
+
+	t.Run("creates and caches client for new subscription", func(t *testing.T) {
+		defaultClient := &armresources.DeploymentOperationsClient{}
+		getter := NewCachedOperationsClientGetter("sub-1", defaultClient, nil, nil)
+
+		client1, err := getter("sub-2")
+		require.NoError(t, err)
+		require.NotNil(t, client1)
+		assert.NotSame(t, defaultClient, client1)
+
+		client2, err := getter("sub-2")
+		require.NoError(t, err)
+		assert.Same(t, client1, client2, "should return cached client on second call")
+	})
+}
+
+func TestFetchOperationsForCrossSubscription(t *testing.T) {
+	parentSub := "parent-sub-111"
+	childSub := "child-sub-222"
+
+	transport := &fakeTransport{
+		responses: map[string]string{
+			parentSub: fakeOperationsResponse(t,
+				fakeDeploymentOp("Create", "PT1M", to.Ptr(fmt.Sprintf(
+					"/subscriptions/%s/resourceGroups/child-rg/providers/Microsoft.Resources/deployments/child-deploy", childSub,
+				))),
+			),
+			childSub: fakeOperationsResponse(t,
+				fakeDeploymentOp("Create", "PT30S", to.Ptr(fmt.Sprintf(
+					"/subscriptions/%s/resourceGroups/child-rg/providers/Microsoft.KeyVault/vaults/my-vault", childSub,
+				))),
+			),
+		},
+	}
+
+	var requestedSubs []string
+	getter := func(subID string) (*armresources.DeploymentOperationsClient, error) {
+		requestedSubs = append(requestedSubs, subID)
+		return armresources.NewDeploymentOperationsClient(subID, &fakeCredential{}, &azcorearm.ClientOptions{ClientOptions: azcore.ClientOptions{Transport: transport}})
+	}
+
+	ops, err := fetchOperationsFor(context.Background(), getter, parentSub, "parent-rg", "parent-deploy")
+	require.NoError(t, err)
+
+	require.Len(t, ops, 1, "should have one top-level operation")
+	require.Len(t, ops[0].Children, 1, "nested deployment should have one child operation")
+	assert.Equal(t, "Microsoft.KeyVault/vaults", ops[0].Children[0].Resource.ResourceType)
+	assert.Equal(t, childSub, ops[0].Children[0].Resource.SubscriptionID)
+
+	require.Len(t, requestedSubs, 2, "getClient should be called twice (parent + child)")
+	assert.Equal(t, parentSub, requestedSubs[0], "first call should be for parent subscription")
+	assert.Equal(t, childSub, requestedSubs[1], "second call should be for child subscription")
+}
+
+func TestFetchOperationsForSameSubscription(t *testing.T) {
+	sub := "same-sub-333"
+
+	callCount := 0
+	transport := &fakeTransport{}
+	// Return a nested deployment on the first call, then a leaf resource on the second
+	// to avoid infinite recursion while still testing same-subscription routing.
+	transport.interceptor = func(req *http.Request) (*http.Response, error) {
+		callCount++
+		var body string
+		if callCount == 1 {
+			body = fakeOperationsResponse(t,
+				fakeDeploymentOp("Create", "PT1M", to.Ptr(fmt.Sprintf(
+					"/subscriptions/%s/resourceGroups/rg/providers/Microsoft.Resources/deployments/child-deploy", sub,
+				))),
+			)
+		} else {
+			body = fakeOperationsResponse(t,
+				fakeDeploymentOp("Create", "PT30S", to.Ptr(fmt.Sprintf(
+					"/subscriptions/%s/resourceGroups/rg/providers/Microsoft.KeyVault/vaults/my-vault", sub,
+				))),
+			)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(body)),
+		}, nil
+	}
+
+	var requestedSubs []string
+	getter := func(subID string) (*armresources.DeploymentOperationsClient, error) {
+		requestedSubs = append(requestedSubs, subID)
+		return armresources.NewDeploymentOperationsClient(subID, &fakeCredential{}, &azcorearm.ClientOptions{ClientOptions: azcore.ClientOptions{Transport: transport}})
+	}
+
+	_, err := fetchOperationsFor(context.Background(), getter, sub, "rg", "parent-deploy")
+	require.NoError(t, err)
+
+	for _, s := range requestedSubs {
+		assert.Equal(t, sub, s, "all getClient calls should use the same subscription when child matches parent")
+	}
+}

--- a/tooling/templatize/pkg/pipeline/arm_stack.go
+++ b/tooling/templatize/pkg/pipeline/arm_stack.go
@@ -86,6 +86,7 @@ func runArmStackStep(
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create deployment operations client: %w", err)
 	}
+	getOperationsClient := NewCachedOperationsClientGetter(executionTarget.GetSubscriptionID(), operationsClient, cred, nil)
 
 	if err := ensureResourceGroupExists(ctx, resourceGroupClient, executionTarget.GetRegion(), executionTarget.GetResourceGroup(), !options.NoPersist); err != nil {
 		return nil, nil, fmt.Errorf("failed to ensure resource group exists: %w", err)
@@ -202,9 +203,9 @@ func runArmStackStep(
 		underlyingDeploymentName := (*output.Properties.DeploymentID)[strings.LastIndex(*output.Properties.DeploymentID, "/")+1:]
 		switch step.DeploymentLevel {
 		case "Subscription":
-			details = DetermineOperationsForSubscriptionDeployment(operationsClient, underlyingDeploymentName)
+			details = DetermineOperationsForSubscriptionDeployment(getOperationsClient, executionTarget.GetSubscriptionID(), underlyingDeploymentName)
 		case "ResourceGroup":
-			details = DetermineOperationsForResourceGroupDeployment(operationsClient, executionTarget.GetResourceGroup(), underlyingDeploymentName)
+			details = DetermineOperationsForResourceGroupDeployment(getOperationsClient, executionTarget.GetSubscriptionID(), executionTarget.GetResourceGroup(), underlyingDeploymentName)
 		}
 	}
 

--- a/tooling/utilitytypes/timing/types.go
+++ b/tooling/utilitytypes/timing/types.go
@@ -53,6 +53,9 @@ type Operation struct {
 type Resource struct {
 	// ResourceType is the resource provider and resource name, like "Microsoft.KeyVault/vaults".
 	ResourceType string `json:"resourceType"`
+	// SubscriptionID is the Azure subscription in which the resource exists.
+	// Not serialized to avoid leaking sensitive identifiers into published artifacts.
+	SubscriptionID string `json:"-"`
 	// ResourceGroup is the Azure resource group in which the resource exists.
 	ResourceGroup string `json:"resourceGroup"`
 	// Name is the name of the resource.


### PR DESCRIPTION
Addresses [ARO-27236](https://redhat.atlassian.net/browse/ARO-27236)

### What

Introduce a subscription-aware `OperationsClientGetter` factory that lazily creates and caches `DeploymentOperationsClient` instances per Azure subscription. Populate `Resource.SubscriptionID` from parsed ARM resource IDs to carry subscription context through the operation tree.

Additionally, consolidate `fetchSubscriptionScopedOperationsFor` into `fetchOperationsFor` by branching on `resourceGroup == ""`. This fixes a pre-existing bug where subscription-scoped parent deployments would recurse into child deployments using `NewListAtSubscriptionScopePager` instead of `NewListPager`, which failed for resource-group-scoped children.

### Why

The `DeploymentOperationsClient` was bound to a single subscription, causing `ResourceGroupNotFound` errors when traversing child deployments that reside in a different subscription. This broke deployment operation visualization and timing metadata collection for cross-subscription bicep deployments.

### Testing

- Unit tests for `operationFor` validating `SubscriptionID` extraction from ARM resource IDs (including cross-subscription nested deployments)
- Unit tests for `NewCachedOperationsClientGetter` validating default client reuse and lazy creation/caching for new subscriptions
- Existing E2E deployment timing collection exercises the updated `fetchOperationsFor` path
- Unit tests for cross-subscription and same-subscription routing in `fetchOperationsFor`

### Special notes for your reviewer

- The `OperationsClientGetter` closure uses a `sync.Mutex` to protect the internal client cache, even though current usage is sequential. This is cheap insurance against future concurrent callers.
- The pipeline and test framework each have their own copy of `NewCachedOperationsClientGetter` with slightly different signatures (the test framework version accepts `*azcorearm.ClientOptions`). This is intentional — they have different dependency chains and the test framework needs to pass custom client options for its Azure environment.

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge