### PR TITLE
use 45m timeout for multiversion cluster/nodepool creation

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -213,6 +213,8 @@ Framework helpers include an API version suffix. See [`test/AGENTS.md`](../AGENT
 |----------|----------|-------------|
 | Provisioning | `ClusterCreationTimeout` | `CreateHCPClusterFromParam20240610`, `CreateHCPClusterAndWait20240610`; preview: `CreateHCPClusterFromParam20251223`, `CreateHCPClusterAndWait20251223` |
 | Provisioning | `NodePoolCreationTimeout` | `CreateNodePoolFromParam20240610`, `CreateNodePoolAndWait20240610`; preview: `CreateNodePoolFromParam20251223`, `CreateNodePoolAndWait20251223` |
+| Provisioning | `MultiversionClusterCreationTimeout` | `CreateHCPClusterAndWait20251223`, `CreateHCPClusterFromParam20251223` in multiversion cross-version install matrix |
+| Provisioning | `MultiversionNodePoolCreationTimeout` | `CreateNodePoolFromParam20240610` in multiversion cross-version install matrix |
 | Provisioning | `ExternalAuthCreationTimeout` | `CreateOrUpdateExternalAuthAndWait20240610` |
 | Access cluster | `GetAdminRESTConfigTimeout` | `GetAdminRESTConfigForHCPCluster20240610` |
 | Deletion | `HCPClusterDeletionTimeout` | `DeleteHCPCluster20240610`, `DeleteAllHCPClusters20240610`, inline delete pollers |

--- a/test/e2e/complete_cluster_create_multiversion.go
+++ b/test/e2e/complete_cluster_create_multiversion.go
@@ -121,7 +121,7 @@ var _ = Describe("ARO-HCP", func() {
 					*resourceGroup.Name,
 					clusterName,
 					clusterResource,
-					framework.ClusterCreationTimeout,
+					framework.MultiversionClusterCreationTimeout,
 				)
 				Expect(err).NotTo(HaveOccurred(), "Swift cluster %s/%s should provision", *resourceGroup.Name, clusterName)
 			} else {
@@ -132,7 +132,7 @@ var _ = Describe("ARO-HCP", func() {
 					*resourceGroup.Name,
 					clusterParams,
 					nil,
-					framework.ClusterCreationTimeout,
+					framework.MultiversionClusterCreationTimeout,
 				)
 				Expect(err).NotTo(HaveOccurred(), "HCP cluster %s/%s should provision", *resourceGroup.Name, clusterName)
 			}
@@ -187,7 +187,7 @@ var _ = Describe("ARO-HCP", func() {
 				managedResourceGroupName,
 				clusterName,
 				nodePoolParams,
-				framework.NodePoolCreationTimeout,
+				framework.MultiversionNodePoolCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred(), "failed to create node pool %q for cluster %q", nodePoolName, clusterName)
 

--- a/test/util/framework/constants.go
+++ b/test/util/framework/constants.go
@@ -24,6 +24,13 @@ const (
 	NodePoolCreationTimeout     = 20 * time.Minute
 	ExternalAuthCreationTimeout = 15 * time.Minute
 	GetAdminRESTConfigTimeout   = 10 * time.Minute
+
+	// Multiversion timeouts cover the cross-version install matrix
+	// (test/e2e/complete_cluster_create_multiversion.go), which exercises
+	// pre-release channels (e.g. "nightly" for 4.23 / 5.0). Pre-release
+	// images take longer to settle than stable ones.
+	MultiversionClusterCreationTimeout  = 45 * time.Minute
+	MultiversionNodePoolCreationTimeout = 45 * time.Minute
 )
 
 // Deletion timeouts


### PR DESCRIPTION
[AROSLSRE-1026](https://redhat.atlassian.net/browse/AROSLSRE-1026)

 ## Summary
  - 8 consecutive failures of `e2e-integration-e2e-parallel` (Jun 3–4), all in `complete_cluster_create_multiversion.go` with `context deadline exceeded` against the 20-min
  `ClusterCreationTimeout`/`NodePoolCreationTimeout`.
  - Kusto evidence (INT, hcp-int-uk): clusters reach CS-ready at ~T+7–9 min but ARM `provisioningState` remains `Provisioning` when the test cancels at T+20 min. Total
  time-to-Succeeded for nightly images (4.23/5.0) is ~22–25 min.
  - Introduces dedicated `MultiversionClusterCreationTimeout` / `MultiversionNodePoolCreationTimeout` constants at 45 min so multiversion tests get the headroom they need
  without changing the budget for unrelated suites.

  ## Changes
  - `test/util/framework/constants.go`: new `Multiversion*` constants (45m)
  - `test/e2e/complete_cluster_create_multiversion.go`: 3 call sites switched to the new constants
  - `test/e2e/README.md`: timeout table updated

  ## Test plan
  - [x ] Verify `go build ./test/...` passes
  - [ x] Confirm no other test files reference the new constants (scoped to multiversion only)
  - [ ] Watch next `e2e-integration-e2e-parallel` run for green multiversion results