### PR TITLE
config: add endpoint to pav2 schema

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -1611,6 +1611,9 @@
           "properties": {
             "cloudName": {
               "type": "string"
+            },
+            "endpoint": {
+              "type": "string"
             }
           },
           "required": [

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -798,6 +798,7 @@ defaults:
       cloudSuffix: ""
     pav2:
       cloudName: ""
+      endpoint: ""
     kusto:
       sku: ""
       clusterName: ""

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -149,6 +149,7 @@ billing:
     vmUsageStaleThreshold: ""
   pav2:
     cloudName: ""
+    endpoint: ""
   rg: placeholder
 cloud: Public
 cloudEnvironmentName: AzurePublicCloud

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -149,6 +149,7 @@ billing:
     vmUsageStaleThreshold: ""
   pav2:
     cloudName: ""
+    endpoint: ""
   rg: placeholder
 cloud: Public
 cloudEnvironmentName: AzurePublicCloud

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -149,6 +149,7 @@ billing:
     vmUsageStaleThreshold: ""
   pav2:
     cloudName: ""
+    endpoint: ""
   rg: placeholder
 cloud: Public
 cloudEnvironmentName: AzurePublicCloud

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -149,6 +149,7 @@ billing:
     vmUsageStaleThreshold: ""
   pav2:
     cloudName: ""
+    endpoint: ""
   rg: placeholder
 cloud: Public
 cloudEnvironmentName: AzurePublicCloud

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -149,6 +149,7 @@ billing:
     vmUsageStaleThreshold: ""
   pav2:
     cloudName: ""
+    endpoint: ""
   rg: placeholder
 cloud: Public
 cloudEnvironmentName: AzurePublicCloud

--- a/config/rendered/dev/prow/centralus.yaml
+++ b/config/rendered/dev/prow/centralus.yaml
@@ -149,6 +149,7 @@ billing:
     vmUsageStaleThreshold: ""
   pav2:
     cloudName: ""
+    endpoint: ""
   rg: placeholder
 cloud: Public
 cloudEnvironmentName: AzurePublicCloud


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-1124

The pav2 billing block in config.schema.json declared only cloudName. 
With [#5360](https://github.com/Azure/ARO-HCP/pull/5360) locking down nested objects via additionalProperties:false, downstream consumers in sdp-pipelines that supply billing.pav2.endpoint (used as --pav2-management-endpoint by the billing service helm chart) fail validation when the bumper pulls the schema.
Example failure: https://dev.azure.com/msazure/AzureRedHatOpenShift/_build/results?buildId=166864341&view=logs&j=e07a6700-b69e-5756-0459-0afa1acfa8c7&t=083be486-6881-5ab0-68d6-0514cddac9ff

Declare endpoint as an optional string property and add an empty placeholder in the defaults block of config.yaml. Re-rendered configs under config/rendered/dev/ pick up the new field.

### Testing

Only schema change

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
