### PR TITLE
infra: refactor sql role assignments

### DIFF
--- a/dev-infrastructure/modules/rp-cosmos-kube-applier.bicep
+++ b/dev-infrastructure/modules/rp-cosmos-kube-applier.bicep
@@ -4,7 +4,7 @@ param containerMaxScale int
 param kubeApplierManagedIdentityPrincipalId string
 
 // https://learn.microsoft.com/en-us/azure/cosmos-db/reference-data-plane-security#cosmos-db-built-in-data-contributor
-param cosmosdbBuiltInDataContributorRoleId string = '00000000-0000-0000-0000-000000000002'
+param cosmosDataContributorRoleDefinitionId string = '00000000-0000-0000-0000-000000000002'
 
 resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2023-11-15' existing = {
   name: cosmosDBAccountName
@@ -58,14 +58,17 @@ resource container 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/container
   }
 }
 
-var kubeApplierRoleDefinitionId = guid('kube-applier-role', cosmosDbAccount.id, cosmosdbBuiltInDataContributorRoleId)
 var containerScope = '${cosmosDbAccount.id}/dbs/${cosmosDBAccountName}/colls/${containerName}'
 
 resource sqlRoleAssignment 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments@2021-04-15' = {
-  name: guid(kubeApplierRoleDefinitionId, kubeApplierManagedIdentityPrincipalId, container.id)
+  name: guid(
+    guid('kube-applier-role', cosmosDbAccount.id, cosmosDataContributorRoleDefinitionId),
+    kubeApplierManagedIdentityPrincipalId,
+    container.id
+  )
   parent: cosmosDbAccount
   properties: {
-    roleDefinitionId: '/${subscription().id}/resourceGroups/${resourceGroup().name}/providers/Microsoft.DocumentDB/databaseAccounts/${cosmosDbAccount.name}/sqlRoleDefinitions/${cosmosdbBuiltInDataContributorRoleId}'
+    roleDefinitionId: '${cosmosDbAccount.id}/sqlRoleDefinitions/${cosmosDataContributorRoleDefinitionId}'
     principalId: kubeApplierManagedIdentityPrincipalId
     scope: containerScope
   }

--- a/dev-infrastructure/modules/rp-cosmos.bicep
+++ b/dev-infrastructure/modules/rp-cosmos.bicep
@@ -34,8 +34,9 @@ var containers = [
   }
 ]
 
-param roleDefinitionId string = '00000000-0000-0000-0000-000000000002'
-param readOnlyRoleDefinitionId string = '00000000-0000-0000-0000-000000000001'
+// https://learn.microsoft.com/en-us/azure/cosmos-db/reference-data-plane-security#cosmos-db-built-in-data-contributor
+param cosmosDataContributorRoleDefinitionId string = '00000000-0000-0000-0000-000000000002'
+param cosmosReadOnlyRoleDefinitionId string = '00000000-0000-0000-0000-000000000001'
 
 resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2023-11-15' existing = {
   name: cosmosDBAccountName
@@ -93,10 +94,10 @@ resource cosmosDbContainers 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/
 
 resource sqlRoleAssignment 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments@2021-04-15' = [
   for uami in userAssignedMIs: {
-    name: guid(roleDefinitionId, uami.uamiPrincipalID, cosmosDbAccount.id)
+    name: guid(cosmosDataContributorRoleDefinitionId, uami.uamiPrincipalID, cosmosDbAccount.id)
     parent: cosmosDbAccount
     properties: {
-      roleDefinitionId: '/${subscription().id}/resourceGroups/${resourceGroup().name}/providers/Microsoft.DocumentDB/databaseAccounts/${cosmosDbAccount.name}/sqlRoleDefinitions/${roleDefinitionId}'
+      roleDefinitionId: '${cosmosDbAccount.id}/sqlRoleDefinitions/${cosmosDataContributorRoleDefinitionId}'
       principalId: uami.uamiPrincipalID
       scope: cosmosDbAccount.id
     }
@@ -105,10 +106,10 @@ resource sqlRoleAssignment 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignm
 
 resource sqlRoleAssignmentReadOnly 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments@2021-04-15' = [
   for uami in readOnlyUserAssignedMIs: {
-    name: guid(readOnlyRoleDefinitionId, uami.uamiPrincipalID, cosmosDbAccount.id)
+    name: guid(cosmosReadOnlyRoleDefinitionId, uami.uamiPrincipalID, cosmosDbAccount.id)
     parent: cosmosDbAccount
     properties: {
-      roleDefinitionId: '/${subscription().id}/resourceGroups/${resourceGroup().name}/providers/Microsoft.DocumentDB/databaseAccounts/${cosmosDbAccount.name}/sqlRoleDefinitions/${readOnlyRoleDefinitionId}'
+      roleDefinitionId: '${cosmosDbAccount.id}/sqlRoleDefinitions/${cosmosReadOnlyRoleDefinitionId}'
       principalId: uami.uamiPrincipalID
       scope: cosmosDbAccount.id
     }

--- a/dev-infrastructure/templates/dev-roleassignments.bicep
+++ b/dev-infrastructure/templates/dev-roleassignments.bicep
@@ -44,7 +44,7 @@ resource sqlRoleAssignment 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignm
   name: cosmosRoleAssignmentId
   parent: cosmosDbAccount
   properties: {
-    roleDefinitionId: '/${subscription().id}/resourceGroups/${resourceGroup().name}/providers/Microsoft.DocumentDB/databaseAccounts/${cosmosDbAccount.name}/sqlRoleDefinitions/${cosmosRoleDefinitionId}'
+    roleDefinitionId: '${cosmosDbAccount.id}/sqlRoleDefinitions/${cosmosRoleDefinitionId}'
     principalId: principalID
     scope: cosmosDbAccount.id
   }


### PR DESCRIPTION
### What

Use resourceID of referenced cosmosdb instance in bicep rather than forming manually.

### Why

- There was a leading '/' character at the beginning of all our roleDefinitionIDs for our sql role assignments for comsosdb, which are now fixed.
- Also links the cosmosdb built-in DP role assignments and renames things to make them more clear
- Maintains the name on the kube-applier role assignment to not recreate it.  

### Testing

e2e tests. 

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
