### PR TITLE
Use mode: runtime-selected for e2e-parallel

### DIFF
--- a/test/cmd/aro-hcp-tests/slot-manager/DESIGN.md
+++ b/test/cmd/aro-hcp-tests/slot-manager/DESIGN.md
@@ -152,8 +152,9 @@ flowchart TD
 - Multi-pool candidate selection and fallback are implemented:
   - fixed-mode environments filter candidate pools by `ALLOWED_SUBSCRIPTIONS` and either `ALLOWED_LOCATIONS` or `MULTISTAGE_PARAM_OVERRIDE_LOCATION`, then try pools in catalog order,
   - runtime-selected environments use `ALLOWED_SUBSCRIPTIONS` for pool identity, ignore `ALLOWED_LOCATIONS` for candidate selection, and use `MULTISTAGE_PARAM_OVERRIDE_LOCATION` only as the concrete runtime location,
-  - current `openshift/release` dev rollout pins the normal `e2e-parallel` job to the first dev pool on `ARO HCP E2E Hosted Clusters (EA Subscription)` in `centralus`,
-  - the separate `e2e-parallel-multipool` job exercises only the additional pools on `ARO HCP E2E Hosted Clusters 2 (EA Subscription)` in `centralus` and `westus3`.
+  - the dev catalog now uses one runtime-selected pool per customer subscription, with `westus3` as the default runtime region,
+  - those shared dev pools provision their MSI container stacks in `westus3` via `identity_provisioning_region`,
+  - that intentionally optimizes the current rollout for multi-subscription, single-region operation first; multi-region CI behavior will need a follow-up job strategy.
 - Pool fallback is now adapted to the Boskos proxy's blocking acquire behavior:
   - the proxy does not reliably give `slot-manager` a distinct immediate "pool exhausted" signal for candidate failover,
   - each candidate pool probe is therefore bounded by `lease-proxy-timeout` and interpreted through the client-side `ErrLeasePoolUnavailableNow` classification,

--- a/test/e2e-config/e2e-slots.yaml
+++ b/test/e2e-config/e2e-slots.yaml
@@ -5,23 +5,24 @@ environments:
     - prow
     - ci01
     pools:
+    # shard1: additional dev capacity for multi-subscription testing.
+    # Capacity is still limited to 4000 role assignments.
+    - subscription_name: "ARO HCP E2E Hosted Clusters 2 (EA Subscription)"
+      region: westus3
+      region_mode: runtime-selected
+      resource_type: aro-hcp-dev-shard1-slot
+      slot_count: 7
+      identity_container_prefix: aro-hcp-msi-container-dev-shard1
+      identity_container_count: 20
+    # shard0: current CI dev capacity on the first customer subscription.
+    # Jobs choose the runtime region; `region` is only the default when no runtime override is provided.
+    # Identity containers are provisioned in westus3.
     - subscription_name: "ARO HCP E2E Hosted Clusters (EA Subscription)"
-      region: centralus
-      resource_type: aro-hcp-dev-shard0-centralus-slot
+      region: westus3
+      region_mode: runtime-selected
+      resource_type: aro-hcp-dev-shard0-slot
       slot_count: 15
-      identity_container_prefix: aro-hcp-msi-container-dev
-      identity_container_count: 20
-    - subscription_name: "ARO HCP E2E Hosted Clusters 2 (EA Subscription)"
-      region: canadacentral
-      resource_type: aro-hcp-dev-shard1-canadacentral-slot
-      slot_count: 1
-      identity_container_prefix: aro-hcp-msi-container-dev
-      identity_container_count: 20
-    - subscription_name: "ARO HCP E2E Hosted Clusters 2 (EA Subscription)"
-      region: centralus
-      resource_type: aro-hcp-dev-shard1-centralus-slot
-      slot_count: 6
-      identity_container_prefix: aro-hcp-msi-container-dev
+      identity_container_prefix: aro-hcp-msi-container-dev-shard0
       identity_container_count: 20
 
 # int:
@@ -30,6 +31,7 @@ environments:
 #   pools:
 #     - subscription_name: "ARO SRE Team - INT (EA Subscription 3)"
 #       region: uksouth
+#       region_mode: fixed
 #       resource_type: aro-hcp-int-uksouth-slot
 #       slot_count: 1
 #       identity_container_prefix: aro-hcp-msi-container-int
@@ -41,6 +43,7 @@ environments:
 #   pools:
 #     - subscription_name: "ARO HCP E2E - Staging"
 #       region: uksouth
+#       region_mode: fixed
 #       resource_type: aro-hcp-stg-uksouth-slot
 #       slot_count: 1
 #       identity_container_prefix: aro-hcp-msi-container-stg


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-27243

The dev slot catalog was reshaped from several fixed regional pools per subscription to one runtime-selected pool per subscription because the previous fixed-mode direction does not fit within Azure’s resource group limits for the E2E identity pool.

With the current E2E identity-pool model, each fixed regional pool needs its own distinct identity_container_prefix, which means its own dedicated set of MSI container resource groups. That footprint scales quickly: a pool with 15 slots and 20 identity containers consumes about 300 resource groups, so modeling three fixed regions for the same subscription would consume about 900 RGs in that subscription by itself, leaving almost no headroom under Azure’s practical ~980 RG limit.

Reusing the same identity container prefix across fixed regional pools is not a safe alternative, because different Boskos leases would then point at the same underlying E2E identity-pool RG set.

For that reason, dev now uses one runtime-selected pool per customer subscription, with the runtime region selected by the job and the shared E2E identity pool provisioned once in westus3. This keeps the current rollout aligned with the immediate goal of multi-subscription scaling in a single region, while avoiding an unsustainable RG explosion.