### PR TITLE
Bump CIHealth image

### DIFF
--- a/config/config-dev-ci.yaml
+++ b/config/config-dev-ci.yaml
@@ -124,7 +124,7 @@ clouds:
           image:
             registry: "quay.io"
             repository: "roivaz/cihealth"
-            tag: "8e6b0cd"
+            tag: "9763534"
           disableRuntimeWorkloads: false
           app:
             replicas: 2

--- a/dev-infrastructure/dev-ci/cihealth/deploy/templates/controllers-deployment.yaml
+++ b/dev-infrastructure/dev-ci/cihealth/deploy/templates/controllers-deployment.yaml
@@ -53,6 +53,7 @@ spec:
                 "--source.sippy.release.stg={{ .Values.controllers.source.sippyReleases.stg }}" \
                 "--source.sippy.release.prod={{ .Values.controllers.source.sippyReleases.prod }}" \
                 "--source.prow-artifacts.base-url={{ .Values.controllers.source.prowArtifactsBaseUrl }}" \
+                "--controllers.source.prow.runs.threads={{ .Values.controllers.threads.sourceProwRuns }}" \
                 "--controllers.source.sippy.runs.threads={{ .Values.controllers.threads.sourceSippyRuns }}" \
                 "--controllers.source.sippy.tests-daily.threads={{ .Values.controllers.threads.sourceSippyTestsDaily }}" \
                 "--controllers.source.github.pull-requests.threads={{ .Values.controllers.threads.sourceGitHubPullRequests }}" \

--- a/dev-infrastructure/dev-ci/cihealth/deploy/values.yaml
+++ b/dev-infrastructure/dev-ci/cihealth/deploy/values.yaml
@@ -83,6 +83,7 @@ controllers:
       stg: aro-stage
       prod: aro-production
   threads:
+    sourceProwRuns: 1
     sourceSippyRuns: 1
     sourceSippyTestsDaily: 1
     sourceGitHubPullRequests: 1


### PR DESCRIPTION
* Deploys the following changes to the live site https://github.com/roivaz/ARO-HCP-CIHealth/pull/3
* Enables the `source.prow.runs controller`