### PR TITLE
fix: TestNodeRolloutConfig needs to include image digests known to cause node rollouts

### DIFF
--- a/hypershiftoperator/zz_fixture_TestNodeRolloutConfig_dev_westus3_mgmt_1_hypershift.yaml
+++ b/hypershiftoperator/zz_fixture_TestNodeRolloutConfig_dev_westus3_mgmt_1_hypershift.yaml
@@ -15,4 +15,4 @@ registryOverrides:
 - quay.io/openshift-release-dev/ocp-v4.0-art-dev=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-v4.0-art-dev
 - quay.io/openshift-release-dev/ocp-v5.0-art-dev=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-v5.0-art-dev
 - registry.redhat.io/redhat=arohcpocpdev.azurecr.io/redhat
-sharedIngressHAProxyImage: arohcpocpdev.azurecr.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main@sha256:1234567890
+sharedIngressHAProxyImage: arohcpocpdev.azurecr.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main@sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678

--- a/tooling/helmtest/internal/config.go
+++ b/tooling/helmtest/internal/config.go
@@ -17,6 +17,7 @@ package internal
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"sigs.k8s.io/yaml"
 
@@ -47,13 +48,30 @@ func LoadConfigAndMerge(configPath string, configOverride map[string]any) (map[s
 }
 
 func ReplaceImageDigest(yamlCfg map[string]any) map[string]any {
+	return ReplaceImageDigestExcluding(yamlCfg, nil)
+}
+
+// ReplaceImageDigestExcluding replaces all config values keyed "digest" with a
+// placeholder, except for dotted config paths listed in skipPaths (e.g.
+// "hypershift.sharedIngressImage.digest"). Skipped paths preserve their real
+// value so tests can detect when a node-affecting digest changes.
+func ReplaceImageDigestExcluding(yamlCfg map[string]any, skipPaths []string) map[string]any {
+	skip := make(map[string]bool, len(skipPaths))
+	for _, p := range skipPaths {
+		skip[p] = true
+	}
+	replaceImageDigest(yamlCfg, nil, skip)
+	return yamlCfg
+}
+
+func replaceImageDigest(yamlCfg map[string]any, prefix []string, skip map[string]bool) {
 	for key, value := range yamlCfg {
-		if _, ok := value.(map[string]any); ok {
-			yamlCfg[key] = ReplaceImageDigest(value.(map[string]any))
+		path := append(prefix, key)
+		if nested, ok := value.(map[string]any); ok {
+			replaceImageDigest(nested, path, skip)
 		}
-		if key == "digest" {
+		if key == "digest" && !skip[strings.Join(path, ".")] {
 			yamlCfg[key] = "sha256:1234567890"
 		}
 	}
-	return yamlCfg
 }

--- a/tooling/helmtest/testrunner/node_rollout_config.go
+++ b/tooling/helmtest/testrunner/node_rollout_config.go
@@ -90,6 +90,14 @@ var envVarCategories = map[string]flagEffect{
 	"IMAGE_SHARED_INGRESS_HAPROXY": flagNodeAffecting,
 }
 
+// nodeAffectingDigestPaths lists dotted config paths whose digest values affect
+// worker node configuration. These paths are excluded from placeholder
+// replacement during helm rendering so the golden fixture contains the real
+// digest and any change surfaces as a diff requiring explicit review.
+var nodeAffectingDigestPaths = []string{
+	"hypershift.sharedIngressImage.digest",
+}
+
 type NodeRolloutConfig struct {
 	RegistryOverrides         []string `json:"registryOverrides" yaml:"registryOverrides"`
 	SharedIngressHAProxyImage string   `json:"sharedIngressHAProxyImage,omitempty" yaml:"sharedIngressHAProxyImage,omitempty"`
@@ -137,7 +145,7 @@ func RunTestNodeRolloutConfig(t *testing.T, settingsPath string) {
 		}
 
 		t.Run(testName, func(t *testing.T) {
-			manifest, err := runTest(t.Context(), settings, testCase)
+			manifest, err := runTest(t.Context(), settings, testCase, withDigestSkipPaths(nodeAffectingDigestPaths))
 			assert.NoError(t, err)
 
 			config, err := extractNodeRolloutConfig(manifest)

--- a/tooling/helmtest/testrunner/test_runner.go
+++ b/tooling/helmtest/testrunner/test_runner.go
@@ -39,7 +39,19 @@ import (
 	"github.com/Azure/ARO-HCP/tooling/helmtest/internal"
 )
 
-func runTest(ctx context.Context, settings *internal.Settings, testCase internal.TestCase) (string, error) {
+type runTestOption func(*runTestOptions)
+
+type runTestOptions struct {
+	digestSkipPaths []string
+}
+
+func withDigestSkipPaths(paths []string) runTestOption {
+	return func(o *runTestOptions) {
+		o.digestSkipPaths = paths
+	}
+}
+
+func runTest(ctx context.Context, settings *internal.Settings, testCase internal.TestCase, opts ...runTestOption) (string, error) {
 	helmSettings := cli.New()
 	cfg := action.Configuration{}
 	err := cfg.Init(helmSettings.RESTClientGetter(), testCase.Namespace, "memory")
@@ -59,12 +71,17 @@ func runTest(ctx context.Context, settings *internal.Settings, testCase internal
 		Minor:   "30",
 	}
 
+	o := &runTestOptions{}
+	for _, opt := range opts {
+		opt(o)
+	}
+
 	cfgYaml, err := internal.LoadConfigAndMerge(settings.ConfigPath, testCase.TestData)
 	if err != nil {
 		return "", fmt.Errorf("error loading config, %v", err)
 	}
 
-	cfgYaml = internal.ReplaceImageDigest(cfgYaml)
+	cfgYaml = internal.ReplaceImageDigestExcluding(cfgYaml, o.digestSkipPaths)
 
 	values, err := config.PreprocessFile(testCase.Values, cfgYaml)
 	if err != nil {


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-27490

### What

Fixes issue with helmtest TestNodeRolloutConfig not including image digests known to cause node rollouts.

### Why

Previous pre-merge check only checked hypershift flags. This makes the check more comprehensive.

### Testing

Confirmed test builds/runs with fixtures re-configured to images matching current main.

### Special notes for your reviewer

Please confirm I have all known-to-cause-node-rollout image digests in the fixture.

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [ ] All comment threads resolved before merge
