### PR TITLE
fix(ops): size temp pools like source pools (AROSLSRE-1003)

### DIFF
--- a/dev-infrastructure/scripts/recreate-broken-pools/main.go
+++ b/dev-infrastructure/scripts/recreate-broken-pools/main.go
@@ -1567,7 +1567,9 @@ func (c *clients) maybeAbortLRO(ctx context.Context) (bool, error) {
 // different VM SKUs and disk sizes (see config/config.yaml entries
 // across environments), and AKS rejects an all-User cluster (the
 // existing System pool, if any, must be replaced by another System
-// pool). The temporary pool overrides Count=1 and tags itself with
+// pool). The temporary pool uses the source pool's current Count so it
+// can absorb the source pool's capacity during drain/delete, and tags
+// itself with
 // (1) the purpose marker so detection can skip it and (2) the full
 // Azure resource ID of the source pool (read from live.ID) so a
 // leftover temp pool can always be matched back to a unique source —
@@ -1591,7 +1593,10 @@ func buildTempAgentPool(live *armcs.AgentPool, cpVersion string) (*armcs.AgentPo
 	if cpVersion == "" {
 		return nil, errors.New("buildTempAgentPool: empty cpVersion")
 	}
-	cnt := int32(1)
+	if body.Properties.Count == nil || *body.Properties.Count <= 0 {
+		return nil, errors.New("buildTempAgentPool: live snapshot has no positive Count")
+	}
+	cnt := *body.Properties.Count
 	body.Properties.Count = &cnt
 	body.Properties.MinCount = nil
 	body.Properties.MaxCount = nil
@@ -1610,8 +1615,9 @@ func (c *clients) addTempPool(ctx context.Context, target nodePoolTarget, live *
 		return err
 	}
 	tmpName := tempPoolName(target.name)
-	logf("creating temp pool %s for %s (vmSize=%s, mode=%v, 1 node, k8s=%s, inherited taints)",
-		tmpName, target.name, strDeref(live.Properties.VMSize), ptrValue(live.Properties.Mode), c.cfg.cpVersion)
+	wantReady := int(*body.Properties.Count)
+	logf("creating temp pool %s for %s (vmSize=%s, mode=%v, count=%d, k8s=%s, inherited taints)",
+		tmpName, target.name, strDeref(live.Properties.VMSize), ptrValue(live.Properties.Mode), wantReady, c.cfg.cpVersion)
 	poller, err := c.pools.BeginCreateOrUpdate(ctx, c.cfg.resourceGroup, c.cfg.clusterName, tmpName, *body, nil)
 	if err != nil {
 		return fmt.Errorf("begin create temp pool %s: %w", tmpName, err)
@@ -1620,7 +1626,7 @@ func (c *clients) addTempPool(ctx context.Context, target nodePoolTarget, live *
 		return fmt.Errorf("poll create temp pool %s: %w", tmpName, err)
 	}
 	logf("temp pool %s created; waiting for k8s node Ready", tmpName)
-	return c.waitForReadyNodes(ctx, tmpName, 1, tempReadyTOMin*time.Minute)
+	return c.waitForReadyNodes(ctx, tmpName, wantReady, tempReadyTOMin*time.Minute)
 }
 
 // ---------------------------------------------------------------------------

--- a/dev-infrastructure/scripts/recreate-broken-pools/main.go
+++ b/dev-infrastructure/scripts/recreate-broken-pools/main.go
@@ -1568,8 +1568,9 @@ func (c *clients) maybeAbortLRO(ctx context.Context) (bool, error) {
 // across environments), and AKS rejects an all-User cluster (the
 // existing System pool, if any, must be replaced by another System
 // pool). The temporary pool uses the source pool's current Count so it
-// can absorb the source pool's capacity during drain/delete, and tags
-// itself with
+// can absorb the source pool's capacity during drain/delete. If Count is
+// unavailable, it falls back to MinCount and then to one node so remediation
+// can still proceed. The temporary pool tags itself with
 // (1) the purpose marker so detection can skip it and (2) the full
 // Azure resource ID of the source pool (read from live.ID) so a
 // leftover temp pool can always be matched back to a unique source —
@@ -1593,10 +1594,7 @@ func buildTempAgentPool(live *armcs.AgentPool, cpVersion string) (*armcs.AgentPo
 	if cpVersion == "" {
 		return nil, errors.New("buildTempAgentPool: empty cpVersion")
 	}
-	if body.Properties.Count == nil || *body.Properties.Count <= 0 {
-		return nil, errors.New("buildTempAgentPool: live snapshot has no positive Count")
-	}
-	cnt := *body.Properties.Count
+	cnt, _ := tempPoolDesiredCount(body.Properties)
 	body.Properties.Count = &cnt
 	body.Properties.MinCount = nil
 	body.Properties.MaxCount = nil
@@ -1615,9 +1613,16 @@ func (c *clients) addTempPool(ctx context.Context, target nodePoolTarget, live *
 		return err
 	}
 	tmpName := tempPoolName(target.name)
+	_, countSource := tempPoolDesiredCount(live.Properties)
 	wantReady := int(*body.Properties.Count)
-	logf("creating temp pool %s for %s (vmSize=%s, mode=%v, count=%d, k8s=%s, inherited taints)",
-		tmpName, target.name, strDeref(live.Properties.VMSize), ptrValue(live.Properties.Mode), wantReady, c.cfg.cpVersion)
+	if countSource == "MinCount" {
+		logf("source pool %s has no positive Count; using MinCount=%d for temp pool size", target.name, wantReady)
+	}
+	if countSource == "default" {
+		logf("WARN: source pool %s has no positive Count or MinCount; using minimal temp pool size count=1", target.name)
+	}
+	logf("creating temp pool %s for %s (vmSize=%s, mode=%v, count=%d, countSource=%s, k8s=%s, inherited taints)",
+		tmpName, target.name, strDeref(live.Properties.VMSize), ptrValue(live.Properties.Mode), wantReady, countSource, c.cfg.cpVersion)
 	poller, err := c.pools.BeginCreateOrUpdate(ctx, c.cfg.resourceGroup, c.cfg.clusterName, tmpName, *body, nil)
 	if err != nil {
 		return fmt.Errorf("begin create temp pool %s: %w", tmpName, err)
@@ -1625,8 +1630,28 @@ func (c *clients) addTempPool(ctx context.Context, target nodePoolTarget, live *
 	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
 		return fmt.Errorf("poll create temp pool %s: %w", tmpName, err)
 	}
-	logf("temp pool %s created; waiting for k8s node Ready", tmpName)
-	return c.waitForReadyNodes(ctx, tmpName, wantReady, tempReadyTOMin*time.Minute)
+	readyTimeout := tempPoolReadyTimeout(wantReady)
+	logf("temp pool %s created; waiting for %d k8s node(s) Ready (timeout=%s)", tmpName, wantReady, readyTimeout)
+	return c.waitForReadyNodes(ctx, tmpName, wantReady, readyTimeout)
+}
+
+func tempPoolDesiredCount(props *armcs.ManagedClusterAgentPoolProfileProperties) (int32, string) {
+	if props != nil {
+		if props.Count != nil && *props.Count > 0 {
+			return *props.Count, "Count"
+		}
+		if props.MinCount != nil && *props.MinCount > 0 {
+			return *props.MinCount, "MinCount"
+		}
+	}
+	return 1, "default"
+}
+
+func tempPoolReadyTimeout(wantReady int) time.Duration {
+	if wantReady > 1 {
+		return poolReadyTOMin * time.Minute
+	}
+	return tempReadyTOMin * time.Minute
 }
 
 // ---------------------------------------------------------------------------

--- a/dev-infrastructure/scripts/recreate-broken-pools/main_test.go
+++ b/dev-infrastructure/scripts/recreate-broken-pools/main_test.go
@@ -1077,17 +1077,44 @@ func TestBuildTempAgentPool_MissingCPVersion(t *testing.T) {
 	}
 }
 
-func TestBuildTempAgentPool_MissingOrInvalidCount(t *testing.T) {
-	live := mkLiveSystemPool()
-	live.Properties.Count = nil
-	if _, err := buildTempAgentPool(live, "1.35.4"); err == nil {
-		t.Fatal("expected error for missing Count")
+func TestBuildTempAgentPool_CountFallbacks(t *testing.T) {
+	cases := []struct {
+		name      string
+		count     *int32
+		minCount  *int32
+		wantCount int32
+	}{
+		{name: "count_wins", count: ptr(int32(3)), minCount: ptr(int32(5)), wantCount: 3},
+		{name: "missing_count_uses_min_count", count: nil, minCount: ptr(int32(4)), wantCount: 4},
+		{name: "zero_count_uses_min_count", count: ptr(int32(0)), minCount: ptr(int32(2)), wantCount: 2},
+		{name: "missing_count_and_min_count_uses_one", count: nil, minCount: nil, wantCount: 1},
+		{name: "zero_count_and_zero_min_count_uses_one", count: ptr(int32(0)), minCount: ptr(int32(0)), wantCount: 1},
 	}
 
-	zero := int32(0)
-	live.Properties.Count = &zero
-	if _, err := buildTempAgentPool(live, "1.35.4"); err == nil {
-		t.Fatal("expected error for Count == 0")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			live := mkLiveSystemPool()
+			live.Properties.Count = tc.count
+			live.Properties.MinCount = tc.minCount
+			body, err := buildTempAgentPool(live, "1.35.4")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got := *body.Properties.Count; got != tc.wantCount {
+				t.Fatalf("Count=%d want %d", got, tc.wantCount)
+			}
+		})
+	}
+}
+
+func TestTempPoolReadyTimeout(t *testing.T) {
+	if got := tempPoolReadyTimeout(1); got != tempReadyTOMin*time.Minute {
+		t.Errorf("single-node temp timeout=%s want %dm", got, tempReadyTOMin)
+	}
+	for _, wantReady := range []int{2, 3, 4} {
+		if got := tempPoolReadyTimeout(wantReady); got != poolReadyTOMin*time.Minute {
+			t.Errorf("multi-node temp timeout for wantReady=%d got %s want %dm", wantReady, got, poolReadyTOMin)
+		}
 	}
 }
 

--- a/dev-infrastructure/scripts/recreate-broken-pools/main_test.go
+++ b/dev-infrastructure/scripts/recreate-broken-pools/main_test.go
@@ -813,8 +813,8 @@ func TestBuildTempAgentPool_ValidInputs(t *testing.T) {
 	if p.VMSize == nil || *p.VMSize != "Standard_E8ds_v5" {
 		t.Errorf("temp VMSize should match live: %v", p.VMSize)
 	}
-	if p.Count == nil || *p.Count != 1 {
-		t.Errorf("temp Count should be 1, got %v", p.Count)
+	if p.Count == nil || *p.Count != 2 {
+		t.Errorf("temp Count should match live Count=2, got %v", p.Count)
 	}
 	if p.OrchestratorVersion == nil || *p.OrchestratorVersion != "1.35.4" {
 		t.Errorf("OrchestratorVersion: %v", p.OrchestratorVersion)
@@ -1074,6 +1074,20 @@ func TestBuildTempAgentPool_MissingCPVersion(t *testing.T) {
 	live := mkLiveSystemPool()
 	if _, err := buildTempAgentPool(live, ""); err == nil {
 		t.Fatal("expected error for empty cpVersion")
+	}
+}
+
+func TestBuildTempAgentPool_MissingOrInvalidCount(t *testing.T) {
+	live := mkLiveSystemPool()
+	live.Properties.Count = nil
+	if _, err := buildTempAgentPool(live, "1.35.4"); err == nil {
+		t.Fatal("expected error for missing Count")
+	}
+
+	zero := int32(0)
+	live.Properties.Count = &zero
+	if _, err := buildTempAgentPool(live, "1.35.4"); err == nil {
+		t.Fatal("expected error for Count == 0")
 	}
 }
 


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-1003

### What

Changes `recreate-broken-pools` temp pools to use the source pool's current `Count` instead of hardcoding the temp pool to one node.

If `Count` is unavailable or non-positive, the temp pool falls back to positive `MinCount`, then to one node as a last-resort safety fallback. The temp pool still disables autoscaling and remains a throwaway pool, but it now waits for the expected number of Ready temp nodes before draining and deleting the wedged source pool.

### Why

The temp pool is the only replacement capacity while the source pool is drained/deleted/recreated. In stage, replacing a 3–4 node worker pool with a single temp node worked, but it reduced safety margin and would be riskier for production workloads.

Sizing the temp pool like the source pool preserves capacity during the remediation window while keeping remediation sequential per pool. The fallback behavior prevents remediation from aborting when AKS omits `Count` for autoscaled pools.

### Testing

`go test ./dev-infrastructure/scripts/recreate-broken-pools`

### Special notes for your reviewer

This increases temporary quota/capacity usage during remediation. Because remediation remains sequential, the extra capacity is bounded to one source pool at a time.

The temp-pool readiness timeout now uses the larger pool readiness budget for multi-node temp pools to avoid aborting while a larger temp pool is still progressing.

Screenshots are not applicable; this is an operational Go helper change.

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [x] All comment threads resolved before merge
