### PR TITLE
feature: adding additional labels to titles and correlation ids for msft alerts

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedMsftPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedMsftPrometheusAlertingRules.bicep
@@ -110,12 +110,12 @@ resource msftKubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroup
           severity: 'info'
         }
         annotations: {
-          correlationId: 'KubeQuotaAlmostFull/{{ $labels.cluster }}'
+          correlationId: 'KubeQuotaAlmostFull/{{ $labels.cluster }}/{{ $labels.namespace }}/{{ $labels.resource }}'
           description: 'Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage }} of its {{ $labels.resource }} quota.'
           info: 'Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage }} of its {{ $labels.resource }} quota.'
           runbook_url: 'https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubequotaalmostfull'
           summary: 'Namespace quota is going to be full.'
-          title: 'Namespace quota is going to be full.'
+          title: 'Namespace quota is going to be full. namespace:{{ $labels.namespace }} resource:{{ $labels.resource }}'
         }
         expression: 'kube_resourcequota{job="kube-state-metrics", type="used"} / ignoring(instance, job, type) (kube_resourcequota{job="kube-state-metrics", type="hard"} > 0) > 0.9 < 1'
         for: 'PT15M'
@@ -137,12 +137,12 @@ resource msftKubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroup
           severity: 'info'
         }
         annotations: {
-          correlationId: 'KubeQuotaFullyUsed/{{ $labels.cluster }}'
+          correlationId: 'KubeQuotaFullyUsed/{{ $labels.cluster }}/{{ $labels.namespace }}/{{ $labels.resource }}'
           description: 'Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage }} of its {{ $labels.resource }} quota.'
           info: 'Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage }} of its {{ $labels.resource }} quota.'
           runbook_url: 'https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubequotafullyused'
           summary: 'Namespace quota is fully used.'
-          title: 'Namespace quota is fully used.'
+          title: 'Namespace quota is fully used. namespace:{{ $labels.namespace }} resource:{{ $labels.resource }}'
         }
         expression: 'kube_resourcequota{job="kube-state-metrics", type="used"} / ignoring(instance, job, type) (kube_resourcequota{job="kube-state-metrics", type="hard"} > 0) == 1'
         for: 'PT15M'
@@ -164,12 +164,12 @@ resource msftKubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroup
           severity: 'warning'
         }
         annotations: {
-          correlationId: 'KubeQuotaExceeded/{{ $labels.cluster }}'
+          correlationId: 'KubeQuotaExceeded/{{ $labels.cluster }}/{{ $labels.namespace }}/{{ $labels.resource }}'
           description: 'Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage }} of its {{ $labels.resource }} quota.'
           info: 'Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage }} of its {{ $labels.resource }} quota.'
           runbook_url: 'https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubequotaexceeded'
           summary: 'Namespace quota has exceeded the limits.'
-          title: 'Namespace quota has exceeded the limits.'
+          title: 'Namespace quota has exceeded the limits. namespace:{{ $labels.namespace }} resource:{{ $labels.resource }}'
         }
         expression: 'kube_resourcequota{job="kube-state-metrics", type="used"} / ignoring(instance, job, type) (kube_resourcequota{job="kube-state-metrics", type="hard"} > 0) > 1'
         for: 'PT15M'
@@ -204,12 +204,12 @@ resource msftKubernetesStorage 'Microsoft.AlertsManagement/prometheusRuleGroups@
           severity: 'critical'
         }
         annotations: {
-          correlationId: 'KubePersistentVolumeErrors/{{ $labels.cluster }}'
+          correlationId: 'KubePersistentVolumeErrors/{{ $labels.cluster }}/{{ $labels.persistentvolume }}/{{ $labels.phase }}'
           description: 'The persistent volume {{ $labels.persistentvolume }} {{ with $labels.cluster -}} on Cluster {{ . }} {{- end }} has status {{ $labels.phase }}.'
           info: 'The persistent volume {{ $labels.persistentvolume }} {{ with $labels.cluster -}} on Cluster {{ . }} {{- end }} has status {{ $labels.phase }}.'
           runbook_url: 'https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubepersistentvolumeerrors'
           summary: 'PersistentVolume is having issues with provisioning.'
-          title: 'PersistentVolume is having issues with provisioning.'
+          title: 'PersistentVolume is having issues with provisioning. persistentvolume:{{ $labels.persistentvolume }} phase:{{ $labels.phase }}'
         }
         expression: 'kube_persistentvolume_status_phase{phase=~"Failed|Pending",job="kube-state-metrics"} > 0'
         for: 'PT5M'
@@ -244,12 +244,12 @@ resource msftKubernetesSystem 'Microsoft.AlertsManagement/prometheusRuleGroups@2
           severity: 'warning'
         }
         annotations: {
-          correlationId: 'KubeClientErrors/{{ $labels.cluster }}'
+          correlationId: 'KubeClientErrors/{{ $labels.cluster }}/{{ $labels.job }}/{{ $labels.instance }}'
           description: 'Kubernetes API server client \'{{ $labels.job }}/{{ $labels.instance }}\' is experiencing {{ $value | humanizePercentage }} errors.\''
           info: 'Kubernetes API server client \'{{ $labels.job }}/{{ $labels.instance }}\' is experiencing {{ $value | humanizePercentage }} errors.\''
           runbook_url: 'https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeclienterrors'
           summary: 'Kubernetes API server client is experiencing errors.'
-          title: 'Kubernetes API server client is experiencing errors.'
+          title: 'Kubernetes API server client is experiencing errors. job:{{ $labels.job }} instance:{{ $labels.instance }}'
         }
         expression: '(sum(rate(rest_client_requests_total{job="controlplane-apiserver",code=~"5.."}[5m])) by (cluster, instance, job, namespace) / sum(rate(rest_client_requests_total{job="controlplane-apiserver"}[5m])) by (cluster, instance, job, namespace)) > 0.01'
         for: 'PT15M'
@@ -467,12 +467,12 @@ resource msftKubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRul
           severity: 'warning'
         }
         annotations: {
-          correlationId: 'KubeAggregatedAPIErrors/{{ $labels.cluster }}'
+          correlationId: 'KubeAggregatedAPIErrors/{{ $labels.cluster }}/{{ $labels.name }}/{{ $labels.namespace }}'
           description: 'Kubernetes aggregated API {{ $labels.name }}/{{ $labels.namespace }} has reported errors. It has appeared unavailable {{ $value | humanize }} times averaged over the past 10m.'
           info: 'Kubernetes aggregated API {{ $labels.name }}/{{ $labels.namespace }} has reported errors. It has appeared unavailable {{ $value | humanize }} times averaged over the past 10m.'
           runbook_url: 'https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeaggregatedapierrors'
           summary: 'Kubernetes aggregated API has reported errors.'
-          title: 'Kubernetes aggregated API has reported errors.'
+          title: 'Kubernetes aggregated API has reported errors. name:{{ $labels.name }} namespace:{{ $labels.namespace }}'
         }
         expression: 'sum by(name, namespace, cluster)(increase(aggregator_unavailable_apiservice_total{job="controlplane-apiserver"}[10m])) > 4'
         severity: 3
@@ -493,12 +493,12 @@ resource msftKubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRul
           severity: 'warning'
         }
         annotations: {
-          correlationId: 'KubeAggregatedAPIDown/{{ $labels.cluster }}'
+          correlationId: 'KubeAggregatedAPIDown/{{ $labels.cluster }}/{{ $labels.name }}/{{ $labels.namespace }}'
           description: 'Kubernetes aggregated API {{ $labels.name }}/{{ $labels.namespace }} has been only {{ $value | humanize }}% available over the last 10m.'
           info: 'Kubernetes aggregated API {{ $labels.name }}/{{ $labels.namespace }} has been only {{ $value | humanize }}% available over the last 10m.'
           runbook_url: 'https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeaggregatedapidown'
           summary: 'Kubernetes aggregated API is down.'
-          title: 'Kubernetes aggregated API is down.'
+          title: 'Kubernetes aggregated API is down. name:{{ $labels.name }} namespace:{{ $labels.namespace }}'
         }
         expression: '(1 - max by(name, namespace, cluster)(avg_over_time(aggregator_unavailable_apiservice{job="controlplane-apiserver"}[10m]))) * 100 < 85'
         for: 'PT5M'
@@ -587,12 +587,12 @@ resource msftKubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleG
           severity: 'warning'
         }
         annotations: {
-          correlationId: 'KubeNodeNotReady/{{ $labels.cluster }}'
+          correlationId: 'KubeNodeNotReady/{{ $labels.cluster }}/{{ $labels.node }}'
           description: '{{ $labels.node }} has been unready for more than 15 minutes.'
           info: '{{ $labels.node }} has been unready for more than 15 minutes.'
           runbook_url: 'https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubenodenotready'
           summary: 'Node is not ready.'
-          title: 'Node is not ready.'
+          title: 'Node is not ready. node:{{ $labels.node }}'
         }
         expression: 'kube_node_status_condition{job="kube-state-metrics",condition="Ready",status="true"} == 0'
         for: 'PT15M'
@@ -614,12 +614,12 @@ resource msftKubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleG
           severity: 'warning'
         }
         annotations: {
-          correlationId: 'KubeNodeUnreachable/{{ $labels.cluster }}'
+          correlationId: 'KubeNodeUnreachable/{{ $labels.cluster }}/{{ $labels.node }}'
           description: '{{ $labels.node }} is unreachable and some workloads may be rescheduled.'
           info: '{{ $labels.node }} is unreachable and some workloads may be rescheduled.'
           runbook_url: 'https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubenodeunreachable'
           summary: 'Node is unreachable.'
-          title: 'Node is unreachable.'
+          title: 'Node is unreachable. node:{{ $labels.node }}'
         }
         expression: '(kube_node_spec_taint{job="kube-state-metrics",key="node.kubernetes.io/unreachable",effect="NoSchedule"} unless ignoring(key,value) kube_node_spec_taint{job="kube-state-metrics",key=~"ToBeDeletedByClusterAutoscaler|cloud.google.com/impending-node-termination|aws-node-termination-handler/spot-itn"}) == 1'
         for: 'PT15M'
@@ -641,12 +641,12 @@ resource msftKubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleG
           severity: 'info'
         }
         annotations: {
-          correlationId: 'KubeletTooManyPods/{{ $labels.cluster }}'
+          correlationId: 'KubeletTooManyPods/{{ $labels.cluster }}/{{ $labels.node }}'
           description: 'Kubelet \'{{ $labels.node }}\' is running at {{ $value | humanizePercentage }} of its Pod capacity.'
           info: 'Kubelet \'{{ $labels.node }}\' is running at {{ $value | humanizePercentage }} of its Pod capacity.'
           runbook_url: 'https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubelettoomanypods'
           summary: 'Kubelet is running at capacity.'
-          title: 'Kubelet is running at capacity.'
+          title: 'Kubelet is running at capacity. node:{{ $labels.node }}'
         }
         expression: 'count by(cluster, node) ( (kube_pod_status_phase{job="kube-state-metrics",phase="Running"} == 1) * on(instance,pod,namespace,cluster) group_left(node) topk by(instance,pod,namespace,cluster) (1, kube_pod_info{job="kube-state-metrics"}) ) / max by(cluster, node) ( kube_node_status_capacity{job="kube-state-metrics",resource="pods"} != 1 ) > 0.95'
         for: 'PT15M'
@@ -668,12 +668,12 @@ resource msftKubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleG
           severity: 'warning'
         }
         annotations: {
-          correlationId: 'KubeNodeReadinessFlapping/{{ $labels.cluster }}'
+          correlationId: 'KubeNodeReadinessFlapping/{{ $labels.cluster }}/{{ $labels.node }}'
           description: 'The readiness status of node {{ $labels.node }} has changed {{ $value }} times in the last 15 minutes.'
           info: 'The readiness status of node {{ $labels.node }} has changed {{ $value }} times in the last 15 minutes.'
           runbook_url: 'https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubenodereadinessflapping'
           summary: 'Node readiness status is flapping.'
-          title: 'Node readiness status is flapping.'
+          title: 'Node readiness status is flapping. node:{{ $labels.node }}'
         }
         expression: 'sum(changes(kube_node_status_condition{job="kube-state-metrics",status="true",condition="Ready"}[15m])) by (cluster, node) > 2'
         for: 'PT15M'
@@ -695,12 +695,12 @@ resource msftKubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleG
           severity: 'warning'
         }
         annotations: {
-          correlationId: 'KubeletPlegDurationHigh/{{ $labels.cluster }}'
+          correlationId: 'KubeletPlegDurationHigh/{{ $labels.cluster }}/{{ $labels.node }}'
           description: 'The Kubelet Pod Lifecycle Event Generator has a 99th percentile duration of {{ $value }} seconds on node {{ $labels.node }}.'
           info: 'The Kubelet Pod Lifecycle Event Generator has a 99th percentile duration of {{ $value }} seconds on node {{ $labels.node }}.'
           runbook_url: 'https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeletplegdurationhigh'
           summary: 'Kubelet Pod Lifecycle Event Generator is taking too long to relist.'
-          title: 'Kubelet Pod Lifecycle Event Generator is taking too long to relist.'
+          title: 'Kubelet Pod Lifecycle Event Generator is taking too long to relist. node:{{ $labels.node }}'
         }
         expression: 'node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile{quantile="0.99"} >= 10'
         for: 'PT5M'
@@ -722,12 +722,12 @@ resource msftKubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleG
           severity: 'warning'
         }
         annotations: {
-          correlationId: 'KubeletPodStartUpLatencyHigh/{{ $labels.cluster }}'
+          correlationId: 'KubeletPodStartUpLatencyHigh/{{ $labels.cluster }}/{{ $labels.node }}'
           description: 'Kubelet Pod startup 99th percentile latency is {{ $value }} seconds on node {{ $labels.node }}.'
           info: 'Kubelet Pod startup 99th percentile latency is {{ $value }} seconds on node {{ $labels.node }}.'
           runbook_url: 'https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeletpodstartuplatencyhigh'
           summary: 'Kubelet Pod startup latency is too high.'
-          title: 'Kubelet Pod startup latency is too high.'
+          title: 'Kubelet Pod startup latency is too high. node:{{ $labels.node }}'
         }
         expression: 'histogram_quantile(0.99, sum(rate(kubelet_pod_worker_duration_seconds_bucket{job="kubelet", metrics_path="/metrics"}[5m])) by (cluster, instance, le)) * on(cluster, instance) group_left(node) kubelet_node_name{job="kubelet", metrics_path="/metrics"} > 60'
         for: 'PT15M'
@@ -749,12 +749,12 @@ resource msftKubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleG
           severity: 'warning'
         }
         annotations: {
-          correlationId: 'KubeletClientCertificateExpiration/{{ $labels.cluster }}'
+          correlationId: 'KubeletClientCertificateExpiration/{{ $labels.cluster }}/{{ $labels.node }}'
           description: 'Client certificate for Kubelet on node {{ $labels.node }} expires in {{ $value | humanizeDuration }}.'
           info: 'Client certificate for Kubelet on node {{ $labels.node }} expires in {{ $value | humanizeDuration }}.'
           runbook_url: 'https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeletclientcertificateexpiration'
           summary: 'Kubelet client certificate is about to expire.'
-          title: 'Kubelet client certificate is about to expire.'
+          title: 'Kubelet client certificate is about to expire. node:{{ $labels.node }}'
         }
         expression: 'kubelet_certificate_manager_client_ttl_seconds < 604800'
         severity: 3
@@ -775,12 +775,12 @@ resource msftKubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleG
           severity: 'critical'
         }
         annotations: {
-          correlationId: 'KubeletClientCertificateExpiration/{{ $labels.cluster }}'
+          correlationId: 'KubeletClientCertificateExpiration/{{ $labels.cluster }}/{{ $labels.node }}'
           description: 'Client certificate for Kubelet on node {{ $labels.node }} expires in {{ $value | humanizeDuration }}.'
           info: 'Client certificate for Kubelet on node {{ $labels.node }} expires in {{ $value | humanizeDuration }}.'
           runbook_url: 'https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeletclientcertificateexpiration'
           summary: 'Kubelet client certificate is about to expire.'
-          title: 'Kubelet client certificate is about to expire.'
+          title: 'Kubelet client certificate is about to expire. node:{{ $labels.node }}'
         }
         expression: 'kubelet_certificate_manager_client_ttl_seconds < 86400'
         severity: 2
@@ -801,12 +801,12 @@ resource msftKubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleG
           severity: 'warning'
         }
         annotations: {
-          correlationId: 'KubeletServerCertificateExpiration/{{ $labels.cluster }}'
+          correlationId: 'KubeletServerCertificateExpiration/{{ $labels.cluster }}/{{ $labels.node }}'
           description: 'Server certificate for Kubelet on node {{ $labels.node }} expires in {{ $value | humanizeDuration }}.'
           info: 'Server certificate for Kubelet on node {{ $labels.node }} expires in {{ $value | humanizeDuration }}.'
           runbook_url: 'https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeletservercertificateexpiration'
           summary: 'Kubelet server certificate is about to expire.'
-          title: 'Kubelet server certificate is about to expire.'
+          title: 'Kubelet server certificate is about to expire. node:{{ $labels.node }}'
         }
         expression: 'kubelet_certificate_manager_server_ttl_seconds < 604800'
         severity: 3
@@ -827,12 +827,12 @@ resource msftKubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleG
           severity: 'critical'
         }
         annotations: {
-          correlationId: 'KubeletServerCertificateExpiration/{{ $labels.cluster }}'
+          correlationId: 'KubeletServerCertificateExpiration/{{ $labels.cluster }}/{{ $labels.node }}'
           description: 'Server certificate for Kubelet on node {{ $labels.node }} expires in {{ $value | humanizeDuration }}.'
           info: 'Server certificate for Kubelet on node {{ $labels.node }} expires in {{ $value | humanizeDuration }}.'
           runbook_url: 'https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeletservercertificateexpiration'
           summary: 'Kubelet server certificate is about to expire.'
-          title: 'Kubelet server certificate is about to expire.'
+          title: 'Kubelet server certificate is about to expire. node:{{ $labels.node }}'
         }
         expression: 'kubelet_certificate_manager_server_ttl_seconds < 86400'
         severity: 2
@@ -853,12 +853,12 @@ resource msftKubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleG
           severity: 'warning'
         }
         annotations: {
-          correlationId: 'KubeletClientCertificateRenewalErrors/{{ $labels.cluster }}'
+          correlationId: 'KubeletClientCertificateRenewalErrors/{{ $labels.cluster }}/{{ $labels.node }}'
           description: 'Kubelet on node {{ $labels.node }} has failed to renew its client certificate ({{ $value | humanize }} errors in the last 5 minutes).'
           info: 'Kubelet on node {{ $labels.node }} has failed to renew its client certificate ({{ $value | humanize }} errors in the last 5 minutes).'
           runbook_url: 'https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeletclientcertificaterenewalerrors'
           summary: 'Kubelet has failed to renew its client certificate.'
-          title: 'Kubelet has failed to renew its client certificate.'
+          title: 'Kubelet has failed to renew its client certificate. node:{{ $labels.node }}'
         }
         expression: 'increase(kubelet_certificate_manager_client_expiration_renew_errors[5m]) > 0'
         for: 'PT15M'
@@ -880,12 +880,12 @@ resource msftKubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleG
           severity: 'warning'
         }
         annotations: {
-          correlationId: 'KubeletServerCertificateRenewalErrors/{{ $labels.cluster }}'
+          correlationId: 'KubeletServerCertificateRenewalErrors/{{ $labels.cluster }}/{{ $labels.node }}'
           description: 'Kubelet on node {{ $labels.node }} has failed to renew its server certificate ({{ $value | humanize }} errors in the last 5 minutes).'
           info: 'Kubelet on node {{ $labels.node }} has failed to renew its server certificate ({{ $value | humanize }} errors in the last 5 minutes).'
           runbook_url: 'https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeletservercertificaterenewalerrors'
           summary: 'Kubelet has failed to renew its server certificate.'
-          title: 'Kubelet has failed to renew its server certificate.'
+          title: 'Kubelet has failed to renew its server certificate. node:{{ $labels.node }}'
         }
         expression: 'increase(kubelet_server_expiration_renew_errors[5m]) > 0'
         for: 'PT15M'
@@ -1301,12 +1301,12 @@ resource msftPrometheusOperatorRules 'Microsoft.AlertsManagement/prometheusRuleG
           severity: 'warning'
         }
         annotations: {
-          correlationId: 'PrometheusOperatorNotReady/{{ $labels.cluster }}'
+          correlationId: 'PrometheusOperatorNotReady/{{ $labels.cluster }}/{{ $labels.namespace }}'
           description: 'Prometheus operator in {{ $labels.namespace }} namespace isn\'t ready to reconcile {{ $labels.controller }} resources.'
           info: 'Prometheus operator in {{ $labels.namespace }} namespace isn\'t ready to reconcile {{ $labels.controller }} resources.'
           runbook_url: 'https://runbooks.prometheus-operator.dev/runbooks/prometheus-operator/prometheusoperatornotready'
           summary: 'Prometheus operator not ready'
-          title: 'Prometheus operator not ready'
+          title: 'Prometheus operator not ready namespace:{{ $labels.namespace }}'
         }
         expression: 'min by (cluster, controller, namespace) (max_over_time(prometheus_operator_ready{job="prometheus-operator",namespace="prometheus"}[5m])) == 0'
         for: 'PT5M'

--- a/observability/alerts-msft-services.yaml
+++ b/observability/alerts-msft-services.yaml
@@ -93,4 +93,21 @@ prometheusRules:
   # an actual cluster name
   - from: 'absent\(up{job="(.+)"} == 1\)'
     to: 'count by (cluster) (up{job="$1"} == 1) == 0'
+  labelsToExtract:
+  - persistentvolumeclaim
+  - persistentvolume
+  - node
+  - name
+  - job
+  - instance
+  - namespace
+  - horizontalpodautoscaler
+  - deployment
+  - daemonset
+  - statefulset
+  - job_name
+  - pod
+  - container
+  - phase
+  - resource
   groupNamePrefix: "msft-"

--- a/tooling/prometheus-rules/README.md
+++ b/tooling/prometheus-rules/README.md
@@ -15,6 +15,13 @@ This tool converts Kubernetes PrometheusRule custom resources (used by the Prome
 - Automatically generates IcM correlation IDs for proper incident aggregation
 - Supports expression replacements for platform-specific adjustments
 
+## Recent Change
+
+- Added support for `labelsToExtract` in config.
+- During generation, labels listed in `labelsToExtract` are detected from the `description` annotation template text and then appended to generated alert metadata in configured order.
+- This ensures generated alert title/correlation fields can include extra routing context (such as cluster/namespace/pod) without hard-coding those labels in the generator.
+- Using `description` as the signal for which labels to append is not perfectly precise, but for upstream-managed alert sources that cannot be edited directly (for example, `kubernetesControlPlane-prometheusRule.yaml`), it provides a practical way to preserve useful alert scoping.
+
 ## Usage
 
 ### Build

--- a/tooling/prometheus-rules/internal/generator.go
+++ b/tooling/prometheus-rules/internal/generator.go
@@ -31,6 +31,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/utils/ptr"
+	"k8s.io/utils/set"
 
 	"sigs.k8s.io/yaml"
 
@@ -38,6 +39,10 @@ import (
 )
 
 var defaultEvaluationInterval = "1m"
+
+func labelTemplateToken(label string) string {
+	return "{{ $labels." + label + " }}"
+}
 
 type alertingRuleFile struct {
 	DefaultEvaluationInterval string
@@ -57,6 +62,7 @@ type Options struct {
 	promtoolPath            string
 	outputBicep             string
 	includedAlerts          map[string][]string
+	labelsToExtract         []string
 	ruleFiles               []alertingRuleFile
 	outputReplacements      []Replacements
 	regexOutputReplacements []RegexReplacements
@@ -68,6 +74,7 @@ type PrometheusRulesConfig struct {
 	UntestedRules             []string       `json:"untestedRules,omitempty"`
 	OutputBicep               string         `json:"outputBicep"`
 	IncludedAlertsByGroup     []GroupAlerts  `json:"includedAlertsByGroup,omitempty"` // Optional: Only alerts listed here are included; if empty, all alerts are included
+	LabelsToExtract           []string       `json:"labelsToExtract,omitempty"`
 	OutputReplacements        []Replacements `json:"outputReplacements,omitempty"`
 	RegexOutputReplacements   []Replacements `json:"regexOutputReplacements,omitempty"`
 	DefaultEvaluationInterval string         `json:"defaultEvaluationInterval,omitempty"`
@@ -145,6 +152,7 @@ func (o *Options) Complete(configFilePath string, promtoolPath string) error {
 
 	o.outputBicep = path.Join(baseDirectory, config.PrometheusRules.OutputBicep)
 	o.groupNamePrefix = config.PrometheusRules.GroupNamePrefix
+	o.labelsToExtract = append([]string{}, config.PrometheusRules.LabelsToExtract...)
 
 	// Convert includedAlertsByGroup to a map
 	o.includedAlerts = make(map[string][]string)
@@ -268,6 +276,34 @@ func (o *Options) RunTests() error {
 
 var whitespaceMatcher = regexp.MustCompile(`\s*\n\s*`)
 
+func (o *Options) labelsFromTextInConfiguredOrder(text string) []string {
+	if len(o.labelsToExtract) == 0 || text == "" {
+		return nil
+	}
+
+	labelsInDescription := set.New[string]()
+	for _, label := range o.labelsToExtract {
+		if strings.Contains(text, labelTemplateToken(label)) {
+			labelsInDescription.Insert(label)
+		}
+	}
+	orderedLabels := make([]string, 0, len(o.labelsToExtract))
+	seen := set.New[string]()
+
+	for _, labelToExtract := range o.labelsToExtract {
+		if !labelsInDescription.Has(labelToExtract) {
+			continue
+		}
+		if seen.Has(labelToExtract) {
+			continue
+		}
+		seen.Insert(labelToExtract)
+		orderedLabels = append(orderedLabels, labelToExtract)
+	}
+
+	return orderedLabels
+}
+
 func (o *Options) Generate() error {
 	output, err := os.Create(o.outputBicep)
 	if err != nil {
@@ -373,17 +409,31 @@ param location string = resourceGroup().location
 				for k, v := range rule.Annotations {
 					annotations[k] = ptr.To(strings.ReplaceAll(v, "'", "\\'"))
 				}
+
+				descriptionText := ""
 				// Some part of the Azure Monitor stack consumes the `description` annotation, removing it from the
 				// alert context. We want to use this value in our IcM connector, so we need to have it in the alert
 				// context - simply duplicating it in the annotations and referring to our new copy is enough to side-
 				// step the post-processing.
 				if description, exists := annotations["description"]; exists {
+					descriptionText = ptr.Deref(description, "")
 					annotations["info"] = description
 				}
 
-				// If the summary annotation is present, use it as the title. Otherwise, use the alert name as the title.
+				extractedLabels := o.labelsFromTextInConfiguredOrder(descriptionText)
+
+				// If the summary annotation is present, use it as the title.
+				// Append scoped labels based on `labelsToExtract`
+				// Otherwise, use the alert name as the title.
 				if summary, exists := annotations["summary"]; exists {
-					annotations["title"] = summary
+					title := ptr.Deref(summary, "")
+					for _, label := range extractedLabels {
+						if strings.Contains(title, labelTemplateToken(label)) {
+							continue
+						}
+						title = title + " " + label + ":" + labelTemplateToken(label)
+					}
+					annotations["title"] = ptr.To(title)
 				} else {
 					annotations["title"] = ptr.To(rule.Alert)
 				}
@@ -393,7 +443,14 @@ param location string = resourceGroup().location
 				// annotation in their source rule — useful when finer-grained grouping is wanted
 				// (e.g. one incident per hosted cluster, not per management cluster).
 				if _, hasOverride := annotations["correlationId"]; !hasOverride {
-					annotations["correlationId"] = ptr.To(rule.Alert + "/{{ $labels.cluster }}")
+					correlationID := rule.Alert + "/{{ $labels.cluster }}"
+					for _, label := range extractedLabels {
+						if strings.Contains(correlationID, labelTemplateToken(label)) {
+							continue
+						}
+						correlationID += "/" + labelTemplateToken(label)
+					}
+					annotations["correlationId"] = ptr.To(correlationID)
 				}
 
 				// Filter rules based on the output file type

--- a/tooling/prometheus-rules/internal/generator_test.go
+++ b/tooling/prometheus-rules/internal/generator_test.go
@@ -258,6 +258,38 @@ spec:
 			errorMsg:    "error unmarshaling configFile",
 		},
 		{
+			name: "config with labelsToExtract",
+			configFile: `
+prometheusRules:
+  untestedRules:
+  - untested.yaml
+  outputBicep: generated.bicep
+  labelsToExtract:
+  - namespace
+  - pod
+  - container
+`,
+			setupFiles: func(tmpDir string) error {
+				ruleContent := `
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: test-rules
+spec:
+  groups:
+  - name: test.rules
+    rules:
+    - alert: IncludedAlert
+      expr: up == 0
+`
+				return os.WriteFile(filepath.Join(tmpDir, "untested.yaml"), []byte(ruleContent), 0644)
+			},
+			expectError: false,
+			validateFunc: func(t *testing.T, opts *Options) {
+				require.Equal(t, []string{"namespace", "pod", "container"}, opts.labelsToExtract)
+			},
+		},
+		{
 			name: "config with includedAlertsByGroup",
 			configFile: `
 prometheusRules:
@@ -561,6 +593,99 @@ func TestOptionsGenerate(t *testing.T) {
 		generated := string(content)
 		assert.Contains(t, generated, "correlationId: 'hostedcluster-KubeAPIServer-ErrorBudgetBurn/{{ $labels.cluster }}/{{ $labels._id }}'")
 		assert.NotContains(t, generated, "correlationId: 'hostedcluster-KubeAPIServer-ErrorBudgetBurn/{{ $labels.cluster }}'")
+	})
+
+	t.Run("enriches default correlationId and summary title using labelsToExtract", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		outputFile := filepath.Join(tmpDir, "generatedAlertingRules.bicep")
+
+		opts := &Options{
+			outputBicep:     outputFile,
+			labelsToExtract: []string{"cluster", "namespace", "pod", "container"},
+			ruleFiles: []alertingRuleFile{
+				{
+					Rules: monitoringv1.PrometheusRule{
+						Spec: monitoringv1.PrometheusRuleSpec{
+							Groups: []monitoringv1.RuleGroup{
+								{
+									Name: "test-group",
+									Rules: []monitoringv1.Rule{
+										{
+											Alert: "EnrichedAlert",
+											Expr:  intstr.FromString("up == 0"),
+											Labels: map[string]string{
+												"severity": "warning",
+											},
+											Annotations: map[string]string{
+												"summary":     "Pod in namespace {{ $labels.namespace }} is unhealthy",
+												"description": "Pod {{ $labels.namespace }}/{{ $labels.pod }} has issues",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := opts.Generate()
+		assert.NoError(t, err)
+
+		content, err := os.ReadFile(outputFile)
+		assert.NoError(t, err)
+		generated := string(content)
+
+		assert.Contains(t, generated, "correlationId: 'EnrichedAlert/{{ $labels.cluster }}/{{ $labels.namespace }}/{{ $labels.pod }}'")
+		assert.NotContains(t, generated, "{{ $labels.cluster }}/{{ $labels.cluster }}")
+		assert.Contains(t, generated, "title: 'Pod in namespace {{ $labels.namespace }} is unhealthy pod:{{ $labels.pod }}'")
+		assert.NotContains(t, generated, "namespace: {{ $labels.namespace }}")
+	})
+
+	t.Run("does not enrich title when summary is absent", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		outputFile := filepath.Join(tmpDir, "generatedAlertingRules.bicep")
+
+		opts := &Options{
+			outputBicep:     outputFile,
+			labelsToExtract: []string{"namespace", "pod"},
+			ruleFiles: []alertingRuleFile{
+				{
+					Rules: monitoringv1.PrometheusRule{
+						Spec: monitoringv1.PrometheusRuleSpec{
+							Groups: []monitoringv1.RuleGroup{
+								{
+									Name: "test-group",
+									Rules: []monitoringv1.Rule{
+										{
+											Alert: "NoSummaryAlert",
+											Expr:  intstr.FromString("up == 0"),
+											Labels: map[string]string{
+												"severity": "warning",
+											},
+											Annotations: map[string]string{
+												"description": "Pod {{ $labels.namespace }}/{{ $labels.pod }} has issues",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := opts.Generate()
+		assert.NoError(t, err)
+
+		content, err := os.ReadFile(outputFile)
+		assert.NoError(t, err)
+		generated := string(content)
+
+		assert.Contains(t, generated, "title: 'NoSummaryAlert'")
+		assert.NotContains(t, generated, "title: 'NoSummaryAlert namespace:")
 	})
 }
 


### PR DESCRIPTION
[ARO-27539](https://redhat.atlassian.net/browse/ARO-27539?atlOrigin=eyJpIjoiYjcyNjAzYmNmYzRkNDgzOWE0MDA2ZTRiNzNkNWEyNTciLCJwIjoiaiJ9)

### What

<!-- Briefly describe what this PR does -->
This pull request updates several Prometheus alerting rules in `generatedMsftPrometheusAlertingRules.bicep` to improve alert correlation and clarity. The main changes are to the `correlationId` and `title` fields of various alerts, making them more specific by including additional label information (such as namespace, resource, node, etc.) in both the correlation ID and alert title. This will help distinguish alerts more precisely and provide clearer context for troubleshooting.

**Alert specificity improvements:**

* Updated `correlationId` fields to include more identifying labels (e.g., namespace, resource, node, job, instance, name) for all major alert types, ensuring each alert instance is uniquely identifiable.
* Enhanced `title` fields in alert annotations to include relevant label values (such as namespace, resource, node, job, instance, name), providing more actionable information directly in the alert message.

### Why

These changes will make it easier to correlate, filter, and act on alerts.

### Testing

Added unit test to test enrichment

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [x] All comment threads resolved before merge
