### PR TITLE
feat: Allow node pool to use a different channel group than its cluster

### DIFF
--- a/internal/admission/admit_nodepool.go
+++ b/internal/admission/admit_nodepool.go
@@ -116,18 +116,6 @@ func admitNodePoolProperties(ctx context.Context, admissionContext *NodePoolAdmi
 func admitNodePoolVersion(ctx context.Context, admissionContext *NodePoolAdmissionContext, op operation.Operation, fldPath *field.Path, newObj, oldObj *api.NodePoolVersionProfile) field.ErrorList {
 	errs := field.ErrorList{}
 
-	clusterVersion := &admissionContext.Cluster.CustomerProperties.Version
-
-	// Check only if it is a creating nodepool or a change in the channelGroup
-	if (op.Type == operation.Create || newObj.ChannelGroup != oldObj.ChannelGroup) &&
-		newObj.ChannelGroup != clusterVersion.ChannelGroup {
-		errs = append(errs, field.Invalid(
-			fldPath.Child("channelGroup"),
-			newObj.ChannelGroup,
-			fmt.Sprintf("must be the same as control plane channel group '%s'", clusterVersion.ChannelGroup),
-		))
-	}
-
 	// Perform update-specific version upgrade validation
 	if op.Type == operation.Update {
 		errs = append(errs, validateNodePoolVersionChange(ctx, admissionContext, op, fldPath.Child("id"), newObj, oldObj)...)

--- a/internal/admission/admit_nodepool_test.go
+++ b/internal/admission/admit_nodepool_test.go
@@ -709,21 +709,12 @@ func TestAdmitNodePool_VersionValidation(t *testing.T) {
 	}
 }
 
-func TestAdmitNodePool_IncludesChannelGroupCheck(t *testing.T) {
-	// Test that AdmitNodePool performs channel group validation from service provider state
+func TestAdmitNodePool_AllowsDifferentChannelGroupClusterAndNodePool(t *testing.T) {
 	newNodePool := &api.HCPOpenShiftClusterNodePool{
 		Properties: api.HCPOpenShiftClusterNodePoolProperties{
 			Version: api.NodePoolVersionProfile{
 				ID:           "4.17.0",
-				ChannelGroup: "fast", // Different from cluster
-			},
-		},
-	}
-	oldNodePool := &api.HCPOpenShiftClusterNodePool{
-		Properties: api.HCPOpenShiftClusterNodePoolProperties{
-			Version: api.NodePoolVersionProfile{
-				ID:           "4.16.0",
-				ChannelGroup: "stable", // Different from cluster
+				ChannelGroup: "fast",
 			},
 		},
 	}
@@ -731,12 +722,11 @@ func TestAdmitNodePool_IncludesChannelGroupCheck(t *testing.T) {
 		CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
 			Version: api.VersionProfile{
 				ID:           "4.18",
-				ChannelGroup: "stable", // Different from node pool
+				ChannelGroup: "stable",
 			},
 		},
 	}
 
-	// Create ServiceProviderNodePool with same version as new (so version validation is skipped)
 	ver := semver.MustParse("4.17.0")
 	spNodePool := &api.ServiceProviderNodePool{
 		Spec: api.ServiceProviderNodePoolSpec{
@@ -760,20 +750,15 @@ func TestAdmitNodePool_IncludesChannelGroupCheck(t *testing.T) {
 		},
 	}
 
-	// Empty update operation (no experimental features)
-	op := operation.Operation{Type: operation.Update}
+	op := operation.Operation{Type: operation.Create}
 
 	errs := AdmitNodePool(context.Background(), &NodePoolAdmissionContext{
 		Cluster:                 cluster,
 		ServiceProviderNodePool: spNodePool,
 		ServiceProviderCluster:  spCluster,
-	}, op, newNodePool, oldNodePool)
+	}, op, newNodePool, nil)
 
-	expectedErrors := []utils.ExpectedError{
-		{FieldPath: "properties.version.channelGroup", Message: "must be the same as control plane channel group"},
-	}
-
-	utils.VerifyErrorsMatch(t, expectedErrors, errs)
+	require.Empty(t, errs)
 }
 
 func TestAdmitNodePoolOnDelete(t *testing.T) {

--- a/internal/api/types_nodepool.go
+++ b/internal/api/types_nodepool.go
@@ -173,23 +173,6 @@ func (np *HCPOpenShiftClusterNodePool) EnsureDefaults() {
 	}
 }
 
-func (nodePool *HCPOpenShiftClusterNodePool) validateVersion(cluster *HCPOpenShiftCluster) []arm.CloudErrorBody {
-	var errorDetails []arm.CloudErrorBody
-
-	if nodePool.Properties.Version.ChannelGroup != cluster.CustomerProperties.Version.ChannelGroup {
-		errorDetails = append(errorDetails, arm.CloudErrorBody{
-			Code: arm.CloudErrorCodeInvalidRequestContent,
-			Message: fmt.Sprintf(
-				"Node pool channel group '%s' must be the same as control plane channel group '%s'",
-				nodePool.Properties.Version.ChannelGroup,
-				cluster.CustomerProperties.Version.ChannelGroup),
-			Target: "properties.version.channelGroup",
-		})
-	}
-
-	return errorDetails
-}
-
 func (nodePool *HCPOpenShiftClusterNodePool) validateSubnetID(cluster *HCPOpenShiftCluster) []arm.CloudErrorBody {
 	var errorDetails []arm.CloudErrorBody
 
@@ -218,7 +201,6 @@ func (nodePool *HCPOpenShiftClusterNodePool) Validate(cluster *HCPOpenShiftClust
 	var errorDetails []arm.CloudErrorBody
 
 	if cluster != nil {
-		errorDetails = append(errorDetails, nodePool.validateVersion(cluster)...)
 		errorDetails = append(errorDetails, nodePool.validateSubnetID(cluster)...)
 	}
 

--- a/internal/api/utils.go
+++ b/internal/api/utils.go
@@ -58,6 +58,12 @@ var AllowControlPlaneNodePoolMajorVersionSkew = map[string][]string{
 	"4.23": {"5.1", "5.2"},
 }
 
+// AllowedChannelGroups is the set ARO-HCP allows to use for customer purposes
+var AllowedChannelGroups = sets.New("stable", "fast")
+
+// AllowedChannelGroupsWithExperimentalFlag is the set the service allows to use when using the Experimental Feature AFEC flag
+var AllowedChannelGroupsWithExperimentalFlag = sets.New("stable", "fast", "candidate", "nightly")
+
 // Ptr returns a pointer to p.
 func Ptr[T any](p T) *T {
 	return &p

--- a/internal/validation/validate_cluster.go
+++ b/internal/validation/validate_cluster.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/operation"
 	"k8s.io/apimachinery/pkg/api/safe"
 	"k8s.io/apimachinery/pkg/api/validate"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
@@ -367,10 +366,10 @@ func validateVersionProfile(ctx context.Context, op operation.Operation, fldPath
 
 	if !op.HasOption(api.FeatureExperimentalReleaseFeatures) {
 		// Without feature flag: "candidate" and "nightly" aren't allowed.
-		errs = append(errs, validate.Enum(ctx, op, fldPath.Child("channelGroup"), &newObj.ChannelGroup, nil, sets.New("stable", "fast"), nil)...)
+		errs = append(errs, validate.Enum(ctx, op, fldPath.Child("channelGroup"), &newObj.ChannelGroup, nil, api.AllowedChannelGroups, nil)...)
 	} else {
 		// TODO I think everyone should be able to do this, but we'll need to notify first
-		errs = append(errs, validate.Enum(ctx, op, fldPath.Child("channelGroup"), &newObj.ChannelGroup, nil, sets.New("stable", "fast", "candidate", "nightly"), nil)...)
+		errs = append(errs, validate.Enum(ctx, op, fldPath.Child("channelGroup"), &newObj.ChannelGroup, nil, api.AllowedChannelGroupsWithExperimentalFlag, nil)...)
 	}
 
 	return errs

--- a/internal/validation/validate_nodepools.go
+++ b/internal/validation/validate_nodepools.go
@@ -210,13 +210,14 @@ func validateNodePoolVersionProfile(ctx context.Context, op operation.Operation,
 	}
 
 	//ChannelGroup string `json:"channelGroup,omitempty"`
-	// this is required and is later checked for matching the control plane.
-	// TODO   Interestingly, they won't match long term since clusters can change channels and aren't check
 	errs = append(errs, validate.RequiredValue(ctx, op, fldPath.Child("channelGroup"), &newObj.ChannelGroup, safe.Field(oldObj, toNodePoolVersionProfileChannelGroup))...)
 
 	if !op.HasOption(api.FeatureExperimentalReleaseFeatures) {
+		errs = append(errs, validate.Enum(ctx, op, fldPath.Child("channelGroup"), &newObj.ChannelGroup, safe.Field(oldObj, toNodePoolVersionProfileChannelGroup), api.AllowedChannelGroups, nil)...)
 		// without feature flag, only allow version 4.20.8 and above
 		errs = append(errs, VersionMustBeAtLeast(ctx, op, fldPath.Child("id"), &newObj.ID, safe.Field(oldObj, toNodePoolVersionProfileID), "4.20.8")...)
+	} else {
+		errs = append(errs, validate.Enum(ctx, op, fldPath.Child("channelGroup"), &newObj.ChannelGroup, safe.Field(oldObj, toNodePoolVersionProfileChannelGroup), api.AllowedChannelGroupsWithExperimentalFlag, nil)...)
 	}
 
 	return errs

--- a/internal/validation/validate_nodepools_comprehensive_test.go
+++ b/internal/validation/validate_nodepools_comprehensive_test.go
@@ -189,6 +189,42 @@ func TestValidateNodePoolCreate(t *testing.T) {
 			}(),
 			expectErrors: []utils.ExpectedError{
 				{Message: "Required value", FieldPath: "properties.version.channelGroup"},
+				{Message: "Unsupported value", FieldPath: "properties.version.channelGroup"},
+			},
+		},
+		{
+			name: "invalid channel group - create",
+			nodePool: func() *api.HCPOpenShiftClusterNodePool {
+				np := createValidNodePool()
+				np.Properties.Version.ChannelGroup = "invalid-cg"
+				return np
+			}(),
+			expectErrors: []utils.ExpectedError{
+				{Message: "Unsupported value", FieldPath: "properties.version.channelGroup"},
+			},
+		},
+		{
+			name: "candidate channel group rejected without feature flag - create",
+			nodePool: func() *api.HCPOpenShiftClusterNodePool {
+				np := createValidNodePool()
+				np.Properties.Version.ID = "4.21.0-rc.1"
+				np.Properties.Version.ChannelGroup = "candidate"
+				return np
+			}(),
+			expectErrors: []utils.ExpectedError{
+				{Message: "Unsupported value", FieldPath: "properties.version.channelGroup"},
+			},
+		},
+		{
+			name: "nightly channel group rejected without feature flag - create",
+			nodePool: func() *api.HCPOpenShiftClusterNodePool {
+				np := createValidNodePool()
+				np.Properties.Version.ID = "4.21.0-0.nightly-2024-01-15-123456"
+				np.Properties.Version.ChannelGroup = "nightly"
+				return np
+			}(),
+			expectErrors: []utils.ExpectedError{
+				{Message: "Unsupported value", FieldPath: "properties.version.channelGroup"},
 			},
 		},
 		{
@@ -1474,6 +1510,18 @@ func TestValidateNodePoolVersionWithFeatureFlags(t *testing.T) {
 			}(),
 			opOptions:    testNodePoolFeatureOptions(api.FeatureExperimentalReleaseFeatures),
 			expectErrors: []utils.ExpectedError{},
+		},
+		{
+			name: "invalid channel group rejected even with experimental flag",
+			nodePool: func() *api.HCPOpenShiftClusterNodePool {
+				np := createValidNodePool()
+				np.Properties.Version.ChannelGroup = "invalid-cg"
+				return np
+			}(),
+			opOptions: testNodePoolFeatureOptions(api.FeatureExperimentalReleaseFeatures),
+			expectErrors: []utils.ExpectedError{
+				{Message: "Unsupported value", FieldPath: "properties.version.channelGroup"},
+			},
 		},
 		{
 			name: "malformed version rejected",

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/allow-creation-when-cluster-and-nodepool-channel-group-different/00-httpCreate-subscription/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/allow-creation-when-cluster-and-nodepool-channel-group-different/00-httpCreate-subscription/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "2f2d4ba3-1ee6-57b6-bde9-b61d09eaf989",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/allow-creation-when-cluster-and-nodepool-channel-group-different/00-httpCreate-subscription/subscription.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/allow-creation-when-cluster-and-nodepool-channel-group-different/00-httpCreate-subscription/subscription.json
@@ -1,0 +1,6 @@
+{
+	"properties": null,
+	"registrationDate": "2025-12-19T19:53:15+00:00",
+	"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7",
+	"state": "Registered"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/allow-creation-when-cluster-and-nodepool-channel-group-different/01-httpCreate-cluster-stable-channel/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/allow-creation-when-cluster-and-nodepool-channel-group-different/01-httpCreate-cluster-stable-channel/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "96b154eb-638c-5dae-ba08-9b2df5cd8f61",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/stable-cluster"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/allow-creation-when-cluster-and-nodepool-channel-group-different/01-httpCreate-cluster-stable-channel/cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/allow-creation-when-cluster-and-nodepool-channel-group-different/01-httpCreate-cluster-stable-channel/cluster.json
@@ -1,0 +1,53 @@
+{
+	"identity": {
+		"type": "UserAssigned",
+		"userAssignedIdentities": {}
+	},
+	"name": "stable-cluster",
+	"properties": {
+		"api": {
+			"visibility": "Public"
+		},
+		"clusterImageRegistry": {
+			"state": "Disabled"
+		},
+		"console": {},
+		"dns": {},
+		"etcd": {
+			"dataEncryption": {
+				"customerManaged": {
+					"encryptionType": "KMS",
+					"kms": {
+						"activeKey": {
+							"name": "encryptionKeyName",
+							"vaultName": "keyVaultName",
+							"version": "2024-12-01-preview"
+						}
+					}
+				},
+				"keyManagementMode": "CustomerManaged"
+			}
+		},
+		"network": {
+			"hostPrefix": 23,
+			"machineCidr": "10.0.0.0/16",
+			"networkType": "OVNKubernetes",
+			"podCidr": "10.128.0.0/14",
+			"serviceCidr": "172.30.0.0/16"
+		},
+		"platform": {
+			"managedResourceGroup": "managed-resource-group-name",
+			"networkSecurityGroupId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/networkSecurityGroups/nsg",
+			"outboundType": "LoadBalancer",
+			"subnetId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
+		},
+		"version": {
+			"channelGroup": "stable",
+			"id": "4.20"
+		}
+	},
+	"tags": {
+		"one": "apple"
+	},
+	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/allow-creation-when-cluster-and-nodepool-channel-group-different/02-completeOperation-cluster-stable-cluster/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/allow-creation-when-cluster-and-nodepool-channel-group-different/02-completeOperation-cluster-stable-cluster/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "96b154eb-638c-5dae-ba08-9b2df5cd8f61",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/stable-cluster"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/allow-creation-when-cluster-and-nodepool-channel-group-different/03-httpCreate-nodepool-fast-channel/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/allow-creation-when-cluster-and-nodepool-channel-group-different/03-httpCreate-nodepool-fast-channel/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "2b834a28-7e5b-50e2-9fb9-b6679cdd6a1b",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/stable-cluster/nodePools/fast-node-pool"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/allow-creation-when-cluster-and-nodepool-channel-group-different/03-httpCreate-nodepool-fast-channel/nodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/allow-creation-when-cluster-and-nodepool-channel-group-different/03-httpCreate-nodepool-fast-channel/nodepool.json
@@ -1,0 +1,32 @@
+{
+	"name": "fast-node-pool",
+	"properties": {
+		"autoRepair": true,
+		"autoScaling": {
+			"max": 5,
+			"min": 1
+		},
+		"labels": [
+			{
+				"key": "label-ky",
+				"value": "label-value"
+			}
+		],
+		"nodeDrainTimeoutMinutes": 2,
+		"platform": {
+			"vmSize": "large"
+		},
+		"taints": [
+			{
+				"effect": "NoExecute",
+				"key": "foo.com/key",
+				"value": "valid"
+			}
+		],
+		"version": {
+			"channelGroup": "fast",
+			"id": "4.20.8"
+		}
+	},
+	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
+}


### PR DESCRIPTION
[ARO-27518](https://redhat.atlassian.net/browse/ARO-27518)

### What

Allow node pools to use a different channel group than their parent cluster. Previously, creating or updating a node pool with a channel group that didn't match the cluster's would be rejected. This PR removes that constraint and adds enum validation to ensure the channel group is a known value.

### Why

Node pools should be able to independently select their channel group (e.g., a "stable" node pool on a "candidate" cluster). There is no constraint in Hypershift around this.

### Testing

- **Unit tests (admission):** Rewrote `TestAdmitNodePool_IncludesChannelGroupCheck` -> `TestAdmitNodePool_AllowsDifferentChannelGroup` to verify that a node pool with a different channel group than the cluster is accepted.
- **Unit tests (validation):** Added test cases for channel group enum enforcement: invalid values rejected with and without feature flag, `candidate`/`nightly` rejected without `ExperimentalReleaseFeatures` AFEC, `stable`/`fast` accepted.


### Special notes for your reviewer

- The `validateVersion()` method on `HCPOpenShiftClusterNodePool` was deleted entirely since its only purpose was the channel group match check.
- The `Validate()` method on `HCPOpenShiftClusterNodePool` still validates subnet via `validateSubnetID()`.
- The enum validation follows the same pattern as clusters in `validate_cluster.go:368-374`.
- The existing `"stable"` default in `SetDefaultValuesNodePool()` is kept as-is for backwards compatibility.
- This works requires a CS change to be merged and deployed in ARO-HCP https://gitlab.cee.redhat.com/service/aro-hcp-clusters-service/-/merge_requests/348

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
