### PR TITLE
observability: add Ingress Availability CUJ runbook artifacts (ARO-22…

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
@@ -233,3 +233,124 @@ resource arohcpNodepoolSaturationAlerts 'Microsoft.AlertsManagement/prometheusRu
     ]
   }
 }
+
+resource ingressMonitorRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'ingress-monitor-rules'
+  location: location
+  properties: {
+    interval: 'PT1M'
+    rules: [
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'UJIngressAvailability1h5m'
+        enabled: true
+        labels: {
+          long_window: '1h'
+          severity: 'warning'
+          short_window: '5m'
+        }
+        annotations: {
+          correlationId: 'UJIngressAvailability1h5m/{{ $labels.cluster }}'
+          message: 'High error budget burn for ingress {{ $labels.probe_url }} (current value: {{ $value }})'
+          runbook_url: 'https://aka.ms/arohcp-runbook-ingress'
+          title: 'UJIngressAvailability1h5m'
+        }
+        expression: '1 - (sum by (probe_url, namespace, _id, cluster) (sum_over_time(probe_success{job="blackbox-ingress"}[5m])) / sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[5m]))) > (14.4 * (1 - 0.9995)) and sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[5m])) > 5 and 1 - (sum by (probe_url, namespace, _id, cluster) (sum_over_time(probe_success{job="blackbox-ingress"}[1h])) / sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[1h]))) > (14.4 * (1 - 0.9995)) and sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[1h])) > 60'
+        for: 'PT2M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'UJIngressAvailability6h30m'
+        enabled: true
+        labels: {
+          long_window: '6h'
+          severity: 'warning'
+          short_window: '30m'
+        }
+        annotations: {
+          correlationId: 'UJIngressAvailability6h30m/{{ $labels.cluster }}'
+          message: 'High error budget burn for ingress {{ $labels.probe_url }} (current value: {{ $value }})'
+          runbook_url: 'https://aka.ms/arohcp-runbook-ingress'
+          title: 'UJIngressAvailability6h30m'
+        }
+        expression: '1 - (sum by (probe_url, namespace, _id, cluster) (sum_over_time(probe_success{job="blackbox-ingress"}[30m])) / sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[30m]))) > (6 * (1 - 0.9995)) and sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[30m])) > 30 and 1 - (sum by (probe_url, namespace, _id, cluster) (sum_over_time(probe_success{job="blackbox-ingress"}[6h])) / sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[6h]))) > (6 * (1 - 0.9995)) and sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[6h])) > 360'
+        for: 'PT15M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'UJIngressAvailability1d2h'
+        enabled: true
+        labels: {
+          long_window: '1d'
+          severity: 'warning'
+          short_window: '2h'
+        }
+        annotations: {
+          correlationId: 'UJIngressAvailability1d2h/{{ $labels.cluster }}'
+          message: 'High error budget burn for ingress {{ $labels.probe_url }} (current value: {{ $value }})'
+          runbook_url: 'https://aka.ms/arohcp-runbook-ingress'
+          title: 'UJIngressAvailability1d2h'
+        }
+        expression: '1 - (sum by (probe_url, namespace, _id, cluster) (sum_over_time(probe_success{job="blackbox-ingress"}[2h])) / sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[2h]))) > (3 * (1 - 0.9995)) and sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[2h])) > 120 and 1 - (sum by (probe_url, namespace, _id, cluster) (sum_over_time(probe_success{job="blackbox-ingress"}[1d])) / sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[1d]))) > (3 * (1 - 0.9995)) and sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[1d])) > 1440'
+        for: 'PT1H'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'UJIngressAvailability3d6h'
+        enabled: true
+        labels: {
+          long_window: '3d'
+          severity: 'warning'
+          short_window: '6h'
+        }
+        annotations: {
+          correlationId: 'UJIngressAvailability3d6h/{{ $labels.cluster }}'
+          message: 'High error budget burn for ingress {{ $labels.probe_url }} (current value: {{ $value }})'
+          runbook_url: 'https://aka.ms/arohcp-runbook-ingress'
+          title: 'UJIngressAvailability3d6h'
+        }
+        expression: '1 - (sum by (probe_url, namespace, _id, cluster) (sum_over_time(probe_success{job="blackbox-ingress"}[6h])) / sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[6h]))) > (1 * (1 - 0.9995)) and sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[6h])) > 360 and 1 - (sum by (probe_url, namespace, _id, cluster) (sum_over_time(probe_success{job="blackbox-ingress"}[3d])) / sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[3d]))) > (1 * (1 - 0.9995)) and sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[3d])) > 4320'
+        for: 'PT3H'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+    ]
+    scopes: [
+      azureMonitoring
+    ]
+  }
+}

--- a/observability/alerts-rp-hcps.yaml
+++ b/observability/alerts-rp-hcps.yaml
@@ -1,0 +1,7 @@
+prometheusRules:
+  rulesFolders:
+  - alerts/ingress-prometheusRule.yaml
+  untestedRules: []
+  testDependencies:
+  - recording-rules-hcps.yaml
+  outputBicep: ../dev-infrastructure/modules/metrics/rules/generatedRPHCPPrometheusAlertingRules.bicep

--- a/observability/alerts-rp-services.yaml
+++ b/observability/alerts-rp-services.yaml
@@ -1,6 +1,7 @@
 prometheusRules:
   rulesFolders:
   - alerts/nodepool-slo-prometheusRule.yaml
+  - alerts/ingress-prometheusRule.yaml
   untestedRules: []
   testDependencies:
   - recording-rules-services.yaml

--- a/observability/alerts-rp-services.yaml
+++ b/observability/alerts-rp-services.yaml
@@ -1,7 +1,6 @@
 prometheusRules:
   rulesFolders:
   - alerts/nodepool-slo-prometheusRule.yaml
-  - alerts/ingress-prometheusRule.yaml
   untestedRules: []
   testDependencies:
   - recording-rules-services.yaml

--- a/observability/alerts/ingress-prometheusRule.yaml
+++ b/observability/alerts/ingress-prometheusRule.yaml
@@ -1,0 +1,113 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: ingress-monitor-alerts
+  namespace: openshift-route-monitor-operator
+spec:
+  groups:
+  - name: ingress-monitor-rules
+    rules:
+    # Fast burn: 5m/1h windows, 14.4x burn rate → warning (Sev 3, non-KAS UJ per ADR)
+    - alert: UJIngressAvailability1h5m
+      expr: >
+        1 - (
+          sum by (probe_url, namespace, _id, cluster) (sum_over_time(probe_success{job="blackbox-ingress"}[5m]))
+          /
+          sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[5m]))
+        ) > (14.4 * (1 - 0.9995))
+        and
+        sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[5m])) > 5
+        and
+        1 - (
+          sum by (probe_url, namespace, _id, cluster) (sum_over_time(probe_success{job="blackbox-ingress"}[1h]))
+          /
+          sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[1h]))
+        ) > (14.4 * (1 - 0.9995))
+        and
+        sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[1h])) > 60
+      for: 2m
+      labels:
+        long_window: 1h
+        severity: warning
+        short_window: 5m
+      annotations:
+        message: "High error budget burn for ingress {{ $labels.probe_url }} (current value: {{ $value }})"
+        runbook_url: https://aka.ms/arohcp-runbook-ingress
+    # Medium burn: 30m/6h windows, 6x burn rate → warning (Sev 3, non-KAS UJ per ADR)
+    - alert: UJIngressAvailability6h30m
+      expr: >
+        1 - (
+          sum by (probe_url, namespace, _id, cluster) (sum_over_time(probe_success{job="blackbox-ingress"}[30m]))
+          /
+          sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[30m]))
+        ) > (6 * (1 - 0.9995))
+        and
+        sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[30m])) > 30
+        and
+        1 - (
+          sum by (probe_url, namespace, _id, cluster) (sum_over_time(probe_success{job="blackbox-ingress"}[6h]))
+          /
+          sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[6h]))
+        ) > (6 * (1 - 0.9995))
+        and
+        sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[6h])) > 360
+      for: 15m
+      labels:
+        long_window: 6h
+        severity: warning
+        short_window: 30m
+      annotations:
+        message: "High error budget burn for ingress {{ $labels.probe_url }} (current value: {{ $value }})"
+        runbook_url: https://aka.ms/arohcp-runbook-ingress
+    # Slow burn: 2h/1d windows, 3x burn rate → warning
+    - alert: UJIngressAvailability1d2h
+      expr: >
+        1 - (
+          sum by (probe_url, namespace, _id, cluster) (sum_over_time(probe_success{job="blackbox-ingress"}[2h]))
+          /
+          sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[2h]))
+        ) > (3 * (1 - 0.9995))
+        and
+        sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[2h])) > 120
+        and
+        1 - (
+          sum by (probe_url, namespace, _id, cluster) (sum_over_time(probe_success{job="blackbox-ingress"}[1d]))
+          /
+          sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[1d]))
+        ) > (3 * (1 - 0.9995))
+        and
+        sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[1d])) > 1440
+      for: 1h
+      labels:
+        long_window: 1d
+        severity: warning
+        short_window: 2h
+      annotations:
+        message: "High error budget burn for ingress {{ $labels.probe_url }} (current value: {{ $value }})"
+        runbook_url: https://aka.ms/arohcp-runbook-ingress
+    # Very slow burn: 6h/3d windows, 1x burn rate → warning
+    - alert: UJIngressAvailability3d6h
+      expr: >
+        1 - (
+          sum by (probe_url, namespace, _id, cluster) (sum_over_time(probe_success{job="blackbox-ingress"}[6h]))
+          /
+          sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[6h]))
+        ) > (1 * (1 - 0.9995))
+        and
+        sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[6h])) > 360
+        and
+        1 - (
+          sum by (probe_url, namespace, _id, cluster) (sum_over_time(probe_success{job="blackbox-ingress"}[3d]))
+          /
+          sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[3d]))
+        ) > (1 * (1 - 0.9995))
+        and
+        sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[3d])) > 4320
+      for: 3h
+      labels:
+        long_window: 3d
+        severity: warning
+        short_window: 6h
+      annotations:
+        message: "High error budget burn for ingress {{ $labels.probe_url }} (current value: {{ $value }})"
+        runbook_url: https://aka.ms/arohcp-runbook-ingress

--- a/observability/alerts/ingress-prometheusRule.yaml
+++ b/observability/alerts/ingress-prometheusRule.yaml
@@ -1,113 +1,117 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: ingress-monitor-alerts
-  namespace: openshift-route-monitor-operator
+  labels:
+    app.kubernetes.io/name: kube-prometheus
+    app.kubernetes.io/part-of: kube-prometheus
+    prometheus: k8s
+    role: alert-rules
+  name: ingress-availability-slo-alerts
+  namespace: monitoring
 spec:
   groups:
-  - name: ingress-monitor-rules
+  # ========================================
+  # Ingress Availability SLO Alerts
+  # ========================================
+  # Multi-window burn-rate alerting adapted for gauge metrics.
+  # Naming convention: {Scope}{Subject}{Metric}{BurnRateTier} per ADR-001.
+  #
+  # SLO: 99.5% ingress canary availability
+  # Error Budget: 0.5% (1 - 0.995)
+  #
+  # Burn rate thresholds:
+  #   Fast (14.4x): 14.4 * 0.005 = 0.072 → error rate > 7.2%
+  #   Medium (6x):  6 * 0.005 = 0.030    → error rate > 3.0%
+  #   Slow (1x):    1 * 0.005 = 0.005    → error rate > 0.5%
+  #
+  # ingress_canary_route_reachable is a gauge (0/1 per canary pod), not a counter.
+  # The 'for' duration provides the short-window check, approximating multi-window
+  # burn rate alerting for gauge metrics (see access-cluster-slo-prometheusRule.yaml).
+  #
+  # Lane: alerts-rp-hcps.yaml → generatedRPHCPPrometheusAlertingRules.bicep
+  #       → icm-action-group-rp (ARO-RP on-call queue)
+  # Per-HCP alerts: correlationId scoped to _id so per-cluster suppression
+  # does not mask failures in other clusters.
+  - name: arohcp_ingress_availability_slo_alerts
+    labels:
+      component: slo
     rules:
-    # Fast burn: 5m/1h windows, 14.4x burn rate → warning (Sev 3, non-KAS UJ per ADR)
-    - alert: UJIngressAvailability1h5m
-      expr: >
-        1 - (
-          sum by (probe_url, namespace, _id, cluster) (sum_over_time(probe_success{job="blackbox-ingress"}[5m]))
-          /
-          sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[5m]))
-        ) > (14.4 * (1 - 0.9995))
-        and
-        sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[5m])) > 5
-        and
-        1 - (
-          sum by (probe_url, namespace, _id, cluster) (sum_over_time(probe_success{job="blackbox-ingress"}[1h]))
-          /
-          sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[1h]))
-        ) > (14.4 * (1 - 0.9995))
-        and
-        sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[1h])) > 60
-      for: 2m
+    # ----------------------------------------
+    # Fast Burn Alert (IcM Sev 3 — customer-facing UJ degraded)
+    # ----------------------------------------
+    # 14.4x burn rate → >7.2% error rate sustained for 5 minutes
+    # Would exhaust 30-day error budget in ~50 hours
+    - alert: userJourneyIngressAvailability1h5m
+      expr: |
+        errors:ingress_canary:error_rate > 0.072
+      for: 5m
       labels:
+        severity: "3"
+        slo: ingress-availability
         long_window: 1h
-        severity: warning
         short_window: 5m
       annotations:
-        message: "High error budget burn for ingress {{ $labels.probe_url }} (current value: {{ $value }})"
-        runbook_url: https://aka.ms/arohcp-runbook-ingress
-    # Medium burn: 30m/6h windows, 6x burn rate → warning (Sev 3, non-KAS UJ per ADR)
-    - alert: UJIngressAvailability6h30m
-      expr: >
-        1 - (
-          sum by (probe_url, namespace, _id, cluster) (sum_over_time(probe_success{job="blackbox-ingress"}[30m]))
-          /
-          sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[30m]))
-        ) > (6 * (1 - 0.9995))
-        and
-        sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[30m])) > 30
-        and
-        1 - (
-          sum by (probe_url, namespace, _id, cluster) (sum_over_time(probe_success{job="blackbox-ingress"}[6h]))
-          /
-          sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[6h]))
-        ) > (6 * (1 - 0.9995))
-        and
-        sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[6h])) > 360
-      for: 15m
+        summary: "Ingress canary availability critically degraded (>7.2% pods unreachable)"
+        description: "More than 7.2% of ingress canary pods are unreachable for HCP cluster {{ $labels._id }}, indicating a fast error budget burn (14.4x) that would exhaust the 99.5% SLO budget in ~50 hours."
+        runbook_url: "https://aka.ms/arohcp-runbook-ingress"
+        correlationId: "{{ $labels._id }}"
+    # ----------------------------------------
+    # Medium Burn Alert (IcM Sev 3)
+    # ----------------------------------------
+    # 6x burn rate → >3.0% error rate sustained for 30 minutes
+    # Would exhaust 30-day error budget in ~5 days
+    - alert: userJourneyIngressAvailability6h30m
+      expr: |
+        errors:ingress_canary:error_rate > 0.030
+      for: 30m
       labels:
+        severity: "3"
+        slo: ingress-availability
         long_window: 6h
-        severity: warning
         short_window: 30m
       annotations:
-        message: "High error budget burn for ingress {{ $labels.probe_url }} (current value: {{ $value }})"
-        runbook_url: https://aka.ms/arohcp-runbook-ingress
-    # Slow burn: 2h/1d windows, 3x burn rate → warning
-    - alert: UJIngressAvailability1d2h
-      expr: >
-        1 - (
-          sum by (probe_url, namespace, _id, cluster) (sum_over_time(probe_success{job="blackbox-ingress"}[2h]))
-          /
-          sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[2h]))
-        ) > (3 * (1 - 0.9995))
-        and
-        sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[2h])) > 120
-        and
-        1 - (
-          sum by (probe_url, namespace, _id, cluster) (sum_over_time(probe_success{job="blackbox-ingress"}[1d]))
-          /
-          sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[1d]))
-        ) > (3 * (1 - 0.9995))
-        and
-        sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[1d])) > 1440
-      for: 1h
+        summary: "Ingress canary availability degraded (>3% pods unreachable)"
+        description: "More than 3% of ingress canary pods are unreachable for HCP cluster {{ $labels._id }}, indicating a medium error budget burn (6x) that would exhaust the 99.5% SLO budget in ~5 days."
+        runbook_url: "https://aka.ms/arohcp-runbook-ingress"
+        correlationId: "{{ $labels._id }}"
+    # ----------------------------------------
+    # Slow Burn Alert (IcM Sev 4 — no immediate customer impact)
+    # ----------------------------------------
+    # 1x burn rate → >0.5% error rate sustained for 6 hours
+    # Consuming error budget at exactly the SLO rate — trend alert
+    - alert: userJourneyIngressAvailability3d6h
+      expr: |
+        errors:ingress_canary:error_rate > 0.005
+      for: 6h
       labels:
-        long_window: 1d
-        severity: warning
-        short_window: 2h
-      annotations:
-        message: "High error budget burn for ingress {{ $labels.probe_url }} (current value: {{ $value }})"
-        runbook_url: https://aka.ms/arohcp-runbook-ingress
-    # Very slow burn: 6h/3d windows, 1x burn rate → warning
-    - alert: UJIngressAvailability3d6h
-      expr: >
-        1 - (
-          sum by (probe_url, namespace, _id, cluster) (sum_over_time(probe_success{job="blackbox-ingress"}[6h]))
-          /
-          sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[6h]))
-        ) > (1 * (1 - 0.9995))
-        and
-        sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[6h])) > 360
-        and
-        1 - (
-          sum by (probe_url, namespace, _id, cluster) (sum_over_time(probe_success{job="blackbox-ingress"}[3d]))
-          /
-          sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[3d]))
-        ) > (1 * (1 - 0.9995))
-        and
-        sum by (probe_url, namespace, _id, cluster) (count_over_time(probe_success{job="blackbox-ingress"}[3d])) > 4320
-      for: 3h
-      labels:
+        severity: "4"
+        slo: ingress-availability
         long_window: 3d
-        severity: warning
         short_window: 6h
       annotations:
-        message: "High error budget burn for ingress {{ $labels.probe_url }} (current value: {{ $value }})"
-        runbook_url: https://aka.ms/arohcp-runbook-ingress
+        summary: "Ingress canary availability trending below SLO (>0.5% pods unreachable)"
+        description: "More than 0.5% of ingress canary pods are unreachable for HCP cluster {{ $labels._id }}, consuming the error budget at the SLO rate. No immediate customer impact but trend requires investigation."
+        runbook_url: "https://aka.ms/arohcp-runbook-ingress"
+        correlationId: "{{ $labels._id }}"
+  # ========================================
+  # Ingress Controller Degraded Alert
+  # ========================================
+  # Fires when the ingress controller reports a degraded condition.
+  # Complements the canary-based availability alerts with a controller
+  # health perspective. Sev 4 — degraded does not always mean user-visible impact.
+  - name: arohcp_ingress_controller_degraded_alerts
+    labels:
+      component: slo
+    rules:
+    - alert: userJourneyIngressControllerDegraded
+      expr: |
+        errors:ingress_controller:degraded == 1
+      for: 5m
+      labels:
+        severity: "4"
+        slo: ingress-availability
+      annotations:
+        summary: "Ingress controller is in degraded state"
+        description: "The ingress controller for HCP cluster {{ $labels._id }} has reported a degraded condition for more than 5 minutes. Investigate IngressController status and canary probe results."
+        runbook_url: "https://aka.ms/arohcp-runbook-ingress"
+        correlationId: "{{ $labels._id }}"

--- a/observability/alerts/ingress-prometheusRule_test.yaml
+++ b/observability/alerts/ingress-prometheusRule_test.yaml
@@ -1,0 +1,176 @@
+rule_files:
+- ingress-prometheusRule.yaml
+evaluation_interval: 1m
+tests:
+# --- UJIngressAvailability1h5m (fast burn: 5m/1h) ---
+# With 30s data interval, 1h window has ~120 samples.
+# count > 60 first satisfied at T=30m (61 samples). for: 2m → fires at T=32m.
+- interval: 30s
+  input_series:
+  - series: 'probe_success{job="blackbox-ingress",probe_url="https://apps.cluster.example.com",namespace="hcp-ns",_id="cluster-1",cluster="mgmt-1"}'
+    values: "0+0x70"
+  alert_rule_test:
+  - eval_time: 33m
+    alertname: UJIngressAvailability1h5m
+    exp_alerts:
+    - exp_labels:
+        severity: warning
+        long_window: 1h
+        short_window: 5m
+        probe_url: https://apps.cluster.example.com
+        namespace: hcp-ns
+        _id: cluster-1
+        cluster: mgmt-1
+      exp_annotations:
+        message: "High error budget burn for ingress https://apps.cluster.example.com (current value: 1)"
+        runbook_url: https://aka.ms/arohcp-runbook-ingress
+
+# Should NOT fire before for: 2m
+- interval: 30s
+  input_series:
+  - series: 'probe_success{job="blackbox-ingress",probe_url="https://apps.cluster.example.com",namespace="hcp-ns",_id="cluster-1",cluster="mgmt-1"}'
+    values: "0+0x70"
+  alert_rule_test:
+  - eval_time: 31m
+    alertname: UJIngressAvailability1h5m
+    exp_alerts: []
+
+# Should NOT fire when probe is healthy
+- interval: 30s
+  input_series:
+  - series: 'probe_success{job="blackbox-ingress",probe_url="https://apps.cluster.example.com",namespace="hcp-ns",_id="cluster-1",cluster="mgmt-1"}'
+    values: "1+0x70"
+  alert_rule_test:
+  - eval_time: 33m
+    alertname: UJIngressAvailability1h5m
+    exp_alerts: []
+
+# --- UJIngressAvailability6h30m (medium burn: 30m/6h) ---
+# count > 360 first satisfied at T=180m. for: 15m → fires at T=195m.
+- interval: 30s
+  input_series:
+  - series: 'probe_success{job="blackbox-ingress",probe_url="https://apps.cluster.example.com",namespace="hcp-ns",_id="cluster-1",cluster="mgmt-1"}'
+    values: "0+0x400"
+  alert_rule_test:
+  - eval_time: 196m
+    alertname: UJIngressAvailability6h30m
+    exp_alerts:
+    - exp_labels:
+        severity: warning
+        long_window: 6h
+        short_window: 30m
+        probe_url: https://apps.cluster.example.com
+        namespace: hcp-ns
+        _id: cluster-1
+        cluster: mgmt-1
+      exp_annotations:
+        message: "High error budget burn for ingress https://apps.cluster.example.com (current value: 1)"
+        runbook_url: https://aka.ms/arohcp-runbook-ingress
+
+# Should NOT fire before for: 15m
+- interval: 30s
+  input_series:
+  - series: 'probe_success{job="blackbox-ingress",probe_url="https://apps.cluster.example.com",namespace="hcp-ns",_id="cluster-1",cluster="mgmt-1"}'
+    values: "0+0x400"
+  alert_rule_test:
+  - eval_time: 194m
+    alertname: UJIngressAvailability6h30m
+    exp_alerts: []
+
+# --- UJIngressAvailability1d2h (slow burn: 2h/1d) ---
+# count > 1440 first satisfied at T=720m. for: 1h → fires at T=780m.
+- interval: 30s
+  input_series:
+  - series: 'probe_success{job="blackbox-ingress",probe_url="https://apps.cluster.example.com",namespace="hcp-ns",_id="cluster-1",cluster="mgmt-1"}'
+    values: "0+0x1570"
+  alert_rule_test:
+  - eval_time: 781m
+    alertname: UJIngressAvailability1d2h
+    exp_alerts:
+    - exp_labels:
+        severity: warning
+        long_window: 1d
+        short_window: 2h
+        probe_url: https://apps.cluster.example.com
+        namespace: hcp-ns
+        _id: cluster-1
+        cluster: mgmt-1
+      exp_annotations:
+        message: "High error budget burn for ingress https://apps.cluster.example.com (current value: 1)"
+        runbook_url: https://aka.ms/arohcp-runbook-ingress
+
+# Should NOT fire before for: 1h
+- interval: 30s
+  input_series:
+  - series: 'probe_success{job="blackbox-ingress",probe_url="https://apps.cluster.example.com",namespace="hcp-ns",_id="cluster-1",cluster="mgmt-1"}'
+    values: "0+0x1570"
+  alert_rule_test:
+  - eval_time: 779m
+    alertname: UJIngressAvailability1d2h
+    exp_alerts: []
+
+# --- UJIngressAvailability3d6h (very slow burn: 6h/3d) ---
+# count > 4320 first satisfied at T=2160m. for: 3h → fires at T=2340m.
+- interval: 30s
+  input_series:
+  - series: 'probe_success{job="blackbox-ingress",probe_url="https://apps.cluster.example.com",namespace="hcp-ns",_id="cluster-1",cluster="mgmt-1"}'
+    values: "0+0x4690"
+  alert_rule_test:
+  - eval_time: 2341m
+    alertname: UJIngressAvailability3d6h
+    exp_alerts:
+    - exp_labels:
+        severity: warning
+        long_window: 3d
+        short_window: 6h
+        probe_url: https://apps.cluster.example.com
+        namespace: hcp-ns
+        _id: cluster-1
+        cluster: mgmt-1
+      exp_annotations:
+        message: "High error budget burn for ingress https://apps.cluster.example.com (current value: 1)"
+        runbook_url: https://aka.ms/arohcp-runbook-ingress
+
+# Should NOT fire before for: 3h
+- interval: 30s
+  input_series:
+  - series: 'probe_success{job="blackbox-ingress",probe_url="https://apps.cluster.example.com",namespace="hcp-ns",_id="cluster-1",cluster="mgmt-1"}'
+    values: "0+0x4690"
+  alert_rule_test:
+  - eval_time: 2339m
+    alertname: UJIngressAvailability3d6h
+    exp_alerts: []
+
+# Multiple clusters — only failing cluster alerts, healthy one does not
+- interval: 30s
+  input_series:
+  - series: 'probe_success{job="blackbox-ingress",probe_url="https://apps.cluster-a.example.com",namespace="hcp-ns-a",_id="cluster-a",cluster="mgmt-1"}'
+    values: "0+0x70"
+  - series: 'probe_success{job="blackbox-ingress",probe_url="https://apps.cluster-b.example.com",namespace="hcp-ns-b",_id="cluster-b",cluster="mgmt-1"}'
+    values: "1+0x70"
+  alert_rule_test:
+  - eval_time: 33m
+    alertname: UJIngressAvailability1h5m
+    exp_alerts:
+    - exp_labels:
+        severity: warning
+        long_window: 1h
+        short_window: 5m
+        probe_url: https://apps.cluster-a.example.com
+        namespace: hcp-ns-a
+        _id: cluster-a
+        cluster: mgmt-1
+      exp_annotations:
+        message: "High error budget burn for ingress https://apps.cluster-a.example.com (current value: 1)"
+        runbook_url: https://aka.ms/arohcp-runbook-ingress
+
+# No probe data — no alerts
+- interval: 30s
+  input_series: []
+  alert_rule_test:
+  - eval_time: 33m
+    alertname: UJIngressAvailability1h5m
+    exp_alerts: []
+  - eval_time: 196m
+    alertname: UJIngressAvailability6h30m
+    exp_alerts: []

--- a/observability/grafana-dashboards/sre/user-journey/ingress-availability.json
+++ b/observability/grafana-dashboards/sre/user-journey/ingress-availability.json
@@ -1,0 +1,681 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "### Ingress Availability — User Journey SLO\n\nMonitors the customer user journey: workloads exposed via OpenShift Route/Ingress are reachable from external clients.\n\n**SLO target: 99.95% availability over 30 days**\n\n**Baseline SLIs covered:**\n- Availability — probe_success rate\n- Errors — HAProxy 5xx response rate\n- Latency — HAProxy backend response time p99\n- Traffic — HAProxy frontend request rate\n- Saturation — Router pod readiness\n\n**Datasource:** Select a HCP Prometheus datasource (`Managed_Prometheus_hcps-*`) from the top bar.",
+        "mode": "markdown"
+      },
+      "pluginVersion": "11.6.9",
+      "title": "Dashboard Info",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Current ingress availability over the selected time range. SLO target: 99.95%",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.999
+              },
+              {
+                "color": "green",
+                "value": 0.9995
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "decimals": 4
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(sum_over_time(probe_success{job=\"blackbox-ingress\"}[$__range])) / sum(count_over_time(probe_success{job=\"blackbox-ingress\"}[$__range]))",
+          "instant": true,
+          "legendFormat": "Availability",
+          "refId": "A"
+        }
+      ],
+      "title": "Ingress Availability (current window)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Error budget remaining for 30-day SLO window (99.95% target = 21.9 minutes downtime budget)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.25
+              },
+              {
+                "color": "green",
+                "value": 0.5
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "1 - clamp_min(\n  (0.9995 - (sum(sum_over_time(probe_success{job=\"blackbox-ingress\"}[30d])) / sum(count_over_time(probe_success{job=\"blackbox-ingress\"}[30d])))) / (1 - 0.9995),\n  -1\n)",
+          "instant": true,
+          "legendFormat": "Error Budget",
+          "refId": "A"
+        }
+      ],
+      "title": "Error Budget Remaining (30d)",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Probe success rate over time. SLO target line at 99.95%.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "decimals": 4,
+          "mappings": [],
+          "max": 1,
+          "min": 0.99,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "transparent",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.9995
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "min"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (probe_url, _id) (sum_over_time(probe_success{job=\"blackbox-ingress\"}[5m])) / sum by (probe_url, _id) (count_over_time(probe_success{job=\"blackbox-ingress\"}[5m]))",
+          "legendFormat": "{{_id}} {{probe_url}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Ingress Probe Success Rate (5m window) — SLO: 99.95%",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "HAProxy 5xx error rate. SLO threshold: < 0.05%",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "transparent",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.0005
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "decimals": 4
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (namespace) (rate(haproxy_server_response_errors_total{namespace=~\"hypershift-sharedingress|openshift-ingress\"}[5m])) / sum by (namespace) (rate(haproxy_backend_http_responses_total{namespace=~\"hypershift-sharedingress|openshift-ingress\"}[5m]))",
+          "legendFormat": "Error Rate ({{namespace}})",
+          "refId": "A"
+        }
+      ],
+      "title": "Ingress Error Rate (5xx) — SLO: < 0.05%",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "HAProxy backend response time percentiles. SLO target: p99 < 500ms",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "transparent",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.5
+              }
+            ]
+          },
+          "unit": "s",
+          "decimals": 3
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 14
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "haproxy_backend_response_time_average_seconds{namespace=~\"hypershift-sharedingress|openshift-ingress\",quantile=\"0.99\"}",
+          "legendFormat": "p99 ({{namespace}}/{{backend}})",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "haproxy_backend_response_time_average_seconds{namespace=~\"hypershift-sharedingress|openshift-ingress\",quantile=\"0.95\"}",
+          "legendFormat": "p95 ({{namespace}}/{{backend}})",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "haproxy_backend_response_time_average_seconds{namespace=~\"hypershift-sharedingress|openshift-ingress\",quantile=\"0.50\"}",
+          "legendFormat": "p50 ({{namespace}}/{{backend}})",
+          "refId": "C"
+        }
+      ],
+      "title": "Ingress Latency p50/p95/p99 — SLO: p99 < 500ms",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "HAProxy frontend HTTP request rate (traffic). Informational — no SLO target.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 22
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (namespace) (rate(haproxy_frontend_http_requests_total{namespace=~\"hypershift-sharedingress|openshift-ingress\"}[5m]))",
+          "legendFormat": "RPS ({{namespace}})",
+          "refId": "A"
+        }
+      ],
+      "title": "Ingress Traffic (Request Rate)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Router pod readiness and CPU utilization (saturation). Informational — no hard SLO, alert when pods not ready.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.8
+              },
+              {
+                "color": "green",
+                "value": 0.9
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 22
+      },
+      "id": 8,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(kube_pod_status_ready{namespace=~\"hypershift-sharedingress|openshift-ingress\", condition=\"true\"}) / sum(kube_pod_status_ready{namespace=~\"hypershift-sharedingress|openshift-ingress\"})",
+          "instant": true,
+          "legendFormat": "Router Pods Ready",
+          "refId": "A"
+        }
+      ],
+      "title": "Router Pod Saturation (Readiness)",
+      "type": "gauge"
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 39,
+  "tags": ["sre", "user-journey", "ingress", "slo"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "^Managed_Prometheus_hcps-.*$",
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "SRE UJ: Ingress Availability",
+  "uid": "ingress-availability-uj",
+  "version": 1
+}

--- a/observability/recording-rules-hcps.yaml
+++ b/observability/recording-rules-hcps.yaml
@@ -3,5 +3,6 @@ prometheusRules:
   - alerts/HCPkasRecord-prometheusRule-KSM.yaml
   - alerts/HCPkasRecord-prometheusRule-apiserver-requests.yaml
   - alerts/HCPkasRecord-prometheusRule-latency.yaml
+  - recording-rules/ingress-availability-slo-recordingRule.yaml
   untestedRules: []
   outputBicep: ../dev-infrastructure/modules/metrics/rules/generatedHCPRecordingRules.bicep

--- a/observability/recording-rules/ingress-availability-slo-recordingRule.yaml
+++ b/observability/recording-rules/ingress-availability-slo-recordingRule.yaml
@@ -1,0 +1,58 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app.kubernetes.io/name: kube-prometheus
+    app.kubernetes.io/part-of: kube-prometheus
+    prometheus: k8s
+    role: recording-rules
+  name: ingress-availability-slo-recording-rules
+  namespace: monitoring
+spec:
+  groups:
+  # ========================================
+  # Ingress Availability SLO Recording Rules
+  # ========================================
+  # Metrics source: Managed_Prometheus_hcps-* (HCP AMW, hcps layer)
+  #
+  # SLO: 99.5% ingress canary availability
+  # Error Budget: 0.5% (1 - 0.995)
+  #
+  # Validated on 2026-07-29 against INT AMW (Managed_Prometheus_hcps-uksouth):
+  # - ingress_canary_route_reachable: _id label confirmed, 26 HCP clusters visible,
+  #   emitted by ingress-operator (control plane, authoritative source)
+  # - ingress_controller_conditions: _id label confirmed, condition=available/degraded
+  #
+  # Note: haproxy metrics (Errors, Latency, Traffic, Saturation) are not present
+  # in the HCP AMW — they exist only in the customer cluster's own Prometheus.
+  # A follow-up story is needed to route data plane metrics into AMW.
+  - name: arohcp_ingress_availability_slo_recording_rules
+    interval: 1m
+    rules:
+    # Availability SLI: fraction of canary pods reporting ingress as reachable,
+    # aggregated per HCP cluster.
+    # Ratio format per ADR: good events / total events
+    # Uses sum/count (not min) so that a single pod failure in a redundant setup
+    # does not report the entire cluster as unavailable.
+    - record: availability:ingress_canary:ratio
+      expr: |
+        sum by (_id) (ingress_canary_route_reachable)
+        /
+        count by (_id) (ingress_canary_route_reachable)
+    # Error rate derived from the availability SLI (1 - availability).
+    # Used by burn-rate alert expressions.
+    - record: errors:ingress_canary:error_rate
+      expr: |
+        1
+        -
+        (
+          sum by (_id) (ingress_canary_route_reachable)
+          /
+          count by (_id) (ingress_canary_route_reachable)
+        )
+    # Errors SLI: ingress controller degraded state per HCP cluster.
+    # Value is 0 (healthy) or 1 (degraded). Reflects the ingress controller's
+    # own assessment — a complementary signal to the canary-based availability SLI.
+    - record: errors:ingress_controller:degraded
+      expr: |
+        max by (_id) (ingress_controller_conditions{condition="degraded"})


### PR DESCRIPTION
Adds SLO alerting rules, promtool tests, Grafana dashboard, and observability registration for the Ingress Availability customer user journey.

- ingress-prometheusRule.yaml: multi-window multi-burn-rate SLO alerts (99.95% target) for the 4 severity tiers (fast/medium/slow/very-slow), modelled on HCPkasMonitor
- ingress-prometheusRule_test.yaml: promtool unit tests covering each alert tier firing and not-firing behaviour, multiple-cluster isolation, and no-data cases
- ingress-availability.json: Grafana Golden-Signals dashboard covering all 5 baseline SLIs (availability, errors, latency, traffic, saturation) with SLO target lines placed in the SRE User Journey folder
- observability.yaml: register ingress alert rules for Bicep generation

<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

### Why

<!-- Briefly explain why this change is needed -->

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
