### PR TITLE
 Cache role definition fetch errors

### DIFF
--- a/backend/pkg/azure/cachedreader/role_definitions.go
+++ b/backend/pkg/azure/cachedreader/role_definitions.go
@@ -18,7 +18,6 @@ package cachedreader
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -32,9 +31,13 @@ import (
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
 
-// roleDefinitionResourceIDCacheKeyTTL defines how long a cached role definition is considered valid.
+// roleDefinitionResourceIDCacheKeySuccessTTL defines how long a cached successful GetByID is valid.
 // After this TTL (6 hours), the cached entry is stale and the next GetCachedByID refreshes it from Azure.
-const roleDefinitionResourceIDCacheKeyTTL = 6 * time.Hour
+const roleDefinitionResourceIDCacheKeySuccessTTL = 6 * time.Hour
+
+// roleDefinitionResourceIDCacheKeyErrorTTL defines how long a cached GetByID that returned an error is valid.
+// After this TTL (5 minutes), the cached entry is stale and the next GetCachedByID retries Azure.
+const roleDefinitionResourceIDCacheKeyErrorTTL = 5 * time.Minute
 
 // RoleDefinitionsCachedReader exposes cached reads of role definitions by ARM resource ID.
 type RoleDefinitionsCachedReader interface {
@@ -44,6 +47,9 @@ type RoleDefinitionsCachedReader interface {
 // roleDefinitionsCachedReader wraps an uncached azureclient.RoleDefinitionsClient. GetCachedByID
 // responses are cached in memory with a TTL and singleflight deduplication; other RoleDefinitionsClient
 // methods are not exposed on this type.
+// TTLs used for cached role definition entries.
+// Successful lookups are cached for 6 hours (roleDefinitionResourceIDCacheKeySuccessTTL).
+// Error responses are cached for 5 minutes (roleDefinitionResourceIDCacheKeyErrorTTL).
 type roleDefinitionsCachedReader struct {
 	// inner is the uncached Azure Role Definitions client used for live GetByID calls.
 	inner azureclient.RoleDefinitionsClient
@@ -61,6 +67,8 @@ type roleDefinitionsCachedReader struct {
 
 type cachedGetByIDResponse struct {
 	response armauthorization.RoleDefinitionsClientGetByIDResponse
+	// err contains the error returned by the GetByID call made to Azure. nil if no error in the GetByID call.
+	err error
 	// lastUpdate is the wall-clock instant (UTC) when this cache entry was written, from time.Now().UTC().
 	// It is compared with time.Since for TTL / staleness checks (same interpretation as time.Now).
 	lastUpdate time.Time
@@ -83,7 +91,7 @@ func (c *roleDefinitionsCachedReader) GetCachedByID(ctx context.Context, roleDef
 	c.roleDefinitionsCacheLock.RLock()
 	entry := c.roleDefinitionsCache[roleDefinitionResourceID]
 	c.roleDefinitionsCacheLock.RUnlock()
-	return entry.response, nil
+	return entry.response, entry.err
 }
 
 // ensureCachedGetByID loads a fresh role definition when missing or stale. Concurrent callers for the
@@ -98,13 +106,11 @@ func (c *roleDefinitionsCachedReader) ensureCachedGetByID(ctx context.Context, r
 	}
 	_, err, _ := c.sfGroup.Do(roleDefinitionResourceID, func() (interface{}, error) {
 		resp, err := c.inner.GetByID(ctx, roleDefinitionResourceID, options)
-		if err != nil {
-			return nil, utils.TrackError(fmt.Errorf("failed to get role definition for '%s': %w", roleDefinitionResourceID, err))
-		}
 		c.roleDefinitionsCacheLock.Lock()
 		defer c.roleDefinitionsCacheLock.Unlock()
 		c.roleDefinitionsCache[roleDefinitionResourceID] = cachedGetByIDResponse{
 			response:   resp,
+			err:        err,
 			lastUpdate: c.clock.Now().UTC(),
 		}
 		return nil, nil
@@ -116,7 +122,11 @@ func (c *roleDefinitionsCachedReader) ensureCachedGetByID(ctx context.Context, r
 }
 
 func (c *roleDefinitionsCachedReader) isStale(entry cachedGetByIDResponse) bool {
-	return c.clock.Since(entry.lastUpdate) > roleDefinitionResourceIDCacheKeyTTL
+	ttl := roleDefinitionResourceIDCacheKeySuccessTTL
+	if entry.err != nil {
+		ttl = roleDefinitionResourceIDCacheKeyErrorTTL
+	}
+	return c.clock.Since(entry.lastUpdate) > ttl
 }
 
 var _ RoleDefinitionsCachedReader = (*roleDefinitionsCachedReader)(nil)

--- a/backend/pkg/azure/cachedreader/role_definitions_test.go
+++ b/backend/pkg/azure/cachedreader/role_definitions_test.go
@@ -51,7 +51,6 @@ func TestRoleDefinitionsCachedReader_GetCachedByID(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	innerErr := errors.New("azure unavailable")
 	cachedResponse := roleDefByIDResponse(testRoleDefinitionRID)
 	initialCached := roleDefByIDResponse(testRoleDefinitionRID)
 	refreshedCached := roleDefByIDResponse(testRoleDefinitionRID)
@@ -99,13 +98,15 @@ func TestRoleDefinitionsCachedReader_GetCachedByID(t *testing.T) {
 			},
 		},
 		{
-			name: "propagates azure api interaction error when it occurs",
+			name: "caches error within error TTL",
 			setupClient: func(ctrl *gomock.Controller) azureclient.RoleDefinitionsClient {
 				mockClient := azureclient.NewMockRoleDefinitionsClient(ctrl)
-				mockClient.EXPECT().GetByID(gomock.Any(), testRoleDefinitionRID, nil).Return(armauthorization.RoleDefinitionsClientGetByIDResponse{}, innerErr).Times(1)
+				apiErr := errors.New("service unavailable")
+				// Times(1): all GetCachedByID calls within error TTL must not call Azure again.
+				mockClient.EXPECT().GetByID(gomock.Any(), testRoleDefinitionRID, nil).Return(armauthorization.RoleDefinitionsClientGetByIDResponse{}, apiErr).Times(1)
 				return mockClient
 			},
-			clock: utilsclock.RealClock{},
+			clock: clocktesting.NewFakePassiveClock(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)),
 			calls: []struct {
 				advanceClockBy   time.Duration
 				roleDefinitionID string
@@ -116,12 +117,25 @@ func TestRoleDefinitionsCachedReader_GetCachedByID(t *testing.T) {
 				{
 					roleDefinitionID: testRoleDefinitionRID,
 					wantError:        true,
-					wantErrContains:  "failed to get role definition",
+					wantErrContains:  "service unavailable",
+				},
+				{
+					advanceClockBy:   2 * time.Minute,
+					roleDefinitionID: testRoleDefinitionRID,
+					wantError:        true,
+					wantErrContains:  "service unavailable",
+				},
+				{
+					// At exactly error TTL (isStale uses >), entry must still be fresh.
+					advanceClockBy:   roleDefinitionResourceIDCacheKeyErrorTTL - 2*time.Minute,
+					roleDefinitionID: testRoleDefinitionRID,
+					wantError:        true,
+					wantErrContains:  "service unavailable",
 				},
 			},
 		},
 		{
-			name: "error is not cached; next call retries",
+			name: "recovers after error TTL and caches success for success TTL",
 			setupClient: func(ctrl *gomock.Controller) azureclient.RoleDefinitionsClient {
 				mockClient := azureclient.NewMockRoleDefinitionsClient(ctrl)
 				gomock.InOrder(
@@ -130,7 +144,7 @@ func TestRoleDefinitionsCachedReader_GetCachedByID(t *testing.T) {
 				)
 				return mockClient
 			},
-			clock: utilsclock.RealClock{},
+			clock: clocktesting.NewFakePassiveClock(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)),
 			calls: []struct {
 				advanceClockBy   time.Duration
 				roleDefinitionID string
@@ -141,15 +155,28 @@ func TestRoleDefinitionsCachedReader_GetCachedByID(t *testing.T) {
 				{
 					roleDefinitionID: testRoleDefinitionRID,
 					wantError:        true,
+					wantErrContains:  "temporary",
 				},
 				{
+					advanceClockBy:   2 * time.Minute,
+					roleDefinitionID: testRoleDefinitionRID,
+					wantError:        true,
+					wantErrContains:  "temporary",
+				},
+				{
+					advanceClockBy:   roleDefinitionResourceIDCacheKeyErrorTTL - 2*time.Minute + time.Second,
+					roleDefinitionID: testRoleDefinitionRID,
+					wantResponse:     cachedResponse,
+				},
+				{
+					advanceClockBy:   3 * time.Hour,
 					roleDefinitionID: testRoleDefinitionRID,
 					wantResponse:     cachedResponse,
 				},
 			},
 		},
 		{
-			name: "refreshes expired cache entry from inner client",
+			name: "caches success within success TTL and refreshes after expiry",
 			setupClient: func(ctrl *gomock.Controller) azureclient.RoleDefinitionsClient {
 				mockClient := azureclient.NewMockRoleDefinitionsClient(ctrl)
 				gomock.InOrder(
@@ -171,7 +198,12 @@ func TestRoleDefinitionsCachedReader_GetCachedByID(t *testing.T) {
 					wantResponse:     initialCached,
 				},
 				{
-					advanceClockBy:   roleDefinitionResourceIDCacheKeyTTL + time.Second,
+					advanceClockBy:   3 * time.Hour,
+					roleDefinitionID: testRoleDefinitionRID,
+					wantResponse:     initialCached,
+				},
+				{
+					advanceClockBy:   roleDefinitionResourceIDCacheKeySuccessTTL - 3*time.Hour + time.Second,
 					roleDefinitionID: testRoleDefinitionRID,
 					wantResponse:     refreshedCached,
 				},


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-27501

### What

Extends RoleDefinitionsCachedReader so failed Azure GetByID calls are cached in memory, not only successful responses.

- Success entries: unchanged 6 hour TTL (roleDefinitionResourceIDCacheKeySuccessTTL)
- Error entries: new 5 minute TTL (roleDefinitionResourceIDCacheKeyErrorTTL)

### Why

Enhancement to https://github.com/Azure/ARO-HCP/pull/4403. 
It will reduce repeated Azure API calls when the same invalid or missing role definition is requested multiple times, helping reduce load on the service.

