### PR TITLE
don't hard fail when cache is latent for operation

### DIFF
--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_create.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_create.go
@@ -210,6 +210,9 @@ func (c *operationClusterCreate) determineOperationStatus(ctx context.Context, o
 
 func (c *operationClusterCreate) clusterOperationStatus(ctx context.Context, operation *api.Operation) (*operationState, error) {
 	cluster, err := c.clusterLister.Get(ctx, operation.ExternalID.SubscriptionID, operation.ExternalID.ResourceGroupName, operation.ExternalID.Name)
+	if database.IsNotFoundError(err) {
+		return newOperationState(arm.ProvisioningStateProvisioning, "cluster not yet observed in cache"), nil
+	}
 	if err != nil {
 		return nil, utils.TrackError(err)
 	}


### PR DESCRIPTION
Found by looking at the backend metrics failures in https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/batch/pull-ci-Azure-ARO-HCP-main-e2e-parallel/2062131664804384768 again.  And again thanks @geoberle .

When the cache is latent, we can reasonably infer it's accepted, just not ready. So that particular error doesn't need a failure.