### PR TITLE
test: add IdentityContainerAssignmentRetryInterval constant to replace hardcoded retry intervals

### DIFF
--- a/test/e2e/admin_api.go
+++ b/test/e2e/admin_api.go
@@ -52,7 +52,7 @@ var _ = Describe("SRE", func() {
 			tc := framework.NewTestContext()
 
 			if tc.UsePooledIdentities() {
-				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign identity containers")
 			}
 
@@ -267,7 +267,7 @@ var _ = Describe("SRE", func() {
 			tc := framework.NewTestContext()
 
 			if tc.UsePooledIdentities() {
-				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign identity containers")
 			}
 
@@ -375,7 +375,7 @@ var _ = Describe("SRE", func() {
 			tc := framework.NewTestContext()
 
 			if tc.UsePooledIdentities() {
-				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign identity containers")
 			}
 

--- a/test/e2e/admin_credential_lifecycle.go
+++ b/test/e2e/admin_credential_lifecycle.go
@@ -62,7 +62,7 @@ var _ = Describe("Customer", func() {
 			tc := framework.NewTestContext()
 
 			if tc.UsePooledIdentities() {
-				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign identity containers")
 			}
 

--- a/test/e2e/arm64_nodepool.go
+++ b/test/e2e/arm64_nodepool.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"regexp"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -51,7 +50,7 @@ var _ = Describe("Customer", func() {
 			tc := framework.NewTestContext()
 
 			if tc.UsePooledIdentities() {
-				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign identity containers")
 			}
 

--- a/test/e2e/cluster_authorized_cidrs_connectivity.go
+++ b/test/e2e/cluster_authorized_cidrs_connectivity.go
@@ -61,7 +61,7 @@ var _ = Describe("Authorized CIDRs", func() {
 				tc := framework.NewTestContext()
 
 				if tc.UsePooledIdentities() {
-					err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+					err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 					Expect(err).NotTo(HaveOccurred(), "failed to assign identity containers")
 				}
 

--- a/test/e2e/cluster_autoscaling.go
+++ b/test/e2e/cluster_autoscaling.go
@@ -16,7 +16,6 @@ package e2e
 
 import (
 	"context"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -56,7 +55,7 @@ var _ = Describe("Customer", func() {
 			tc := framework.NewTestContext()
 
 			if tc.UsePooledIdentities() {
-				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign identity containers")
 			}
 

--- a/test/e2e/cluster_create_cni_cilium.go
+++ b/test/e2e/cluster_create_cni_cilium.go
@@ -17,7 +17,6 @@ package e2e
 import (
 	"context"
 	"errors"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -42,7 +41,7 @@ var _ = Describe("Customer", func() {
 			tc := framework.NewTestContext()
 
 			if tc.UsePooledIdentities() {
-				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
 			}
 

--- a/test/e2e/cluster_create_complex_cilium_kv.go
+++ b/test/e2e/cluster_create_complex_cilium_kv.go
@@ -17,7 +17,6 @@ package e2e
 import (
 	"context"
 	"errors"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -52,7 +51,7 @@ var _ = Describe("Customer", func() {
 			tc := framework.NewTestContext()
 
 			if tc.UsePooledIdentities() {
-				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
 			}
 

--- a/test/e2e/cluster_create_nodepool_osdisk.go
+++ b/test/e2e/cluster_create_nodepool_osdisk.go
@@ -16,7 +16,6 @@ package e2e
 
 import (
 	"context"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -46,7 +45,7 @@ var _ = Describe("Customer", func() {
 			tc := framework.NewTestContext()
 
 			if tc.UsePooledIdentities() {
-				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
 			}
 

--- a/test/e2e/cluster_create_private_kv.go
+++ b/test/e2e/cluster_create_private_kv.go
@@ -46,7 +46,7 @@ var _ = Describe("Create HCPOpenShiftCluster with Private KeyVault", func() {
 			tc := framework.NewTestContext()
 
 			if tc.UsePooledIdentities() {
-				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
 			}
 

--- a/test/e2e/cluster_delayed_role_assignments.go
+++ b/test/e2e/cluster_delayed_role_assignments.go
@@ -52,7 +52,7 @@ var _ = Describe("ARO HCP Service", func() {
 			tc := framework.NewTestContext()
 
 			if tc.UsePooledIdentities() {
-				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign identity containers")
 			}
 

--- a/test/e2e/cluster_delete_cx_rg.go
+++ b/test/e2e/cluster_delete_cx_rg.go
@@ -50,7 +50,7 @@ var _ = Describe("Customer", func() {
 			tc := framework.NewTestContext()
 
 			if tc.UsePooledIdentities() {
-				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
 			}
 

--- a/test/e2e/cluster_nsg_subnet_reuse.go
+++ b/test/e2e/cluster_nsg_subnet_reuse.go
@@ -42,7 +42,7 @@ var _ = Describe("Customer", func() {
 			tc := framework.NewTestContext()
 
 			if tc.UsePooledIdentities() {
-				err := tc.AssignIdentityContainers(ctx, 2, 60*time.Second)
+				err := tc.AssignIdentityContainers(ctx, 2, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
 			}
 

--- a/test/e2e/cluster_pullsecret.go
+++ b/test/e2e/cluster_pullsecret.go
@@ -78,7 +78,7 @@ var _ = Describe("Customer", func() {
 			}
 
 			if tc.UsePooledIdentities() {
-				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
 			}
 

--- a/test/e2e/cluster_tls_endpoints.go
+++ b/test/e2e/cluster_tls_endpoints.go
@@ -56,7 +56,7 @@ var _ = Describe("Customer", func() {
 			tc := framework.NewTestContext()
 
 			if tc.UsePooledIdentities() {
-				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
 			}
 

--- a/test/e2e/cluster_update.go
+++ b/test/e2e/cluster_update.go
@@ -17,7 +17,6 @@ package e2e
 import (
 	"context"
 	"strings"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -49,7 +48,7 @@ var _ = Describe("Update HCPOpenShiftCluster", func() {
 				tc := framework.NewTestContext()
 
 				if tc.UsePooledIdentities() {
-					err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+					err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 					Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
 				}
 
@@ -125,7 +124,7 @@ var _ = Describe("Update HCPOpenShiftCluster", func() {
 				tc := framework.NewTestContext()
 
 				if tc.UsePooledIdentities() {
-					err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+					err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 					Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
 				}
 

--- a/test/e2e/cluster_version_backlevel.go
+++ b/test/e2e/cluster_version_backlevel.go
@@ -62,7 +62,7 @@ var _ = Describe("Customer", func() {
 				tc := framework.NewTestContext()
 
 				if tc.UsePooledIdentities() {
-					err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+					err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 					Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
 				}
 

--- a/test/e2e/clusters_sharing_resgroup.go
+++ b/test/e2e/clusters_sharing_resgroup.go
@@ -16,7 +16,6 @@ package e2e
 
 import (
 	"context"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -58,7 +57,7 @@ var _ = Describe("Customer", func() {
 			tc := framework.NewTestContext()
 
 			if tc.UsePooledIdentities() {
-				err := tc.AssignIdentityContainers(ctx, 3, 60*time.Second)
+				err := tc.AssignIdentityContainers(ctx, 3, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
 			}
 

--- a/test/e2e/complete_cluster_create_multiversion.go
+++ b/test/e2e/complete_cluster_create_multiversion.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -80,7 +79,7 @@ var _ = Describe("ARO-HCP", func() {
 
 			tc := framework.NewTestContext()
 			if tc.UsePooledIdentities() {
-				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
 			}
 

--- a/test/e2e/control_plane_automated_z_stream_upgrade.go
+++ b/test/e2e/control_plane_automated_z_stream_upgrade.go
@@ -58,7 +58,7 @@ var _ = Describe("Service Provider", func() {
 				Expect(err).NotTo(HaveOccurred(), "failed to get install version for z-stream upgrade of %s", minorVersion)
 			}
 			if tc.UsePooledIdentities() {
-				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
 			}
 

--- a/test/e2e/control_plane_minor_upgrade.go
+++ b/test/e2e/control_plane_minor_upgrade.go
@@ -113,7 +113,7 @@ var _ = Describe("Customer", func() {
 
 			tc := framework.NewTestContext()
 			if tc.UsePooledIdentities() {
-				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
 			}
 

--- a/test/e2e/external_auth_create.go
+++ b/test/e2e/external_auth_create.go
@@ -59,7 +59,7 @@ var _ = Describe("Customer", func() {
 			tc := framework.NewTestContext()
 
 			if tc.UsePooledIdentities() {
-				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
 			}
 

--- a/test/e2e/external_auth_list_and_verify.go
+++ b/test/e2e/external_auth_list_and_verify.go
@@ -18,7 +18,6 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -50,7 +49,7 @@ var _ = Describe("Customer", func() {
 			tc := framework.NewTestContext()
 
 			if tc.UsePooledIdentities() {
-				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
 			}
 

--- a/test/e2e/gpu_nodepools_create_delete.go
+++ b/test/e2e/gpu_nodepools_create_delete.go
@@ -66,7 +66,7 @@ var _ = Describe("HCP Nodepools GPU instances", func() {
 				tc := framework.NewTestContext()
 
 				if tc.UsePooledIdentities() {
-					err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+					err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 					Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
 				}
 

--- a/test/e2e/idms_lifecycle.go
+++ b/test/e2e/idms_lifecycle.go
@@ -60,7 +60,7 @@ var _ = Describe("Customer", func() {
 			tc := framework.NewTestContext()
 
 			if tc.UsePooledIdentities() {
-				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
 			}
 

--- a/test/e2e/image_registry_cluster_create.go
+++ b/test/e2e/image_registry_cluster_create.go
@@ -16,7 +16,6 @@ package e2e
 
 import (
 	"context"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -49,7 +48,7 @@ var _ = Describe("Customer", func() {
 			tc := framework.NewTestContext()
 
 			if tc.UsePooledIdentities() {
-				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
 			}
 

--- a/test/e2e/kusto_logs_present.go
+++ b/test/e2e/kusto_logs_present.go
@@ -48,7 +48,7 @@ var _ = Describe("Engineering", func() {
 			tc := framework.NewTestContext()
 
 			if tc.UsePooledIdentities() {
-				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
 			}
 

--- a/test/e2e/mise_routing.go
+++ b/test/e2e/mise_routing.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -83,7 +82,7 @@ var _ = Describe("MISE Routing", func() {
 			tc := framework.NewTestContext()
 
 			if tc.UsePooledIdentities() {
-				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign identity containers")
 			}
 

--- a/test/e2e/nodepool_autoscaling.go
+++ b/test/e2e/nodepool_autoscaling.go
@@ -57,7 +57,7 @@ var _ = Describe("Customer", func() {
 			tc := framework.NewTestContext()
 
 			if tc.UsePooledIdentities() {
-				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
 			}
 
@@ -247,7 +247,7 @@ var _ = Describe("Customer", func() {
 			tc := framework.NewTestContext()
 
 			if tc.UsePooledIdentities() {
-				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
 			}
 

--- a/test/e2e/nodepool_drain_timeout_update.go
+++ b/test/e2e/nodepool_drain_timeout_update.go
@@ -67,7 +67,7 @@ var _ = Describe("Customer", func() {
 			tc := framework.NewTestContext()
 
 			if tc.UsePooledIdentities() {
-				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign identity containers")
 			}
 

--- a/test/e2e/nodepool_ephemeral_osdisk.go
+++ b/test/e2e/nodepool_ephemeral_osdisk.go
@@ -77,7 +77,7 @@ var _ = Describe("Nodepool Ephemeral OS Disk", func() {
 			tc := framework.NewTestContext()
 
 			if tc.UsePooledIdentities() {
-				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
 			}
 

--- a/test/e2e/nodepool_labels_taints.go
+++ b/test/e2e/nodepool_labels_taints.go
@@ -52,7 +52,7 @@ var _ = Describe("Customer", func() {
 			tc := framework.NewTestContext()
 
 			if tc.UsePooledIdentities() {
-				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
 			}
 

--- a/test/e2e/nodepool_update_nodes.go
+++ b/test/e2e/nodepool_update_nodes.go
@@ -16,7 +16,6 @@ package e2e
 
 import (
 	"context"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -48,7 +47,7 @@ var _ = Describe("Customer", func() {
 			tc := framework.NewTestContext()
 
 			if tc.UsePooledIdentities() {
-				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
 			}
 

--- a/test/e2e/nodepool_version_upgrade.go
+++ b/test/e2e/nodepool_version_upgrade.go
@@ -83,7 +83,7 @@ var _ = Describe("Customer", func() {
 			tc := framework.NewTestContext()
 
 			if tc.UsePooledIdentities() {
-				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
 			}
 
@@ -269,7 +269,7 @@ var _ = Describe("Customer", func() {
 			tc := framework.NewTestContext()
 
 			if tc.UsePooledIdentities() {
-				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign identity containers")
 			}
 
@@ -399,7 +399,7 @@ var _ = Describe("Customer", func() {
 			tc := framework.NewTestContext()
 
 			if tc.UsePooledIdentities() {
-				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign identity containers")
 			}
 
@@ -529,7 +529,7 @@ var _ = Describe("Customer", func() {
 			tc := framework.NewTestContext()
 
 			if tc.UsePooledIdentities() {
-				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign identity containers")
 			}
 
@@ -660,7 +660,7 @@ var _ = Describe("Customer", func() {
 			tc := framework.NewTestContext()
 
 			if tc.UsePooledIdentities() {
-				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign identity containers")
 			}
 

--- a/test/e2e/oidc_issuer_workload_identity.go
+++ b/test/e2e/oidc_issuer_workload_identity.go
@@ -182,7 +182,7 @@ var _ = Describe("Customer", func() {
 			tc := framework.NewTestContext()
 
 			if tc.UsePooledIdentities() {
-				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
 			}
 

--- a/test/e2e/shoebox_logs.go
+++ b/test/e2e/shoebox_logs.go
@@ -234,7 +234,7 @@ var _ = Describe("Customer", func() {
 			tc := framework.NewTestContext()
 
 			if tc.UsePooledIdentities() {
-				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
 			}
 

--- a/test/e2e/simple_negative_cases.go
+++ b/test/e2e/simple_negative_cases.go
@@ -54,7 +54,7 @@ var _ = Describe("Customer", func() {
 			tc := framework.NewTestContext()
 
 			if tc.UsePooledIdentities() {
-				err := tc.AssignIdentityContainers(ctx, 1, 60*time.Second)
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
 			}
 

--- a/test/util/framework/constants.go
+++ b/test/util/framework/constants.go
@@ -38,3 +38,8 @@ const (
 	NodePoolScalingTimeout          = 20 * time.Minute
 	UpdateHCPClusterTimeout         = 10 * time.Minute
 )
+
+// Identity assignment
+const (
+	IdentityContainerAssignmentRetryInterval = 60 * time.Second
+)


### PR DESCRIPTION
[ARO-24505](https://redhat.atlassian.net/browse/ARO-24505)

### What

Extract the `60*time.Second` retry interval literal passed to `AssignIdentityContainers()` into a shared constant `IdentityContainerAssignmentRetryInterval` in `test/util/framework/constants.go`, and replace all occurrences in test files.

### Why

Every call site passed the same `60*time.Second` value. Durations shared across multiple test cases should be named constants in `constants.go` rather than repeated magic numbers. This makes the value easier to find and tune from a single location.

### Testing

No new tests added. This is a mechanical refactor — the constant preserves the same `60*time.Second` value.

### PR Checklist
- [X] PR is scoped to a single task (no mixed concerns)
- [X] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [X] Summary explains the "Why" behind the change
- [X] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [X] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [X] Commit history is clean (rebased/squashed)
- [X] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
