### PR TITLE
read the domain base prefix from CS and infer the rest of the properties from the hosted cluster cr

### DIFF
--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -559,6 +559,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		activeOperationLister,
 		backendInformers,
 		unionKubeApplierInformers,
+		unionReadDesireLister,
 	)
 	identityMigrationController := clusterpropertiescontroller.NewIdentityMigrationController(
 		b.options.ResourcesDBClient,

--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -553,9 +553,15 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		backendInformers,
 		unionKubeApplierInformers,
 	)
-	clusterPropertiesSyncController := clusterpropertiescontroller.NewClusterPropertiesSyncController(
+	clusterBaseDomainPrefixSyncController := clusterpropertiescontroller.NewClusterBaseDomainPrefixSyncController(
 		b.options.ResourcesDBClient,
 		b.options.ClustersServiceClient,
+		activeOperationLister,
+		backendInformers,
+		unionKubeApplierInformers,
+	)
+	clusterPropertiesSyncController := clusterpropertiescontroller.NewClusterPropertiesSyncController(
+		b.options.ResourcesDBClient,
 		activeOperationLister,
 		backendInformers,
 		unionKubeApplierInformers,
@@ -740,6 +746,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 				go controlPlaneActiveVersionController.Run(ctx, 20)
 				go controlPlaneDesiredVersionController.Run(ctx, 20)
 				go triggerControlPlaneUpgradeController.Run(ctx, 20)
+				go clusterBaseDomainPrefixSyncController.Run(ctx, 20)
 				go clusterPropertiesSyncController.Run(ctx, 20)
 				go identityMigrationController.Run(ctx, 20)
 				go azureRPRegistrationValidationController.Run(ctx, 20)

--- a/backend/pkg/controllers/clusterpropertiescontroller/cluster_base_domain_prefix_sync.go
+++ b/backend/pkg/controllers/clusterpropertiescontroller/cluster_base_domain_prefix_sync.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
 	"github.com/Azure/ARO-HCP/backend/pkg/informers"
 	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/internal/api"
 	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/database"
 	unionkubeapplierinformers "github.com/Azure/ARO-HCP/internal/database/unioninformers/kubeapplier"
@@ -35,6 +36,7 @@ import (
 // Cluster Service to Cosmos DB when the field is unset.
 type clusterBaseDomainPrefixSyncer struct {
 	cooldownChecker      controllerutil.CooldownChecker
+	clusterLister        listers.ClusterLister
 	resourcesDBClient    database.ResourcesDBClient
 	clusterServiceClient ocm.ClusterServiceClientSpec
 }
@@ -50,8 +52,11 @@ func NewClusterBaseDomainPrefixSyncController(
 	informers informers.BackendInformers,
 	kubeApplierInformers *unionkubeapplierinformers.UnionKubeApplierInformers,
 ) controllerutils.Controller {
+	_, clusterLister := informers.Clusters()
+
 	syncer := &clusterBaseDomainPrefixSyncer{
 		cooldownChecker:      controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		clusterLister:        clusterLister,
 		resourcesDBClient:    resourcesDBClient,
 		clusterServiceClient: clusterServiceClient,
 	}
@@ -70,8 +75,28 @@ func (c *clusterBaseDomainPrefixSyncer) CooldownChecker() controllerutil.Cooldow
 	return c.cooldownChecker
 }
 
+func (c *clusterBaseDomainPrefixSyncer) needsWork(existingCluster *api.HCPOpenShiftCluster) bool {
+	if existingCluster.ServiceProviderProperties.ClusterServiceID == nil ||
+		len(existingCluster.ServiceProviderProperties.ClusterServiceID.String()) == 0 {
+		return false
+	}
+
+	return len(existingCluster.CustomerProperties.DNS.BaseDomainPrefix) == 0
+}
+
 func (c *clusterBaseDomainPrefixSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPClusterKey) error {
 	logger := utils.LoggerFromContext(ctx)
+
+	cachedCluster, err := c.clusterLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get cluster from cache: %w", err))
+	}
+	if !c.needsWork(cachedCluster) {
+		return nil
+	}
 
 	clusterCRUD := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName)
 	existingCluster, err := clusterCRUD.Get(ctx, key.HCPClusterName)
@@ -81,30 +106,23 @@ func (c *clusterBaseDomainPrefixSyncer) SyncOnce(ctx context.Context, key contro
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to get Cluster: %w", err))
 	}
-
-	if len(existingCluster.CustomerProperties.DNS.BaseDomainPrefix) > 0 {
+	if !c.needsWork(existingCluster) {
 		return nil
 	}
-
-	if existingCluster.ServiceProviderProperties.ClusterServiceID == nil ||
-		len(existingCluster.ServiceProviderProperties.ClusterServiceID.String()) == 0 {
-		return nil
-	}
-
-	originalCluster := existingCluster.DeepCopy()
 
 	csCluster, err := c.clusterServiceClient.GetCluster(ctx, *existingCluster.ServiceProviderProperties.ClusterServiceID)
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to get cluster from Cluster Service: %w", err))
 	}
 
-	existingCluster.CustomerProperties.DNS.BaseDomainPrefix = csCluster.DomainPrefix()
+	replacement := existingCluster.DeepCopy()
+	replacement.CustomerProperties.DNS.BaseDomainPrefix = csCluster.DomainPrefix()
 
-	if equality.Semantic.DeepEqual(originalCluster, existingCluster) {
+	if equality.Semantic.DeepEqual(existingCluster, replacement) {
 		return nil
 	}
 
-	if _, err := clusterCRUD.Replace(ctx, existingCluster, nil); err != nil {
+	if _, err := clusterCRUD.Replace(ctx, replacement, nil); err != nil {
 		return utils.TrackError(fmt.Errorf("failed to replace Cluster: %w", err))
 	}
 

--- a/backend/pkg/controllers/clusterpropertiescontroller/cluster_base_domain_prefix_sync.go
+++ b/backend/pkg/controllers/clusterpropertiescontroller/cluster_base_domain_prefix_sync.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusterpropertiescontroller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/database"
+	unionkubeapplierinformers "github.com/Azure/ARO-HCP/internal/database/unioninformers/kubeapplier"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// clusterBaseDomainPrefixSyncer synchronizes CustomerProperties.DNS.BaseDomainPrefix from
+// Cluster Service to Cosmos DB when the field is unset.
+type clusterBaseDomainPrefixSyncer struct {
+	cooldownChecker      controllerutil.CooldownChecker
+	resourcesDBClient    database.ResourcesDBClient
+	clusterServiceClient ocm.ClusterServiceClientSpec
+}
+
+var _ controllerutils.ClusterSyncer = (*clusterBaseDomainPrefixSyncer)(nil)
+
+// NewClusterBaseDomainPrefixSyncController creates a controller that synchronizes
+// CustomerProperties.DNS.BaseDomainPrefix from Cluster Service to Cosmos DB.
+func NewClusterBaseDomainPrefixSyncController(
+	resourcesDBClient database.ResourcesDBClient,
+	clusterServiceClient ocm.ClusterServiceClientSpec,
+	activeOperationLister listers.ActiveOperationLister,
+	informers informers.BackendInformers,
+	kubeApplierInformers *unionkubeapplierinformers.UnionKubeApplierInformers,
+) controllerutils.Controller {
+	syncer := &clusterBaseDomainPrefixSyncer{
+		cooldownChecker:      controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		resourcesDBClient:    resourcesDBClient,
+		clusterServiceClient: clusterServiceClient,
+	}
+
+	return controllerutils.NewClusterWatchingController(
+		"ClusterBaseDomainPrefixSync",
+		resourcesDBClient,
+		informers,
+		kubeApplierInformers,
+		5*time.Minute,
+		syncer,
+	)
+}
+
+func (c *clusterBaseDomainPrefixSyncer) CooldownChecker() controllerutil.CooldownChecker {
+	return c.cooldownChecker
+}
+
+func (c *clusterBaseDomainPrefixSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPClusterKey) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	clusterCRUD := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName)
+	existingCluster, err := clusterCRUD.Get(ctx, key.HCPClusterName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get Cluster: %w", err))
+	}
+
+	if len(existingCluster.CustomerProperties.DNS.BaseDomainPrefix) > 0 {
+		return nil
+	}
+
+	if existingCluster.ServiceProviderProperties.ClusterServiceID == nil ||
+		len(existingCluster.ServiceProviderProperties.ClusterServiceID.String()) == 0 {
+		return nil
+	}
+
+	originalCluster := existingCluster.DeepCopy()
+
+	csCluster, err := c.clusterServiceClient.GetCluster(ctx, *existingCluster.ServiceProviderProperties.ClusterServiceID)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get cluster from Cluster Service: %w", err))
+	}
+
+	existingCluster.CustomerProperties.DNS.BaseDomainPrefix = csCluster.DomainPrefix()
+
+	if equality.Semantic.DeepEqual(originalCluster, existingCluster) {
+		return nil
+	}
+
+	if _, err := clusterCRUD.Replace(ctx, existingCluster, nil); err != nil {
+		return utils.TrackError(fmt.Errorf("failed to replace Cluster: %w", err))
+	}
+
+	logger.Info("synced cluster base domain prefix")
+	return nil
+}

--- a/backend/pkg/controllers/clusterpropertiescontroller/cluster_base_domain_prefix_sync_test.go
+++ b/backend/pkg/controllers/clusterpropertiescontroller/cluster_base_domain_prefix_sync_test.go
@@ -25,6 +25,7 @@ import (
 	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
 
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/databasetesting"
 	"github.com/Azure/ARO-HCP/internal/ocm"
@@ -35,6 +36,7 @@ func TestClusterBaseDomainPrefixSyncer_SyncOnce(t *testing.T) {
 
 	testCases := []struct {
 		name                     string
+		cachedCluster            *api.HCPOpenShiftCluster
 		existingCluster          *api.HCPOpenShiftCluster
 		csDomainPrefix           string
 		expectCSGetCluster       bool
@@ -42,6 +44,14 @@ func TestClusterBaseDomainPrefixSyncer_SyncOnce(t *testing.T) {
 	}{
 		{
 			name: "short-circuit when base domain prefix already set",
+			existingCluster: newTestCluster(testClusterName, func(c *api.HCPOpenShiftCluster) {
+				c.CustomerProperties.DNS.BaseDomainPrefix = testBaseDomainPrefix
+			}),
+			expectedBaseDomainPrefix: testBaseDomainPrefix,
+		},
+		{
+			name:          "cache says work needed but live data has base domain prefix",
+			cachedCluster: newTestCluster(testClusterName),
 			existingCluster: newTestCluster(testClusterName, func(c *api.HCPOpenShiftCluster) {
 				c.CustomerProperties.DNS.BaseDomainPrefix = testBaseDomainPrefix
 			}),
@@ -67,6 +77,14 @@ func TestClusterBaseDomainPrefixSyncer_SyncOnce(t *testing.T) {
 			mockResourcesDB, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, []any{tc.existingCluster})
 			require.NoError(t, err)
 
+			cachedCluster := tc.cachedCluster
+			if cachedCluster == nil {
+				cachedCluster = tc.existingCluster
+			}
+			clusterLister := &listertesting.SliceClusterLister{
+				Clusters: []*api.HCPOpenShiftCluster{cachedCluster},
+			}
+
 			mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
 			if tc.expectCSGetCluster {
 				csCluster, err := arohcpv1alpha1.NewCluster().DomainPrefix(tc.csDomainPrefix).Build()
@@ -78,6 +96,7 @@ func TestClusterBaseDomainPrefixSyncer_SyncOnce(t *testing.T) {
 
 			syncer := &clusterBaseDomainPrefixSyncer{
 				cooldownChecker:      &alwaysSyncCooldownChecker{},
+				clusterLister:        clusterLister,
 				resourcesDBClient:    mockResourcesDB,
 				clusterServiceClient: mockCSClient,
 			}

--- a/backend/pkg/controllers/clusterpropertiescontroller/cluster_base_domain_prefix_sync_test.go
+++ b/backend/pkg/controllers/clusterpropertiescontroller/cluster_base_domain_prefix_sync_test.go
@@ -1,0 +1,99 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusterpropertiescontroller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+)
+
+func TestClusterBaseDomainPrefixSyncer_SyncOnce(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name                     string
+		existingCluster          *api.HCPOpenShiftCluster
+		csDomainPrefix           string
+		expectCSGetCluster       bool
+		expectedBaseDomainPrefix string
+	}{
+		{
+			name: "short-circuit when base domain prefix already set",
+			existingCluster: newTestCluster(testClusterName, func(c *api.HCPOpenShiftCluster) {
+				c.CustomerProperties.DNS.BaseDomainPrefix = testBaseDomainPrefix
+			}),
+			expectedBaseDomainPrefix: testBaseDomainPrefix,
+		},
+		{
+			name:                     "sync base domain prefix from Cluster Service when missing",
+			existingCluster:          newTestCluster(testClusterName),
+			csDomainPrefix:           testBaseDomainPrefix,
+			expectCSGetCluster:       true,
+			expectedBaseDomainPrefix: testBaseDomainPrefix,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockResourcesDB, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, []any{tc.existingCluster})
+			require.NoError(t, err)
+
+			mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
+			if tc.expectCSGetCluster {
+				csCluster, err := arohcpv1alpha1.NewCluster().DomainPrefix(tc.csDomainPrefix).Build()
+				require.NoError(t, err)
+				mockCSClient.EXPECT().
+					GetCluster(gomock.Any(), api.Must(api.NewInternalID(testClusterServiceIDStr))).
+					Return(csCluster, nil)
+			}
+
+			syncer := &clusterBaseDomainPrefixSyncer{
+				cooldownChecker:      &alwaysSyncCooldownChecker{},
+				resourcesDBClient:    mockResourcesDB,
+				clusterServiceClient: mockCSClient,
+			}
+
+			key := controllerutils.HCPClusterKey{
+				SubscriptionID:    testSubscriptionID,
+				ResourceGroupName: testResourceGroupName,
+				HCPClusterName:    tc.existingCluster.Name,
+			}
+			err = syncer.SyncOnce(ctx, key)
+			require.NoError(t, err)
+
+			updatedCluster, err := mockResourcesDB.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, tc.existingCluster.Name)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expectedBaseDomainPrefix, updatedCluster.CustomerProperties.DNS.BaseDomainPrefix)
+		})
+	}
+}

--- a/backend/pkg/controllers/clusterpropertiescontroller/cluster_properties_sync.go
+++ b/backend/pkg/controllers/clusterpropertiescontroller/cluster_properties_sync.go
@@ -35,7 +35,6 @@ import (
 // from Cluster Service to Cosmos DB. It ensures that the following fields are populated:
 //   - ServiceProviderProperties.Console.URL
 //   - ServiceProviderProperties.DNS.BaseDomain
-//   - ServiceProviderProperties.ManagedIdentitiesDataPlaneIdentityURL
 //   - ServiceProviderProperties.API.URL
 //   - ServiceProviderProperties.Platform.IssuerURL
 //   - CustomerProperties.DNS.BaseDomainPrefix
@@ -50,7 +49,7 @@ var _ controllerutils.ClusterSyncer = (*clusterPropertiesSyncer)(nil)
 // NewClusterPropertiesSyncController creates a new controller that synchronizes
 // cluster properties from Cluster Service to Cosmos DB.
 // It periodically checks each cluster and populates the Console.URL, DNS.BaseDomain,
-// ManagedIdentitiesDataPlaneIdentityURL, Platform.IssuerURL, and DNS.BaseDomainPrefix fields if they are not set.
+// Platform.IssuerURL, and DNS.BaseDomainPrefix fields if they are not set.
 func NewClusterPropertiesSyncController(
 	resourcesDBClient database.ResourcesDBClient,
 	clusterServiceClient ocm.ClusterServiceClientSpec,
@@ -81,8 +80,8 @@ func (c *clusterPropertiesSyncer) CooldownChecker() controllerutil.CooldownCheck
 }
 
 // SyncOnce performs a single reconciliation of cluster properties.
-// It checks if the Console.URL, DNS.BaseDomain, ManagedIdentitiesDataPlaneIdentityURL,
-// Platform.IssuerURL, or DNS.BaseDomainPrefix fields are unset, and if so, fetches the
+// It checks if the Console.URL, DNS.BaseDomain, Platform.IssuerURL, or
+// DNS.BaseDomainPrefix fields are unset, and if so, fetches the
 // values from Cluster Service and updates Cosmos.
 func (c *clusterPropertiesSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPClusterKey) error {
 	logger := utils.LoggerFromContext(ctx)
@@ -106,11 +105,10 @@ func (c *clusterPropertiesSyncer) SyncOnce(ctx context.Context, key controllerut
 	needsConsoleURL := len(existingCluster.ServiceProviderProperties.Console.URL) == 0
 	needsBaseDomain := len(existingCluster.ServiceProviderProperties.DNS.BaseDomain) == 0
 	needsAPIURL := len(existingCluster.ServiceProviderProperties.API.URL) == 0
-	needsManagedIdentitiesDataPlaneIdentityURL := len(existingCluster.ServiceProviderProperties.ManagedIdentitiesDataPlaneIdentityURL) == 0
 	needsIssuerURL := len(existingCluster.ServiceProviderProperties.Platform.IssuerURL) == 0
 	needsBaseDomainPrefix := len(existingCluster.CustomerProperties.DNS.BaseDomainPrefix) == 0
 
-	if !needsConsoleURL && !needsBaseDomain && !needsBaseDomainPrefix && !needsManagedIdentitiesDataPlaneIdentityURL && !needsAPIURL && !needsIssuerURL {
+	if !needsConsoleURL && !needsBaseDomain && !needsBaseDomainPrefix && !needsAPIURL && !needsIssuerURL {
 		return nil
 	}
 
@@ -129,13 +127,6 @@ func (c *clusterPropertiesSyncer) SyncOnce(ctx context.Context, key controllerut
 	}
 	if needsBaseDomain {
 		existingCluster.ServiceProviderProperties.DNS.BaseDomain = csCluster.DNS().BaseDomain()
-	}
-	if needsManagedIdentitiesDataPlaneIdentityURL {
-		if csCluster.Azure() != nil && csCluster.Azure().OperatorsAuthentication() != nil {
-			if mi, ok := csCluster.Azure().OperatorsAuthentication().GetManagedIdentities(); ok {
-				existingCluster.ServiceProviderProperties.ManagedIdentitiesDataPlaneIdentityURL = mi.ManagedIdentitiesDataPlaneIdentityUrl()
-			}
-		}
 	}
 	if needsAPIURL {
 		existingCluster.ServiceProviderProperties.API.URL = csCluster.API().URL()

--- a/backend/pkg/controllers/clusterpropertiescontroller/cluster_properties_sync.go
+++ b/backend/pkg/controllers/clusterpropertiescontroller/cluster_properties_sync.go
@@ -17,6 +17,9 @@ package clusterpropertiescontroller
 import (
 	"context"
 	"fmt"
+	"net"
+	"strconv"
+	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -24,43 +27,49 @@ import (
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
 	"github.com/Azure/ARO-HCP/backend/pkg/informers"
 	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/backend/pkg/maestrohelpers"
 	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/database"
+	dblisters "github.com/Azure/ARO-HCP/internal/database/listers"
 	unionkubeapplierinformers "github.com/Azure/ARO-HCP/internal/database/unioninformers/kubeapplier"
 	"github.com/Azure/ARO-HCP/internal/ocm"
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
 
 // clusterPropertiesSyncer is a Cluster syncer that synchronizes cluster properties
-// from Cluster Service to Cosmos DB. It ensures that the following fields are populated:
+// to Cosmos DB. CustomerProperties.DNS.BaseDomainPrefix is synced from Cluster Service
+// first so downstream ReadDesires can target the HostedCluster on the management cluster.
+// The remaining fields are synced from the observed HostedCluster ReadDesire content:
 //   - ServiceProviderProperties.Console.URL
 //   - ServiceProviderProperties.DNS.BaseDomain
 //   - ServiceProviderProperties.API.URL
 //   - ServiceProviderProperties.Platform.IssuerURL
-//   - CustomerProperties.DNS.BaseDomainPrefix
 type clusterPropertiesSyncer struct {
 	cooldownChecker      controllerutil.CooldownChecker
 	resourcesDBClient    database.ResourcesDBClient
 	clusterServiceClient ocm.ClusterServiceClientSpec
+	readDesireLister     dblisters.ReadDesireLister
 }
 
 var _ controllerutils.ClusterSyncer = (*clusterPropertiesSyncer)(nil)
 
 // NewClusterPropertiesSyncController creates a new controller that synchronizes
-// cluster properties from Cluster Service to Cosmos DB.
+// cluster properties from Cluster Service and HostedCluster to Cosmos DB.
 // It periodically checks each cluster and populates the Console.URL, DNS.BaseDomain,
-// Platform.IssuerURL, and DNS.BaseDomainPrefix fields if they are not set.
+// API.URL, and Platform.IssuerURL fields from CS and HostedCluster and updates Cosmos.
 func NewClusterPropertiesSyncController(
 	resourcesDBClient database.ResourcesDBClient,
 	clusterServiceClient ocm.ClusterServiceClientSpec,
 	activeOperationLister listers.ActiveOperationLister,
 	informers informers.BackendInformers,
 	kubeApplierInformers *unionkubeapplierinformers.UnionKubeApplierInformers,
+	readDesireLister dblisters.ReadDesireLister,
 ) controllerutils.Controller {
 	syncer := &clusterPropertiesSyncer{
 		cooldownChecker:      controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
 		resourcesDBClient:    resourcesDBClient,
 		clusterServiceClient: clusterServiceClient,
+		readDesireLister:     readDesireLister,
 	}
 
 	controller := controllerutils.NewClusterWatchingController(
@@ -80,9 +89,9 @@ func (c *clusterPropertiesSyncer) CooldownChecker() controllerutil.CooldownCheck
 }
 
 // SyncOnce performs a single reconciliation of cluster properties.
-// It checks if the Console.URL, DNS.BaseDomain, Platform.IssuerURL, or
-// DNS.BaseDomainPrefix fields are unset, and if so, fetches the
-// values from Cluster Service and updates Cosmos.
+// It checks if the Console.URL, DNS.BaseDomain, API.URL,
+// Platform.IssuerURL, or DNS.BaseDomainPrefix fields are unset, and if so, fetches the
+// values from CS and HostedCluster and updates Cosmos.
 func (c *clusterPropertiesSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPClusterKey) error {
 	logger := utils.LoggerFromContext(ctx)
 
@@ -96,11 +105,6 @@ func (c *clusterPropertiesSyncer) SyncOnce(ctx context.Context, key controllerut
 		return utils.TrackError(fmt.Errorf("failed to get Cluster: %w", err))
 	}
 
-	// Check if we have a cluster service ID to query
-	if existingCluster.ServiceProviderProperties.ClusterServiceID == nil || len(existingCluster.ServiceProviderProperties.ClusterServiceID.String()) == 0 {
-		return nil
-	}
-
 	// Check if any of the properties need to be synced
 	needsConsoleURL := len(existingCluster.ServiceProviderProperties.Console.URL) == 0
 	needsBaseDomain := len(existingCluster.ServiceProviderProperties.DNS.BaseDomain) == 0
@@ -112,30 +116,43 @@ func (c *clusterPropertiesSyncer) SyncOnce(ctx context.Context, key controllerut
 		return nil
 	}
 
-	// Fetch the cluster from Cluster Service
-	csCluster, err := c.clusterServiceClient.GetCluster(ctx, *existingCluster.ServiceProviderProperties.ClusterServiceID)
-	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to get cluster from Cluster Service: %w", err))
-	}
-
-	// Take a copy before making changes for comparison
 	originalCluster := existingCluster.DeepCopy()
 
-	// Update the properties if they are not set
-	if needsConsoleURL {
-		existingCluster.ServiceProviderProperties.Console.URL = csCluster.Console().URL()
-	}
-	if needsBaseDomain {
-		existingCluster.ServiceProviderProperties.DNS.BaseDomain = csCluster.DNS().BaseDomain()
-	}
-	if needsAPIURL {
-		existingCluster.ServiceProviderProperties.API.URL = csCluster.API().URL()
-	}
-	if needsIssuerURL {
-		existingCluster.ServiceProviderProperties.Platform.IssuerURL = csCluster.Azure().OidcIssuerUrl()
-	}
+	// Sync domain prefix from CS first; ReadDesire targeting needs it before HostedCluster content is observed.
 	if needsBaseDomainPrefix {
+		// Check if we have a cluster service ID to query
+		if existingCluster.ServiceProviderProperties.ClusterServiceID == nil ||
+			len(existingCluster.ServiceProviderProperties.ClusterServiceID.String()) == 0 {
+			return nil
+		}
+		csCluster, err := c.clusterServiceClient.GetCluster(ctx, *existingCluster.ServiceProviderProperties.ClusterServiceID)
+		if err != nil {
+			return utils.TrackError(fmt.Errorf("failed to get cluster from Cluster Service: %w", err))
+		}
 		existingCluster.CustomerProperties.DNS.BaseDomainPrefix = csCluster.DomainPrefix()
+	}
+
+	hostedCluster, err := maestrohelpers.GetCachedHostedClusterForCluster(ctx, c.readDesireLister, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get HostedCluster from ReadDesire: %w", err))
+	}
+	if hostedCluster != nil {
+		domainPrefix := existingCluster.CustomerProperties.DNS.BaseDomainPrefix
+		if needsConsoleURL {
+			existingCluster.ServiceProviderProperties.Console.URL = fmt.Sprintf("https://console-openshift-console.apps.%s", hostedCluster.Spec.DNS.BaseDomain)
+		}
+		if needsBaseDomain {
+			existingCluster.ServiceProviderProperties.DNS.BaseDomain = strings.TrimPrefix(
+				hostedCluster.Spec.KubeAPIServerDNSName,
+				fmt.Sprintf("api.%s.", domainPrefix),
+			)
+		}
+		if needsAPIURL {
+			existingCluster.ServiceProviderProperties.API.URL = fmt.Sprintf("https://%s", net.JoinHostPort(hostedCluster.Spec.KubeAPIServerDNSName, strconv.Itoa(int(hostedCluster.Status.ControlPlaneEndpoint.Port))))
+		}
+		if needsIssuerURL {
+			existingCluster.ServiceProviderProperties.Platform.IssuerURL = hostedCluster.Spec.IssuerURL
+		}
 	}
 
 	// Only write back if something actually changed
@@ -148,6 +165,6 @@ func (c *clusterPropertiesSyncer) SyncOnce(ctx context.Context, key controllerut
 		return utils.TrackError(fmt.Errorf("failed to replace Cluster: %w", err))
 	}
 
-	logger.Info("synced cluster properties from Cluster Service")
+	logger.Info("synced cluster properties")
 	return nil
 }

--- a/backend/pkg/controllers/clusterpropertiescontroller/cluster_properties_sync.go
+++ b/backend/pkg/controllers/clusterpropertiescontroller/cluster_properties_sync.go
@@ -32,135 +32,89 @@ import (
 	"github.com/Azure/ARO-HCP/internal/database"
 	dblisters "github.com/Azure/ARO-HCP/internal/database/listers"
 	unionkubeapplierinformers "github.com/Azure/ARO-HCP/internal/database/unioninformers/kubeapplier"
-	"github.com/Azure/ARO-HCP/internal/ocm"
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
 
-// clusterPropertiesSyncer is a Cluster syncer that synchronizes cluster properties
-// to Cosmos DB. CustomerProperties.DNS.BaseDomainPrefix is synced from Cluster Service
-// first so downstream ReadDesires can target the HostedCluster on the management cluster.
-// The remaining fields are synced from the observed HostedCluster ReadDesire content:
+// clusterPropertiesSyncer synchronizes ServiceProviderProperties from the observed
+// HostedCluster ReadDesire content to Cosmos DB, reconciling when values differ:
 //   - ServiceProviderProperties.Console.URL
 //   - ServiceProviderProperties.DNS.BaseDomain
 //   - ServiceProviderProperties.API.URL
 //   - ServiceProviderProperties.Platform.IssuerURL
 type clusterPropertiesSyncer struct {
-	cooldownChecker      controllerutil.CooldownChecker
-	resourcesDBClient    database.ResourcesDBClient
-	clusterServiceClient ocm.ClusterServiceClientSpec
-	readDesireLister     dblisters.ReadDesireLister
+	cooldownChecker   controllerutil.CooldownChecker
+	resourcesDBClient database.ResourcesDBClient
+	readDesireLister  dblisters.ReadDesireLister
 }
 
 var _ controllerutils.ClusterSyncer = (*clusterPropertiesSyncer)(nil)
 
-// NewClusterPropertiesSyncController creates a new controller that synchronizes
-// cluster properties from Cluster Service and HostedCluster to Cosmos DB.
-// It periodically checks each cluster and populates the Console.URL, DNS.BaseDomain,
-// API.URL, and Platform.IssuerURL fields from CS and HostedCluster and updates Cosmos.
+// NewClusterPropertiesSyncController creates a controller that synchronizes
+// cluster properties from the HostedCluster ReadDesire mirror to Cosmos DB.
 func NewClusterPropertiesSyncController(
 	resourcesDBClient database.ResourcesDBClient,
-	clusterServiceClient ocm.ClusterServiceClientSpec,
 	activeOperationLister listers.ActiveOperationLister,
 	informers informers.BackendInformers,
 	kubeApplierInformers *unionkubeapplierinformers.UnionKubeApplierInformers,
 	readDesireLister dblisters.ReadDesireLister,
 ) controllerutils.Controller {
 	syncer := &clusterPropertiesSyncer{
-		cooldownChecker:      controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
-		resourcesDBClient:    resourcesDBClient,
-		clusterServiceClient: clusterServiceClient,
-		readDesireLister:     readDesireLister,
+		cooldownChecker:   controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		resourcesDBClient: resourcesDBClient,
+		readDesireLister:  readDesireLister,
 	}
 
-	controller := controllerutils.NewClusterWatchingController(
+	return controllerutils.NewClusterWatchingController(
 		"ClusterPropertiesSync",
 		resourcesDBClient,
 		informers,
 		kubeApplierInformers,
-		5*time.Minute, // Check every 5 minutes
+		5*time.Minute,
 		syncer,
 	)
-
-	return controller
 }
 
 func (c *clusterPropertiesSyncer) CooldownChecker() controllerutil.CooldownChecker {
 	return c.cooldownChecker
 }
 
-// SyncOnce performs a single reconciliation of cluster properties.
-// It checks if the Console.URL, DNS.BaseDomain, API.URL,
-// Platform.IssuerURL, or DNS.BaseDomainPrefix fields are unset, and if so, fetches the
-// values from CS and HostedCluster and updates Cosmos.
 func (c *clusterPropertiesSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPClusterKey) error {
 	logger := utils.LoggerFromContext(ctx)
 
-	// Get the cluster from Cosmos
 	clusterCRUD := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName)
 	existingCluster, err := clusterCRUD.Get(ctx, key.HCPClusterName)
 	if database.IsNotFoundError(err) {
-		return nil // cluster doesn't exist, no work to do
+		return nil
 	}
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to get Cluster: %w", err))
-	}
-
-	// Check if any of the properties need to be synced
-	needsConsoleURL := len(existingCluster.ServiceProviderProperties.Console.URL) == 0
-	needsBaseDomain := len(existingCluster.ServiceProviderProperties.DNS.BaseDomain) == 0
-	needsAPIURL := len(existingCluster.ServiceProviderProperties.API.URL) == 0
-	needsIssuerURL := len(existingCluster.ServiceProviderProperties.Platform.IssuerURL) == 0
-	needsBaseDomainPrefix := len(existingCluster.CustomerProperties.DNS.BaseDomainPrefix) == 0
-
-	if !needsConsoleURL && !needsBaseDomain && !needsBaseDomainPrefix && !needsAPIURL && !needsIssuerURL {
-		return nil
-	}
-
-	originalCluster := existingCluster.DeepCopy()
-
-	// Sync domain prefix from CS first; ReadDesire targeting needs it before HostedCluster content is observed.
-	if needsBaseDomainPrefix {
-		// Check if we have a cluster service ID to query
-		if existingCluster.ServiceProviderProperties.ClusterServiceID == nil ||
-			len(existingCluster.ServiceProviderProperties.ClusterServiceID.String()) == 0 {
-			return nil
-		}
-		csCluster, err := c.clusterServiceClient.GetCluster(ctx, *existingCluster.ServiceProviderProperties.ClusterServiceID)
-		if err != nil {
-			return utils.TrackError(fmt.Errorf("failed to get cluster from Cluster Service: %w", err))
-		}
-		existingCluster.CustomerProperties.DNS.BaseDomainPrefix = csCluster.DomainPrefix()
 	}
 
 	hostedCluster, err := maestrohelpers.GetCachedHostedClusterForCluster(ctx, c.readDesireLister, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to get HostedCluster from ReadDesire: %w", err))
 	}
-	if hostedCluster != nil {
-		domainPrefix := existingCluster.CustomerProperties.DNS.BaseDomainPrefix
-		if needsConsoleURL {
-			existingCluster.ServiceProviderProperties.Console.URL = fmt.Sprintf("https://console-openshift-console.apps.%s", hostedCluster.Spec.DNS.BaseDomain)
-		}
-		if needsBaseDomain {
-			existingCluster.ServiceProviderProperties.DNS.BaseDomain = strings.TrimPrefix(
-				hostedCluster.Spec.KubeAPIServerDNSName,
-				fmt.Sprintf("api.%s.", domainPrefix),
-			)
-		}
-		if needsAPIURL {
-			existingCluster.ServiceProviderProperties.API.URL = fmt.Sprintf("https://%s", net.JoinHostPort(hostedCluster.Spec.KubeAPIServerDNSName, strconv.Itoa(int(hostedCluster.Status.ControlPlaneEndpoint.Port))))
-		}
-		if needsIssuerURL {
-			existingCluster.ServiceProviderProperties.Platform.IssuerURL = hostedCluster.Spec.IssuerURL
-		}
+	if hostedCluster == nil {
+		return nil
 	}
 
-	// Only write back if something actually changed
+	originalCluster := existingCluster.DeepCopy()
+	domainPrefix := existingCluster.CustomerProperties.DNS.BaseDomainPrefix
+
+	existingCluster.ServiceProviderProperties.Console.URL = fmt.Sprintf("https://console-openshift-console.apps.%s", hostedCluster.Spec.DNS.BaseDomain)
+	existingCluster.ServiceProviderProperties.DNS.BaseDomain = strings.TrimPrefix(
+		hostedCluster.Spec.KubeAPIServerDNSName,
+		fmt.Sprintf("api.%s.", domainPrefix),
+	)
+	if hostedCluster.Status.ControlPlaneEndpoint.Port != 0 {
+		existingCluster.ServiceProviderProperties.API.URL = fmt.Sprintf("https://%s", net.JoinHostPort(hostedCluster.Spec.KubeAPIServerDNSName, strconv.Itoa(int(hostedCluster.Status.ControlPlaneEndpoint.Port))))
+	}
+	existingCluster.ServiceProviderProperties.Platform.IssuerURL = hostedCluster.Spec.IssuerURL
+
 	if equality.Semantic.DeepEqual(originalCluster, existingCluster) {
 		return nil
 	}
 
-	// Write the updated cluster back to Cosmos
 	if _, err := clusterCRUD.Replace(ctx, existingCluster, nil); err != nil {
 		return utils.TrackError(fmt.Errorf("failed to replace Cluster: %w", err))
 	}

--- a/backend/pkg/controllers/clusterpropertiescontroller/cluster_properties_sync.go
+++ b/backend/pkg/controllers/clusterpropertiescontroller/cluster_properties_sync.go
@@ -43,6 +43,7 @@ import (
 //   - ServiceProviderProperties.Platform.IssuerURL
 type clusterPropertiesSyncer struct {
 	cooldownChecker   controllerutil.CooldownChecker
+	clusterLister     listers.ClusterLister
 	resourcesDBClient database.ResourcesDBClient
 	readDesireLister  dblisters.ReadDesireLister
 }
@@ -58,8 +59,11 @@ func NewClusterPropertiesSyncController(
 	kubeApplierInformers *unionkubeapplierinformers.UnionKubeApplierInformers,
 	readDesireLister dblisters.ReadDesireLister,
 ) controllerutils.Controller {
+	_, clusterLister := informers.Clusters()
+
 	syncer := &clusterPropertiesSyncer{
 		cooldownChecker:   controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		clusterLister:     clusterLister,
 		resourcesDBClient: resourcesDBClient,
 		readDesireLister:  readDesireLister,
 	}
@@ -81,13 +85,15 @@ func (c *clusterPropertiesSyncer) CooldownChecker() controllerutil.CooldownCheck
 func (c *clusterPropertiesSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPClusterKey) error {
 	logger := utils.LoggerFromContext(ctx)
 
-	clusterCRUD := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName)
-	existingCluster, err := clusterCRUD.Get(ctx, key.HCPClusterName)
+	existingCluster, err := c.clusterLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
 	if database.IsNotFoundError(err) {
 		return nil
 	}
 	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to get Cluster: %w", err))
+		return utils.TrackError(fmt.Errorf("failed to get cluster from cache: %w", err))
+	}
+	if len(existingCluster.CustomerProperties.DNS.BaseDomainPrefix) == 0 {
+		return nil
 	}
 
 	hostedCluster, err := maestrohelpers.GetCachedHostedClusterForCluster(ctx, c.readDesireLister, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
@@ -98,24 +104,32 @@ func (c *clusterPropertiesSyncer) SyncOnce(ctx context.Context, key controllerut
 		return nil
 	}
 
-	originalCluster := existingCluster.DeepCopy()
-	domainPrefix := existingCluster.CustomerProperties.DNS.BaseDomainPrefix
+	replacement := existingCluster.DeepCopy()
 
-	existingCluster.ServiceProviderProperties.Console.URL = fmt.Sprintf("https://console-openshift-console.apps.%s", hostedCluster.Spec.DNS.BaseDomain)
-	existingCluster.ServiceProviderProperties.DNS.BaseDomain = strings.TrimPrefix(
+	replacement.ServiceProviderProperties.Console.URL = fmt.Sprintf("https://console-openshift-console.apps.%s", hostedCluster.Spec.DNS.BaseDomain)
+	kubeAPIServerDNSNamePrefix := fmt.Sprintf("api.%s.", replacement.CustomerProperties.DNS.BaseDomainPrefix)
+	// A mismatch should not happen in normal operation; error so any regression is visible.
+	if !strings.HasPrefix(hostedCluster.Spec.KubeAPIServerDNSName, kubeAPIServerDNSNamePrefix) {
+		return utils.TrackError(fmt.Errorf(
+			"failed to derive DNS base domain from kubeAPIServerDNSName %q: does not have expected prefix %q",
+			hostedCluster.Spec.KubeAPIServerDNSName,
+			kubeAPIServerDNSNamePrefix,
+		))
+	}
+	replacement.ServiceProviderProperties.DNS.BaseDomain = strings.TrimPrefix(
 		hostedCluster.Spec.KubeAPIServerDNSName,
-		fmt.Sprintf("api.%s.", domainPrefix),
+		kubeAPIServerDNSNamePrefix,
 	)
 	if hostedCluster.Status.ControlPlaneEndpoint.Port != 0 {
-		existingCluster.ServiceProviderProperties.API.URL = fmt.Sprintf("https://%s", net.JoinHostPort(hostedCluster.Spec.KubeAPIServerDNSName, strconv.Itoa(int(hostedCluster.Status.ControlPlaneEndpoint.Port))))
+		replacement.ServiceProviderProperties.API.URL = fmt.Sprintf("https://%s", net.JoinHostPort(hostedCluster.Spec.KubeAPIServerDNSName, strconv.Itoa(int(hostedCluster.Status.ControlPlaneEndpoint.Port))))
 	}
-	existingCluster.ServiceProviderProperties.Platform.IssuerURL = hostedCluster.Spec.IssuerURL
+	replacement.ServiceProviderProperties.Platform.IssuerURL = hostedCluster.Spec.IssuerURL
 
-	if equality.Semantic.DeepEqual(originalCluster, existingCluster) {
+	if equality.Semantic.DeepEqual(existingCluster, replacement) {
 		return nil
 	}
 
-	if _, err := clusterCRUD.Replace(ctx, existingCluster, nil); err != nil {
+	if _, err := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).Replace(ctx, replacement, nil); err != nil {
 		return utils.TrackError(fmt.Errorf("failed to replace Cluster: %w", err))
 	}
 

--- a/backend/pkg/controllers/clusterpropertiescontroller/cluster_properties_sync_test.go
+++ b/backend/pkg/controllers/clusterpropertiescontroller/cluster_properties_sync_test.go
@@ -22,13 +22,23 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/json"
+
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
 	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+	hsv1beta1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/maestrohelpers"
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/api/fleet"
+	"github.com/Azure/ARO-HCP/internal/api/kubeapplier"
+	dblisters "github.com/Azure/ARO-HCP/internal/database/listers"
+	internallistertesting "github.com/Azure/ARO-HCP/internal/database/listertesting"
 	"github.com/Azure/ARO-HCP/internal/databasetesting"
 	"github.com/Azure/ARO-HCP/internal/ocm"
 )
@@ -37,22 +47,37 @@ const (
 	testSubscriptionID      = "00000000-0000-0000-0000-000000000000"
 	testResourceGroupName   = "test-rg"
 	testClusterName         = "test-cluster"
+	testOtherClusterName    = "other-cluster"
 	testClusterServiceIDStr = "/api/clusters_mgmt/v1/clusters/abc123"
 
-	testConsoleURL       = "https://console.example.com"
-	testBaseDomain       = "example.openshiftapps.com"
-	testBaseDomainPrefix = "my-cluster"
-	testAPIURL           = "https://api.example.com:6443"
-	testIssuerURL        = "https://storage.z1.web.core.windows.net/tenant-id/cluster-id"
+	testConsoleURL                     = "https://console-openshift-console.apps.aro.cluster1.example.com"
+	testBaseDomain                     = "example.com"
+	testHostedClusterIngressBaseDomain = "aro.cluster1.example.com"
+	testBaseDomainPrefix               = "cluster1"
+	testAPIHost                        = "api.cluster1.example.com"
+	testAPIPort                        = int32(6443)
+	testAPIURL                         = "https://api.cluster1.example.com:6443"
+	testIssuerURL                      = "https://issuer.example.com/cluster1"
 )
 
 func TestClusterPropertiesSyncer_SyncOnce(t *testing.T) {
+	hostedClusterReadDesire := newHostedClusterReadDesire(t, &hsv1beta1.HostedCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: testBaseDomainPrefix},
+		Spec: hsv1beta1.HostedClusterSpec{
+			DNS:                  hsv1beta1.DNSSpec{BaseDomain: testHostedClusterIngressBaseDomain},
+			KubeAPIServerDNSName: testAPIHost,
+			IssuerURL:            testIssuerURL,
+		},
+		Status: hsv1beta1.HostedClusterStatus{
+			ControlPlaneEndpoint: hsv1beta1.APIEndpoint{Port: testAPIPort},
+		},
+	})
+
 	testCases := []struct {
 		name                     string
 		existingCluster          *api.HCPOpenShiftCluster
-		csCluster                *arohcpv1alpha1.Cluster
-		expectCSCall             bool
-		expectCosmosUpdate       bool
+		csDomainPrefix           string
+		expectCSGetCluster       bool
 		expectedConsoleURL       string
 		expectedBaseDomain       string
 		expectedBaseDomainPrefix string
@@ -61,15 +86,14 @@ func TestClusterPropertiesSyncer_SyncOnce(t *testing.T) {
 	}{
 		{
 			name: "short-circuit when all properties already set",
-			existingCluster: newTestCluster(func(c *api.HCPOpenShiftCluster) {
+			existingCluster: newTestCluster(testClusterName, func(c *api.HCPOpenShiftCluster) {
 				c.ServiceProviderProperties.Console.URL = testConsoleURL
 				c.ServiceProviderProperties.DNS.BaseDomain = testBaseDomain
 				c.ServiceProviderProperties.API.URL = testAPIURL
 				c.ServiceProviderProperties.Platform.IssuerURL = testIssuerURL
 				c.CustomerProperties.DNS.BaseDomainPrefix = testBaseDomainPrefix
 			}),
-			expectCSCall:             false,
-			expectCosmosUpdate:       false,
+
 			expectedConsoleURL:       testConsoleURL,
 			expectedBaseDomain:       testBaseDomain,
 			expectedBaseDomainPrefix: testBaseDomainPrefix,
@@ -77,17 +101,10 @@ func TestClusterPropertiesSyncer_SyncOnce(t *testing.T) {
 			expectedIssuerURL:        testIssuerURL,
 		},
 		{
-			name:            "sync all properties from CS when all are missing",
-			existingCluster: newTestCluster(),
-			csCluster: buildCSCluster(
-				testConsoleURL,
-				testBaseDomain,
-				testAPIURL,
-				testBaseDomainPrefix,
-				testIssuerURL,
-			),
-			expectCSCall:             true,
-			expectCosmosUpdate:       true,
+			name:                     "sync all properties from Cluster Service and HostedCluster when all are missing",
+			existingCluster:          newTestCluster(testClusterName),
+			csDomainPrefix:           testBaseDomainPrefix,
+			expectCSGetCluster:       true,
 			expectedConsoleURL:       testConsoleURL,
 			expectedBaseDomain:       testBaseDomain,
 			expectedBaseDomainPrefix: testBaseDomainPrefix,
@@ -96,21 +113,13 @@ func TestClusterPropertiesSyncer_SyncOnce(t *testing.T) {
 		},
 		{
 			name: "sync only missing Console.URL",
-			existingCluster: newTestCluster(func(c *api.HCPOpenShiftCluster) {
+			existingCluster: newTestCluster(testClusterName, func(c *api.HCPOpenShiftCluster) {
 				c.ServiceProviderProperties.DNS.BaseDomain = testBaseDomain
 				c.ServiceProviderProperties.API.URL = testAPIURL
 				c.ServiceProviderProperties.Platform.IssuerURL = testIssuerURL
 				c.CustomerProperties.DNS.BaseDomainPrefix = testBaseDomainPrefix
 			}),
-			csCluster: buildCSCluster(
-				testConsoleURL,
-				testBaseDomain,
-				testAPIURL,
-				testBaseDomainPrefix,
-				testIssuerURL,
-			),
-			expectCSCall:             true,
-			expectCosmosUpdate:       true,
+
 			expectedConsoleURL:       testConsoleURL,
 			expectedBaseDomain:       testBaseDomain,
 			expectedBaseDomainPrefix: testBaseDomainPrefix,
@@ -119,21 +128,13 @@ func TestClusterPropertiesSyncer_SyncOnce(t *testing.T) {
 		},
 		{
 			name: "sync only missing DNS.BaseDomain",
-			existingCluster: newTestCluster(func(c *api.HCPOpenShiftCluster) {
+			existingCluster: newTestCluster(testClusterName, func(c *api.HCPOpenShiftCluster) {
 				c.ServiceProviderProperties.Console.URL = testConsoleURL
 				c.ServiceProviderProperties.API.URL = testAPIURL
 				c.ServiceProviderProperties.Platform.IssuerURL = testIssuerURL
 				c.CustomerProperties.DNS.BaseDomainPrefix = testBaseDomainPrefix
 			}),
-			csCluster: buildCSCluster(
-				testConsoleURL,
-				testBaseDomain,
-				testAPIURL,
-				testBaseDomainPrefix,
-				testIssuerURL,
-			),
-			expectCSCall:             true,
-			expectCosmosUpdate:       true,
+
 			expectedConsoleURL:       testConsoleURL,
 			expectedBaseDomain:       testBaseDomain,
 			expectedBaseDomainPrefix: testBaseDomainPrefix,
@@ -142,21 +143,13 @@ func TestClusterPropertiesSyncer_SyncOnce(t *testing.T) {
 		},
 		{
 			name: "sync only missing API.URL",
-			existingCluster: newTestCluster(func(c *api.HCPOpenShiftCluster) {
+			existingCluster: newTestCluster(testClusterName, func(c *api.HCPOpenShiftCluster) {
 				c.ServiceProviderProperties.Console.URL = testConsoleURL
 				c.ServiceProviderProperties.DNS.BaseDomain = testBaseDomain
 				c.ServiceProviderProperties.Platform.IssuerURL = testIssuerURL
 				c.CustomerProperties.DNS.BaseDomainPrefix = testBaseDomainPrefix
 			}),
-			csCluster: buildCSCluster(
-				testConsoleURL,
-				testBaseDomain,
-				testAPIURL,
-				testBaseDomainPrefix,
-				testIssuerURL,
-			),
-			expectCSCall:             true,
-			expectCosmosUpdate:       true,
+
 			expectedConsoleURL:       testConsoleURL,
 			expectedBaseDomain:       testBaseDomain,
 			expectedBaseDomainPrefix: testBaseDomainPrefix,
@@ -164,62 +157,46 @@ func TestClusterPropertiesSyncer_SyncOnce(t *testing.T) {
 			expectedIssuerURL:        testIssuerURL,
 		},
 		{
-			name: "sync only missing DNS.BaseDomainPrefix",
-			existingCluster: newTestCluster(func(c *api.HCPOpenShiftCluster) {
+			name: "sync only missing DNS.BaseDomainPrefix from Cluster Service",
+			existingCluster: newTestCluster(testClusterName, func(c *api.HCPOpenShiftCluster) {
 				c.ServiceProviderProperties.Console.URL = testConsoleURL
 				c.ServiceProviderProperties.DNS.BaseDomain = testBaseDomain
 				c.ServiceProviderProperties.API.URL = testAPIURL
 				c.ServiceProviderProperties.Platform.IssuerURL = testIssuerURL
 			}),
-			csCluster: buildCSCluster(
-				testConsoleURL,
-				testBaseDomain,
-				testAPIURL,
-				testBaseDomainPrefix,
-				testIssuerURL,
-			),
-			expectCSCall:             true,
-			expectCosmosUpdate:       true,
+			csDomainPrefix:           testBaseDomainPrefix,
+			expectCSGetCluster:       true,
 			expectedConsoleURL:       testConsoleURL,
 			expectedBaseDomain:       testBaseDomain,
 			expectedBaseDomainPrefix: testBaseDomainPrefix,
 			expectedAPIURL:           testAPIURL,
 			expectedIssuerURL:        testIssuerURL,
-		},
-		{
-			name:                     "no update when CS returns empty values",
-			existingCluster:          newTestCluster(),
-			csCluster:                buildCSCluster("", "", "", "", ""),
-			expectCSCall:             true,
-			expectCosmosUpdate:       false,
-			expectedConsoleURL:       "",
-			expectedBaseDomain:       "",
-			expectedBaseDomainPrefix: "",
-			expectedAPIURL:           "",
-			expectedIssuerURL:        "",
 		},
 		{
 			name: "sync only missing Platform.IssuerURL",
-			existingCluster: newTestCluster(func(c *api.HCPOpenShiftCluster) {
+			existingCluster: newTestCluster(testClusterName, func(c *api.HCPOpenShiftCluster) {
 				c.ServiceProviderProperties.Console.URL = testConsoleURL
 				c.ServiceProviderProperties.DNS.BaseDomain = testBaseDomain
 				c.ServiceProviderProperties.API.URL = testAPIURL
 				c.CustomerProperties.DNS.BaseDomainPrefix = testBaseDomainPrefix
 			}),
-			csCluster: buildCSCluster(
-				testConsoleURL,
-				testBaseDomain,
-				testAPIURL,
-				testBaseDomainPrefix,
-				testIssuerURL,
-			),
-			expectCSCall:             true,
-			expectCosmosUpdate:       true,
+
 			expectedConsoleURL:       testConsoleURL,
 			expectedBaseDomain:       testBaseDomain,
 			expectedBaseDomainPrefix: testBaseDomainPrefix,
 			expectedAPIURL:           testAPIURL,
 			expectedIssuerURL:        testIssuerURL,
+		},
+		{
+			name:                     "sync domain prefix from Cluster Service when HostedCluster ReadDesire not found",
+			existingCluster:          newTestCluster(testOtherClusterName),
+			csDomainPrefix:           testBaseDomainPrefix,
+			expectCSGetCluster:       true,
+			expectedConsoleURL:       "",
+			expectedBaseDomain:       "",
+			expectedBaseDomainPrefix: testBaseDomainPrefix,
+			expectedAPIURL:           "",
+			expectedIssuerURL:        "",
 		},
 	}
 
@@ -233,13 +210,17 @@ func TestClusterPropertiesSyncer_SyncOnce(t *testing.T) {
 			mockResourcesDB, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, []any{tc.existingCluster})
 			require.NoError(t, err)
 
+			readDesireLister, err := newSeededReadDesireLister(ctx, hostedClusterReadDesire)
+			require.NoError(t, err)
+
 			// Setup mock CS client
 			mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
-
-			if tc.expectCSCall {
+			if tc.expectCSGetCluster {
+				csCluster, err := arohcpv1alpha1.NewCluster().DomainPrefix(tc.csDomainPrefix).Build()
+				require.NoError(t, err)
 				mockCSClient.EXPECT().
-					GetCluster(gomock.Any(), api.Must(api.NewInternalID(testClusterServiceIDStr))).
-					Return(tc.csCluster, nil)
+					GetCluster(gomock.Any(), gomock.Any()).
+					Return(csCluster, nil)
 			}
 
 			// Create syncer
@@ -247,19 +228,20 @@ func TestClusterPropertiesSyncer_SyncOnce(t *testing.T) {
 				cooldownChecker:      &alwaysSyncCooldownChecker{},
 				resourcesDBClient:    mockResourcesDB,
 				clusterServiceClient: mockCSClient,
+				readDesireLister:     readDesireLister,
 			}
 
 			// Execute
 			key := controllerutils.HCPClusterKey{
 				SubscriptionID:    testSubscriptionID,
 				ResourceGroupName: testResourceGroupName,
-				HCPClusterName:    testClusterName,
+				HCPClusterName:    tc.existingCluster.Name,
 			}
 			err = syncer.SyncOnce(ctx, key)
 			require.NoError(t, err)
 
 			// Verify the cluster state in Cosmos
-			updatedCluster, err := mockResourcesDB.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
+			updatedCluster, err := mockResourcesDB.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, tc.existingCluster.Name)
 			require.NoError(t, err)
 
 			assert.Equal(t, tc.expectedConsoleURL, updatedCluster.ServiceProviderProperties.Console.URL)
@@ -271,13 +253,35 @@ func TestClusterPropertiesSyncer_SyncOnce(t *testing.T) {
 	}
 }
 
-// newTestCluster creates a test HCPOpenShiftCluster with default values.
-// Options can be provided to customize the cluster.
-func newTestCluster(opts ...func(*api.HCPOpenShiftCluster)) *api.HCPOpenShiftCluster {
+func newSeededReadDesireLister(ctx context.Context, readDesire *kubeapplier.ReadDesire) (dblisters.ReadDesireLister, error) {
+	mockKubeApplierDB, err := databasetesting.NewMockKubeApplierDBClientWithResources(ctx, []any{readDesire})
+	if err != nil {
+		return nil, err
+	}
+
+	kubeApplierClients := databasetesting.NewMockKubeApplierDBClients()
+	managementClusterID := api.Must(azcorearm.ParseResourceID(
+		"/providers/microsoft.redhatopenshift/stamps/1/managementclusters/mgmt-a"))
+	kubeApplierClients.Register(managementClusterID, mockKubeApplierDB)
+
+	return &internallistertesting.DBReadDesireLister{
+		Clients: kubeApplierClients,
+		Lister: &internallistertesting.SliceManagementClusterLister{
+			ManagementClusters: []*fleet.ManagementCluster{
+				{
+					CosmosMetadata: api.CosmosMetadata{ResourceID: managementClusterID},
+					ResourceID:     managementClusterID,
+				},
+			},
+		},
+	}, nil
+}
+
+func newTestCluster(hcpClusterName string, opts ...func(*api.HCPOpenShiftCluster)) *api.HCPOpenShiftCluster {
 	resourceID := api.Must(azcorearm.ParseResourceID(
 		"/subscriptions/" + testSubscriptionID +
 			"/resourceGroups/" + testResourceGroupName +
-			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName,
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + hcpClusterName,
 	))
 
 	cluster := &api.HCPOpenShiftCluster{
@@ -287,7 +291,7 @@ func newTestCluster(opts ...func(*api.HCPOpenShiftCluster)) *api.HCPOpenShiftClu
 		TrackedResource: arm.TrackedResource{
 			Resource: arm.Resource{
 				ID:   resourceID,
-				Name: testClusterName,
+				Name: hcpClusterName,
 				Type: resourceID.ResourceType.String(),
 			},
 		},
@@ -303,26 +307,34 @@ func newTestCluster(opts ...func(*api.HCPOpenShiftCluster)) *api.HCPOpenShiftClu
 	return cluster
 }
 
-// buildCSCluster creates a mock Cluster Service cluster with the given values.
-func buildCSCluster(consoleURL, baseDomain, apiURL, domainPrefix, issuerURL string) *arohcpv1alpha1.Cluster {
-	builder := arohcpv1alpha1.NewCluster().
-		Console(arohcpv1alpha1.NewClusterConsole().URL(consoleURL)).
-		DNS(arohcpv1alpha1.NewDNS().BaseDomain(baseDomain)).
-		API(arohcpv1alpha1.NewClusterAPI().URL(apiURL)).
-		DomainPrefix(domainPrefix)
+func newHostedClusterReadDesire(t *testing.T, hostedCluster *hsv1beta1.HostedCluster) *kubeapplier.ReadDesire {
+	t.Helper()
 
-	if issuerURL != "" {
-		builder = builder.Azure(arohcpv1alpha1.NewAzure().OidcIssuerUrl(issuerURL))
-	}
+	resourceIDString := kubeapplier.ToClusterScopedReadDesireResourceIDString(
+		testSubscriptionID,
+		testResourceGroupName,
+		testClusterName,
+		maestrohelpers.ReadDesireNameReadonlyHostedCluster,
+	)
+	resourceID := api.Must(azcorearm.ParseResourceID(resourceIDString))
 
-	cluster, err := builder.Build()
-	if err != nil {
-		panic(err)
+	raw, err := json.Marshal(hostedCluster)
+	require.NoError(t, err)
+
+	return &kubeapplier.ReadDesire{
+		CosmosMetadata: api.CosmosMetadata{
+			ResourceID: resourceID,
+		},
+		Spec: kubeapplier.ReadDesireSpec{
+			ManagementCluster: api.Must(azcorearm.ParseResourceID(
+				"/providers/microsoft.redhatopenshift/stamps/1/managementclusters/mgmt-a")),
+		},
+		Status: kubeapplier.ReadDesireStatus{
+			KubeContent: &runtime.RawExtension{Raw: raw},
+		},
 	}
-	return cluster
 }
 
-// alwaysSyncCooldownChecker always allows syncing
 type alwaysSyncCooldownChecker struct{}
 
 func (c *alwaysSyncCooldownChecker) CanSync(ctx context.Context, key any) bool {

--- a/backend/pkg/controllers/clusterpropertiescontroller/cluster_properties_sync_test.go
+++ b/backend/pkg/controllers/clusterpropertiescontroller/cluster_properties_sync_test.go
@@ -39,27 +39,25 @@ const (
 	testClusterName         = "test-cluster"
 	testClusterServiceIDStr = "/api/clusters_mgmt/v1/clusters/abc123"
 
-	testConsoleURL         = "https://console.example.com"
-	testBaseDomain         = "example.openshiftapps.com"
-	testBaseDomainPrefix   = "my-cluster"
-	testManagedIdentityURL = "https://dummyhost.identity.azure.net/otherinformation?aqueryarg=somevalue"
-	testAPIURL             = "https://api.example.com:6443"
-	testIssuerURL          = "https://storage.z1.web.core.windows.net/tenant-id/cluster-id"
+	testConsoleURL       = "https://console.example.com"
+	testBaseDomain       = "example.openshiftapps.com"
+	testBaseDomainPrefix = "my-cluster"
+	testAPIURL           = "https://api.example.com:6443"
+	testIssuerURL        = "https://storage.z1.web.core.windows.net/tenant-id/cluster-id"
 )
 
 func TestClusterPropertiesSyncer_SyncOnce(t *testing.T) {
 	testCases := []struct {
-		name                       string
-		existingCluster            *api.HCPOpenShiftCluster
-		csCluster                  *arohcpv1alpha1.Cluster
-		expectCSCall               bool
-		expectCosmosUpdate         bool
-		expectedConsoleURL         string
-		expectedBaseDomain         string
-		expectedBaseDomainPrefix   string
-		expectedManagedIdentityURL string
-		expectedAPIURL             string
-		expectedIssuerURL          string
+		name                     string
+		existingCluster          *api.HCPOpenShiftCluster
+		csCluster                *arohcpv1alpha1.Cluster
+		expectCSCall             bool
+		expectCosmosUpdate       bool
+		expectedConsoleURL       string
+		expectedBaseDomain       string
+		expectedBaseDomainPrefix string
+		expectedAPIURL           string
+		expectedIssuerURL        string
 	}{
 		{
 			name: "short-circuit when all properties already set",
@@ -67,18 +65,16 @@ func TestClusterPropertiesSyncer_SyncOnce(t *testing.T) {
 				c.ServiceProviderProperties.Console.URL = testConsoleURL
 				c.ServiceProviderProperties.DNS.BaseDomain = testBaseDomain
 				c.ServiceProviderProperties.API.URL = testAPIURL
-				c.ServiceProviderProperties.ManagedIdentitiesDataPlaneIdentityURL = testManagedIdentityURL
 				c.ServiceProviderProperties.Platform.IssuerURL = testIssuerURL
 				c.CustomerProperties.DNS.BaseDomainPrefix = testBaseDomainPrefix
 			}),
-			expectCSCall:               false,
-			expectCosmosUpdate:         false,
-			expectedConsoleURL:         testConsoleURL,
-			expectedBaseDomain:         testBaseDomain,
-			expectedBaseDomainPrefix:   testBaseDomainPrefix,
-			expectedManagedIdentityURL: testManagedIdentityURL,
-			expectedAPIURL:             testAPIURL,
-			expectedIssuerURL:          testIssuerURL,
+			expectCSCall:             false,
+			expectCosmosUpdate:       false,
+			expectedConsoleURL:       testConsoleURL,
+			expectedBaseDomain:       testBaseDomain,
+			expectedBaseDomainPrefix: testBaseDomainPrefix,
+			expectedAPIURL:           testAPIURL,
+			expectedIssuerURL:        testIssuerURL,
 		},
 		{
 			name:            "sync all properties from CS when all are missing",
@@ -88,24 +84,21 @@ func TestClusterPropertiesSyncer_SyncOnce(t *testing.T) {
 				testBaseDomain,
 				testAPIURL,
 				testBaseDomainPrefix,
-				testManagedIdentityURL,
 				testIssuerURL,
 			),
-			expectCSCall:               true,
-			expectCosmosUpdate:         true,
-			expectedConsoleURL:         testConsoleURL,
-			expectedBaseDomain:         testBaseDomain,
-			expectedBaseDomainPrefix:   testBaseDomainPrefix,
-			expectedManagedIdentityURL: testManagedIdentityURL,
-			expectedAPIURL:             testAPIURL,
-			expectedIssuerURL:          testIssuerURL,
+			expectCSCall:             true,
+			expectCosmosUpdate:       true,
+			expectedConsoleURL:       testConsoleURL,
+			expectedBaseDomain:       testBaseDomain,
+			expectedBaseDomainPrefix: testBaseDomainPrefix,
+			expectedAPIURL:           testAPIURL,
+			expectedIssuerURL:        testIssuerURL,
 		},
 		{
 			name: "sync only missing Console.URL",
 			existingCluster: newTestCluster(func(c *api.HCPOpenShiftCluster) {
 				c.ServiceProviderProperties.DNS.BaseDomain = testBaseDomain
 				c.ServiceProviderProperties.API.URL = testAPIURL
-				c.ServiceProviderProperties.ManagedIdentitiesDataPlaneIdentityURL = testManagedIdentityURL
 				c.ServiceProviderProperties.Platform.IssuerURL = testIssuerURL
 				c.CustomerProperties.DNS.BaseDomainPrefix = testBaseDomainPrefix
 			}),
@@ -114,24 +107,21 @@ func TestClusterPropertiesSyncer_SyncOnce(t *testing.T) {
 				testBaseDomain,
 				testAPIURL,
 				testBaseDomainPrefix,
-				testManagedIdentityURL,
 				testIssuerURL,
 			),
-			expectCSCall:               true,
-			expectCosmosUpdate:         true,
-			expectedConsoleURL:         testConsoleURL,
-			expectedBaseDomain:         testBaseDomain,
-			expectedBaseDomainPrefix:   testBaseDomainPrefix,
-			expectedManagedIdentityURL: testManagedIdentityURL,
-			expectedAPIURL:             testAPIURL,
-			expectedIssuerURL:          testIssuerURL,
+			expectCSCall:             true,
+			expectCosmosUpdate:       true,
+			expectedConsoleURL:       testConsoleURL,
+			expectedBaseDomain:       testBaseDomain,
+			expectedBaseDomainPrefix: testBaseDomainPrefix,
+			expectedAPIURL:           testAPIURL,
+			expectedIssuerURL:        testIssuerURL,
 		},
 		{
 			name: "sync only missing DNS.BaseDomain",
 			existingCluster: newTestCluster(func(c *api.HCPOpenShiftCluster) {
 				c.ServiceProviderProperties.Console.URL = testConsoleURL
 				c.ServiceProviderProperties.API.URL = testAPIURL
-				c.ServiceProviderProperties.ManagedIdentitiesDataPlaneIdentityURL = testManagedIdentityURL
 				c.ServiceProviderProperties.Platform.IssuerURL = testIssuerURL
 				c.CustomerProperties.DNS.BaseDomainPrefix = testBaseDomainPrefix
 			}),
@@ -140,24 +130,21 @@ func TestClusterPropertiesSyncer_SyncOnce(t *testing.T) {
 				testBaseDomain,
 				testAPIURL,
 				testBaseDomainPrefix,
-				testManagedIdentityURL,
 				testIssuerURL,
 			),
-			expectCSCall:               true,
-			expectCosmosUpdate:         true,
-			expectedConsoleURL:         testConsoleURL,
-			expectedBaseDomain:         testBaseDomain,
-			expectedBaseDomainPrefix:   testBaseDomainPrefix,
-			expectedManagedIdentityURL: testManagedIdentityURL,
-			expectedAPIURL:             testAPIURL,
-			expectedIssuerURL:          testIssuerURL,
+			expectCSCall:             true,
+			expectCosmosUpdate:       true,
+			expectedConsoleURL:       testConsoleURL,
+			expectedBaseDomain:       testBaseDomain,
+			expectedBaseDomainPrefix: testBaseDomainPrefix,
+			expectedAPIURL:           testAPIURL,
+			expectedIssuerURL:        testIssuerURL,
 		},
 		{
 			name: "sync only missing API.URL",
 			existingCluster: newTestCluster(func(c *api.HCPOpenShiftCluster) {
 				c.ServiceProviderProperties.Console.URL = testConsoleURL
 				c.ServiceProviderProperties.DNS.BaseDomain = testBaseDomain
-				c.ServiceProviderProperties.ManagedIdentitiesDataPlaneIdentityURL = testManagedIdentityURL
 				c.ServiceProviderProperties.Platform.IssuerURL = testIssuerURL
 				c.CustomerProperties.DNS.BaseDomainPrefix = testBaseDomainPrefix
 			}),
@@ -166,17 +153,15 @@ func TestClusterPropertiesSyncer_SyncOnce(t *testing.T) {
 				testBaseDomain,
 				testAPIURL,
 				testBaseDomainPrefix,
-				testManagedIdentityURL,
 				testIssuerURL,
 			),
-			expectCSCall:               true,
-			expectCosmosUpdate:         true,
-			expectedConsoleURL:         testConsoleURL,
-			expectedBaseDomain:         testBaseDomain,
-			expectedBaseDomainPrefix:   testBaseDomainPrefix,
-			expectedManagedIdentityURL: testManagedIdentityURL,
-			expectedAPIURL:             testAPIURL,
-			expectedIssuerURL:          testIssuerURL,
+			expectCSCall:             true,
+			expectCosmosUpdate:       true,
+			expectedConsoleURL:       testConsoleURL,
+			expectedBaseDomain:       testBaseDomain,
+			expectedBaseDomainPrefix: testBaseDomainPrefix,
+			expectedAPIURL:           testAPIURL,
+			expectedIssuerURL:        testIssuerURL,
 		},
 		{
 			name: "sync only missing DNS.BaseDomainPrefix",
@@ -184,7 +169,6 @@ func TestClusterPropertiesSyncer_SyncOnce(t *testing.T) {
 				c.ServiceProviderProperties.Console.URL = testConsoleURL
 				c.ServiceProviderProperties.DNS.BaseDomain = testBaseDomain
 				c.ServiceProviderProperties.API.URL = testAPIURL
-				c.ServiceProviderProperties.ManagedIdentitiesDataPlaneIdentityURL = testManagedIdentityURL
 				c.ServiceProviderProperties.Platform.IssuerURL = testIssuerURL
 			}),
 			csCluster: buildCSCluster(
@@ -192,56 +176,27 @@ func TestClusterPropertiesSyncer_SyncOnce(t *testing.T) {
 				testBaseDomain,
 				testAPIURL,
 				testBaseDomainPrefix,
-				testManagedIdentityURL,
 				testIssuerURL,
 			),
-			expectCSCall:               true,
-			expectCosmosUpdate:         true,
-			expectedConsoleURL:         testConsoleURL,
-			expectedBaseDomain:         testBaseDomain,
-			expectedBaseDomainPrefix:   testBaseDomainPrefix,
-			expectedManagedIdentityURL: testManagedIdentityURL,
-			expectedAPIURL:             testAPIURL,
-			expectedIssuerURL:          testIssuerURL,
+			expectCSCall:             true,
+			expectCosmosUpdate:       true,
+			expectedConsoleURL:       testConsoleURL,
+			expectedBaseDomain:       testBaseDomain,
+			expectedBaseDomainPrefix: testBaseDomainPrefix,
+			expectedAPIURL:           testAPIURL,
+			expectedIssuerURL:        testIssuerURL,
 		},
 		{
-			name:                       "no update when CS returns empty values",
-			existingCluster:            newTestCluster(),
-			csCluster:                  buildCSCluster("", "", "", "", "", ""),
-			expectCSCall:               true,
-			expectCosmosUpdate:         false,
-			expectedConsoleURL:         "",
-			expectedBaseDomain:         "",
-			expectedBaseDomainPrefix:   "",
-			expectedManagedIdentityURL: "",
-			expectedAPIURL:             "",
-			expectedIssuerURL:          "",
-		},
-		{
-			name: "sync only missing ManagedIdentitiesDataPlaneIdentityURL",
-			existingCluster: newTestCluster(func(c *api.HCPOpenShiftCluster) {
-				c.ServiceProviderProperties.Console.URL = testConsoleURL
-				c.ServiceProviderProperties.DNS.BaseDomain = testBaseDomain
-				c.ServiceProviderProperties.API.URL = testAPIURL
-				c.ServiceProviderProperties.Platform.IssuerURL = testIssuerURL
-				c.CustomerProperties.DNS.BaseDomainPrefix = testBaseDomainPrefix
-			}),
-			csCluster: buildCSCluster(
-				testConsoleURL,
-				testBaseDomain,
-				testAPIURL,
-				testBaseDomainPrefix,
-				testManagedIdentityURL,
-				testIssuerURL,
-			),
-			expectCSCall:               true,
-			expectCosmosUpdate:         true,
-			expectedConsoleURL:         testConsoleURL,
-			expectedBaseDomain:         testBaseDomain,
-			expectedBaseDomainPrefix:   testBaseDomainPrefix,
-			expectedManagedIdentityURL: testManagedIdentityURL,
-			expectedAPIURL:             testAPIURL,
-			expectedIssuerURL:          testIssuerURL,
+			name:                     "no update when CS returns empty values",
+			existingCluster:          newTestCluster(),
+			csCluster:                buildCSCluster("", "", "", "", ""),
+			expectCSCall:             true,
+			expectCosmosUpdate:       false,
+			expectedConsoleURL:       "",
+			expectedBaseDomain:       "",
+			expectedBaseDomainPrefix: "",
+			expectedAPIURL:           "",
+			expectedIssuerURL:        "",
 		},
 		{
 			name: "sync only missing Platform.IssuerURL",
@@ -249,7 +204,6 @@ func TestClusterPropertiesSyncer_SyncOnce(t *testing.T) {
 				c.ServiceProviderProperties.Console.URL = testConsoleURL
 				c.ServiceProviderProperties.DNS.BaseDomain = testBaseDomain
 				c.ServiceProviderProperties.API.URL = testAPIURL
-				c.ServiceProviderProperties.ManagedIdentitiesDataPlaneIdentityURL = testManagedIdentityURL
 				c.CustomerProperties.DNS.BaseDomainPrefix = testBaseDomainPrefix
 			}),
 			csCluster: buildCSCluster(
@@ -257,17 +211,15 @@ func TestClusterPropertiesSyncer_SyncOnce(t *testing.T) {
 				testBaseDomain,
 				testAPIURL,
 				testBaseDomainPrefix,
-				testManagedIdentityURL,
 				testIssuerURL,
 			),
-			expectCSCall:               true,
-			expectCosmosUpdate:         true,
-			expectedConsoleURL:         testConsoleURL,
-			expectedBaseDomain:         testBaseDomain,
-			expectedBaseDomainPrefix:   testBaseDomainPrefix,
-			expectedManagedIdentityURL: testManagedIdentityURL,
-			expectedAPIURL:             testAPIURL,
-			expectedIssuerURL:          testIssuerURL,
+			expectCSCall:             true,
+			expectCosmosUpdate:       true,
+			expectedConsoleURL:       testConsoleURL,
+			expectedBaseDomain:       testBaseDomain,
+			expectedBaseDomainPrefix: testBaseDomainPrefix,
+			expectedAPIURL:           testAPIURL,
+			expectedIssuerURL:        testIssuerURL,
 		},
 	}
 
@@ -314,7 +266,6 @@ func TestClusterPropertiesSyncer_SyncOnce(t *testing.T) {
 			assert.Equal(t, tc.expectedBaseDomain, updatedCluster.ServiceProviderProperties.DNS.BaseDomain)
 			assert.Equal(t, tc.expectedAPIURL, updatedCluster.ServiceProviderProperties.API.URL)
 			assert.Equal(t, tc.expectedBaseDomainPrefix, updatedCluster.CustomerProperties.DNS.BaseDomainPrefix)
-			assert.Equal(t, tc.expectedManagedIdentityURL, updatedCluster.ServiceProviderProperties.ManagedIdentitiesDataPlaneIdentityURL)
 			assert.Equal(t, tc.expectedIssuerURL, updatedCluster.ServiceProviderProperties.Platform.IssuerURL)
 		})
 	}
@@ -353,31 +304,15 @@ func newTestCluster(opts ...func(*api.HCPOpenShiftCluster)) *api.HCPOpenShiftClu
 }
 
 // buildCSCluster creates a mock Cluster Service cluster with the given values.
-func buildCSCluster(consoleURL, baseDomain, apiURL, domainPrefix, managedIdentityURL, issuerURL string) *arohcpv1alpha1.Cluster {
+func buildCSCluster(consoleURL, baseDomain, apiURL, domainPrefix, issuerURL string) *arohcpv1alpha1.Cluster {
 	builder := arohcpv1alpha1.NewCluster().
 		Console(arohcpv1alpha1.NewClusterConsole().URL(consoleURL)).
 		DNS(arohcpv1alpha1.NewDNS().BaseDomain(baseDomain)).
 		API(arohcpv1alpha1.NewClusterAPI().URL(apiURL)).
 		DomainPrefix(domainPrefix)
 
-	azureBuilder := arohcpv1alpha1.NewAzure()
-	needsAzure := false
-
-	if managedIdentityURL != "" {
-		azureBuilder = azureBuilder.
-			OperatorsAuthentication(arohcpv1alpha1.NewAzureOperatorsAuthentication().
-				ManagedIdentities(arohcpv1alpha1.NewAzureOperatorsAuthenticationManagedIdentities().
-					ControlPlaneOperatorsManagedIdentities(make(map[string]*arohcpv1alpha1.AzureControlPlaneManagedIdentityBuilder)).
-					DataPlaneOperatorsManagedIdentities(make(map[string]*arohcpv1alpha1.AzureDataPlaneManagedIdentityBuilder)).
-					ManagedIdentitiesDataPlaneIdentityUrl(managedIdentityURL)))
-		needsAzure = true
-	}
 	if issuerURL != "" {
-		azureBuilder = azureBuilder.OidcIssuerUrl(issuerURL)
-		needsAzure = true
-	}
-	if needsAzure {
-		builder = builder.Azure(azureBuilder)
+		builder = builder.Azure(arohcpv1alpha1.NewAzure().OidcIssuerUrl(issuerURL))
 	}
 
 	cluster, err := builder.Build()

--- a/backend/pkg/controllers/clusterpropertiescontroller/cluster_properties_sync_test.go
+++ b/backend/pkg/controllers/clusterpropertiescontroller/cluster_properties_sync_test.go
@@ -20,47 +20,19 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/mock/gomock"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/json"
 
-	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-
-	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
 	hsv1beta1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
-	"github.com/Azure/ARO-HCP/backend/pkg/maestrohelpers"
 	"github.com/Azure/ARO-HCP/internal/api"
-	"github.com/Azure/ARO-HCP/internal/api/arm"
-	"github.com/Azure/ARO-HCP/internal/api/fleet"
-	"github.com/Azure/ARO-HCP/internal/api/kubeapplier"
-	dblisters "github.com/Azure/ARO-HCP/internal/database/listers"
-	internallistertesting "github.com/Azure/ARO-HCP/internal/database/listertesting"
 	"github.com/Azure/ARO-HCP/internal/databasetesting"
-	"github.com/Azure/ARO-HCP/internal/ocm"
-)
-
-const (
-	testSubscriptionID      = "00000000-0000-0000-0000-000000000000"
-	testResourceGroupName   = "test-rg"
-	testClusterName         = "test-cluster"
-	testOtherClusterName    = "other-cluster"
-	testClusterServiceIDStr = "/api/clusters_mgmt/v1/clusters/abc123"
-
-	testConsoleURL                     = "https://console-openshift-console.apps.aro.cluster1.example.com"
-	testBaseDomain                     = "example.com"
-	testHostedClusterIngressBaseDomain = "aro.cluster1.example.com"
-	testBaseDomainPrefix               = "cluster1"
-	testAPIHost                        = "api.cluster1.example.com"
-	testAPIPort                        = int32(6443)
-	testAPIURL                         = "https://api.cluster1.example.com:6443"
-	testIssuerURL                      = "https://issuer.example.com/cluster1"
 )
 
 func TestClusterPropertiesSyncer_SyncOnce(t *testing.T) {
+	t.Parallel()
+
 	hostedClusterReadDesire := newHostedClusterReadDesire(t, &hsv1beta1.HostedCluster{
 		ObjectMeta: metav1.ObjectMeta{Name: testBaseDomainPrefix},
 		Spec: hsv1beta1.HostedClusterSpec{
@@ -74,18 +46,25 @@ func TestClusterPropertiesSyncer_SyncOnce(t *testing.T) {
 	})
 
 	testCases := []struct {
-		name                     string
-		existingCluster          *api.HCPOpenShiftCluster
-		csDomainPrefix           string
-		expectCSGetCluster       bool
-		expectedConsoleURL       string
-		expectedBaseDomain       string
-		expectedBaseDomainPrefix string
-		expectedAPIURL           string
-		expectedIssuerURL        string
+		name               string
+		existingCluster    *api.HCPOpenShiftCluster
+		expectedConsoleURL string
+		expectedBaseDomain string
+		expectedAPIURL     string
+		expectedIssuerURL  string
 	}{
 		{
-			name: "short-circuit when all properties already set",
+			name: "sync cluster properties from HostedCluster ReadDesire when they differ from Cosmos",
+			existingCluster: newTestCluster(testClusterName, func(c *api.HCPOpenShiftCluster) {
+				c.CustomerProperties.DNS.BaseDomainPrefix = testBaseDomainPrefix
+			}),
+			expectedConsoleURL: testConsoleURL,
+			expectedBaseDomain: testBaseDomain,
+			expectedAPIURL:     testAPIURL,
+			expectedIssuerURL:  testIssuerURL,
+		},
+		{
+			name: "short-circuit when cluster properties match HostedCluster ReadDesire",
 			existingCluster: newTestCluster(testClusterName, func(c *api.HCPOpenShiftCluster) {
 				c.ServiceProviderProperties.Console.URL = testConsoleURL
 				c.ServiceProviderProperties.DNS.BaseDomain = testBaseDomain
@@ -93,145 +72,39 @@ func TestClusterPropertiesSyncer_SyncOnce(t *testing.T) {
 				c.ServiceProviderProperties.Platform.IssuerURL = testIssuerURL
 				c.CustomerProperties.DNS.BaseDomainPrefix = testBaseDomainPrefix
 			}),
-
-			expectedConsoleURL:       testConsoleURL,
-			expectedBaseDomain:       testBaseDomain,
-			expectedBaseDomainPrefix: testBaseDomainPrefix,
-			expectedAPIURL:           testAPIURL,
-			expectedIssuerURL:        testIssuerURL,
+			expectedConsoleURL: testConsoleURL,
+			expectedBaseDomain: testBaseDomain,
+			expectedAPIURL:     testAPIURL,
+			expectedIssuerURL:  testIssuerURL,
 		},
 		{
-			name:                     "sync all properties from Cluster Service and HostedCluster when all are missing",
-			existingCluster:          newTestCluster(testClusterName),
-			csDomainPrefix:           testBaseDomainPrefix,
-			expectCSGetCluster:       true,
-			expectedConsoleURL:       testConsoleURL,
-			expectedBaseDomain:       testBaseDomain,
-			expectedBaseDomainPrefix: testBaseDomainPrefix,
-			expectedAPIURL:           testAPIURL,
-			expectedIssuerURL:        testIssuerURL,
-		},
-		{
-			name: "sync only missing Console.URL",
-			existingCluster: newTestCluster(testClusterName, func(c *api.HCPOpenShiftCluster) {
-				c.ServiceProviderProperties.DNS.BaseDomain = testBaseDomain
-				c.ServiceProviderProperties.API.URL = testAPIURL
-				c.ServiceProviderProperties.Platform.IssuerURL = testIssuerURL
-				c.CustomerProperties.DNS.BaseDomainPrefix = testBaseDomainPrefix
-			}),
-
-			expectedConsoleURL:       testConsoleURL,
-			expectedBaseDomain:       testBaseDomain,
-			expectedBaseDomainPrefix: testBaseDomainPrefix,
-			expectedAPIURL:           testAPIURL,
-			expectedIssuerURL:        testIssuerURL,
-		},
-		{
-			name: "sync only missing DNS.BaseDomain",
-			existingCluster: newTestCluster(testClusterName, func(c *api.HCPOpenShiftCluster) {
-				c.ServiceProviderProperties.Console.URL = testConsoleURL
-				c.ServiceProviderProperties.API.URL = testAPIURL
-				c.ServiceProviderProperties.Platform.IssuerURL = testIssuerURL
-				c.CustomerProperties.DNS.BaseDomainPrefix = testBaseDomainPrefix
-			}),
-
-			expectedConsoleURL:       testConsoleURL,
-			expectedBaseDomain:       testBaseDomain,
-			expectedBaseDomainPrefix: testBaseDomainPrefix,
-			expectedAPIURL:           testAPIURL,
-			expectedIssuerURL:        testIssuerURL,
-		},
-		{
-			name: "sync only missing API.URL",
-			existingCluster: newTestCluster(testClusterName, func(c *api.HCPOpenShiftCluster) {
-				c.ServiceProviderProperties.Console.URL = testConsoleURL
-				c.ServiceProviderProperties.DNS.BaseDomain = testBaseDomain
-				c.ServiceProviderProperties.Platform.IssuerURL = testIssuerURL
-				c.CustomerProperties.DNS.BaseDomainPrefix = testBaseDomainPrefix
-			}),
-
-			expectedConsoleURL:       testConsoleURL,
-			expectedBaseDomain:       testBaseDomain,
-			expectedBaseDomainPrefix: testBaseDomainPrefix,
-			expectedAPIURL:           testAPIURL,
-			expectedIssuerURL:        testIssuerURL,
-		},
-		{
-			name: "sync only missing DNS.BaseDomainPrefix from Cluster Service",
-			existingCluster: newTestCluster(testClusterName, func(c *api.HCPOpenShiftCluster) {
-				c.ServiceProviderProperties.Console.URL = testConsoleURL
-				c.ServiceProviderProperties.DNS.BaseDomain = testBaseDomain
-				c.ServiceProviderProperties.API.URL = testAPIURL
-				c.ServiceProviderProperties.Platform.IssuerURL = testIssuerURL
-			}),
-			csDomainPrefix:           testBaseDomainPrefix,
-			expectCSGetCluster:       true,
-			expectedConsoleURL:       testConsoleURL,
-			expectedBaseDomain:       testBaseDomain,
-			expectedBaseDomainPrefix: testBaseDomainPrefix,
-			expectedAPIURL:           testAPIURL,
-			expectedIssuerURL:        testIssuerURL,
-		},
-		{
-			name: "sync only missing Platform.IssuerURL",
-			existingCluster: newTestCluster(testClusterName, func(c *api.HCPOpenShiftCluster) {
-				c.ServiceProviderProperties.Console.URL = testConsoleURL
-				c.ServiceProviderProperties.DNS.BaseDomain = testBaseDomain
-				c.ServiceProviderProperties.API.URL = testAPIURL
-				c.CustomerProperties.DNS.BaseDomainPrefix = testBaseDomainPrefix
-			}),
-
-			expectedConsoleURL:       testConsoleURL,
-			expectedBaseDomain:       testBaseDomain,
-			expectedBaseDomainPrefix: testBaseDomainPrefix,
-			expectedAPIURL:           testAPIURL,
-			expectedIssuerURL:        testIssuerURL,
-		},
-		{
-			name:                     "sync domain prefix from Cluster Service when HostedCluster ReadDesire not found",
-			existingCluster:          newTestCluster(testOtherClusterName),
-			csDomainPrefix:           testBaseDomainPrefix,
-			expectCSGetCluster:       true,
-			expectedConsoleURL:       "",
-			expectedBaseDomain:       "",
-			expectedBaseDomainPrefix: testBaseDomainPrefix,
-			expectedAPIURL:           "",
-			expectedIssuerURL:        "",
+			name:               "no-op when HostedCluster ReadDesire not found",
+			existingCluster:    newTestCluster(testOtherClusterName),
+			expectedConsoleURL: "",
+			expectedBaseDomain: "",
+			expectedAPIURL:     "",
+			expectedIssuerURL:  "",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
+			t.Parallel()
 
-			// Setup mock DB with the existing cluster
+			ctx := context.Background()
+
 			mockResourcesDB, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, []any{tc.existingCluster})
 			require.NoError(t, err)
 
 			readDesireLister, err := newSeededReadDesireLister(ctx, hostedClusterReadDesire)
 			require.NoError(t, err)
 
-			// Setup mock CS client
-			mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
-			if tc.expectCSGetCluster {
-				csCluster, err := arohcpv1alpha1.NewCluster().DomainPrefix(tc.csDomainPrefix).Build()
-				require.NoError(t, err)
-				mockCSClient.EXPECT().
-					GetCluster(gomock.Any(), gomock.Any()).
-					Return(csCluster, nil)
-			}
-
-			// Create syncer
 			syncer := &clusterPropertiesSyncer{
-				cooldownChecker:      &alwaysSyncCooldownChecker{},
-				resourcesDBClient:    mockResourcesDB,
-				clusterServiceClient: mockCSClient,
-				readDesireLister:     readDesireLister,
+				cooldownChecker:   &alwaysSyncCooldownChecker{},
+				resourcesDBClient: mockResourcesDB,
+				readDesireLister:  readDesireLister,
 			}
 
-			// Execute
 			key := controllerutils.HCPClusterKey{
 				SubscriptionID:    testSubscriptionID,
 				ResourceGroupName: testResourceGroupName,
@@ -240,103 +113,13 @@ func TestClusterPropertiesSyncer_SyncOnce(t *testing.T) {
 			err = syncer.SyncOnce(ctx, key)
 			require.NoError(t, err)
 
-			// Verify the cluster state in Cosmos
 			updatedCluster, err := mockResourcesDB.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, tc.existingCluster.Name)
 			require.NoError(t, err)
 
 			assert.Equal(t, tc.expectedConsoleURL, updatedCluster.ServiceProviderProperties.Console.URL)
 			assert.Equal(t, tc.expectedBaseDomain, updatedCluster.ServiceProviderProperties.DNS.BaseDomain)
 			assert.Equal(t, tc.expectedAPIURL, updatedCluster.ServiceProviderProperties.API.URL)
-			assert.Equal(t, tc.expectedBaseDomainPrefix, updatedCluster.CustomerProperties.DNS.BaseDomainPrefix)
 			assert.Equal(t, tc.expectedIssuerURL, updatedCluster.ServiceProviderProperties.Platform.IssuerURL)
 		})
 	}
-}
-
-func newSeededReadDesireLister(ctx context.Context, readDesire *kubeapplier.ReadDesire) (dblisters.ReadDesireLister, error) {
-	mockKubeApplierDB, err := databasetesting.NewMockKubeApplierDBClientWithResources(ctx, []any{readDesire})
-	if err != nil {
-		return nil, err
-	}
-
-	kubeApplierClients := databasetesting.NewMockKubeApplierDBClients()
-	managementClusterID := api.Must(azcorearm.ParseResourceID(
-		"/providers/microsoft.redhatopenshift/stamps/1/managementclusters/mgmt-a"))
-	kubeApplierClients.Register(managementClusterID, mockKubeApplierDB)
-
-	return &internallistertesting.DBReadDesireLister{
-		Clients: kubeApplierClients,
-		Lister: &internallistertesting.SliceManagementClusterLister{
-			ManagementClusters: []*fleet.ManagementCluster{
-				{
-					CosmosMetadata: api.CosmosMetadata{ResourceID: managementClusterID},
-					ResourceID:     managementClusterID,
-				},
-			},
-		},
-	}, nil
-}
-
-func newTestCluster(hcpClusterName string, opts ...func(*api.HCPOpenShiftCluster)) *api.HCPOpenShiftCluster {
-	resourceID := api.Must(azcorearm.ParseResourceID(
-		"/subscriptions/" + testSubscriptionID +
-			"/resourceGroups/" + testResourceGroupName +
-			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + hcpClusterName,
-	))
-
-	cluster := &api.HCPOpenShiftCluster{
-		CosmosMetadata: arm.CosmosMetadata{
-			ResourceID: resourceID,
-		},
-		TrackedResource: arm.TrackedResource{
-			Resource: arm.Resource{
-				ID:   resourceID,
-				Name: hcpClusterName,
-				Type: resourceID.ResourceType.String(),
-			},
-		},
-		ServiceProviderProperties: api.HCPOpenShiftClusterServiceProviderProperties{
-			ClusterServiceID: api.Ptr(api.Must(api.NewInternalID(testClusterServiceIDStr))),
-		},
-	}
-
-	for _, opt := range opts {
-		opt(cluster)
-	}
-
-	return cluster
-}
-
-func newHostedClusterReadDesire(t *testing.T, hostedCluster *hsv1beta1.HostedCluster) *kubeapplier.ReadDesire {
-	t.Helper()
-
-	resourceIDString := kubeapplier.ToClusterScopedReadDesireResourceIDString(
-		testSubscriptionID,
-		testResourceGroupName,
-		testClusterName,
-		maestrohelpers.ReadDesireNameReadonlyHostedCluster,
-	)
-	resourceID := api.Must(azcorearm.ParseResourceID(resourceIDString))
-
-	raw, err := json.Marshal(hostedCluster)
-	require.NoError(t, err)
-
-	return &kubeapplier.ReadDesire{
-		CosmosMetadata: api.CosmosMetadata{
-			ResourceID: resourceID,
-		},
-		Spec: kubeapplier.ReadDesireSpec{
-			ManagementCluster: api.Must(azcorearm.ParseResourceID(
-				"/providers/microsoft.redhatopenshift/stamps/1/managementclusters/mgmt-a")),
-		},
-		Status: kubeapplier.ReadDesireStatus{
-			KubeContent: &runtime.RawExtension{Raw: raw},
-		},
-	}
-}
-
-type alwaysSyncCooldownChecker struct{}
-
-func (c *alwaysSyncCooldownChecker) CanSync(ctx context.Context, key any) bool {
-	return true
 }

--- a/backend/pkg/controllers/clusterpropertiescontroller/cluster_properties_sync_test.go
+++ b/backend/pkg/controllers/clusterpropertiescontroller/cluster_properties_sync_test.go
@@ -21,43 +21,36 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	hsv1beta1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
 	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/kubeapplier"
 	"github.com/Azure/ARO-HCP/internal/databasetesting"
 )
 
 func TestClusterPropertiesSyncer_SyncOnce(t *testing.T) {
 	t.Parallel()
 
-	hostedClusterReadDesire := newHostedClusterReadDesire(t, &hsv1beta1.HostedCluster{
-		ObjectMeta: metav1.ObjectMeta{Name: testBaseDomainPrefix},
-		Spec: hsv1beta1.HostedClusterSpec{
-			DNS:                  hsv1beta1.DNSSpec{BaseDomain: testHostedClusterIngressBaseDomain},
-			KubeAPIServerDNSName: testAPIHost,
-			IssuerURL:            testIssuerURL,
-		},
-		Status: hsv1beta1.HostedClusterStatus{
-			ControlPlaneEndpoint: hsv1beta1.APIEndpoint{Port: testAPIPort},
-		},
-	})
+	const unexpectedKubeAPIServerDNSName = "api.unexpected.example.com"
 
 	testCases := []struct {
 		name               string
 		existingCluster    *api.HCPOpenShiftCluster
+		readDesire         *kubeapplier.ReadDesire
+		wantErr            bool
 		expectedConsoleURL string
 		expectedBaseDomain string
 		expectedAPIURL     string
 		expectedIssuerURL  string
 	}{
 		{
-			name: "sync cluster properties from HostedCluster ReadDesire when they differ from Cosmos",
+			name: "sync cluster properties from HostedCluster ReadDesire when they differ from cache",
 			existingCluster: newTestCluster(testClusterName, func(c *api.HCPOpenShiftCluster) {
 				c.CustomerProperties.DNS.BaseDomainPrefix = testBaseDomainPrefix
 			}),
+			readDesire:         newTestHostedClusterReadDesire(t),
 			expectedConsoleURL: testConsoleURL,
 			expectedBaseDomain: testBaseDomain,
 			expectedAPIURL:     testAPIURL,
@@ -72,18 +65,33 @@ func TestClusterPropertiesSyncer_SyncOnce(t *testing.T) {
 				c.ServiceProviderProperties.Platform.IssuerURL = testIssuerURL
 				c.CustomerProperties.DNS.BaseDomainPrefix = testBaseDomainPrefix
 			}),
+			readDesire:         newTestHostedClusterReadDesire(t),
 			expectedConsoleURL: testConsoleURL,
 			expectedBaseDomain: testBaseDomain,
 			expectedAPIURL:     testAPIURL,
 			expectedIssuerURL:  testIssuerURL,
 		},
 		{
-			name:               "no-op when HostedCluster ReadDesire not found",
-			existingCluster:    newTestCluster(testOtherClusterName),
-			expectedConsoleURL: "",
-			expectedBaseDomain: "",
-			expectedAPIURL:     "",
-			expectedIssuerURL:  "",
+			name: "no-op when HostedCluster ReadDesire not found",
+			existingCluster: newTestCluster(testOtherClusterName, func(c *api.HCPOpenShiftCluster) {
+				c.CustomerProperties.DNS.BaseDomainPrefix = testBaseDomainPrefix
+			}),
+			readDesire: nil,
+		},
+		{
+			name:            "no-op when base domain prefix is unset",
+			existingCluster: newTestCluster(testClusterName),
+			readDesire:      nil,
+		},
+		{
+			name: "error when KubeAPIServerDNSName does not match base domain prefix",
+			existingCluster: newTestCluster(testClusterName, func(c *api.HCPOpenShiftCluster) {
+				c.CustomerProperties.DNS.BaseDomainPrefix = testBaseDomainPrefix
+			}),
+			readDesire: newTestHostedClusterReadDesire(t, func(hc *hsv1beta1.HostedCluster) {
+				hc.Spec.KubeAPIServerDNSName = unexpectedKubeAPIServerDNSName
+			}),
+			wantErr: true,
 		},
 	}
 
@@ -96,11 +104,16 @@ func TestClusterPropertiesSyncer_SyncOnce(t *testing.T) {
 			mockResourcesDB, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, []any{tc.existingCluster})
 			require.NoError(t, err)
 
-			readDesireLister, err := newSeededReadDesireLister(ctx, hostedClusterReadDesire)
+			readDesireLister, err := newSeededReadDesireLister(ctx, tc.readDesire)
 			require.NoError(t, err)
+
+			clusterLister := &listertesting.SliceClusterLister{
+				Clusters: []*api.HCPOpenShiftCluster{tc.existingCluster},
+			}
 
 			syncer := &clusterPropertiesSyncer{
 				cooldownChecker:   &alwaysSyncCooldownChecker{},
+				clusterLister:     clusterLister,
 				resourcesDBClient: mockResourcesDB,
 				readDesireLister:  readDesireLister,
 			}
@@ -111,6 +124,19 @@ func TestClusterPropertiesSyncer_SyncOnce(t *testing.T) {
 				HCPClusterName:    tc.existingCluster.Name,
 			}
 			err = syncer.SyncOnce(ctx, key)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), unexpectedKubeAPIServerDNSName)
+				assert.Contains(t, err.Error(), "api."+testBaseDomainPrefix+".")
+
+				unchangedCluster, getErr := mockResourcesDB.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, tc.existingCluster.Name)
+				require.NoError(t, getErr)
+				assert.Empty(t, unchangedCluster.ServiceProviderProperties.Console.URL)
+				assert.Empty(t, unchangedCluster.ServiceProviderProperties.DNS.BaseDomain)
+				assert.Empty(t, unchangedCluster.ServiceProviderProperties.API.URL)
+				assert.Empty(t, unchangedCluster.ServiceProviderProperties.Platform.IssuerURL)
+				return
+			}
 			require.NoError(t, err)
 
 			updatedCluster, err := mockResourcesDB.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, tc.existingCluster.Name)

--- a/backend/pkg/controllers/clusterpropertiescontroller/cluster_properties_test_helpers_test.go
+++ b/backend/pkg/controllers/clusterpropertiescontroller/cluster_properties_test_helpers_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/json"
 
@@ -55,7 +56,12 @@ const (
 )
 
 func newSeededReadDesireLister(ctx context.Context, readDesire *kubeapplier.ReadDesire) (dblisters.ReadDesireLister, error) {
-	mockKubeApplierDB, err := databasetesting.NewMockKubeApplierDBClientWithResources(ctx, []any{readDesire})
+	resources := []any{}
+	if readDesire != nil {
+		resources = append(resources, readDesire)
+	}
+
+	mockKubeApplierDB, err := databasetesting.NewMockKubeApplierDBClientWithResources(ctx, resources)
 	if err != nil {
 		return nil, err
 	}
@@ -108,8 +114,23 @@ func newTestCluster(hcpClusterName string, opts ...func(*api.HCPOpenShiftCluster
 	return cluster
 }
 
-func newHostedClusterReadDesire(t *testing.T, hostedCluster *hsv1beta1.HostedCluster) *kubeapplier.ReadDesire {
+func newTestHostedClusterReadDesire(t *testing.T, opts ...func(*hsv1beta1.HostedCluster)) *kubeapplier.ReadDesire {
 	t.Helper()
+
+	hostedCluster := &hsv1beta1.HostedCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: testBaseDomainPrefix},
+		Spec: hsv1beta1.HostedClusterSpec{
+			DNS:                  hsv1beta1.DNSSpec{BaseDomain: testHostedClusterIngressBaseDomain},
+			KubeAPIServerDNSName: testAPIHost,
+			IssuerURL:            testIssuerURL,
+		},
+		Status: hsv1beta1.HostedClusterStatus{
+			ControlPlaneEndpoint: hsv1beta1.APIEndpoint{Port: testAPIPort},
+		},
+	}
+	for _, opt := range opts {
+		opt(hostedCluster)
+	}
 
 	resourceIDString := kubeapplier.ToClusterScopedReadDesireResourceIDString(
 		testSubscriptionID,

--- a/backend/pkg/controllers/clusterpropertiescontroller/cluster_properties_test_helpers_test.go
+++ b/backend/pkg/controllers/clusterpropertiescontroller/cluster_properties_test_helpers_test.go
@@ -1,0 +1,143 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusterpropertiescontroller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/json"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	hsv1beta1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/maestrohelpers"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/api/fleet"
+	"github.com/Azure/ARO-HCP/internal/api/kubeapplier"
+	dblisters "github.com/Azure/ARO-HCP/internal/database/listers"
+	internallistertesting "github.com/Azure/ARO-HCP/internal/database/listertesting"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+)
+
+const (
+	testSubscriptionID      = "00000000-0000-0000-0000-000000000000"
+	testResourceGroupName   = "test-rg"
+	testClusterName         = "test-cluster"
+	testOtherClusterName    = "other-cluster"
+	testClusterServiceIDStr = "/api/clusters_mgmt/v1/clusters/abc123"
+
+	testConsoleURL                     = "https://console-openshift-console.apps.aro.cluster1.example.com"
+	testBaseDomain                     = "example.com"
+	testHostedClusterIngressBaseDomain = "aro.cluster1.example.com"
+	testBaseDomainPrefix               = "cluster1"
+	testAPIHost                        = "api.cluster1.example.com"
+	testAPIPort                        = int32(6443)
+	testAPIURL                         = "https://api.cluster1.example.com:6443"
+	testIssuerURL                      = "https://issuer.example.com/cluster1"
+)
+
+func newSeededReadDesireLister(ctx context.Context, readDesire *kubeapplier.ReadDesire) (dblisters.ReadDesireLister, error) {
+	mockKubeApplierDB, err := databasetesting.NewMockKubeApplierDBClientWithResources(ctx, []any{readDesire})
+	if err != nil {
+		return nil, err
+	}
+
+	kubeApplierClients := databasetesting.NewMockKubeApplierDBClients()
+	managementClusterID := api.Must(azcorearm.ParseResourceID(
+		"/providers/microsoft.redhatopenshift/stamps/1/managementclusters/mgmt-a"))
+	kubeApplierClients.Register(managementClusterID, mockKubeApplierDB)
+
+	return &internallistertesting.DBReadDesireLister{
+		Clients: kubeApplierClients,
+		Lister: &internallistertesting.SliceManagementClusterLister{
+			ManagementClusters: []*fleet.ManagementCluster{
+				{
+					CosmosMetadata: api.CosmosMetadata{ResourceID: managementClusterID},
+					ResourceID:     managementClusterID,
+				},
+			},
+		},
+	}, nil
+}
+
+func newTestCluster(hcpClusterName string, opts ...func(*api.HCPOpenShiftCluster)) *api.HCPOpenShiftCluster {
+	resourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + hcpClusterName,
+	))
+
+	cluster := &api.HCPOpenShiftCluster{
+		CosmosMetadata: arm.CosmosMetadata{
+			ResourceID: resourceID,
+		},
+		TrackedResource: arm.TrackedResource{
+			Resource: arm.Resource{
+				ID:   resourceID,
+				Name: hcpClusterName,
+				Type: resourceID.ResourceType.String(),
+			},
+		},
+		ServiceProviderProperties: api.HCPOpenShiftClusterServiceProviderProperties{
+			ClusterServiceID: api.Ptr(api.Must(api.NewInternalID(testClusterServiceIDStr))),
+		},
+	}
+
+	for _, opt := range opts {
+		opt(cluster)
+	}
+
+	return cluster
+}
+
+func newHostedClusterReadDesire(t *testing.T, hostedCluster *hsv1beta1.HostedCluster) *kubeapplier.ReadDesire {
+	t.Helper()
+
+	resourceIDString := kubeapplier.ToClusterScopedReadDesireResourceIDString(
+		testSubscriptionID,
+		testResourceGroupName,
+		testClusterName,
+		maestrohelpers.ReadDesireNameReadonlyHostedCluster,
+	)
+	resourceID := api.Must(azcorearm.ParseResourceID(resourceIDString))
+
+	raw, err := json.Marshal(hostedCluster)
+	require.NoError(t, err)
+
+	return &kubeapplier.ReadDesire{
+		CosmosMetadata: api.CosmosMetadata{
+			ResourceID: resourceID,
+		},
+		Spec: kubeapplier.ReadDesireSpec{
+			ManagementCluster: api.Must(azcorearm.ParseResourceID(
+				"/providers/microsoft.redhatopenshift/stamps/1/managementclusters/mgmt-a")),
+		},
+		Status: kubeapplier.ReadDesireStatus{
+			KubeContent: &runtime.RawExtension{Raw: raw},
+		},
+	}
+}
+
+type alwaysSyncCooldownChecker struct{}
+
+func (c *alwaysSyncCooldownChecker) CanSync(ctx context.Context, key any) bool {
+	return true
+}

--- a/backend/pkg/controllers/clusterpropertiescontroller/identity_migration_test.go
+++ b/backend/pkg/controllers/clusterpropertiescontroller/identity_migration_test.go
@@ -276,7 +276,7 @@ func TestIdentityMigrationSyncer_SyncOnce(t *testing.T) {
 // newTestClusterForIdentityMigration creates a test HCPOpenShiftCluster with default values
 // for identity migration testing.
 func newTestClusterForIdentityMigration(opts ...func(*api.HCPOpenShiftCluster)) *api.HCPOpenShiftCluster {
-	cluster := newTestCluster(opts...)
+	cluster := newTestCluster(testClusterName, opts...)
 	cluster.Location = testLocation
 	return cluster
 }

--- a/backend/pkg/controllers/create_cluster_scoped_read_desires_controller.go
+++ b/backend/pkg/controllers/create_cluster_scoped_read_desires_controller.go
@@ -118,7 +118,7 @@ func (c *createClusterScopedReadDesiresSyncer) SyncOnce(ctx context.Context, key
 	}
 
 	// Pull the domain prefix from cosmos rather than Cluster Service: the
-	// cluster_properties_sync controller already mirrors CS DomainPrefix into
+	// cluster_base_domain_prefix_sync controller already mirrors CS DomainPrefix into
 	// CustomerProperties.DNS.BaseDomainPrefix, so we'd just be re-doing its
 	// work. Skip until that sync has happened; we'll retrigger on relist.
 	csClusterDomainPrefix := existingCluster.CustomerProperties.DNS.BaseDomainPrefix

--- a/backend/pkg/controllers/create_nodepool_scoped_read_desires_controller.go
+++ b/backend/pkg/controllers/create_nodepool_scoped_read_desires_controller.go
@@ -107,7 +107,7 @@ func (c *createNodePoolScopedReadDesiresSyncer) SyncOnce(ctx context.Context, ke
 	}
 
 	// Pull the parent cluster's domain prefix from cosmos rather than Cluster
-	// Service: the cluster_properties_sync controller already mirrors CS
+	// Service: the cluster_base_domain_prefix_sync controller already mirrors CS
 	// DomainPrefix into CustomerProperties.DNS.BaseDomainPrefix on the parent
 	// HCPCluster. Skip until that sync has happened; we'll retrigger on relist.
 	parentCluster, err := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).Get(ctx, key.HCPClusterName)


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

read the domain base prefix from CS and infer the rest of the properties from the hosted cluster cr

### Why

We need to continue reading the base domain prefix from CS as it is required by the hostedcluster CreateClusterScopedReadDesires controller.

The start reading the rest of the properties when the hostedcluster cr has been synced from the management cluster.
- the api url is infered from KubeAPIServerDNSName and the ControlPlaneEndpoint.Port
- the console url is inferred from the BaseDomain; this will contain a value even though there are cases where it won't be available up until when the customer creates the nodepool + configure external auth. Attempt to access it will show that the app isn't available.
- the parent base domain is inferred from KubeAPIServerDNSName by stripping api.basedomainprefix from it
- the issuer url is taken from hostedCluster.Spec.IssuerURL

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
