### PR TITLE
test(e2e): reduce STG suite parallelism (AROSLSRE-1022)

### DIFF
--- a/test/cmd/aro-hcp-tests/main.go
+++ b/test/cmd/aro-hcp-tests/main.go
@@ -111,8 +111,8 @@ func setupCli() *cobra.Command {
 		},
 		// Spec parallelism is limited by the leased identity containers. We set suite parallelism slightly above the number of
 		// leased identity containers to avoid multi-HCP tests blocking single-HCP tests from obtaining a lease.
-		// LEASED_MSI_CONTAINERS=30
-		Parallelism: 34,
+		// LEASED_MSI_CONTAINERS=21
+		Parallelism: 25,
 		TestTimeout: &stageTestTimeout,
 	})
 	ext.AddSuite(e.Suite{
@@ -122,8 +122,8 @@ func setupCli() *cobra.Command {
 		},
 		// Spec parallelism is limited by the leased identity containers. We set suite parallelism slightly above the number of
 		// leased identity containers to avoid multi-HCP tests blocking single-HCP tests from obtaining a lease.
-		// LEASED_MSI_CONTAINERS=30
-		Parallelism: 34,
+		// LEASED_MSI_CONTAINERS=21
+		Parallelism: 25,
 		TestTimeout: &stageTestTimeout,
 	})
 


### PR DESCRIPTION
<!-- Link to Jira issue -->

[AROSLSRE-1022](https://redhat.atlassian.net/browse/AROSLSRE-1022)

### What

Reduce the STG E2E suite parallelism from 34 to 25 and update the inline lease-count comments from 30 to 21 for both `stage/parallel` and `stage/parallel/slow`.

### Why

STG E2E failures are timing out while waiting for API/console readiness after ManagedCluster creation. Lowering suite pressure by 30% lets us test whether readiness/status propagation is load-sensitive.

### Testing

```bash
go test ./test/cmd/aro-hcp-tests
git diff --check
```

### Special notes for your reviewer

This pairs with an openshift/release PR that reduces STG Prow `LEASED_MSI_CONTAINERS` from 30 to 21.

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
