### PR TITLE
added arohcp-e2e-cx as prefix for e2e clusters

### DIFF
--- a/test/e2e/cluster_delete_cx_rg.go
+++ b/test/e2e/cluster_delete_cx_rg.go
@@ -40,12 +40,12 @@ var _ = Describe("Customer", func() {
 		labels.Positive,
 		func(ctx context.Context) {
 			const (
-				customerNetworkSecurityGroupName = "customer-nsg"
-				customerVnetName                 = "customer-vnet"
-				customerVnetSubnetName           = "customer-vnet-subnet1"
-				customerClusterName              = "cx-rg-hcp-cluster"
-				customerNodePool1Name            = "np-1"
-				customerNodePool2Name            = "np-2"
+				customerNetworkSecurityGroupName = "arohcp-e2e-cx-nsg"
+				customerVnetName                 = "arohcp-e2e-cx-vnet"
+				customerVnetSubnetName           = "arohcp-e2e-cx-vnet-subnet1"
+				customerClusterName              = "arohcp-e2e-cluster"
+				customerNodePool1Name            = "arohcp-e2e-cx-np-1"
+				customerNodePool2Name            = "arohcp-e2e-cx-np-2"
 			)
 			tc := framework.NewTestContext()
 
@@ -55,7 +55,7 @@ var _ = Describe("Customer", func() {
 			}
 
 			By("creating the customer resource group")
-			resourceGroup, err := tc.NewResourceGroup(ctx, "cx-rg-cluster", tc.Location())
+			resourceGroup, err := tc.NewResourceGroup(ctx, "arohcp-e2e-cx-rg", tc.Location())
 			Expect(err).NotTo(HaveOccurred(), "failed to create customer resource group")
 
 			By("creating cluster parameters")


### PR DESCRIPTION
### What
This change updates the resource naming in the customer RG delete e2e scenario to use the arohcp-e2e-cx prefix for all test-created resources.

Updated names include:

NSG
VNet
subnet
cluster name
node pool names
customer resource group prefix

### Why
The previous names were generic and harder to identify in shared environments.
Using a consistent, recognizable prefix makes e2e-created resources easier to find, troubleshoot, and clean up, and reduces ambiguity when multiple runs/users are active.

### Testing
Code/testing changes:

Updated constants and RG prefix used by the existing e2e flow.
No logic/path changes beyond naming.