### PR TITLE
fix(ops): shorten forced-evidence restore timeout (AROSLSRE-1003)

### DIFF
--- a/dev-infrastructure/scripts/recreate-broken-pools/main.go
+++ b/dev-infrastructure/scripts/recreate-broken-pools/main.go
@@ -219,13 +219,12 @@ const (
 
 	// forcedEvidenceRestoreTimeoutMin caps the wait for the restorePoolSpec
 	// PUT + PollUntilDone that reverses the forced-evidence scale-up. ARM
-	// pool PUTs against AKS can legitimately take 5-10m, so this runs on
-	// its own context (also derived from context.Background) rather than
-	// sharing the shorter abort budget. Without a dedicated context, an
-	// abort that consumed most of forcedEvidenceAbortTimeoutMin would
-	// silently skip the restore and leave the pool one node larger than
-	// the original snapshot.
-	forcedEvidenceRestoreTimeoutMin = 15
+	// pool PUTs in the NRP-KVS wedge path are expected to fail or hang, so
+	// the restore is best-effort and intentionally short. This runs on its
+	// own context (also derived from context.Background) rather than sharing
+	// the abort budget. Without a dedicated context, an abort that consumed
+	// most of forcedEvidenceAbortTimeoutMin would silently skip the restore.
+	forcedEvidenceRestoreTimeoutMin = 5
 )
 
 const nodePoolRoleLabel = "aro-hcp.azure.com/role"

--- a/dev-infrastructure/scripts/recreate-broken-pools/main_test.go
+++ b/dev-infrastructure/scripts/recreate-broken-pools/main_test.go
@@ -1854,6 +1854,20 @@ func TestRunWith(t *testing.T) {
 				m.pollForNRPEvidenceFn = func(context.Context, time.Duration, time.Duration, int, int) (int, error) {
 					return 12, nil
 				}
+				m.restorePoolSpecFn = func(ctx context.Context, _ nodePoolTarget, _ *armcs.AgentPool) error {
+					deadline, ok := ctx.Deadline()
+					if !ok {
+						t.Fatalf("restorePoolSpec context has no deadline")
+					}
+					remaining := time.Until(deadline)
+					if remaining <= 0 || remaining > forcedEvidenceRestoreTimeoutMin*time.Minute {
+						t.Fatalf("restorePoolSpec deadline remaining=%s, want <= %dm and > 0", remaining, forcedEvidenceRestoreTimeoutMin)
+					}
+					if remaining < (forcedEvidenceRestoreTimeoutMin*time.Minute)-10*time.Second {
+						t.Fatalf("restorePoolSpec deadline remaining=%s, want near %dm", remaining, forcedEvidenceRestoreTimeoutMin)
+					}
+					return nil
+				}
 			},
 			wantCalls: []string{
 				"ensureCluster", "dumpPreflight", "detect:1",


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-1003

### What

Shortens the `recreate-broken-pools` forced-evidence restore timeout from 15 minutes to 5 minutes.

This only affects the best-effort restore PUT after the forced-evidence scale-up probe. It does not change the actual remediation pool create/delete/recreate waits.

### Why

Stage logs showed the forced-evidence path spending ~15 minutes per confirmed wedged worker pool waiting for a restore PUT that is expected to fail or hang in the NRP-KVS wedge path. With multiple failed worker pools, that serial wait can consume most of the 120-minute script budget before actual remediation starts.

Keeping the forced-evidence restore short lets the script move from evidence collection to the real recreate flow sooner while still attempting cleanup.

### Testing

`go test ./dev-infrastructure/scripts/recreate-broken-pools`

### Special notes for your reviewer

The added test asserts that the forced-evidence restore receives the shortened dedicated context deadline. Screenshots are not applicable; this is an operational Go helper change.

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [x] All comment threads resolved before merge
