### PR TITLE
fix(config): drop patch from kubernetesVersion to prevent drift (AROSLSRE-1008)

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -468,7 +468,7 @@ defaults:
       vnetAddressPrefix: "10.128.0.0/14"
       subnetPrefix: "10.128.8.0/21"
       podSubnetPrefix: "10.128.64.0/18"
-      kubernetesVersion: 1.35.1
+      kubernetesVersion: "1.35"
       networkDataplane: "cilium"
       networkPolicy: "cilium"
       systemAgentPool:
@@ -594,7 +594,7 @@ defaults:
       vnetAddressPrefix: "10.128.0.0/14"
       subnetPrefix: "10.128.8.0/21"
       podSubnetPrefix: "10.128.64.0/18"
-      kubernetesVersion: 1.35.1
+      kubernetesVersion: "1.35"
       networkDataplane: "azure"
       networkPolicy: "azure"
       etcd:

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -596,7 +596,7 @@ mgmt:
       vmSize: Standard_D4ds_v6
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.35.1
+    kubernetesVersion: "1.35"
     name: ci01-j7654321-mgmt-1
     networkDataplane: azure
     networkPolicy: azure
@@ -921,7 +921,7 @@ svc:
       vmSize: Standard_D4ds_v6
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.35.1
+    kubernetesVersion: "1.35"
     name: ci01-j7654321-svc
     networkDataplane: cilium
     networkPolicy: cilium

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -596,7 +596,7 @@ mgmt:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.35.1
+    kubernetesVersion: "1.35"
     name: cspr-westus3-mgmt-1
     networkDataplane: azure
     networkPolicy: azure
@@ -919,7 +919,7 @@ svc:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.35.1
+    kubernetesVersion: "1.35"
     name: cspr-westus3-svc-1
     networkDataplane: cilium
     networkPolicy: cilium

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -596,7 +596,7 @@ mgmt:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.35.1
+    kubernetesVersion: "1.35"
     name: dev-westus3-mgmt-1
     networkDataplane: azure
     networkPolicy: azure
@@ -919,7 +919,7 @@ svc:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.35.1
+    kubernetesVersion: "1.35"
     name: dev-westus3-svc-1
     networkDataplane: cilium
     networkPolicy: cilium

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -596,7 +596,7 @@ mgmt:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.35.1
+    kubernetesVersion: "1.35"
     name: perf-usw3ptest-mgmt-1
     networkDataplane: azure
     networkPolicy: azure
@@ -919,7 +919,7 @@ svc:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.35.1
+    kubernetesVersion: "1.35"
     name: perf-usw3ptest-svc
     networkDataplane: cilium
     networkPolicy: cilium

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -596,7 +596,7 @@ mgmt:
       vmSize: Standard_D4s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.35.1
+    kubernetesVersion: "1.35"
     name: pers-usw3test-mgmt-1
     networkDataplane: azure
     networkPolicy: azure
@@ -921,7 +921,7 @@ svc:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.35.1
+    kubernetesVersion: "1.35"
     name: pers-usw3test-svc
     networkDataplane: cilium
     networkPolicy: cilium

--- a/config/rendered/dev/prow/centralus.yaml
+++ b/config/rendered/dev/prow/centralus.yaml
@@ -596,7 +596,7 @@ mgmt:
       vmSize: Standard_D4ds_v6
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.35.1
+    kubernetesVersion: "1.35"
     name: prow-j7654321-mgmt-1
     networkDataplane: azure
     networkPolicy: azure
@@ -921,7 +921,7 @@ svc:
       vmSize: Standard_D4ds_v6
       zoneRedundantMode: Auto
       zones: ""
-    kubernetesVersion: 1.35.1
+    kubernetesVersion: "1.35"
     name: prow-j7654321-svc
     networkDataplane: cilium
     networkPolicy: cilium


### PR DESCRIPTION
[AROSLSRE-1008](https://redhat.atlassian.net/browse/AROSLSRE-1008)

### What

Drop the patch component from `kubernetesVersion` in config defaults (`1.35.1` -> `"1.35"`).

### Why

AKS auto-patches clusters to the latest patch version. Pinning to `1.35.1` caused version drift when clusters upgraded to `1.35.4`, which made `recreate-system-pool` enter forced-evidence verification unnecessarily.

Using minor-only `"1.35"` lets AKS manage patch versions without triggering drift detection.

### Testing

- `make -C config materialize` passes (schema validation, rendering, helm fixtures)
- Deployed `Service.Infra` and `Management.Infra` on personal dev env (`pers-usw3rael`, westus3) — both clusters show `desired=1.35`, no wedged LROs
- No functional change to cluster behavior -- AKS already selects the latest patch for the specified minor version

### Special notes for your reviewer

The value must be quoted (`"1.35"`) because YAML interprets unquoted `1.35` as a float, and the schema requires a string.

Companion sdp-pipelines PR: [PR #15952546](https://msazure.visualstudio.com/AzureRedHatOpenShift/_git/sdp-pipelines/pullrequest/15952546)

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows Conventional Commits format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [x] All comment threads resolved before merge