### PR TITLE
feat: add data plane haproxy image configuration to the cs deployment

### DIFF
--- a/cluster-service/Makefile
+++ b/cluster-service/Makefile
@@ -97,7 +97,8 @@ deploy:
 	  --set deployment.zoneCount=${AVAILABILITY_ZONE_COUNT} \
 	  --set memoryRequest=${CS_MEMORY_REQUEST} \
 	  --set cpuRequest=${CS_CPU_REQUEST} \
-	  --set memoryLimit=${CS_MEMORY_LIMIT}
+	  --set memoryLimit=${CS_MEMORY_LIMIT} \
+	  --set dataPlaneHAProxyImage=${DATA_PLANE_HA_PROXY_IMAGE}
 
 deploy-cs-debug-jobs:
 	./hack/helm.sh cs-debug-jobs helm-charts/cs-debug-jobs ${NAMESPACE} \

--- a/cluster-service/helm-charts/cluster-service/templates/deployment.yaml
+++ b/cluster-service/helm-charts/cluster-service/templates/deployment.yaml
@@ -243,6 +243,9 @@ spec:
         {{ if .Values.tracing.address }}
         - --tracing-otlp-url={{ .Values.tracing.address }}
         {{- end }}
+        {{ if .Values.dataPlaneHAProxyImage }}
+        - --data-plane-ha-proxy-image={{ .Values.dataPlaneHAProxyImage }}
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /api/clusters_mgmt/v1

--- a/cluster-service/helm-charts/cluster-service/values.yaml
+++ b/cluster-service/helm-charts/cluster-service/values.yaml
@@ -217,6 +217,10 @@ databaseName: "ocm-cs-db"
 databasePort: "5432"
 # The name of the managed identities data plane audience resource.
 managedIdentitiesDataPlaneAudienceResource: "https://dummy.org"
+# The image used to override the HAProxy image of the worker node API server proxy.
+# If set to an empty string, either the environment variable IMAGE_SHARED_INGRESS_HAPROXY or the default shared ingress image will be used.
+# If given a value, it must be a valid image reference.
+dataPlaneHAProxyImage: ""
 # The Azure Operator Managed Identities.
 azureOperatorsMI:
   roleSetName: ""

--- a/cluster-service/pipeline.yaml
+++ b/cluster-service/pipeline.yaml
@@ -195,6 +195,8 @@ resourceGroups:
       configRef: clustersService.k8s.resources.requests.cpu
     - name: CS_MEMORY_LIMIT
       configRef: clustersService.k8s.resources.limits.memory
+    - name: DATA_PLANE_HA_PROXY_IMAGE
+      configRef: clustersService.dataPlaneHAProxyImage
     shellIdentity:
       input:
         resourceGroup: global

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -1185,6 +1185,10 @@
           "required": [
             "tlsCertificatesIssuer"
           ]
+        },
+        "dataPlaneHAProxyImage": {
+          "type": "string",
+          "description": "A valid image reference used for overriding the HAProxy image of the worker node API server proxy. If set to an empty string, either the environment variable IMAGE_SHARED_INGRESS_HAPROXY or the default shared ingress image will be used."
         }
       },
       "additionalProperties": false,

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -961,6 +961,8 @@ defaults:
       exporter: ""
     environment: "arohcp{{ .ctx.environment }}"
     denyAssignments: "disabled"
+    # The image used to override the HAProxy image of the worker node API server proxy.
+    dataPlaneHAProxyImage: ""
     postgres:
       name: "arohcp-{{ .ctx.environment }}-dbcs-{{ .ctx.regionShort }}" # [globally-unique]
       deploy: true

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -160,6 +160,7 @@ clustersService:
     tlsCertificatesIssuer: Self
   batchProcesses: ""
   batchProcessesDryRun: true
+  dataPlaneHAProxyImage: ""
   denyAssignments: disabled
   deployDebugJobs: false
   environment: arohcpci00

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -160,6 +160,7 @@ clustersService:
     tlsCertificatesIssuer: Self
   batchProcesses: ""
   batchProcessesDryRun: true
+  dataPlaneHAProxyImage: ""
   denyAssignments: disabled
   deployDebugJobs: false
   environment: arohcpci01

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -160,6 +160,7 @@ clustersService:
     tlsCertificatesIssuer: Self
   batchProcesses: ""
   batchProcessesDryRun: true
+  dataPlaneHAProxyImage: ""
   denyAssignments: disabled
   deployDebugJobs: false
   environment: arohcpcspr

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -160,6 +160,7 @@ clustersService:
     tlsCertificatesIssuer: Self
   batchProcesses: ""
   batchProcessesDryRun: true
+  dataPlaneHAProxyImage: ""
   denyAssignments: disabled
   deployDebugJobs: false
   environment: arohcpdev

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -160,6 +160,7 @@ clustersService:
     tlsCertificatesIssuer: Self
   batchProcesses: ""
   batchProcessesDryRun: true
+  dataPlaneHAProxyImage: ""
   denyAssignments: disabled
   deployDebugJobs: false
   environment: arohcpperf

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -160,6 +160,7 @@ clustersService:
     tlsCertificatesIssuer: Self
   batchProcesses: ""
   batchProcessesDryRun: true
+  dataPlaneHAProxyImage: ""
   denyAssignments: disabled
   deployDebugJobs: false
   environment: arohcppers


### PR DESCRIPTION
### What

Allow an image to be specified via a cli flag called 'data-plane-ha-proxy-image' in the CS deployment, which would override the haproxy image for the worker node API server proxy. A new property called `dataPlaneHAProxyImage` is also added to the config schema to allow this configuration to be specified per environment/region.

When specified:
* A valid image reference must be given. Otherwise, CS will fail to start.
* The haproxy image annotation is added to new and existing node pools, which takes precedence over the `IMAGE_SHARED_INGRESS_HAPROXY` env var and the default shared ingress image.

When not defined or is set to an empty string:
* The current behaviour persists, where the worker node haproxy will derive its image from the same `IMAGE_SHARED_INGRESS_HAPROXY` env var used by the management cluster on creation.
* For any existing node pools, if the annotation was already present in the node pool CR, it is removed.

Note that this does not contain changes to actually set the values for each environment/region. This will be done in a separate PR once CS, with this new feature, has been deployed to all environment/regions.

JIRA: [ARO-27421](https://redhat.atlassian.net/browse/ARO-27421)

### Why

This allows us to decouple the image used for the kube-apiserver-proxy pod on each worker node. Currently, this is being derived from the same env var that also controls the management cluster's shared ingress haproxy deployment. Decoupling this allows us to freely update or bump the management cluster haproxy image without affecting any worker nodes.

Note that this is not a long term solution. A new feature will be released in the hypershift operator that defaults the image used for the worker node haproxy from the release payload. Once available, and all requirements are met for us to use that feature, this configuration can be removed.

### Testing
Existing node pool E2E tests should catch failures with any changes to this configuration.

### Special notes for your reviewer
* See JIRA issue above for additional context and the related CS changes that added this feature.
* Rollout of worker nodes will only occur if the image differs. 
  * It will not occur if:
    * an annotation is added with the same image the haproxy is already using.
    * annotation was removed but the `IMAGE_SHARED_INGRESS_HAPROXY` env var or the default shared ingress image uses the same image.
  * Therefore, in the follow up PRs setting this configuration, it is critical that we use the same image used by that env/region to avoid unnecessary rollouts. 
* **IMPORTANT**: ~~The CLI flag can't be set until CS has been deployed with the latest changes - it will fail on an unknown flag.~~ This change has now been released to all environments/regions.

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] ~~Screenshots included (if graph/UI/metrics changes)~~
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] ~~Draft PR used for WIP (if applicable)~~
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [ ] All comment threads resolved before merge
