### PR TITLE
feat(monitoring): KAS availability budget burn alerts to SRE

### DIFF
--- a/dev-infrastructure/modules/metrics/rp-hcp-rules.bicep
+++ b/dev-infrastructure/modules/metrics/rp-hcp-rules.bicep
@@ -1,0 +1,14 @@
+// Alerts for HCP KubeAPIServer availability, routed to the RP ICM queue.
+
+@description('The Azure resource ID of the Azure Monitor Workspace (stores prometheus metrics for hosted control planes)')
+param azureMonitoringWorkspaceId string
+
+param actionGroups array
+
+module generatedAlerts 'rules/generatedRPHCPPrometheusAlertingRules.bicep' = {
+  name: 'generatedRPHCPPrometheusAlertingRules'
+  params: {
+    azureMonitoring: azureMonitoringWorkspaceId
+    actionGroups: actionGroups
+  }
+}

--- a/dev-infrastructure/modules/metrics/rules/generatedHCPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedHCPPrometheusAlertingRules.bicep
@@ -20,6 +20,8 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -47,6 +49,8 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -74,6 +78,8 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -101,6 +107,8 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -128,6 +136,8 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -155,6 +165,8 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -182,6 +194,8 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -209,6 +223,8 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -236,6 +252,8 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -263,6 +281,8 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -290,6 +310,8 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -317,6 +339,8 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -344,6 +368,8 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -370,6 +396,8 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -397,6 +425,8 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -424,6 +454,8 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -464,6 +496,8 @@ resource kubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups@20
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -491,6 +525,8 @@ resource kubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups@20
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -518,6 +554,8 @@ resource kubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups@20
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -545,6 +583,8 @@ resource kubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups@20
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -572,6 +612,8 @@ resource kubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups@20
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -599,6 +641,8 @@ resource kubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups@20
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -626,6 +670,8 @@ resource kubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups@20
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -653,6 +699,8 @@ resource kubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups@20
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -693,6 +741,8 @@ resource kubernetesStorage 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -720,6 +770,8 @@ resource kubernetesStorage 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -747,6 +799,8 @@ resource kubernetesStorage 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -774,6 +828,8 @@ resource kubernetesStorage 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -801,6 +857,8 @@ resource kubernetesStorage 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -841,6 +899,8 @@ resource kubernetesSystem 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -868,6 +928,8 @@ resource kubernetesSystem 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -908,6 +970,8 @@ resource kubeApiserverSlos 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -937,6 +1001,8 @@ resource kubeApiserverSlos 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -966,6 +1032,8 @@ resource kubeApiserverSlos 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -995,6 +1063,8 @@ resource kubeApiserverSlos 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1037,6 +1107,8 @@ resource kubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRuleGro
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1064,6 +1136,8 @@ resource kubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRuleGro
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1091,6 +1165,8 @@ resource kubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRuleGro
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1117,6 +1193,8 @@ resource kubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRuleGro
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1144,6 +1222,8 @@ resource kubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRuleGro
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1171,6 +1251,8 @@ resource kubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRuleGro
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1211,6 +1293,8 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1238,6 +1322,8 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1265,6 +1351,8 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1292,6 +1380,8 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1319,6 +1409,8 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1346,6 +1438,8 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1373,6 +1467,8 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1399,6 +1495,8 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1425,6 +1523,8 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1451,6 +1551,8 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1477,6 +1579,8 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1504,6 +1608,8 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1531,6 +1637,8 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1571,6 +1679,8 @@ resource kubernetesSystemScheduler 'Microsoft.AlertsManagement/prometheusRuleGro
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1611,6 +1721,8 @@ resource kubernetesSystemControllerManager 'Microsoft.AlertsManagement/prometheu
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1651,6 +1763,8 @@ resource mgmtCapacityRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1680,6 +1794,8 @@ resource mgmtCapacityRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1709,6 +1825,8 @@ resource mgmtCapacityRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1751,6 +1869,8 @@ resource hcpHostedclusterMonitorRules 'Microsoft.AlertsManagement/prometheusRule
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1779,6 +1899,8 @@ resource hcpHostedclusterMonitorRules 'Microsoft.AlertsManagement/prometheusRule
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1807,6 +1929,8 @@ resource hcpHostedclusterMonitorRules 'Microsoft.AlertsManagement/prometheusRule
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1835,6 +1959,8 @@ resource hcpHostedclusterMonitorRules 'Microsoft.AlertsManagement/prometheusRule
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1876,6 +2002,8 @@ resource hcpClusterHealthRules 'Microsoft.AlertsManagement/prometheusRuleGroups@
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]

--- a/dev-infrastructure/modules/metrics/rules/generatedHCPRecordingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedHCPRecordingRules.bicep
@@ -84,6 +84,14 @@ resource hcpKmsRecordingRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2
         record: 'hostedClusterAPI_kubeapiserver_available:sli_count_6h'
         expression: 'sum by (name, namespace, _id, cluster) ( count_over_time( ( max by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available) and on (name, namespace, _id, cluster) max by (name, namespace, _id, cluster) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0) )[6h:5m] ) ) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
       }
+      {
+        record: 'hostedClusterAPI_kubeapiserver_available:sli_sum_3d'
+        expression: 'sum by (name, namespace, _id, cluster) ( sum_over_time( ( hostedClusterAPI_kubeapiserver_available{status="True"} and on (name, namespace, _id, cluster) max by (name, namespace, _id, cluster) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0) )[3d:30m] ) ) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
+      }
+      {
+        record: 'hostedClusterAPI_kubeapiserver_available:sli_count_3d'
+        expression: 'sum by (name, namespace, _id, cluster) ( count_over_time( ( max by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available) and on (name, namespace, _id, cluster) max by (name, namespace, _id, cluster) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0) )[3d:30m] ) ) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
+      }
     ]
   }
 }
@@ -191,6 +199,44 @@ resource hcpKasLatencyRecordingRules 'Microsoft.AlertsManagement/prometheusRuleG
       {
         record: 'kas:apiserver_request_latency:sli_ratio:rate_avg_30d'
         expression: 'avg_over_time(kas:apiserver_request_latency:sli_ratio:rate5m[30d:5m])'
+      }
+    ]
+  }
+}
+
+resource ujKubeapiserverAvailabilityRecordingRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'uj-kubeapiserver-availability-recording-rules'
+  location: location
+  properties: {
+    scopes: [
+      azureMonitoring
+    ]
+    enabled: true
+    interval: 'PT1M'
+    rules: [
+      {
+        record: 'hostedClusterAPI_kubeapiserver_available:sli_sum_5m'
+        expression: 'sum by (name, namespace, _id, cluster) ( sum_over_time( ( hostedClusterAPI_kubeapiserver_available{status="True"} and on (name, namespace, _id, cluster) max by (name, namespace, _id, cluster) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0) )[5m:1m] ) ) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
+      }
+      {
+        record: 'hostedClusterAPI_kubeapiserver_available:sli_count_5m'
+        expression: 'sum by (name, namespace, _id, cluster) ( count_over_time( ( max by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available) and on (name, namespace, _id, cluster) max by (name, namespace, _id, cluster) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0) )[5m:1m] ) ) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
+      }
+      {
+        record: 'hostedClusterAPI_kubeapiserver_available:sli_sum_1h'
+        expression: 'sum by (name, namespace, _id, cluster) ( sum_over_time( ( hostedClusterAPI_kubeapiserver_available{status="True"} and on (name, namespace, _id, cluster) max by (name, namespace, _id, cluster) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0) )[1h:1m] ) ) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
+      }
+      {
+        record: 'hostedClusterAPI_kubeapiserver_available:sli_count_1h'
+        expression: 'sum by (name, namespace, _id, cluster) ( count_over_time( ( max by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available) and on (name, namespace, _id, cluster) max by (name, namespace, _id, cluster) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0) )[1h:1m] ) ) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
+      }
+      {
+        record: 'hostedClusterAPI_kubeapiserver_available:sli_sum_30m'
+        expression: 'sum by (name, namespace, _id, cluster) ( sum_over_time( ( hostedClusterAPI_kubeapiserver_available{status="True"} and on (name, namespace, _id, cluster) max by (name, namespace, _id, cluster) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0) )[30m:1m] ) ) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
+      }
+      {
+        record: 'hostedClusterAPI_kubeapiserver_available:sli_count_30m'
+        expression: 'sum by (name, namespace, _id, cluster) ( count_over_time( ( max by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available) and on (name, namespace, _id, cluster) max by (name, namespace, _id, cluster) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0) )[30m:1m] ) ) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
       }
     ]
   }

--- a/dev-infrastructure/modules/metrics/rules/generatedMsftPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedMsftPrometheusAlertingRules.bicep
@@ -20,6 +20,8 @@ resource msftKubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroup
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -47,6 +49,8 @@ resource msftKubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroup
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -74,6 +78,8 @@ resource msftKubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroup
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -101,6 +107,8 @@ resource msftKubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroup
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -128,6 +136,8 @@ resource msftKubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroup
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -155,6 +165,8 @@ resource msftKubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroup
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -195,6 +207,8 @@ resource msftKubernetesStorage 'Microsoft.AlertsManagement/prometheusRuleGroups@
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -235,6 +249,8 @@ resource msftKubernetesSystem 'Microsoft.AlertsManagement/prometheusRuleGroups@2
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -275,6 +291,8 @@ resource msftKubeApiserverSlos 'Microsoft.AlertsManagement/prometheusRuleGroups@
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -304,6 +322,8 @@ resource msftKubeApiserverSlos 'Microsoft.AlertsManagement/prometheusRuleGroups@
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -333,6 +353,8 @@ resource msftKubeApiserverSlos 'Microsoft.AlertsManagement/prometheusRuleGroups@
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -362,6 +384,8 @@ resource msftKubeApiserverSlos 'Microsoft.AlertsManagement/prometheusRuleGroups@
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -404,6 +428,8 @@ resource msftKubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRul
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -431,6 +457,8 @@ resource msftKubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRul
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -458,6 +486,8 @@ resource msftKubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRul
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -484,6 +514,8 @@ resource msftKubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRul
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -511,6 +543,8 @@ resource msftKubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRul
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -538,6 +572,8 @@ resource msftKubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRul
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -578,6 +614,8 @@ resource msftKubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleG
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -605,6 +643,8 @@ resource msftKubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleG
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -632,6 +672,8 @@ resource msftKubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleG
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -659,6 +701,8 @@ resource msftKubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleG
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -686,6 +730,8 @@ resource msftKubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleG
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -713,6 +759,8 @@ resource msftKubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleG
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -740,6 +788,8 @@ resource msftKubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleG
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -766,6 +816,8 @@ resource msftKubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleG
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -792,6 +844,8 @@ resource msftKubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleG
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -818,6 +872,8 @@ resource msftKubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleG
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -844,6 +900,8 @@ resource msftKubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleG
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -871,6 +929,8 @@ resource msftKubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleG
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -898,6 +958,8 @@ resource msftKubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleG
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -938,6 +1000,8 @@ resource msftKubernetesSystemScheduler 'Microsoft.AlertsManagement/prometheusRul
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -978,6 +1042,8 @@ resource msftKubernetesSystemControllerManager 'Microsoft.AlertsManagement/prome
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1018,6 +1084,8 @@ resource msftPrometheusWipRules 'Microsoft.AlertsManagement/prometheusRuleGroups
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1051,6 +1119,8 @@ Check the status of the Prometheus pods, service endpoints, and network connecti
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1084,6 +1154,8 @@ Please check the status of the Prometheus pods, service endpoints, and network c
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1121,6 +1193,8 @@ Investigate the health and performance of the remote storage endpoint, network l
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1171,6 +1245,8 @@ resource msftPrometheusRules 'Microsoft.AlertsManagement/prometheusRuleGroups@20
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1198,6 +1274,8 @@ resource msftPrometheusRules 'Microsoft.AlertsManagement/prometheusRuleGroups@20
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1225,6 +1303,8 @@ resource msftPrometheusRules 'Microsoft.AlertsManagement/prometheusRuleGroups@20
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1252,6 +1332,8 @@ resource msftPrometheusRules 'Microsoft.AlertsManagement/prometheusRuleGroups@20
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1292,6 +1374,8 @@ resource msftPrometheusOperatorRules 'Microsoft.AlertsManagement/prometheusRuleG
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1332,6 +1416,8 @@ resource msftMise 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' =
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1372,6 +1458,8 @@ resource msftMsiCredentialRefresher 'Microsoft.AlertsManagement/prometheusRuleGr
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1399,6 +1487,8 @@ resource msftMsiCredentialRefresher 'Microsoft.AlertsManagement/prometheusRuleGr
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1426,6 +1516,8 @@ resource msftMsiCredentialRefresher 'Microsoft.AlertsManagement/prometheusRuleGr
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]

--- a/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
@@ -20,6 +20,8 @@ resource prometheusWipRules 'Microsoft.AlertsManagement/prometheusRuleGroups@202
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -53,6 +55,8 @@ Check the status of the Prometheus pods, service endpoints, and network connecti
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -86,6 +90,8 @@ Please check the status of the Prometheus pods, service endpoints, and network c
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -123,6 +129,8 @@ Investigate the health and performance of the remote storage endpoint, network l
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -173,6 +181,8 @@ resource prometheusRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -200,6 +210,8 @@ resource prometheusRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -227,6 +239,8 @@ resource prometheusRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -254,6 +268,8 @@ resource prometheusRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -294,6 +310,8 @@ resource prometheusOperatorRules 'Microsoft.AlertsManagement/prometheusRuleGroup
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -321,6 +339,8 @@ resource prometheusOperatorRules 'Microsoft.AlertsManagement/prometheusRuleGroup
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -361,6 +381,8 @@ resource frontend 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' =
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -388,6 +410,8 @@ resource frontend 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' =
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -415,6 +439,8 @@ resource frontend 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' =
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -442,6 +468,8 @@ resource frontend 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' =
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -482,6 +510,8 @@ resource arohcpCsSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometheusRul
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -511,6 +541,8 @@ resource arohcpCsSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometheusRul
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -539,6 +571,8 @@ resource arohcpCsSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometheusRul
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -569,6 +603,8 @@ resource arohcpCsSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometheusRul
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -597,6 +633,8 @@ resource arohcpCsSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometheusRul
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -627,6 +665,8 @@ resource arohcpCsSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometheusRul
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -668,6 +708,8 @@ resource backend 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -695,6 +737,8 @@ resource backend 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -735,6 +779,8 @@ resource fleet 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -762,6 +808,8 @@ resource fleet 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -789,6 +837,8 @@ resource fleet 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -829,6 +879,8 @@ resource adminApi 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' =
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -856,6 +908,8 @@ resource adminApi 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' =
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -896,6 +950,8 @@ resource maestro 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -923,6 +979,8 @@ resource maestro 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -950,6 +1008,8 @@ resource maestro 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -977,6 +1037,8 @@ resource maestro 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1017,6 +1079,8 @@ resource arobitRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1046,6 +1110,8 @@ resource arobitRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1079,6 +1145,8 @@ Investigate the Fluent Bit logs for the specific error details and check the Kus
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1112,6 +1180,8 @@ Investigate the Fluent Bit logs for the specific error details and check the Kus
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1143,6 +1213,8 @@ Investigate the Fluent Bit logs for the specific error details and check the Kus
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1187,6 +1259,8 @@ resource serviceTagCapacityRules 'Microsoft.AlertsManagement/prometheusRuleGroup
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1216,6 +1290,8 @@ resource serviceTagCapacityRules 'Microsoft.AlertsManagement/prometheusRuleGroup
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1245,6 +1321,8 @@ resource serviceTagCapacityRules 'Microsoft.AlertsManagement/prometheusRuleGroup
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1274,6 +1352,8 @@ resource serviceTagCapacityRules 'Microsoft.AlertsManagement/prometheusRuleGroup
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1303,6 +1383,8 @@ resource serviceTagCapacityRules 'Microsoft.AlertsManagement/prometheusRuleGroup
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1332,6 +1414,8 @@ resource serviceTagCapacityRules 'Microsoft.AlertsManagement/prometheusRuleGroup
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1361,6 +1445,8 @@ resource serviceTagCapacityRules 'Microsoft.AlertsManagement/prometheusRuleGroup
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1390,6 +1476,8 @@ resource serviceTagCapacityRules 'Microsoft.AlertsManagement/prometheusRuleGroup
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1419,6 +1507,8 @@ resource serviceTagCapacityRules 'Microsoft.AlertsManagement/prometheusRuleGroup
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1448,6 +1538,8 @@ resource serviceTagCapacityRules 'Microsoft.AlertsManagement/prometheusRuleGroup
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1490,6 +1582,8 @@ resource hcpDeletionRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1534,6 +1628,8 @@ resource kubeContainerOomRules 'Microsoft.AlertsManagement/prometheusRuleGroups@
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1573,6 +1669,8 @@ resource kubeNodeRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1612,6 +1710,8 @@ resource imageRegistryPolicy 'Microsoft.AlertsManagement/prometheusRuleGroups@20
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1639,6 +1739,8 @@ resource imageRegistryPolicy 'Microsoft.AlertsManagement/prometheusRuleGroups@20
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -1679,6 +1781,8 @@ resource kustoLogsAgeRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]

--- a/dev-infrastructure/modules/metrics/rules/generatedRPHCPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRPHCPPrometheusAlertingRules.bicep
@@ -1,0 +1,129 @@
+#disable-next-line no-unused-params
+param azureMonitoring string
+
+#disable-next-line no-unused-params
+param actionGroups array
+
+#disable-next-line no-unused-params
+param location string = resourceGroup().location
+
+resource rpUjKasAvailabilityMonitorRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'rp-uj-kas-availability-monitor-rules'
+  location: location
+  properties: {
+    interval: 'PT1M'
+    rules: [
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
+            }
+          }
+        ]
+        alert: 'UJKubeApiserverAvailability1h5m'
+        enabled: true
+        labels: {
+          long_window: '1h'
+          severity: 'critical'
+          short_window: '5m'
+          slo: 'kas-availability'
+        }
+        annotations: {
+          correlationId: 'UJKubeApiserverAvailability/{{ $labels.cluster }}/{{ $labels._id }}'
+          description: '''CID: {{ $labels._id }}
+Management Cluster: {{ $labels.cluster }}/{{ $labels.namespace }}
+'''
+          info: '''CID: {{ $labels._id }}
+Management Cluster: {{ $labels.cluster }}/{{ $labels.namespace }}
+'''
+          runbook_url: 'https://aka.ms/arohcp-runbook-ujkasavailable'
+          summary: '[HCP] [{{ $labels.name }}] KubeAPIServer Fast Error Budget Burn (1h/5m)'
+          title: '[HCP] [{{ $labels.name }}] KubeAPIServer Fast Error Budget Burn (1h/5m)'
+        }
+        expression: '( 1 - (hostedClusterAPI_kubeapiserver_available:sli_sum_5m / hostedClusterAPI_kubeapiserver_available:sli_count_5m) > (14.4 * (1 - 0.9995)) and on (name, namespace, _id, cluster) hostedClusterAPI_kubeapiserver_available:sli_count_5m > 3 ) and on (name, namespace, _id, cluster) ( 1 - (hostedClusterAPI_kubeapiserver_available:sli_sum_1h / hostedClusterAPI_kubeapiserver_available:sli_count_1h) > (14.4 * (1 - 0.9995)) and on (name, namespace, _id, cluster) hostedClusterAPI_kubeapiserver_available:sli_count_1h > 54 )'
+        for: 'PT10M'
+        severity: 2
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
+            }
+          }
+        ]
+        alert: 'UJKubeApiserverAvailability6h30m'
+        enabled: true
+        labels: {
+          long_window: '6h'
+          severity: 'critical'
+          short_window: '30m'
+          slo: 'kas-availability'
+        }
+        annotations: {
+          correlationId: 'UJKubeApiserverAvailability/{{ $labels.cluster }}/{{ $labels._id }}'
+          description: '''CID: {{ $labels._id }}
+Management Cluster: {{ $labels.cluster }}/{{ $labels.namespace }}
+'''
+          info: '''CID: {{ $labels._id }}
+Management Cluster: {{ $labels.cluster }}/{{ $labels.namespace }}
+'''
+          runbook_url: 'https://aka.ms/arohcp-runbook-ujkasavailable'
+          summary: '[HCP] [{{ $labels.name }}] KubeAPIServer Medium Error Budget Burn (6h/30m)'
+          title: '[HCP] [{{ $labels.name }}] KubeAPIServer Medium Error Budget Burn (6h/30m)'
+        }
+        expression: '( 1 - (hostedClusterAPI_kubeapiserver_available:sli_sum_30m / hostedClusterAPI_kubeapiserver_available:sli_count_30m) > (6 * (1 - 0.9995)) and on (name, namespace, _id, cluster) hostedClusterAPI_kubeapiserver_available:sli_count_30m > 27 ) and on (name, namespace, _id, cluster) ( 1 - (hostedClusterAPI_kubeapiserver_available:sli_sum_6h / hostedClusterAPI_kubeapiserver_available:sli_count_6h) > (6 * (1 - 0.9995)) and on (name, namespace, _id, cluster) hostedClusterAPI_kubeapiserver_available:sli_count_6h > 64 )'
+        for: 'PT30M'
+        severity: 2
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
+            }
+          }
+        ]
+        alert: 'UJKubeApiserverAvailability3d6h'
+        enabled: true
+        labels: {
+          long_window: '3d'
+          severity: 'warning'
+          short_window: '6h'
+          slo: 'kas-availability'
+        }
+        annotations: {
+          correlationId: 'UJKubeApiserverAvailability/{{ $labels.cluster }}/{{ $labels._id }}'
+          description: '''CID: {{ $labels._id }}
+Management Cluster: {{ $labels.cluster }}/{{ $labels.namespace }}
+'''
+          info: '''CID: {{ $labels._id }}
+Management Cluster: {{ $labels.cluster }}/{{ $labels.namespace }}
+'''
+          runbook_url: 'https://aka.ms/arohcp-runbook-ujkasavailable'
+          summary: '[HCP] [{{ $labels.name }}] KubeAPIServer Slow Error Budget Burn (3d/6h)'
+          title: '[HCP] [{{ $labels.name }}] KubeAPIServer Slow Error Budget Burn (3d/6h)'
+        }
+        expression: '( 1 - (hostedClusterAPI_kubeapiserver_available:sli_sum_6h / hostedClusterAPI_kubeapiserver_available:sli_count_6h) > (1 * (1 - 0.9995)) and on (name, namespace, _id, cluster) hostedClusterAPI_kubeapiserver_available:sli_count_6h > 64 ) and on (name, namespace, _id, cluster) ( 1 - (hostedClusterAPI_kubeapiserver_available:sli_sum_3d / hostedClusterAPI_kubeapiserver_available:sli_count_3d) > (1 * (1 - 0.9995)) and on (name, namespace, _id, cluster) hostedClusterAPI_kubeapiserver_available:sli_count_3d > 130 )'
+        for: 'PT3H'
+        severity: 3
+      }
+    ]
+    scopes: [
+      azureMonitoring
+    ]
+  }
+}

--- a/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
@@ -20,6 +20,8 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -50,6 +52,8 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -80,6 +84,8 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -109,6 +115,8 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -137,6 +145,8 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -177,6 +187,8 @@ resource arohcpNodepoolSaturationAlerts 'Microsoft.AlertsManagement/prometheusRu
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -204,6 +216,8 @@ resource arohcpNodepoolSaturationAlerts 'Microsoft.AlertsManagement/prometheusRu
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]

--- a/dev-infrastructure/modules/metrics/rules/generatedSREServicePrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedSREServicePrometheusAlertingRules.bicep
@@ -20,6 +20,8 @@ resource frontendLatency 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -60,6 +62,8 @@ resource backendRetryhotloop 'Microsoft.AlertsManagement/prometheusRuleGroups@20
             actionProperties: {
               'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
               'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
             }
           }
         ]
@@ -73,8 +77,8 @@ resource backendRetryhotloop 'Microsoft.AlertsManagement/prometheusRuleGroups@20
           description: 'Backend controller workqueue {{ $labels.name }} has a retry ratio of > 50% sustained over 10 minutes, indicating most queue activity is failed retries rather than fresh work.'
           info: 'Backend controller workqueue {{ $labels.name }} has a retry ratio of > 50% sustained over 10 minutes, indicating most queue activity is failed retries rather than fresh work.'
           runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/troubleshooting/backend-tsg.html'
-          summary: 'Backend controller workqueue retry hot loop'
-          title: 'Backend controller workqueue retry hot loop'
+          summary: 'Backend controller workqueue {{ $labels.name }} retry hot loop'
+          title: 'Backend controller workqueue {{ $labels.name }} retry hot loop'
         }
         expression: '( sum by (name, cluster) ( max without(prometheus_replica) ( rate(workqueue_retries_total{namespace="aro-hcp"}[10m]) ) ) / sum by (name, cluster) ( max without(prometheus_replica) ( rate(workqueue_adds_total{namespace="aro-hcp"}[10m]) ) ) ) > 0.5'
         for: 'PT10M'

--- a/dev-infrastructure/templates/monitoring.bicep
+++ b/dev-infrastructure/templates/monitoring.bicep
@@ -130,6 +130,14 @@ module rpAlerts '../modules/metrics/rp-rules.bicep' = {
   }
 }
 
+module rpHcpAlerts '../modules/metrics/rp-hcp-rules.bicep' = {
+  name: 'rpHcpAlerts'
+  params: {
+    azureMonitoringWorkspaceId: hcpAzureMonitoringWorkspaceId
+    actionGroups: rpActionGroups
+  }
+}
+
 module msftAlerts '../modules/metrics/msft-rules.bicep' = {
   name: 'msftAlerts'
   params: {

--- a/observability/alerts-rp-hcps.yaml
+++ b/observability/alerts-rp-hcps.yaml
@@ -1,0 +1,7 @@
+prometheusRules:
+  rulesFolders:
+  - ../observability/alerts/UJKubeApiserverAvailabilityMonitor-prometheusRule-KSM.yaml
+  untestedRules: []
+  testDependencies:
+  - recording-rules-hcps.yaml
+  outputBicep: ../dev-infrastructure/modules/metrics/rules/generatedRPHCPPrometheusAlertingRules.bicep

--- a/observability/alerts/HCPkasRecord-prometheusRule-KSM.yaml
+++ b/observability/alerts/HCPkasRecord-prometheusRule-KSM.yaml
@@ -141,3 +141,29 @@ spec:
         )
         and on (name, namespace, _id, cluster)
         count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
+    - record: hostedClusterAPI_kubeapiserver_available:sli_sum_3d
+      expr: |
+        sum by (name, namespace, _id, cluster) (
+          sum_over_time(
+            (
+              hostedClusterAPI_kubeapiserver_available{status="True"}
+              and on (name, namespace, _id, cluster)
+              max by (name, namespace, _id, cluster) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0)
+            )[3d:30m]
+          )
+        )
+        and on (name, namespace, _id, cluster)
+        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
+    - record: hostedClusterAPI_kubeapiserver_available:sli_count_3d
+      expr: |
+        sum by (name, namespace, _id, cluster) (
+          count_over_time(
+            (
+              max by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
+              and on (name, namespace, _id, cluster)
+              max by (name, namespace, _id, cluster) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0)
+            )[3d:30m]
+          )
+        )
+        and on (name, namespace, _id, cluster)
+        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)

--- a/observability/alerts/UJKubeApiserverAvailabilityMonitor-prometheusRule-KSM.yaml
+++ b/observability/alerts/UJKubeApiserverAvailabilityMonitor-prometheusRule-KSM.yaml
@@ -1,0 +1,96 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: uj-kubeapiserver-availability-alerts
+  namespace: prometheus
+spec:
+  groups:
+  - name: rp-uj-kas-availability-monitor-rules
+    rules:
+    - alert: UJKubeApiserverAvailability1h5m
+      expr: |
+        (
+          1 - (hostedClusterAPI_kubeapiserver_available:sli_sum_5m / hostedClusterAPI_kubeapiserver_available:sli_count_5m)
+          > (14.4 * (1 - 0.9995))
+          and on (name, namespace, _id, cluster)
+          hostedClusterAPI_kubeapiserver_available:sli_count_5m > 3
+        )
+        and on (name, namespace, _id, cluster)
+        (
+          1 - (hostedClusterAPI_kubeapiserver_available:sli_sum_1h / hostedClusterAPI_kubeapiserver_available:sli_count_1h)
+          > (14.4 * (1 - 0.9995))
+          and on (name, namespace, _id, cluster)
+          hostedClusterAPI_kubeapiserver_available:sli_count_1h > 54
+        )
+      for: 10m
+      labels:
+        long_window: 1h
+        short_window: 5m
+        severity: critical
+        slo: kas-availability
+      annotations:
+        summary: "[HCP] [{{ $labels.name }}] KubeAPIServer Fast Error Budget Burn (1h/5m)"
+        description: |
+          CID: {{ $labels._id }}
+          Management Cluster: {{ $labels.cluster }}/{{ $labels.namespace }}
+        runbook_url: https://aka.ms/arohcp-runbook-ujkasavailable
+        correlationId: "UJKubeApiserverAvailability/{{ $labels.cluster }}/{{ $labels._id }}"
+    - alert: UJKubeApiserverAvailability6h30m
+      # sli_sum_6h and sli_count_6h are recording rules defined in HCPkasRecord-prometheusRule-KSM.yaml
+      expr: |
+        (
+          1 - (hostedClusterAPI_kubeapiserver_available:sli_sum_30m / hostedClusterAPI_kubeapiserver_available:sli_count_30m)
+          > (6 * (1 - 0.9995))
+          and on (name, namespace, _id, cluster)
+          hostedClusterAPI_kubeapiserver_available:sli_count_30m > 27
+        )
+        and on (name, namespace, _id, cluster)
+        (
+          1 - (hostedClusterAPI_kubeapiserver_available:sli_sum_6h / hostedClusterAPI_kubeapiserver_available:sli_count_6h)
+          > (6 * (1 - 0.9995))
+          and on (name, namespace, _id, cluster)
+          hostedClusterAPI_kubeapiserver_available:sli_count_6h > 64
+        )
+      for: 30m
+      labels:
+        long_window: 6h
+        short_window: 30m
+        severity: critical
+        slo: kas-availability
+      annotations:
+        summary: "[HCP] [{{ $labels.name }}] KubeAPIServer Medium Error Budget Burn (6h/30m)"
+        description: |
+          CID: {{ $labels._id }}
+          Management Cluster: {{ $labels.cluster }}/{{ $labels.namespace }}
+        runbook_url: https://aka.ms/arohcp-runbook-ujkasavailable
+        correlationId: "UJKubeApiserverAvailability/{{ $labels.cluster }}/{{ $labels._id }}"
+    - alert: UJKubeApiserverAvailability3d6h
+      # sli_sum_3d, sli_count_3d (long window) and sli_sum_6h, sli_count_6h (short window)
+      # are recording rules defined in HCPkasRecord-prometheusRule-KSM.yaml
+      expr: |
+        (
+          1 - (hostedClusterAPI_kubeapiserver_available:sli_sum_6h / hostedClusterAPI_kubeapiserver_available:sli_count_6h)
+          > (1 * (1 - 0.9995))
+          and on (name, namespace, _id, cluster)
+          hostedClusterAPI_kubeapiserver_available:sli_count_6h > 64
+        )
+        and on (name, namespace, _id, cluster)
+        (
+          1 - (hostedClusterAPI_kubeapiserver_available:sli_sum_3d / hostedClusterAPI_kubeapiserver_available:sli_count_3d)
+          > (1 * (1 - 0.9995))
+          and on (name, namespace, _id, cluster)
+          hostedClusterAPI_kubeapiserver_available:sli_count_3d > 130
+        )
+      for: 3h
+      labels:
+        long_window: 3d
+        short_window: 6h
+        severity: warning
+        slo: kas-availability
+      annotations:
+        summary: "[HCP] [{{ $labels.name }}] KubeAPIServer Slow Error Budget Burn (3d/6h)"
+        description: |
+          CID: {{ $labels._id }}
+          Management Cluster: {{ $labels.cluster }}/{{ $labels.namespace }}
+        runbook_url: https://aka.ms/arohcp-runbook-ujkasavailable
+        correlationId: "UJKubeApiserverAvailability/{{ $labels.cluster }}/{{ $labels._id }}"

--- a/observability/alerts/UJKubeApiserverAvailabilityMonitor-prometheusRule-KSM_test.yaml
+++ b/observability/alerts/UJKubeApiserverAvailabilityMonitor-prometheusRule-KSM_test.yaml
@@ -1,0 +1,293 @@
+rule_files:
+- HCPkasRecord-prometheusRule-KSM.yaml
+- UJKubeApiserverAvailabilityRecord-prometheusRule-KSM.yaml
+- UJKubeApiserverAvailabilityMonitor-prometheusRule-KSM.yaml
+group_eval_order:
+- hcp-kms-recording-rules
+- uj-kubeapiserver-availability-recording-rules
+- rp-uj-kas-availability-monitor-rules
+evaluation_interval: 1m
+tests:
+# Test 1: Normal operation - KubeAPIServer always available, no alerts should fire
+- interval: 1m
+  name: "Test 1: Normal operation - perfect availability, no alerts"
+  input_series:
+  - series: 'hostedClusterAPI_kubeapiserver_available{status="True", name="test-cluster", namespace="clusters", _id="abc-123", cluster="mgmt-cluster"}'
+    values: "1+0x600" # 10 hours of perfect availability
+  alert_rule_test:
+  - eval_time: 600m
+    alertname: UJKubeApiserverAvailability1h5m
+    exp_alerts: []
+  - eval_time: 600m
+    alertname: UJKubeApiserverAvailability6h30m
+    exp_alerts: []
+  - eval_time: 600m
+    alertname: UJKubeApiserverAvailability3d6h
+    exp_alerts: [] # sli_count_3d uses [3d:30m]; at 600m only ~20 steps pass offset gate — far below 130 guard
+# Test 2: Fast burn - complete failure triggers UJKubeApiserverAvailability1h5m
+# SLI rules require the series to have existed 15m ago (offset blackout). The binding
+# constraint is the sli_count_1h > 54 guard: with [1h:1m] subquery and data from t=0,
+# the count of gate-passing steps is T-14, which first exceeds 54 at T=69m (55 steps).
+# With for:10m, the fast-burn alert first fires at T=79m.
+- interval: 30s
+  name: "Test 2: Fast burn - complete failure triggers UJKubeApiserverAvailability1h5m"
+  input_series:
+  - series: 'hostedClusterAPI_kubeapiserver_available{status="True", name="test-cluster", namespace="clusters", _id="abc-123", cluster="mgmt-cluster"}'
+    values: "0+0x200" # 100 minutes of complete failure (200 * 30s)
+  alert_rule_test:
+  - eval_time: 10m
+    alertname: UJKubeApiserverAvailability1h5m
+    exp_alerts: [] # Offset blackout: series has not existed for 15m yet
+  - eval_time: 10m
+    alertname: UJKubeApiserverAvailability6h30m
+    exp_alerts: [] # Offset blackout: series has not existed for 15m yet
+  - eval_time: 78m
+    alertname: UJKubeApiserverAvailability1h5m
+    exp_alerts: [] # for: timer = 9m, not yet 10m — alert not yet firing
+  - eval_time: 80m # T=79m: for: timer reaches 10m; T=80m: still firing
+    alertname: UJKubeApiserverAvailability1h5m
+    exp_alerts:
+    - exp_labels:
+        severity: critical
+        slo: kas-availability
+        long_window: 1h
+        short_window: 5m
+        name: test-cluster
+        namespace: clusters
+        _id: abc-123
+        cluster: mgmt-cluster
+      exp_annotations:
+        summary: "[HCP] [test-cluster] KubeAPIServer Fast Error Budget Burn (1h/5m)"
+        description: "CID: abc-123\nManagement Cluster: mgmt-cluster/clusters\n"
+        runbook_url: https://aka.ms/arohcp-runbook-ujkasavailable
+        correlationId: "UJKubeApiserverAvailability/mgmt-cluster/abc-123"
+# Test 3: Medium burn - complete failure triggers both tiers after 6h+
+# The fast-burn (1h/5m) alert fires at T=79m (same binding constraint as Test 2).
+# The medium-burn (6h/30m) alert requires sli_count_6h > 64 guard: with [6h:5m]
+# subquery at 5m step, gate-passing steps first exceed 64 at T=335m (65 steps),
+# and with for:30m fires at T=365m. At eval_time=420m (7 hours), both tiers fire.
+- interval: 30s
+  name: "Test 3: Medium burn - complete failure triggers both tiers after 6h+"
+  input_series:
+  - series: 'hostedClusterAPI_kubeapiserver_available{status="True", name="test-cluster", namespace="clusters", _id="abc-123", cluster="mgmt-cluster"}'
+    values: "0+0x900" # 450 minutes = 7.5 hours of complete failure (900 * 30s)
+  alert_rule_test:
+  - eval_time: 80m
+    alertname: UJKubeApiserverAvailability1h5m
+    exp_alerts:
+    - exp_labels:
+        severity: critical
+        slo: kas-availability
+        long_window: 1h
+        short_window: 5m
+        name: test-cluster
+        namespace: clusters
+        _id: abc-123
+        cluster: mgmt-cluster
+      exp_annotations:
+        summary: "[HCP] [test-cluster] KubeAPIServer Fast Error Budget Burn (1h/5m)"
+        description: "CID: abc-123\nManagement Cluster: mgmt-cluster/clusters\n"
+        runbook_url: https://aka.ms/arohcp-runbook-ujkasavailable
+        correlationId: "UJKubeApiserverAvailability/mgmt-cluster/abc-123"
+  - eval_time: 364m
+    alertname: UJKubeApiserverAvailability6h30m
+    exp_alerts: [] # for: timer = 29m at T=364m, not yet 30m — alert not yet firing
+  - eval_time: 366m # T=365m: for: timer reaches 30m; T=366m: still firing
+    alertname: UJKubeApiserverAvailability6h30m
+    exp_alerts:
+    - exp_labels:
+        severity: critical
+        slo: kas-availability
+        long_window: 6h
+        short_window: 30m
+        name: test-cluster
+        namespace: clusters
+        _id: abc-123
+        cluster: mgmt-cluster
+      exp_annotations:
+        summary: "[HCP] [test-cluster] KubeAPIServer Medium Error Budget Burn (6h/30m)"
+        description: "CID: abc-123\nManagement Cluster: mgmt-cluster/clusters\n"
+        runbook_url: https://aka.ms/arohcp-runbook-ujkasavailable
+        correlationId: "UJKubeApiserverAvailability/mgmt-cluster/abc-123"
+  - eval_time: 420m # 7 hours — both tiers firing
+    alertname: UJKubeApiserverAvailability1h5m
+    exp_alerts:
+    - exp_labels:
+        severity: critical
+        slo: kas-availability
+        long_window: 1h
+        short_window: 5m
+        name: test-cluster
+        namespace: clusters
+        _id: abc-123
+        cluster: mgmt-cluster
+      exp_annotations:
+        summary: "[HCP] [test-cluster] KubeAPIServer Fast Error Budget Burn (1h/5m)"
+        description: "CID: abc-123\nManagement Cluster: mgmt-cluster/clusters\n"
+        runbook_url: https://aka.ms/arohcp-runbook-ujkasavailable
+        correlationId: "UJKubeApiserverAvailability/mgmt-cluster/abc-123"
+  - eval_time: 420m
+    alertname: UJKubeApiserverAvailability6h30m
+    exp_alerts:
+    - exp_labels:
+        severity: critical
+        slo: kas-availability
+        long_window: 6h
+        short_window: 30m
+        name: test-cluster
+        namespace: clusters
+        _id: abc-123
+        cluster: mgmt-cluster
+      exp_annotations:
+        summary: "[HCP] [test-cluster] KubeAPIServer Medium Error Budget Burn (6h/30m)"
+        description: "CID: abc-123\nManagement Cluster: mgmt-cluster/clusters\n"
+        runbook_url: https://aka.ms/arohcp-runbook-ujkasavailable
+        correlationId: "UJKubeApiserverAvailability/mgmt-cluster/abc-123"
+  - eval_time: 420m
+    alertname: UJKubeApiserverAvailability3d6h
+    exp_alerts: [] # sli_count_3d guard: only 14 steps at T=420m, need > 130; 3d alert not triggered by 7.5h failure
+# Test 4: Provisioning grace - newly created cluster (< 15m) does NOT trigger alert
+# The offset blackout (hostedClusterAPI_kubeapiserver_available offset 15m) requires
+# the series to have existed 15 minutes ago. A brand-new cluster has no offset data,
+# so the SLI recording rules produce no output and no alert can fire.
+- interval: 1m
+  name: "Test 4: Provisioning grace - new cluster excluded from alerting"
+  input_series:
+  - series: 'hostedClusterAPI_kubeapiserver_available{status="True", name="new-cluster", namespace="clusters", _id="new-123", cluster="mgmt-cluster"}'
+    values: "0+0x10" # 10 minutes of complete failure (new cluster)
+  alert_rule_test:
+  - eval_time: 10m
+    alertname: UJKubeApiserverAvailability1h5m
+    exp_alerts: [] # Offset blackout: no data 15m ago, SLI rules produce no output
+  - eval_time: 10m
+    alertname: UJKubeApiserverAvailability6h30m
+    exp_alerts: []
+  - eval_time: 10m
+    alertname: UJKubeApiserverAvailability3d6h
+    exp_alerts: [] # sli_count_3d far below 130 guard at 10m
+# Test 5: Partial failure below threshold - no alert fires
+# One failure at t=21m; at eval_time=400m this falls outside both the 5m (t=395-400m)
+# and 1h (t=340-400m) windows — no burn in either window.
+- interval: 1m
+  name: "Test 5: Transient failure outside evaluation windows - no alert fires"
+  input_series:
+  - series: 'hostedClusterAPI_kubeapiserver_available{status="True", name="test-cluster", namespace="clusters", _id="abc-123", cluster="mgmt-cluster"}'
+    values: "1+0x20 0 1+0x580" # One failure in ~603 samples
+  alert_rule_test:
+  - eval_time: 400m
+    alertname: UJKubeApiserverAvailability1h5m
+    exp_alerts: []
+  - eval_time: 400m
+    alertname: UJKubeApiserverAvailability6h30m
+    exp_alerts: []
+# Test 6: Sample guard behavior - short burst suppressed by minimum-sample guards
+# Failure burst from t=20m to t=41m (22 samples: 0+0x21 = 22 samples).
+# At eval_time=35m:
+#   - sli_count_1h uses [1h:1m] with offset 15m gate; gate passes samples from t>=15m.
+#     At t=35m, only t=15..35m = 21 samples are visible → below the > 54 guard.
+#   - Fast-burn alert is suppressed by the sli_count_1h > 54 minimum-sample guard.
+# At eval_time=65m:
+#   - sli_count_6h uses [6h:5m] with offset 15m gate; at t=65m only t=15,20,...,65m
+#     = 11 samples at 5m step → far below the > 64 guard.
+#   - Medium-burn alert is suppressed by the sli_count_6h > 64 minimum-sample guard,
+#     even though the 30m error rate is elevated.
+#   - This is the intended guard behavior: prevent sparse-window false pages.
+# Note: Test 3 covers the scenario where both alerts fire with sufficient data.
+- interval: 1m
+  name: "Test 6: Sample guards suppress sparse-window alerts during short burst"
+  input_series:
+  - series: 'hostedClusterAPI_kubeapiserver_available{status="True", name="test-cluster", namespace="clusters", _id="abc-123", cluster="mgmt-cluster"}'
+    values: "1+0x19 0+0x21 1+0x800" # 20m healthy, 22m failure (t=20..t=41), then recovery
+  alert_rule_test:
+  - eval_time: 35m
+    alertname: UJKubeApiserverAvailability1h5m
+    exp_alerts: [] # sli_count_1h guard: only ~21 samples visible at t=35m, need > 54
+  - eval_time: 35m
+    alertname: UJKubeApiserverAvailability6h30m
+    exp_alerts: [] # for:30m not yet satisfied; sli_count_6h guard also blocks (~5 samples at 5m step, need > 64)
+  - eval_time: 65m
+    alertname: UJKubeApiserverAvailability1h5m
+    exp_alerts: [] # Fast tier: 5m window (t=61-65) clean; sli_count_1h guard still blocks (~51 samples)
+  - eval_time: 65m
+    alertname: UJKubeApiserverAvailability6h30m
+    exp_alerts: [] # sli_count_6h guard blocks: only ~11 samples at 5m step, need > 64
+# Test 7: Near-threshold - minimal failure burst validates for:10m boundary
+# 80m of success (t=0..79m), then 7 failures (t=80..86m), then success.
+# The [5m:1m] subquery at eval time T covers steps (T-5m, T] (exclusive start, 5 steps).
+# At T=80m: 5m window (75,80]={76..80m} has failure at t=80m → error_rate_5m=1/5=20% ✓
+#   sli_count_1h = 60 steps in (20,80], all > 54 ✓, error_rate_1h=1/60≈1.7%>threshold ✓
+#   Condition first becomes true at T=80m (start of for: timer).
+# At T=89m: for: timer = 9m → NOT firing.
+# At T=90m: for: timer = 10m (80+10=90). 5m window (85,90]={86..90m} has failure at
+#   t=86m → error_rate_5m=1/5=20% → condition still true → FIRES.
+# At T=91m: 5m window (86,91]={87..91m} all success → error_rate_5m=0 → condition
+#   false → RESOLVES.
+- interval: 1m
+  name: "Test 7: Near-threshold - minimal burst validates for:10m boundary"
+  input_series:
+  - series: 'hostedClusterAPI_kubeapiserver_available{status="True", name="test-cluster", namespace="clusters", _id="abc-123", cluster="mgmt-cluster"}'
+    values: "1+0x79 0+0x6 1+0x100" # 80 successes (t=0..79m), 7 failures (t=80..86m), then success
+  alert_rule_test:
+  - eval_time: 89m
+    alertname: UJKubeApiserverAvailability1h5m
+    exp_alerts: [] # for: timer = 9m, not yet 10m — alert not yet firing
+  - eval_time: 90m
+    alertname: UJKubeApiserverAvailability1h5m
+    exp_alerts:
+    - exp_labels:
+        severity: critical
+        slo: kas-availability
+        long_window: 1h
+        short_window: 5m
+        name: test-cluster
+        namespace: clusters
+        _id: abc-123
+        cluster: mgmt-cluster
+      exp_annotations:
+        summary: "[HCP] [test-cluster] KubeAPIServer Fast Error Budget Burn (1h/5m)"
+        description: "CID: abc-123\nManagement Cluster: mgmt-cluster/clusters\n"
+        runbook_url: https://aka.ms/arohcp-runbook-ujkasavailable
+        correlationId: "UJKubeApiserverAvailability/mgmt-cluster/abc-123"
+  - eval_time: 91m
+    alertname: UJKubeApiserverAvailability1h5m
+    exp_alerts: [] # 5m window (86,91]={87..91m} all success → error_rate_5m=0 → alert resolves
+# Test 8: Slow burn - sustained complete failure triggers UJKubeApiserverAvailability3d6h
+# The slow-burn (3d/6h) alert uses sli_count_3d with [3d:30m] subquery (30m step).
+# With interval:1m and data from t=0, the offset gate (offset 15m) requires data at t-15m.
+# At subquery step t=30m: needs data at 15m (exists with 1m data density) → passes.
+# At evaluation T: valid steps in [3d:30m] = T/30 (steps at 30m, 60m, ..., T).
+# sli_count_3d > 130: first satisfied when T/30 > 130 → T > 3900 → T=3930m (131 steps).
+# sli_count_6h > 64: satisfied at T=335m (steps at 5m from 15m to T; floor((T-15)/5)+1 > 64).
+# for:3h timer starts at T=3930m, fires at T=3930m+180m=4110m.
+# Boundary: eval_time=4080m → for:timer=150m → NOT firing.
+#           eval_time=4109m → for:timer=179m → NOT firing (1-minute before threshold).
+#           eval_time=4110m → for:timer=180m=3h → FIRES.
+- interval: 1m
+  name: "Test 8: Slow burn - sustained failure triggers UJKubeApiserverAvailability3d6h"
+  input_series:
+  - series: 'hostedClusterAPI_kubeapiserver_available{status="True", name="test-cluster", namespace="clusters", _id="abc-123", cluster="mgmt-cluster"}'
+    values: "0+0x4110" # 4111 samples at 1m interval, t=0 to t=4110m, complete failure
+  alert_rule_test:
+  - eval_time: 4080m
+    alertname: UJKubeApiserverAvailability3d6h
+    exp_alerts: [] # for: timer = 150m at T=4080m, not yet 3h — alert not yet firing
+  - eval_time: 4109m
+    alertname: UJKubeApiserverAvailability3d6h
+    exp_alerts: [] # for: timer = 179m at T=4109m, not yet 3h — alert not yet firing
+  - eval_time: 4110m
+    alertname: UJKubeApiserverAvailability3d6h
+    exp_alerts:
+    - exp_labels:
+        severity: warning
+        slo: kas-availability
+        long_window: 3d
+        short_window: 6h
+        name: test-cluster
+        namespace: clusters
+        _id: abc-123
+        cluster: mgmt-cluster
+      exp_annotations:
+        summary: "[HCP] [test-cluster] KubeAPIServer Slow Error Budget Burn (3d/6h)"
+        description: "CID: abc-123\nManagement Cluster: mgmt-cluster/clusters\n"
+        runbook_url: https://aka.ms/arohcp-runbook-ujkasavailable
+        correlationId: "UJKubeApiserverAvailability/mgmt-cluster/abc-123"

--- a/observability/alerts/UJKubeApiserverAvailabilityRecord-prometheusRule-KSM.yaml
+++ b/observability/alerts/UJKubeApiserverAvailabilityRecord-prometheusRule-KSM.yaml
@@ -1,0 +1,87 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: uj-kubeapiserver-availability-recording-rules
+  namespace: prometheus
+spec:
+  groups:
+  - name: uj-kubeapiserver-availability-recording-rules
+    rules:
+    - record: hostedClusterAPI_kubeapiserver_available:sli_sum_5m
+      expr: |
+        sum by (name, namespace, _id, cluster) (
+          sum_over_time(
+            (
+              hostedClusterAPI_kubeapiserver_available{status="True"}
+              and on (name, namespace, _id, cluster)
+              max by (name, namespace, _id, cluster) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0)
+            )[5m:1m]
+          )
+        )
+        and on (name, namespace, _id, cluster)
+        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
+    - record: hostedClusterAPI_kubeapiserver_available:sli_count_5m
+      expr: |
+        sum by (name, namespace, _id, cluster) (
+          count_over_time(
+            (
+              max by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
+              and on (name, namespace, _id, cluster)
+              max by (name, namespace, _id, cluster) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0)
+            )[5m:1m]
+          )
+        )
+        and on (name, namespace, _id, cluster)
+        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
+    - record: hostedClusterAPI_kubeapiserver_available:sli_sum_1h
+      expr: |
+        sum by (name, namespace, _id, cluster) (
+          sum_over_time(
+            (
+              hostedClusterAPI_kubeapiserver_available{status="True"}
+              and on (name, namespace, _id, cluster)
+              max by (name, namespace, _id, cluster) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0)
+            )[1h:1m]
+          )
+        )
+        and on (name, namespace, _id, cluster)
+        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
+    - record: hostedClusterAPI_kubeapiserver_available:sli_count_1h
+      expr: |
+        sum by (name, namespace, _id, cluster) (
+          count_over_time(
+            (
+              max by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
+              and on (name, namespace, _id, cluster)
+              max by (name, namespace, _id, cluster) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0)
+            )[1h:1m]
+          )
+        )
+        and on (name, namespace, _id, cluster)
+        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
+    - record: hostedClusterAPI_kubeapiserver_available:sli_sum_30m
+      expr: |
+        sum by (name, namespace, _id, cluster) (
+          sum_over_time(
+            (
+              hostedClusterAPI_kubeapiserver_available{status="True"}
+              and on (name, namespace, _id, cluster)
+              max by (name, namespace, _id, cluster) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0)
+            )[30m:1m]
+          )
+        )
+        and on (name, namespace, _id, cluster)
+        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
+    - record: hostedClusterAPI_kubeapiserver_available:sli_count_30m
+      expr: |
+        sum by (name, namespace, _id, cluster) (
+          count_over_time(
+            (
+              max by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
+              and on (name, namespace, _id, cluster)
+              max by (name, namespace, _id, cluster) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0)
+            )[30m:1m]
+          )
+        )
+        and on (name, namespace, _id, cluster)
+        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)

--- a/observability/alerts/UJKubeApiserverAvailabilityRecord-prometheusRule-KSM_test.yaml
+++ b/observability/alerts/UJKubeApiserverAvailabilityRecord-prometheusRule-KSM_test.yaml
@@ -1,0 +1,23 @@
+rule_files:
+- HCPkasRecord-prometheusRule-KSM.yaml
+- UJKubeApiserverAvailabilityRecord-prometheusRule-KSM.yaml
+evaluation_interval: 1m
+tests:
+# Recording rules are exercised end-to-end by UJKubeApiserverAvailabilityMonitor-prometheusRule-KSM_test.yaml
+# (6 alert scenarios covering all 6 SLI rules). This file satisfies the generator's
+# test-file requirement with a basic smoke test.
+- interval: 1m
+  input_series:
+  - series: 'hostedClusterAPI_kubeapiserver_available{status="True", name="test-cluster", namespace="clusters", _id="abc-123", cluster="mgmt-cluster"}'
+    values: "1+0x30"
+  promql_expr_test:
+  - eval_time: 20m
+    expr: hostedClusterAPI_kubeapiserver_available:sli_sum_5m{name="test-cluster"}
+    exp_samples:
+    - labels: 'hostedClusterAPI_kubeapiserver_available:sli_sum_5m{_id="abc-123", cluster="mgmt-cluster", name="test-cluster", namespace="clusters"}'
+      value: 5
+  - eval_time: 20m
+    expr: hostedClusterAPI_kubeapiserver_available:sli_count_5m{name="test-cluster"}
+    exp_samples:
+    - labels: 'hostedClusterAPI_kubeapiserver_available:sli_count_5m{_id="abc-123", cluster="mgmt-cluster", name="test-cluster", namespace="clusters"}'
+      value: 5

--- a/observability/recording-rules-hcps.yaml
+++ b/observability/recording-rules-hcps.yaml
@@ -3,5 +3,6 @@ prometheusRules:
   - ../observability/alerts/HCPkasRecord-prometheusRule-KSM.yaml
   - ../observability/alerts/HCPkasRecord-prometheusRule-apiserver-requests.yaml
   - ../observability/alerts/HCPkasRecord-prometheusRule-latency.yaml
+  - ../observability/alerts/UJKubeApiserverAvailabilityRecord-prometheusRule-KSM.yaml
   untestedRules: []
   outputBicep: ../dev-infrastructure/modules/metrics/rules/generatedHCPRecordingRules.bicep

--- a/tooling/prometheus-rules/Makefile
+++ b/tooling/prometheus-rules/Makefile
@@ -23,7 +23,7 @@ fmt-devinfra:
 run: alerts recording-rules
 .PHONY: run
 
-alerts: run-sl-services run-sre-hcps run-sre-services run-rp-services run-msft-services
+alerts: run-sl-services run-sre-hcps run-sre-services run-rp-services run-rp-hcps run-msft-services
 	$(MAKE) fmt-devinfra
 .PHONY: alerts
 
@@ -46,6 +46,10 @@ run-sre-services:
 run-rp-services:
 	go run ./...  --config-file ../../observability/alerts-rp-services.yaml $(EXTRA_FLAGS)
 .PHONY: run-rp-services
+
+run-rp-hcps:
+	go run ./...  --config-file ../../observability/alerts-rp-hcps.yaml $(EXTRA_FLAGS)
+.PHONY: run-rp-hcps
 
 run-msft-services:
 	go run ./...  --config-file ../../observability/alerts-msft-services.yaml $(EXTRA_FLAGS)

--- a/tooling/prometheus-rules/internal/generator.go
+++ b/tooling/prometheus-rules/internal/generator.go
@@ -581,6 +581,8 @@ resource {{.name}} 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' 
           actionProperties: {
             'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
             'IcM.CorrelationId': '#$.annotations.correlationId#'
+            'IcM.Description': '#$.annotations.info#'
+            'IcM.TsgId': '#$.annotations.runbook_url#'
           }
         }]
         alert: '{{.Alert}}'

--- a/tooling/prometheus-rules/testdata/generated.bicep
+++ b/tooling/prometheus-rules/testdata/generated.bicep
@@ -19,6 +19,8 @@ resource InstancesDownV1 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
           actionProperties: {
             'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
             'IcM.CorrelationId': '#$.annotations.correlationId#'
+            'IcM.Description': '#$.annotations.info#'
+            'IcM.TsgId': '#$.annotations.runbook_url#'
           }
         }]
         alert: 'InstancesDownV1'
@@ -42,6 +44,8 @@ resource InstancesDownV1 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
           actionProperties: {
             'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
             'IcM.CorrelationId': '#$.annotations.correlationId#'
+            'IcM.Description': '#$.annotations.info#'
+            'IcM.TsgId': '#$.annotations.runbook_url#'
           }
         }]
         alert: 'KubePodNotReady'

--- a/tooling/prometheus-rules/testdata/generated_5m.bicep
+++ b/tooling/prometheus-rules/testdata/generated_5m.bicep
@@ -19,6 +19,8 @@ resource InstancesDownV1 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
           actionProperties: {
             'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
             'IcM.CorrelationId': '#$.annotations.correlationId#'
+            'IcM.Description': '#$.annotations.info#'
+            'IcM.TsgId': '#$.annotations.runbook_url#'
           }
         }]
         alert: 'InstancesDownV1'
@@ -42,6 +44,8 @@ resource InstancesDownV1 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
           actionProperties: {
             'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
             'IcM.CorrelationId': '#$.annotations.correlationId#'
+            'IcM.Description': '#$.annotations.info#'
+            'IcM.TsgId': '#$.annotations.runbook_url#'
           }
         }]
         alert: 'KubePodNotReady'


### PR DESCRIPTION
<!-- Link to Jira issue -->
https://redhat.atlassian.net/browse/ARO-26202

### What

<!-- Briefly describe what this PR does -->

Add multi-window burn-rate KubeAPIServer availability alerts for
Hosted Control Planes, routed to the Resource Provider ICM queue.

Alerting rules (slo: kas-availability):
- UJKubeApiserverAvailability1h5m: fast burn (14.4x, 1h/5m, for: 10m, Sev2)
- UJKubeApiserverAvailability6h30m: medium burn (6x, 6h/30m, for: 30m, Sev2)
- UJKubeApiserverAvailability3d6h: slow burn (1x, 3d/6h, for: 3h, Sev3)
- 99.95% SLO target with per-HCP correlationId for IcM grouping
- Provisioning grace period via offset 15m gate on recording rules

Recording rules (in recording-rules-hcps.yaml only):
- 5m, 1h, 30m SLI sum/count windows with offset blackout
- 6h windows reused from HCPkasRecord to avoid duplicates

Generator enhancements:
- IcM.Description and IcM.TsgId in bicep alert action template

### Why

<!-- Briefly explain why this change is needed -->

Enable SLA (Sev2) impacting alerts on KAS for the ARO SRE team. Enable all teams to see TSGs and Descriptions in ICMs for their alerts.

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

Included unit tests.

### Special notes for your reviewer

<!-- optional -->

There are known gaps to this monitoring approach. My hope is that these alerts are replaced by metrics backed by [RFE-9299](https://redhat.atlassian.net/browse/RFE-9299) someday soon.

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge