### PR TITLE
defer utilruntime.HandleCrash() in production goroutines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,10 @@ Each service follows consistent patterns:
 ### Build Tags
 - Lint tags: `LINT_GOTAGS='${GOTAGS},E2Etests'`
 
+### Go conventions
+
+- Every `go func(...)` spawned in non-test code must `defer utilruntime.HandleCrash()` (alias `k8s.io/apimachinery/pkg/util/runtime`) as its first deferred call, so an unhandled panic in the goroutine respects `utilruntime.ReallyCrash` and the binary's crash-on-panic policy instead of silently taking down the process. Goroutines whose body is passed to a kube wait helper that already wraps the call (e.g. `wait.Until`, `wait.UntilWithContext`, `wait.JitterUntil`) do not need it — those helpers call `HandleCrash` internally. When the goroutine invokes a named function via `go fn(...)`, put the `defer utilruntime.HandleCrash()` at the top of `fn` rather than wrapping the call site in a closure. Test code (`*_test.go`, `test/`, `test-integration/`, generated SDK fakes) is exempt.
+
 ### Infrastructure as Code
 - Bicep templates in `dev-infrastructure/templates/`
 - Reusable modules in `dev-infrastructure/modules/`

--- a/admin/server/cmd/server/options.go
+++ b/admin/server/cmd/server/options.go
@@ -28,6 +28,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/spf13/cobra"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/utils/set"
@@ -366,6 +367,7 @@ func (opts *Options) Run(ctx context.Context) error {
 
 	runErrCh := make(chan error, 1)
 	go func() {
+		defer utilruntime.HandleCrash()
 		runErrCh <- adminAPI.Run(ctx)
 		logger.Info("admin api exited")
 	}()

--- a/admin/server/server/admin.go
+++ b/admin/server/server/admin.go
@@ -27,6 +27,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/utils/set"
 
 	"github.com/Azure/azure-kusto-go/kusto"
@@ -198,10 +199,12 @@ func (a *AdminAPI) Run(ctx context.Context) error {
 	wg := sync.WaitGroup{}
 	wg.Add(2)
 	go func() {
+		defer utilruntime.HandleCrash()
 		defer wg.Done()
 		errCh <- a.server.Serve(a.listener)
 	}()
 	go func() {
+		defer utilruntime.HandleCrash()
 		defer wg.Done()
 		errCh <- a.metricsServer.Serve(a.metricsListener)
 	}()

--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -118,6 +118,7 @@ func (o *BackendOptions) RunBackend(ctx context.Context) error {
 	}
 	runErrCh := make(chan error, 1)
 	go func() {
+		defer k8sutilruntime.HandleCrash()
 		runErrCh <- backend.Run(ctx)
 		cancel(fmt.Errorf("backend exited"))
 	}()
@@ -214,6 +215,7 @@ func (b *Backend) Run(ctx context.Context) error {
 			electionChecker:   electionChecker,
 		}
 		go func() {
+			defer k8sutilruntime.HandleCrash()
 			err := s.Run(ctx)
 			if err != nil {
 				cancel(fmt.Errorf("healthz server exited: %w", err))
@@ -230,6 +232,7 @@ func (b *Backend) Run(ctx context.Context) error {
 			metricsGatherer:   b.options.MetricsGatherer,
 		}
 		go func() {
+			defer k8sutilruntime.HandleCrash()
 			err := s.Run(ctx)
 			if err != nil {
 				cancel(fmt.Errorf("metrics server exited: %w", err))
@@ -239,6 +242,7 @@ func (b *Backend) Run(ctx context.Context) error {
 	}
 
 	go func() {
+		defer k8sutilruntime.HandleCrash()
 		err := b.runBackendControllersUnderLeaderElection(ctx, electionChecker)
 		// When leader election exits (e.g. lost lease), cancel so Run() unblocks and performs shutdown.
 		cancel(fmt.Errorf("backend controllers leader election exited"))
@@ -319,6 +323,7 @@ func runHTTPServer(ctx context.Context, name string, addr string, server *http.S
 	done := make(chan struct{})
 	defer close(done)
 	go func() {
+		defer k8sutilruntime.HandleCrash()
 		select {
 		case <-ctx.Done():
 			shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), backendShutdownTimeout)

--- a/backend/pkg/informers/expiring_watcher.go
+++ b/backend/pkg/informers/expiring_watcher.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 )
 
@@ -41,6 +42,7 @@ func NewExpiringWatcher(ctx context.Context, expiry time.Duration) watch.Interfa
 		done:   make(chan struct{}),
 	}
 	go func() {
+		defer utilruntime.HandleCrash()
 		select {
 		case <-time.After(expiry):
 			w.result <- watch.Event{

--- a/backend/pkg/informers/types.go
+++ b/backend/pkg/informers/types.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"time"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/Azure/ARO-HCP/backend/pkg/listers"
@@ -179,6 +180,7 @@ func NewBackendInformersWithRelistDuration(ctx context.Context, resourcesGlobalL
 }
 
 func (b *backendInformers) RunWithContext(ctx context.Context) {
+	defer utilruntime.HandleCrash()
 	logger := utils.LoggerFromContext(ctx)
 	logger.Info("starting informers")
 	defer logger.Info("stopped informers")
@@ -187,56 +189,67 @@ func (b *backendInformers) RunWithContext(ctx context.Context) {
 
 	wg.Add(1)
 	go func() {
+		defer utilruntime.HandleCrash()
 		defer wg.Done()
 		b.subscriptionInformer.RunWithContext(ctx)
 	}()
 	wg.Add(1)
 	go func() {
+		defer utilruntime.HandleCrash()
 		defer wg.Done()
 		b.activeOperationInformer.RunWithContext(ctx)
 	}()
 	wg.Add(1)
 	go func() {
+		defer utilruntime.HandleCrash()
 		defer wg.Done()
 		b.allOperationInformer.RunWithContext(ctx)
 	}()
 	wg.Add(1)
 	go func() {
+		defer utilruntime.HandleCrash()
 		defer wg.Done()
 		b.clusterInformer.RunWithContext(ctx)
 	}()
 	wg.Add(1)
 	go func() {
+		defer utilruntime.HandleCrash()
 		defer wg.Done()
 		b.nodePoolInformer.RunWithContext(ctx)
 	}()
 	wg.Add(1)
 	go func() {
+		defer utilruntime.HandleCrash()
 		defer wg.Done()
 		b.externalAuthInformer.RunWithContext(ctx)
 	}()
 	wg.Add(1)
 	go func() {
+		defer utilruntime.HandleCrash()
 		defer wg.Done()
 		b.serviceProviderClusterInformer.RunWithContext(ctx)
 	}()
 	wg.Add(1)
 	go func() {
+		defer utilruntime.HandleCrash()
 		defer wg.Done()
 		b.serviceProviderNodePoolInformer.RunWithContext(ctx)
 	}()
 	wg.Add(1)
 	go func() {
+		defer utilruntime.HandleCrash()
 		defer wg.Done()
 		b.controllerInformer.RunWithContext(ctx)
 	}()
 	wg.Add(1)
 	go func() {
+		defer utilruntime.HandleCrash()
 		defer wg.Done()
 		b.managementClusterContentInformer.RunWithContext(ctx)
 	}()
 	wg.Add(1)
 	go func() {
+		defer utilruntime.HandleCrash()
 		defer wg.Done()
 		b.billingInformer.RunWithContext(ctx)
 	}()

--- a/fleet/pkg/manager/manager.go
+++ b/fleet/pkg/manager/manager.go
@@ -28,6 +28,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
@@ -91,6 +92,7 @@ func (m *Manager) Run(ctx context.Context) error {
 		healthzServer = &http.Server{Addr: m.HealthzListenAddr, Handler: mux}
 		wg.Add(1)
 		go func() {
+			defer utilruntime.HandleCrash()
 			defer wg.Done()
 			logger.Info("healthz server listening", "address", m.HealthzListenAddr)
 			err := healthzServer.ListenAndServe()
@@ -110,6 +112,7 @@ func (m *Manager) Run(ctx context.Context) error {
 		metricsServer = &http.Server{Addr: m.MetricsListenAddr, Handler: mux}
 		wg.Add(1)
 		go func() {
+			defer utilruntime.HandleCrash()
 			defer wg.Done()
 			logger.Info("metrics server listening", "address", m.MetricsListenAddr)
 			err := metricsServer.ListenAndServe()
@@ -122,6 +125,7 @@ func (m *Manager) Run(ctx context.Context) error {
 
 	wg.Add(1)
 	go func() {
+		defer utilruntime.HandleCrash()
 		defer wg.Done()
 		err := m.runControllersUnderLeaderElection(ctx, electionChecker)
 		cancel(fmt.Errorf("leader election exited"))

--- a/frontend/cmd/cmd.go
+++ b/frontend/cmd/cmd.go
@@ -29,6 +29,7 @@ import (
 	"go.opentelemetry.io/otel"
 	semconv "go.opentelemetry.io/otel/semconv/v1.27.0"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/component-base/metrics/legacyregistry"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
@@ -274,6 +275,7 @@ func (opts *FrontendOpts) Run() error {
 
 	runErrCh := make(chan error, 1)
 	go func() {
+		defer utilruntime.HandleCrash()
 		runErrCh <- f.Run(ctx)
 		cancel(fmt.Errorf("frontend exited"))
 	}()

--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -178,14 +178,17 @@ func (f *Frontend) Run(ctx context.Context) error {
 	wg := sync.WaitGroup{}
 	wg.Add(3)
 	go func() {
+		defer k8sutilruntime.HandleCrash()
 		defer wg.Done()
 		errCh <- f.server.Serve(f.listener)
 	}()
 	go func() {
+		defer k8sutilruntime.HandleCrash()
 		defer wg.Done()
 		errCh <- f.metricsServer.Serve(f.metricsListener)
 	}()
 	go func() {
+		defer k8sutilruntime.HandleCrash()
 		defer wg.Done()
 		f.collector.Run(ctx)
 	}()

--- a/internal/database/informers/fleet_types.go
+++ b/internal/database/informers/fleet_types.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"time"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/Azure/ARO-HCP/internal/database"
@@ -75,6 +76,7 @@ func NewFleetInformersWithRelistDuration(ctx context.Context, gl database.FleetG
 }
 
 func (f *fleetInformers) RunWithContext(ctx context.Context) {
+	defer utilruntime.HandleCrash()
 	logger := utils.LoggerFromContext(ctx)
 	logger.Info("starting fleet informers")
 	defer logger.Info("stopped fleet informers")
@@ -83,12 +85,14 @@ func (f *fleetInformers) RunWithContext(ctx context.Context) {
 
 	wg.Add(1)
 	go func() {
+		defer utilruntime.HandleCrash()
 		defer wg.Done()
 		f.stampInformer.RunWithContext(ctx)
 	}()
 
 	wg.Add(1)
 	go func() {
+		defer utilruntime.HandleCrash()
 		defer wg.Done()
 		f.managementClusterInformer.RunWithContext(ctx)
 	}()

--- a/internal/database/informers/list_watch.go
+++ b/internal/database/informers/list_watch.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
 )
@@ -57,6 +58,7 @@ func newExpiringWatcher(ctx context.Context, expiry time.Duration) watch.Interfa
 		done:   make(chan struct{}),
 	}
 	go func() {
+		defer utilruntime.HandleCrash()
 		select {
 		case <-time.After(expiry):
 			w.result <- watch.Event{

--- a/internal/database/informers/types.go
+++ b/internal/database/informers/types.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"time"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/Azure/ARO-HCP/internal/database"
@@ -100,6 +101,7 @@ func NewKubeApplierInformersWithRelistDuration(
 }
 
 func (k *kubeApplierInformers) RunWithContext(ctx context.Context) {
+	defer utilruntime.HandleCrash()
 	logger := utils.LoggerFromContext(ctx)
 	logger.Info("starting kube-applier informers")
 	defer logger.Info("stopped kube-applier informers")
@@ -108,16 +110,19 @@ func (k *kubeApplierInformers) RunWithContext(ctx context.Context) {
 
 	wg.Add(1)
 	go func() {
+		defer utilruntime.HandleCrash()
 		defer wg.Done()
 		k.applyDesireInformer.RunWithContext(ctx)
 	}()
 	wg.Add(1)
 	go func() {
+		defer utilruntime.HandleCrash()
 		defer wg.Done()
 		k.deleteDesireInformer.RunWithContext(ctx)
 	}()
 	wg.Add(1)
 	go func() {
+		defer utilruntime.HandleCrash()
 		defer wg.Done()
 		k.readDesireInformer.RunWithContext(ctx)
 	}()

--- a/internal/database/lock.go
+++ b/internal/database/lock.go
@@ -23,6 +23,8 @@ import (
 	"strconv"
 	"time"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
 )
 
@@ -183,6 +185,7 @@ func (c *LockClient) HoldLock(ctx context.Context, item *azcosmos.ItemResponse) 
 	}
 
 	go func() {
+		defer utilruntime.HandleCrash()
 		defer close(done)
 		for {
 			var doc *lockDocument

--- a/internal/database/unioninformers/kubeapplier/controller.go
+++ b/internal/database/unioninformers/kubeapplier/controller.go
@@ -302,6 +302,7 @@ func (c *UnionKubeApplierInformersController) ensureAdded(ctx context.Context, r
 	logger.Info("added per-MC sub-informer to union", "resourceID", rid)
 
 	go func() {
+		defer utilruntime.HandleCrash()
 		defer close(entry.done)
 		sub.RunWithContext(subCtx)
 	}()

--- a/internal/signal/signal.go
+++ b/internal/signal/signal.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"os"
 	"os/signal"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
 
 var onlyOneSignalHandler = make(chan struct{})
@@ -43,6 +45,7 @@ func SetupSignalContext() context.Context {
 	ctx, cancel := context.WithCancel(context.Background())
 	signal.Notify(shutdownHandler, shutdownSignals...)
 	go func() {
+		defer utilruntime.HandleCrash()
 		<-shutdownHandler
 		cancel()
 		<-shutdownHandler

--- a/internal/utils/fswatcher.go
+++ b/internal/utils/fswatcher.go
@@ -23,6 +23,8 @@ import (
 	"path/filepath"
 	"sync"
 	"time"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
 
 // FSWatcher watches a file for content changes using hash-based change detection.
@@ -129,6 +131,7 @@ func (w *FSWatcher) checkAndSignal(ctx context.Context) {
 
 // watchLoop periodically checks for file changes and invokes the callback if so
 func (w *FSWatcher) watchLoop(ctx context.Context) {
+	defer utilruntime.HandleCrash()
 	logger := LoggerFromContext(ctx)
 	ticker := time.NewTicker(w.checkInterval)
 	defer ticker.Stop()

--- a/kube-applier/pkg/app/kube_applier.go
+++ b/kube-applier/pkg/app/kube_applier.go
@@ -85,6 +85,7 @@ func (o *Options) Run(ctx context.Context) error {
 		healthzServer = &http.Server{Addr: o.HealthzServerListenAddress, Handler: mux}
 		wg.Add(1)
 		go func() {
+			defer kuberuntime.HandleCrash()
 			defer wg.Done()
 			logger.Info(fmt.Sprintf("healthz server listening on %s", o.HealthzServerListenAddress))
 			errCh <- healthzServer.ListenAndServe()
@@ -100,6 +101,7 @@ func (o *Options) Run(ctx context.Context) error {
 		metricsServer = &http.Server{Addr: o.MetricsServerListenAddress, Handler: mux}
 		wg.Add(1)
 		go func() {
+			defer kuberuntime.HandleCrash()
 			defer wg.Done()
 			logger.Info(fmt.Sprintf("metrics server listening on %s", o.MetricsServerListenAddress))
 			errCh <- metricsServer.ListenAndServe()
@@ -108,6 +110,7 @@ func (o *Options) Run(ctx context.Context) error {
 
 	wg.Add(1)
 	go func() {
+		defer kuberuntime.HandleCrash()
 		defer wg.Done()
 		err := o.runControllersUnderLeaderElection(ctx, electionChecker)
 		cancel(fmt.Errorf("leader election exited"))

--- a/kube-applier/pkg/controllers/read_desire_kubernetes/controller.go
+++ b/kube-applier/pkg/controllers/read_desire_kubernetes/controller.go
@@ -178,6 +178,7 @@ func (c *ReadDesireKubernetesController) Run(ctx context.Context) {
 	ticker := time.NewTicker(ResyncDuration)
 	defer ticker.Stop()
 	go func() {
+		defer utilruntime.HandleCrash()
 		for {
 			select {
 			case <-ctx.Done():

--- a/kube-applier/pkg/controllers/read_desire_manager/controller.go
+++ b/kube-applier/pkg/controllers/read_desire_manager/controller.go
@@ -340,6 +340,7 @@ func (c *ReadDesireInformerManagingController) SyncOnce(ctx context.Context, key
 	c.mu.Unlock()
 
 	go func() {
+		defer utilruntime.HandleCrash()
 		defer close(done)
 		per.Run(childCtx)
 	}()

--- a/mgmt-agent/cmd/options.go
+++ b/mgmt-agent/cmd/options.go
@@ -27,6 +27,7 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -195,6 +196,7 @@ func (o *ControllerOptions) Run(ctx context.Context) error {
 		mux.Handle("/metrics", legacyregistry.Handler())
 		server := &http.Server{Addr: o.healthAddress, Handler: mux}
 		go func() {
+			defer utilruntime.HandleCrash()
 			<-ctx.Done()
 			if err := server.Shutdown(context.Background()); err != nil {
 				logger.Error(err, "Error shutting down health server")

--- a/sessiongate/pkg/server/server.go
+++ b/sessiongate/pkg/server/server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 
@@ -126,6 +127,7 @@ func (s *Server) Run(ctx context.Context) error {
 	// Start server in goroutine
 	serverErr := make(chan error, 1)
 	go func() {
+		defer utilruntime.HandleCrash()
 		if err := s.server.Serve(listener); err != nil && err != http.ErrServerClosed {
 			serverErr <- err
 		}

--- a/sessiongate/pkg/signals/signal.go
+++ b/sessiongate/pkg/signals/signal.go
@@ -28,6 +28,8 @@ import (
 	"context"
 	"os"
 	"os/signal"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
 
 var onlyOneSignalHandler = make(chan struct{})
@@ -42,6 +44,7 @@ func SetupSignalHandler(ctx context.Context) context.Context {
 	ctx, cancel := context.WithCancel(ctx)
 	signal.Notify(c, shutdownSignals...)
 	go func() {
+		defer utilruntime.HandleCrash()
 		<-c
 		cancel()
 		<-c

--- a/tooling/aro-hcp-exporter/go.mod
+++ b/tooling/aro-hcp-exporter/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/prometheus/client_model v0.6.2
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
+	k8s.io/apimachinery v0.35.3
 )
 
 require (
@@ -35,7 +36,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
-	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/samber/lo v1.53.0 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
@@ -47,6 +47,7 @@ require (
 	golang.org/x/text v0.36.0 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/klog/v2 v2.140.0 // indirect
 )
 
 replace github.com/Azure/ARO-HCP/tooling/hcpctl => ../hcpctl

--- a/tooling/aro-hcp-exporter/go.sum
+++ b/tooling/aro-hcp-exporter/go.sum
@@ -106,5 +106,9 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+k8s.io/apimachinery v0.35.3 h1:MeaUwQCV3tjKP4bcwWGgZ/cp/vpsRnQzqO6J6tJyoF8=
+k8s.io/apimachinery v0.35.3/go.mod h1:jQCgFZFR1F4Ik7hvr2g84RTJSZegBc8yHgFWKn//hns=
+k8s.io/klog/v2 v2.140.0 h1:Tf+J3AH7xnUzZyVVXhTgGhEKnFqye14aadWv7bzXdzc=
+k8s.io/klog/v2 v2.140.0/go.mod h1:o+/RWfJ6PwpnFn7OyAG3QnO47BFsymfEfrz6XyYSSp0=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=

--- a/tooling/aro-hcp-exporter/internal/cmd/serve.go
+++ b/tooling/aro-hcp-exporter/internal/cmd/serve.go
@@ -25,6 +25,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/cobra"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
 	"github.com/Azure/ARO-HCP/tooling/aro-hcp-exporter/internal/metrics"
 )
 
@@ -96,6 +98,7 @@ func (o *CompletedOptions) Run(ctx context.Context) error {
 	// Start server in a goroutine
 	errChan := make(chan error, 1)
 	go func() {
+		defer utilruntime.HandleCrash()
 		logger.Info("Starting server", "address", o.ListenAddress)
 		logger.Info("Metrics available", "url", fmt.Sprintf("http://%s%s", o.ListenAddress, metricsPath))
 		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
@@ -125,6 +128,7 @@ func (o *CompletedOptions) Run(ctx context.Context) error {
 }
 
 func collectLoop(ctx context.Context, collector metrics.CachingCollector, collectionInterval time.Duration) {
+	defer utilruntime.HandleCrash()
 	logger := logr.FromContextOrDiscard(ctx)
 	for {
 		select {

--- a/tooling/cleanup-sweeper/pkg/engine/runner/engine.go
+++ b/tooling/cleanup-sweeper/pkg/engine/runner/engine.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/go-logr/logr"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -119,6 +120,7 @@ func (e *Engine) runStep(ctx context.Context, step Step, parallelism int) error 
 	wg.Add(parallelism)
 	for i := 0; i < parallelism; i++ {
 		go func() {
+			defer utilruntime.HandleCrash()
 			defer wg.Done()
 			for {
 				select {

--- a/tooling/hcpctl/pkg/agent/agent.go
+++ b/tooling/hcpctl/pkg/agent/agent.go
@@ -29,6 +29,8 @@ import (
 	copilot "github.com/github/copilot-sdk/go"
 	"github.com/go-logr/logr"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 )
@@ -232,6 +234,7 @@ func (s *Session) SendAndWait(ctx context.Context, prompt string) (string, error
 	}
 	ch := make(chan result, 1)
 	go func() {
+		defer utilruntime.HandleCrash()
 		ev, err := s.inner.SendAndWait(ctx, copilot.MessageOptions{
 			Prompt: prompt,
 		})

--- a/tooling/hcpctl/pkg/breakglass/execute.go
+++ b/tooling/hcpctl/pkg/breakglass/execute.go
@@ -27,6 +27,7 @@ import (
 	"github.com/go-logr/logr"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -398,6 +399,7 @@ func setupPortForwarding(ctx context.Context, params *ExecutionParams, localPort
 	stopOnce := &sync.Once{} // Prevent double-close
 
 	go func() {
+		defer utilruntime.HandleCrash()
 		if err := portforward.ForwardToService(ctx, params.RestConfig, params.Namespace, kasServiceName, localPort, KubeAPIServerPort, stopCh, readyCh); err != nil {
 			logger.Error(err, "Port forwarding failed")
 		}

--- a/tooling/hcpctl/pkg/breakglass/portforward/portforward.go
+++ b/tooling/hcpctl/pkg/breakglass/portforward/portforward.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/rest"
 	"k8s.io/kubectl/pkg/cmd/portforward"
@@ -74,6 +75,7 @@ func ForwardToService(ctx context.Context, restConfig *rest.Config, namespace, s
 
 	// monitor our caller's stop channel and cancel context when signaled
 	go func() {
+		defer utilruntime.HandleCrash()
 		<-stopCh
 		stopCancel()
 	}()
@@ -105,6 +107,7 @@ func ForwardToService(ctx context.Context, restConfig *rest.Config, namespace, s
 
 	// forward kubectl's ready signal to our caller's ready channel
 	go func() {
+		defer utilruntime.HandleCrash()
 		<-opts.ReadyChannel
 		close(readyCh)
 	}()
@@ -113,6 +116,7 @@ func ForwardToService(ctx context.Context, restConfig *rest.Config, namespace, s
 	// RunPortForwardContext is blocking, so we need to run it in a goroutine
 	errCh := make(chan error, 1)
 	go func() {
+		defer utilruntime.HandleCrash()
 		defer close(errCh)
 		if err := opts.RunPortForwardContext(stopCtx); err != nil {
 			errCh <- fmt.Errorf("port forwarding failed for service %s: %w", serviceName, err)

--- a/tooling/hcpctl/pkg/shell/shell.go
+++ b/tooling/hcpctl/pkg/shell/shell.go
@@ -24,6 +24,8 @@ import (
 	"sync"
 
 	"github.com/google/shlex"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
 
 // Config represents the configuration for spawning a shell with kubeconfig access.
@@ -123,6 +125,7 @@ func spawnShell(ctx context.Context, config *Config, stopCh chan struct{}, stopO
 	// Wait for shell to exit
 	done := make(chan error, 1)
 	go func() {
+		defer utilruntime.HandleCrash()
 		done <- cmd.Wait()
 	}()
 
@@ -167,6 +170,7 @@ func ExecCommand(ctx context.Context, config *Config, command []string, stopCh c
 	// Wait for command to exit
 	done := make(chan error, 1)
 	go func() {
+		defer utilruntime.HandleCrash()
 		done <- cmd.Wait()
 	}()
 

--- a/tooling/hcpctl/pkg/snapshot/pool.go
+++ b/tooling/hcpctl/pkg/snapshot/pool.go
@@ -19,6 +19,8 @@ import (
 	"sync"
 
 	"github.com/go-logr/logr"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
 
 // workItem represents a single query to be executed in the pool.
@@ -107,6 +109,7 @@ func (p *queryPool) runPool(ctx context.Context, items []workItem) {
 	for i := 0; i < concurrency; i++ {
 		consumerWg.Add(1)
 		go func() {
+			defer utilruntime.HandleCrash()
 			defer consumerWg.Done()
 			for {
 				select {

--- a/tooling/templatize/bicep/client.go
+++ b/tooling/templatize/bicep/client.go
@@ -26,6 +26,8 @@ import (
 	"github.com/go-logr/logr"
 	"go.lsp.dev/jsonrpc2"
 	"go.lsp.dev/protocol"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
 
 // DetermineCLIPath tries to parse `az bicep version` output to find the path to the `bicep` CLI path, and falls back
@@ -93,6 +95,7 @@ func StartJSONRPCServer(ctx context.Context, logger logr.Logger, debug bool) (*L
 	logger.V(4).Info("started bicep JSON-RPC server", "pid", cmd.Process.Pid)
 
 	go func() {
+		defer utilruntime.HandleCrash()
 		if err := cmd.Wait(); err != nil {
 			logger.Error(err, "bicep JSON-RPC server exited with error")
 		}

--- a/tooling/templatize/pkg/azauth/github.go
+++ b/tooling/templatize/pkg/azauth/github.go
@@ -25,6 +25,8 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
 
 const (
@@ -62,6 +64,7 @@ func setupGithubAzureFederationAuthRefresher(ctx context.Context) error {
 		return fmt.Errorf("failed to refresh Azure session with federated GitHub ID token: %w", err)
 	}
 	go func() {
+		defer utilruntime.HandleCrash()
 		ticker := time.NewTicker(5 * time.Minute)
 		defer ticker.Stop()
 		for {

--- a/tooling/templatize/pkg/pipeline/run.go
+++ b/tooling/templatize/pkg/pipeline/run.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/go-logr/logr"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"sigs.k8s.io/yaml"
@@ -494,6 +495,7 @@ func runGraph(ctx context.Context, logger logr.Logger, executionGraph *graph.Gra
 	producerWg.Add(1)
 	// producer routine checks to see if we can queue more steps when we finish executing one
 	go func() {
+		defer utilruntime.HandleCrash()
 		thisLogger := logger.WithValues("routine", "producer")
 		defer func() {
 			close(queue)
@@ -550,6 +552,7 @@ func runGraph(ctx context.Context, logger logr.Logger, executionGraph *graph.Gra
 	for i := 0; i < maxConcurrency; i++ {
 		consumerWg.Add(1)
 		go func() {
+			defer utilruntime.HandleCrash()
 			thisLogger := logger.WithValues("routine", fmt.Sprintf("consumer-%d", i))
 			defer func() {
 				consumerWg.Done()
@@ -577,6 +580,7 @@ func runGraph(ctx context.Context, logger logr.Logger, executionGraph *graph.Gra
 					if details != nil {
 						consumerWg.Add(1)
 						go func(step graph.Identifier, logger logr.Logger) {
+							defer utilruntime.HandleCrash()
 							defer func() {
 								consumerWg.Done()
 								stepLogger.V(4).Info("Finished fetching execution details.")

--- a/tooling/tenant-quota/go.mod
+++ b/tooling/tenant-quota/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.3.0
 	github.com/prometheus/client_golang v1.23.2
 	gopkg.in/yaml.v3 v3.0.1
+	k8s.io/apimachinery v0.35.3
 )
 
 require (
@@ -41,7 +42,6 @@ require (
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
-	k8s.io/apimachinery v0.35.3 // indirect
 	k8s.io/component-base v0.35.3 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5 // indirect

--- a/tooling/tenant-quota/main.go
+++ b/tooling/tenant-quota/main.go
@@ -28,6 +28,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
 	"github.com/Azure/ARO-HCP/internal/version"
 	"github.com/Azure/ARO-HCP/tooling/tenant-quota/pkg/config"
 	"github.com/Azure/ARO-HCP/tooling/tenant-quota/pkg/credentials"
@@ -103,6 +105,7 @@ func run(logger *slog.Logger) error {
 
 	errChan := make(chan error, 1)
 	go func() {
+		defer utilruntime.HandleCrash()
 		logger.Info("Starting HTTP server", "port", port)
 		if err := server.ListenAndServe(); err != http.ErrServerClosed {
 			errChan <- err

--- a/tooling/tenant-quota/pkg/subscriptionquota/collector.go
+++ b/tooling/tenant-quota/pkg/subscriptionquota/collector.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 
 	"github.com/Azure/ARO-HCP/tooling/tenant-quota/pkg/config"
@@ -92,6 +94,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 // Start runs the background collection loop. It collects immediately on
 // startup, then on every interval tick.
 func (c *Collector) Start(ctx context.Context) {
+	defer utilruntime.HandleCrash()
 	interval := c.config.GetInterval()
 	c.logger.Info("Starting subscription quota collection",
 		"interval", interval,

--- a/tooling/tenant-quota/pkg/tenantquota/collector.go
+++ b/tooling/tenant-quota/pkg/tenantquota/collector.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
 	"github.com/Azure/ARO-HCP/tooling/tenant-quota/pkg/config"
 	"github.com/Azure/ARO-HCP/tooling/tenant-quota/pkg/credentials"
 )
@@ -63,6 +65,7 @@ func NewCollector(cfg *config.Config, logger *slog.Logger, credProvider *credent
 }
 
 func (c *Collector) Start(ctx context.Context) {
+	defer utilruntime.HandleCrash()
 	interval := c.config.GetInterval()
 	c.logger.Info("Starting quota collection",
 		"interval", interval,


### PR DESCRIPTION
Codify the convention in CLAUDE.md and add the defer to every `go func` / `go fn(...)` launched in non-test code, so a panic inside a goroutine honors utilruntime.ReallyCrash instead of silently bringing down the process. Wait helpers (wait.Until etc.) already wrap in HandleCrash and are left alone.
