### PR TITLE
feat: introduce asynchronous cluster deletion in backend in a disabled state

### DIFF
--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -37,6 +37,7 @@ import (
 	azureclient "github.com/Azure/ARO-HCP/backend/pkg/azure/client"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/billingcontrollers"
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/clusterdeletion"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/clusterpropertiescontroller"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/datadumpcontrollers"
@@ -681,19 +682,51 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		activeOperationLister,
 		backendInformers,
 	)
+
 	externalAuthClusterServiceIDClearerController := externalauthdeletion.NewExternalAuthClusterServiceIDClearerController(
 		b.options.ResourcesDBClient,
 		b.options.ClustersServiceClient,
 		activeOperationLister,
 		backendInformers,
 	)
+
 	externalAuthChildResourcesCleanupController := externalauthdeletion.NewExternalAuthChildResourcesCleanupController(
 		b.options.ResourcesDBClient,
 		activeOperationLister,
 		backendInformers,
 	)
+
 	externalAuthDeletionController := externalauthdeletion.NewExternalAuthDeletionController(
 		b.options.ResourcesDBClient,
+		activeOperationLister,
+		backendInformers,
+	)
+
+	clusterDeletionClusterServiceDeleteDispatchController := clusterdeletion.NewClusterClusterServiceDeleteDispatchController(
+		utilsclock.RealClock{},
+		b.options.ResourcesDBClient,
+		b.options.ClustersServiceClient,
+		activeOperationLister,
+		backendInformers,
+	)
+
+	clusterClusterServiceIDClearerController := clusterdeletion.NewClusterClusterServiceIDClearerController(
+		b.options.ResourcesDBClient,
+		b.options.ClustersServiceClient,
+		activeOperationLister,
+		backendInformers,
+	)
+
+	clusterChildResourcesCleanupController := clusterdeletion.NewClusterChildResourcesCleanupController(
+		b.options.ResourcesDBClient,
+		activeOperationLister,
+		backendInformers,
+	)
+
+	clusterDeletionController := clusterdeletion.NewClusterDeletionController(
+		utilsclock.RealClock{},
+		b.options.ResourcesDBClient,
+		b.options.BillingDBClient,
 		activeOperationLister,
 		backendInformers,
 	)
@@ -766,6 +799,10 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 				go externalAuthClusterServiceIDClearerController.Run(ctx, 20)
 				go externalAuthChildResourcesCleanupController.Run(ctx, 20)
 				go externalAuthDeletionController.Run(ctx, 20)
+				go clusterDeletionClusterServiceDeleteDispatchController.Run(ctx, 20)
+				go clusterClusterServiceIDClearerController.Run(ctx, 20)
+				go clusterChildResourcesCleanupController.Run(ctx, 20)
+				go clusterDeletionController.Run(ctx, 20)
 				go operationPhaseMetricsController.Run(ctx, 1)
 				go clusterMetricsController.Run(ctx, 1)
 				go nodePoolMetricsController.Run(ctx, 1)

--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -672,8 +672,6 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 	)
 	nodePoolDeletionController := nodepooldeletion.NewNodePoolDeletionController(
 		b.options.ResourcesDBClient,
-		b.options.KubeApplierDBClients,
-		b.options.FleetDBClient,
 		activeOperationLister,
 		backendInformers,
 	)
@@ -731,8 +729,6 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		utilsclock.RealClock{},
 		b.options.ResourcesDBClient,
 		b.options.BillingDBClient,
-		b.options.KubeApplierDBClients,
-		b.options.FleetDBClient,
 		activeOperationLister,
 		backendInformers,
 	)

--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -666,11 +666,14 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 	)
 	nodePoolChildResourcesCleanupController := nodepooldeletion.NewNodePoolChildResourcesCleanupController(
 		b.options.ResourcesDBClient,
+		b.options.KubeApplierDBClients,
 		activeOperationLister,
 		backendInformers,
 	)
 	nodePoolDeletionController := nodepooldeletion.NewNodePoolDeletionController(
 		b.options.ResourcesDBClient,
+		b.options.KubeApplierDBClients,
+		b.options.FleetDBClient,
 		activeOperationLister,
 		backendInformers,
 	)
@@ -719,6 +722,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 
 	clusterChildResourcesCleanupController := clusterdeletion.NewClusterChildResourcesCleanupController(
 		b.options.ResourcesDBClient,
+		b.options.KubeApplierDBClients,
 		activeOperationLister,
 		backendInformers,
 	)
@@ -727,6 +731,8 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		utilsclock.RealClock{},
 		b.options.ResourcesDBClient,
 		b.options.BillingDBClient,
+		b.options.KubeApplierDBClients,
+		b.options.FleetDBClient,
 		activeOperationLister,
 		backendInformers,
 	)

--- a/backend/pkg/controllers/billingcontrollers/create_billing_doc.go
+++ b/backend/pkg/controllers/billingcontrollers/create_billing_doc.go
@@ -63,6 +63,8 @@ func (c *createBillingDoc) NeedsWork(ctx context.Context, existingCluster *api.H
 		return false
 	}
 
+	// TODO should we add a cluster.DeletionTimestamp == nil check here?
+
 	// Skip if the billing document has already been created (BillingDocumentCosmosID is set)
 	if len(existingCluster.ServiceProviderProperties.BillingDocumentCosmosID) != 0 {
 		return false

--- a/backend/pkg/controllers/billingcontrollers/create_billing_doc.go
+++ b/backend/pkg/controllers/billingcontrollers/create_billing_doc.go
@@ -63,8 +63,6 @@ func (c *createBillingDoc) NeedsWork(ctx context.Context, existingCluster *api.H
 		return false
 	}
 
-	// TODO should we add a cluster.DeletionTimestamp == nil check here?
-
 	// Skip if the billing document has already been created (BillingDocumentCosmosID is set)
 	if len(existingCluster.ServiceProviderProperties.BillingDocumentCosmosID) != 0 {
 		return false

--- a/backend/pkg/controllers/clusterdeletion/cluster_child_resources_cleanup_controller.go
+++ b/backend/pkg/controllers/clusterdeletion/cluster_child_resources_cleanup_controller.go
@@ -39,23 +39,26 @@ import (
 // deletion pipelines. The orphan scraper handles controller status after the
 // Cluster document itself is removed.
 type clusterChildResourcesCleanupController struct {
-	cooldownChecker   controllerutil.CooldownChecker
-	clusterLister     listers.ClusterLister
-	resourcesDBClient database.ResourcesDBClient
+	cooldownChecker      controllerutil.CooldownChecker
+	clusterLister        listers.ClusterLister
+	resourcesDBClient    database.ResourcesDBClient
+	kubeApplierDBClients database.KubeApplierDBClients
 }
 
 var _ controllerutils.ClusterSyncer = (*clusterChildResourcesCleanupController)(nil)
 
 func NewClusterChildResourcesCleanupController(
 	resourcesDBClient database.ResourcesDBClient,
+	kubeApplierDBClients database.KubeApplierDBClients,
 	activeOperationLister listers.ActiveOperationLister,
 	informers informers.BackendInformers,
 ) controllerutils.Controller {
 	_, clusterLister := informers.Clusters()
 	syncer := &clusterChildResourcesCleanupController{
-		cooldownChecker:   controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
-		clusterLister:     clusterLister,
-		resourcesDBClient: resourcesDBClient,
+		cooldownChecker:      controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		clusterLister:        clusterLister,
+		resourcesDBClient:    resourcesDBClient,
+		kubeApplierDBClients: kubeApplierDBClients,
 	}
 
 	return controllerutils.NewClusterWatchingController(
@@ -114,7 +117,11 @@ func (c *clusterChildResourcesCleanupController) SyncOnce(ctx context.Context, k
 	// We must not delete cluster-scoped resources (like ServiceProviderCluster,
 	// ManagementClusterContent) until all nodepools and externalauths are fully
 	// deleted, because their deletion controllers may depend on cluster-scoped
-	// resources.
+	// resources. ServiceProviderCluster also carries ManagementClusterResourceID,
+	// which we need to reach the per-MC kube-applier container, so cluster-scoped
+	// kube-applier *Desires must be removed before the ServiceProviderCluster
+	// document. Nodepool-scoped *Desires are cleaned up by the nodepool deletion
+	// pipeline.
 	allNodePoolsGone, err := deletePreconditionAllNodePoolsDeleted(ctx, c.resourcesDBClient, key)
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to check nodepool precondition: %w", err))
@@ -134,10 +141,6 @@ func (c *clusterChildResourcesCleanupController) SyncOnce(ctx context.Context, k
 	}
 
 	clusterResourceID := cluster.ID
-	untypedCRUD, err := c.resourcesDBClient.UntypedCRUD(*clusterResourceID)
-	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to create untyped CRUD for cluster children: %w", err))
-	}
 
 	// skipSubtreeTypes lists resource types whose entire subtrees are skipped.
 	// A child resource is left alone if its type path starts with any of these
@@ -155,6 +158,15 @@ func (c *clusterChildResourcesCleanupController) SyncOnce(ctx context.Context, k
 		// We never delete cluster controllers here, as there might be controllers still running
 		// for the Cluster until the very end of the deletion process
 		strings.ToLower(api.ClusterControllerResourceType.String()): func(ctx context.Context, resourceID *azcorearm.ResourceID) (bool, error) { return false, nil },
+	}
+
+	if err := c.ensureClusterScopedKubeApplierResourcesDeleted(ctx, clusterResourceID); err != nil {
+		return utils.TrackError(fmt.Errorf("failed to delete cluster-scoped kube-applier content: %w", err))
+	}
+
+	untypedCRUD, err := c.resourcesDBClient.UntypedCRUD(*clusterResourceID)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to create untyped CRUD for cluster children: %w", err))
 	}
 
 	childIterator, err := untypedCRUD.ListRecursive(ctx, nil)
@@ -208,9 +220,9 @@ func hasSkippedResourceTypePrefix(resourceID *azcorearm.ResourceID, skipSubtreeT
 	return false
 }
 
-// extraDeleteGateShouldDeleteServiceProviderCluster checks if the
-// ServiceProviderCluster has any Maestro readonly bundles. If there are
-// bundles it returns false, otherwise it returns true.
+// extraDeleteGateShouldDeleteServiceProviderCluster returns false while the
+// ServiceProviderCluster still has Maestro readonly bundles or cluster-scoped
+// kube-applier *Desire documents.
 func (c *clusterChildResourcesCleanupController) extraDeleteGateShouldDeleteServiceProviderCluster(ctx context.Context, serviceProviderClusterResourceID *azcorearm.ResourceID) (bool, error) {
 	logger := utils.LoggerFromContext(ctx)
 
@@ -234,12 +246,126 @@ func (c *clusterChildResourcesCleanupController) extraDeleteGateShouldDeleteServ
 		return false, utils.TrackError(fmt.Errorf("failed to get ServiceProviderCluster: %w", err))
 	}
 
+	// Check if there are any Maestro readonly bundles remaining.
 	if len(spc.Status.MaestroReadonlyBundles) > 0 {
 		logger.Info("waiting for cluster-scoped Maestro readonly bundles to be deleted before removing Cosmos entry",
 			"serviceProviderClusterResourceID", spc.ResourceID.String(), "remainingBundles", len(spc.Status.MaestroReadonlyBundles))
 		return false, nil
 	}
+
+	// Check if there are any cluster-scoped kube-applier *Desire documents remaining.
+	if spc.Status.ManagementClusterResourceID != nil {
+		kaClient := c.kubeApplierDBClients.For(ctx, spc.Status.ManagementClusterResourceID)
+		if kaClient == nil {
+			logger.Info("no kube-applier client for management cluster. Continuing with deletion of ServiceProviderCluster document",
+				"serviceProviderClusterResourceID", spc.ResourceID.String(),
+				"managementClusterResourceID", spc.Status.ManagementClusterResourceID.String())
+			return true, nil
+		}
+
+		desireCRUD, err := kaClient.UntypedCRUD(*serviceProviderClusterResourceID.Parent)
+		if err != nil {
+			return false, utils.TrackError(fmt.Errorf("failed to create kube-applier untyped CRUD: %w", err))
+		}
+
+		desireIterator, err := desireCRUD.List(ctx, nil)
+		if err != nil {
+			return false, utils.TrackError(fmt.Errorf("failed to list cluster-scoped kube-applier resources: %w", err))
+		}
+		for range desireIterator.Items(ctx) {
+			logger.Info("waiting for cluster-scoped kube-applier content to be deleted before removing ServiceProviderCluster",
+				"serviceProviderClusterResourceID", spc.ResourceID.String(),
+				"managementClusterResourceID", spc.Status.ManagementClusterResourceID.String())
+			return false, nil
+		}
+		if err := desireIterator.GetError(); err != nil {
+			return false, utils.TrackError(fmt.Errorf("error iterating cluster-scoped kube-applier resources: %w", err))
+		}
+	} else {
+		logger.Info("no management cluster resource ID found for ServiceProviderCluster. Continuing with deletion of ServiceProviderCluster document")
+		return true, nil
+	}
+
 	return true, nil
+}
+
+// ensureClusterScopedKubeApplierResourcesDeleted ensures that the cluster-scoped *Desire documents are deleted
+// from the database. *Desire documents on non-cluster scoped resources are deleted by their corresponding deletion controllers.
+func (c *clusterChildResourcesCleanupController) ensureClusterScopedKubeApplierResourcesDeleted(ctx context.Context, clusterResourceID *azcorearm.ResourceID) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	spc, err := c.resourcesDBClient.ServiceProviderClusters(clusterResourceID.SubscriptionID, clusterResourceID.ResourceGroupName, clusterResourceID.Name).Get(ctx, api.ServiceProviderClusterResourceName)
+	if database.IsNotFoundError(err) {
+		// If there is no ServiceProviderCluster, we cannot determine the management cluster resource ID, so we skip the deletion of the
+		// *Desire documents without erroring.
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get ServiceProviderCluster: %w", err))
+	}
+
+	// If the ServiceProviderCluster has no management cluster resource ID, we cannot determine the management
+	// cluster resource ID, so we skip the deletion of the *Desire documents without erroring.
+	mcResourceID := spc.Status.ManagementClusterResourceID
+	if mcResourceID == nil {
+		logger.Info("no management cluster resource ID found for ServiceProviderCluster; skipping deletion of cluster-scoped kube-applier content",
+			"serviceProviderClusterResourceID", spc.ResourceID.String())
+		return nil
+	}
+
+	// Best-effort: if the kube-applier client is unavailable, skip desire deletion here.
+	// Remaining *Desires are cleaned up by later deletion stages and the orphan scraper.
+	kaClient := c.kubeApplierDBClients.For(ctx, mcResourceID)
+	if kaClient == nil {
+		logger.Info("no kube-applier client configured for management cluster; skipping cluster-scoped desire deletion",
+			"managementClusterResourceID", mcResourceID.String())
+		return nil
+	}
+
+	// extraDeleteGates uses lowercased kubeapplier.*DesireResourceTypeName keys. Types not
+	// in the map are deleted unconditionally.
+	extraDeleteGates := map[string]func(ctx context.Context, resourceID *azcorearm.ResourceID) (bool, error){
+		// strings.ToLower(kubeapplier.ClusterScopedReadDesireResourceType.String()): c.extraDeleteGateShouldDeleteReadDesire,
+		// strings.ToLower(kubeapplier.ClusterScopedApplyDesireResourceType.String()): c.extraDeleteGateShouldDeleteApplyDesire,
+		// strings.ToLower(kubeapplier.ClusterScopedDeleteDesireResourceType.String()): c.extraDeleteGateShouldDeleteDeleteDesire,
+	}
+
+	desireCRUD, err := kaClient.UntypedCRUD(*clusterResourceID)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to create kube-applier untyped CRUD: %w", err))
+	}
+
+	// We do non-recursive list so we only deal with cluster-scoped *Desires. Other scoped resources are handled by their corresponding
+	// deletion controllers.
+	desireIterator, err := desireCRUD.List(ctx, nil)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to list cluster-scoped kube-applier resources: %w", err))
+	}
+	for _, resource := range desireIterator.Items(ctx) {
+		if resource.ResourceID == nil {
+			return utils.TrackError(fmt.Errorf("kube-applier document at cosmosID %q has no resourceID. Refusing to delete", resource.ID))
+		}
+
+		if extraDeleteGate, ok := extraDeleteGates[strings.ToLower(resource.ResourceType)]; ok {
+			shouldDelete, err := extraDeleteGate(ctx, resource.ResourceID)
+			if err != nil {
+				return utils.TrackError(err)
+			}
+			if !shouldDelete {
+				continue
+			}
+		}
+
+		logger.Info("deleting cluster-scoped kube-applier resource", "resourceID", resource.ResourceID)
+		if err := desireCRUD.DeleteByCosmosID(ctx, resource.PartitionKey, resource.ID); err != nil {
+			return utils.TrackError(fmt.Errorf("failed to delete cluster-scoped kube-applier resource %q: %w", resource.CosmosResourceID, err))
+		}
+	}
+	if err := desireIterator.GetError(); err != nil {
+		return utils.TrackError(fmt.Errorf("error iterating cluster-scoped kube-applier resources: %w", err))
+	}
+
+	return nil
 }
 
 func deletePreconditionAllNodePoolsDeleted(ctx context.Context, dbClient database.ResourcesDBClient, key controllerutils.HCPClusterKey) (bool, error) {

--- a/backend/pkg/controllers/clusterdeletion/cluster_child_resources_cleanup_controller.go
+++ b/backend/pkg/controllers/clusterdeletion/cluster_child_resources_cleanup_controller.go
@@ -1,0 +1,271 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusterdeletion
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/internal/api"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// clusterChildResourcesCleanupController deletes child resources scoped
+// under a Cluster recursively once the Cluster is marked for deletion and
+// Cluster Service has confirmed the delete on its side. Controller status
+// documents (ClusterControllerResourceType) are left alone. Resources scoped
+// under NodePools and ExternalAuths are skipped because they have their own
+// deletion pipelines. The orphan scraper handles controller status after the
+// Cluster document itself is removed.
+type clusterChildResourcesCleanupController struct {
+	cooldownChecker   controllerutil.CooldownChecker
+	clusterLister     listers.ClusterLister
+	resourcesDBClient database.ResourcesDBClient
+}
+
+var _ controllerutils.ClusterSyncer = (*clusterChildResourcesCleanupController)(nil)
+
+func NewClusterChildResourcesCleanupController(
+	resourcesDBClient database.ResourcesDBClient,
+	activeOperationLister listers.ActiveOperationLister,
+	informers informers.BackendInformers,
+) controllerutils.Controller {
+	_, clusterLister := informers.Clusters()
+	syncer := &clusterChildResourcesCleanupController{
+		cooldownChecker:   controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		clusterLister:     clusterLister,
+		resourcesDBClient: resourcesDBClient,
+	}
+
+	return controllerutils.NewClusterWatchingController(
+		"ClusterChildResourcesCleanupController",
+		resourcesDBClient,
+		informers,
+		nil,
+		time.Minute,
+		syncer,
+	)
+}
+
+func (c *clusterChildResourcesCleanupController) CooldownChecker() controllerutil.CooldownChecker {
+	return c.cooldownChecker
+}
+
+func (c *clusterChildResourcesCleanupController) NeedsWork(cluster *api.HCPOpenShiftCluster) bool {
+	// TODO temporary check to skip the new deletion approach for Clusters that were created before the new approach was implemented.
+	// This will be removed once all clusters whose deletion was triggered before the new approach is fully rolled out have been
+	// fully deleted in all ARO-HCP permanent environments, for all regions.
+	if !cluster.ServiceProviderProperties.UsesNewClusterDeletionApproach {
+		return false
+	}
+
+	return cluster.ServiceProviderProperties.DeletionTimestamp != nil &&
+		cluster.ServiceProviderProperties.ClusterServiceDeletionTimestamp != nil &&
+		cluster.ServiceProviderProperties.ClusterServiceID == nil
+}
+
+func (c *clusterChildResourcesCleanupController) SyncOnce(ctx context.Context, key controllerutils.HCPClusterKey) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	cachedCluster, err := c.clusterLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get cluster from cache: %w", err))
+	}
+	if !c.NeedsWork(cachedCluster) {
+		return nil
+	}
+
+	clusterCRUD := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName)
+	cluster, err := clusterCRUD.Get(ctx, key.HCPClusterName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get cluster: %w", err))
+	}
+	if !c.NeedsWork(cluster) {
+		return nil
+	}
+
+	// We must not delete cluster-scoped resources (like ServiceProviderCluster,
+	// ManagementClusterContent) until all nodepools and externalauths are fully
+	// deleted, because their deletion controllers may depend on cluster-scoped
+	// resources.
+	allNodePoolsGone, err := deletePreconditionAllNodePoolsDeleted(ctx, c.resourcesDBClient, key)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to check nodepool precondition: %w", err))
+	}
+	if !allNodePoolsGone {
+		logger.Info("waiting for all nodepools to be deleted before cleaning up cluster child resources")
+		return nil
+	}
+
+	allExternalAuthsGone, err := deletePreconditionAllExternalAuthsDeleted(ctx, c.resourcesDBClient, key)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to check externalauth precondition: %w", err))
+	}
+	if !allExternalAuthsGone {
+		logger.Info("waiting for all external auths to be deleted before cleaning up cluster child resources")
+		return nil
+	}
+
+	clusterResourceID := cluster.ID
+	untypedCRUD, err := c.resourcesDBClient.UntypedCRUD(*clusterResourceID)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to create untyped CRUD for cluster children: %w", err))
+	}
+
+	// skipSubtreeTypes lists resource types whose entire subtrees are skipped.
+	// A child resource is left alone if its type path starts with any of these
+	// types, because those subtrees have their own deletion pipelines.
+	skipSubtreeTypes := []azcorearm.ResourceType{
+		api.NodePoolResourceType,
+		api.ExternalAuthResourceType,
+	}
+
+	// extraDeleteGates contains per-resource-type conditional logic for
+	// resources that are not part of a skipped subtree. If the resource type
+	// is not in this map, the resource is deleted unconditionally.
+	extraDeleteGates := map[string]func(ctx context.Context, resourceID *azcorearm.ResourceID) (bool, error){
+		strings.ToLower(api.ServiceProviderClusterResourceType.String()): c.extraDeleteGateShouldDeleteServiceProviderCluster,
+		// We never delete cluster controllers here, as there might be controllers still running
+		// for the Cluster until the very end of the deletion process
+		strings.ToLower(api.ClusterControllerResourceType.String()): func(ctx context.Context, resourceID *azcorearm.ResourceID) (bool, error) { return false, nil },
+	}
+
+	childIterator, err := untypedCRUD.ListRecursive(ctx, nil)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to list cluster child resources: %w", err))
+	}
+	for _, childResource := range childIterator.Items(ctx) {
+		if childResource.ResourceID == nil {
+			return utils.TrackError(fmt.Errorf("child resource at cosmosID %q has no resourceID; refusing to delete", childResource.ID))
+		}
+
+		if hasSkippedResourceTypePrefix(childResource.ResourceID, skipSubtreeTypes) {
+			continue
+		}
+
+		extraDeleteGate, ok := extraDeleteGates[strings.ToLower(childResource.ResourceType)]
+		if ok {
+			shouldDelete, err := extraDeleteGate(ctx, childResource.ResourceID)
+			if err != nil {
+				return utils.TrackError(err)
+			}
+			if !shouldDelete {
+				continue
+			}
+		}
+
+		logger.Info("deleting child resource", "childResourceID", childResource.ResourceID)
+		if err := untypedCRUD.Delete(ctx, childResource.ResourceID); err != nil {
+			return utils.TrackError(err)
+		}
+	}
+	if err := childIterator.GetError(); err != nil {
+		return utils.TrackError(err)
+	}
+
+	return nil
+}
+
+// hasSkippedResourceTypePrefix returns true if the resource's type path starts with
+// any of the skip entries. Each entry is a lowercased ResourceType.Type such
+// as "hcpopenshiftclusters/nodepools". This catches both the resource itself
+// and all its descendants.
+func hasSkippedResourceTypePrefix(resourceID *azcorearm.ResourceID, skipSubtreeTypes []azcorearm.ResourceType) bool {
+	resourceTypeLower := strings.ToLower(resourceID.ResourceType.Type)
+	for _, skip := range skipSubtreeTypes {
+		skipLower := strings.ToLower(skip.Type)
+		if resourceTypeLower == skipLower || strings.HasPrefix(resourceTypeLower, skipLower+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// extraDeleteGateShouldDeleteServiceProviderCluster checks if the
+// ServiceProviderCluster has any Maestro readonly bundles. If there are
+// bundles it returns false, otherwise it returns true.
+func (c *clusterChildResourcesCleanupController) extraDeleteGateShouldDeleteServiceProviderCluster(ctx context.Context, serviceProviderClusterResourceID *azcorearm.ResourceID) (bool, error) {
+	logger := utils.LoggerFromContext(ctx)
+
+	if serviceProviderClusterResourceID.Parent == nil {
+		return false, utils.TrackError(fmt.Errorf(
+			"service provider cluster resource ID missing cluster parent: %s",
+			serviceProviderClusterResourceID.String()))
+	}
+
+	clusterName := serviceProviderClusterResourceID.Parent.Name
+
+	spc, err := c.resourcesDBClient.ServiceProviderClusters(
+		serviceProviderClusterResourceID.SubscriptionID,
+		serviceProviderClusterResourceID.ResourceGroupName,
+		clusterName,
+	).Get(ctx, api.ServiceProviderClusterResourceName)
+	if database.IsNotFoundError(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, utils.TrackError(fmt.Errorf("failed to get ServiceProviderCluster: %w", err))
+	}
+
+	if len(spc.Status.MaestroReadonlyBundles) > 0 {
+		logger.Info("waiting for cluster-scoped Maestro readonly bundles to be deleted before removing Cosmos entry",
+			"serviceProviderClusterResourceID", spc.ResourceID.String(), "remainingBundles", len(spc.Status.MaestroReadonlyBundles))
+		return false, nil
+	}
+	return true, nil
+}
+
+func deletePreconditionAllNodePoolsDeleted(ctx context.Context, dbClient database.ResourcesDBClient, key controllerutils.HCPClusterKey) (bool, error) {
+	nodePoolIterator, err := dbClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).NodePools(key.HCPClusterName).List(ctx, nil)
+	if err != nil {
+		return false, utils.TrackError(fmt.Errorf("failed to list node pools: %w", err))
+	}
+	for range nodePoolIterator.Items(ctx) {
+		return false, nil
+	}
+	if err := nodePoolIterator.GetError(); err != nil {
+		return false, utils.TrackError(fmt.Errorf("error iterating node pools: %w", err))
+	}
+	return true, nil
+}
+
+func deletePreconditionAllExternalAuthsDeleted(ctx context.Context, dbClient database.ResourcesDBClient, key controllerutils.HCPClusterKey) (bool, error) {
+	externalAuthIterator, err := dbClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).ExternalAuth(key.HCPClusterName).List(ctx, nil)
+	if err != nil {
+		return false, utils.TrackError(fmt.Errorf("failed to list external auths: %w", err))
+	}
+	for range externalAuthIterator.Items(ctx) {
+		return false, nil
+	}
+	if err := externalAuthIterator.GetError(); err != nil {
+		return false, utils.TrackError(fmt.Errorf("error iterating external auths: %w", err))
+	}
+	return true, nil
+}

--- a/backend/pkg/controllers/clusterdeletion/cluster_child_resources_cleanup_controller_test.go
+++ b/backend/pkg/controllers/clusterdeletion/cluster_child_resources_cleanup_controller_test.go
@@ -31,47 +31,150 @@ import (
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
 	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
 	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/api/kubeapplier"
 	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/databasetesting"
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
 
-func newTestClusterScopedManagementClusterContent(t *testing.T, name string) *api.ManagementClusterContent {
-	t.Helper()
-	resourceID := api.Must(azcorearm.ParseResourceID(
-		"/subscriptions/" + testSubscriptionID +
-			"/resourceGroups/" + testResourceGroupName +
-			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
-			"/managementClusterContents/" + name))
-	return &api.ManagementClusterContent{
-		CosmosMetadata: api.CosmosMetadata{ResourceID: resourceID},
-	}
-}
+func TestClusterChildResourcesCleanupController_SyncOnce(t *testing.T) {
+	managementClusterResourceID := api.Must(azcorearm.ParseResourceID(
+		"/providers/microsoft.redhatopenshift/stamps/1/managementclusters/default"))
+	unregisteredManagementClusterResourceID := api.Must(azcorearm.ParseResourceID(
+		"/providers/microsoft.redhatopenshift/stamps/1/managementclusters/unregistered"))
 
-func newTestClusterController(t *testing.T, name string) *api.Controller {
-	t.Helper()
-	resourceID := api.Must(azcorearm.ParseResourceID(
-		"/subscriptions/" + testSubscriptionID +
-			"/resourceGroups/" + testResourceGroupName +
-			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
-			"/hcpOpenShiftControllers/" + name))
-	return &api.Controller{
-		CosmosMetadata: api.CosmosMetadata{ResourceID: resourceID},
-		ExternalID: api.Must(azcorearm.ParseResourceID(
+	newTestSPCWithManagementCluster := func(mcResourceID *azcorearm.ResourceID) *api.ServiceProviderCluster {
+		spcResourceID := api.Must(azcorearm.ParseResourceID(
 			"/subscriptions/" + testSubscriptionID +
 				"/resourceGroups/" + testResourceGroupName +
-				"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName)),
-		Status: api.ControllerStatus{
-			Conditions: []metav1.Condition{},
-		},
+				"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+				"/serviceProviderClusters/default"))
+		return &api.ServiceProviderCluster{
+			CosmosMetadata: arm.CosmosMetadata{ResourceID: spcResourceID},
+			Status: api.ServiceProviderClusterStatus{
+				ManagementClusterResourceID: mcResourceID,
+			},
+		}
 	}
-}
+	newTestClusterScopedManagementClusterContent := func(name string) *api.ManagementClusterContent {
+		resourceID := api.Must(azcorearm.ParseResourceID(
+			"/subscriptions/" + testSubscriptionID +
+				"/resourceGroups/" + testResourceGroupName +
+				"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+				"/managementClusterContents/" + name))
+		return &api.ManagementClusterContent{
+			CosmosMetadata: api.CosmosMetadata{ResourceID: resourceID},
+		}
+	}
+	newTestClusterController := func(name string) *api.Controller {
+		resourceID := api.Must(azcorearm.ParseResourceID(
+			"/subscriptions/" + testSubscriptionID +
+				"/resourceGroups/" + testResourceGroupName +
+				"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+				"/hcpOpenShiftControllers/" + name))
+		return &api.Controller{
+			CosmosMetadata: api.CosmosMetadata{ResourceID: resourceID},
+			ExternalID: api.Must(azcorearm.ParseResourceID(
+				"/subscriptions/" + testSubscriptionID +
+					"/resourceGroups/" + testResourceGroupName +
+					"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName)),
+			Status: api.ControllerStatus{
+				Conditions: []metav1.Condition{},
+			},
+		}
+	}
 
-func TestClusterChildResourcesCleanupController_SyncOnce(t *testing.T) {
-	fixedClockTime := time.Now().UTC().Truncate(time.Second)
+	newTestReadDesire := func(resourceIDString string) *kubeapplier.ReadDesire {
+		resourceID := api.Must(azcorearm.ParseResourceID(resourceIDString))
+		return &kubeapplier.ReadDesire{
+			CosmosMetadata: api.CosmosMetadata{ResourceID: resourceID},
+			Spec: kubeapplier.ReadDesireSpec{
+				ManagementCluster: managementClusterResourceID,
+			},
+		}
+	}
+	newTestClusterScopedReadDesire := func(name string) *kubeapplier.ReadDesire {
+		return newTestReadDesire(kubeapplier.ToClusterScopedReadDesireResourceIDString(
+			testSubscriptionID, testResourceGroupName, testClusterName, name))
+	}
+	newTestNodePoolScopedReadDesire := func(nodePoolName, name string) *kubeapplier.ReadDesire {
+		return newTestReadDesire(kubeapplier.ToNodePoolScopedReadDesireResourceIDString(
+			testSubscriptionID, testResourceGroupName, testClusterName, nodePoolName, name))
+	}
+	newTestClusterScopedApplyDesire := func(name string) *kubeapplier.ApplyDesire {
+		resourceID := api.Must(azcorearm.ParseResourceID(
+			kubeapplier.ToClusterScopedApplyDesireResourceIDString(
+				testSubscriptionID, testResourceGroupName, testClusterName, name)))
+		return &kubeapplier.ApplyDesire{
+			CosmosMetadata: api.CosmosMetadata{ResourceID: resourceID},
+			Spec: kubeapplier.ApplyDesireSpec{
+				ManagementCluster: managementClusterResourceID,
+			},
+		}
+	}
+	newTestNodePoolScopedDeleteDesire := func(nodePoolName, name string) *kubeapplier.DeleteDesire {
+		resourceID := api.Must(azcorearm.ParseResourceID(
+			kubeapplier.ToNodePoolScopedDeleteDesireResourceIDString(
+				testSubscriptionID, testResourceGroupName, testClusterName, nodePoolName, name)))
+		return &kubeapplier.DeleteDesire{
+			CosmosMetadata: api.CosmosMetadata{ResourceID: resourceID},
+			Spec: kubeapplier.DeleteDesireSpec{
+				ManagementCluster: managementClusterResourceID,
+			},
+		}
+	}
+	assertNoClusterScopedKubeApplierResources := func(
+		t *testing.T,
+		ctx context.Context,
+		kubeApplierDBClients *databasetesting.MockKubeApplierDBClients,
+	) {
+		t.Helper()
+		client := kubeApplierDBClients.For(ctx, managementClusterResourceID)
+		require.NotNil(t, client)
+		clusterResourceID := api.Must(azcorearm.ParseResourceID(
+			"/subscriptions/" + testSubscriptionID +
+				"/resourceGroups/" + testResourceGroupName +
+				"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName))
+		untypedCRUD, err := client.UntypedCRUD(*clusterResourceID)
+		require.NoError(t, err)
+		iter, err := untypedCRUD.List(ctx, nil)
+		require.NoError(t, err)
+		for _, resource := range iter.Items(ctx) {
+			if resource.ResourceID != nil {
+				t.Fatalf("expected no cluster-scoped kube-applier resources, found %q", resource.ResourceID)
+			}
+		}
+		require.NoError(t, iter.GetError())
+	}
+	assertClusterScopedKubeApplierResourceExists := func(
+		t *testing.T,
+		ctx context.Context,
+		kubeApplierDBClients *databasetesting.MockKubeApplierDBClients,
+		resourceIDString string,
+	) {
+		t.Helper()
+		client := kubeApplierDBClients.For(ctx, managementClusterResourceID)
+		require.NotNil(t, client)
+		resourceID := api.Must(azcorearm.ParseResourceID(resourceIDString))
+		untypedCRUD, err := client.UntypedCRUD(*resourceID.Parent)
+		require.NoError(t, err)
+		iter, err := untypedCRUD.ListRecursive(ctx, nil)
+		require.NoError(t, err)
+		for _, resource := range iter.Items(ctx) {
+			if resource.ResourceID != nil && strings.EqualFold(resource.ResourceID.String(), resourceIDString) {
+				require.NoError(t, iter.GetError())
+				return
+			}
+		}
+		require.NoError(t, iter.GetError())
+		t.Fatalf("expected kube-applier resource %q to still exist", resourceIDString)
+	}
+
+	fixedNow := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
 	readyToDeleteClusterOptsFunc := func(c *api.HCPOpenShiftCluster) {
-		c.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
-		c.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-30 * time.Minute)}
+		c.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-time.Hour)}
+		c.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-30 * time.Minute)}
 		c.ServiceProviderProperties.ClusterServiceID = nil
 	}
 
@@ -82,17 +185,19 @@ func TestClusterChildResourcesCleanupController_SyncOnce(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name            string
-		existingCluster *api.HCPOpenShiftCluster
-		childResources  []any
-		wantErr         bool
-		verifyDB        func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient)
+		name               string
+		existingCluster    *api.HCPOpenShiftCluster
+		childResources     []any
+		kubeApplierDesires []any
+		wantErr            bool
+		verifyDB           func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, kubeApplierDBClients *databasetesting.MockKubeApplierDBClients,
+		)
 	}{
 		{
 			name:            "when no DeletionTimestamp is set performs a no-op",
 			existingCluster: newTestClusterWithNewDeletionApproach(t, nil),
-			childResources:  []any{newTestClusterScopedManagementClusterContent(t, "untouched-mcc")},
-			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+			childResources:  []any{newTestClusterScopedManagementClusterContent("untouched-mcc")},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, _ *databasetesting.MockKubeApplierDBClients) {
 				mccCRUD := db.HCPClusters(testSubscriptionID, testResourceGroupName).ManagementClusterContents(testClusterName)
 				_, err := mccCRUD.Get(ctx, "untouched-mcc")
 				require.NoError(t, err, "expected child resource to still exist")
@@ -101,12 +206,12 @@ func TestClusterChildResourcesCleanupController_SyncOnce(t *testing.T) {
 		{
 			name: "when no ClusterServiceDeletionTimestamp is set performs a no-op",
 			existingCluster: newTestClusterWithNewDeletionApproach(t, func(c *api.HCPOpenShiftCluster) {
-				c.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
+				c.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-time.Hour)}
 				c.ServiceProviderProperties.ClusterServiceDeletionTimestamp = nil
 				c.ServiceProviderProperties.ClusterServiceID = nil
 			}),
-			childResources: []any{newTestClusterScopedManagementClusterContent(t, "untouched-mcc")},
-			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+			childResources: []any{newTestClusterScopedManagementClusterContent("untouched-mcc")},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, _ *databasetesting.MockKubeApplierDBClients) {
 				mccCRUD := db.HCPClusters(testSubscriptionID, testResourceGroupName).ManagementClusterContents(testClusterName)
 				_, err := mccCRUD.Get(ctx, "untouched-mcc")
 				require.NoError(t, err, "expected child resource to still exist")
@@ -115,11 +220,11 @@ func TestClusterChildResourcesCleanupController_SyncOnce(t *testing.T) {
 		{
 			name: "when ClusterServiceID is set performs a no-op",
 			existingCluster: newTestClusterWithNewDeletionApproach(t, func(c *api.HCPOpenShiftCluster) {
-				c.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
-				c.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-30 * time.Minute)}
+				c.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-time.Hour)}
+				c.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-30 * time.Minute)}
 			}),
-			childResources: []any{newTestClusterScopedManagementClusterContent(t, "untouched-mcc")},
-			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+			childResources: []any{newTestClusterScopedManagementClusterContent("untouched-mcc")},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, _ *databasetesting.MockKubeApplierDBClients) {
 				mccCRUD := db.HCPClusters(testSubscriptionID, testResourceGroupName).ManagementClusterContents(testClusterName)
 				_, err := mccCRUD.Get(ctx, "untouched-mcc")
 				require.NoError(t, err, "expected child resource to still exist")
@@ -132,8 +237,8 @@ func TestClusterChildResourcesCleanupController_SyncOnce(t *testing.T) {
 		{
 			name:            "when there is a child resource it deletes it",
 			existingCluster: newTestClusterWithNewDeletionApproach(t, readyToDeleteClusterOptsFunc),
-			childResources:  []any{newTestClusterScopedManagementClusterContent(t, "test-mcc")},
-			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+			childResources:  []any{newTestClusterScopedManagementClusterContent("test-mcc")},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, _ *databasetesting.MockKubeApplierDBClients) {
 				mccCRUD := db.HCPClusters(testSubscriptionID, testResourceGroupName).ManagementClusterContents(testClusterName)
 				_, err := mccCRUD.Get(ctx, "test-mcc")
 				require.True(t, database.IsNotFoundError(err), "expected MCC to be deleted")
@@ -142,8 +247,8 @@ func TestClusterChildResourcesCleanupController_SyncOnce(t *testing.T) {
 		{
 			name:            "deletion of cluster controllers is skipped",
 			existingCluster: newTestClusterWithNewDeletionApproach(t, readyToDeleteClusterOptsFunc),
-			childResources:  []any{newTestClusterController(t, "test-controller")},
-			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+			childResources:  []any{newTestClusterController("test-controller")},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, _ *databasetesting.MockKubeApplierDBClients) {
 				cluster := newTestClusterWithNewDeletionApproach(t, nil)
 				untypedCRUD, err := db.UntypedCRUD(*cluster.ID)
 				require.NoError(t, err)
@@ -163,8 +268,8 @@ func TestClusterChildResourcesCleanupController_SyncOnce(t *testing.T) {
 		{
 			name:            "when there are controller and non-controller children it deletes only non-controller children",
 			existingCluster: newTestClusterWithNewDeletionApproach(t, readyToDeleteClusterOptsFunc),
-			childResources:  []any{newTestClusterScopedManagementClusterContent(t, "test-mcc"), newTestClusterController(t, "test-controller")},
-			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+			childResources:  []any{newTestClusterScopedManagementClusterContent("test-mcc"), newTestClusterController("test-controller")},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, _ *databasetesting.MockKubeApplierDBClients) {
 				cluster := newTestClusterWithNewDeletionApproach(t, nil)
 				untypedCRUD, err := db.UntypedCRUD(*cluster.ID)
 				require.NoError(t, err)
@@ -191,10 +296,65 @@ func TestClusterChildResourcesCleanupController_SyncOnce(t *testing.T) {
 			name:            "when there is a child ServiceProviderCluster without Maestro bundles it deletes it",
 			existingCluster: newTestClusterWithNewDeletionApproach(t, readyToDeleteClusterOptsFunc),
 			childResources:  []any{newTestSPC(t, nil)},
-			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, _ *databasetesting.MockKubeApplierDBClients) {
 				spcCRUD := db.ServiceProviderClusters(testSubscriptionID, testResourceGroupName, testClusterName)
 				_, err := spcCRUD.Get(ctx, api.ServiceProviderClusterResourceName)
 				require.True(t, database.IsNotFoundError(err), "expected SPC to be deleted")
+			},
+		},
+		{
+			name:            "when SPC has kube-applier desires it deletes desires then deletes SPC",
+			existingCluster: newTestClusterWithNewDeletionApproach(t, readyToDeleteClusterOptsFunc),
+			childResources: []any{
+				newTestSPCWithManagementCluster(managementClusterResourceID),
+			},
+			kubeApplierDesires: []any{newTestClusterScopedReadDesire("readonly-hostedcluster")},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, kubeApplierDBClients *databasetesting.MockKubeApplierDBClients) {
+				spcCRUD := db.ServiceProviderClusters(testSubscriptionID, testResourceGroupName, testClusterName)
+				_, err := spcCRUD.Get(ctx, api.ServiceProviderClusterResourceName)
+				require.True(t, database.IsNotFoundError(err), "expected SPC to be deleted")
+
+				assertNoClusterScopedKubeApplierResources(t, ctx, kubeApplierDBClients)
+			},
+		},
+		{
+			name:            "when cluster has cluster and nodepool scoped kube-applier resources it deletes only cluster scoped ones",
+			existingCluster: newTestClusterWithNewDeletionApproach(t, readyToDeleteClusterOptsFunc),
+			childResources: []any{
+				newTestSPCWithManagementCluster(managementClusterResourceID),
+			},
+			kubeApplierDesires: []any{
+				newTestClusterScopedReadDesire("readonly-hostedcluster"),
+				newTestClusterScopedApplyDesire("apply-example"),
+				newTestNodePoolScopedReadDesire("workers", "readonly-nodepool"),
+				newTestNodePoolScopedDeleteDesire("workers", "delete-example"),
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, kubeApplierDBClients *databasetesting.MockKubeApplierDBClients) {
+				spcCRUD := db.ServiceProviderClusters(testSubscriptionID, testResourceGroupName, testClusterName)
+				_, err := spcCRUD.Get(ctx, api.ServiceProviderClusterResourceName)
+				require.True(t, database.IsNotFoundError(err), "expected SPC to be deleted")
+
+				assertNoClusterScopedKubeApplierResources(t, ctx, kubeApplierDBClients)
+				assertClusterScopedKubeApplierResourceExists(t, ctx, kubeApplierDBClients,
+					kubeapplier.ToNodePoolScopedReadDesireResourceIDString(
+						testSubscriptionID, testResourceGroupName, testClusterName, "workers", "readonly-nodepool"))
+				assertClusterScopedKubeApplierResourceExists(t, ctx, kubeApplierDBClients,
+					kubeapplier.ToNodePoolScopedDeleteDesireResourceIDString(
+						testSubscriptionID, testResourceGroupName, testClusterName, "workers", "delete-example"))
+			},
+		},
+		{
+			name:            "when SPC has kube-applier desires but no kube-applier client it deletes SPC best-effort",
+			existingCluster: newTestClusterWithNewDeletionApproach(t, readyToDeleteClusterOptsFunc),
+			childResources: []any{
+				newTestSPCWithManagementCluster(unregisteredManagementClusterResourceID),
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, kubeApplierDBClients *databasetesting.MockKubeApplierDBClients) {
+				spcCRUD := db.ServiceProviderClusters(testSubscriptionID, testResourceGroupName, testClusterName)
+				_, err := spcCRUD.Get(ctx, api.ServiceProviderClusterResourceName)
+				require.True(t, database.IsNotFoundError(err), "expected SPC to be deleted")
+
+				require.Nil(t, kubeApplierDBClients.For(ctx, unregisteredManagementClusterResourceID))
 			},
 		},
 		{
@@ -203,7 +363,7 @@ func TestClusterChildResourcesCleanupController_SyncOnce(t *testing.T) {
 			childResources: []any{newTestSPC(t, api.MaestroBundleReferenceList{
 				{Name: "bundle-a", MaestroAPIMaestroBundleName: "name-a", MaestroAPIMaestroBundleID: "id-a"},
 			})},
-			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, _ *databasetesting.MockKubeApplierDBClients) {
 				spcCRUD := db.ServiceProviderClusters(testSubscriptionID, testResourceGroupName, testClusterName)
 				_, err := spcCRUD.Get(ctx, api.ServiceProviderClusterResourceName)
 				require.NoError(t, err, "expected SPC to still exist")
@@ -213,12 +373,12 @@ func TestClusterChildResourcesCleanupController_SyncOnce(t *testing.T) {
 			name:            "when there are children including SPC with Maestro bundles it deletes all except SPC",
 			existingCluster: newTestClusterWithNewDeletionApproach(t, readyToDeleteClusterOptsFunc),
 			childResources: []any{
-				newTestClusterScopedManagementClusterContent(t, "gate-mcc"),
+				newTestClusterScopedManagementClusterContent("gate-mcc"),
 				newTestSPC(t, api.MaestroBundleReferenceList{
 					{Name: "bundle-a", MaestroAPIMaestroBundleName: "name-a", MaestroAPIMaestroBundleID: "id-a"},
 				}),
 			},
-			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, _ *databasetesting.MockKubeApplierDBClients) {
 				mccCRUD := db.HCPClusters(testSubscriptionID, testResourceGroupName).ManagementClusterContents(testClusterName)
 				_, err := mccCRUD.Get(ctx, "gate-mcc")
 				require.True(t, database.IsNotFoundError(err), "expected MCC to be deleted")
@@ -232,7 +392,7 @@ func TestClusterChildResourcesCleanupController_SyncOnce(t *testing.T) {
 			name:            "orphaned nodepool-subtree resource is skipped",
 			existingCluster: newTestClusterWithNewDeletionApproach(t, readyToDeleteClusterOptsFunc),
 			childResources:  []any{newTestNodePoolController(t, "orphaned-np-controller")},
-			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, _ *databasetesting.MockKubeApplierDBClients) {
 				cluster := newTestClusterWithNewDeletionApproach(t, nil)
 				untypedCRUD, err := db.UntypedCRUD(*cluster.ID)
 				require.NoError(t, err)
@@ -251,7 +411,7 @@ func TestClusterChildResourcesCleanupController_SyncOnce(t *testing.T) {
 			name:            "orphaned externalauth-subtree resource is skipped",
 			existingCluster: newTestClusterWithNewDeletionApproach(t, readyToDeleteClusterOptsFunc),
 			childResources:  []any{newTestExternalAuthController(t, "orphaned-ea-controller")},
-			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, _ *databasetesting.MockKubeApplierDBClients) {
 				cluster := newTestClusterWithNewDeletionApproach(t, nil)
 				untypedCRUD, err := db.UntypedCRUD(*cluster.ID)
 				require.NoError(t, err)
@@ -269,8 +429,8 @@ func TestClusterChildResourcesCleanupController_SyncOnce(t *testing.T) {
 		{
 			name:            "deletable MCC is deleted while orphaned nodepool-subtree resource is skipped",
 			existingCluster: newTestClusterWithNewDeletionApproach(t, readyToDeleteClusterOptsFunc),
-			childResources:  []any{newTestClusterScopedManagementClusterContent(t, "test-mcc"), newTestNodePoolController(t, "orphaned-np-controller")},
-			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+			childResources:  []any{newTestClusterScopedManagementClusterContent("test-mcc"), newTestNodePoolController(t, "orphaned-np-controller")},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, _ *databasetesting.MockKubeApplierDBClients) {
 				mccCRUD := db.HCPClusters(testSubscriptionID, testResourceGroupName).ManagementClusterContents(testClusterName)
 				_, err := mccCRUD.Get(ctx, "test-mcc")
 				require.True(t, database.IsNotFoundError(err), "expected MCC to be deleted")
@@ -292,8 +452,8 @@ func TestClusterChildResourcesCleanupController_SyncOnce(t *testing.T) {
 		{
 			name:            "blocks when nodepools still exist",
 			existingCluster: newTestClusterWithNewDeletionApproach(t, readyToDeleteClusterOptsFunc),
-			childResources:  []any{newTestNodePool(t), newTestClusterScopedManagementClusterContent(t, "untouched-mcc")},
-			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+			childResources:  []any{newTestNodePool(t), newTestClusterScopedManagementClusterContent("untouched-mcc")},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, _ *databasetesting.MockKubeApplierDBClients) {
 				mccCRUD := db.HCPClusters(testSubscriptionID, testResourceGroupName).ManagementClusterContents(testClusterName)
 				_, err := mccCRUD.Get(ctx, "untouched-mcc")
 				require.NoError(t, err, "expected child resource to still exist")
@@ -302,8 +462,8 @@ func TestClusterChildResourcesCleanupController_SyncOnce(t *testing.T) {
 		{
 			name:            "blocks when external auths still exist",
 			existingCluster: newTestClusterWithNewDeletionApproach(t, readyToDeleteClusterOptsFunc),
-			childResources:  []any{newTestExternalAuth(t), newTestClusterScopedManagementClusterContent(t, "untouched-mcc")},
-			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+			childResources:  []any{newTestExternalAuth(t), newTestClusterScopedManagementClusterContent("untouched-mcc")},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, _ *databasetesting.MockKubeApplierDBClients) {
 				mccCRUD := db.HCPClusters(testSubscriptionID, testResourceGroupName).ManagementClusterContents(testClusterName)
 				_, err := mccCRUD.Get(ctx, "untouched-mcc")
 				require.NoError(t, err, "expected child resource to still exist")
@@ -312,8 +472,8 @@ func TestClusterChildResourcesCleanupController_SyncOnce(t *testing.T) {
 		{
 			name:            "UsesNewClusterDeletionApproach false -- no-op even when all cleanup conditions met and children exist",
 			existingCluster: newTestClusterWithOldDeletionApproach(t, readyToDeleteClusterOptsFunc),
-			childResources:  []any{newTestClusterScopedManagementClusterContent(t, "untouched-mcc"), newTestSPC(t, nil)},
-			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+			childResources:  []any{newTestClusterScopedManagementClusterContent("untouched-mcc"), newTestSPC(t, nil)},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, _ *databasetesting.MockKubeApplierDBClients) {
 				mccCRUD := db.HCPClusters(testSubscriptionID, testResourceGroupName).ManagementClusterContents(testClusterName)
 				_, err := mccCRUD.Get(ctx, "untouched-mcc")
 				require.NoError(t, err, "expected child resource to still exist")
@@ -342,10 +502,16 @@ func TestClusterChildResourcesCleanupController_SyncOnce(t *testing.T) {
 				clustersForLister = append(clustersForLister, tc.existingCluster)
 			}
 
+			mockKubeApplierDBClients := databasetesting.NewMockKubeApplierDBClients()
+			mockKubeApplierClient, err := databasetesting.NewMockKubeApplierDBClientWithResources(ctx, tc.kubeApplierDesires)
+			require.NoError(t, err)
+			mockKubeApplierDBClients.Register(managementClusterResourceID, mockKubeApplierClient)
+
 			syncer := &clusterChildResourcesCleanupController{
-				cooldownChecker:   &alwaysSyncCooldownChecker{},
-				clusterLister:     &listertesting.SliceClusterLister{Clusters: clustersForLister},
-				resourcesDBClient: mockResourcesDBClient,
+				cooldownChecker:      &alwaysSyncCooldownChecker{},
+				clusterLister:        &listertesting.SliceClusterLister{Clusters: clustersForLister},
+				resourcesDBClient:    mockResourcesDBClient,
+				kubeApplierDBClients: mockKubeApplierDBClients,
 			}
 
 			err = syncer.SyncOnce(ctx, testKey)
@@ -356,7 +522,7 @@ func TestClusterChildResourcesCleanupController_SyncOnce(t *testing.T) {
 			require.NoError(t, err)
 
 			if tc.verifyDB != nil {
-				tc.verifyDB(t, ctx, mockResourcesDBClient)
+				tc.verifyDB(t, ctx, mockResourcesDBClient, mockKubeApplierDBClients)
 			}
 		})
 	}

--- a/backend/pkg/controllers/clusterdeletion/cluster_child_resources_cleanup_controller_test.go
+++ b/backend/pkg/controllers/clusterdeletion/cluster_child_resources_cleanup_controller_test.go
@@ -1,0 +1,425 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusterdeletion
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+func newTestClusterScopedManagementClusterContent(t *testing.T, name string) *api.ManagementClusterContent {
+	t.Helper()
+	resourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+			"/managementClusterContents/" + name))
+	return &api.ManagementClusterContent{
+		CosmosMetadata: api.CosmosMetadata{ResourceID: resourceID},
+	}
+}
+
+func newTestClusterController(t *testing.T, name string) *api.Controller {
+	t.Helper()
+	resourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+			"/hcpOpenShiftControllers/" + name))
+	return &api.Controller{
+		CosmosMetadata: api.CosmosMetadata{ResourceID: resourceID},
+		ExternalID: api.Must(azcorearm.ParseResourceID(
+			"/subscriptions/" + testSubscriptionID +
+				"/resourceGroups/" + testResourceGroupName +
+				"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName)),
+		Status: api.ControllerStatus{
+			Conditions: []metav1.Condition{},
+		},
+	}
+}
+
+func TestClusterChildResourcesCleanupController_SyncOnce(t *testing.T) {
+	fixedClockTime := time.Now().UTC().Truncate(time.Second)
+	readyToDeleteClusterOptsFunc := func(c *api.HCPOpenShiftCluster) {
+		c.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
+		c.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-30 * time.Minute)}
+		c.ServiceProviderProperties.ClusterServiceID = nil
+	}
+
+	testKey := controllerutils.HCPClusterKey{
+		SubscriptionID:    testSubscriptionID,
+		ResourceGroupName: testResourceGroupName,
+		HCPClusterName:    testClusterName,
+	}
+
+	testCases := []struct {
+		name            string
+		existingCluster *api.HCPOpenShiftCluster
+		childResources  []any
+		wantErr         bool
+		verifyDB        func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient)
+	}{
+		{
+			name:            "when no DeletionTimestamp is set performs a no-op",
+			existingCluster: newTestClusterWithNewDeletionApproach(t, nil),
+			childResources:  []any{newTestClusterScopedManagementClusterContent(t, "untouched-mcc")},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				mccCRUD := db.HCPClusters(testSubscriptionID, testResourceGroupName).ManagementClusterContents(testClusterName)
+				_, err := mccCRUD.Get(ctx, "untouched-mcc")
+				require.NoError(t, err, "expected child resource to still exist")
+			},
+		},
+		{
+			name: "when no ClusterServiceDeletionTimestamp is set performs a no-op",
+			existingCluster: newTestClusterWithNewDeletionApproach(t, func(c *api.HCPOpenShiftCluster) {
+				c.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
+				c.ServiceProviderProperties.ClusterServiceDeletionTimestamp = nil
+				c.ServiceProviderProperties.ClusterServiceID = nil
+			}),
+			childResources: []any{newTestClusterScopedManagementClusterContent(t, "untouched-mcc")},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				mccCRUD := db.HCPClusters(testSubscriptionID, testResourceGroupName).ManagementClusterContents(testClusterName)
+				_, err := mccCRUD.Get(ctx, "untouched-mcc")
+				require.NoError(t, err, "expected child resource to still exist")
+			},
+		},
+		{
+			name: "when ClusterServiceID is set performs a no-op",
+			existingCluster: newTestClusterWithNewDeletionApproach(t, func(c *api.HCPOpenShiftCluster) {
+				c.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
+				c.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-30 * time.Minute)}
+			}),
+			childResources: []any{newTestClusterScopedManagementClusterContent(t, "untouched-mcc")},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				mccCRUD := db.HCPClusters(testSubscriptionID, testResourceGroupName).ManagementClusterContents(testClusterName)
+				_, err := mccCRUD.Get(ctx, "untouched-mcc")
+				require.NoError(t, err, "expected child resource to still exist")
+			},
+		},
+		{
+			name:            "when all conditions met and there are no children performs a no-op",
+			existingCluster: newTestClusterWithNewDeletionApproach(t, readyToDeleteClusterOptsFunc),
+		},
+		{
+			name:            "when there is a child resource it deletes it",
+			existingCluster: newTestClusterWithNewDeletionApproach(t, readyToDeleteClusterOptsFunc),
+			childResources:  []any{newTestClusterScopedManagementClusterContent(t, "test-mcc")},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				mccCRUD := db.HCPClusters(testSubscriptionID, testResourceGroupName).ManagementClusterContents(testClusterName)
+				_, err := mccCRUD.Get(ctx, "test-mcc")
+				require.True(t, database.IsNotFoundError(err), "expected MCC to be deleted")
+			},
+		},
+		{
+			name:            "deletion of cluster controllers is skipped",
+			existingCluster: newTestClusterWithNewDeletionApproach(t, readyToDeleteClusterOptsFunc),
+			childResources:  []any{newTestClusterController(t, "test-controller")},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				cluster := newTestClusterWithNewDeletionApproach(t, nil)
+				untypedCRUD, err := db.UntypedCRUD(*cluster.ID)
+				require.NoError(t, err)
+				childIterator, err := untypedCRUD.ListRecursive(ctx, nil)
+				require.NoError(t, err)
+
+				var controllerCount int
+				for _, child := range childIterator.Items(ctx) {
+					if strings.EqualFold(child.ResourceType, api.ClusterControllerResourceType.String()) {
+						controllerCount++
+					}
+				}
+				require.NoError(t, childIterator.GetError())
+				assert.Equal(t, 1, controllerCount, "expected controller child to remain")
+			},
+		},
+		{
+			name:            "when there are controller and non-controller children it deletes only non-controller children",
+			existingCluster: newTestClusterWithNewDeletionApproach(t, readyToDeleteClusterOptsFunc),
+			childResources:  []any{newTestClusterScopedManagementClusterContent(t, "test-mcc"), newTestClusterController(t, "test-controller")},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				cluster := newTestClusterWithNewDeletionApproach(t, nil)
+				untypedCRUD, err := db.UntypedCRUD(*cluster.ID)
+				require.NoError(t, err)
+				childIterator, err := untypedCRUD.ListRecursive(ctx, nil)
+				require.NoError(t, err)
+
+				var remainingCount int
+				var controllerCount int
+				for _, child := range childIterator.Items(ctx) {
+					remainingCount++
+					if strings.EqualFold(child.ResourceType, api.ClusterControllerResourceType.String()) {
+						controllerCount++
+					}
+				}
+				require.NoError(t, childIterator.GetError())
+				assert.Equal(t, 1, remainingCount, "expected only controller child to remain")
+				assert.Equal(t, 1, controllerCount, "expected the remaining child to be a controller")
+			},
+		},
+		{
+			name: "when the cluster is not found performs a no-op",
+		},
+		{
+			name:            "when there is a child ServiceProviderCluster without Maestro bundles it deletes it",
+			existingCluster: newTestClusterWithNewDeletionApproach(t, readyToDeleteClusterOptsFunc),
+			childResources:  []any{newTestSPC(t, nil)},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				spcCRUD := db.ServiceProviderClusters(testSubscriptionID, testResourceGroupName, testClusterName)
+				_, err := spcCRUD.Get(ctx, api.ServiceProviderClusterResourceName)
+				require.True(t, database.IsNotFoundError(err), "expected SPC to be deleted")
+			},
+		},
+		{
+			name:            "when there is a child ServiceProviderCluster with Maestro bundles it does not delete it",
+			existingCluster: newTestClusterWithNewDeletionApproach(t, readyToDeleteClusterOptsFunc),
+			childResources: []any{newTestSPC(t, api.MaestroBundleReferenceList{
+				{Name: "bundle-a", MaestroAPIMaestroBundleName: "name-a", MaestroAPIMaestroBundleID: "id-a"},
+			})},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				spcCRUD := db.ServiceProviderClusters(testSubscriptionID, testResourceGroupName, testClusterName)
+				_, err := spcCRUD.Get(ctx, api.ServiceProviderClusterResourceName)
+				require.NoError(t, err, "expected SPC to still exist")
+			},
+		},
+		{
+			name:            "when there are children including SPC with Maestro bundles it deletes all except SPC",
+			existingCluster: newTestClusterWithNewDeletionApproach(t, readyToDeleteClusterOptsFunc),
+			childResources: []any{
+				newTestClusterScopedManagementClusterContent(t, "gate-mcc"),
+				newTestSPC(t, api.MaestroBundleReferenceList{
+					{Name: "bundle-a", MaestroAPIMaestroBundleName: "name-a", MaestroAPIMaestroBundleID: "id-a"},
+				}),
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				mccCRUD := db.HCPClusters(testSubscriptionID, testResourceGroupName).ManagementClusterContents(testClusterName)
+				_, err := mccCRUD.Get(ctx, "gate-mcc")
+				require.True(t, database.IsNotFoundError(err), "expected MCC to be deleted")
+
+				spcCRUD := db.ServiceProviderClusters(testSubscriptionID, testResourceGroupName, testClusterName)
+				_, err = spcCRUD.Get(ctx, api.ServiceProviderClusterResourceName)
+				require.NoError(t, err, "expected SPC to still exist")
+			},
+		},
+		{
+			name:            "orphaned nodepool-subtree resource is skipped",
+			existingCluster: newTestClusterWithNewDeletionApproach(t, readyToDeleteClusterOptsFunc),
+			childResources:  []any{newTestNodePoolController(t, "orphaned-np-controller")},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				cluster := newTestClusterWithNewDeletionApproach(t, nil)
+				untypedCRUD, err := db.UntypedCRUD(*cluster.ID)
+				require.NoError(t, err)
+				childIterator, err := untypedCRUD.ListRecursive(ctx, nil)
+				require.NoError(t, err)
+
+				var remainingCount int
+				for range childIterator.Items(ctx) {
+					remainingCount++
+				}
+				require.NoError(t, childIterator.GetError())
+				assert.Equal(t, 1, remainingCount, "expected orphaned nodepool-subtree resource to remain")
+			},
+		},
+		{
+			name:            "orphaned externalauth-subtree resource is skipped",
+			existingCluster: newTestClusterWithNewDeletionApproach(t, readyToDeleteClusterOptsFunc),
+			childResources:  []any{newTestExternalAuthController(t, "orphaned-ea-controller")},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				cluster := newTestClusterWithNewDeletionApproach(t, nil)
+				untypedCRUD, err := db.UntypedCRUD(*cluster.ID)
+				require.NoError(t, err)
+				childIterator, err := untypedCRUD.ListRecursive(ctx, nil)
+				require.NoError(t, err)
+
+				var remainingCount int
+				for range childIterator.Items(ctx) {
+					remainingCount++
+				}
+				require.NoError(t, childIterator.GetError())
+				assert.Equal(t, 1, remainingCount, "expected orphaned externalauth-subtree resource to remain")
+			},
+		},
+		{
+			name:            "deletable MCC is deleted while orphaned nodepool-subtree resource is skipped",
+			existingCluster: newTestClusterWithNewDeletionApproach(t, readyToDeleteClusterOptsFunc),
+			childResources:  []any{newTestClusterScopedManagementClusterContent(t, "test-mcc"), newTestNodePoolController(t, "orphaned-np-controller")},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				mccCRUD := db.HCPClusters(testSubscriptionID, testResourceGroupName).ManagementClusterContents(testClusterName)
+				_, err := mccCRUD.Get(ctx, "test-mcc")
+				require.True(t, database.IsNotFoundError(err), "expected MCC to be deleted")
+
+				cluster := newTestClusterWithNewDeletionApproach(t, nil)
+				untypedCRUD, err := db.UntypedCRUD(*cluster.ID)
+				require.NoError(t, err)
+				childIterator, err := untypedCRUD.ListRecursive(ctx, nil)
+				require.NoError(t, err)
+
+				var remainingCount int
+				for range childIterator.Items(ctx) {
+					remainingCount++
+				}
+				require.NoError(t, childIterator.GetError())
+				assert.Equal(t, 1, remainingCount, "expected only orphaned nodepool-subtree resource to remain")
+			},
+		},
+		{
+			name:            "blocks when nodepools still exist",
+			existingCluster: newTestClusterWithNewDeletionApproach(t, readyToDeleteClusterOptsFunc),
+			childResources:  []any{newTestNodePool(t), newTestClusterScopedManagementClusterContent(t, "untouched-mcc")},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				mccCRUD := db.HCPClusters(testSubscriptionID, testResourceGroupName).ManagementClusterContents(testClusterName)
+				_, err := mccCRUD.Get(ctx, "untouched-mcc")
+				require.NoError(t, err, "expected child resource to still exist")
+			},
+		},
+		{
+			name:            "blocks when external auths still exist",
+			existingCluster: newTestClusterWithNewDeletionApproach(t, readyToDeleteClusterOptsFunc),
+			childResources:  []any{newTestExternalAuth(t), newTestClusterScopedManagementClusterContent(t, "untouched-mcc")},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				mccCRUD := db.HCPClusters(testSubscriptionID, testResourceGroupName).ManagementClusterContents(testClusterName)
+				_, err := mccCRUD.Get(ctx, "untouched-mcc")
+				require.NoError(t, err, "expected child resource to still exist")
+			},
+		},
+		{
+			name:            "UsesNewClusterDeletionApproach false -- no-op even when all cleanup conditions met and children exist",
+			existingCluster: newTestClusterWithOldDeletionApproach(t, readyToDeleteClusterOptsFunc),
+			childResources:  []any{newTestClusterScopedManagementClusterContent(t, "untouched-mcc"), newTestSPC(t, nil)},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				mccCRUD := db.HCPClusters(testSubscriptionID, testResourceGroupName).ManagementClusterContents(testClusterName)
+				_, err := mccCRUD.Get(ctx, "untouched-mcc")
+				require.NoError(t, err, "expected child resource to still exist")
+
+				spcCRUD := db.ServiceProviderClusters(testSubscriptionID, testResourceGroupName, testClusterName)
+				_, err = spcCRUD.Get(ctx, api.ServiceProviderClusterResourceName)
+				require.NoError(t, err, "expected SPC to still exist")
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+
+			resources := []any{}
+			if tc.existingCluster != nil {
+				resources = append(resources, tc.existingCluster)
+			}
+			resources = append(resources, tc.childResources...)
+			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, resources)
+			require.NoError(t, err)
+
+			clustersForLister := []*api.HCPOpenShiftCluster{}
+			if tc.existingCluster != nil {
+				clustersForLister = append(clustersForLister, tc.existingCluster)
+			}
+
+			syncer := &clusterChildResourcesCleanupController{
+				cooldownChecker:   &alwaysSyncCooldownChecker{},
+				clusterLister:     &listertesting.SliceClusterLister{Clusters: clustersForLister},
+				resourcesDBClient: mockResourcesDBClient,
+			}
+
+			err = syncer.SyncOnce(ctx, testKey)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			if tc.verifyDB != nil {
+				tc.verifyDB(t, ctx, mockResourcesDBClient)
+			}
+		})
+	}
+}
+
+func TestIsUnderSkippedSubtree(t *testing.T) {
+	skipSubtreeTypes := []azcorearm.ResourceType{
+		api.NodePoolResourceType,
+		api.ExternalAuthResourceType,
+	}
+
+	testCases := []struct {
+		name       string
+		resourceID string
+		want       bool
+	}{
+		{
+			name:       "cluster itself is not under a skipped subtree",
+			resourceID: "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster",
+			want:       false,
+		},
+		{
+			name:       "service provider cluster is not under a skipped subtree",
+			resourceID: "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster/serviceProviderClusters/default",
+			want:       false,
+		},
+		{
+			name:       "cluster controller is not under a skipped subtree",
+			resourceID: "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster/controllers/SomeController",
+			want:       false,
+		},
+		{
+			name:       "nodepool is under a skipped subtree",
+			resourceID: "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster/nodePools/np1",
+			want:       true,
+		},
+		{
+			name:       "service provider nodepool is a descendant of a skipped subtree",
+			resourceID: "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster/nodePools/np1/serviceProviderNodePools/default",
+			want:       true,
+		},
+		{
+			name:       "nodepool controller is a descendant of a skipped subtree",
+			resourceID: "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster/nodePools/np1/controllers/SomeController",
+			want:       true,
+		},
+		{
+			name:       "externalauth is under a skipped subtree",
+			resourceID: "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster/externalAuths/auth1",
+			want:       true,
+		},
+		{
+			name:       "externalauth controller is a descendant of a skipped subtree",
+			resourceID: "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster/externalAuths/auth1/controllers/SomeController",
+			want:       true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resourceID := api.Must(azcorearm.ParseResourceID(tc.resourceID))
+			got := hasSkippedResourceTypePrefix(resourceID, skipSubtreeTypes)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/backend/pkg/controllers/clusterdeletion/cluster_cluster_service_delete_dispatch_controller.go
+++ b/backend/pkg/controllers/clusterdeletion/cluster_cluster_service_delete_dispatch_controller.go
@@ -1,0 +1,200 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusterdeletion
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilsclock "k8s.io/utils/clock"
+	"k8s.io/utils/lru"
+
+	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/internal/api"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// missingClusterServiceIDTimeout is how long we wait after first observing
+// DeletionTimestamp for the ClusterServiceID to appear before concluding
+// that the corresponding Cluster Service Cluster was never created and we have
+// no work to do (or before treating a 404 from Cluster Service as definitive).
+const missingClusterServiceIDTimeout = 120 * time.Second
+
+// clusterClusterServiceDeleteDispatchSyncer issues a Cluster Service delete for any
+// Cluster whose DeletionTimestamp has been set. The frontend records the
+// timestamp on the Cluster when DeleteCluster is invoked, this controller
+// picks it up and calls Cluster Service out-of-band so the frontend never has
+// to block on it. Once the controller has issued the delete (or given up
+// waiting for a ClusterServiceID), it stamps ClusterServiceDeletionTimestamp
+// on the Cluster to record that this step is complete and avoid re-issuing
+// the delete on subsequent syncs.
+type clusterClusterServiceDeleteDispatchSyncer struct {
+	clock                utilsclock.PassiveClock
+	cooldownChecker      controllerutil.CooldownChecker
+	clusterLister        listers.ClusterLister
+	resourcesDBClient    database.ResourcesDBClient
+	clusterServiceClient ocm.ClusterServiceClientSpec
+	// firstSeenDeletionTimestampCache is a cache that contains the time the controller
+	// has first seen the serviceProviderProperties.deletionTimestamp being set
+	// for a cluster. The cache key is the lowercased cluster's resource ID and
+	// the value is a time.Time in UTC indicating the first seen deletion timestamp.
+	firstSeenDeletionTimestampCache *lru.Cache
+}
+
+var _ controllerutils.ClusterSyncer = (*clusterClusterServiceDeleteDispatchSyncer)(nil)
+
+func NewClusterClusterServiceDeleteDispatchController(
+	clock utilsclock.PassiveClock,
+	resourcesDBClient database.ResourcesDBClient,
+	clusterServiceClient ocm.ClusterServiceClientSpec,
+	activeOperationLister listers.ActiveOperationLister,
+	informers informers.BackendInformers,
+) controllerutils.Controller {
+	_, clusterLister := informers.Clusters()
+	syncer := &clusterClusterServiceDeleteDispatchSyncer{
+		clock:                           clock,
+		cooldownChecker:                 controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		clusterLister:                   clusterLister,
+		resourcesDBClient:               resourcesDBClient,
+		clusterServiceClient:            clusterServiceClient,
+		firstSeenDeletionTimestampCache: lru.New(50000),
+	}
+
+	return controllerutils.NewClusterWatchingController(
+		"ClusterClusterServiceDeleteDispatch",
+		resourcesDBClient,
+		informers,
+		nil, // no kubeApplierInformers needed for deletion
+		time.Minute,
+		syncer,
+	)
+}
+
+func (c *clusterClusterServiceDeleteDispatchSyncer) CooldownChecker() controllerutil.CooldownChecker {
+	return c.cooldownChecker
+}
+
+// NeedsWork reports whether the deleter has unfinished business for the given
+// Cluster: DeletionTimestamp must be set and ClusterServiceDeletionTimestamp
+// must not yet be set.
+func (c *clusterClusterServiceDeleteDispatchSyncer) NeedsWork(cluster *api.HCPOpenShiftCluster) bool {
+	// TODO temporary check to skip the new deletion approach for Clusters that were created before the new approach was implemented.
+	// This will be removed once all clusters whose deletion was triggered before the new approach is fully rolled out have been
+	// fully deleted in all ARO-HCP permanent environments, for all regions.
+	if !cluster.ServiceProviderProperties.UsesNewClusterDeletionApproach {
+		return false
+	}
+
+	return cluster.ServiceProviderProperties.DeletionTimestamp != nil &&
+		cluster.ServiceProviderProperties.ClusterServiceDeletionTimestamp == nil
+}
+
+// SyncOnce calls Cluster Service to delete the Cluster when its DeletionTimestamp is set.
+
+// If the Cluster has no ClusterServiceID yet, we may have raced cluster-service Cluster
+// creation. We wait for missingClusterServiceIDTimeout from when we first observed
+// DeletionTimestamp before concluding the cluster-service Cluster was never created.
+//
+// In either terminal case - CS delete issued or wait abandoned - we stamp
+// ClusterServiceDeletionTimestamp so the next sync short-circuits.
+func (c *clusterClusterServiceDeleteDispatchSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPClusterKey) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	cachedCluster, err := c.clusterLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get cluster from cache: %w", err))
+	}
+	if !c.NeedsWork(cachedCluster) {
+		return nil
+	}
+
+	// Confirm against the live document.
+	clusterCRUD := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName)
+	cluster, err := clusterCRUD.Get(ctx, key.HCPClusterName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get cluster: %w", err))
+	}
+	if !c.NeedsWork(cluster) {
+		return nil
+	}
+
+	clusterDeletionTimestamp := cluster.ServiceProviderProperties.DeletionTimestamp.Time
+	cacheKey := strings.ToLower(cluster.ID.String())
+	var firstSeenClusterDeletionTimestamp time.Time
+	firstSeenEntry, ok := c.firstSeenDeletionTimestampCache.Get(cacheKey)
+	if ok {
+		firstSeenClusterDeletionTimestamp = firstSeenEntry.(time.Time)
+	} else {
+		firstSeenClusterDeletionTimestamp = c.clock.Now().UTC()
+		c.firstSeenDeletionTimestampCache.Add(cacheKey, firstSeenClusterDeletionTimestamp)
+	}
+
+	csID := cluster.ServiceProviderProperties.ClusterServiceID
+	if csID == nil || len(csID.String()) == 0 {
+		elapsed := c.clock.Since(firstSeenClusterDeletionTimestamp)
+		if elapsed < missingClusterServiceIDTimeout {
+			// The frontend may still be in the middle of creating the cluster-service
+			// Cluster, or the controller that does so hasn't run yet. Re-check on the
+			// next sync. The resync interval and informer change events drive retries.
+			return nil
+		}
+		logger.Info("giving up on cluster-service Cluster delete - ClusterServiceID never appeared",
+			"clusterDeletionTimestamp", clusterDeletionTimestamp, "clusterFirstSeenDeletionTimestamp", firstSeenClusterDeletionTimestamp)
+	} else if err := c.clusterServiceClient.DeleteCluster(ctx, *csID); err != nil {
+		var ocmError *ocmerrors.Error
+
+		switch {
+		case errors.As(err, &ocmError) && ocmError.Status() == http.StatusNotFound:
+			// OCM error 404 - could be a stale CSID or a race against an in-flight CS
+			// create. Wait before treating the Cluster as definitively gone
+			elapsed := c.clock.Since(firstSeenClusterDeletionTimestamp)
+			if elapsed < missingClusterServiceIDTimeout {
+				return nil
+			}
+			logger.Info("cluster-service Cluster already deleted or race against in-flight CS create", "clusterServiceID", csID.String())
+		default:
+			return utils.TrackError(fmt.Errorf("failed to delete cluster-service Cluster: %w", err))
+		}
+	} else {
+		logger.Info("requested cluster-service Cluster delete", "clusterServiceID", csID.String())
+	}
+
+	cluster.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: c.clock.Now().UTC()}
+	_, err = clusterCRUD.Replace(ctx, cluster, nil)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to stamp ClusterServiceDeletionTimestamp: %w", err))
+	}
+	c.firstSeenDeletionTimestampCache.Remove(cacheKey)
+
+	return nil
+}

--- a/backend/pkg/controllers/clusterdeletion/cluster_cluster_service_delete_dispatch_controller_test.go
+++ b/backend/pkg/controllers/clusterdeletion/cluster_cluster_service_delete_dispatch_controller_test.go
@@ -1,0 +1,415 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusterdeletion
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clocktesting "k8s.io/utils/clock/testing"
+	"k8s.io/utils/lru"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+const (
+	testSubscriptionID      = "00000000-0000-0000-0000-000000000000"
+	testResourceGroupName   = "test-rg"
+	testClusterName         = "test-cluster"
+	testClusterServiceIDStr = "/api/aro_hcp/v1alpha1/clusters/abc123"
+)
+
+type alwaysSyncCooldownChecker struct{}
+
+func (c *alwaysSyncCooldownChecker) CanSync(ctx context.Context, key any) bool {
+	return true
+}
+
+func fakeOCMNotFoundError() error {
+	e, _ := ocmerrors.NewError().Status(http.StatusNotFound).Reason("not found").Build()
+	return e
+}
+
+func newTestClusterWithNewDeletionApproach(t *testing.T, opts func(*api.HCPOpenShiftCluster)) *api.HCPOpenShiftCluster {
+	t.Helper()
+	resourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName))
+	clusterInternalID := api.Ptr(api.Must(api.NewInternalID(testClusterServiceIDStr)))
+	cluster := &api.HCPOpenShiftCluster{
+		TrackedResource: arm.TrackedResource{
+			Resource: arm.Resource{
+				ID:   resourceID,
+				Name: testClusterName,
+				Type: api.ClusterResourceType.String(),
+			},
+			Location: "eastus",
+		},
+		CosmosMetadata: arm.CosmosMetadata{ResourceID: resourceID},
+		ServiceProviderProperties: api.HCPOpenShiftClusterServiceProviderProperties{
+			ClusterServiceID:               clusterInternalID,
+			UsesNewClusterDeletionApproach: true,
+		},
+	}
+	if opts != nil {
+		opts(cluster)
+	}
+	return cluster
+}
+
+func newTestClusterWithOldDeletionApproach(t *testing.T, opts func(*api.HCPOpenShiftCluster)) *api.HCPOpenShiftCluster {
+	cluster := newTestClusterWithNewDeletionApproach(t, opts)
+	cluster.ServiceProviderProperties.UsesNewClusterDeletionApproach = false
+	return cluster
+}
+
+func TestClusterClusterServiceDeleteDispatchSyncer_SyncOnce(t *testing.T) {
+	fixedClockTime := time.Now().UTC().Truncate(time.Second)
+
+	testKey := controllerutils.HCPClusterKey{
+		SubscriptionID:    testSubscriptionID,
+		ResourceGroupName: testResourceGroupName,
+		HCPClusterName:    testClusterName,
+	}
+
+	verifyClusterServiceDeletionTimestampIsNil := func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+		t.Helper()
+		stored, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
+		require.NoError(t, err)
+		assert.Nil(t, stored.ServiceProviderProperties.ClusterServiceDeletionTimestamp)
+	}
+
+	verifyClusterServiceDeletionTimestampStamped := func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+		t.Helper()
+		stored, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
+		require.NoError(t, err)
+		require.NotNil(t, stored.ServiceProviderProperties.ClusterServiceDeletionTimestamp, "expected ClusterServiceDeletionTimestamp to be stamped")
+		assert.True(t, stored.ServiceProviderProperties.ClusterServiceDeletionTimestamp.Time.Equal(fixedClockTime),
+			"expected ClusterServiceDeletionTimestamp to equal fixedClockTime, got %v", stored.ServiceProviderProperties.ClusterServiceDeletionTimestamp.Time)
+	}
+
+	testCases := []struct {
+		name                string
+		existingCluster     *api.HCPOpenShiftCluster
+		firstSeenDeletionAt time.Time
+		setupMockCSClient   func(mock *ocm.MockClusterServiceClientSpec)
+		wantErr             bool
+		wantErrContain      string
+		verifyDB            func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient)
+	}{
+		{
+			name:            "when no DeletionTimestamp no-op is performed",
+			existingCluster: newTestClusterWithNewDeletionApproach(t, nil),
+			verifyDB:        verifyClusterServiceDeletionTimestampIsNil,
+		},
+		{
+			name: "when ClusterServiceDeletionTimestamp is set no-op is performed",
+			existingCluster: newTestClusterWithNewDeletionApproach(t, func(c *api.HCPOpenShiftCluster) {
+				c.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
+				c.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-30 * time.Minute)}
+			}),
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				stored, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
+				require.NoError(t, err)
+				require.NotNil(t, stored.ServiceProviderProperties.ClusterServiceDeletionTimestamp)
+				assert.True(t, stored.ServiceProviderProperties.ClusterServiceDeletionTimestamp.Time.Equal(fixedClockTime.Add(-30*time.Minute)),
+					"expected ClusterServiceDeletionTimestamp unchanged")
+			},
+		},
+		{
+			name: "when ClusterServiceID is not set and deletion is first observed then first seen is recorded and no-op is performed",
+			existingCluster: newTestClusterWithNewDeletionApproach(t, func(c *api.HCPOpenShiftCluster) {
+				c.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
+				c.ServiceProviderProperties.ClusterServiceID = nil
+			}),
+			verifyDB: verifyClusterServiceDeletionTimestampIsNil,
+		},
+		{
+			name: "when ClusterServiceID is not set and first seen within timeout no-op is performed",
+			existingCluster: newTestClusterWithNewDeletionApproach(t, func(c *api.HCPOpenShiftCluster) {
+				c.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
+				c.ServiceProviderProperties.ClusterServiceID = nil
+			}),
+			firstSeenDeletionAt: fixedClockTime.Add(-missingClusterServiceIDTimeout / 2),
+			verifyDB:            verifyClusterServiceDeletionTimestampIsNil,
+		},
+		{
+			name: "when ClusterServiceID is not set and first seen older than timeout then we give up and stamp",
+			existingCluster: newTestClusterWithNewDeletionApproach(t, func(c *api.HCPOpenShiftCluster) {
+				c.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
+				c.ServiceProviderProperties.ClusterServiceID = nil
+			}),
+			firstSeenDeletionAt: fixedClockTime.Add(-missingClusterServiceIDTimeout - time.Second),
+			verifyDB:            verifyClusterServiceDeletionTimestampStamped,
+		},
+		{
+			name: "when ClusterServiceID is set we trigger CS cluster deletion and stamp",
+			existingCluster: newTestClusterWithNewDeletionApproach(t, func(c *api.HCPOpenShiftCluster) {
+				c.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Minute)}
+			}),
+			firstSeenDeletionAt: fixedClockTime.Add(-missingClusterServiceIDTimeout / 2),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					DeleteCluster(gomock.Any(), api.Must(api.NewInternalID(testClusterServiceIDStr))).
+					Return(nil)
+			},
+			verifyDB: verifyClusterServiceDeletionTimestampStamped,
+		},
+		{
+			name: "when CS cluster deletion returns 404 within timeout no-op is performed",
+			existingCluster: newTestClusterWithNewDeletionApproach(t, func(c *api.HCPOpenShiftCluster) {
+				c.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
+			}),
+			firstSeenDeletionAt: fixedClockTime.Add(-missingClusterServiceIDTimeout / 2),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					DeleteCluster(gomock.Any(), api.Must(api.NewInternalID(testClusterServiceIDStr))).
+					Return(fakeOCMNotFoundError())
+			},
+			verifyDB: verifyClusterServiceDeletionTimestampIsNil,
+		},
+		{
+			name: "when CS cluster deletion returns 404 past timeout then we stamp",
+			existingCluster: newTestClusterWithNewDeletionApproach(t, func(c *api.HCPOpenShiftCluster) {
+				c.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
+			}),
+			firstSeenDeletionAt: fixedClockTime.Add(-missingClusterServiceIDTimeout - time.Second),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					DeleteCluster(gomock.Any(), api.Must(api.NewInternalID(testClusterServiceIDStr))).
+					Return(fakeOCMNotFoundError())
+			},
+			verifyDB: verifyClusterServiceDeletionTimestampStamped,
+		},
+		{
+			name: "when CS cluster deletion returns unhandled error we propagate it",
+			existingCluster: newTestClusterWithNewDeletionApproach(t, func(c *api.HCPOpenShiftCluster) {
+				c.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Minute)}
+			}),
+			firstSeenDeletionAt: fixedClockTime.Add(-missingClusterServiceIDTimeout / 2),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					DeleteCluster(gomock.Any(), api.Must(api.NewInternalID(testClusterServiceIDStr))).
+					Return(errors.New("boom"))
+			},
+			wantErr:        true,
+			wantErrContain: "failed to delete cluster-service Cluster",
+		},
+		{
+			name: "UsesNewClusterDeletionApproach false -- no-op even when DeletionTimestamp is set",
+			existingCluster: newTestClusterWithOldDeletionApproach(t, func(c *api.HCPOpenShiftCluster) {
+				c.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Minute)}
+			}),
+			verifyDB: verifyClusterServiceDeletionTimestampIsNil,
+		},
+		{
+			name: "cluster not found no-op is performed",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+			ctrl := gomock.NewController(t)
+
+			resources := []any{}
+			if tc.existingCluster != nil {
+				resources = append(resources, tc.existingCluster)
+			}
+			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, resources)
+			require.NoError(t, err)
+
+			mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
+			if tc.setupMockCSClient != nil {
+				tc.setupMockCSClient(mockCSClient)
+			}
+
+			clustersForLister := []*api.HCPOpenShiftCluster{}
+			if tc.existingCluster != nil {
+				clustersForLister = append(clustersForLister, tc.existingCluster)
+			}
+
+			firstSeenDeletionTimestampCache := lru.New(10)
+			if !tc.firstSeenDeletionAt.IsZero() {
+				firstSeenDeletionTimestampCache.Add(
+					strings.ToLower(tc.existingCluster.ID.String()),
+					tc.firstSeenDeletionAt,
+				)
+			}
+
+			syncer := &clusterClusterServiceDeleteDispatchSyncer{
+				clock:                           clocktesting.NewFakePassiveClock(fixedClockTime),
+				cooldownChecker:                 &alwaysSyncCooldownChecker{},
+				clusterLister:                   &listertesting.SliceClusterLister{Clusters: clustersForLister},
+				resourcesDBClient:               mockResourcesDBClient,
+				clusterServiceClient:            mockCSClient,
+				firstSeenDeletionTimestampCache: firstSeenDeletionTimestampCache,
+			}
+
+			err = syncer.SyncOnce(ctx, testKey)
+			if tc.wantErr {
+				require.Error(t, err)
+				if len(tc.wantErrContain) > 0 {
+					require.ErrorContains(t, err, tc.wantErrContain)
+				}
+				return
+			}
+			require.NoError(t, err)
+
+			if tc.verifyDB != nil {
+				tc.verifyDB(t, ctx, mockResourcesDBClient)
+			}
+		})
+	}
+}
+
+func TestClusterClusterServiceDeleteDispatchSyncer_SyncOnce_cacheShortCircuit(t *testing.T) {
+	fixedClockTime := time.Now().UTC().Truncate(time.Second)
+	ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+	ctrl := gomock.NewController(t)
+
+	clusterInDB := newTestClusterWithNewDeletionApproach(t, func(c *api.HCPOpenShiftCluster) {
+		c.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
+	})
+	mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, []any{clusterInDB})
+	require.NoError(t, err)
+
+	// Here the cached cluster does not have a DeletionTimestamp set, so the syncer will short-circuit.
+	cachedCluster := newTestClusterWithNewDeletionApproach(t, nil)
+
+	syncer := &clusterClusterServiceDeleteDispatchSyncer{
+		clock:                           clocktesting.NewFakePassiveClock(fixedClockTime),
+		cooldownChecker:                 &alwaysSyncCooldownChecker{},
+		clusterLister:                   &listertesting.SliceClusterLister{Clusters: []*api.HCPOpenShiftCluster{cachedCluster}},
+		resourcesDBClient:               mockResourcesDBClient,
+		clusterServiceClient:            ocm.NewMockClusterServiceClientSpec(ctrl),
+		firstSeenDeletionTimestampCache: lru.New(10),
+	}
+
+	testKey := controllerutils.HCPClusterKey{
+		SubscriptionID:    testSubscriptionID,
+		ResourceGroupName: testResourceGroupName,
+		HCPClusterName:    testClusterName,
+	}
+
+	require.NoError(t, syncer.SyncOnce(ctx, testKey))
+
+	stored, err := mockResourcesDBClient.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
+	require.NoError(t, err)
+	assert.Nil(t, stored.ServiceProviderProperties.ClusterServiceDeletionTimestamp)
+}
+
+func TestClusterClusterServiceDeleteDispatchSyncer_SyncOnce_firstSeenDeletionCachePopulation(t *testing.T) {
+	fixedClockTime := time.Now().UTC().Truncate(time.Second)
+	ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+	ctrl := gomock.NewController(t)
+
+	cluster := newTestClusterWithNewDeletionApproach(t, func(c *api.HCPOpenShiftCluster) {
+		c.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
+		c.ServiceProviderProperties.ClusterServiceID = nil
+	})
+	mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, []any{cluster})
+	require.NoError(t, err)
+
+	firstSeenDeletionTimestampCache := lru.New(10)
+	syncer := &clusterClusterServiceDeleteDispatchSyncer{
+		clock:                           clocktesting.NewFakePassiveClock(fixedClockTime),
+		cooldownChecker:                 &alwaysSyncCooldownChecker{},
+		clusterLister:                   &listertesting.SliceClusterLister{Clusters: []*api.HCPOpenShiftCluster{cluster}},
+		resourcesDBClient:               mockResourcesDBClient,
+		clusterServiceClient:            ocm.NewMockClusterServiceClientSpec(ctrl),
+		firstSeenDeletionTimestampCache: firstSeenDeletionTimestampCache,
+	}
+
+	testKey := controllerutils.HCPClusterKey{
+		SubscriptionID:    testSubscriptionID,
+		ResourceGroupName: testResourceGroupName,
+		HCPClusterName:    testClusterName,
+	}
+
+	require.NoError(t, syncer.SyncOnce(ctx, testKey))
+
+	cacheKey := strings.ToLower(cluster.ID.String())
+	firstSeenEntry, ok := firstSeenDeletionTimestampCache.Get(cacheKey)
+	require.True(t, ok, "expected first seen deletion timestamp to be cached")
+	assert.True(t, firstSeenEntry.(time.Time).Equal(fixedClockTime))
+}
+
+func TestClusterClusterServiceDeleteDispatchSyncer_SyncOnce_firstSeenDeletionCacheCleared(t *testing.T) {
+	fixedClockTime := time.Now().UTC().Truncate(time.Second)
+	ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+	ctrl := gomock.NewController(t)
+
+	cluster := newTestClusterWithNewDeletionApproach(t, func(c *api.HCPOpenShiftCluster) {
+		c.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Minute)}
+	})
+	mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, []any{cluster})
+	require.NoError(t, err)
+
+	cacheKey := strings.ToLower(cluster.ID.String())
+	firstSeenDeletionTimestampCache := lru.New(10)
+	firstSeenDeletionTimestampCache.Add(cacheKey, fixedClockTime.Add(-missingClusterServiceIDTimeout/2))
+
+	mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
+	mockCSClient.EXPECT().
+		DeleteCluster(gomock.Any(), api.Must(api.NewInternalID(testClusterServiceIDStr))).
+		Return(nil)
+
+	syncer := &clusterClusterServiceDeleteDispatchSyncer{
+		clock:                           clocktesting.NewFakePassiveClock(fixedClockTime),
+		cooldownChecker:                 &alwaysSyncCooldownChecker{},
+		clusterLister:                   &listertesting.SliceClusterLister{Clusters: []*api.HCPOpenShiftCluster{cluster}},
+		resourcesDBClient:               mockResourcesDBClient,
+		clusterServiceClient:            mockCSClient,
+		firstSeenDeletionTimestampCache: firstSeenDeletionTimestampCache,
+	}
+
+	testKey := controllerutils.HCPClusterKey{
+		SubscriptionID:    testSubscriptionID,
+		ResourceGroupName: testResourceGroupName,
+		HCPClusterName:    testClusterName,
+	}
+
+	require.NoError(t, syncer.SyncOnce(ctx, testKey))
+
+	_, ok := firstSeenDeletionTimestampCache.Get(cacheKey)
+	assert.False(t, ok, "expected first seen deletion cache entry to be removed after terminal sync")
+
+	stored, err := mockResourcesDBClient.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
+	require.NoError(t, err)
+	require.NotNil(t, stored.ServiceProviderProperties.ClusterServiceDeletionTimestamp)
+	assert.True(t, stored.ServiceProviderProperties.ClusterServiceDeletionTimestamp.Time.Equal(fixedClockTime))
+}

--- a/backend/pkg/controllers/clusterdeletion/cluster_cluster_service_id_clearer.go
+++ b/backend/pkg/controllers/clusterdeletion/cluster_cluster_service_id_clearer.go
@@ -1,0 +1,142 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusterdeletion
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/internal/api"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// clusterClusterServiceIDClearer clears ClusterServiceID after the
+// cluster-service Cluster itself has been confirmed gone. This runs after the
+// delete dispatch controller has already issued the delete request
+// (ClusterServiceDeletionTimestamp is set). We poll cluster-service for the
+// Cluster and, on 404, zero out the stored ClusterServiceID so downstream
+// code knows the CS resource is fully gone.
+type clusterClusterServiceIDClearer struct {
+	cooldownChecker      controllerutil.CooldownChecker
+	clusterLister        listers.ClusterLister
+	resourcesDBClient    database.ResourcesDBClient
+	clusterServiceClient ocm.ClusterServiceClientSpec
+}
+
+var _ controllerutils.ClusterSyncer = (*clusterClusterServiceIDClearer)(nil)
+
+func NewClusterClusterServiceIDClearerController(
+	resourcesDBClient database.ResourcesDBClient,
+	clusterServiceClient ocm.ClusterServiceClientSpec,
+	activeOperationLister listers.ActiveOperationLister,
+	informers informers.BackendInformers,
+) controllerutils.Controller {
+	_, clusterLister := informers.Clusters()
+	syncer := &clusterClusterServiceIDClearer{
+		cooldownChecker:      controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		clusterLister:        clusterLister,
+		resourcesDBClient:    resourcesDBClient,
+		clusterServiceClient: clusterServiceClient,
+	}
+
+	return controllerutils.NewClusterWatchingController(
+		"ClusterDeletionClusterServiceIDClearer",
+		resourcesDBClient,
+		informers,
+		nil,
+		time.Minute,
+		syncer,
+	)
+}
+
+func (c *clusterClusterServiceIDClearer) CooldownChecker() controllerutil.CooldownChecker {
+	return c.cooldownChecker
+}
+
+// NeedsWork reports whether this controller has unfinished business for the
+// given Cluster: deletion has been started (DeletionTimestamp), the deleter
+// has already issued the CS delete (ClusterServiceDeletionTimestamp), and a
+// ClusterServiceID is still recorded that needs verification before clearing.
+func (c *clusterClusterServiceIDClearer) NeedsWork(cluster *api.HCPOpenShiftCluster) bool {
+	// TODO temporary check to skip the new deletion approach for Clusters that were created before the new approach was implemented.
+	// This will be removed once all clusters whose deletion was triggered before the new approach is fully rolled out have been
+	// fully deleted in all ARO-HCP permanent environments, for all regions.
+	if !cluster.ServiceProviderProperties.UsesNewClusterDeletionApproach {
+		return false
+	}
+
+	return cluster.ServiceProviderProperties.DeletionTimestamp != nil &&
+		cluster.ServiceProviderProperties.ClusterServiceDeletionTimestamp != nil &&
+		cluster.ServiceProviderProperties.ClusterServiceID != nil && len(cluster.ServiceProviderProperties.ClusterServiceID.String()) > 0
+}
+
+// SyncOnce reads the Cluster from cluster-service. If cluster-service reports
+// 404, the deletion has finished and we zero out ClusterServiceID.
+func (c *clusterClusterServiceIDClearer) SyncOnce(ctx context.Context, key controllerutils.HCPClusterKey) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	cachedCluster, err := c.clusterLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get cluster from cache: %w", err))
+	}
+	if !c.NeedsWork(cachedCluster) {
+		return nil
+	}
+
+	clusterCRUD := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName)
+	cluster, err := clusterCRUD.Get(ctx, key.HCPClusterName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get cluster: %w", err))
+	}
+	if !c.NeedsWork(cluster) {
+		return nil
+	}
+
+	csID := cluster.ServiceProviderProperties.ClusterServiceID
+	_, err = c.clusterServiceClient.GetClusterStatus(ctx, *csID)
+	if err != nil {
+		var ocmError *ocmerrors.Error
+		if !errors.As(err, &ocmError) || ocmError.Status() != http.StatusNotFound {
+			return utils.TrackError(fmt.Errorf("failed to get cluster-service Cluster: %w", err))
+		}
+		// 404 - cluster-service has finished deleting the Cluster, clear the CS ID.
+		logger.Info("cluster-service Cluster gone. Clearing ClusterServiceID", "clusterServiceID", csID.String())
+		cluster.ServiceProviderProperties.ClusterServiceID = nil
+		if _, err := clusterCRUD.Replace(ctx, cluster, nil); err != nil {
+			return utils.TrackError(fmt.Errorf("failed to clear ClusterServiceID: %w", err))
+		}
+		return nil
+	}
+
+	// Cluster still exists in cluster-service. Nothing to do yet.
+	return nil
+}

--- a/backend/pkg/controllers/clusterdeletion/cluster_cluster_service_id_clearer_test.go
+++ b/backend/pkg/controllers/clusterdeletion/cluster_cluster_service_id_clearer_test.go
@@ -1,0 +1,182 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusterdeletion
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+func TestClusterClusterServiceIDClearer_SyncOnce(t *testing.T) {
+	fixedClockTime := time.Now().UTC().Truncate(time.Second)
+
+	testKey := controllerutils.HCPClusterKey{
+		SubscriptionID:    testSubscriptionID,
+		ResourceGroupName: testResourceGroupName,
+		HCPClusterName:    testClusterName,
+	}
+
+	withDeletionStampsClusterOptsFunc := func(c *api.HCPOpenShiftCluster) {
+		c.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
+		c.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-30 * time.Minute)}
+	}
+
+	verifyClusterServiceIDUnchanged := func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+		t.Helper()
+		stored, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
+		require.NoError(t, err)
+		require.NotNil(t, stored.ServiceProviderProperties.ClusterServiceID, "ClusterServiceID should not be nil")
+		assert.Equal(t, testClusterServiceIDStr, stored.ServiceProviderProperties.ClusterServiceID.String(),
+			"ClusterServiceID should be unchanged")
+	}
+
+	testCases := []struct {
+		name              string
+		existingCluster   *api.HCPOpenShiftCluster
+		setupMockCSClient func(mock *ocm.MockClusterServiceClientSpec)
+		wantErr           bool
+		wantErrContain    string
+		verifyDB          func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient)
+	}{
+		{
+			name:            "when CS returns 404 ClusterServiceID is cleared",
+			existingCluster: newTestClusterWithNewDeletionApproach(t, withDeletionStampsClusterOptsFunc),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetClusterStatus(gomock.Any(), api.Must(api.NewInternalID(testClusterServiceIDStr))).
+					Return(nil, fakeOCMNotFoundError())
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				stored, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
+				require.NoError(t, err)
+				assert.Nil(t, stored.ServiceProviderProperties.ClusterServiceID)
+			},
+		},
+		{
+			name:            "when CS returns cluster still exists no-op is performed",
+			existingCluster: newTestClusterWithNewDeletionApproach(t, withDeletionStampsClusterOptsFunc),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetClusterStatus(gomock.Any(), api.Must(api.NewInternalID(testClusterServiceIDStr))).
+					Return(nil, nil)
+			},
+			verifyDB: verifyClusterServiceIDUnchanged,
+		},
+		{
+			name:            "feature flag false -- no-op even with all timestamps set",
+			existingCluster: newTestClusterWithOldDeletionApproach(t, withDeletionStampsClusterOptsFunc),
+			verifyDB:        verifyClusterServiceIDUnchanged,
+		},
+		{
+			name: "DeletionTimestamp set but ClusterServiceDeletionTimestamp not yet -- no-op",
+			existingCluster: newTestClusterWithNewDeletionApproach(t, func(c *api.HCPOpenShiftCluster) {
+				c.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
+			}),
+			verifyDB: verifyClusterServiceIDUnchanged,
+		},
+		{
+			name: "ClusterServiceID already cleared -- no-op",
+			existingCluster: newTestClusterWithNewDeletionApproach(t, func(c *api.HCPOpenShiftCluster) {
+				withDeletionStampsClusterOptsFunc(c)
+				c.ServiceProviderProperties.ClusterServiceID = nil
+			}),
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				stored, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
+				require.NoError(t, err)
+				assert.Nil(t, stored.ServiceProviderProperties.ClusterServiceID, "ClusterServiceID should remain nil")
+			},
+		},
+		{
+			name:            "CS returns unhandled error -- propagated, no clear",
+			existingCluster: newTestClusterWithNewDeletionApproach(t, withDeletionStampsClusterOptsFunc),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetClusterStatus(gomock.Any(), api.Must(api.NewInternalID(testClusterServiceIDStr))).
+					Return(nil, errors.New("boom"))
+			},
+			wantErr:        true,
+			wantErrContain: "failed to get cluster-service Cluster",
+		},
+		{
+			name:            "when no DeletionTimestamp no-op is performed",
+			existingCluster: newTestClusterWithNewDeletionApproach(t, nil),
+			verifyDB:        verifyClusterServiceIDUnchanged,
+		},
+		{
+			name: "cluster not found no-op is performed",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+			ctrl := gomock.NewController(t)
+
+			resources := []any{}
+			if tc.existingCluster != nil {
+				resources = append(resources, tc.existingCluster)
+			}
+			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, resources)
+			require.NoError(t, err)
+
+			mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
+			if tc.setupMockCSClient != nil {
+				tc.setupMockCSClient(mockCSClient)
+			}
+
+			clustersForLister := []*api.HCPOpenShiftCluster{}
+			if tc.existingCluster != nil {
+				clustersForLister = append(clustersForLister, tc.existingCluster)
+			}
+
+			syncer := &clusterClusterServiceIDClearer{
+				cooldownChecker:      &alwaysSyncCooldownChecker{},
+				clusterLister:        &listertesting.SliceClusterLister{Clusters: clustersForLister},
+				resourcesDBClient:    mockResourcesDBClient,
+				clusterServiceClient: mockCSClient,
+			}
+
+			err = syncer.SyncOnce(ctx, testKey)
+			if tc.wantErr {
+				require.Error(t, err)
+				if len(tc.wantErrContain) > 0 {
+					require.ErrorContains(t, err, tc.wantErrContain)
+				}
+				return
+			}
+			require.NoError(t, err)
+
+			if tc.verifyDB != nil {
+				tc.verifyDB(t, ctx, mockResourcesDBClient)
+			}
+		})
+	}
+}

--- a/backend/pkg/controllers/clusterdeletion/cluster_deletion_controller.go
+++ b/backend/pkg/controllers/clusterdeletion/cluster_deletion_controller.go
@@ -45,8 +45,6 @@ type clusterDeletionController struct {
 	serviceProviderClusterLister listers.ServiceProviderClusterLister
 	resourcesDBClient            database.ResourcesDBClient
 	billingDBClient              database.BillingDBClient
-	kubeApplierDBClients         database.KubeApplierDBClients
-	fleetDBClient                database.FleetDBClient
 	passiveClock                 utilsclock.PassiveClock
 }
 
@@ -56,8 +54,6 @@ func NewClusterDeletionController(
 	clock utilsclock.PassiveClock,
 	resourcesDBClient database.ResourcesDBClient,
 	billingDBClient database.BillingDBClient,
-	kubeApplierDBClients database.KubeApplierDBClients,
-	fleetDBClient database.FleetDBClient,
 	activeOperationLister listers.ActiveOperationLister,
 	informers informers.BackendInformers,
 ) controllerutils.Controller {
@@ -69,8 +65,6 @@ func NewClusterDeletionController(
 		serviceProviderClusterLister: serviceProviderClusterLister,
 		resourcesDBClient:            resourcesDBClient,
 		billingDBClient:              billingDBClient,
-		kubeApplierDBClients:         kubeApplierDBClients,
-		fleetDBClient:                fleetDBClient,
 		passiveClock:                 clock,
 	}
 
@@ -183,15 +177,6 @@ func (c *clusterDeletionController) SyncOnce(ctx context.Context, key controller
 		return nil
 	}
 
-	// Precondition: all cluster-scoped kube-applier *Desire documents must be deleted
-	preconditionMet, err = c.deletePreconditionClusterScopedKubeApplierResourcesDeleted(ctx, key)
-	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to check precondition: %w", err))
-	}
-	if !preconditionMet {
-		return nil
-	}
-
 	// Mark billing document as deleted before deleting the cluster document.
 	// This is idempotent: if the billing document was already marked or never
 	// existed, MarkBillingDocumentDeleted returns nil.
@@ -229,58 +214,6 @@ func (c *clusterDeletionController) deletePreconditionAllMaestroClusterScopedRea
 			"remainingBundles", len(spc.Status.MaestroReadonlyBundles))
 		return false, nil
 	}
-	return true, nil
-}
-
-// deletePreconditionClusterScopedKubeApplierResourcesDeleted checks whether any
-// cluster-scoped kube-applier *Desire documents remain. ServiceProviderCluster may
-// already be gone, so placement is resolved by searching all management clusters.
-func (c *clusterDeletionController) deletePreconditionClusterScopedKubeApplierResourcesDeleted(
-	ctx context.Context,
-	key controllerutils.HCPClusterKey,
-) (bool, error) {
-	logger := utils.LoggerFromContext(ctx)
-
-	clusterResourceID := key.GetResourceID()
-	managementClusters, err := database.NewDBBackedManagementClusterLister(c.fleetDBClient).List(ctx)
-	if err != nil {
-		return false, utils.TrackError(fmt.Errorf("listing management clusters for kube-applier check: %w", err))
-	}
-
-	for _, mc := range managementClusters {
-		mcResourceID := mc.ResourceID
-		if mcResourceID == nil {
-			mcResourceID = mc.CosmosMetadata.ResourceID
-		}
-		if mcResourceID == nil {
-			continue
-		}
-
-		// If no management cluster matches we cannot determine it so we consider the precondition met.
-		kaClient := c.kubeApplierDBClients.For(ctx, mcResourceID)
-		if kaClient == nil {
-			continue
-		}
-
-		desireCRUD, err := kaClient.UntypedCRUD(*clusterResourceID)
-		if err != nil {
-			return false, utils.TrackError(fmt.Errorf("failed to create kube-applier untyped CRUD: %w", err))
-		}
-
-		// If the management cluster doesn't have the cluster resource id this list will be empty too.
-		desireIterator, err := desireCRUD.List(ctx, nil)
-		if err != nil {
-			return false, utils.TrackError(fmt.Errorf("failed to list cluster-scoped kube-applier resources: %w", err))
-		}
-		for range desireIterator.Items(ctx) {
-			logger.Info("waiting for cluster-scoped kube-applier content to be deleted before removing cluster")
-			return false, nil
-		}
-		if err := desireIterator.GetError(); err != nil {
-			return false, utils.TrackError(fmt.Errorf("error iterating cluster-scoped kube-applier resources: %w", err))
-		}
-	}
-
 	return true, nil
 }
 

--- a/backend/pkg/controllers/clusterdeletion/cluster_deletion_controller.go
+++ b/backend/pkg/controllers/clusterdeletion/cluster_deletion_controller.go
@@ -103,7 +103,6 @@ func (c *clusterDeletionController) NeedsWork(cluster *api.HCPOpenShiftCluster) 
 //  2. All node pool documents are deleted.
 //  3. All external auth documents are deleted.
 //  4. All other Cosmos child resources are deleted.
-//  5. All cluster-scoped kube-applier *Desire documents are deleted.
 //
 // Before removing the cluster document, the corresponding billing document is
 // marked as deleted (idempotent). Returns nil without acting when NeedsWork is
@@ -150,7 +149,7 @@ func (c *clusterDeletionController) SyncOnce(ctx context.Context, key controller
 		return nil
 	}
 
-	// Preconditio: all node pool Cosmos docs must be deleted
+	// Precondition: all node pool Cosmos docs must be deleted
 	preconditionMet, err = deletePreconditionAllNodePoolsDeleted(ctx, c.resourcesDBClient, key)
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to check precondition: %w", err))

--- a/backend/pkg/controllers/clusterdeletion/cluster_deletion_controller.go
+++ b/backend/pkg/controllers/clusterdeletion/cluster_deletion_controller.go
@@ -1,0 +1,267 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusterdeletion
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	utilsclock "k8s.io/utils/clock"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/internal/api"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// clusterDeletionController issues a Cosmos cluster delete
+// for the Clusters that have their DeletionTimestamp and ClusterServiceDeletionTimestamp set,
+// their ClusterServiceID has been cleared, all cluster-scoped Maestro readonly bundles
+// have been deleted from the ServiceProviderCluster, and all child NodePool and
+// ExternalAuth Cosmos documents have been deleted.
+type clusterDeletionController struct {
+	cooldownChecker              controllerutil.CooldownChecker
+	clusterLister                listers.ClusterLister
+	serviceProviderClusterLister listers.ServiceProviderClusterLister
+	resourcesDBClient            database.ResourcesDBClient
+	billingDBClient              database.BillingDBClient
+	passiveClock                 utilsclock.PassiveClock
+}
+
+var _ controllerutils.ClusterSyncer = (*clusterDeletionController)(nil)
+
+func NewClusterDeletionController(
+	clock utilsclock.PassiveClock,
+	resourcesDBClient database.ResourcesDBClient,
+	billingDBClient database.BillingDBClient,
+	activeOperationLister listers.ActiveOperationLister,
+	informers informers.BackendInformers,
+) controllerutils.Controller {
+	_, clusterLister := informers.Clusters()
+	_, serviceProviderClusterLister := informers.ServiceProviderClusters()
+	syncer := &clusterDeletionController{
+		cooldownChecker:              controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		clusterLister:                clusterLister,
+		serviceProviderClusterLister: serviceProviderClusterLister,
+		resourcesDBClient:            resourcesDBClient,
+		billingDBClient:              billingDBClient,
+		passiveClock:                 clock,
+	}
+
+	return controllerutils.NewClusterWatchingController(
+		"ClusterDeletionController",
+		resourcesDBClient,
+		informers,
+		nil,
+		time.Minute,
+		syncer,
+	)
+}
+
+func (c *clusterDeletionController) CooldownChecker() controllerutil.CooldownChecker {
+	return c.cooldownChecker
+}
+
+// NeedsWork reports whether the deleter has unfinished business for the given
+// Cluster. All the following conditions must be met:
+// - DeletionTimestamp must be set
+// - ClusterServiceDeletionTimestamp must be set
+// - ClusterServiceID must be nil
+func (c *clusterDeletionController) NeedsWork(cluster *api.HCPOpenShiftCluster) bool {
+	if !cluster.ServiceProviderProperties.UsesNewClusterDeletionApproach {
+		return false
+	}
+
+	return cluster.ServiceProviderProperties.DeletionTimestamp != nil &&
+		cluster.ServiceProviderProperties.ClusterServiceDeletionTimestamp != nil &&
+		cluster.ServiceProviderProperties.ClusterServiceID == nil
+}
+
+// SyncOnce deletes a Cluster document from Cosmos after verifying that all
+// deletion preconditions are satisfied:
+//  1. All cluster-scoped Maestro readonly bundles are cleared.
+//  2. All node pool documents are deleted.
+//  3. All external auth documents are deleted.
+//  4. All other Cosmos child resources are deleted.
+//
+// Before removing the cluster document, the corresponding billing document is
+// marked as deleted (idempotent). Returns nil without acting when NeedsWork is
+// false or any precondition is not yet met.
+func (c *clusterDeletionController) SyncOnce(ctx context.Context, key controllerutils.HCPClusterKey) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	cachedCluster, err := c.clusterLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get cluster from cache: %w", err))
+	}
+	if !c.NeedsWork(cachedCluster) {
+		return nil
+	}
+
+	// Quick cache check for Maestro readonly bundles
+	cachedSPC, spcCacheErr := c.serviceProviderClusterLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if spcCacheErr == nil && len(cachedSPC.Status.MaestroReadonlyBundles) > 0 {
+		return nil
+	}
+
+	// Confirm against the live document.
+	clusterCRUD := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName)
+	cluster, err := clusterCRUD.Get(ctx, key.HCPClusterName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get cluster: %w", err))
+	}
+	if !c.NeedsWork(cluster) {
+		return nil
+	}
+
+	// Precondition: all cluster-scoped Maestro readonly bundles must be cleared
+	preconditionMet, err := c.deletePreconditionAllMaestroClusterScopedReadonlyBundlesCleared(ctx, key)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to check precondition: %w", err))
+	}
+	if !preconditionMet {
+		return nil
+	}
+
+	// Preconditio: all node pool Cosmos docs must be deleted
+	preconditionMet, err = deletePreconditionAllNodePoolsDeleted(ctx, c.resourcesDBClient, key)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to check precondition: %w", err))
+	}
+	if !preconditionMet {
+		return nil
+	}
+
+	// Precondition: all external auth Cosmos docs must be deleted
+	preconditionMet, err = deletePreconditionAllExternalAuthsDeleted(ctx, c.resourcesDBClient, key)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to check precondition: %w", err))
+	}
+	if !preconditionMet {
+		return nil
+	}
+
+	// Precondition: all Cosmos child resources must be deleted (except controllers)
+	preconditionMet, err = c.deletePreconditionCosmosChildResourcesDeleted(ctx, key)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to check precondition: %w", err))
+	}
+	if !preconditionMet {
+		return nil
+	}
+
+	// Mark billing document as deleted before deleting the cluster document.
+	// This is idempotent: if the billing document was already marked or never
+	// existed, MarkBillingDocumentDeleted returns nil.
+	// ErrAmbiguousResult (multiple billing docs for one cluster) is a data
+	// integrity issue that retrying won't fix, so we log and continue.
+	err = controllerutils.MarkBillingDocumentDeleted(ctx, c.billingDBClient, cluster.ID, c.passiveClock.Now())
+	if errors.Is(err, database.ErrAmbiguousResult) {
+		logger.Error(err, "Failed to mark CosmosDB billing record for deletion")
+	} else if err != nil {
+		return utils.TrackError(err)
+	}
+
+	logger.Info("deleting cluster from Cosmos")
+	err = clusterCRUD.Delete(ctx, key.HCPClusterName)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to delete cluster from Cosmos: %w", err))
+	}
+	logger.Info("cluster deleted from Cosmos")
+
+	return nil
+}
+
+// deletePreconditionAllMaestroClusterScopedReadonlyBundlesCleared checks if the
+// ServiceProviderCluster has any Maestro readonly bundles.
+func (c *clusterDeletionController) deletePreconditionAllMaestroClusterScopedReadonlyBundlesCleared(ctx context.Context, key controllerutils.HCPClusterKey) (bool, error) {
+	logger := utils.LoggerFromContext(ctx)
+
+	spcCRUD := c.resourcesDBClient.ServiceProviderClusters(key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	spc, spcErr := spcCRUD.Get(ctx, api.ServiceProviderClusterResourceName)
+	if spcErr != nil && !database.IsNotFoundError(spcErr) {
+		return false, utils.TrackError(fmt.Errorf("failed to get ServiceProviderCluster: %w", spcErr))
+	}
+	if spc != nil && len(spc.Status.MaestroReadonlyBundles) > 0 {
+		logger.Info("waiting for cluster-scoped Maestro readonly bundles to be deleted before removing Cosmos entry",
+			"remainingBundles", len(spc.Status.MaestroReadonlyBundles))
+		return false, nil
+	}
+	return true, nil
+}
+
+// deletePreconditionCosmosChildResourcesDeleted checks if the cosmos child resources
+// have been deleted, ignoring cluster controllers and orphaned nodepool/externalauth
+// controller status documents (which are left behind by the nodepool/externalauth
+// deletion pipelines and cleaned up by the orphan scraper).
+func (c *clusterDeletionController) deletePreconditionCosmosChildResourcesDeleted(ctx context.Context, key controllerutils.HCPClusterKey) (bool, error) {
+	logger := utils.LoggerFromContext(ctx)
+
+	clusterCRUD := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName)
+	cluster, err := clusterCRUD.Get(ctx, key.HCPClusterName)
+	if database.IsNotFoundError(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, utils.TrackError(fmt.Errorf("failed to get cluster: %w", err))
+	}
+
+	// Orphaned controller status documents may linger under nodepools and
+	// externalauths after their parent documents have been deleted. We skip
+	// those here because the orphan scraper handles them.
+	skipSubtreeTypes := []azcorearm.ResourceType{
+		api.NodePoolResourceType,
+		api.ExternalAuthResourceType,
+	}
+
+	clusterResourceID := cluster.ID
+	untypedCRUD, err := c.resourcesDBClient.UntypedCRUD(*clusterResourceID)
+	if err != nil {
+		return false, utils.TrackError(fmt.Errorf("failed to create untyped CRUD for child check: %w", err))
+	}
+	childIterator, err := untypedCRUD.ListRecursive(ctx, nil)
+	if err != nil {
+		return false, utils.TrackError(fmt.Errorf("failed to list child resources: %w", err))
+	}
+	for _, childResource := range childIterator.Items(ctx) {
+		if strings.EqualFold(childResource.ResourceType, api.ClusterControllerResourceType.String()) {
+			continue
+		}
+		if hasSkippedResourceTypePrefix(childResource.ResourceID, skipSubtreeTypes) {
+			continue
+		}
+		logger.Info("child resource still exists, waiting for cleanup", "childResourceID", childResource.ResourceID)
+		return false, nil
+	}
+	if err := childIterator.GetError(); err != nil {
+		return false, utils.TrackError(fmt.Errorf("error iterating child resources: %w", err))
+	}
+
+	return true, nil
+}

--- a/backend/pkg/controllers/clusterdeletion/cluster_deletion_controller.go
+++ b/backend/pkg/controllers/clusterdeletion/cluster_deletion_controller.go
@@ -45,6 +45,8 @@ type clusterDeletionController struct {
 	serviceProviderClusterLister listers.ServiceProviderClusterLister
 	resourcesDBClient            database.ResourcesDBClient
 	billingDBClient              database.BillingDBClient
+	kubeApplierDBClients         database.KubeApplierDBClients
+	fleetDBClient                database.FleetDBClient
 	passiveClock                 utilsclock.PassiveClock
 }
 
@@ -54,6 +56,8 @@ func NewClusterDeletionController(
 	clock utilsclock.PassiveClock,
 	resourcesDBClient database.ResourcesDBClient,
 	billingDBClient database.BillingDBClient,
+	kubeApplierDBClients database.KubeApplierDBClients,
+	fleetDBClient database.FleetDBClient,
 	activeOperationLister listers.ActiveOperationLister,
 	informers informers.BackendInformers,
 ) controllerutils.Controller {
@@ -65,6 +69,8 @@ func NewClusterDeletionController(
 		serviceProviderClusterLister: serviceProviderClusterLister,
 		resourcesDBClient:            resourcesDBClient,
 		billingDBClient:              billingDBClient,
+		kubeApplierDBClients:         kubeApplierDBClients,
+		fleetDBClient:                fleetDBClient,
 		passiveClock:                 clock,
 	}
 
@@ -103,6 +109,7 @@ func (c *clusterDeletionController) NeedsWork(cluster *api.HCPOpenShiftCluster) 
 //  2. All node pool documents are deleted.
 //  3. All external auth documents are deleted.
 //  4. All other Cosmos child resources are deleted.
+//  5. All cluster-scoped kube-applier *Desire documents are deleted.
 //
 // Before removing the cluster document, the corresponding billing document is
 // marked as deleted (idempotent). Returns nil without acting when NeedsWork is
@@ -176,6 +183,15 @@ func (c *clusterDeletionController) SyncOnce(ctx context.Context, key controller
 		return nil
 	}
 
+	// Precondition: all cluster-scoped kube-applier *Desire documents must be deleted
+	preconditionMet, err = c.deletePreconditionClusterScopedKubeApplierResourcesDeleted(ctx, key)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to check precondition: %w", err))
+	}
+	if !preconditionMet {
+		return nil
+	}
+
 	// Mark billing document as deleted before deleting the cluster document.
 	// This is idempotent: if the billing document was already marked or never
 	// existed, MarkBillingDocumentDeleted returns nil.
@@ -213,6 +229,58 @@ func (c *clusterDeletionController) deletePreconditionAllMaestroClusterScopedRea
 			"remainingBundles", len(spc.Status.MaestroReadonlyBundles))
 		return false, nil
 	}
+	return true, nil
+}
+
+// deletePreconditionClusterScopedKubeApplierResourcesDeleted checks whether any
+// cluster-scoped kube-applier *Desire documents remain. ServiceProviderCluster may
+// already be gone, so placement is resolved by searching all management clusters.
+func (c *clusterDeletionController) deletePreconditionClusterScopedKubeApplierResourcesDeleted(
+	ctx context.Context,
+	key controllerutils.HCPClusterKey,
+) (bool, error) {
+	logger := utils.LoggerFromContext(ctx)
+
+	clusterResourceID := key.GetResourceID()
+	managementClusters, err := database.NewDBBackedManagementClusterLister(c.fleetDBClient).List(ctx)
+	if err != nil {
+		return false, utils.TrackError(fmt.Errorf("listing management clusters for kube-applier check: %w", err))
+	}
+
+	for _, mc := range managementClusters {
+		mcResourceID := mc.ResourceID
+		if mcResourceID == nil {
+			mcResourceID = mc.CosmosMetadata.ResourceID
+		}
+		if mcResourceID == nil {
+			continue
+		}
+
+		// If no management cluster matches we cannot determine it so we consider the precondition met.
+		kaClient := c.kubeApplierDBClients.For(ctx, mcResourceID)
+		if kaClient == nil {
+			continue
+		}
+
+		desireCRUD, err := kaClient.UntypedCRUD(*clusterResourceID)
+		if err != nil {
+			return false, utils.TrackError(fmt.Errorf("failed to create kube-applier untyped CRUD: %w", err))
+		}
+
+		// If the management cluster doesn't have the cluster resource id this list will be empty too.
+		desireIterator, err := desireCRUD.List(ctx, nil)
+		if err != nil {
+			return false, utils.TrackError(fmt.Errorf("failed to list cluster-scoped kube-applier resources: %w", err))
+		}
+		for range desireIterator.Items(ctx) {
+			logger.Info("waiting for cluster-scoped kube-applier content to be deleted before removing cluster")
+			return false, nil
+		}
+		if err := desireIterator.GetError(); err != nil {
+			return false, utils.TrackError(fmt.Errorf("error iterating cluster-scoped kube-applier resources: %w", err))
+		}
+	}
+
 	return true, nil
 }
 

--- a/backend/pkg/controllers/clusterdeletion/cluster_deletion_controller_test.go
+++ b/backend/pkg/controllers/clusterdeletion/cluster_deletion_controller_test.go
@@ -1,0 +1,361 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusterdeletion
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clocktesting "k8s.io/utils/clock/testing"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+func TestClusterDeletionController_SyncOnce(t *testing.T) {
+	fixedClockTime := time.Now().UTC().Truncate(time.Second)
+
+	testKey := controllerutils.HCPClusterKey{
+		SubscriptionID:    testSubscriptionID,
+		ResourceGroupName: testResourceGroupName,
+		HCPClusterName:    testClusterName,
+	}
+
+	readyForDeletionCluster := func(t *testing.T) *api.HCPOpenShiftCluster {
+		return newTestClusterWithNewDeletionApproach(t, func(c *api.HCPOpenShiftCluster) {
+			c.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
+			c.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-30 * time.Minute)}
+			c.ServiceProviderProperties.ClusterServiceID = nil
+		})
+	}
+
+	verifyClusterStillExists := func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+		t.Helper()
+		_, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
+		require.NoError(t, err, "expected cluster to still exist in Cosmos")
+	}
+
+	verifyClusterDeleted := func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+		t.Helper()
+		_, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
+		assert.True(t, database.IsNotFoundError(err), "expected cluster to be deleted from Cosmos")
+	}
+
+	testCases := []struct {
+		name            string
+		existingCluster *api.HCPOpenShiftCluster
+		extraResources  []any
+		wantErr         bool
+		verifyDB        func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient)
+	}{
+		{
+			name:            "all preconditions met, no children -- cluster is deleted",
+			existingCluster: readyForDeletionCluster(t),
+			verifyDB:        verifyClusterDeleted,
+		},
+		{
+			name:            "no DeletionTimestamp -- no-op",
+			existingCluster: newTestClusterWithNewDeletionApproach(t, nil),
+			verifyDB:        verifyClusterStillExists,
+		},
+		{
+			name: "DeletionTimestamp set but ClusterServiceDeletionTimestamp not -- no-op",
+			existingCluster: newTestClusterWithNewDeletionApproach(t, func(c *api.HCPOpenShiftCluster) {
+				c.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
+			}),
+			verifyDB: verifyClusterStillExists,
+		},
+		{
+			name: "ClusterServiceID still set -- no-op",
+			existingCluster: newTestClusterWithNewDeletionApproach(t, func(c *api.HCPOpenShiftCluster) {
+				c.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
+				c.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-30 * time.Minute)}
+			}),
+			verifyDB: verifyClusterStillExists,
+		},
+		{
+			name:            "cluster still has nodepools -- blocks",
+			existingCluster: readyForDeletionCluster(t),
+			extraResources:  []any{newTestNodePool(t)},
+			verifyDB:        verifyClusterStillExists,
+		},
+		{
+			name:            "cluster still has external auths -- blocks",
+			existingCluster: readyForDeletionCluster(t),
+			extraResources:  []any{newTestExternalAuth(t)},
+			verifyDB:        verifyClusterStillExists,
+		},
+		{
+			name:            "cluster still has maestro readonly bundles -- blocks",
+			existingCluster: readyForDeletionCluster(t),
+			extraResources: []any{
+				newTestSPC(t, api.MaestroBundleReferenceList{
+					{Name: "test-bundle"},
+				}),
+			},
+			verifyDB: verifyClusterStillExists,
+		},
+		{
+			name:            "SPC with no bundles still present as child -- blocks",
+			existingCluster: readyForDeletionCluster(t),
+			extraResources:  []any{newTestSPC(t, nil)},
+			verifyDB:        verifyClusterStillExists,
+		},
+		{
+			name:            "non-controller child resource still exists -- blocks",
+			existingCluster: readyForDeletionCluster(t),
+			extraResources:  []any{newTestClusterScopedManagementClusterContent(t, "test-mcc")},
+			verifyDB:        verifyClusterStillExists,
+		},
+		{
+			name:            "only cluster controller children remain -- deletes cluster",
+			existingCluster: readyForDeletionCluster(t),
+			extraResources:  []any{newTestClusterController(t, "test-controller")},
+			verifyDB:        verifyClusterDeleted,
+		},
+		{
+			name:            "orphaned nodepool controller docs do not block deletion",
+			existingCluster: readyForDeletionCluster(t),
+			extraResources:  []any{newTestNodePoolController(t, "orphaned-np-controller")},
+			verifyDB:        verifyClusterDeleted,
+		},
+		{
+			name:            "orphaned externalauth controller docs do not block deletion",
+			existingCluster: readyForDeletionCluster(t),
+			extraResources:  []any{newTestExternalAuthController(t, "orphaned-ea-controller")},
+			verifyDB:        verifyClusterDeleted,
+		},
+		{
+			name: "feature flag false -- no-op even when all delete conditions met",
+			existingCluster: newTestClusterWithOldDeletionApproach(t, func(c *api.HCPOpenShiftCluster) {
+				c.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-time.Hour)}
+				c.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: fixedClockTime.Add(-30 * time.Minute)}
+				c.ServiceProviderProperties.ClusterServiceID = nil
+			}),
+			verifyDB: verifyClusterStillExists,
+		},
+		{
+			name: "cluster not found -- no-op",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+
+			resources := []any{}
+			if tc.existingCluster != nil {
+				resources = append(resources, tc.existingCluster)
+			}
+			resources = append(resources, tc.extraResources...)
+
+			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, resources)
+			require.NoError(t, err)
+
+			mockBillingDBClient := databasetesting.NewMockBillingDBClient()
+
+			clustersForLister := []*api.HCPOpenShiftCluster{}
+			if tc.existingCluster != nil {
+				clustersForLister = append(clustersForLister, tc.existingCluster)
+			}
+
+			spcForLister := []*api.ServiceProviderCluster{}
+			for _, r := range tc.extraResources {
+				if spc, ok := r.(*api.ServiceProviderCluster); ok {
+					spcForLister = append(spcForLister, spc)
+				}
+			}
+
+			syncer := &clusterDeletionController{
+				cooldownChecker:              &alwaysSyncCooldownChecker{},
+				clusterLister:                &listertesting.SliceClusterLister{Clusters: clustersForLister},
+				serviceProviderClusterLister: &listertesting.SliceServiceProviderClusterLister{ServiceProviderClusters: spcForLister},
+				resourcesDBClient:            mockResourcesDBClient,
+				billingDBClient:              mockBillingDBClient,
+				passiveClock:                 clocktesting.NewFakePassiveClock(fixedClockTime),
+			}
+
+			err = syncer.SyncOnce(ctx, testKey)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			if tc.verifyDB != nil {
+				tc.verifyDB(t, ctx, mockResourcesDBClient)
+			}
+		})
+	}
+}
+
+func TestClusterDeletionController_NeedsWork(t *testing.T) {
+	fixedClockTime := time.Now().UTC().Truncate(time.Second)
+
+	testCases := []struct {
+		name    string
+		cluster *api.HCPOpenShiftCluster
+		want    bool
+	}{
+		{
+			name:    "feature flag false",
+			cluster: newTestClusterWithOldDeletionApproach(t, nil),
+			want:    false,
+		},
+		{
+			name:    "no DeletionTimestamp",
+			cluster: newTestClusterWithNewDeletionApproach(t, nil),
+			want:    false,
+		},
+		{
+			name: "DeletionTimestamp set but no ClusterServiceDeletionTimestamp",
+			cluster: newTestClusterWithNewDeletionApproach(t, func(c *api.HCPOpenShiftCluster) {
+				c.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime}
+			}),
+			want: false,
+		},
+		{
+			name: "both timestamps set but ClusterServiceID not nil",
+			cluster: newTestClusterWithNewDeletionApproach(t, func(c *api.HCPOpenShiftCluster) {
+				c.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime}
+				c.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: fixedClockTime}
+			}),
+			want: false,
+		},
+		{
+			name: "all conditions met",
+			cluster: newTestClusterWithNewDeletionApproach(t, func(c *api.HCPOpenShiftCluster) {
+				c.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedClockTime}
+				c.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: fixedClockTime}
+				c.ServiceProviderProperties.ClusterServiceID = nil
+			}),
+			want: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			controller := &clusterDeletionController{}
+			assert.Equal(t, tc.want, controller.NeedsWork(tc.cluster))
+		})
+	}
+}
+
+func newTestNodePool(t *testing.T) *api.HCPOpenShiftClusterNodePool {
+	t.Helper()
+	resourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+			"/nodePools/test-nodepool"))
+	return &api.HCPOpenShiftClusterNodePool{
+		TrackedResource: arm.TrackedResource{
+			Resource: arm.Resource{
+				ID:   resourceID,
+				Name: "test-nodepool",
+				Type: api.NodePoolResourceType.String(),
+			},
+			Location: "eastus",
+		},
+		CosmosMetadata: arm.CosmosMetadata{ResourceID: resourceID},
+		Properties: api.HCPOpenShiftClusterNodePoolProperties{
+			Platform: api.NodePoolPlatformProfile{
+				OSDisk: api.OSDiskProfile{
+					DiskStorageAccountType: api.DiskStorageAccountTypePremium_LRS,
+					DiskType:               api.OsDiskTypeManaged,
+				},
+			},
+		},
+	}
+}
+
+func newTestExternalAuth(t *testing.T) *api.HCPOpenShiftClusterExternalAuth {
+	t.Helper()
+	resourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+			"/externalAuths/test-auth"))
+	return &api.HCPOpenShiftClusterExternalAuth{
+		CosmosMetadata: arm.CosmosMetadata{ResourceID: resourceID},
+		ProxyResource: arm.ProxyResource{
+			Resource: arm.Resource{
+				ID:   resourceID,
+				Name: "test-auth",
+				Type: api.ExternalAuthResourceType.String(),
+			},
+		},
+	}
+}
+
+func newTestSPC(t *testing.T, bundles api.MaestroBundleReferenceList) *api.ServiceProviderCluster {
+	t.Helper()
+	spcResourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+			"/serviceProviderClusters/default"))
+	return &api.ServiceProviderCluster{
+		CosmosMetadata: arm.CosmosMetadata{ResourceID: spcResourceID},
+		Status: api.ServiceProviderClusterStatus{
+			MaestroReadonlyBundles: bundles,
+		},
+	}
+}
+
+func newTestNodePoolController(t *testing.T, name string) *api.Controller {
+	t.Helper()
+	resourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+			"/nodePools/test-nodepool" +
+			"/hcpOpenShiftControllers/" + name))
+	return &api.Controller{
+		CosmosMetadata: api.CosmosMetadata{ResourceID: resourceID},
+		Status: api.ControllerStatus{
+			Conditions: []metav1.Condition{},
+		},
+	}
+}
+
+func newTestExternalAuthController(t *testing.T, name string) *api.Controller {
+	t.Helper()
+	resourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+			"/externalAuths/test-auth" +
+			"/hcpOpenShiftControllers/" + name))
+	return &api.Controller{
+		CosmosMetadata: api.CosmosMetadata{ResourceID: resourceID},
+		Status: api.ControllerStatus{
+			Conditions: []metav1.Condition{},
+		},
+	}
+}

--- a/backend/pkg/controllers/clusterdeletion/cluster_deletion_controller_test.go
+++ b/backend/pkg/controllers/clusterdeletion/cluster_deletion_controller_test.go
@@ -328,6 +328,37 @@ func newTestSPC(t *testing.T, bundles api.MaestroBundleReferenceList) *api.Servi
 	}
 }
 
+func newTestClusterScopedManagementClusterContent(t *testing.T, name string) *api.ManagementClusterContent {
+	t.Helper()
+	resourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+			"/managementClusterContents/" + name))
+	return &api.ManagementClusterContent{
+		CosmosMetadata: api.CosmosMetadata{ResourceID: resourceID},
+	}
+}
+
+func newTestClusterController(t *testing.T, name string) *api.Controller {
+	t.Helper()
+	resourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+			"/hcpOpenShiftControllers/" + name))
+	return &api.Controller{
+		CosmosMetadata: api.CosmosMetadata{ResourceID: resourceID},
+		ExternalID: api.Must(azcorearm.ParseResourceID(
+			"/subscriptions/" + testSubscriptionID +
+				"/resourceGroups/" + testResourceGroupName +
+				"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName)),
+		Status: api.ControllerStatus{
+			Conditions: []metav1.Condition{},
+		},
+	}
+}
+
 func newTestNodePoolController(t *testing.T, name string) *api.Controller {
 	t.Helper()
 	resourceID := api.Must(azcorearm.ParseResourceID(

--- a/backend/pkg/controllers/nodepooldeletion/node_pool_child_resources_cleanup_controller.go
+++ b/backend/pkg/controllers/nodepooldeletion/node_pool_child_resources_cleanup_controller.go
@@ -35,26 +35,30 @@ import (
 // under a NodePool (e.g. ManagementClusterContent documents) recursively once
 // the NodePool is marked for deletion and Cluster Service has confirmed the
 // delete on its side. Controller status documents (NodePoolControllerResourceType)
-// are left alone. The orphan scraper handles those after the NodePool document
-// itself is removed.
+// are left alone. Nodepool-scoped kube-applier *Desires are deleted here using
+// the parent cluster's ServiceProviderCluster placement. The orphan scraper
+// handles controller status after the NodePool document itself is removed.
 type nodePoolChildResourcesCleanupController struct {
-	cooldownChecker   controllerutil.CooldownChecker
-	nodePoolLister    listers.NodePoolLister
-	resourcesDBClient database.ResourcesDBClient
+	cooldownChecker      controllerutil.CooldownChecker
+	nodePoolLister       listers.NodePoolLister
+	resourcesDBClient    database.ResourcesDBClient
+	kubeApplierDBClients database.KubeApplierDBClients
 }
 
 var _ controllerutils.NodePoolSyncer = (*nodePoolChildResourcesCleanupController)(nil)
 
 func NewNodePoolChildResourcesCleanupController(
 	resourcesDBClient database.ResourcesDBClient,
+	kubeApplierDBClients database.KubeApplierDBClients,
 	activeOperationLister listers.ActiveOperationLister,
 	informers informers.BackendInformers,
 ) controllerutils.Controller {
 	_, nodePoolLister := informers.NodePools()
 	syncer := &nodePoolChildResourcesCleanupController{
-		cooldownChecker:   controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
-		nodePoolLister:    nodePoolLister,
-		resourcesDBClient: resourcesDBClient,
+		cooldownChecker:      controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		nodePoolLister:       nodePoolLister,
+		resourcesDBClient:    resourcesDBClient,
+		kubeApplierDBClients: kubeApplierDBClients,
 	}
 
 	return controllerutils.NewNodePoolWatchingController(
@@ -110,6 +114,10 @@ func (c *nodePoolChildResourcesCleanupController) SyncOnce(ctx context.Context, 
 	}
 
 	nodePoolResourceID := key.GetResourceID()
+	if err := c.ensureNodePoolScopedKubeApplierResourcesDeleted(ctx, nodePoolResourceID); err != nil {
+		return utils.TrackError(fmt.Errorf("failed to delete nodepool-scoped kube-applier content: %w", err))
+	}
+
 	untypedCRUD, err := c.resourcesDBClient.UntypedCRUD(*nodePoolResourceID)
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to create untyped CRUD for node pool children: %w", err))
@@ -159,9 +167,9 @@ func (c *nodePoolChildResourcesCleanupController) SyncOnce(ctx context.Context, 
 	return nil
 }
 
-// extraDeleteGateShouldDeleteServiceProviderNodePool is an extra delete gate that checks if the ServiceProviderNodePool has any Maestro readonly bundles.
-// serviceProviderNodePoolResourceID is the child's ARM resource ID (serviceProviderNodePools/default).
-// If there are bundles it returns false, otherwise it returns true.
+// extraDeleteGateShouldDeleteServiceProviderNodePool returns false while the
+// ServiceProviderNodePool still has Maestro readonly bundles or nodepool-scoped
+// kube-applier *Desire documents.
 func (c *nodePoolChildResourcesCleanupController) extraDeleteGateShouldDeleteServiceProviderNodePool(ctx context.Context, serviceProviderNodePoolResourceID *azcorearm.ResourceID) (bool, error) {
 	logger := utils.LoggerFromContext(ctx)
 
@@ -182,10 +190,133 @@ func (c *nodePoolChildResourcesCleanupController) extraDeleteGateShouldDeleteSer
 		return false, utils.TrackError(fmt.Errorf("failed to get ServiceProviderNodePool: %w", err))
 	}
 
+	// Check if there are any Maestro readonly bundles remaining.
 	if len(spnp.Status.MaestroReadonlyBundles) > 0 {
 		logger.Info("waiting for nodepool-scoped Maestro readonly bundles to be deleted before removing Cosmos entry",
 			"serviceProviderNodePoolResourceID", spnp.ResourceID.String(), "remainingBundles", len(spnp.Status.MaestroReadonlyBundles))
 		return false, nil
 	}
+
+	// Check if there are any nodepool-scoped kube-applier *Desire documents remaining.
+	nodePoolResourceID := serviceProviderNodePoolResourceID.Parent
+	clusterResourceID := nodePoolResourceID.Parent
+	spc, err := c.resourcesDBClient.ServiceProviderClusters(clusterResourceID.SubscriptionID, clusterResourceID.ResourceGroupName, clusterResourceID.Name).Get(ctx, api.ServiceProviderClusterResourceName)
+	if database.IsNotFoundError(err) {
+		logger.Info("no ServiceProviderCluster found associated to the cluster. Continuing with deletion of ServiceProviderNodePool document")
+		return true, nil
+	}
+	if err != nil {
+		return false, utils.TrackError(fmt.Errorf("failed to get ServiceProviderCluster: %w", err))
+	}
+	mcResourceID := spc.Status.ManagementClusterResourceID
+	if mcResourceID != nil {
+		kaClient := c.kubeApplierDBClients.For(ctx, mcResourceID)
+		if kaClient == nil {
+			logger.Info("no kube-applier client for management cluster. Continuing with deletion of ServiceProviderNodePool document",
+				"serviceProviderNodePoolResourceID", spnp.ResourceID.String(),
+				"managementClusterResourceID", mcResourceID.String())
+			return true, nil
+		}
+		desireCRUD, err := kaClient.UntypedCRUD(*nodePoolResourceID)
+		if err != nil {
+			return false, utils.TrackError(fmt.Errorf("failed to create kube-applier untyped CRUD: %w", err))
+		}
+
+		desireIterator, err := desireCRUD.List(ctx, nil)
+		if err != nil {
+			return false, utils.TrackError(fmt.Errorf("failed to list nodepool-scoped kube-applier resources: %w", err))
+		}
+		for _, resource := range desireIterator.Items(ctx) {
+			if resource.ResourceID != nil {
+				logger.Info("waiting for nodepool-scoped kube-applier content to be deleted before removing ServiceProviderNodePool",
+					"serviceProviderNodePoolResourceID", spnp.ResourceID.String(),
+					"managementClusterResourceID", mcResourceID.String())
+				return false, nil
+			}
+		}
+		if err := desireIterator.GetError(); err != nil {
+			return false, utils.TrackError(fmt.Errorf("error iterating nodepool-scoped kube-applier resources: %w", err))
+		}
+
+	} else {
+		logger.Info("no management cluster resource ID found for ServiceProviderNodePool. Continuing with deletion of ServiceProviderNodePool document")
+	}
+
 	return true, nil
+}
+
+func (c *nodePoolChildResourcesCleanupController) ensureNodePoolScopedKubeApplierResourcesDeleted(ctx context.Context, nodePoolResourceID *azcorearm.ResourceID) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	clusterResourceID := nodePoolResourceID.Parent
+	spc, err := c.resourcesDBClient.ServiceProviderClusters(clusterResourceID.SubscriptionID, clusterResourceID.ResourceGroupName, clusterResourceID.Name).Get(ctx, api.ServiceProviderClusterResourceName)
+	if database.IsNotFoundError(err) {
+		// If there is no ServiceProviderCluster, we cannot determine the management cluster resource ID, so we skip the deletion of the
+		// *Desire documents without erroring.
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get ServiceProviderCluster: %w", err))
+	}
+
+	// If the ServiceProviderCluster has no management cluster resource ID, we cannot determine the management
+	// cluster resource ID, so we skip the deletion of the *Desire documents without erroring.
+	mcResourceID := spc.Status.ManagementClusterResourceID
+	if mcResourceID == nil {
+		logger.Info("no management cluster resource ID found for ServiceProviderCluster; skipping deletion of nodepool-scoped kube-applier content",
+			"serviceProviderClusterResourceID", spc.ResourceID.String())
+		return nil
+	}
+
+	// Best-effort: if the kube-applier client is unavailable, skip desire deletion here.
+	// Remaining *Desires are cleaned up by later deletion stages and the orphan scraper.
+	kaClient := c.kubeApplierDBClients.For(ctx, mcResourceID)
+	if kaClient == nil {
+		logger.Info("no kube-applier client configured for management cluster; skipping nodepool-scoped desire deletion",
+			"managementClusterResourceID", mcResourceID.String())
+		return nil
+	}
+
+	// extraDeleteGates uses lowercased kubeapplier.*DesireResourceTypeName keys. Types not
+	// in the map are deleted unconditionally.
+	extraDeleteGates := map[string]func(ctx context.Context, resourceID *azcorearm.ResourceID) (bool, error){
+		// strings.ToLower(kubeapplier.ClusterScopedReadDesireResourceType.String()): c.extraDeleteGateShouldDeleteReadDesire,
+		// strings.ToLower(kubeapplier.ClusterScopedApplyDesireResourceType.String()): c.extraDeleteGateShouldDeleteApplyDesire,
+		// strings.ToLower(kubeapplier.ClusterScopedDeleteDesireResourceType.String()): c.extraDeleteGateShouldDeleteDeleteDesire,
+	}
+
+	desireCRUD, err := kaClient.UntypedCRUD(*nodePoolResourceID)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to create kube-applier untyped CRUD: %w", err))
+	}
+
+	desireIterator, err := desireCRUD.List(ctx, nil)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to list nodepool-scoped kube-applier resources: %w", err))
+	}
+	for _, resource := range desireIterator.Items(ctx) {
+		if resource.ResourceID == nil {
+			return utils.TrackError(fmt.Errorf("kube-applier document at cosmosID %q has no resourceID; refusing to delete", resource.ID))
+		}
+
+		if extraDeleteGate, ok := extraDeleteGates[strings.ToLower(resource.ResourceType)]; ok {
+			shouldDelete, err := extraDeleteGate(ctx, resource.ResourceID)
+			if err != nil {
+				return utils.TrackError(err)
+			}
+			if !shouldDelete {
+				continue
+			}
+		}
+
+		logger.Info("deleting nodepool-scoped kube-applier resource", "resourceID", resource.ResourceID)
+		if err := desireCRUD.DeleteByCosmosID(ctx, resource.PartitionKey, resource.ID); err != nil {
+			return utils.TrackError(fmt.Errorf("failed to delete nodepool-scoped kube-applier resource %q: %w", resource.CosmosResourceID, err))
+		}
+	}
+	if err := desireIterator.GetError(); err != nil {
+		return utils.TrackError(fmt.Errorf("error iterating nodepool-scoped kube-applier resources: %w", err))
+	}
+
+	return nil
 }

--- a/backend/pkg/controllers/nodepooldeletion/node_pool_child_resources_cleanup_controller.go
+++ b/backend/pkg/controllers/nodepooldeletion/node_pool_child_resources_cleanup_controller.go
@@ -226,13 +226,11 @@ func (c *nodePoolChildResourcesCleanupController) extraDeleteGateShouldDeleteSer
 		if err != nil {
 			return false, utils.TrackError(fmt.Errorf("failed to list nodepool-scoped kube-applier resources: %w", err))
 		}
-		for _, resource := range desireIterator.Items(ctx) {
-			if resource.ResourceID != nil {
-				logger.Info("waiting for nodepool-scoped kube-applier content to be deleted before removing ServiceProviderNodePool",
-					"serviceProviderNodePoolResourceID", spnp.ResourceID.String(),
-					"managementClusterResourceID", mcResourceID.String())
-				return false, nil
-			}
+		for range desireIterator.Items(ctx) {
+			logger.Info("waiting for nodepool-scoped kube-applier content to be deleted before removing ServiceProviderNodePool",
+				"serviceProviderNodePoolResourceID", spnp.ResourceID.String(),
+				"managementClusterResourceID", mcResourceID.String())
+			return false, nil
 		}
 		if err := desireIterator.GetError(); err != nil {
 			return false, utils.TrackError(fmt.Errorf("error iterating nodepool-scoped kube-applier resources: %w", err))

--- a/backend/pkg/controllers/nodepooldeletion/node_pool_child_resources_cleanup_controller_test.go
+++ b/backend/pkg/controllers/nodepooldeletion/node_pool_child_resources_cleanup_controller_test.go
@@ -209,12 +209,12 @@ func TestNodePoolChildResourcesCleanupController_SyncOnce(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name             string
-		existingNodePool *api.HCPOpenShiftClusterNodePool
-		childResources   []any
+		name               string
+		existingNodePool   *api.HCPOpenShiftClusterNodePool
+		childResources     []any
 		kubeApplierDesires []any
 		wantErr            bool
-		verifyDB                  func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, kubeApplierDBClients *databasetesting.MockKubeApplierDBClients)
+		verifyDB           func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, kubeApplierDBClients *databasetesting.MockKubeApplierDBClients)
 	}{
 		{
 			name:             "when no DeletionTimestamp, no ClusterServiceDeletionTimestamp are set and ClusterServiceID is set performs a no-op",

--- a/backend/pkg/controllers/nodepooldeletion/node_pool_child_resources_cleanup_controller_test.go
+++ b/backend/pkg/controllers/nodepooldeletion/node_pool_child_resources_cleanup_controller_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
 	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
 	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/api/kubeapplier"
 	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/databasetesting"
 	"github.com/Azure/ARO-HCP/internal/utils"
@@ -71,6 +73,127 @@ func newTestNodePoolController(t *testing.T, name string) *api.Controller {
 }
 
 func TestNodePoolChildResourcesCleanupController_SyncOnce(t *testing.T) {
+	managementClusterResourceID := api.Must(azcorearm.ParseResourceID(
+		"/providers/microsoft.redhatopenshift/stamps/1/managementclusters/default"))
+	unregisteredManagementClusterResourceID := api.Must(azcorearm.ParseResourceID(
+		"/providers/microsoft.redhatopenshift/stamps/1/managementclusters/unregistered"))
+
+	newTestSPCWithManagementCluster := func(mcResourceID *azcorearm.ResourceID) *api.ServiceProviderCluster {
+		spcResourceID := api.Must(azcorearm.ParseResourceID(
+			"/subscriptions/" + testSubscriptionID +
+				"/resourceGroups/" + testResourceGroupName +
+				"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+				"/serviceProviderClusters/default"))
+		return &api.ServiceProviderCluster{
+			CosmosMetadata: arm.CosmosMetadata{ResourceID: spcResourceID},
+			Status: api.ServiceProviderClusterStatus{
+				ManagementClusterResourceID: mcResourceID,
+			},
+		}
+	}
+	newTestNodePoolScopedReadDesire := func(name string) *kubeapplier.ReadDesire {
+		resourceID := api.Must(azcorearm.ParseResourceID(
+			kubeapplier.ToNodePoolScopedReadDesireResourceIDString(
+				testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName, name)))
+		return &kubeapplier.ReadDesire{
+			CosmosMetadata: api.CosmosMetadata{ResourceID: resourceID},
+			Spec: kubeapplier.ReadDesireSpec{
+				ManagementCluster: managementClusterResourceID,
+			},
+		}
+	}
+	newTestClusterScopedReadDesire := func(name string) *kubeapplier.ReadDesire {
+		resourceID := api.Must(azcorearm.ParseResourceID(
+			kubeapplier.ToClusterScopedReadDesireResourceIDString(
+				testSubscriptionID, testResourceGroupName, testClusterName, name)))
+		return &kubeapplier.ReadDesire{
+			CosmosMetadata: api.CosmosMetadata{ResourceID: resourceID},
+			Spec: kubeapplier.ReadDesireSpec{
+				ManagementCluster: managementClusterResourceID,
+			},
+		}
+	}
+	newTestClusterScopedApplyDesire := func(name string) *kubeapplier.ApplyDesire {
+		resourceID := api.Must(azcorearm.ParseResourceID(
+			kubeapplier.ToClusterScopedApplyDesireResourceIDString(
+				testSubscriptionID, testResourceGroupName, testClusterName, name)))
+		return &kubeapplier.ApplyDesire{
+			CosmosMetadata: api.CosmosMetadata{ResourceID: resourceID},
+			Spec: kubeapplier.ApplyDesireSpec{
+				ManagementCluster: managementClusterResourceID,
+			},
+		}
+	}
+	newTestNodePoolScopedApplyDesire := func(name string) *kubeapplier.ApplyDesire {
+		resourceID := api.Must(azcorearm.ParseResourceID(
+			kubeapplier.ToNodePoolScopedApplyDesireResourceIDString(
+				testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName, name)))
+		return &kubeapplier.ApplyDesire{
+			CosmosMetadata: api.CosmosMetadata{ResourceID: resourceID},
+			Spec: kubeapplier.ApplyDesireSpec{
+				ManagementCluster: managementClusterResourceID,
+			},
+		}
+	}
+	newTestNodePoolScopedDeleteDesire := func(name string) *kubeapplier.DeleteDesire {
+		resourceID := api.Must(azcorearm.ParseResourceID(
+			kubeapplier.ToNodePoolScopedDeleteDesireResourceIDString(
+				testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName, name)))
+		return &kubeapplier.DeleteDesire{
+			CosmosMetadata: api.CosmosMetadata{ResourceID: resourceID},
+			Spec: kubeapplier.DeleteDesireSpec{
+				ManagementCluster: managementClusterResourceID,
+			},
+		}
+	}
+	assertNoNodePoolScopedKubeApplierResources := func(
+		t *testing.T,
+		ctx context.Context,
+		kubeApplierDBClients *databasetesting.MockKubeApplierDBClients,
+	) {
+		t.Helper()
+		client := kubeApplierDBClients.For(ctx, managementClusterResourceID)
+		require.NotNil(t, client)
+		nodePoolResourceID := api.Must(azcorearm.ParseResourceID(
+			"/subscriptions/" + testSubscriptionID +
+				"/resourceGroups/" + testResourceGroupName +
+				"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+				"/nodePools/" + testNodePoolName))
+		untypedCRUD, err := client.UntypedCRUD(*nodePoolResourceID)
+		require.NoError(t, err)
+		iter, err := untypedCRUD.List(ctx, nil)
+		require.NoError(t, err)
+		for _, resource := range iter.Items(ctx) {
+			if resource.ResourceID != nil {
+				t.Fatalf("expected no nodepool-scoped kube-applier resources, found %q", resource.ResourceID)
+			}
+		}
+		require.NoError(t, iter.GetError())
+	}
+	assertClusterScopedKubeApplierResourceExists := func(
+		t *testing.T,
+		ctx context.Context,
+		kubeApplierDBClients *databasetesting.MockKubeApplierDBClients,
+		resourceIDString string,
+	) {
+		t.Helper()
+		client := kubeApplierDBClients.For(ctx, managementClusterResourceID)
+		require.NotNil(t, client)
+		resourceID := api.Must(azcorearm.ParseResourceID(resourceIDString))
+		untypedCRUD, err := client.UntypedCRUD(*resourceID.Parent)
+		require.NoError(t, err)
+		iter, err := untypedCRUD.ListRecursive(ctx, nil)
+		require.NoError(t, err)
+		for _, resource := range iter.Items(ctx) {
+			if resource.ResourceID != nil && strings.EqualFold(resource.ResourceID.String(), resourceIDString) {
+				require.NoError(t, iter.GetError())
+				return
+			}
+		}
+		require.NoError(t, iter.GetError())
+		t.Fatalf("expected kube-applier resource %q to still exist", resourceIDString)
+	}
+
 	fixedNow := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
 	readyToDeleteNodePoolOptsFunc := func(np *api.HCPOpenShiftClusterNodePool) {
 		np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-time.Hour)}
@@ -89,14 +212,15 @@ func TestNodePoolChildResourcesCleanupController_SyncOnce(t *testing.T) {
 		name             string
 		existingNodePool *api.HCPOpenShiftClusterNodePool
 		childResources   []any
-		wantErr          bool
-		verifyDB         func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient)
+		kubeApplierDesires []any
+		wantErr            bool
+		verifyDB                  func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, kubeApplierDBClients *databasetesting.MockKubeApplierDBClients)
 	}{
 		{
 			name:             "when no DeletionTimestamp, no ClusterServiceDeletionTimestamp are set and ClusterServiceID is set performs a no-op",
 			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, nil),
 			childResources:   []any{newTestManagementClusterContent(t, "untouched-mcc")},
-			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, _ *databasetesting.MockKubeApplierDBClients) {
 				mccCRUD := db.HCPClusters(testSubscriptionID, testResourceGroupName).
 					NodePools(testClusterName).ManagementClusterContents(testNodePoolName)
 				_, err := mccCRUD.Get(ctx, "untouched-mcc")
@@ -111,7 +235,7 @@ func TestNodePoolChildResourcesCleanupController_SyncOnce(t *testing.T) {
 				np.ServiceProviderProperties.ClusterServiceID = nil
 			}),
 			childResources: []any{newTestManagementClusterContent(t, "untouched-mcc")},
-			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, _ *databasetesting.MockKubeApplierDBClients) {
 				mccCRUD := db.HCPClusters(testSubscriptionID, testResourceGroupName).
 					NodePools(testClusterName).ManagementClusterContents(testNodePoolName)
 				_, err := mccCRUD.Get(ctx, "untouched-mcc")
@@ -125,7 +249,7 @@ func TestNodePoolChildResourcesCleanupController_SyncOnce(t *testing.T) {
 				np.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: fixedNow.Add(-30 * time.Minute)}
 			}),
 			childResources: []any{newTestManagementClusterContent(t, "untouched-mcc")},
-			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, _ *databasetesting.MockKubeApplierDBClients) {
 				mccCRUD := db.HCPClusters(testSubscriptionID, testResourceGroupName).
 					NodePools(testClusterName).ManagementClusterContents(testNodePoolName)
 				_, err := mccCRUD.Get(ctx, "untouched-mcc")
@@ -140,7 +264,7 @@ func TestNodePoolChildResourcesCleanupController_SyncOnce(t *testing.T) {
 			name:             "when there is a children resource it deletes it",
 			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
 			childResources:   []any{newTestManagementClusterContent(t, "test-mcc")},
-			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, _ *databasetesting.MockKubeApplierDBClients) {
 				nodePoolResourceID := testKey.GetResourceID()
 				untypedCRUD, err := db.UntypedCRUD(*nodePoolResourceID)
 				require.NoError(t, err)
@@ -159,7 +283,7 @@ func TestNodePoolChildResourcesCleanupController_SyncOnce(t *testing.T) {
 			name:             "deletion of node pool controllers is skipped",
 			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
 			childResources:   []any{newTestNodePoolController(t, "test-controller")},
-			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, _ *databasetesting.MockKubeApplierDBClients) {
 				nodePoolResourceID := testKey.GetResourceID()
 				untypedCRUD, err := db.UntypedCRUD(*nodePoolResourceID)
 				require.NoError(t, err)
@@ -180,7 +304,7 @@ func TestNodePoolChildResourcesCleanupController_SyncOnce(t *testing.T) {
 			name:             "when there are nodepool controller and non nodepool controller children it deletes the non nodepool controller children",
 			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
 			childResources:   []any{newTestManagementClusterContent(t, "test-mcc"), newTestNodePoolController(t, "test-controller")},
-			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, _ *databasetesting.MockKubeApplierDBClients) {
 				nodePoolResourceID := testKey.GetResourceID()
 				untypedCRUD, err := db.UntypedCRUD(*nodePoolResourceID)
 				require.NoError(t, err)
@@ -204,10 +328,24 @@ func TestNodePoolChildResourcesCleanupController_SyncOnce(t *testing.T) {
 			name: "when the node pool is not found performs a no-op",
 		},
 		{
-			name:             "when there is a child ServiceProviderNodePool and it does not have Maestro bundle references it deletes it",
+			name:             "when there is a child ServiceProviderNodePool and ServiceProviderCluster is missing it deletes SPNP best-effort",
 			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
 			childResources:   []any{newTestSPNP(t, nil)},
-			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, _ *databasetesting.MockKubeApplierDBClients) {
+				spnpCRUD := db.ServiceProviderNodePools(
+					testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName)
+				_, err := spnpCRUD.Get(ctx, api.ServiceProviderNodePoolResourceName)
+				require.True(t, database.IsNotFoundError(err), "expected SPNP to be deleted")
+			},
+		},
+		{
+			name:             "when there is a child ServiceProviderNodePool and it does not have Maestro bundle references it deletes it",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			childResources: []any{
+				newTestSPCWithManagementCluster(nil),
+				newTestSPNP(t, nil),
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, _ *databasetesting.MockKubeApplierDBClients) {
 				spnpCRUD := db.ServiceProviderNodePools(
 					testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName)
 				_, err := spnpCRUD.Get(ctx, api.ServiceProviderNodePoolResourceName)
@@ -220,7 +358,7 @@ func TestNodePoolChildResourcesCleanupController_SyncOnce(t *testing.T) {
 			childResources: []any{newTestSPNP(t, api.MaestroBundleReferenceList{
 				{Name: "bundle-a", MaestroAPIMaestroBundleName: "name-a", MaestroAPIMaestroBundleID: "id-a"},
 			})},
-			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, _ *databasetesting.MockKubeApplierDBClients) {
 				spnpCRUD := db.ServiceProviderNodePools(
 					testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName)
 				_, err := spnpCRUD.Get(ctx, api.ServiceProviderNodePoolResourceName)
@@ -236,7 +374,7 @@ func TestNodePoolChildResourcesCleanupController_SyncOnce(t *testing.T) {
 					{Name: "bundle-a", MaestroAPIMaestroBundleName: "name-a", MaestroAPIMaestroBundleID: "id-a"},
 				}),
 			},
-			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, _ *databasetesting.MockKubeApplierDBClients) {
 				mccCRUD := db.HCPClusters(testSubscriptionID, testResourceGroupName).
 					NodePools(testClusterName).ManagementClusterContents(testNodePoolName)
 				_, err := mccCRUD.Get(ctx, "gate-mcc")
@@ -252,7 +390,7 @@ func TestNodePoolChildResourcesCleanupController_SyncOnce(t *testing.T) {
 			name:             "UsesNewNodePoolDeletionApproach false -- no-op even when all cleanup conditions met and children exist",
 			existingNodePool: newTestNodePoolWithOldDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
 			childResources:   []any{newTestManagementClusterContent(t, "untouched-mcc"), newTestSPNP(t, nil)},
-			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, _ *databasetesting.MockKubeApplierDBClients) {
 				mccCRUD := db.HCPClusters(testSubscriptionID, testResourceGroupName).
 					NodePools(testClusterName).ManagementClusterContents(testNodePoolName)
 				_, err := mccCRUD.Get(ctx, "untouched-mcc")
@@ -262,6 +400,73 @@ func TestNodePoolChildResourcesCleanupController_SyncOnce(t *testing.T) {
 					testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName)
 				_, err = spnpCRUD.Get(ctx, api.ServiceProviderNodePoolResourceName)
 				require.NoError(t, err, "expected SPNP to still exist")
+			},
+		},
+		{
+			name:             "when nodepool has nodepool-scoped kube-applier desires it deletes them",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			childResources: []any{
+				newTestSPCWithManagementCluster(managementClusterResourceID),
+			},
+			kubeApplierDesires: []any{newTestNodePoolScopedReadDesire("readonly-nodepool")},
+			verifyDB: func(t *testing.T, ctx context.Context, _ *databasetesting.MockResourcesDBClient, kubeApplierDBClients *databasetesting.MockKubeApplierDBClients) {
+				assertNoNodePoolScopedKubeApplierResources(t, ctx, kubeApplierDBClients)
+			},
+		},
+		{
+			name:             "when SPNP has nodepool-scoped kube-applier desires but no kube-applier client it deletes SPNP best-effort",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			childResources: []any{
+				newTestSPCWithManagementCluster(unregisteredManagementClusterResourceID),
+				newTestSPNP(t, nil),
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, kubeApplierDBClients *databasetesting.MockKubeApplierDBClients) {
+				spnpCRUD := db.ServiceProviderNodePools(
+					testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName)
+				_, err := spnpCRUD.Get(ctx, api.ServiceProviderNodePoolResourceName)
+				require.True(t, database.IsNotFoundError(err), "expected SPNP to be deleted")
+
+				require.Nil(t, kubeApplierDBClients.For(ctx, unregisteredManagementClusterResourceID))
+			},
+		},
+		{
+			name:             "when SPNP has nodepool-scoped kube-applier desires it deletes desires then SPNP",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			childResources: []any{
+				newTestSPCWithManagementCluster(managementClusterResourceID),
+				newTestSPNP(t, nil),
+			},
+			kubeApplierDesires: []any{newTestNodePoolScopedReadDesire("readonly-nodepool")},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, kubeApplierDBClients *databasetesting.MockKubeApplierDBClients) {
+				spnpCRUD := db.ServiceProviderNodePools(
+					testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName)
+				_, err := spnpCRUD.Get(ctx, api.ServiceProviderNodePoolResourceName)
+				require.True(t, database.IsNotFoundError(err), "expected SPNP to be deleted")
+
+				assertNoNodePoolScopedKubeApplierResources(t, ctx, kubeApplierDBClients)
+			},
+		},
+		{
+			name:             "when nodepool has cluster and nodepool scoped kube-applier resources it deletes only nodepool scoped ones",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			childResources: []any{
+				newTestSPCWithManagementCluster(managementClusterResourceID),
+			},
+			kubeApplierDesires: []any{
+				newTestClusterScopedReadDesire("readonly-hostedcluster"),
+				newTestClusterScopedApplyDesire("apply-example"),
+				newTestNodePoolScopedReadDesire("readonly-nodepool"),
+				newTestNodePoolScopedApplyDesire("apply-nodepool"),
+				newTestNodePoolScopedDeleteDesire("delete-example"),
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, _ *databasetesting.MockResourcesDBClient, kubeApplierDBClients *databasetesting.MockKubeApplierDBClients) {
+				assertNoNodePoolScopedKubeApplierResources(t, ctx, kubeApplierDBClients)
+				assertClusterScopedKubeApplierResourceExists(t, ctx, kubeApplierDBClients,
+					kubeapplier.ToClusterScopedReadDesireResourceIDString(
+						testSubscriptionID, testResourceGroupName, testClusterName, "readonly-hostedcluster"))
+				assertClusterScopedKubeApplierResourceExists(t, ctx, kubeApplierDBClients,
+					kubeapplier.ToClusterScopedApplyDesireResourceIDString(
+						testSubscriptionID, testResourceGroupName, testClusterName, "apply-example"))
 			},
 		},
 	}
@@ -278,15 +483,21 @@ func TestNodePoolChildResourcesCleanupController_SyncOnce(t *testing.T) {
 			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, resources)
 			require.NoError(t, err)
 
+			mockKubeApplierDBClients := databasetesting.NewMockKubeApplierDBClients()
+			mockKubeApplierClient, err := databasetesting.NewMockKubeApplierDBClientWithResources(ctx, tc.kubeApplierDesires)
+			require.NoError(t, err)
+			mockKubeApplierDBClients.Register(managementClusterResourceID, mockKubeApplierClient)
+
 			nodePoolsForLister := []*api.HCPOpenShiftClusterNodePool{}
 			if tc.existingNodePool != nil {
 				nodePoolsForLister = append(nodePoolsForLister, tc.existingNodePool)
 			}
 
 			syncer := &nodePoolChildResourcesCleanupController{
-				cooldownChecker:   &alwaysSyncCooldownChecker{},
-				nodePoolLister:    &listertesting.SliceNodePoolLister{NodePools: nodePoolsForLister},
-				resourcesDBClient: mockResourcesDBClient,
+				cooldownChecker:      &alwaysSyncCooldownChecker{},
+				nodePoolLister:       &listertesting.SliceNodePoolLister{NodePools: nodePoolsForLister},
+				resourcesDBClient:    mockResourcesDBClient,
+				kubeApplierDBClients: mockKubeApplierDBClients,
 			}
 
 			err = syncer.SyncOnce(ctx, testKey)
@@ -297,7 +508,7 @@ func TestNodePoolChildResourcesCleanupController_SyncOnce(t *testing.T) {
 			require.NoError(t, err)
 
 			if tc.verifyDB != nil {
-				tc.verifyDB(t, ctx, mockResourcesDBClient)
+				tc.verifyDB(t, ctx, mockResourcesDBClient, mockKubeApplierDBClients)
 			}
 		})
 	}

--- a/backend/pkg/controllers/nodepooldeletion/node_pool_deletion_controller.go
+++ b/backend/pkg/controllers/nodepooldeletion/node_pool_deletion_controller.go
@@ -92,7 +92,6 @@ func (c *nodePoolDeletionController) NeedsWork(nodePool *api.HCPOpenShiftCluster
 // all the delete preconditions are met:
 //  1. All nodepool-scoped Maestro readonly bundles are cleared.
 //  2. All other Cosmos child resources are deleted.
-//  3. All nodepool-scoped kube-applier *Desire documents are deleted.
 func (c *nodePoolDeletionController) SyncOnce(ctx context.Context, key controllerutils.HCPNodePoolKey) error {
 	logger := utils.LoggerFromContext(ctx)
 

--- a/backend/pkg/controllers/nodepooldeletion/node_pool_deletion_controller.go
+++ b/backend/pkg/controllers/nodepooldeletion/node_pool_deletion_controller.go
@@ -39,16 +39,12 @@ type nodePoolDeletionController struct {
 	nodePoolLister                listers.NodePoolLister
 	serviceProviderNodePoolLister listers.ServiceProviderNodePoolLister
 	resourcesDBClient             database.ResourcesDBClient
-	kubeApplierDBClients          database.KubeApplierDBClients
-	fleetDBClient                 database.FleetDBClient
 }
 
 var _ controllerutils.NodePoolSyncer = (*nodePoolDeletionController)(nil)
 
 func NewNodePoolDeletionController(
 	resourcesDBClient database.ResourcesDBClient,
-	kubeApplierDBClients database.KubeApplierDBClients,
-	fleetDBClient database.FleetDBClient,
 	activeOperationLister listers.ActiveOperationLister,
 	informers informers.BackendInformers,
 ) controllerutils.Controller {
@@ -59,8 +55,6 @@ func NewNodePoolDeletionController(
 		nodePoolLister:                nodePoolLister,
 		serviceProviderNodePoolLister: serviceProviderNodePoolLister,
 		resourcesDBClient:             resourcesDBClient,
-		kubeApplierDBClients:          kubeApplierDBClients,
-		fleetDBClient:                 fleetDBClient,
 	}
 
 	return controllerutils.NewNodePoolWatchingController(
@@ -152,15 +146,6 @@ func (c *nodePoolDeletionController) SyncOnce(ctx context.Context, key controlle
 		return nil
 	}
 
-	// Precondition: all nodepool-scoped kube-applier *Desire documents must be deleted
-	preconditionMet, err = c.deletePreconditionNodePoolScopedKubeApplierResourcesDeleted(ctx, key)
-	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to check precondition: %w", err))
-	}
-	if !preconditionMet {
-		return nil
-	}
-
 	logger.Info("deleting node pool from Cosmos")
 	err = nodePoolCRUD.Delete(ctx, key.HCPNodePoolName)
 	if err != nil {
@@ -186,58 +171,6 @@ func (c *nodePoolDeletionController) deletePreconditionAllMaestroNodePoolScopedR
 			"remainingBundles", len(spnp.Status.MaestroReadonlyBundles))
 		return false, nil
 	}
-	return true, nil
-}
-
-// deletePreconditionNodePoolScopedKubeApplierResourcesDeleted checks whether any
-// nodepool-scoped kube-applier *Desire documents remain. ServiceProviderNodePool may
-// already be gone, so placement is resolved by searching all management clusters.
-func (c *nodePoolDeletionController) deletePreconditionNodePoolScopedKubeApplierResourcesDeleted(
-	ctx context.Context,
-	key controllerutils.HCPNodePoolKey,
-) (bool, error) {
-	logger := utils.LoggerFromContext(ctx)
-
-	nodePoolResourceID := key.GetResourceID()
-	managementClusters, err := database.NewDBBackedManagementClusterLister(c.fleetDBClient).List(ctx)
-	if err != nil {
-		return false, utils.TrackError(fmt.Errorf("listing management clusters for kube-applier check: %w", err))
-	}
-
-	for _, mc := range managementClusters {
-		mcResourceID := mc.ResourceID
-		if mcResourceID == nil {
-			mcResourceID = mc.CosmosMetadata.ResourceID
-		}
-		if mcResourceID == nil {
-			continue
-		}
-
-		// If no management cluster matches we cannot determine it so we consider the precondition met.
-		kaClient := c.kubeApplierDBClients.For(ctx, mcResourceID)
-		if kaClient == nil {
-			continue
-		}
-
-		desireCRUD, err := kaClient.UntypedCRUD(*nodePoolResourceID)
-		if err != nil {
-			return false, utils.TrackError(fmt.Errorf("failed to create kube-applier untyped CRUD: %w", err))
-		}
-
-		// If the management cluster doesn't have the cluster resource id this list will be empty too.
-		desireIterator, err := desireCRUD.List(ctx, nil)
-		if err != nil {
-			return false, utils.TrackError(fmt.Errorf("failed to list nodepool-scoped kube-applier resources: %w", err))
-		}
-		for range desireIterator.Items(ctx) {
-			logger.Info("waiting for nodepool-scoped kube-applier content to be deleted before removing node pool")
-			return false, nil
-		}
-		if err := desireIterator.GetError(); err != nil {
-			return false, utils.TrackError(fmt.Errorf("error iterating nodepool-scoped kube-applier resources: %w", err))
-		}
-	}
-
 	return true, nil
 }
 

--- a/backend/pkg/controllers/nodepooldeletion/node_pool_deletion_controller.go
+++ b/backend/pkg/controllers/nodepooldeletion/node_pool_deletion_controller.go
@@ -31,19 +31,24 @@ import (
 
 // nodePoolDeletionController issues a Cosmos nodepool delete
 // for the Node Pools that have their DeletionTimestamp and ClusterServiceDeletionTimestamp set,
-// their ClusterServiceID has been cleared, and all nodepool-scoped Maestro readonly bundles
-// have been deleted from the ServiceProviderNodePool.
+// their ClusterServiceID has been cleared, all nodepool-scoped Maestro readonly bundles
+// have been deleted from the ServiceProviderNodePool, and all nodepool-scoped kube-applier
+// *Desire documents have been deleted.
 type nodePoolDeletionController struct {
 	cooldownChecker               controllerutil.CooldownChecker
 	nodePoolLister                listers.NodePoolLister
 	serviceProviderNodePoolLister listers.ServiceProviderNodePoolLister
 	resourcesDBClient             database.ResourcesDBClient
+	kubeApplierDBClients          database.KubeApplierDBClients
+	fleetDBClient                 database.FleetDBClient
 }
 
 var _ controllerutils.NodePoolSyncer = (*nodePoolDeletionController)(nil)
 
 func NewNodePoolDeletionController(
 	resourcesDBClient database.ResourcesDBClient,
+	kubeApplierDBClients database.KubeApplierDBClients,
+	fleetDBClient database.FleetDBClient,
 	activeOperationLister listers.ActiveOperationLister,
 	informers informers.BackendInformers,
 ) controllerutils.Controller {
@@ -54,6 +59,8 @@ func NewNodePoolDeletionController(
 		nodePoolLister:                nodePoolLister,
 		serviceProviderNodePoolLister: serviceProviderNodePoolLister,
 		resourcesDBClient:             resourcesDBClient,
+		kubeApplierDBClients:          kubeApplierDBClients,
+		fleetDBClient:                 fleetDBClient,
 	}
 
 	return controllerutils.NewNodePoolWatchingController(
@@ -88,7 +95,10 @@ func (c *nodePoolDeletionController) NeedsWork(nodePool *api.HCPOpenShiftCluster
 }
 
 // SyncOnce calls Cosmos to delete the NodePool when the NeedsWork condition is met and
-// all the delete preconditions are met.
+// all the delete preconditions are met:
+//  1. All nodepool-scoped Maestro readonly bundles are cleared.
+//  2. All other Cosmos child resources are deleted.
+//  3. All nodepool-scoped kube-applier *Desire documents are deleted.
 func (c *nodePoolDeletionController) SyncOnce(ctx context.Context, key controllerutils.HCPNodePoolKey) error {
 	logger := utils.LoggerFromContext(ctx)
 
@@ -142,6 +152,15 @@ func (c *nodePoolDeletionController) SyncOnce(ctx context.Context, key controlle
 		return nil
 	}
 
+	// Precondition: all nodepool-scoped kube-applier *Desire documents must be deleted
+	preconditionMet, err = c.deletePreconditionNodePoolScopedKubeApplierResourcesDeleted(ctx, key)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to check precondition: %w", err))
+	}
+	if !preconditionMet {
+		return nil
+	}
+
 	logger.Info("deleting node pool from Cosmos")
 	err = nodePoolCRUD.Delete(ctx, key.HCPNodePoolName)
 	if err != nil {
@@ -167,6 +186,58 @@ func (c *nodePoolDeletionController) deletePreconditionAllMaestroNodePoolScopedR
 			"remainingBundles", len(spnp.Status.MaestroReadonlyBundles))
 		return false, nil
 	}
+	return true, nil
+}
+
+// deletePreconditionNodePoolScopedKubeApplierResourcesDeleted checks whether any
+// nodepool-scoped kube-applier *Desire documents remain. ServiceProviderNodePool may
+// already be gone, so placement is resolved by searching all management clusters.
+func (c *nodePoolDeletionController) deletePreconditionNodePoolScopedKubeApplierResourcesDeleted(
+	ctx context.Context,
+	key controllerutils.HCPNodePoolKey,
+) (bool, error) {
+	logger := utils.LoggerFromContext(ctx)
+
+	nodePoolResourceID := key.GetResourceID()
+	managementClusters, err := database.NewDBBackedManagementClusterLister(c.fleetDBClient).List(ctx)
+	if err != nil {
+		return false, utils.TrackError(fmt.Errorf("listing management clusters for kube-applier check: %w", err))
+	}
+
+	for _, mc := range managementClusters {
+		mcResourceID := mc.ResourceID
+		if mcResourceID == nil {
+			mcResourceID = mc.CosmosMetadata.ResourceID
+		}
+		if mcResourceID == nil {
+			continue
+		}
+
+		// If no management cluster matches we cannot determine it so we consider the precondition met.
+		kaClient := c.kubeApplierDBClients.For(ctx, mcResourceID)
+		if kaClient == nil {
+			continue
+		}
+
+		desireCRUD, err := kaClient.UntypedCRUD(*nodePoolResourceID)
+		if err != nil {
+			return false, utils.TrackError(fmt.Errorf("failed to create kube-applier untyped CRUD: %w", err))
+		}
+
+		// If the management cluster doesn't have the cluster resource id this list will be empty too.
+		desireIterator, err := desireCRUD.List(ctx, nil)
+		if err != nil {
+			return false, utils.TrackError(fmt.Errorf("failed to list nodepool-scoped kube-applier resources: %w", err))
+		}
+		for range desireIterator.Items(ctx) {
+			logger.Info("waiting for nodepool-scoped kube-applier content to be deleted before removing node pool")
+			return false, nil
+		}
+		if err := desireIterator.GetError(); err != nil {
+			return false, utils.TrackError(fmt.Errorf("error iterating nodepool-scoped kube-applier resources: %w", err))
+		}
+	}
+
 	return true, nil
 }
 

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_delete.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_delete.go
@@ -176,7 +176,7 @@ func (c *operationClusterDelete) reconcileOperationAndResourceStatus(ctx context
 		return nil
 	}
 
-	// If the external auth is in the Ready state from CS side, we wait until the Cosmos Cluster document is deleted, which
+	// If the cluster is in the Ready state from CS side, we wait until the Cosmos Cluster document is deleted, which
 	// will be picked up by a next reconciliation of this controller and we will update the operation to Succeeded.
 	if csClusterStatus.State() == arohcpv1alpha1.ClusterStateReady {
 		logger.Info("cluster-service Cluster in Ready state. Waiting until Cosmos Cluster document is deleted.")

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_delete.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_delete.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	utilsclock "k8s.io/utils/clock"
 
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
 	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
 
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
@@ -45,6 +46,15 @@ type operationClusterDelete struct {
 // NewOperationClusterDeleteController returns a new Controller instance that
 // follows an asynchronous cluster deletion operation to completion and updates
 // the corresponding operation document in Cosmos DB.
+//
+// The controller has the following responsibilities:
+//   - While the Cluster Cosmos document is present, it reconciles the
+//     operation and the cluster status.
+//   - When the Cluster Cosmos document is deleted (by the clusterDeletionController),
+//     it marks the operation as Succeeded. It also cleans up child
+//     resources. Note: This last part is handled by other controllers too but
+//     because the SetDeleteOperationAsCompleted is still reused by other operations
+//     that have not been migrated to asynchronous flow yet this remains.
 //
 // Operation documents relevant to this controller will have the following values:
 //
@@ -107,85 +117,73 @@ func (c *operationClusterDelete) SynchronizeOperation(ctx context.Context, key c
 	if err != nil {
 		return fmt.Errorf("failed to get active operation: %w", err)
 	}
+
+	// TODO remove this once migration of cluster deletion from frontend to backend is fully completed.
+	if !operation.UsesNewClusterDeletionApproach {
+		return c.legacySynchronizeOperation(ctx, operation)
+	}
+
+	// From here, we know it uses the new deletion approach.
+
 	if !c.ShouldProcess(ctx, operation) {
 		return nil // no work to do
 	}
 
-	if len(operation.InternalID.String()) == 0 {
-		// we cannot proceed: yet.
-		// TODO when we update to make clusterserice creation async, we need to handle this correctly.
-		return nil
-	}
-
-	clusterStatus, err := c.clusterServiceClient.GetClusterStatus(ctx, operation.InternalID)
-	var ocmGetClusterError *ocmerrors.Error
-	if err != nil && errors.As(err, &ocmGetClusterError) && ocmGetClusterError.Status() == http.StatusNotFound {
-		logger.Info("cluster was deleted")
-
-		// Some nodepool controllers require of the Cosmos document to do their cleanup work so we block
-		// the cluster cosmos deletion until the nodepools are gone.
-		nodePoolIterator, err := c.resourcesDBClient.HCPClusters(operation.ExternalID.SubscriptionID, operation.ExternalID.ResourceGroupName).NodePools(operation.ExternalID.Name).List(ctx, nil)
-		if err != nil {
-			return utils.TrackError(err)
-		}
-		foundAtLeastOneNodePool := false
-		for range nodePoolIterator.Items(ctx) {
-			foundAtLeastOneNodePool = true
-			break
-		}
-		err = nodePoolIterator.GetError()
-		if err != nil {
-			return utils.TrackError(err)
-		}
-		if foundAtLeastOneNodePool {
-			logger.Info("cluster still has cosmos nodepools")
-			return nil
-		}
-
-		// Some external auth controllers require the Cosmos document to do their cleanup work, so we block
-		// the cluster cosmos deletion until the external auths are gone.
-		externalAuthIterator, err := c.resourcesDBClient.HCPClusters(operation.ExternalID.SubscriptionID, operation.ExternalID.ResourceGroupName).ExternalAuth(operation.ExternalID.Name).List(ctx, nil)
-		if err != nil {
-			return utils.TrackError(err)
-		}
-		foundAtLeastOneExternalAuth := false
-		for range externalAuthIterator.Items(ctx) {
-			foundAtLeastOneExternalAuth = true
-			break
-		}
-		err = externalAuthIterator.GetError()
-		if err != nil {
-			return utils.TrackError(err)
-		}
-		if foundAtLeastOneExternalAuth {
-			logger.Info("cluster still has cosmos externalauths")
-			return nil
-		}
-
-		// Update the Cosmos DB billing document with a deletion timestamp.
-		// Do this before calling setDeleteOperationAsCompleted so that in
-		// case of error the backend will retry by virtue of the operation
-		// document still having a non-terminal status.
-		err = controllerutils.MarkBillingDocumentDeleted(ctx, c.billingDBClient, operation.ExternalID, c.clock.Now())
-		if errors.Is(err, database.ErrAmbiguousResult) {
-			// TODO: Remove when we enforce there's a single billing document per cluster.
-			logger.Error(err, "Failed to mark CosmosDB billing record for deletion")
-		} else if err != nil {
-			return utils.TrackError(err)
-		}
-
+	clusterCRUD := c.resourcesDBClient.HCPClusters(operation.ExternalID.SubscriptionID, operation.ExternalID.ResourceGroupName)
+	cluster, err := clusterCRUD.Get(ctx, operation.ExternalID.Name)
+	if database.IsNotFoundError(err) {
+		logger.Info("cluster document deleted - completing operation")
 		err = SetDeleteOperationAsCompleted(ctx, c.clock, c.resourcesDBClient, operation, postAsyncNotificationFn(c.notificationClient))
 		if err != nil {
 			return utils.TrackError(err)
 		}
-		// without cluster-status, there is nothing remaining to do.  the orphan controller will cleanup any remaining cosmos bits.
 		return nil
 	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get cluster: %w", err))
+	}
+
+	if !c.shouldReconcileOperationAndResourceStatus(cluster) {
+		return nil
+	}
+	err = c.reconcileOperationAndResourceStatus(ctx, operation, cluster)
 	if err != nil {
 		return utils.TrackError(err)
 	}
 
-	newOperationStatus, newOperationError, err := convertClusterStatus(ctx, c.clusterServiceClient, operation, clusterStatus)
+	return nil
+}
+
+func (c *operationClusterDelete) shouldReconcileOperationAndResourceStatus(cluster *api.HCPOpenShiftCluster) bool {
+	return cluster.ServiceProviderProperties.DeletionTimestamp != nil &&
+		cluster.ServiceProviderProperties.ClusterServiceDeletionTimestamp != nil &&
+		cluster.ServiceProviderProperties.ClusterServiceID != nil
+}
+
+func (c *operationClusterDelete) reconcileOperationAndResourceStatus(ctx context.Context, operation *api.Operation, cluster *api.HCPOpenShiftCluster) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	clusterCSID := cluster.ServiceProviderProperties.ClusterServiceID
+
+	csClusterStatus, err := c.clusterServiceClient.GetClusterStatus(ctx, *clusterCSID)
+	if err != nil {
+		var ocmError *ocmerrors.Error
+		if !errors.As(err, &ocmError) || ocmError.Status() != http.StatusNotFound {
+			return utils.TrackError(fmt.Errorf("failed to get cluster-service Cluster status: %w", err))
+		}
+		// 404 - CS has finished deleting. clusterClusterServiceIDClearer will clear the ID.
+		logger.Info("cluster-service Cluster gone - skipping operation update", "clusterServiceID", clusterCSID.String())
+		return nil
+	}
+
+	// If the external auth is in the Ready state from CS side, we wait until the Cosmos Cluster document is deleted, which
+	// will be picked up by a next reconciliation of this controller and we will update the operation to Succeeded.
+	if csClusterStatus.State() == arohcpv1alpha1.ClusterStateReady {
+		logger.Info("cluster-service Cluster in Ready state. Waiting until Cosmos Cluster document is deleted.")
+		return nil
+	}
+
+	newOperationStatus, newOperationError, err := convertClusterStatus(ctx, c.clusterServiceClient, operation, csClusterStatus)
 	if err != nil {
 		return utils.TrackError(err)
 	}

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_delete_legacy.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_delete_legacy.go
@@ -1,0 +1,129 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operationcontrollers
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+
+	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+func (c *operationClusterDelete) legacyShouldProcess(ctx context.Context, operation *api.Operation) bool {
+	if operation.Status.IsTerminal() {
+		return false
+	}
+	if operation.Request != database.OperationRequestDelete {
+		return false
+	}
+	if operation.ExternalID == nil || !strings.EqualFold(operation.ExternalID.ResourceType.String(), api.ClusterResourceType.String()) {
+		return false
+	}
+	return true
+}
+
+func (c *operationClusterDelete) legacySynchronizeOperation(ctx context.Context, operation *api.Operation) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	if !c.legacyShouldProcess(ctx, operation) {
+		return nil // no work to do
+	}
+
+	if len(operation.InternalID.String()) == 0 {
+		return nil
+	}
+
+	clusterStatus, err := c.clusterServiceClient.GetClusterStatus(ctx, operation.InternalID)
+	var ocmGetClusterError *ocmerrors.Error
+	if err != nil && errors.As(err, &ocmGetClusterError) && ocmGetClusterError.Status() == http.StatusNotFound {
+		logger.Info("cluster was deleted")
+
+		// Some nodepool controllers require of the Cosmos document to do their cleanup work so we block
+		// the cluster cosmos deletion until the nodepools are gone.
+		nodePoolIterator, err := c.resourcesDBClient.HCPClusters(operation.ExternalID.SubscriptionID, operation.ExternalID.ResourceGroupName).NodePools(operation.ExternalID.Name).List(ctx, nil)
+		if err != nil {
+			return utils.TrackError(err)
+		}
+		foundAtLeastOneNodePool := false
+		for range nodePoolIterator.Items(ctx) {
+			foundAtLeastOneNodePool = true
+			break
+		}
+		err = nodePoolIterator.GetError()
+		if err != nil {
+			return utils.TrackError(err)
+		}
+		if foundAtLeastOneNodePool {
+			logger.Info("cluster still has cosmos nodepools")
+			return nil
+		}
+
+		// Some external auth controllers require the Cosmos document to do their cleanup work, so we block
+		// the cluster cosmos deletion until the external auths are gone.
+		externalAuthIterator, err := c.resourcesDBClient.HCPClusters(operation.ExternalID.SubscriptionID, operation.ExternalID.ResourceGroupName).ExternalAuth(operation.ExternalID.Name).List(ctx, nil)
+		if err != nil {
+			return utils.TrackError(err)
+		}
+		foundAtLeastOneExternalAuth := false
+		for range externalAuthIterator.Items(ctx) {
+			foundAtLeastOneExternalAuth = true
+			break
+		}
+		err = externalAuthIterator.GetError()
+		if err != nil {
+			return utils.TrackError(err)
+		}
+		if foundAtLeastOneExternalAuth {
+			logger.Info("cluster still has cosmos externalauths")
+			return nil
+		}
+
+		// Update the Cosmos DB billing document with a deletion timestamp.
+		err = controllerutils.MarkBillingDocumentDeleted(ctx, c.billingDBClient, operation.ExternalID, c.clock.Now())
+		if errors.Is(err, database.ErrAmbiguousResult) {
+			logger.Error(err, "Failed to mark CosmosDB billing record for deletion")
+		} else if err != nil {
+			return utils.TrackError(err)
+		}
+
+		err = SetDeleteOperationAsCompleted(ctx, c.clock, c.resourcesDBClient, operation, postAsyncNotificationFn(c.notificationClient))
+		if err != nil {
+			return utils.TrackError(err)
+		}
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(err)
+	}
+
+	newOperationStatus, newOperationError, err := convertClusterStatus(ctx, c.clusterServiceClient, operation, clusterStatus)
+	if err != nil {
+		return utils.TrackError(err)
+	}
+
+	err = UpdateOperationStatus(ctx, c.clock, c.resourcesDBClient, operation, newOperationStatus, newOperationError, postAsyncNotificationFn(c.notificationClient))
+	if err != nil {
+		return utils.TrackError(err)
+	}
+
+	return nil
+}

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_delete_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_delete_test.go
@@ -18,12 +18,14 @@ import (
 	"context"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr/testr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clocktesting "k8s.io/utils/clock/testing"
 
 	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
@@ -41,17 +43,30 @@ func TestOperationClusterDelete_SynchronizeOperation(t *testing.T) {
 	fixedTime := mustParseTime("2025-01-20T10:30:00Z")
 	createdAt := mustParseTime("2025-01-15T10:30:00Z")
 
-	tests := []struct {
-		name          string
-		nodePools     []*api.HCPOpenShiftClusterNodePool
-		externalAuths []*api.HCPOpenShiftClusterExternalAuth
-		setupMock     func(ctrl *gomock.Controller, fixture *clusterTestFixture) ocm.ClusterServiceClientSpec
-		expectError   bool
-		verify        func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *clusterTestFixture)
+	fixture := newClusterTestFixture()
+
+	clusterPassingReconcileGate := func() *api.HCPOpenShiftCluster {
+		now := time.Now()
+		cluster := fixture.newCluster(nil)
+		cluster.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: now}
+		cluster.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: now}
+		return cluster
+	}
+
+	testCases := []struct {
+		name                           string
+		nodePools                      []*api.HCPOpenShiftClusterNodePool
+		externalAuths                  []*api.HCPOpenShiftClusterExternalAuth
+		usesNewClusterDeletionApproach bool
+		existingCluster                *api.HCPOpenShiftCluster
+		setupCSMock                    func(ctrl *gomock.Controller, fixture *clusterTestFixture) ocm.ClusterServiceClientSpec
+		wantErr                        bool
+		verifyDB                       func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient)
 	}{
 		{
-			name: "cluster not found marks billing as deleted and removes cluster",
-			setupMock: func(ctrl *gomock.Controller, fixture *clusterTestFixture) ocm.ClusterServiceClientSpec {
+			name:            "legacy approach: cluster not found marks billing as deleted and removes cluster",
+			existingCluster: fixture.newCluster(&createdAt),
+			setupCSMock: func(ctrl *gomock.Controller, fixture *clusterTestFixture) ocm.ClusterServiceClientSpec {
 				mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
 				notFoundErr, _ := ocmerrors.NewError().Status(http.StatusNotFound).Build()
 				mockCSClient.EXPECT().
@@ -59,21 +74,22 @@ func TestOperationClusterDelete_SynchronizeOperation(t *testing.T) {
 					Return(nil, notFoundErr)
 				return mockCSClient
 			},
-			expectError: false,
-			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *clusterTestFixture) {
-				// Verify operation succeeded
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateSucceeded, op.Status)
 
-				// Verify cluster document was deleted
 				_, err = db.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
 				assert.Error(t, err, "cluster should have been deleted")
 			},
 		},
 		{
-			name: "cluster not found does not remove cluster while nodepools exist",
-			setupMock: func(ctrl *gomock.Controller, fixture *clusterTestFixture) ocm.ClusterServiceClientSpec {
+			name:            "legacy approach: cluster not found does not remove cluster while nodepools exist",
+			existingCluster: fixture.newCluster(&createdAt),
+			nodePools: []*api.HCPOpenShiftClusterNodePool{
+				newNodePoolTestFixture().newNodePool(),
+			},
+			setupCSMock: func(ctrl *gomock.Controller, fixture *clusterTestFixture) ocm.ClusterServiceClientSpec {
 				mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
 				notFoundErr, _ := ocmerrors.NewError().Status(http.StatusNotFound).Build()
 				mockCSClient.EXPECT().
@@ -81,12 +97,7 @@ func TestOperationClusterDelete_SynchronizeOperation(t *testing.T) {
 					Return(nil, notFoundErr)
 				return mockCSClient
 			},
-			expectError: false,
-			nodePools: []*api.HCPOpenShiftClusterNodePool{
-				newNodePoolTestFixture().newNodePool(),
-			},
-			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *clusterTestFixture) {
-				// Operation should remain non-terminal since nodepools still exist
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
@@ -98,8 +109,9 @@ func TestOperationClusterDelete_SynchronizeOperation(t *testing.T) {
 			},
 		},
 		{
-			name: "cluster not found does not remove cluster while external auths exist",
-			setupMock: func(ctrl *gomock.Controller, fixture *clusterTestFixture) ocm.ClusterServiceClientSpec {
+			name:            "legacy approach: cluster not found does not remove cluster while external auths exist",
+			existingCluster: fixture.newCluster(&createdAt),
+			setupCSMock: func(ctrl *gomock.Controller, fixture *clusterTestFixture) ocm.ClusterServiceClientSpec {
 				mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
 				notFoundErr, _ := ocmerrors.NewError().Status(http.StatusNotFound).Build()
 				mockCSClient.EXPECT().
@@ -107,11 +119,11 @@ func TestOperationClusterDelete_SynchronizeOperation(t *testing.T) {
 					Return(nil, notFoundErr)
 				return mockCSClient
 			},
-			expectError: false,
+			wantErr: false,
 			externalAuths: []*api.HCPOpenShiftClusterExternalAuth{
 				newExternalAuthTestFixture().newExternalAuth(),
 			},
-			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *clusterTestFixture) {
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				// Operation should remain non-terminal since external auths still exist
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
@@ -124,8 +136,9 @@ func TestOperationClusterDelete_SynchronizeOperation(t *testing.T) {
 			},
 		},
 		{
-			name: "cluster uninstalling updates operation to deleting",
-			setupMock: func(ctrl *gomock.Controller, fixture *clusterTestFixture) ocm.ClusterServiceClientSpec {
+			name:            "legacy approach: cluster uninstalling updates operation to deleting",
+			existingCluster: fixture.newCluster(&createdAt),
+			setupCSMock: func(ctrl *gomock.Controller, fixture *clusterTestFixture) ocm.ClusterServiceClientSpec {
 				mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
 				clusterStatus, _ := arohcpv1alpha1.NewClusterStatus().
 					State(arohcpv1alpha1.ClusterStateUninstalling).
@@ -135,21 +148,20 @@ func TestOperationClusterDelete_SynchronizeOperation(t *testing.T) {
 					Return(clusterStatus, nil)
 				return mockCSClient
 			},
-			expectError: false,
-			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *clusterTestFixture) {
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateDeleting, op.Status)
 
-				// Cluster should still exist during uninstalling
 				cluster, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
 				require.NoError(t, err)
 				assert.NotNil(t, cluster)
 			},
 		},
 		{
-			name: "cluster ready during delete stays at current status",
-			setupMock: func(ctrl *gomock.Controller, fixture *clusterTestFixture) ocm.ClusterServiceClientSpec {
+			name:            "legacy approach: cluster ready during delete stays at current status",
+			existingCluster: fixture.newCluster(&createdAt),
+			setupCSMock: func(ctrl *gomock.Controller, fixture *clusterTestFixture) ocm.ClusterServiceClientSpec {
 				mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
 				clusterStatus, _ := arohcpv1alpha1.NewClusterStatus().
 					State(arohcpv1alpha1.ClusterStateReady).
@@ -159,22 +171,20 @@ func TestOperationClusterDelete_SynchronizeOperation(t *testing.T) {
 					Return(clusterStatus, nil)
 				return mockCSClient
 			},
-			expectError: false,
-			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *clusterTestFixture) {
-				// When cluster is Ready during delete, operation stays at Accepted
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
 
-				// Cluster should still exist
 				cluster, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
 				require.NoError(t, err)
 				assert.NotNil(t, cluster)
 			},
 		},
 		{
-			name: "cluster error during delete transitions to failed",
-			setupMock: func(ctrl *gomock.Controller, fixture *clusterTestFixture) ocm.ClusterServiceClientSpec {
+			name:            "legacy approach: cluster error during delete transitions to failed",
+			existingCluster: fixture.newCluster(&createdAt),
+			setupCSMock: func(ctrl *gomock.Controller, fixture *clusterTestFixture) ocm.ClusterServiceClientSpec {
 				mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
 				clusterStatus, _ := arohcpv1alpha1.NewClusterStatus().
 					State(arohcpv1alpha1.ClusterStateError).
@@ -186,54 +196,178 @@ func TestOperationClusterDelete_SynchronizeOperation(t *testing.T) {
 					Return(clusterStatus, nil)
 				return mockCSClient
 			},
-			expectError: false,
-			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *clusterTestFixture) {
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateFailed, op.Status)
 				assert.NotNil(t, op.Error)
 				assert.Equal(t, "ERR001", op.Error.Code)
 
-				// Cluster should still exist on failure
 				cluster, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
 				require.NoError(t, err)
 				assert.NotNil(t, cluster)
 			},
 		},
+		{
+			name:                           "cluster document gone completes operation",
+			usesNewClusterDeletionApproach: true,
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateSucceeded, op.Status)
+			},
+		},
+		{
+			name:                           "shouldReconcile gate not passed skips cluster service",
+			usesNewClusterDeletionApproach: true,
+			existingCluster: func() *api.HCPOpenShiftCluster {
+				cluster := fixture.newCluster(nil)
+				cluster.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+				return cluster
+			}(),
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+			},
+		},
+		{
+			name:                           "shouldReconcile gate not passed when ClusterServiceID is nil",
+			usesNewClusterDeletionApproach: true,
+			existingCluster: func() *api.HCPOpenShiftCluster {
+				cluster := fixture.newCluster(nil)
+				cluster.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+				cluster.ServiceProviderProperties.ClusterServiceDeletionTimestamp = &metav1.Time{Time: time.Now()}
+				cluster.ServiceProviderProperties.ClusterServiceID = nil
+				return cluster
+			}(),
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+			},
+		},
+		{
+			name:                           "reconcile gate passed and CS uninstalling updates operation to deleting",
+			usesNewClusterDeletionApproach: true,
+			existingCluster:                clusterPassingReconcileGate(),
+			setupCSMock: func(ctrl *gomock.Controller, fixture *clusterTestFixture) ocm.ClusterServiceClientSpec {
+				mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
+				clusterStatus, _ := arohcpv1alpha1.NewClusterStatus().
+					State(arohcpv1alpha1.ClusterStateUninstalling).
+					Build()
+				mockCSClient.EXPECT().
+					GetClusterStatus(gomock.Any(), fixture.clusterInternalID).
+					Return(clusterStatus, nil)
+				return mockCSClient
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateDeleting, op.Status)
+			},
+		},
+		{
+			name:                           "reconcile gate passed and CS error marks operation failed",
+			usesNewClusterDeletionApproach: true,
+			existingCluster:                clusterPassingReconcileGate(),
+			setupCSMock: func(ctrl *gomock.Controller, fixture *clusterTestFixture) ocm.ClusterServiceClientSpec {
+				mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
+				clusterStatus, _ := arohcpv1alpha1.NewClusterStatus().
+					State(arohcpv1alpha1.ClusterStateError).
+					ProvisionErrorCode("ERR001").
+					ProvisionErrorMessage("delete failed").
+					Build()
+				mockCSClient.EXPECT().
+					GetClusterStatus(gomock.Any(), fixture.clusterInternalID).
+					Return(clusterStatus, nil)
+				return mockCSClient
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateFailed, op.Status)
+				assert.NotNil(t, op.Error)
+				assert.Equal(t, "ERR001", op.Error.Code)
+			},
+		},
+		{
+			name:                           "reconcile gate passed and CS Ready waits for Cosmos deletion",
+			usesNewClusterDeletionApproach: true,
+			existingCluster:                clusterPassingReconcileGate(),
+			setupCSMock: func(ctrl *gomock.Controller, fixture *clusterTestFixture) ocm.ClusterServiceClientSpec {
+				mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
+				clusterStatus, _ := arohcpv1alpha1.NewClusterStatus().
+					State(arohcpv1alpha1.ClusterStateReady).
+					Build()
+				mockCSClient.EXPECT().
+					GetClusterStatus(gomock.Any(), fixture.clusterInternalID).
+					Return(clusterStatus, nil)
+				return mockCSClient
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status, "operation should stay at Accepted, waiting for Cosmos Cluster document deletion")
+			},
+		},
+		{
+			name:                           "reconcile gate passed and CS 404 skips operation update",
+			usesNewClusterDeletionApproach: true,
+			existingCluster:                clusterPassingReconcileGate(),
+			setupCSMock: func(ctrl *gomock.Controller, fixture *clusterTestFixture) ocm.ClusterServiceClientSpec {
+				mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
+				notFoundErr, _ := ocmerrors.NewError().Status(http.StatusNotFound).Build()
+				mockCSClient.EXPECT().
+					GetClusterStatus(gomock.Any(), fixture.clusterInternalID).
+					Return(nil, notFoundErr)
+				return mockCSClient
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status, "operation should stay at Accepted, waiting for ID clearer")
+			},
+		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
-			ctx = utils.ContextWithLogger(ctx, testr.New(t))
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
-			fixture := newClusterTestFixture()
-			cluster := fixture.newCluster(&createdAt)
 			operation := fixture.newOperation(database.OperationRequestDelete)
+			// TODO remove this once the new deletion approach is fully rolled out in all ARO-HCP permanent environments, for all regions.
+			operation.UsesNewClusterDeletionApproach = tc.usesNewClusterDeletionApproach
 
-			// Create billing document for deletion test
-			billingDoc := database.NewBillingDocument(cluster.ServiceProviderProperties.ClusterUID, fixture.clusterResourceID)
-			billingDoc.CreationTime = createdAt
-			billingDoc.Location = testAzureLocation
-			billingDoc.TenantID = testTenantID
 			mockBillingDBClient := databasetesting.NewMockBillingDBClient()
-			err := mockBillingDBClient.BillingDocs(fixture.clusterResourceID.SubscriptionID).Create(ctx, billingDoc)
-			require.NoError(t, err)
+			if tc.existingCluster != nil {
+				billingDoc := database.NewBillingDocument(tc.existingCluster.ServiceProviderProperties.ClusterUID, fixture.clusterResourceID)
+				billingDoc.CreationTime = createdAt
+				billingDoc.Location = testAzureLocation
+				billingDoc.TenantID = testTenantID
+				err := mockBillingDBClient.BillingDocs(fixture.clusterResourceID.SubscriptionID).Create(ctx, billingDoc)
+				require.NoError(t, err)
+			}
 
-			// Mock resources DB client with cluster, operation, node pools and external auths
-			resources := []any{cluster, operation}
-			for _, nodePool := range tt.nodePools {
+			resources := []any{operation}
+			if tc.existingCluster != nil {
+				resources = append(resources, tc.existingCluster)
+			}
+			for _, nodePool := range tc.nodePools {
 				resources = append(resources, nodePool)
 			}
-			for _, externalAuth := range tt.externalAuths {
+			for _, externalAuth := range tc.externalAuths {
 				resources = append(resources, externalAuth)
 			}
 			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, resources)
 			require.NoError(t, err)
 
-			mockCSClient := tt.setupMock(ctrl, fixture)
+			var mockCSClient ocm.ClusterServiceClientSpec
+			if tc.setupCSMock != nil {
+				mockCSClient = tc.setupCSMock(ctrl, fixture)
+			}
 
 			controller := &operationClusterDelete{
 				clock:                clocktesting.NewFakePassiveClock(fixedTime),
@@ -244,14 +378,14 @@ func TestOperationClusterDelete_SynchronizeOperation(t *testing.T) {
 			}
 
 			err = controller.SynchronizeOperation(ctx, fixture.operationKey())
-			if tt.expectError {
+			if tc.wantErr {
 				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
+				return
 			}
+			require.NoError(t, err)
 
-			if tt.verify != nil {
-				tt.verify(t, ctx, mockResourcesDBClient, fixture)
+			if tc.verifyDB != nil {
+				tc.verifyDB(t, ctx, mockResourcesDBClient)
 			}
 		})
 	}


### PR DESCRIPTION
The backend logic to perform asynchronous cluster deletion is disabled for now: all new controllers and the updated cluster delete operation controller branch on UsesNewClusterDeletionApproach, which is not set by the frontend yet. Legacy synchronous deletion behavior is preserved via legacySynchronizeOperation in operation_cluster_delete.

Changes:
- Add ClusterClusterServiceDeleteDispatchController to call Cluster Service DeleteCluster after DeletionTimestamp is set. It also stamps ClusterServiceDeletionTimestamp
- Add ClusterClusterServiceIDClearerController to clear ClusterServiceID once from the Cluster's serviceProviderProperties when Cluster Service reports the cluster is gone
- Add ClusterChildResourcesCleanupController to recursively delete Cosmos child resources under the cluster with gates for Maestro bundles cleanup as they depend on ServiceProviderCluster, and ignoring controllers documents as well as the entire subtree of NodePools and ExternalAuths as those are deleted by their corresponding deletion processes
- The ClusterChildResourcesCleanupController does not proceed until the Cluster's NodePools and ExternalAuths are fully gone from Cosmos. This is intentional to prevent deleting cluster child resources that the NodePool and ExternalAuth deletion processes might depend on
- Add ClusterDeletionController to delete the Cluster Cosmos document once CS cleanup, Maestro bundles cleanup and child resources cleanup are completed. The controller does not proceed until ExternalAuth and NodePool Cosmos documents are gone. The controller also ignores the child resources of ExternalAuth and NodePool resources. The controller also marks the cluster billing document as deleted before deleting the Cluster Cosmos document itself
- Both ClusterChildResourcesCleanupController and ClusterDeletionController skip checking the child resources of NodePool and ExternalAuth resources, as those should be cleant by their corresponding deletion processes
- Update OperationClusterDeleteController to complete operations when the Cluster Cosmos document is removed (new path), as well as keep CS polling to update the cluster delete operation and the cluster delete status from CS state. The controller also keeps the legacy cluster delete operation controller behavior by branching depending on UsesNewClusterDeletionApproach

<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

### Why

<!-- Briefly explain why this change is needed -->

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
