### PR TITLE
Add degraded summarization controllers for clusters, nodepools, and externalauths

### DIFF
--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -47,6 +47,7 @@ import (
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/mismatchcontrollers"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/nodepooldeletion"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/operationcontrollers"
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/statuscontrollers"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/upgradecontrollers"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/validationcontrollers"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/validationcontrollers/validations"
@@ -406,15 +407,17 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 
 	_, billingLister := backendInformers.BillingDocs()
 
-	nodePoolInformer, _ := backendInformers.NodePools()
+	nodePoolInformer, nodePoolLister := backendInformers.NodePools()
 	nodePoolHandler := metricscontrollers.NewNodePoolMetricsHandler(b.options.MetricsRegisterer)
 	nodePoolMetricsController := metricscontrollers.NewController(
 		"NodePoolMetrics", nodePoolInformer, nodePoolHandler)
 
-	externalAuthInformer, _ := backendInformers.ExternalAuths()
+	externalAuthInformer, externalAuthLister := backendInformers.ExternalAuths()
 	externalAuthHandler := metricscontrollers.NewExternalAuthMetricsHandler(b.options.MetricsRegisterer)
 	externalAuthMetricsController := metricscontrollers.NewController(
 		"ExternalAuthMetrics", externalAuthInformer, externalAuthHandler)
+
+	_, controllerLister := backendInformers.Controllers()
 
 	maestroClientBuilder := maestro.NewMaestroClientBuilder()
 
@@ -578,6 +581,35 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		activeOperationLister,
 		backendInformers,
 		unionKubeApplierInformers,
+	)
+
+	// Each aggregator hardcodes its own inertia inside the statuscontrollers
+	// package so subsystem-specific tuning lives next to the controller that
+	// uses it. The constructors here just supply listers / DB / clock.
+	clusterDegradedAggregatorController := statuscontrollers.NewClusterDegradedAggregatorController(
+		b.options.ResourcesDBClient,
+		clusterLister,
+		controllerLister,
+		activeOperationLister,
+		backendInformers,
+		unionKubeApplierInformers,
+		b.clock,
+	)
+	nodePoolDegradedAggregatorController := statuscontrollers.NewNodePoolDegradedAggregatorController(
+		b.options.ResourcesDBClient,
+		nodePoolLister,
+		controllerLister,
+		activeOperationLister,
+		backendInformers,
+		b.clock,
+	)
+	externalAuthDegradedAggregatorController := statuscontrollers.NewExternalAuthDegradedAggregatorController(
+		b.options.ResourcesDBClient,
+		externalAuthLister,
+		controllerLister,
+		activeOperationLister,
+		backendInformers,
+		b.clock,
 	)
 
 	createClusterScopedReadDesiresController := controllers.NewCreateClusterScopedReadDesiresController(
@@ -783,6 +815,9 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 				go clusterBaseDomainPrefixSyncController.Run(ctx, 20)
 				go clusterPropertiesSyncController.Run(ctx, 20)
 				go identityMigrationController.Run(ctx, 20)
+				go clusterDegradedAggregatorController.Run(ctx, 20)
+				go nodePoolDegradedAggregatorController.Run(ctx, 20)
+				go externalAuthDegradedAggregatorController.Run(ctx, 20)
 				go azureRPRegistrationValidationController.Run(ctx, 20)
 				go azureClusterResourceGroupExistenceValidationController.Run(ctx, 20)
 				go azureClusterManagedIdentitiesExistenceValidationController.Run(ctx, 20)

--- a/backend/pkg/controllers/statuscontrollers/aggregator_testhelpers_test.go
+++ b/backend/pkg/controllers/statuscontrollers/aggregator_testhelpers_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statuscontrollers
+
+import (
+	"context"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+)
+
+// Shared resource-identity constants used across the aggregator tests.
+const (
+	testSubscriptionID    = "00000000-0000-0000-0000-000000000000"
+	testResourceGroupName = "test-rg"
+	testClusterName       = "test-cluster"
+	testNodePoolName      = "test-nodepool"
+	testExternalAuthName  = "test-externalauth"
+)
+
+// alwaysSyncCooldownChecker permits every sync attempt. Aggregator unit
+// tests don't exercise the cooldown path.
+type alwaysSyncCooldownChecker struct{}
+
+func (alwaysSyncCooldownChecker) CanSync(_ context.Context, _ any) bool { return true }
+
+// controllerUnder builds an api.Controller doc that is a direct child of
+// the given parent resource ID (cluster, node pool, or external auth) with
+// the given controller name, carrying a Degraded condition that has held
+// `age` long.
+func controllerUnder(parentResourceID *azcorearm.ResourceID, controllerName string, status metav1.ConditionStatus, reason, message string, age time.Duration) *api.Controller {
+	rid := api.Must(azcorearm.ParseResourceID(parentResourceID.String() + "/" + api.ControllerResourceTypeName + "/" + controllerName))
+	return &api.Controller{
+		CosmosMetadata: api.CosmosMetadata{
+			ResourceID: rid,
+		},
+		ExternalID: parentResourceID,
+		Status: api.ControllerStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:               degradedConditionType,
+					Status:             status,
+					Reason:             reason,
+					Message:            message,
+					LastTransitionTime: metav1.NewTime(fixedNow.Add(-age)),
+				},
+			},
+		},
+	}
+}

--- a/backend/pkg/controllers/statuscontrollers/cluster_degraded_aggregator.go
+++ b/backend/pkg/controllers/statuscontrollers/cluster_degraded_aggregator.go
@@ -1,0 +1,150 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statuscontrollers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilsclock "k8s.io/utils/clock"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/database"
+	unionkubeapplierinformers "github.com/Azure/ARO-HCP/internal/database/unioninformers/kubeapplier"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// degradedConditionType is the metav1.Condition.Type our controllers write
+// onto their per-controller Controller document and that we aggregate up
+// onto the parent.
+const degradedConditionType = "Degraded"
+
+// clusterDegradedAggregator rolls per-controller Degraded conditions
+// (api.Controller.Status.Conditions[Degraded]) up onto
+// HCPOpenShiftCluster.Status.Conditions, using the library-go-style union
+// with configurable per-controller inertia.
+//
+// All reads come from listers — there are no live Cosmos GETs on the
+// reconcile path. Writes go through the CRUD layer because that is the
+// only way to persist; the lister snapshot used as the basis for the
+// Replace carries its own etag so optimistic concurrency still applies,
+// and a stale-etag failure just retries on the next reconcile.
+type clusterDegradedAggregator struct {
+	cooldownChecker   controllerutil.CooldownChecker
+	clusterLister     listers.ClusterLister
+	controllerLister  listers.ControllerLister
+	resourcesDBClient database.ResourcesDBClient
+	inertia           Inertia
+	clock             utilsclock.PassiveClock
+	// firstObservedBad supplies a LastTransitionTime for controllers that
+	// have not yet reported a definite Degraded condition (missing or
+	// Unknown) so they too get inertia protection.
+	firstObservedBad *firstObservedBadCache
+}
+
+var _ controllerutils.ClusterSyncer = (*clusterDegradedAggregator)(nil)
+
+// clusterDegradedAggregatorInertia is the inertia config used by the
+// cluster aggregator. It is built here, not passed in, so all tuning
+// for cluster-scoped Degraded propagation lives next to the controller
+// that uses it. Add per-controller-name overrides to the variadic args
+// when a specific sub-controller needs a wider (or narrower) window than
+// the 30s default.
+func clusterDegradedAggregatorInertia() Inertia {
+	return MustNewInertia(DefaultInertia).Inertia
+}
+
+// NewClusterDegradedAggregatorController creates a controller that
+// aggregates the Degraded condition from every api.Controller under a
+// given HCPOpenShiftCluster onto the cluster's Status.Conditions.
+//
+// clock is used to compute "now" for inertia evaluation; pass nil for
+// utilsclock.RealClock{}.
+func NewClusterDegradedAggregatorController(
+	resourcesDBClient database.ResourcesDBClient,
+	clusterLister listers.ClusterLister,
+	controllerLister listers.ControllerLister,
+	activeOperationLister listers.ActiveOperationLister,
+	informers informers.BackendInformers,
+	kubeApplierInformers *unionkubeapplierinformers.UnionKubeApplierInformers,
+	clock utilsclock.PassiveClock,
+) controllerutils.Controller {
+	if clock == nil {
+		clock = utilsclock.RealClock{}
+	}
+	syncer := &clusterDegradedAggregator{
+		cooldownChecker:   controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		clusterLister:     clusterLister,
+		controllerLister:  controllerLister,
+		resourcesDBClient: resourcesDBClient,
+		inertia:           clusterDegradedAggregatorInertia(),
+		clock:             clock,
+		firstObservedBad:  newFirstObservedBadCache(clock),
+	}
+	return controllerutils.NewClusterWatchingController(
+		"ClusterDegradedAggregator",
+		resourcesDBClient,
+		informers,
+		kubeApplierInformers,
+		1*time.Minute,
+		syncer,
+	)
+}
+
+func (c *clusterDegradedAggregator) CooldownChecker() controllerutil.CooldownChecker {
+	return c.cooldownChecker
+}
+
+func (c *clusterDegradedAggregator) SyncOnce(ctx context.Context, key controllerutils.HCPClusterKey) error {
+	existing, err := c.clusterLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get Cluster from cache: %w", err))
+	}
+
+	controllers, err := c.controllerLister.ListForCluster(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to list Controllers from cache: %w", err))
+	}
+
+	aggregated := UnionCondition(
+		degradedConditionType,
+		metav1.ConditionFalse,
+		c.inertia,
+		c.clock.Now(),
+		collectDegradedConditions(controllers, c.firstObservedBad)...,
+	)
+
+	replacement := existing.DeepCopy()
+	apimeta.SetStatusCondition(&replacement.Status.Conditions, aggregated)
+	if equality.Semantic.DeepEqual(existing.Status.Conditions, replacement.Status.Conditions) {
+		return nil
+	}
+
+	clusterCRUD := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName)
+	if _, err := clusterCRUD.Replace(ctx, replacement, nil); err != nil {
+		return utils.TrackError(fmt.Errorf("failed to replace Cluster: %w", err))
+	}
+	return nil
+}

--- a/backend/pkg/controllers/statuscontrollers/cluster_degraded_aggregator.go
+++ b/backend/pkg/controllers/statuscontrollers/cluster_degraded_aggregator.go
@@ -143,7 +143,11 @@ func (c *clusterDegradedAggregator) SyncOnce(ctx context.Context, key controller
 	}
 
 	clusterCRUD := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName)
-	if _, err := clusterCRUD.Replace(ctx, replacement, nil); err != nil {
+	_, err = clusterCRUD.Replace(ctx, replacement, nil)
+	if database.IsPreconditionFailedError(err) {
+		return nil
+	}
+	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to replace Cluster: %w", err))
 	}
 	return nil

--- a/backend/pkg/controllers/statuscontrollers/cluster_degraded_aggregator_test.go
+++ b/backend/pkg/controllers/statuscontrollers/cluster_degraded_aggregator_test.go
@@ -258,8 +258,8 @@ func TestClusterDegradedAggregator_SyncOnce(t *testing.T) {
 			clock := clocktesting.NewFakePassiveClock(fixedNow)
 			syncer := &clusterDegradedAggregator{
 				cooldownChecker:   alwaysSyncCooldownChecker{},
-				clusterLister:     &listertesting.SliceClusterLister{Clusters: []*api.HCPOpenShiftCluster{existing}},
-				controllerLister:  &listertesting.SliceControllerLister{Controllers: tc.controllers},
+				clusterLister:     &listertesting.DBClusterLister{ResourcesDBClient: mockDB},
+				controllerLister:  &listertesting.DBControllerLister{ResourcesDBClient: mockDB},
 				resourcesDBClient: mockDB,
 				inertia:           tc.inertia,
 				clock:             clock,
@@ -319,8 +319,8 @@ func TestClusterDegradedAggregator_MissingDegradedFlipsAfterInertia(t *testing.T
 	clock := clocktesting.NewFakePassiveClock(fixedNow)
 	syncer := &clusterDegradedAggregator{
 		cooldownChecker:   alwaysSyncCooldownChecker{},
-		clusterLister:     &listertesting.SliceClusterLister{Clusters: []*api.HCPOpenShiftCluster{existing}},
-		controllerLister:  &listertesting.SliceControllerLister{Controllers: []*api.Controller{quietController}},
+		clusterLister:     &listertesting.DBClusterLister{ResourcesDBClient: mockDB},
+		controllerLister:  &listertesting.DBControllerLister{ResourcesDBClient: mockDB},
 		resourcesDBClient: mockDB,
 		inertia:           MustNewInertia(DefaultInertia).Inertia,
 		clock:             clock,

--- a/backend/pkg/controllers/statuscontrollers/cluster_degraded_aggregator_test.go
+++ b/backend/pkg/controllers/statuscontrollers/cluster_degraded_aggregator_test.go
@@ -1,0 +1,361 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statuscontrollers
+
+import (
+	"context"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clocktesting "k8s.io/utils/clock/testing"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+)
+
+// newTestClusterForAggregator builds a minimal HCPOpenShiftCluster suitable
+// for the aggregator tests. Callers can layer in pre-existing
+// Status.Conditions via the opts hook to exercise the "skip write when
+// unchanged" path.
+func newTestClusterForAggregator(opts ...func(*api.HCPOpenShiftCluster)) *api.HCPOpenShiftCluster {
+	resourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName,
+	))
+	cluster := &api.HCPOpenShiftCluster{
+		CosmosMetadata: arm.CosmosMetadata{ResourceID: resourceID},
+		TrackedResource: arm.TrackedResource{
+			Resource: arm.Resource{
+				ID:   resourceID,
+				Name: testClusterName,
+				Type: resourceID.ResourceType.String(),
+			},
+		},
+	}
+	for _, opt := range opts {
+		opt(cluster)
+	}
+	return cluster
+}
+
+func TestClusterDegradedAggregator_SyncOnce(t *testing.T) {
+	parentResourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName,
+	))
+
+	// thirtySecondInertia / fiveMinuteOverrideInertia mirror the two
+	// inertia setups exercised in union_condition_test.go so the table
+	// stays readable.
+	thirtySecondInertia := MustNewInertia(30 * time.Second).Inertia
+	fiveMinuteOverrideInertia := MustNewInertia(
+		30*time.Second,
+		InertiaController{ControllerNameMatcher: regexp.MustCompile(`^SlowController$`), Duration: 5 * time.Minute},
+	).Inertia
+
+	tests := []struct {
+		name string
+
+		controllers []*api.Controller
+		inertia     Inertia
+		// initialConditions, if set, is layered onto the cluster before SyncOnce
+		// runs. Used to drive the "no-op when conditions unchanged" case.
+		initialConditions []metav1.Condition
+
+		expectStatus  metav1.ConditionStatus
+		expectReason  string
+		expectMessage string
+	}{
+		{
+			name:          "no controllers under the cluster -> Unknown/NoData",
+			controllers:   nil,
+			inertia:       thirtySecondInertia,
+			expectStatus:  metav1.ConditionUnknown,
+			expectReason:  "NoData",
+			expectMessage: "",
+		},
+		{
+			name: "all controllers report Degraded=False -> aggregate False/AsExpected",
+			controllers: []*api.Controller{
+				controllerUnder(parentResourceID, "AController", metav1.ConditionFalse, "NoErrors", "fine", 1*time.Minute),
+				controllerUnder(parentResourceID, "BController", metav1.ConditionFalse, "NoErrors", "ok", 1*time.Minute),
+			},
+			inertia:       thirtySecondInertia,
+			expectStatus:  metav1.ConditionFalse,
+			expectReason:  "AsExpected",
+			expectMessage: "AController: fine\nBController: ok",
+		},
+		{
+			name: "bad controller within 30s inertia is hidden -> aggregate stays default",
+			controllers: []*api.Controller{
+				controllerUnder(parentResourceID, "AController", metav1.ConditionTrue, "Failed", "boom", 5*time.Second),
+			},
+			inertia:       thirtySecondInertia,
+			expectStatus:  metav1.ConditionFalse,
+			expectReason:  "AsExpected",
+			expectMessage: "AController: boom",
+		},
+		{
+			name: "bad controller past 30s inertia flips aggregate to True",
+			controllers: []*api.Controller{
+				controllerUnder(parentResourceID, "AController", metav1.ConditionTrue, "Failed", "boom", 31*time.Second),
+			},
+			inertia:       thirtySecondInertia,
+			expectStatus:  metav1.ConditionTrue,
+			expectReason:  "AController_Failed",
+			expectMessage: "AController: boom",
+		},
+		{
+			name: "per-controller inertia override delays SlowController",
+			controllers: []*api.Controller{
+				// SlowController has 5m inertia; 2m old is still fresh -> NOT elder.
+				controllerUnder(parentResourceID, "SlowController", metav1.ConditionTrue, "Failed", "settling", 2*time.Minute),
+			},
+			inertia:       fiveMinuteOverrideInertia,
+			expectStatus:  metav1.ConditionFalse,
+			expectReason:  "AsExpected",
+			expectMessage: "SlowController: settling",
+		},
+		{
+			name: "per-controller inertia override + elder default controller -> aggregate flips",
+			controllers: []*api.Controller{
+				// SlowController has 5m inertia; 2m fresh -> not elder.
+				controllerUnder(parentResourceID, "SlowController", metav1.ConditionTrue, "Failed", "settling", 2*time.Minute),
+				// NormalController uses default 30s inertia; 1m old -> elder.
+				controllerUnder(parentResourceID, "NormalController", metav1.ConditionTrue, "Failed", "boom", 1*time.Minute),
+			},
+			inertia:      fiveMinuteOverrideInertia,
+			expectStatus: metav1.ConditionTrue,
+			// Once elderBad is non-empty the aggregated reason/message enumerate ALL bad
+			// sources (matching library-go).
+			expectReason:  "NormalController_Failed::SlowController_Failed",
+			expectMessage: "NormalController: boom\nSlowController: settling",
+		},
+		{
+			name: "nil inertia propagates a fresh bad source immediately",
+			controllers: []*api.Controller{
+				controllerUnder(parentResourceID, "AController", metav1.ConditionTrue, "Failed", "boom", 1*time.Second),
+			},
+			inertia:       nil,
+			expectStatus:  metav1.ConditionTrue,
+			expectReason:  "AController_Failed",
+			expectMessage: "AController: boom",
+		},
+		{
+			name: "missing Degraded condition is hidden within inertia (first reconcile)",
+			controllers: []*api.Controller{
+				// Controller doc exists but has not reported a Degraded condition yet.
+				// On first reconcile the cache records "now" as first-observed-bad, so
+				// the synthesized entry is age=0 -> within the 30s window -> hidden.
+				{
+					CosmosMetadata: api.CosmosMetadata{
+						ResourceID: api.Must(azcorearm.ParseResourceID(parentResourceID.String() + "/" + api.ControllerResourceTypeName + "/QuietController")),
+					},
+					ExternalID: parentResourceID,
+				},
+			},
+			inertia:      thirtySecondInertia,
+			expectStatus: metav1.ConditionFalse,
+			expectReason: "AsExpected",
+			// Even on the all-good path UnionCondition surfaces the bad source's
+			// message so the aggregate stays attributable, just with a default
+			// (False/AsExpected) status.
+			expectMessage: "QuietController: Controller has not reported a Degraded condition",
+		},
+		{
+			name: "missing Degraded condition flips immediately with nil inertia",
+			controllers: []*api.Controller{
+				{
+					CosmosMetadata: api.CosmosMetadata{
+						ResourceID: api.Must(azcorearm.ParseResourceID(parentResourceID.String() + "/" + api.ControllerResourceTypeName + "/QuietController")),
+					},
+					ExternalID: parentResourceID,
+				},
+			},
+			inertia:       nil,
+			expectStatus:  metav1.ConditionTrue,
+			expectReason:  "QuietController_MissingDegradedCondition",
+			expectMessage: "QuietController: Controller has not reported a Degraded condition",
+		},
+		{
+			name: "Degraded=Unknown past inertia flips (uses condition's real LastTransitionTime)",
+			controllers: []*api.Controller{
+				controllerUnder(parentResourceID, "AController", metav1.ConditionUnknown, "Investigating", "still figuring out", 1*time.Minute),
+			},
+			inertia: thirtySecondInertia,
+			// Unknown != defaultStatus, so it's counted as bad. With a real 1m old
+			// LastTransitionTime it's past the 30s window -> flips. Aggregate
+			// status remains Unknown because Unknown is the only bad status here.
+			expectStatus:  metav1.ConditionUnknown,
+			expectReason:  "AController_Investigating",
+			expectMessage: "AController: still figuring out",
+		},
+		{
+			name: "no-op when computed aggregate equals existing condition",
+			controllers: []*api.Controller{
+				controllerUnder(parentResourceID, "AController", metav1.ConditionFalse, "NoErrors", "fine", 1*time.Minute),
+			},
+			inertia: thirtySecondInertia,
+			// Pre-seed the cluster with the same Degraded=False/AsExpected condition
+			// that the aggregator will compute. The aggregator must detect the no-op
+			// and skip the Replace; we still verify the resulting condition matches.
+			initialConditions: []metav1.Condition{
+				{
+					Type:    degradedConditionType,
+					Status:  metav1.ConditionFalse,
+					Reason:  "AsExpected",
+					Message: "AController: fine",
+				},
+			},
+			expectStatus:  metav1.ConditionFalse,
+			expectReason:  "AsExpected",
+			expectMessage: "AController: fine",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			existing := newTestClusterForAggregator(func(c *api.HCPOpenShiftCluster) {
+				if len(tc.initialConditions) > 0 {
+					c.Status.Conditions = append([]metav1.Condition{}, tc.initialConditions...)
+				}
+			})
+
+			seed := []any{existing}
+			for _, ctrl := range tc.controllers {
+				seed = append(seed, ctrl)
+			}
+			mockDB, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, seed)
+			require.NoError(t, err)
+
+			clock := clocktesting.NewFakePassiveClock(fixedNow)
+			syncer := &clusterDegradedAggregator{
+				cooldownChecker:   alwaysSyncCooldownChecker{},
+				clusterLister:     &listertesting.SliceClusterLister{Clusters: []*api.HCPOpenShiftCluster{existing}},
+				controllerLister:  &listertesting.SliceControllerLister{Controllers: tc.controllers},
+				resourcesDBClient: mockDB,
+				inertia:           tc.inertia,
+				clock:             clock,
+				firstObservedBad:  newFirstObservedBadCache(clock),
+			}
+
+			err = syncer.SyncOnce(ctx, controllerutils.HCPClusterKey{
+				SubscriptionID:    testSubscriptionID,
+				ResourceGroupName: testResourceGroupName,
+				HCPClusterName:    testClusterName,
+			})
+			require.NoError(t, err)
+
+			updated, err := mockDB.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
+			require.NoError(t, err)
+
+			cond := apimeta.FindStatusCondition(updated.Status.Conditions, degradedConditionType)
+			require.NotNil(t, cond, "aggregator must set the Degraded condition on the cluster")
+			assert.Equal(t, tc.expectStatus, cond.Status, "status")
+			assert.Equal(t, tc.expectReason, cond.Reason, "reason")
+			assert.Equal(t, tc.expectMessage, cond.Message, "message")
+		})
+	}
+}
+
+// TestClusterDegradedAggregator_MissingDegradedFlipsAfterInertia drives two
+// SyncOnce passes against the same syncer with the fake clock advanced past
+// the inertia window between them. On the first pass the missing Degraded
+// condition is recorded in the first-observed-bad cache but hidden by
+// inertia (aggregate stays Degraded=False/AsExpected). On the second pass
+// the clock has moved past the 30s default window, so the synthesized
+// missing entry is now elder and the aggregate must flip to Degraded=True
+// with MissingDegradedCondition surfaced in the reason and message.
+//
+// Kept separate from the table-driven TestClusterDegradedAggregator_SyncOnce
+// because that table runs each case with a fresh syncer and clock; this
+// scenario requires state to persist across reconciles.
+func TestClusterDegradedAggregator_MissingDegradedFlipsAfterInertia(t *testing.T) {
+	ctx := context.Background()
+
+	parentResourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName,
+	))
+	quietController := &api.Controller{
+		CosmosMetadata: api.CosmosMetadata{
+			ResourceID: api.Must(azcorearm.ParseResourceID(parentResourceID.String() + "/" + api.ControllerResourceTypeName + "/QuietController")),
+		},
+		ExternalID: parentResourceID,
+	}
+
+	existing := newTestClusterForAggregator()
+	mockDB, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, []any{existing, quietController})
+	require.NoError(t, err)
+
+	clock := clocktesting.NewFakePassiveClock(fixedNow)
+	syncer := &clusterDegradedAggregator{
+		cooldownChecker:   alwaysSyncCooldownChecker{},
+		clusterLister:     &listertesting.SliceClusterLister{Clusters: []*api.HCPOpenShiftCluster{existing}},
+		controllerLister:  &listertesting.SliceControllerLister{Controllers: []*api.Controller{quietController}},
+		resourcesDBClient: mockDB,
+		inertia:           MustNewInertia(DefaultInertia).Inertia,
+		clock:             clock,
+		firstObservedBad:  newFirstObservedBadCache(clock),
+	}
+	key := controllerutils.HCPClusterKey{
+		SubscriptionID:    testSubscriptionID,
+		ResourceGroupName: testResourceGroupName,
+		HCPClusterName:    testClusterName,
+	}
+
+	// First reconcile at fixedNow: cache records first-observed-bad as now,
+	// synthesized entry is age=0 -> within the 30s inertia -> aggregate stays
+	// at the default Degraded=False/AsExpected.
+	require.NoError(t, syncer.SyncOnce(ctx, key))
+
+	afterFirst, err := mockDB.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
+	require.NoError(t, err)
+	firstCond := apimeta.FindStatusCondition(afterFirst.Status.Conditions, degradedConditionType)
+	require.NotNil(t, firstCond)
+	assert.Equal(t, metav1.ConditionFalse, firstCond.Status, "first reconcile: still inside inertia window")
+	assert.Equal(t, "AsExpected", firstCond.Reason)
+	assert.Equal(t, "QuietController: Controller has not reported a Degraded condition", firstCond.Message,
+		"the missing source is still reported in the message, just not in the status")
+
+	// Advance the clock past the 30s default inertia. The cache entry is
+	// sticky, so the synthesized entry is now elder.
+	clock.SetTime(fixedNow.Add(DefaultInertia + time.Second))
+	require.NoError(t, syncer.SyncOnce(ctx, key))
+
+	afterSecond, err := mockDB.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
+	require.NoError(t, err)
+	secondCond := apimeta.FindStatusCondition(afterSecond.Status.Conditions, degradedConditionType)
+	require.NotNil(t, secondCond)
+	assert.Equal(t, metav1.ConditionTrue, secondCond.Status, "second reconcile: past inertia -> aggregate must flip")
+	assert.Equal(t, "QuietController_MissingDegradedCondition", secondCond.Reason)
+	assert.Equal(t, "QuietController: Controller has not reported a Degraded condition", secondCond.Message)
+}

--- a/backend/pkg/controllers/statuscontrollers/externalauth_degraded_aggregator.go
+++ b/backend/pkg/controllers/statuscontrollers/externalauth_degraded_aggregator.go
@@ -1,0 +1,131 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statuscontrollers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilsclock "k8s.io/utils/clock"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// externalAuthDegradedAggregator rolls per-controller Degraded conditions
+// up onto HCPOpenShiftClusterExternalAuth.Status.Conditions. See the
+// package and clusterDegradedAggregator docs for the overall design.
+type externalAuthDegradedAggregator struct {
+	cooldownChecker    controllerutil.CooldownChecker
+	externalAuthLister listers.ExternalAuthLister
+	controllerLister   listers.ControllerLister
+	resourcesDBClient  database.ResourcesDBClient
+	inertia            Inertia
+	clock              utilsclock.PassiveClock
+	firstObservedBad   *firstObservedBadCache
+}
+
+var _ controllerutils.ExternalAuthSyncer = (*externalAuthDegradedAggregator)(nil)
+
+// externalAuthDegradedAggregatorInertia is the inertia config used by the
+// external-auth aggregator. Kept independent of the cluster / node-pool
+// variants so external-auth-specific controllers can be tuned in
+// isolation.
+func externalAuthDegradedAggregatorInertia() Inertia {
+	return MustNewInertia(DefaultInertia).Inertia
+}
+
+// NewExternalAuthDegradedAggregatorController creates a controller that
+// aggregates the Degraded condition from every api.Controller under a
+// given HCPOpenShiftClusterExternalAuth onto the external auth's
+// Status.Conditions.
+//
+// See NewClusterDegradedAggregatorController for the clock semantics —
+// they are identical across the three aggregators.
+func NewExternalAuthDegradedAggregatorController(
+	resourcesDBClient database.ResourcesDBClient,
+	externalAuthLister listers.ExternalAuthLister,
+	controllerLister listers.ControllerLister,
+	activeOperationLister listers.ActiveOperationLister,
+	informers informers.BackendInformers,
+	clock utilsclock.PassiveClock,
+) controllerutils.Controller {
+	if clock == nil {
+		clock = utilsclock.RealClock{}
+	}
+	syncer := &externalAuthDegradedAggregator{
+		cooldownChecker:    controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		externalAuthLister: externalAuthLister,
+		controllerLister:   controllerLister,
+		resourcesDBClient:  resourcesDBClient,
+		inertia:            externalAuthDegradedAggregatorInertia(),
+		clock:              clock,
+		firstObservedBad:   newFirstObservedBadCache(clock),
+	}
+	return controllerutils.NewExternalAuthWatchingController(
+		"ExternalAuthDegradedAggregator",
+		resourcesDBClient,
+		informers,
+		1*time.Minute,
+		syncer,
+	)
+}
+
+func (c *externalAuthDegradedAggregator) CooldownChecker() controllerutil.CooldownChecker {
+	return c.cooldownChecker
+}
+
+func (c *externalAuthDegradedAggregator) SyncOnce(ctx context.Context, key controllerutils.HCPExternalAuthKey) error {
+	existing, err := c.externalAuthLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPExternalAuthName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get ExternalAuth from cache: %w", err))
+	}
+
+	controllers, err := c.controllerLister.ListForExternalAuth(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPExternalAuthName)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to list Controllers from cache: %w", err))
+	}
+
+	aggregated := UnionCondition(
+		degradedConditionType,
+		metav1.ConditionFalse,
+		c.inertia,
+		c.clock.Now(),
+		collectDegradedConditions(controllers, c.firstObservedBad)...,
+	)
+
+	replacement := existing.DeepCopy()
+	apimeta.SetStatusCondition(&replacement.Status.Conditions, aggregated)
+	if equality.Semantic.DeepEqual(existing.Status.Conditions, replacement.Status.Conditions) {
+		return nil
+	}
+
+	externalAuthCRUD := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).ExternalAuth(key.HCPClusterName)
+	if _, err := externalAuthCRUD.Replace(ctx, replacement, nil); err != nil {
+		return utils.TrackError(fmt.Errorf("failed to replace ExternalAuth: %w", err))
+	}
+	return nil
+}

--- a/backend/pkg/controllers/statuscontrollers/externalauth_degraded_aggregator.go
+++ b/backend/pkg/controllers/statuscontrollers/externalauth_degraded_aggregator.go
@@ -124,7 +124,11 @@ func (c *externalAuthDegradedAggregator) SyncOnce(ctx context.Context, key contr
 	}
 
 	externalAuthCRUD := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).ExternalAuth(key.HCPClusterName)
-	if _, err := externalAuthCRUD.Replace(ctx, replacement, nil); err != nil {
+	_, err = externalAuthCRUD.Replace(ctx, replacement, nil)
+	if database.IsPreconditionFailedError(err) {
+		return nil
+	}
+	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to replace ExternalAuth: %w", err))
 	}
 	return nil

--- a/backend/pkg/controllers/statuscontrollers/externalauth_degraded_aggregator_test.go
+++ b/backend/pkg/controllers/statuscontrollers/externalauth_degraded_aggregator_test.go
@@ -207,8 +207,8 @@ func TestExternalAuthDegradedAggregator_SyncOnce(t *testing.T) {
 			clock := clocktesting.NewFakePassiveClock(fixedNow)
 			syncer := &externalAuthDegradedAggregator{
 				cooldownChecker:    alwaysSyncCooldownChecker{},
-				externalAuthLister: &listertesting.SliceExternalAuthLister{ExternalAuths: []*api.HCPOpenShiftClusterExternalAuth{existing}},
-				controllerLister:   &listertesting.SliceControllerLister{Controllers: tc.controllers},
+				externalAuthLister: &listertesting.DBExternalAuthLister{ResourcesDBClient: mockDB},
+				controllerLister:   &listertesting.DBControllerLister{ResourcesDBClient: mockDB},
 				resourcesDBClient:  mockDB,
 				inertia:            tc.inertia,
 				clock:              clock,

--- a/backend/pkg/controllers/statuscontrollers/externalauth_degraded_aggregator_test.go
+++ b/backend/pkg/controllers/statuscontrollers/externalauth_degraded_aggregator_test.go
@@ -1,0 +1,236 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statuscontrollers
+
+import (
+	"context"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clocktesting "k8s.io/utils/clock/testing"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+)
+
+// newTestExternalAuthForAggregator builds a minimal
+// HCPOpenShiftClusterExternalAuth suitable for the aggregator tests.
+func newTestExternalAuthForAggregator(opts ...func(*api.HCPOpenShiftClusterExternalAuth)) *api.HCPOpenShiftClusterExternalAuth {
+	resourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+			"/externalAuths/" + testExternalAuthName,
+	))
+	ea := &api.HCPOpenShiftClusterExternalAuth{
+		CosmosMetadata: arm.CosmosMetadata{ResourceID: resourceID},
+		ProxyResource: arm.ProxyResource{
+			Resource: arm.Resource{
+				ID:   resourceID,
+				Name: testExternalAuthName,
+				Type: resourceID.ResourceType.String(),
+			},
+		},
+	}
+	for _, opt := range opts {
+		opt(ea)
+	}
+	return ea
+}
+
+func TestExternalAuthDegradedAggregator_SyncOnce(t *testing.T) {
+	parentResourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+			"/externalAuths/" + testExternalAuthName,
+	))
+	parentClusterID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName,
+	))
+
+	thirtySecondInertia := MustNewInertia(30 * time.Second).Inertia
+	fiveMinuteOverrideInertia := MustNewInertia(
+		30*time.Second,
+		InertiaController{ControllerNameMatcher: regexp.MustCompile(`^SlowController$`), Duration: 5 * time.Minute},
+	).Inertia
+
+	tests := []struct {
+		name string
+
+		controllers []*api.Controller
+		inertia     Inertia
+		// initialConditions, if set, is layered onto the external auth before
+		// SyncOnce runs.
+		initialConditions []metav1.Condition
+
+		expectStatus  metav1.ConditionStatus
+		expectReason  string
+		expectMessage string
+	}{
+		{
+			name:          "no controllers under the external auth -> Unknown/NoData",
+			controllers:   nil,
+			inertia:       thirtySecondInertia,
+			expectStatus:  metav1.ConditionUnknown,
+			expectReason:  "NoData",
+			expectMessage: "",
+		},
+		{
+			name: "all-good aggregate",
+			controllers: []*api.Controller{
+				controllerUnder(parentResourceID, "AController", metav1.ConditionFalse, "NoErrors", "fine", 1*time.Minute),
+			},
+			inertia:       thirtySecondInertia,
+			expectStatus:  metav1.ConditionFalse,
+			expectReason:  "AsExpected",
+			expectMessage: "AController: fine",
+		},
+		{
+			name: "bad controller within 30s inertia stays hidden",
+			controllers: []*api.Controller{
+				controllerUnder(parentResourceID, "AController", metav1.ConditionTrue, "Failed", "boom", 5*time.Second),
+			},
+			inertia:       thirtySecondInertia,
+			expectStatus:  metav1.ConditionFalse,
+			expectReason:  "AsExpected",
+			expectMessage: "AController: boom",
+		},
+		{
+			name: "bad controller past 30s inertia flips aggregate",
+			controllers: []*api.Controller{
+				controllerUnder(parentResourceID, "AController", metav1.ConditionTrue, "Failed", "boom", 1*time.Minute),
+			},
+			inertia:       thirtySecondInertia,
+			expectStatus:  metav1.ConditionTrue,
+			expectReason:  "AController_Failed",
+			expectMessage: "AController: boom",
+		},
+		{
+			name: "per-controller override delays SlowController",
+			controllers: []*api.Controller{
+				controllerUnder(parentResourceID, "SlowController", metav1.ConditionTrue, "Failed", "settling", 2*time.Minute),
+			},
+			inertia:       fiveMinuteOverrideInertia,
+			expectStatus:  metav1.ConditionFalse,
+			expectReason:  "AsExpected",
+			expectMessage: "SlowController: settling",
+		},
+		{
+			name: "per-controller override: SlowController past 5m flips",
+			controllers: []*api.Controller{
+				controllerUnder(parentResourceID, "SlowController", metav1.ConditionTrue, "Failed", "stuck", 6*time.Minute),
+			},
+			inertia:       fiveMinuteOverrideInertia,
+			expectStatus:  metav1.ConditionTrue,
+			expectReason:  "SlowController_Failed",
+			expectMessage: "SlowController: stuck",
+		},
+		{
+			name: "nil inertia propagates immediately",
+			controllers: []*api.Controller{
+				controllerUnder(parentResourceID, "AController", metav1.ConditionTrue, "Failed", "boom", 1*time.Second),
+			},
+			inertia:       nil,
+			expectStatus:  metav1.ConditionTrue,
+			expectReason:  "AController_Failed",
+			expectMessage: "AController: boom",
+		},
+		{
+			name: "no-op when conditions unchanged",
+			controllers: []*api.Controller{
+				controllerUnder(parentResourceID, "AController", metav1.ConditionFalse, "NoErrors", "fine", 1*time.Minute),
+			},
+			inertia: thirtySecondInertia,
+			initialConditions: []metav1.Condition{
+				{
+					Type:    degradedConditionType,
+					Status:  metav1.ConditionFalse,
+					Reason:  "AsExpected",
+					Message: "AController: fine",
+				},
+			},
+			expectStatus:  metav1.ConditionFalse,
+			expectReason:  "AsExpected",
+			expectMessage: "AController: fine",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			existing := newTestExternalAuthForAggregator(func(ea *api.HCPOpenShiftClusterExternalAuth) {
+				if len(tc.initialConditions) > 0 {
+					ea.Status.Conditions = append([]metav1.Condition{}, tc.initialConditions...)
+				}
+			})
+			parentCluster := &api.HCPOpenShiftCluster{
+				CosmosMetadata: arm.CosmosMetadata{ResourceID: parentClusterID},
+				TrackedResource: arm.TrackedResource{
+					Resource: arm.Resource{ID: parentClusterID, Name: testClusterName, Type: parentClusterID.ResourceType.String()},
+				},
+			}
+
+			seed := []any{parentCluster, existing}
+			for _, ctrl := range tc.controllers {
+				seed = append(seed, ctrl)
+			}
+			mockDB, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, seed)
+			require.NoError(t, err)
+
+			clock := clocktesting.NewFakePassiveClock(fixedNow)
+			syncer := &externalAuthDegradedAggregator{
+				cooldownChecker:    alwaysSyncCooldownChecker{},
+				externalAuthLister: &listertesting.SliceExternalAuthLister{ExternalAuths: []*api.HCPOpenShiftClusterExternalAuth{existing}},
+				controllerLister:   &listertesting.SliceControllerLister{Controllers: tc.controllers},
+				resourcesDBClient:  mockDB,
+				inertia:            tc.inertia,
+				clock:              clock,
+				firstObservedBad:   newFirstObservedBadCache(clock),
+			}
+
+			err = syncer.SyncOnce(ctx, controllerutils.HCPExternalAuthKey{
+				SubscriptionID:      testSubscriptionID,
+				ResourceGroupName:   testResourceGroupName,
+				HCPClusterName:      testClusterName,
+				HCPExternalAuthName: testExternalAuthName,
+			})
+			require.NoError(t, err)
+
+			updated, err := mockDB.HCPClusters(testSubscriptionID, testResourceGroupName).ExternalAuth(testClusterName).Get(ctx, testExternalAuthName)
+			require.NoError(t, err)
+
+			cond := apimeta.FindStatusCondition(updated.Status.Conditions, degradedConditionType)
+			require.NotNil(t, cond, "aggregator must set the Degraded condition on the external auth")
+			assert.Equal(t, tc.expectStatus, cond.Status, "status")
+			assert.Equal(t, tc.expectReason, cond.Reason, "reason")
+			assert.Equal(t, tc.expectMessage, cond.Message, "message")
+		})
+	}
+}

--- a/backend/pkg/controllers/statuscontrollers/firstobservedbad.go
+++ b/backend/pkg/controllers/statuscontrollers/firstobservedbad.go
@@ -1,0 +1,83 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statuscontrollers
+
+import (
+	"strings"
+	"time"
+
+	"k8s.io/utils/clock"
+	"k8s.io/utils/lru"
+)
+
+// firstObservedBadCacheCapacity is sized like the other LRU caches in this
+// codebase (e.g. the deletion-timestamp caches) — large enough that an
+// operator with tens of thousands of controllers won't churn through it.
+const firstObservedBadCacheCapacity = 50000
+
+// firstObservedBadCache records, in memory, the time at which each
+// controller was first observed in a "bad" state for which the controller
+// itself has not supplied a LastTransitionTime — namely a missing
+// Degraded condition. (A controller that has reported any Degraded status,
+// including Unknown, has its own LastTransitionTime, so it does not need
+// this cache; collectDegradedConditions passes those through and calls
+// forget on this cache for them.)
+//
+// The aggregator uses this timestamp as the LastTransitionTime on the
+// synthetic Degraded=True SourcedCondition it feeds into UnionCondition,
+// so the same inertia window that protects against flapping True
+// conditions also protects against not-yet-reported controllers.
+//
+// The cache entry is dropped as soon as the controller reports any
+// Degraded condition, so a controller whose condition disappears later
+// starts its inertia fresh rather than tripping on a stale entry.
+type firstObservedBadCache struct {
+	clock clock.PassiveClock
+	cache *lru.Cache
+}
+
+// newFirstObservedBadCache returns a cache bound to the given clock. The
+// clock is the source of "now" for new observations.
+func newFirstObservedBadCache(clock clock.PassiveClock) *firstObservedBadCache {
+	return &firstObservedBadCache{
+		clock: clock,
+		cache: lru.New(firstObservedBadCacheCapacity),
+	}
+}
+
+// observe returns the first-observed-bad time for the given controller. If
+// no entry exists, the current time is recorded and returned, so callers
+// effectively get "now or the previously-recorded earlier time".
+//
+// Pass the controller's resource ID string as the key; it is lowercased
+// internally to match the rest of the codebase's case-insensitive ID
+// conventions.
+func (c *firstObservedBadCache) observe(controllerResourceID string) time.Time {
+	key := strings.ToLower(controllerResourceID)
+	if v, ok := c.cache.Get(key); ok {
+		return v.(time.Time)
+	}
+	now := c.clock.Now()
+	c.cache.Add(key, now)
+	return now
+}
+
+// forget drops any previously-recorded bad observation for the given
+// controller. Call this when the controller reports a definite Degraded
+// status (True or False) so that a later flap back to Unknown starts a
+// fresh inertia window.
+func (c *firstObservedBadCache) forget(controllerResourceID string) {
+	c.cache.Remove(strings.ToLower(controllerResourceID))
+}

--- a/backend/pkg/controllers/statuscontrollers/helpers.go
+++ b/backend/pkg/controllers/statuscontrollers/helpers.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statuscontrollers
+
+import (
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+)
+
+// reasonMissingDegraded is the synthesized reason used when a controller
+// has no Degraded condition at all. It shows up in the aggregated parent
+// condition's reason via the standard union format (Controller_Reason),
+// which is grep-able from telemetry.
+const reasonMissingDegraded = "MissingDegradedCondition"
+
+// collectDegradedConditions flattens an api.Controller slice into the
+// SourcedCondition form that UnionCondition consumes. Each entry's
+// ControllerName is the trailing name segment of the controller document's
+// resource ID — matching the controller-name argument that writers pass
+// to controllerutils.WriteController, so it is a stable identifier of the
+// producing subsystem.
+//
+// Two shapes are produced:
+//   - Controller reports any Degraded condition (True, False, or Unknown):
+//     passed through untouched. The condition's own LastTransitionTime
+//     drives inertia, and Unknown ends up counted as bad by UnionCondition
+//     because it is not the default ConditionFalse. The aggregator forgets
+//     any prior missing-observation entry for this controller.
+//   - Controller has no Degraded condition at all: synthesized as
+//     Degraded=True with reason MissingDegradedCondition. The synthesized
+//     LastTransitionTime is the first-observed-bad time from the in-memory
+//     cache, so a brand-new controller that hasn't reported yet does not
+//     immediately flip the aggregate — the same inertia window applies.
+//
+// Controllers with a nil ResourceID are skipped — we have no key to track
+// them and no name to attribute them to.
+func collectDegradedConditions(controllers []*api.Controller, firstObservedBad *firstObservedBadCache) []SourcedCondition {
+	out := make([]SourcedCondition, 0, len(controllers))
+	for _, ctrl := range controllers {
+		if ctrl == nil || ctrl.ResourceID == nil {
+			continue
+		}
+		ridString := ctrl.ResourceID.String()
+		controllerName := ctrl.ResourceID.Name
+
+		cond := apimeta.FindStatusCondition(ctrl.Status.Conditions, degradedConditionType)
+		if cond != nil {
+			// Controller has reported a Degraded condition (any status). Drop any
+			// prior missing-observation entry so a future "condition disappeared"
+			// case starts its inertia fresh.
+			firstObservedBad.forget(ridString)
+			out = append(out, SourcedCondition{
+				ControllerName: controllerName,
+				Condition:      *cond,
+			})
+			continue
+		}
+
+		// Missing Degraded -> synthesize Degraded=True so UnionCondition counts
+		// it as bad, using the first-observed-bad cache for LastTransitionTime.
+		out = append(out, SourcedCondition{
+			ControllerName: controllerName,
+			Condition: metav1.Condition{
+				Type:               degradedConditionType,
+				Status:             metav1.ConditionTrue,
+				Reason:             reasonMissingDegraded,
+				Message:            "Controller has not reported a Degraded condition",
+				LastTransitionTime: metav1.NewTime(firstObservedBad.observe(ridString)),
+			},
+		})
+	}
+	return out
+}

--- a/backend/pkg/controllers/statuscontrollers/helpers_test.go
+++ b/backend/pkg/controllers/statuscontrollers/helpers_test.go
@@ -1,0 +1,221 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statuscontrollers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clocktesting "k8s.io/utils/clock/testing"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+)
+
+// buildController is a tiny helper for table cases. It produces a Controller
+// document whose ResourceID has the given trailing controller name; only the
+// fields that collectDegradedConditions reads are populated.
+func buildController(t *testing.T, controllerName string, conditions ...metav1.Condition) *api.Controller {
+	t.Helper()
+	rid, err := azcorearm.ParseResourceID(
+		"/subscriptions/00000000-0000-0000-0000-000000000000" +
+			"/resourceGroups/rg" +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/c" +
+			"/hcpOpenShiftControllers/" + controllerName)
+	if err != nil {
+		t.Fatalf("parsing resource id: %v", err)
+	}
+	return &api.Controller{
+		CosmosMetadata: api.CosmosMetadata{ResourceID: rid},
+		Status:         api.ControllerStatus{Conditions: conditions},
+	}
+}
+
+func TestCollectDegradedConditions(t *testing.T) {
+	degradedTrue := metav1.Condition{Type: degradedConditionType, Status: metav1.ConditionTrue, Reason: "Failed", Message: "boom"}
+	degradedFalse := metav1.Condition{Type: degradedConditionType, Status: metav1.ConditionFalse, Reason: "NoErrors"}
+	degradedUnknown := metav1.Condition{Type: degradedConditionType, Status: metav1.ConditionUnknown, Reason: "Investigating", Message: "still figuring out"}
+	availableTrue := metav1.Condition{Type: "Available", Status: metav1.ConditionTrue}
+
+	// expectation describes what we expect a returned SourcedCondition to
+	// look like at the union-relevant fields. ControllerName is also the
+	// implicit ordering key.
+	type expectation struct {
+		controllerName string
+		status         metav1.ConditionStatus
+		reason         string
+		// useFirstObservedTime is true when the synthetic missing-Degraded entry
+		// is expected — LastTransitionTime should equal fixedNow (the clock's
+		// "now") rather than mirroring any existing condition.
+		useFirstObservedTime bool
+	}
+
+	tests := []struct {
+		name        string
+		controllers []*api.Controller
+		expected    []expectation
+	}{
+		{
+			name:        "empty input -> empty output",
+			controllers: nil,
+			expected:    nil,
+		},
+		{
+			name: "controller missing ResourceID is skipped",
+			controllers: []*api.Controller{
+				{CosmosMetadata: api.CosmosMetadata{}, Status: api.ControllerStatus{Conditions: []metav1.Condition{degradedTrue}}},
+			},
+			expected: nil,
+		},
+		{
+			name: "Degraded=True passes through with its real LastTransitionTime",
+			controllers: []*api.Controller{
+				buildController(t, "A", degradedTrue),
+			},
+			expected: []expectation{{controllerName: "A", status: metav1.ConditionTrue, reason: "Failed"}},
+		},
+		{
+			name: "Degraded=False passes through",
+			controllers: []*api.Controller{
+				buildController(t, "A", degradedFalse),
+			},
+			expected: []expectation{{controllerName: "A", status: metav1.ConditionFalse, reason: "NoErrors"}},
+		},
+		{
+			name: "Degraded=Unknown passes through unchanged (real LastTransitionTime, original reason)",
+			controllers: []*api.Controller{
+				buildController(t, "A", degradedUnknown),
+			},
+			expected: []expectation{{controllerName: "A", status: metav1.ConditionUnknown, reason: "Investigating"}},
+		},
+		{
+			name: "missing Degraded condition -> synthesized Degraded=True with first-observed-bad time",
+			controllers: []*api.Controller{
+				buildController(t, "A", availableTrue),
+			},
+			expected: []expectation{{controllerName: "A", status: metav1.ConditionTrue, reason: reasonMissingDegraded, useFirstObservedTime: true}},
+		},
+		{
+			name: "controller with no conditions at all -> synthesized missing-Degraded entry",
+			controllers: []*api.Controller{
+				buildController(t, "A"),
+			},
+			expected: []expectation{{controllerName: "A", status: metav1.ConditionTrue, reason: reasonMissingDegraded, useFirstObservedTime: true}},
+		},
+		{
+			name: "mix: real conditions and missing controllers each get their own entry",
+			controllers: []*api.Controller{
+				buildController(t, "A", degradedTrue),
+				buildController(t, "B", availableTrue),
+				buildController(t, "C", degradedFalse),
+			},
+			expected: []expectation{
+				{controllerName: "A", status: metav1.ConditionTrue, reason: "Failed"},
+				{controllerName: "B", status: metav1.ConditionTrue, reason: reasonMissingDegraded, useFirstObservedTime: true},
+				{controllerName: "C", status: metav1.ConditionFalse, reason: "NoErrors"},
+			},
+		},
+		{
+			name: "nil entries in the slice are tolerated",
+			controllers: []*api.Controller{
+				nil,
+				buildController(t, "A", degradedTrue),
+				nil,
+			},
+			expected: []expectation{{controllerName: "A", status: metav1.ConditionTrue, reason: "Failed"}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			clock := clocktesting.NewFakePassiveClock(fixedNow)
+			cache := newFirstObservedBadCache(clock)
+			got := collectDegradedConditions(tc.controllers, cache)
+
+			require := assert.New(t)
+			require.Equal(len(tc.expected), len(got), "result length")
+			for i, want := range tc.expected {
+				if i >= len(got) {
+					break
+				}
+				require.Equal(want.controllerName, got[i].ControllerName, "controller name at index %d", i)
+				require.Equal(degradedConditionType, got[i].Condition.Type, "type at index %d", i)
+				require.Equal(want.status, got[i].Condition.Status, "status at index %d", i)
+				require.Equal(want.reason, got[i].Condition.Reason, "reason at index %d", i)
+				if want.useFirstObservedTime {
+					require.True(got[i].Condition.LastTransitionTime.Time.Equal(fixedNow),
+						"index %d: expected LastTransitionTime to be fixedNow (cache observation), got %v", i, got[i].Condition.LastTransitionTime.Time)
+				}
+			}
+		})
+	}
+}
+
+// TestCollectDegradedConditions_FirstObservedBadIsSticky verifies that a
+// controller stuck in "missing Degraded" across multiple reconcile passes
+// keeps its original first-observed-bad time even when the clock advances,
+// so inertia is measured from when the problem began (not from every new
+// "now").
+func TestCollectDegradedConditions_FirstObservedBadIsSticky(t *testing.T) {
+	clock := clocktesting.NewFakePassiveClock(fixedNow)
+	cache := newFirstObservedBadCache(clock)
+
+	controllers := []*api.Controller{buildController(t, "A")}
+
+	first := collectDegradedConditions(controllers, cache)
+	assert.Len(t, first, 1)
+	firstTime := first[0].Condition.LastTransitionTime.Time
+
+	// Advance the clock by an hour. A second pass with the same missing
+	// state should keep using the original observation time.
+	clock.SetTime(fixedNow.Add(time.Hour))
+	second := collectDegradedConditions(controllers, cache)
+	assert.Len(t, second, 1)
+	assert.True(t, second[0].Condition.LastTransitionTime.Time.Equal(firstTime),
+		"expected first-observed-bad time to be sticky across reconciles")
+}
+
+// TestCollectDegradedConditions_RealConditionForgetsCache verifies that
+// once a controller starts reporting a real (non-missing) Degraded
+// condition, the cache entry is dropped so a later "condition disappeared
+// again" starts a fresh inertia window.
+func TestCollectDegradedConditions_RealConditionForgetsCache(t *testing.T) {
+	clock := clocktesting.NewFakePassiveClock(fixedNow)
+	cache := newFirstObservedBadCache(clock)
+
+	missingPhase := []*api.Controller{buildController(t, "A")}
+	reportingPhase := []*api.Controller{
+		buildController(t, "A", metav1.Condition{Type: degradedConditionType, Status: metav1.ConditionFalse, Reason: "NoErrors"}),
+	}
+
+	// First pass: missing -> cache populated at fixedNow.
+	_ = collectDegradedConditions(missingPhase, cache)
+
+	// Second pass: controller now reports Degraded=False -> cache forgets.
+	clock.SetTime(fixedNow.Add(5 * time.Minute))
+	_ = collectDegradedConditions(reportingPhase, cache)
+
+	// Third pass: controller goes missing again. Inertia should start at the
+	// LATER observation (fixedNow+10m), not the original fixedNow.
+	clock.SetTime(fixedNow.Add(10 * time.Minute))
+	third := collectDegradedConditions(missingPhase, cache)
+	assert.Len(t, third, 1)
+	assert.True(t, third[0].Condition.LastTransitionTime.Time.Equal(fixedNow.Add(10*time.Minute)),
+		"expected the cache to start fresh after a real condition appeared and then disappeared")
+}

--- a/backend/pkg/controllers/statuscontrollers/inertia.go
+++ b/backend/pkg/controllers/statuscontrollers/inertia.go
@@ -1,0 +1,91 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statuscontrollers
+
+import (
+	"fmt"
+	"regexp"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Inertia returns how long an off-default condition (e.g. Degraded=True)
+// from a given controller must persist before it is propagated into the
+// aggregated parent condition. The controller name is the key so different
+// controllers can have different inertia; the metav1.Condition is included
+// so callers can additionally vary inertia by reason or message if they
+// ever need to.
+//
+// This mirrors openshift/library-go's status.Inertia, adapted so the keying
+// is the producing controller rather than the condition type — every
+// controller in this codebase reports under Type="Degraded", so it is the
+// controller identity (not the condition type) that carries the signal.
+type Inertia func(controllerName string, condition metav1.Condition) time.Duration
+
+// InertiaController configures an inertia duration for a set of source
+// controllers whose names match a regular expression. Patterns are checked
+// in declaration order and the first match wins, so place more specific
+// patterns before more general ones.
+type InertiaController struct {
+	ControllerNameMatcher *regexp.Regexp
+	Duration              time.Duration
+}
+
+// InertiaConfig is an Inertia implementation: a default duration plus a list
+// of per-controller-name overrides.
+type InertiaConfig struct {
+	defaultDuration time.Duration
+	controllers     []InertiaController
+}
+
+// NewInertia builds an InertiaConfig. The default duration is applied to any
+// controller whose name does not match an override pattern.
+func NewInertia(defaultDuration time.Duration, controllers ...InertiaController) (*InertiaConfig, error) {
+	for i, c := range controllers {
+		if c.ControllerNameMatcher == nil {
+			return nil, fmt.Errorf("controller override %d has a nil ControllerNameMatcher", i)
+		}
+	}
+	return &InertiaConfig{
+		defaultDuration: defaultDuration,
+		controllers:     controllers,
+	}, nil
+}
+
+// MustNewInertia is like NewInertia but panics on configuration error. Use
+// it at process startup where a misconfigured Inertia is a coding bug.
+func MustNewInertia(defaultDuration time.Duration, controllers ...InertiaController) *InertiaConfig {
+	cfg, err := NewInertia(defaultDuration, controllers...)
+	if err != nil {
+		panic(err)
+	}
+	return cfg
+}
+
+// Inertia returns the configured duration for the given source controller.
+func (c *InertiaConfig) Inertia(controllerName string, _ metav1.Condition) time.Duration {
+	for _, override := range c.controllers {
+		if override.ControllerNameMatcher.MatchString(controllerName) {
+			return override.Duration
+		}
+	}
+	return c.defaultDuration
+}
+
+// DefaultInertia is the default per-controller inertia for the aggregators
+// in this package. A controller that flaps a Degraded=True flag for less
+// than this duration is not propagated up to its parent.
+const DefaultInertia = 30 * time.Second

--- a/backend/pkg/controllers/statuscontrollers/inertia_test.go
+++ b/backend/pkg/controllers/statuscontrollers/inertia_test.go
@@ -1,0 +1,190 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statuscontrollers
+
+import (
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestInertiaConfig_Inertia(t *testing.T) {
+	tests := []struct {
+		name             string
+		defaultDuration  time.Duration
+		overrides        []InertiaController
+		controllerName   string
+		expectedDuration time.Duration
+	}{
+		{
+			name:             "no overrides falls back to default",
+			defaultDuration:  30 * time.Second,
+			overrides:        nil,
+			controllerName:   "ClusterPropertiesSync",
+			expectedDuration: 30 * time.Second,
+		},
+		{
+			name:            "exact match override wins over default",
+			defaultDuration: 30 * time.Second,
+			overrides: []InertiaController{
+				{ControllerNameMatcher: regexp.MustCompile(`^ClusterPropertiesSync$`), Duration: 2 * time.Minute},
+			},
+			controllerName:   "ClusterPropertiesSync",
+			expectedDuration: 2 * time.Minute,
+		},
+		{
+			name:            "non-matching override falls back to default",
+			defaultDuration: 30 * time.Second,
+			overrides: []InertiaController{
+				{ControllerNameMatcher: regexp.MustCompile(`^Unrelated$`), Duration: 99 * time.Hour},
+			},
+			controllerName:   "ClusterPropertiesSync",
+			expectedDuration: 30 * time.Second,
+		},
+		{
+			name:            "first matching override wins (ordered evaluation)",
+			defaultDuration: 30 * time.Second,
+			overrides: []InertiaController{
+				{ControllerNameMatcher: regexp.MustCompile(`^Cluster`), Duration: 10 * time.Second},
+				{ControllerNameMatcher: regexp.MustCompile(`Sync$`), Duration: 5 * time.Minute},
+			},
+			controllerName:   "ClusterPropertiesSync",
+			expectedDuration: 10 * time.Second,
+		},
+		{
+			name:            "regex anchored to suffix",
+			defaultDuration: 30 * time.Second,
+			overrides: []InertiaController{
+				{ControllerNameMatcher: regexp.MustCompile(`Migration$`), Duration: 90 * time.Second},
+			},
+			controllerName:   "IdentityMigration",
+			expectedDuration: 90 * time.Second,
+		},
+		{
+			name:             "empty controller name still gets default",
+			defaultDuration:  30 * time.Second,
+			overrides:        nil,
+			controllerName:   "",
+			expectedDuration: 30 * time.Second,
+		},
+		{
+			name:            "DefaultInertia constant is the documented 30s",
+			defaultDuration: DefaultInertia,
+			controllerName:  "Anything",
+			// We compare directly against the constant rather than hard-coding 30s here so the
+			// test reflects intent: callers passing DefaultInertia should see exactly that value.
+			expectedDuration: DefaultInertia,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := NewInertia(tc.defaultDuration, tc.overrides...)
+			require.NoError(t, err)
+			got := cfg.Inertia(tc.controllerName, metav1.Condition{Type: degradedConditionType})
+			assert.Equal(t, tc.expectedDuration, got)
+		})
+	}
+}
+
+func TestNewInertia_Errors(t *testing.T) {
+	tests := []struct {
+		name        string
+		overrides   []InertiaController
+		expectError bool
+	}{
+		{
+			name:        "no overrides is fine",
+			overrides:   nil,
+			expectError: false,
+		},
+		{
+			name: "all-valid overrides is fine",
+			overrides: []InertiaController{
+				{ControllerNameMatcher: regexp.MustCompile(`^A$`), Duration: time.Second},
+				{ControllerNameMatcher: regexp.MustCompile(`^B$`), Duration: time.Second},
+			},
+			expectError: false,
+		},
+		{
+			name: "nil matcher in first slot is rejected",
+			overrides: []InertiaController{
+				{ControllerNameMatcher: nil, Duration: time.Second},
+			},
+			expectError: true,
+		},
+		{
+			name: "nil matcher in later slot is rejected",
+			overrides: []InertiaController{
+				{ControllerNameMatcher: regexp.MustCompile(`^A$`), Duration: time.Second},
+				{ControllerNameMatcher: nil, Duration: time.Second},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := NewInertia(30*time.Second, tc.overrides...)
+			if tc.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, cfg)
+				return
+			}
+			assert.NoError(t, err)
+			assert.NotNil(t, cfg)
+		})
+	}
+}
+
+func TestMustNewInertia_Panic(t *testing.T) {
+	tests := []struct {
+		name        string
+		overrides   []InertiaController
+		expectPanic bool
+	}{
+		{
+			name:        "valid config does not panic",
+			overrides:   nil,
+			expectPanic: false,
+		},
+		{
+			name: "invalid config panics",
+			overrides: []InertiaController{
+				{ControllerNameMatcher: nil, Duration: time.Second},
+			},
+			expectPanic: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.expectPanic {
+				assert.Panics(t, func() {
+					MustNewInertia(30*time.Second, tc.overrides...)
+				})
+				return
+			}
+			assert.NotPanics(t, func() {
+				MustNewInertia(30*time.Second, tc.overrides...)
+			})
+		})
+	}
+}

--- a/backend/pkg/controllers/statuscontrollers/nodepool_degraded_aggregator.go
+++ b/backend/pkg/controllers/statuscontrollers/nodepool_degraded_aggregator.go
@@ -1,0 +1,131 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statuscontrollers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilsclock "k8s.io/utils/clock"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// nodePoolDegradedAggregator rolls per-controller Degraded conditions up
+// onto HCPOpenShiftClusterNodePool.Status.Conditions. See the package and
+// clusterDegradedAggregator docs for the overall design.
+type nodePoolDegradedAggregator struct {
+	cooldownChecker   controllerutil.CooldownChecker
+	nodePoolLister    listers.NodePoolLister
+	controllerLister  listers.ControllerLister
+	resourcesDBClient database.ResourcesDBClient
+	inertia           Inertia
+	clock             utilsclock.PassiveClock
+	firstObservedBad  *firstObservedBadCache
+}
+
+var _ controllerutils.NodePoolSyncer = (*nodePoolDegradedAggregator)(nil)
+
+// nodePoolDegradedAggregatorInertia is the inertia config used by the
+// node-pool aggregator. Same shape as clusterDegradedAggregatorInertia
+// and kept independent so node-pool-specific controllers can be tuned
+// without affecting cluster-scoped propagation.
+func nodePoolDegradedAggregatorInertia() Inertia {
+	return MustNewInertia(DefaultInertia).Inertia
+}
+
+// NewNodePoolDegradedAggregatorController creates a controller that
+// aggregates the Degraded condition from every api.Controller under a
+// given HCPOpenShiftClusterNodePool onto the node pool's
+// Status.Conditions.
+//
+// See NewClusterDegradedAggregatorController for the clock semantics —
+// they are identical across the three aggregators.
+func NewNodePoolDegradedAggregatorController(
+	resourcesDBClient database.ResourcesDBClient,
+	nodePoolLister listers.NodePoolLister,
+	controllerLister listers.ControllerLister,
+	activeOperationLister listers.ActiveOperationLister,
+	informers informers.BackendInformers,
+	clock utilsclock.PassiveClock,
+) controllerutils.Controller {
+	if clock == nil {
+		clock = utilsclock.RealClock{}
+	}
+	syncer := &nodePoolDegradedAggregator{
+		cooldownChecker:   controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		nodePoolLister:    nodePoolLister,
+		controllerLister:  controllerLister,
+		resourcesDBClient: resourcesDBClient,
+		inertia:           nodePoolDegradedAggregatorInertia(),
+		clock:             clock,
+		firstObservedBad:  newFirstObservedBadCache(clock),
+	}
+	return controllerutils.NewNodePoolWatchingController(
+		"NodePoolDegradedAggregator",
+		resourcesDBClient,
+		informers,
+		1*time.Minute,
+		syncer,
+	)
+}
+
+func (c *nodePoolDegradedAggregator) CooldownChecker() controllerutil.CooldownChecker {
+	return c.cooldownChecker
+}
+
+func (c *nodePoolDegradedAggregator) SyncOnce(ctx context.Context, key controllerutils.HCPNodePoolKey) error {
+	existing, err := c.nodePoolLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get NodePool from cache: %w", err))
+	}
+
+	controllers, err := c.controllerLister.ListForNodePool(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to list Controllers from cache: %w", err))
+	}
+
+	aggregated := UnionCondition(
+		degradedConditionType,
+		metav1.ConditionFalse,
+		c.inertia,
+		c.clock.Now(),
+		collectDegradedConditions(controllers, c.firstObservedBad)...,
+	)
+
+	replacement := existing.DeepCopy()
+	apimeta.SetStatusCondition(&replacement.Status.Conditions, aggregated)
+	if equality.Semantic.DeepEqual(existing.Status.Conditions, replacement.Status.Conditions) {
+		return nil
+	}
+
+	nodePoolCRUD := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).NodePools(key.HCPClusterName)
+	if _, err := nodePoolCRUD.Replace(ctx, replacement, nil); err != nil {
+		return utils.TrackError(fmt.Errorf("failed to replace NodePool: %w", err))
+	}
+	return nil
+}

--- a/backend/pkg/controllers/statuscontrollers/nodepool_degraded_aggregator.go
+++ b/backend/pkg/controllers/statuscontrollers/nodepool_degraded_aggregator.go
@@ -124,7 +124,11 @@ func (c *nodePoolDegradedAggregator) SyncOnce(ctx context.Context, key controlle
 	}
 
 	nodePoolCRUD := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).NodePools(key.HCPClusterName)
-	if _, err := nodePoolCRUD.Replace(ctx, replacement, nil); err != nil {
+	_, err = nodePoolCRUD.Replace(ctx, replacement, nil)
+	if database.IsPreconditionFailedError(err) {
+		return nil
+	}
+	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to replace NodePool: %w", err))
 	}
 	return nil

--- a/backend/pkg/controllers/statuscontrollers/nodepool_degraded_aggregator_test.go
+++ b/backend/pkg/controllers/statuscontrollers/nodepool_degraded_aggregator_test.go
@@ -1,0 +1,240 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statuscontrollers
+
+import (
+	"context"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clocktesting "k8s.io/utils/clock/testing"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+)
+
+// newTestNodePoolForAggregator builds a minimal HCPOpenShiftClusterNodePool
+// suitable for the aggregator tests.
+func newTestNodePoolForAggregator(opts ...func(*api.HCPOpenShiftClusterNodePool)) *api.HCPOpenShiftClusterNodePool {
+	resourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+			"/nodePools/" + testNodePoolName,
+	))
+	np := &api.HCPOpenShiftClusterNodePool{
+		CosmosMetadata: arm.CosmosMetadata{ResourceID: resourceID},
+		TrackedResource: arm.TrackedResource{
+			Resource: arm.Resource{
+				ID:   resourceID,
+				Name: testNodePoolName,
+				Type: resourceID.ResourceType.String(),
+			},
+		},
+	}
+	for _, opt := range opts {
+		opt(np)
+	}
+	return np
+}
+
+func TestNodePoolDegradedAggregator_SyncOnce(t *testing.T) {
+	parentResourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+			"/nodePools/" + testNodePoolName,
+	))
+
+	thirtySecondInertia := MustNewInertia(30 * time.Second).Inertia
+	fiveMinuteOverrideInertia := MustNewInertia(
+		30*time.Second,
+		InertiaController{ControllerNameMatcher: regexp.MustCompile(`^SlowController$`), Duration: 5 * time.Minute},
+	).Inertia
+
+	// Parent cluster — also needed so the resourcesDBClient is happy when the
+	// node-pool CRUD looks up the parent path internally during Replace.
+	parentClusterID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName,
+	))
+	_ = parentClusterID
+
+	tests := []struct {
+		name string
+
+		controllers []*api.Controller
+		inertia     Inertia
+		// initialConditions, if set, is layered onto the node pool before SyncOnce
+		// runs. Used to drive the "no-op when conditions unchanged" case.
+		initialConditions []metav1.Condition
+
+		expectStatus  metav1.ConditionStatus
+		expectReason  string
+		expectMessage string
+	}{
+		{
+			name:          "no controllers under the node pool -> Unknown/NoData",
+			controllers:   nil,
+			inertia:       thirtySecondInertia,
+			expectStatus:  metav1.ConditionUnknown,
+			expectReason:  "NoData",
+			expectMessage: "",
+		},
+		{
+			name: "all controllers report Degraded=False -> aggregate False/AsExpected",
+			controllers: []*api.Controller{
+				controllerUnder(parentResourceID, "AController", metav1.ConditionFalse, "NoErrors", "fine", 1*time.Minute),
+			},
+			inertia:       thirtySecondInertia,
+			expectStatus:  metav1.ConditionFalse,
+			expectReason:  "AsExpected",
+			expectMessage: "AController: fine",
+		},
+		{
+			name: "bad controller within 30s inertia stays hidden",
+			controllers: []*api.Controller{
+				controllerUnder(parentResourceID, "AController", metav1.ConditionTrue, "Failed", "boom", 10*time.Second),
+			},
+			inertia:       thirtySecondInertia,
+			expectStatus:  metav1.ConditionFalse,
+			expectReason:  "AsExpected",
+			expectMessage: "AController: boom",
+		},
+		{
+			name: "bad controller past 30s inertia flips aggregate",
+			controllers: []*api.Controller{
+				controllerUnder(parentResourceID, "AController", metav1.ConditionTrue, "Failed", "boom", 31*time.Second),
+			},
+			inertia:       thirtySecondInertia,
+			expectStatus:  metav1.ConditionTrue,
+			expectReason:  "AController_Failed",
+			expectMessage: "AController: boom",
+		},
+		{
+			name: "per-controller override: SlowController stays in inertia window",
+			controllers: []*api.Controller{
+				controllerUnder(parentResourceID, "SlowController", metav1.ConditionTrue, "Failed", "settling", 2*time.Minute),
+			},
+			inertia:       fiveMinuteOverrideInertia,
+			expectStatus:  metav1.ConditionFalse,
+			expectReason:  "AsExpected",
+			expectMessage: "SlowController: settling",
+		},
+		{
+			name: "per-controller override: SlowController past 5m flips",
+			controllers: []*api.Controller{
+				controllerUnder(parentResourceID, "SlowController", metav1.ConditionTrue, "Failed", "stuck", 6*time.Minute),
+			},
+			inertia:       fiveMinuteOverrideInertia,
+			expectStatus:  metav1.ConditionTrue,
+			expectReason:  "SlowController_Failed",
+			expectMessage: "SlowController: stuck",
+		},
+		{
+			name: "nil inertia propagates immediately",
+			controllers: []*api.Controller{
+				controllerUnder(parentResourceID, "AController", metav1.ConditionTrue, "Failed", "boom", 1*time.Second),
+			},
+			inertia:       nil,
+			expectStatus:  metav1.ConditionTrue,
+			expectReason:  "AController_Failed",
+			expectMessage: "AController: boom",
+		},
+		{
+			name: "no-op when conditions unchanged",
+			controllers: []*api.Controller{
+				controllerUnder(parentResourceID, "AController", metav1.ConditionFalse, "NoErrors", "fine", 1*time.Minute),
+			},
+			inertia: thirtySecondInertia,
+			initialConditions: []metav1.Condition{
+				{
+					Type:    degradedConditionType,
+					Status:  metav1.ConditionFalse,
+					Reason:  "AsExpected",
+					Message: "AController: fine",
+				},
+			},
+			expectStatus:  metav1.ConditionFalse,
+			expectReason:  "AsExpected",
+			expectMessage: "AController: fine",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			existing := newTestNodePoolForAggregator(func(np *api.HCPOpenShiftClusterNodePool) {
+				if len(tc.initialConditions) > 0 {
+					np.Status.Conditions = append([]metav1.Condition{}, tc.initialConditions...)
+				}
+			})
+			parentCluster := &api.HCPOpenShiftCluster{
+				CosmosMetadata: arm.CosmosMetadata{ResourceID: parentClusterID},
+				TrackedResource: arm.TrackedResource{
+					Resource: arm.Resource{ID: parentClusterID, Name: testClusterName, Type: parentClusterID.ResourceType.String()},
+				},
+			}
+
+			seed := []any{parentCluster, existing}
+			for _, ctrl := range tc.controllers {
+				seed = append(seed, ctrl)
+			}
+			mockDB, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, seed)
+			require.NoError(t, err)
+
+			clock := clocktesting.NewFakePassiveClock(fixedNow)
+			syncer := &nodePoolDegradedAggregator{
+				cooldownChecker:   alwaysSyncCooldownChecker{},
+				nodePoolLister:    &listertesting.SliceNodePoolLister{NodePools: []*api.HCPOpenShiftClusterNodePool{existing}},
+				controllerLister:  &listertesting.SliceControllerLister{Controllers: tc.controllers},
+				resourcesDBClient: mockDB,
+				inertia:           tc.inertia,
+				clock:             clock,
+				firstObservedBad:  newFirstObservedBadCache(clock),
+			}
+
+			err = syncer.SyncOnce(ctx, controllerutils.HCPNodePoolKey{
+				SubscriptionID:    testSubscriptionID,
+				ResourceGroupName: testResourceGroupName,
+				HCPClusterName:    testClusterName,
+				HCPNodePoolName:   testNodePoolName,
+			})
+			require.NoError(t, err)
+
+			updated, err := mockDB.HCPClusters(testSubscriptionID, testResourceGroupName).NodePools(testClusterName).Get(ctx, testNodePoolName)
+			require.NoError(t, err)
+
+			cond := apimeta.FindStatusCondition(updated.Status.Conditions, degradedConditionType)
+			require.NotNil(t, cond, "aggregator must set the Degraded condition on the node pool")
+			assert.Equal(t, tc.expectStatus, cond.Status, "status")
+			assert.Equal(t, tc.expectReason, cond.Reason, "reason")
+			assert.Equal(t, tc.expectMessage, cond.Message, "message")
+		})
+	}
+}

--- a/backend/pkg/controllers/statuscontrollers/nodepool_degraded_aggregator_test.go
+++ b/backend/pkg/controllers/statuscontrollers/nodepool_degraded_aggregator_test.go
@@ -82,7 +82,6 @@ func TestNodePoolDegradedAggregator_SyncOnce(t *testing.T) {
 			"/resourceGroups/" + testResourceGroupName +
 			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName,
 	))
-	_ = parentClusterID
 
 	tests := []struct {
 		name string
@@ -211,8 +210,8 @@ func TestNodePoolDegradedAggregator_SyncOnce(t *testing.T) {
 			clock := clocktesting.NewFakePassiveClock(fixedNow)
 			syncer := &nodePoolDegradedAggregator{
 				cooldownChecker:   alwaysSyncCooldownChecker{},
-				nodePoolLister:    &listertesting.SliceNodePoolLister{NodePools: []*api.HCPOpenShiftClusterNodePool{existing}},
-				controllerLister:  &listertesting.SliceControllerLister{Controllers: tc.controllers},
+				nodePoolLister:    &listertesting.DBNodePoolLister{ResourcesDBClient: mockDB},
+				controllerLister:  &listertesting.DBControllerLister{ResourcesDBClient: mockDB},
 				resourcesDBClient: mockDB,
 				inertia:           tc.inertia,
 				clock:             clock,

--- a/backend/pkg/controllers/statuscontrollers/union_condition.go
+++ b/backend/pkg/controllers/statuscontrollers/union_condition.go
@@ -1,0 +1,186 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statuscontrollers
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// SourcedCondition is a metav1.Condition tagged with the name of the
+// controller that produced it. The controller name takes the role of the
+// "condition type prefix" in openshift/library-go's status.UnionCondition:
+// it is the key used to disambiguate source subsystems in the aggregate
+// reason and message.
+type SourcedCondition struct {
+	ControllerName string
+	Condition      metav1.Condition
+}
+
+// UnionCondition collapses many per-controller conditions into a single
+// metav1.Condition for the aggregated parent. It is a metav1 port of
+// openshift/library-go's status.UnionCondition:
+//
+//   - defaultStatus picks the "good" status. For Degraded that is False
+//     (degraded should only flip True when something is actually wrong).
+//   - When every source is at defaultStatus the result is defaultStatus
+//     with Reason="AsExpected" and a joined-message ("All is well" if all
+//     source messages are empty).
+//   - When at least one source disagrees with defaultStatus and has held
+//     its current value longer than inertia(...), the result flips to the
+//     disagreeing status. Reason and message are aggregated across all
+//     bad sources, sorted by controller name for stability.
+//   - When inertia is nil, every disagreeing source is propagated
+//     immediately (no flap protection).
+//
+// If no sources are supplied the result is Unknown/NoData — the parent
+// has nothing to base its aggregate on.
+func UnionCondition(
+	conditionType string,
+	defaultStatus metav1.ConditionStatus,
+	inertia Inertia,
+	now time.Time,
+	sources ...SourcedCondition,
+) metav1.Condition {
+	oppositeStatus := metav1.ConditionTrue
+	if defaultStatus == metav1.ConditionTrue {
+		oppositeStatus = metav1.ConditionFalse
+	}
+
+	interesting := make([]SourcedCondition, 0, len(sources))
+	bad := make([]SourcedCondition, 0, len(sources))
+	badStatus := metav1.ConditionUnknown
+	for _, src := range sources {
+		if src.Condition.Type != conditionType {
+			continue
+		}
+		interesting = append(interesting, src)
+		if src.Condition.Status != defaultStatus {
+			bad = append(bad, src)
+			if src.Condition.Status == oppositeStatus {
+				badStatus = oppositeStatus
+			}
+		}
+	}
+	// Sort both slices by controller name so every downstream consumer
+	// (unionMessage / unionReason / latestTransitionTime) sees the same
+	// stable order — including the all-good path that builds its message
+	// from `interesting`. Without this, controller-list iteration order
+	// would leak into the aggregated message and cause churn.
+	sort.Sort(byControllerName(interesting))
+	sort.Sort(byControllerName(bad))
+
+	result := metav1.Condition{Type: conditionType, Status: metav1.ConditionUnknown}
+	if len(interesting) == 0 {
+		result.Reason = "NoData"
+		return result
+	}
+
+	var elderBad []SourcedCondition
+	if inertia == nil {
+		elderBad = bad
+	} else {
+		for _, src := range bad {
+			if src.Condition.LastTransitionTime.Time.Before(now.Add(-inertia(src.ControllerName, src.Condition))) {
+				elderBad = append(elderBad, src)
+			}
+		}
+	}
+
+	if len(elderBad) == 0 {
+		result.Status = defaultStatus
+		result.Message = unionMessage(interesting)
+		if result.Message == "" {
+			result.Message = "All is well"
+		}
+		result.Reason = "AsExpected"
+		result.LastTransitionTime = latestTransitionTime(interesting)
+		return result
+	}
+
+	result.Status = badStatus
+	result.Message = unionMessage(bad)
+	result.Reason = unionReason(bad)
+	result.LastTransitionTime = latestTransitionTime(bad)
+	return result
+}
+
+// unionMessage formats per-source messages, one line per source message
+// line, prefixed with the source controller name so the aggregated message
+// remains attributable.
+func unionMessage(sources []SourcedCondition) string {
+	lines := []string{}
+	for _, src := range sources {
+		if len(src.Condition.Message) == 0 {
+			continue
+		}
+		for _, line := range uniq(strings.Split(src.Condition.Message, "\n")) {
+			lines = append(lines, fmt.Sprintf("%s: %s", src.ControllerName, line))
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// unionReason builds a stable, machine-grep-able reason of the form
+// "Controller1_Reason1::Controller2_Reason2", sorted alphabetically by
+// controller name.
+func unionReason(sources []SourcedCondition) string {
+	parts := make([]string, 0, len(sources))
+	for _, src := range sources {
+		if len(src.Condition.Reason) > 0 {
+			parts = append(parts, src.ControllerName+"_"+src.Condition.Reason)
+		} else {
+			parts = append(parts, src.ControllerName)
+		}
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, "::")
+}
+
+func latestTransitionTime(sources []SourcedCondition) metav1.Time {
+	latest := metav1.Time{}
+	for _, src := range sources {
+		if latest.Before(&src.Condition.LastTransitionTime) {
+			latest = src.Condition.LastTransitionTime
+		}
+	}
+	return latest
+}
+
+func uniq(s []string) []string {
+	seen := make(map[string]struct{}, len(s))
+	j := 0
+	for _, v := range s {
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		s[j] = v
+		j++
+	}
+	return s[:j]
+}
+
+type byControllerName []SourcedCondition
+
+var _ sort.Interface = byControllerName{}
+
+func (s byControllerName) Len() int           { return len(s) }
+func (s byControllerName) Less(i, j int) bool { return s[i].ControllerName < s[j].ControllerName }
+func (s byControllerName) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }

--- a/backend/pkg/controllers/statuscontrollers/union_condition_test.go
+++ b/backend/pkg/controllers/statuscontrollers/union_condition_test.go
@@ -1,0 +1,349 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statuscontrollers
+
+import (
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// fixedNow is the synthetic "now" used by every UnionCondition test case so
+// the inertia arithmetic is reproducible. Pick a value that doesn't sit on
+// a daylight-savings boundary.
+var fixedNow = time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
+
+// degradedAt builds a Degraded SourcedCondition shaped for these tests.
+// `age` is how long ago the condition's LastTransitionTime is from fixedNow
+// — a positive value means the condition has held its current value for at
+// least that long.
+func degradedAt(controllerName string, status metav1.ConditionStatus, reason, message string, age time.Duration) SourcedCondition {
+	return SourcedCondition{
+		ControllerName: controllerName,
+		Condition: metav1.Condition{
+			Type:               degradedConditionType,
+			Status:             status,
+			Reason:             reason,
+			Message:            message,
+			LastTransitionTime: metav1.NewTime(fixedNow.Add(-age)),
+		},
+	}
+}
+
+func TestUnionCondition(t *testing.T) {
+	// Three inertia setups exercised across cases:
+	//   - nilInertia: every disagreeing source is propagated immediately.
+	//   - thirtySecondInertia: the default 30s window the production wiring uses.
+	//   - perControllerInertia: one controller has 5m inertia, everything else
+	//     uses the default 30s. Lets us verify that overrides actually apply.
+	thirtySecondInertia := MustNewInertia(30 * time.Second).Inertia
+	perControllerInertia := MustNewInertia(
+		30*time.Second,
+		InertiaController{ControllerNameMatcher: regexp.MustCompile(`^SlowController$`), Duration: 5 * time.Minute},
+	).Inertia
+
+	tests := []struct {
+		name string
+		// inputs
+		inertia Inertia
+		sources []SourcedCondition
+		// expectations on the resulting aggregated metav1.Condition
+		expectedStatus  metav1.ConditionStatus
+		expectedReason  string
+		expectedMessage string
+	}{
+		// --- shape cases (no inertia involvement) ---
+		{
+			name:           "no sources -> Unknown/NoData",
+			inertia:        thirtySecondInertia,
+			sources:        nil,
+			expectedStatus: metav1.ConditionUnknown,
+			expectedReason: "NoData",
+			// no message expected; the aggregate has nothing to say.
+		},
+		{
+			name:    "all sources at default -> defaultStatus/AsExpected with empty-message fallback",
+			inertia: thirtySecondInertia,
+			sources: []SourcedCondition{
+				degradedAt("AController", metav1.ConditionFalse, "NoErrors", "", 1*time.Minute),
+				degradedAt("BController", metav1.ConditionFalse, "NoErrors", "", 1*time.Minute),
+			},
+			expectedStatus:  metav1.ConditionFalse,
+			expectedReason:  "AsExpected",
+			expectedMessage: "All is well",
+		},
+		{
+			name:    "all sources at default with messages -> joined message kept attributable",
+			inertia: thirtySecondInertia,
+			sources: []SourcedCondition{
+				degradedAt("AController", metav1.ConditionFalse, "NoErrors", "everything green", 1*time.Minute),
+				degradedAt("BController", metav1.ConditionFalse, "NoErrors", "all good", 1*time.Minute),
+			},
+			expectedStatus:  metav1.ConditionFalse,
+			expectedReason:  "AsExpected",
+			expectedMessage: "AController: everything green\nBController: all good",
+		},
+		{
+			name:    "ignores conditions whose type does not match",
+			inertia: thirtySecondInertia,
+			sources: []SourcedCondition{
+				{
+					ControllerName: "AController",
+					Condition: metav1.Condition{
+						Type:               "Available",
+						Status:             metav1.ConditionTrue,
+						LastTransitionTime: metav1.NewTime(fixedNow.Add(-time.Hour)),
+					},
+				},
+			},
+			expectedStatus: metav1.ConditionUnknown,
+			expectedReason: "NoData",
+		},
+
+		// --- inertia: nil disables flap protection entirely ---
+		{
+			name:    "nil inertia propagates a brand-new Degraded=True immediately",
+			inertia: nil,
+			sources: []SourcedCondition{
+				degradedAt("AController", metav1.ConditionTrue, "Failed", "boom", 1*time.Second),
+			},
+			expectedStatus:  metav1.ConditionTrue,
+			expectedReason:  "AController_Failed",
+			expectedMessage: "AController: boom",
+		},
+
+		// --- inertia: 30s default window ---
+		{
+			name:    "single bad source within 30s inertia is hidden as default/AsExpected",
+			inertia: thirtySecondInertia,
+			sources: []SourcedCondition{
+				degradedAt("AController", metav1.ConditionTrue, "Failed", "boom", 10*time.Second),
+			},
+			expectedStatus:  metav1.ConditionFalse,
+			expectedReason:  "AsExpected",
+			expectedMessage: "AController: boom",
+		},
+		{
+			name:    "bad source past 30s inertia flips aggregate to True",
+			inertia: thirtySecondInertia,
+			sources: []SourcedCondition{
+				degradedAt("AController", metav1.ConditionTrue, "Failed", "boom", 31*time.Second),
+			},
+			expectedStatus:  metav1.ConditionTrue,
+			expectedReason:  "AController_Failed",
+			expectedMessage: "AController: boom",
+		},
+		{
+			name:    "bad source exactly at inertia boundary is not yet elder (strictly Before required)",
+			inertia: thirtySecondInertia,
+			sources: []SourcedCondition{
+				degradedAt("AController", metav1.ConditionTrue, "Failed", "boom", 30*time.Second),
+			},
+			expectedStatus:  metav1.ConditionFalse,
+			expectedReason:  "AsExpected",
+			expectedMessage: "AController: boom",
+		},
+		{
+			name:    "mix of fresh and elder bad sources: elder drives the flip, aggregated text covers all bad sources",
+			inertia: thirtySecondInertia,
+			sources: []SourcedCondition{
+				degradedAt("ElderController", metav1.ConditionTrue, "Failed", "long-standing", 2*time.Minute),
+				degradedAt("FreshController", metav1.ConditionTrue, "Failed", "just happened", 5*time.Second),
+				degradedAt("GoodController", metav1.ConditionFalse, "NoErrors", "fine", 1*time.Minute),
+			},
+			// Once elderBad is non-empty the aggregate flips, and the message/reason
+			// then enumerate every bad source (matching library-go). GoodController
+			// is not "bad", so it does not contribute.
+			expectedStatus:  metav1.ConditionTrue,
+			expectedReason:  "ElderController_Failed::FreshController_Failed",
+			expectedMessage: "ElderController: long-standing\nFreshController: just happened",
+		},
+		{
+			name:    "all bad sources fresh -> aggregate stays default and reports all-good (flap protection working)",
+			inertia: thirtySecondInertia,
+			sources: []SourcedCondition{
+				degradedAt("AController", metav1.ConditionTrue, "Failed", "transient blip", 5*time.Second),
+			},
+			expectedStatus:  metav1.ConditionFalse,
+			expectedReason:  "AsExpected",
+			expectedMessage: "AController: transient blip",
+		},
+
+		// --- inertia: per-controller override ---
+		{
+			name:    "per-controller override: SlowController stays in inertia window while NormalController flips",
+			inertia: perControllerInertia,
+			sources: []SourcedCondition{
+				// 2m old: would flip if it had the default 30s, but SlowController has 5m so it is
+				// still in its inertia window and is NOT counted as elder. The aggregated reason and
+				// message still mention all bad sources (matching library-go's behavior), but the
+				// aggregate would not have flipped without the elder NormalController below.
+				degradedAt("SlowController", metav1.ConditionTrue, "Failed", "still settling", 2*time.Minute),
+				// 1m old: default 30s so it is elder, and drives the flip.
+				degradedAt("NormalController", metav1.ConditionTrue, "Failed", "boom", 1*time.Minute),
+			},
+			expectedStatus:  metav1.ConditionTrue,
+			expectedReason:  "NormalController_Failed::SlowController_Failed",
+			expectedMessage: "NormalController: boom\nSlowController: still settling",
+		},
+		{
+			name:    "per-controller override: SlowController alone within window -> no flip",
+			inertia: perControllerInertia,
+			sources: []SourcedCondition{
+				degradedAt("SlowController", metav1.ConditionTrue, "Failed", "still settling", 2*time.Minute),
+			},
+			// 2m old < 5m override window -> elderBad is empty -> all-good path.
+			expectedStatus:  metav1.ConditionFalse,
+			expectedReason:  "AsExpected",
+			expectedMessage: "SlowController: still settling",
+		},
+		{
+			name:    "per-controller override: SlowController past its 5m window also flips",
+			inertia: perControllerInertia,
+			sources: []SourcedCondition{
+				degradedAt("SlowController", metav1.ConditionTrue, "Failed", "really stuck", 6*time.Minute),
+				degradedAt("NormalController", metav1.ConditionFalse, "NoErrors", "fine", 1*time.Minute),
+			},
+			expectedStatus:  metav1.ConditionTrue,
+			expectedReason:  "SlowController_Failed",
+			expectedMessage: "SlowController: really stuck",
+		},
+
+		// --- aggregation of multiple elder bad sources ---
+		{
+			name:    "multiple elder bad sources -> sorted-by-controller reason, joined message",
+			inertia: thirtySecondInertia,
+			sources: []SourcedCondition{
+				// Deliberately out-of-order to verify sort.
+				degradedAt("Zeta", metav1.ConditionTrue, "Failed", "zeta broke", 2*time.Minute),
+				degradedAt("Alpha", metav1.ConditionTrue, "Crashed", "alpha broke", 2*time.Minute),
+			},
+			expectedStatus:  metav1.ConditionTrue,
+			expectedReason:  "Alpha_Crashed::Zeta_Failed",
+			expectedMessage: "Alpha: alpha broke\nZeta: zeta broke",
+		},
+		{
+			name:    "elder bad source with empty reason -> reason carries only the controller name",
+			inertia: thirtySecondInertia,
+			sources: []SourcedCondition{
+				degradedAt("AController", metav1.ConditionTrue, "", "boom", 2*time.Minute),
+			},
+			expectedStatus:  metav1.ConditionTrue,
+			expectedReason:  "AController",
+			expectedMessage: "AController: boom",
+		},
+		{
+			name:    "elder bad source with empty message contributes nothing to the joined message",
+			inertia: thirtySecondInertia,
+			sources: []SourcedCondition{
+				degradedAt("AController", metav1.ConditionTrue, "Failed", "", 2*time.Minute),
+				degradedAt("BController", metav1.ConditionTrue, "Failed", "real failure", 2*time.Minute),
+			},
+			expectedStatus:  metav1.ConditionTrue,
+			expectedReason:  "AController_Failed::BController_Failed",
+			expectedMessage: "BController: real failure",
+		},
+		{
+			name:    "duplicate message lines from a single source are deduped",
+			inertia: thirtySecondInertia,
+			sources: []SourcedCondition{
+				degradedAt("AController", metav1.ConditionTrue, "Failed", "line one\nline one\nline two", 2*time.Minute),
+			},
+			expectedStatus:  metav1.ConditionTrue,
+			expectedReason:  "AController_Failed",
+			expectedMessage: "AController: line one\nAController: line two",
+		},
+
+		// --- Unknown handling ---
+		{
+			name:    "Unknown-status bad source past inertia -> aggregate Unknown",
+			inertia: thirtySecondInertia,
+			sources: []SourcedCondition{
+				degradedAt("AController", metav1.ConditionUnknown, "Investigating", "still figuring out", 2*time.Minute),
+			},
+			// One Unknown bad source and no True bad sources -> aggregate stays at Unknown
+			// (the initial badConditionStatus value).
+			expectedStatus:  metav1.ConditionUnknown,
+			expectedReason:  "AController_Investigating",
+			expectedMessage: "AController: still figuring out",
+		},
+		{
+			name:    "Unknown + True bad sources past inertia -> True wins for the aggregate status",
+			inertia: thirtySecondInertia,
+			sources: []SourcedCondition{
+				degradedAt("AController", metav1.ConditionUnknown, "Investigating", "still figuring out", 2*time.Minute),
+				degradedAt("BController", metav1.ConditionTrue, "Failed", "boom", 2*time.Minute),
+			},
+			expectedStatus:  metav1.ConditionTrue,
+			expectedReason:  "AController_Investigating::BController_Failed",
+			expectedMessage: "AController: still figuring out\nBController: boom",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := UnionCondition(degradedConditionType, metav1.ConditionFalse, tc.inertia, fixedNow, tc.sources...)
+			assert.Equal(t, tc.expectedStatus, got.Status, "status")
+			assert.Equal(t, tc.expectedReason, got.Reason, "reason")
+			assert.Equal(t, tc.expectedMessage, got.Message, "message")
+		})
+	}
+}
+
+// TestUnionCondition_LatestTransitionTime confirms that the
+// LastTransitionTime on the aggregated condition is taken from the source
+// that drives the result (newest interesting source when good, newest bad
+// source when flipped). Kept separate so the main table-driven test stays
+// focused on status / reason / message.
+func TestUnionCondition_LatestTransitionTime(t *testing.T) {
+	tests := []struct {
+		name    string
+		inertia Inertia
+		sources []SourcedCondition
+		// expectedLastTransition is computed relative to fixedNow.
+		expectedAge time.Duration
+	}{
+		{
+			name:    "all-good: pick the most recent interesting source",
+			inertia: MustNewInertia(30 * time.Second).Inertia,
+			sources: []SourcedCondition{
+				degradedAt("AController", metav1.ConditionFalse, "NoErrors", "", 2*time.Minute),
+				degradedAt("BController", metav1.ConditionFalse, "NoErrors", "", 10*time.Second),
+			},
+			expectedAge: 10 * time.Second,
+		},
+		{
+			name:    "elder-bad: pick the most recent bad source (which is still old enough to be elder)",
+			inertia: MustNewInertia(30 * time.Second).Inertia,
+			sources: []SourcedCondition{
+				degradedAt("AController", metav1.ConditionTrue, "Failed", "boom", 5*time.Minute),
+				degradedAt("BController", metav1.ConditionTrue, "Failed", "boom", 1*time.Minute),
+			},
+			expectedAge: 1 * time.Minute,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := UnionCondition(degradedConditionType, metav1.ConditionFalse, tc.inertia, fixedNow, tc.sources...)
+			assert.True(t, got.LastTransitionTime.Time.Equal(fixedNow.Add(-tc.expectedAge)),
+				"expected LastTransitionTime %v, got %v", fixedNow.Add(-tc.expectedAge), got.LastTransitionTime.Time)
+		})
+	}
+}

--- a/backend/pkg/informers/informers.go
+++ b/backend/pkg/informers/informers.go
@@ -614,10 +614,15 @@ func resourceGroupIndexFunc(obj interface{}) ([]string, error) {
 	}
 }
 
-// findAncestorResourceID walks up the resource ID parent chain looking for
-// a resource matching the given type. Returns the lowercased string form
-// of the first match, or nil if no match is found.
-func findAncestorResourceID(resourceType azcorearm.ResourceType, resourceID *azcorearm.ResourceID) ([]string, error) {
+// selfOrDirectParentResourceID returns the lowercased resource ID string of
+// either resourceID itself (when its type matches) or its direct Parent (when
+// the parent's type matches). It is non-recursive on purpose: indexing by
+// "self-or-direct-parent" gives ListFor<Cluster|NodePool|ExternalAuth> the
+// "direct child only" semantics we want, so e.g. a Controller hanging off a
+// NodePool is indexed under that NodePool but NOT under the grandparent
+// Cluster. If a future caller needs a deeper-ancestor lookup, add a separate
+// helper for that case rather than reintroducing recursion here.
+func selfOrDirectParentResourceID(resourceType azcorearm.ResourceType, resourceID *azcorearm.ResourceID) ([]string, error) {
 	if resourceID == nil {
 		return nil, nil
 	}
@@ -627,7 +632,10 @@ func findAncestorResourceID(resourceType azcorearm.ResourceType, resourceID *azc
 	if resourceID.Parent == nil {
 		return nil, nil
 	}
-	return findAncestorResourceID(resourceType, resourceID.Parent)
+	if armhelpers.ResourceTypeEqual(resourceID.Parent.ResourceType, resourceType) {
+		return []string{strings.ToLower(resourceID.Parent.String())}, nil
+	}
+	return nil, nil
 }
 
 func clusterResourceIDIndexFunc(obj interface{}) ([]string, error) {
@@ -642,7 +650,7 @@ func clusterResourceIDIndexFunc(obj interface{}) ([]string, error) {
 }
 
 func clusterResourceIDFromResourceID(resourceID *azcorearm.ResourceID) ([]string, error) {
-	return findAncestorResourceID(api.ClusterResourceType, resourceID)
+	return selfOrDirectParentResourceID(api.ClusterResourceType, resourceID)
 }
 
 func externalAuthResourceIDIndexFunc(obj interface{}) ([]string, error) {
@@ -657,7 +665,7 @@ func externalAuthResourceIDIndexFunc(obj interface{}) ([]string, error) {
 }
 
 func externalAuthResourceIDFromResourceID(resourceID *azcorearm.ResourceID) ([]string, error) {
-	return findAncestorResourceID(api.ExternalAuthResourceType, resourceID)
+	return selfOrDirectParentResourceID(api.ExternalAuthResourceType, resourceID)
 }
 
 // activeOperationResourceGroupIndexFunc indexes operations by the resource group
@@ -701,7 +709,7 @@ func nodePoolResourceIDIndexFunc(obj interface{}) ([]string, error) {
 }
 
 func nodePoolResourceIDFromResourceID(resourceID *azcorearm.ResourceID) ([]string, error) {
-	return findAncestorResourceID(api.NodePoolResourceType, resourceID)
+	return selfOrDirectParentResourceID(api.NodePoolResourceType, resourceID)
 }
 
 // billingDocSubscriptionIndexFunc indexes billing documents by their subscription ID.

--- a/backend/pkg/listertesting/slice_listers.go
+++ b/backend/pkg/listertesting/slice_listers.go
@@ -408,3 +408,73 @@ func (l *SliceBillingLister) ListForSubscription(ctx context.Context, subscripti
 	}
 	return result, nil
 }
+
+// SliceControllerLister implements listers.ControllerLister backed by a
+// slice. The List-for-parent methods filter to controllers whose resource
+// ID hangs DIRECTLY off the requested parent — i.e. they have exactly one
+// path segment beyond the parent's resource ID. That excludes
+// controllers nested further down (e.g. a node-pool controller is not
+// returned by ListForCluster for that node pool's parent cluster).
+type SliceControllerLister struct {
+	Controllers []*api.Controller
+}
+
+var _ listers.ControllerLister = &SliceControllerLister{}
+
+func (l *SliceControllerLister) List(_ context.Context) ([]*api.Controller, error) {
+	return l.Controllers, nil
+}
+
+func (l *SliceControllerLister) ListForResourceGroup(_ context.Context, subscriptionID, resourceGroupName string) ([]*api.Controller, error) {
+	out := []*api.Controller{}
+	for _, c := range l.Controllers {
+		if c.ResourceID == nil {
+			continue
+		}
+		if strings.EqualFold(c.ResourceID.SubscriptionID, subscriptionID) &&
+			strings.EqualFold(c.ResourceID.ResourceGroupName, resourceGroupName) {
+			out = append(out, c)
+		}
+	}
+	return out, nil
+}
+
+func (l *SliceControllerLister) ListForCluster(_ context.Context, subscriptionID, resourceGroupName, clusterName string) ([]*api.Controller, error) {
+	return listControllersUnderPrefix(l.Controllers,
+		api.ToClusterResourceIDString(subscriptionID, resourceGroupName, clusterName))
+}
+
+func (l *SliceControllerLister) ListForNodePool(_ context.Context, subscriptionID, resourceGroupName, clusterName, nodePoolName string) ([]*api.Controller, error) {
+	return listControllersUnderPrefix(l.Controllers,
+		api.ToNodePoolResourceIDString(subscriptionID, resourceGroupName, clusterName, nodePoolName))
+}
+
+func (l *SliceControllerLister) ListForExternalAuth(_ context.Context, subscriptionID, resourceGroupName, clusterName, externalAuthName string) ([]*api.Controller, error) {
+	return listControllersUnderPrefix(l.Controllers,
+		api.ToExternalAuthResourceIDString(subscriptionID, resourceGroupName, clusterName, externalAuthName))
+}
+
+// listControllersUnderPrefix returns the controllers whose ResourceID is a
+// direct child of parentResourceID — exactly one path segment-pair (type +
+// name) below the parent.
+func listControllersUnderPrefix(controllers []*api.Controller, parentResourceID string) ([]*api.Controller, error) {
+	prefix := strings.ToLower(parentResourceID) + "/"
+	out := []*api.Controller{}
+	for _, c := range controllers {
+		if c.ResourceID == nil {
+			continue
+		}
+		lowered := strings.ToLower(c.ResourceID.String())
+		if !strings.HasPrefix(lowered, prefix) {
+			continue
+		}
+		rest := strings.TrimPrefix(lowered, prefix)
+		// A direct child has exactly one "/" in the trailing segment:
+		// "<resourceType>/<name>".
+		if strings.Count(rest, "/") != 1 {
+			continue
+		}
+		out = append(out, c)
+	}
+	return out, nil
+}


### PR DESCRIPTION
These are for internal use. We could use similar techniques for a condition we'll expose to customers to determine reason and message.