### PR TITLE
fix (alerts) : Improving prometheus self monitoring alerts

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
@@ -92,6 +92,74 @@ Please check the status of the Prometheus pods, service endpoints, and network c
             }
           }
         ]
+        alert: 'PrometheusUptimeSampleCount'
+        enabled: true
+        labels: {
+          severity: 'warning'
+        }
+        annotations: {
+          correlationId: 'PrometheusUptimeSampleCount/{{ $labels.cluster }}'
+          description: '''Prometheus has delivered fewer than 95% of expected samples in the past 24 hours (expected 2880 at 30s interval, threshold 2736).
+Unlike PrometheusUptime which averages existing samples, this alert treats data gaps as downtime.
+Complete metric absence (no samples) will also trigger PrometheusMetricsAbsentPerCluster.
+Check the PrometheusAgent pod status, remote write pipeline, and PodMonitor configuration.
+'''
+          info: '''Prometheus has delivered fewer than 95% of expected samples in the past 24 hours (expected 2880 at 30s interval, threshold 2736).
+Unlike PrometheusUptime which averages existing samples, this alert treats data gaps as downtime.
+Complete metric absence (no samples) will also trigger PrometheusMetricsAbsentPerCluster.
+Check the PrometheusAgent pod status, remote write pipeline, and PodMonitor configuration.
+'''
+          runbook_url: 'TBD'
+          summary: 'Prometheus sample count below 95% SLO threshold for 24 hours.'
+          title: 'Prometheus sample count below 95% SLO threshold for 24 hours.'
+        }
+        expression: '(sum by (job, namespace, cluster) (count_over_time(up{job="prometheus/prometheus",namespace="prometheus"}[1d])) < 0.95 * (24 * 3600 / 30)) and sum by (job, namespace, cluster) (count_over_time(up{job="prometheus/prometheus",namespace="prometheus"}[1d] offset 1d)) > 0'
+        for: 'PT10M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'PrometheusMetricsAbsentPerCluster'
+        enabled: true
+        labels: {
+          severity: 'critical'
+        }
+        annotations: {
+          correlationId: 'PrometheusMetricsAbsentPerCluster/{{ $labels.cluster }}'
+          description: '''Prometheus on cluster {{ $labels.cluster }} has not reported any up metrics in the last 10 minutes, but was reporting within the last 7 days.
+This indicates the Prometheus agent on this specific cluster is dead or its remote write pipeline is broken.
+Check the PrometheusAgent pod status and remote write configuration on the affected cluster.
+'''
+          info: '''Prometheus on cluster {{ $labels.cluster }} has not reported any up metrics in the last 10 minutes, but was reporting within the last 7 days.
+This indicates the Prometheus agent on this specific cluster is dead or its remote write pipeline is broken.
+Check the PrometheusAgent pod status and remote write configuration on the affected cluster.
+'''
+          runbook_url: 'TBD'
+          summary: 'Prometheus metrics absent for cluster {{ $labels.cluster }}.'
+          title: 'Prometheus metrics absent for cluster {{ $labels.cluster }}.'
+        }
+        expression: 'count by (cluster) (count_over_time(up{job="prometheus/prometheus",namespace="prometheus"}[1w])) unless count by (cluster) (count_over_time(up{job="prometheus/prometheus",namespace="prometheus"}[10m]))'
+        for: 'PT10M'
+        severity: severityCeiling > 0 ? max(2, severityCeiling) : 2
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
         alert: 'PrometheusPendingRate'
         enabled: true
         labels: {

--- a/observability/alerts/prometheus-prometheusRule.yaml
+++ b/observability/alerts/prometheus-prometheusRule.yaml
@@ -38,6 +38,41 @@ spec:
           Please check the status of the Prometheus pods, service endpoints, and network connectivity.
         runbook_url: TBD # https://runbooks.prometheus-operator.dev/runbooks/prometheus/prometheusdown
         summary: Prometheus is unreachable for 1 day.
+    - alert: PrometheusUptimeSampleCount
+      # The divisor 30 matches spec.scrapeInterval (30s) in prometheus.yaml. Update both together if the interval changes.
+      # sum (not min) so pod restarts don't false-fire: old + new instance samples cover the full day.
+      # The offset 1d gate excludes clusters younger than 24h — without it, new clusters always fire
+      # because count_over_time([1d]) can never reach the full-day threshold until 24h of data exists.
+      expr: |
+        (
+          sum by (job, namespace, cluster) (count_over_time(up{job="prometheus/prometheus",namespace="prometheus"}[1d]))
+          < 0.95 * (24 * 3600 / 30)
+        )
+        and
+        sum by (job, namespace, cluster) (count_over_time(up{job="prometheus/prometheus",namespace="prometheus"}[1d] offset 1d)) > 0
+      for: 10m
+      labels:
+        severity: warning
+      annotations:
+        description: |
+          Prometheus has delivered fewer than 95% of expected samples in the past 24 hours (expected 2880 at 30s interval, threshold 2736).
+          Unlike PrometheusUptime which averages existing samples, this alert treats data gaps as downtime.
+          Complete metric absence (no samples) will also trigger PrometheusMetricsAbsentPerCluster.
+          Check the PrometheusAgent pod status, remote write pipeline, and PodMonitor configuration.
+        runbook_url: TBD
+        summary: Prometheus sample count below 95% SLO threshold for 24 hours.
+    - alert: PrometheusMetricsAbsentPerCluster
+      expr: count by (cluster) (count_over_time(up{job="prometheus/prometheus",namespace="prometheus"}[7d])) unless count by (cluster) (count_over_time(up{job="prometheus/prometheus",namespace="prometheus"}[10m]))
+      for: 10m
+      labels:
+        severity: critical
+      annotations:
+        description: |
+          Prometheus on cluster {{ $labels.cluster }} has not reported any up metrics in the last 10 minutes, but was reporting within the last 7 days.
+          This indicates the Prometheus agent on this specific cluster is dead or its remote write pipeline is broken.
+          Check the PrometheusAgent pod status and remote write configuration on the affected cluster.
+        runbook_url: TBD
+        summary: Prometheus metrics absent for cluster {{ $labels.cluster }}.
     - alert: PrometheusPendingRate
       expr: |
         (

--- a/observability/alerts/prometheus-prometheusRule_test.yaml
+++ b/observability/alerts/prometheus-prometheusRule_test.yaml
@@ -796,6 +796,107 @@ tests:
   - eval_time: 10m
     alertname: PrometheusUptime
     exp_alerts: []
+# Test PrometheusUptimeSampleCount - data gap (dead 6h, no samples)
+# 2160 samples at 30s = 18h of data (t=0 to ~t=1080m), then 6h gap.
+# At eval_time 1450m, [1d] window covers (10m, 1450m] → ~2139 effective samples.
+# 2139 < 2736 (95% of 2880) so the alert fires.
+# The offset 1d gate passes because early samples (t=0–10m) fall in the [1d offset 1d] window.
+- interval: 30s
+  input_series:
+  - series: 'up{job="prometheus/prometheus",namespace="prometheus",cluster="gap-cluster"}'
+    values: "1+0x2160"
+  alert_rule_test:
+  - eval_time: 1450m
+    alertname: PrometheusUptimeSampleCount
+    exp_alerts:
+    - exp_labels:
+        severity: warning
+        job: prometheus/prometheus
+        namespace: prometheus
+        cluster: gap-cluster
+      exp_annotations:
+        summary: Prometheus sample count below 95% SLO threshold for 24 hours.
+        description: |
+          Prometheus has delivered fewer than 95% of expected samples in the past 24 hours (expected 2880 at 30s interval, threshold 2736).
+          Unlike PrometheusUptime which averages existing samples, this alert treats data gaps as downtime.
+          Complete metric absence (no samples) will also trigger PrometheusMetricsAbsentPerCluster.
+          Check the PrometheusAgent pod status, remote write pipeline, and PodMonitor configuration.
+        runbook_url: TBD
+# Test PrometheusUptimeSampleCount - healthy (full 24h of samples)
+# 2880 samples at 30s = 24h of data (t=0 to ~t=1440m).
+# At eval_time 1450m, [1d] window covers (10m, 1450m] → ~2859 effective samples.
+# 2859 > 2736 (95% of 2880) so the alert does not fire.
+- interval: 30s
+  input_series:
+  - series: 'up{job="prometheus/prometheus",namespace="prometheus",cluster="healthy-cluster"}'
+    values: "1+0x2880"
+  alert_rule_test:
+  - eval_time: 1450m
+    alertname: PrometheusUptimeSampleCount
+    exp_alerts: []
+# Test PrometheusUptimeSampleCount - new cluster (< 24h old, should NOT fire)
+# 1440 samples at 30s = 12h of data. Below threshold (1440 < 2736) but the offset 1d gate
+# excludes it: at eval_time 750m the [1d offset 1d] window is entirely before t=0 → no data → gate fails.
+- interval: 30s
+  input_series:
+  - series: 'up{job="prometheus/prometheus",namespace="prometheus",cluster="new-cluster"}'
+    values: "1+0x1440"
+  alert_rule_test:
+  - eval_time: 750m
+    alertname: PrometheusUptimeSampleCount
+    exp_alerts: []
+# Test PrometheusMetricsAbsentPerCluster - cluster went dead
+# 20 samples at 1m interval (t=0 to t=19m), then nothing.
+# At eval_time=40m: [7d] window has 20 samples, [10m] window (t=30m-40m) has 0 → fires.
+- interval: 1m
+  input_series:
+  - series: 'up{job="prometheus/prometheus",namespace="prometheus",cluster="dead-cluster"}'
+    values: "1+0x20"
+  alert_rule_test:
+  - eval_time: 40m
+    alertname: PrometheusMetricsAbsentPerCluster
+    exp_alerts:
+    - exp_labels:
+        severity: critical
+        cluster: dead-cluster
+      exp_annotations:
+        summary: Prometheus metrics absent for cluster dead-cluster.
+        description: |
+          Prometheus on cluster dead-cluster has not reported any up metrics in the last 10 minutes, but was reporting within the last 7 days.
+          This indicates the Prometheus agent on this specific cluster is dead or its remote write pipeline is broken.
+          Check the PrometheusAgent pod status and remote write configuration on the affected cluster.
+        runbook_url: TBD
+# Test PrometheusMetricsAbsentPerCluster - healthy cluster (continuous data)
+- interval: 1m
+  input_series:
+  - series: 'up{job="prometheus/prometheus",namespace="prometheus",cluster="healthy-cluster"}'
+    values: "1+0x50"
+  alert_rule_test:
+  - eval_time: 40m
+    alertname: PrometheusMetricsAbsentPerCluster
+    exp_alerts: []
+# Test PrometheusMetricsAbsentPerCluster - one dead, one healthy
+# Only the dead cluster should fire.
+- interval: 1m
+  input_series:
+  - series: 'up{job="prometheus/prometheus",namespace="prometheus",cluster="alive"}'
+    values: "1+0x50"
+  - series: 'up{job="prometheus/prometheus",namespace="prometheus",cluster="dead"}'
+    values: "1+0x20"
+  alert_rule_test:
+  - eval_time: 40m
+    alertname: PrometheusMetricsAbsentPerCluster
+    exp_alerts:
+    - exp_labels:
+        severity: critical
+        cluster: dead
+      exp_annotations:
+        summary: Prometheus metrics absent for cluster dead.
+        description: |
+          Prometheus on cluster dead has not reported any up metrics in the last 10 minutes, but was reporting within the last 7 days.
+          This indicates the Prometheus agent on this specific cluster is dead or its remote write pipeline is broken.
+          Check the PrometheusAgent pod status and remote write configuration on the affected cluster.
+        runbook_url: TBD
 # Test multiple namespaces and jobs
 - interval: 1m
   input_series:


### PR DESCRIPTION
Two Correlated Issues for Prometheus [JobUp](https://redhat.atlassian.net/browse/ARO-25100) and [UpTime](https://redhat.atlassian.net/browse/ARO-25101) Alerts

### What

Prometheus self monitoring alerts have some blind spots in cases where the Prometheus Agent goes completely down and we do not know about it. 

- Add `PrometheusUptimeSampleCount` alert: fires when Prometheus delivers fewer than 95% of expected samples in a 24-hour window (gap-aware via count_over_time), complementing the existing `PrometheusUptime` alert which only averages existing samples. Uses sum by to avoid false-firing on pod restarts, and an offset 1d gate to exclude clusters younger than 24 hours.
- Add `PrometheusMetricsAbsentPerCluster` alert: fires when a specific cluster stops reporting up metrics entirely (zero samples in 10 minutes while having reported within the last 7 days). Moved from hand-written Bicep (amw-ingestion-alerts.bicep) into prometheus-prometheusRule.yaml so it goes through the promtool testing pipeline.

### Why

To strengthen the observability in ARO HCP with respect to Prometheus self monitoring

### Testing

testing is added for new alerts. Also, this has been performed on a dev env cluster for both svc snd mgmt clusters with success. 

### Special notes for your reviewer

This is an enhancements that will be followed by TSGs and SOPs for related ICMs in SRE queue which is yet to be taken care in real environment linked to ICM. Currently, all testings have been done in a dev env. 

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if graph/UI/metrics changes) [ARO-25099](https://redhat.atlassian.net/browse/ARO-25099)
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [x] All comment threads resolved before merge
