### PR TITLE
fix(backend): populate API URL from ControlPlaneEndpoint to prevent cluster creation timeouts

### DIFF
--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_create.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_create.go
@@ -307,9 +307,34 @@ func (c *operationClusterCreate) hostedClusterOperationStatus(ctx context.Contex
 		return newOperationState(arm.ProvisioningStateProvisioning, "hosted cluster has no control plane endpoint port"), nil
 	}
 
-	// if we got here,
-	// 1. the hosted cluster is available via condition
-	// 2. the hosted cluster has successfully installed at least one version
-	// 3. the hosted cluster has a control plane endpoint host and port
+	// Populate the API URL in the Cosmos cluster document from the HostedCluster's
+	// ControlPlaneEndpoint if it is not already set. This avoids waiting up to 5
+	// minutes for cluster_properties_sync to copy it from Cluster Service.
+	if err := c.ensureAPIURL(ctx, operation, hostedCluster); err != nil {
+		return nil, utils.TrackError(err)
+	}
+
 	return newOperationState(arm.ProvisioningStateSucceeded, ""), nil
+}
+
+func (c *operationClusterCreate) ensureAPIURL(ctx context.Context, operation *api.Operation, hostedCluster *v1beta1.HostedCluster) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	clusterCRUD := c.resourcesDBClient.HCPClusters(operation.ExternalID.SubscriptionID, operation.ExternalID.ResourceGroupName)
+	cluster, err := clusterCRUD.Get(ctx, operation.ExternalID.Name)
+	if err != nil {
+		return fmt.Errorf("failed to get cluster for API URL check: %w", err)
+	}
+
+	if len(cluster.ServiceProviderProperties.API.URL) > 0 {
+		return nil
+	}
+
+	apiURL := fmt.Sprintf("https://%s:%d", hostedCluster.Status.ControlPlaneEndpoint.Host, hostedCluster.Status.ControlPlaneEndpoint.Port)
+	cluster.ServiceProviderProperties.API.URL = apiURL
+	if _, err := clusterCRUD.Replace(ctx, cluster, nil); err != nil {
+		return fmt.Errorf("failed to write API URL to cluster: %w", err)
+	}
+	logger.Info("Populated API URL from HostedCluster ControlPlaneEndpoint", "apiURL", apiURL)
+	return nil
 }

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_create_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_create_test.go
@@ -236,19 +236,28 @@ func TestDetermineOperationStatus(t *testing.T) {
 	operation := fixture.newOperation(database.OperationRequestCreate)
 
 	tests := []struct {
-		name             string
-		clusterLister    listers.ClusterLister
-		readDesireLister dblisters.ReadDesireLister
-		expectedState    arm.ProvisioningState
-		expectedMessage  string
-		expectError      bool
-		errContains      string
+		name              string
+		clusterLister     listers.ClusterLister
+		readDesireLister  dblisters.ReadDesireLister
+		resourcesDBClient database.ResourcesDBClient
+		expectedState     arm.ProvisioningState
+		expectedMessage   string
+		expectError       bool
+		errContains       string
 	}{
 		{
 			name: "both checks succeed → Succeeded",
 			clusterLister: &listertesting.SliceClusterLister{
 				Clusters: []*api.HCPOpenShiftCluster{newClusterWithAPIURL("https://api.example.com")},
 			},
+			resourcesDBClient: func() database.ResourcesDBClient {
+				db, err := databasetesting.NewMockResourcesDBClientWithResources(
+					utils.ContextWithLogger(context.Background(), testr.New(t)),
+					[]any{fixture.newCluster(nil)},
+				)
+				require.NoError(t, err)
+				return db
+			}(),
 			readDesireLister: &internallistertesting.SliceReadDesireLister{
 				Desires: []*kubeapplier.ReadDesire{
 					newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
@@ -277,6 +286,14 @@ func TestDetermineOperationStatus(t *testing.T) {
 			clusterLister: &listertesting.SliceClusterLister{
 				Clusters: []*api.HCPOpenShiftCluster{newClusterWithAPIURL("")},
 			},
+			resourcesDBClient: func() database.ResourcesDBClient {
+				db, err := databasetesting.NewMockResourcesDBClientWithResources(
+					utils.ContextWithLogger(context.Background(), testr.New(t)),
+					[]any{fixture.newCluster(nil)},
+				)
+				require.NoError(t, err)
+				return db
+			}(),
 			readDesireLister: &internallistertesting.SliceReadDesireLister{
 				Desires: []*kubeapplier.ReadDesire{
 					newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
@@ -311,6 +328,14 @@ func TestDetermineOperationStatus(t *testing.T) {
 		{
 			name:          "cluster lister error → error propagated",
 			clusterLister: &errorClusterLister{err: fmt.Errorf("cosmos error")},
+			resourcesDBClient: func() database.ResourcesDBClient {
+				db, err := databasetesting.NewMockResourcesDBClientWithResources(
+					utils.ContextWithLogger(context.Background(), testr.New(t)),
+					[]any{fixture.newCluster(nil)},
+				)
+				require.NoError(t, err)
+				return db
+			}(),
 			readDesireLister: &internallistertesting.SliceReadDesireLister{
 				Desires: []*kubeapplier.ReadDesire{
 					newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
@@ -474,8 +499,9 @@ func TestDetermineOperationStatus(t *testing.T) {
 			ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
 
 			controller := &operationClusterCreate{
-				clusterLister:    tt.clusterLister,
-				readDesireLister: tt.readDesireLister,
+				clusterLister:     tt.clusterLister,
+				readDesireLister:  tt.readDesireLister,
+				resourcesDBClient: tt.resourcesDBClient,
 			}
 
 			result, err := controller.determineOperationStatus(ctx, operation)

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_active_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_active_version_controller.go
@@ -146,6 +146,14 @@ func (c *controlPlaneActiveVersionSyncer) getHostedClusterActiveVersions(ctx con
 	// This is available on 4.22+ clusters,  older clusters once Hypershift backports it.
 	if len(hostedCluster.Status.ControlPlaneVersion.History) > 0 {
 		for _, historyEntry := range hostedCluster.Status.ControlPlaneVersion.History {
+			if historyEntry.Version == "" {
+				if historyEntry.State != configv1.CompletedUpdate {
+					logger.Info("Skipping HostedCluster controlPlaneVersion history entry with empty version (expected during rollout)", "history", historyEntry)
+				} else {
+					logger.Error(fmt.Errorf("empty version in completed entry"), "Skipping HostedCluster controlPlaneVersion history entry with empty version", "history", historyEntry)
+				}
+				continue
+			}
 			parsedVersion, err := semver.Parse(historyEntry.Version)
 			if err != nil {
 				logger.Error(err, "Skipping HostedCluster controlPlaneVersion history entry with unparseable version", "history", historyEntry)
@@ -163,6 +171,14 @@ func (c *controlPlaneActiveVersionSyncer) getHostedClusterActiveVersions(ctx con
 	}
 	// Pre-4.22 clusters: fall back to status.version.history.
 	for _, historyEntry := range hostedCluster.Status.Version.History {
+		if historyEntry.Version == "" {
+			if historyEntry.State != configv1.CompletedUpdate {
+				logger.Info("Skipping HostedCluster version history entry with empty version (expected during rollout)", "history", historyEntry)
+			} else {
+				logger.Error(fmt.Errorf("empty version in completed entry"), "Skipping HostedCluster version history entry with empty version", "history", historyEntry)
+			}
+			continue
+		}
 		parsedVersion, err := semver.Parse(historyEntry.Version)
 		if err != nil {
 			logger.Error(err, "Skipping HostedCluster version history entry with unparseable version", "history", historyEntry)


### PR DESCRIPTION
## Summary

Cluster creation operations time out at 20 minutes because the `clusterOperationStatus` gate requires `ServiceProviderProperties.API.URL` to be non-empty in the Cosmos cluster document. This URL is populated by `cluster_properties_sync`, which copies it from Cluster Service on a **5-minute cycle** — so even after the control plane is serving, there's up to a 5-minute propagation delay where the create operation stays stuck at "Provisioning" with the message `.api.url is empty`.

This PR adds a proactive write: when `hostedClusterOperationStatus` confirms the HostedCluster's `ControlPlaneEndpoint` (host + port) is set, it populates the API URL in Cosmos directly (`https://<host>:<port>`) if not already present. The existing `clusterOperationStatus` check then passes on the next reconcile tick (~10s) instead of waiting for the 5-minute sync. If `cluster_properties_sync` runs later, it finds the field already set and skips the write.

Also graduates log levels for empty version strings in the ActiveVersions controller to reduce log noise during cluster creation.

### Diagnostics

Investigation of Prow runs [2061628914203103232](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-Azure-ARO-HCP-main-periodic-stg-e2e-parallel/2061628914203103232) and [2061583613178155008](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-Azure-ARO-HCP-main-periodic-stg-e2e-parallel/2061583613178155008) (stg-uksouth) showed:

- **39/39** ARM PUT operations timed out at 20 minutes with `timeout '20.000000' minutes exceeded during CreateHCPClusterFromParam`
- Backend logs showed two streams per operation:
  - **Stream A** (`new status via cosmos`): every ~30s tick returned `newStatus=Provisioning, newOperationMessage=".api.url is empty"`
  - **Stream B** (`new status via cluster-service`): returned `newStatus=Succeeded` for 38/39 operations (CS considered clusters Ready)
- The gate at `SynchronizeOperation` requires both to agree — CS said Succeeded but cosmos said Provisioning, so the operation never completed
- `cluster_properties_sync` (5-minute cycle) was the bottleneck: CS had the URL, but the sync hadn't yet copied it to the Cosmos document
- Kusto queries against `hcp-stg-uk-2.uksouth.kusto.windows.net` confirmed 0 polls returned `status=Succeeded` and all operations ended `Canceled` after test-initiated DELETEs

### Changes

- **`operation_cluster_create.go`**: Add `ensureAPIURL` method that writes `https://<host>:<port>` from the HostedCluster's `ControlPlaneEndpoint` to the Cosmos cluster document when the field is empty. Called at the end of `hostedClusterOperationStatus` before returning Succeeded.
- **`operation_cluster_create_test.go`**: Add `resourcesDBClient` to test cases that reach the success path so `ensureAPIURL` has a database to read/write.
- **`control_plane_active_version_controller.go`**: Short-circuit empty version strings before `semver.Parse`. Log at Info (not Error) when `Version=""` with `PartialUpdate` state (expected during rollout); keep Error for `CompletedUpdate` with empty version or non-empty unparseable versions.

Fixes: [ARO-27430](https://redhat.atlassian.net/browse/ARO-27430)
Supersedes: #5485

## Test plan
- [x] `go test ./backend/...` — all pass
- [x] All existing `TestDetermineOperationStatus` cases preserved and passing
- [x] `TestOperationClusterCreate_SynchronizeOperation` passes
- [x] `TestControlPlaneActiveVersionSyncer_SyncOnce` passes
- [x] API URL format (`https://host:port`) matches `cluster_properties_sync` test expectations (`testAPIURL = "https://api.example.com:6443"`)
- [ ] Verify in CSPR that cluster creation no longer times out

🤖 Generated with [Claude Code](https://claude.com/claude-code)