### PR TITLE
kube-applier: fix the role definition reference of kube-applier 

### DIFF
--- a/dev-infrastructure/modules/rp-cosmos-kube-applier.bicep
+++ b/dev-infrastructure/modules/rp-cosmos-kube-applier.bicep
@@ -3,6 +3,9 @@ param containerName string
 param containerMaxScale int
 param kubeApplierManagedIdentityPrincipalId string
 
+// https://learn.microsoft.com/en-us/azure/cosmos-db/reference-data-plane-security#cosmos-db-built-in-data-contributor
+param cosmosdbBuiltInDataContributorRoleId string = '00000000-0000-0000-0000-000000000002'
+
 resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2023-11-15' existing = {
   name: cosmosDBAccountName
 }
@@ -55,14 +58,14 @@ resource container 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/container
   }
 }
 
-var kubeApplierRoleDefinitionId = guid('kube-applier-role', cosmosDbAccount.id)
+var kubeApplierRoleDefinitionId = guid('kube-applier-role', cosmosDbAccount.id, cosmosdbBuiltInDataContributorRoleId)
 var containerScope = '${cosmosDbAccount.id}/dbs/${cosmosDBAccountName}/colls/${containerName}'
 
 resource sqlRoleAssignment 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments@2021-04-15' = {
   name: guid(kubeApplierRoleDefinitionId, kubeApplierManagedIdentityPrincipalId, container.id)
   parent: cosmosDbAccount
   properties: {
-    roleDefinitionId: '${cosmosDbAccount.id}/sqlRoleDefinitions/${kubeApplierRoleDefinitionId}'
+    roleDefinitionId: '/${subscription().id}/resourceGroups/${resourceGroup().name}/providers/Microsoft.DocumentDB/databaseAccounts/${cosmosDbAccount.name}/sqlRoleDefinitions/${cosmosdbBuiltInDataContributorRoleId}'
     principalId: kubeApplierManagedIdentityPrincipalId
     scope: containerScope
   }


### PR DESCRIPTION


### What

Fixes the sqlRoleAssignment for kube-applier to reference the correct built-in role definition for cosmosdb data contributor. 

### Why

Stage is broken for kube-applier trying to talk to its cosmosdb container.

### Testing

e2e should catch this.  We need to investigate why e2e previously passed and this is working in INT and dev.  
### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
