### PR TITLE
fix(config): allow billing PAv2 endpoint (AROSLSRE-1108)

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -1611,6 +1611,9 @@
           "properties": {
             "cloudName": {
               "type": "string"
+            },
+            "endpoint": {
+              "type": "string"
             }
           },
           "required": [


### PR DESCRIPTION
<!-- Link to Jira issue -->

[AROSLSRE-1108](https://redhat.atlassian.net/browse/AROSLSRE-1108)

### What

Allow `billing.pav2.endpoint` in the HCP service configuration schema.

### Why

The ARO-HCP bumper failed when moving sdp-pipelines to an ARO-HCP revision that includes stricter nested `additionalProperties: false` validation. `billing.pav2.endpoint` is an existing sdp-pipelines value used by the billing deployment, but the generated schema only allowed `cloudName` under `billing.pav2`.

### Testing

```bash
go run ./hack/verify-schema-additional-properties config/config.schema.json
make -C config validate
```

Also validated the failed sdp-pipelines candidate bump config against this patched schema:

```bash
./tooling/aro configuration validate --service-config-file ./hcp/config.yaml \
  --digest-file ./hcp/rendered/digests.yaml \
  --dev-settings-file ./hcp/templatize-settings.yaml \
  --output-dir ./hcp/rendered \
  --update \
  --verbosity=2
```

A custom sweep of the candidate rendered public configs reported zero `additionalProperties` errors.

### Special notes for your reviewer

This is schema-only. It intentionally avoids changing sdp-pipelines rendered config or billing runtime behavior.

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
