### PR TITLE
Gate update completion on customer-properties matching observed status

### DIFF
--- a/backend/pkg/controllers/operationcontrollers/customer_properties_status_diff.go
+++ b/backend/pkg/controllers/operationcontrollers/customer_properties_status_diff.go
@@ -1,0 +1,79 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operationcontrollers
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+)
+
+// DiffCustomerPropertiesAgainstStatus walks HCPOpenShiftClusterCustomerProperties
+// (the customer's desired state) and compares each field that has a
+// counterpart in ServiceProviderClusterStatus (the observed state) for equality.
+// It returns one field.Error per mismatch; an empty list means the observed
+// state matches the desired customer properties.
+//
+// The traversal mirrors the style used in internal/validation: one function
+// per struct, each taking a field path and the matching pair of pointers.
+// Customer-properties subfields without an observed counterpart in
+// ServiceProviderClusterStatus are skipped (nothing to compare).
+func DiffCustomerPropertiesAgainstStatus(customerProperties *api.HCPOpenShiftClusterCustomerProperties, status *api.ServiceProviderClusterStatus) field.ErrorList {
+	errs := field.ErrorList{}
+	fldPath := field.NewPath("customerProperties")
+
+	// Version VersionProfile -> Status.CustomerPropertiesStatus.Version VersionProfileStatus
+	errs = append(errs, diffVersionProfileAgainstStatus(
+		fldPath.Child("version"),
+		&customerProperties.Version,
+		&status.CustomerPropertiesStatus.Version,
+	)...)
+
+	// DNS, Network, API, Platform, Autoscaling, NodeDrainTimeoutMinutes, Etcd,
+	// ClusterImageRegistry, ImageDigestMirrors have no counterparts in
+	// ServiceProviderClusterStatus.CustomerPropertiesStatus today, so nothing
+	// to compare. Add per-struct diff functions here as status surfaces grow.
+
+	return errs
+}
+
+// diffVersionProfileAgainstStatus compares the customer-desired VersionProfile
+// against the observed VersionProfileStatus and emits one entry per field
+// that does not match.
+func diffVersionProfileAgainstStatus(fldPath *field.Path, desired *api.VersionProfile, observed *api.VersionProfileStatus) field.ErrorList {
+	errs := field.ErrorList{}
+
+	// ID string
+	if desired.ID != observed.ID {
+		errs = append(errs, field.Invalid(
+			fldPath.Child("id"),
+			desired.ID,
+			fmt.Sprintf("does not match observed value %q", observed.ID),
+		))
+	}
+
+	// ChannelGroup string
+	if desired.ChannelGroup != observed.ChannelGroup {
+		errs = append(errs, field.Invalid(
+			fldPath.Child("channelGroup"),
+			desired.ChannelGroup,
+			fmt.Sprintf("does not match observed value %q", observed.ChannelGroup),
+		))
+	}
+
+	return errs
+}

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_update.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_update.go
@@ -150,6 +150,11 @@ func (c *operationClusterUpdate) determineOperationState(ctx context.Context, op
 	} else {
 		operationStates = append(operationStates, operationState)
 	}
+	if operationState, err := c.customerPropertiesStatusMatchOperationState(ctx, operation); err != nil {
+		errs = append(errs, utils.TrackError(err))
+	} else {
+		operationStates = append(operationStates, operationState)
+	}
 	if operationState, csErr := c.clusterServiceUpdateOperationState(ctx, operation); csErr != nil {
 		errs = append(errs, utils.TrackError(csErr))
 	} else {
@@ -239,6 +244,34 @@ func (c *operationClusterUpdate) desiredVersionResolutionOperationState(ctx cont
 	}
 	c.desiredVersionMismatchFirstSeen.Remove(operation.ResourceID.String())
 	return newOperationState(arm.ProvisioningStateFailed, intentFailedCondition.Message), nil
+}
+
+// customerPropertiesStatusMatchOperationState returns Succeeded when every
+// HCPOpenShiftClusterCustomerProperties field with an observed counterpart in
+// ServiceProviderCluster.Status matches that observed value, and Accepted
+// otherwise. The Accepted message is the stringified, "; "-joined list of
+// field.Errors produced by DiffCustomerPropertiesAgainstStatus so the caller
+// can see exactly which desired-vs-observed fields are still diverging.
+func (c *operationClusterUpdate) customerPropertiesStatusMatchOperationState(ctx context.Context, operation *api.Operation) (*operationState, error) {
+	existingCluster, err := c.resourcesDBClient.HCPClusters(operation.ExternalID.SubscriptionID, operation.ExternalID.ResourceGroupName).Get(ctx, operation.ExternalID.Name)
+	if err != nil {
+		return nil, utils.TrackError(err)
+	}
+	existingServiceProviderCluster, err := c.resourcesDBClient.ServiceProviderClusters(operation.ExternalID.SubscriptionID, operation.ExternalID.ResourceGroupName, operation.ExternalID.Name).Get(ctx, api.ServiceProviderClusterResourceName)
+	if err != nil {
+		return nil, utils.TrackError(err)
+	}
+
+	diffs := DiffCustomerPropertiesAgainstStatus(&existingCluster.CustomerProperties, &existingServiceProviderCluster.Status)
+	if len(diffs) == 0 {
+		return newOperationState(arm.ProvisioningStateSucceeded, ""), nil
+	}
+
+	msgs := make([]string, 0, len(diffs))
+	for _, e := range diffs {
+		msgs = append(msgs, e.Error())
+	}
+	return newOperationState(arm.ProvisioningStateAccepted, strings.Join(msgs, "; ")), nil
 }
 
 func (c *operationClusterUpdate) clusterServiceUpdateOperationState(ctx context.Context, operation *api.Operation) (*operationState, error) {

--- a/backend/pkg/controllers/statuscontrollers/customer_properties_version_status_controller.go
+++ b/backend/pkg/controllers/statuscontrollers/customer_properties_version_status_controller.go
@@ -1,0 +1,160 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statuscontrollers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+
+	hsv1beta1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/backend/pkg/maestrohelpers"
+	"github.com/Azure/ARO-HCP/internal/api"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/database"
+	dblisters "github.com/Azure/ARO-HCP/internal/database/listers"
+	unionkubeapplierinformers "github.com/Azure/ARO-HCP/internal/database/unioninformers/kubeapplier"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// customerPropertiesVersionStatusSyncer is a Cluster syncer that updates
+// ServiceProviderCluster.Status.CustomerPropertiesStatus.Version by reading the
+// observed version from the per-cluster ReadDesire's HostedCluster mirror
+// (the kube-applier's view of the management cluster's HostedCluster).
+type customerPropertiesVersionStatusSyncer struct {
+	cooldownChecker   controllerutil.CooldownChecker
+	resourcesDBClient database.ResourcesDBClient
+	readDesireLister  dblisters.ReadDesireLister
+}
+
+var _ controllerutils.ClusterSyncer = (*customerPropertiesVersionStatusSyncer)(nil)
+
+// NewCustomerPropertiesVersionStatusController creates a controller that
+// populates ServiceProviderCluster.Status.CustomerPropertiesStatus.Version
+// from the per-cluster ReadDesire's observed HostedCluster.
+func NewCustomerPropertiesVersionStatusController(
+	resourcesDBClient database.ResourcesDBClient,
+	activeOperationLister listers.ActiveOperationLister,
+	informers informers.BackendInformers,
+	kubeApplierInformers *unionkubeapplierinformers.UnionKubeApplierInformers,
+	readDesireLister dblisters.ReadDesireLister,
+) controllerutils.Controller {
+	syncer := &customerPropertiesVersionStatusSyncer{
+		cooldownChecker:   controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		resourcesDBClient: resourcesDBClient,
+		readDesireLister:  readDesireLister,
+	}
+
+	return controllerutils.NewClusterWatchingController(
+		"CustomerPropertiesVersionStatus",
+		resourcesDBClient,
+		informers,
+		kubeApplierInformers,
+		5*time.Minute,
+		syncer,
+	)
+}
+
+func (c *customerPropertiesVersionStatusSyncer) CooldownChecker() controllerutil.CooldownChecker {
+	return c.cooldownChecker
+}
+
+func (c *customerPropertiesVersionStatusSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPClusterKey) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	// TODO, decide how fast we'll allow repeated syncs.  Maybe limit firing to HostedCluster changes?
+
+	existingCluster, err := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).Get(ctx, key.HCPClusterName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get Cluster: %w", err))
+	}
+
+	hostedCluster, err := maestrohelpers.GetCachedHostedClusterForCluster(ctx, c.readDesireLister, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get HostedCluster from ReadDesire: %w", err))
+	}
+	if hostedCluster == nil {
+		// ReadDesire absent or kubeContent not yet observed; the next
+		// ReadDesire event will retrigger this controller.
+		return nil
+	}
+
+	observedVersionID := latestAttemptedHostedClusterVersion(hostedCluster)
+	if observedVersionID == "" {
+		// Nothing observable yet — leave the existing status as-is rather than
+		// clearing what may already be a meaningful value.
+		return nil
+	}
+
+	desiredStatusVersion := api.VersionProfileStatus{
+		ID: observedVersionID,
+		// ChannelGroup is not observable from the HostedCluster; mirror the
+		// customer-supplied value from spec so the status surface is complete.
+		ChannelGroup: existingCluster.CustomerProperties.Version.ChannelGroup,
+	}
+
+	existingServiceProviderCluster, err := database.GetOrCreateServiceProviderCluster(ctx, c.resourcesDBClient, key.GetResourceID())
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get or create ServiceProviderCluster: %w", err))
+	}
+
+	if equality.Semantic.DeepEqual(existingServiceProviderCluster.Status.CustomerPropertiesStatus.Version, desiredStatusVersion) {
+		return nil
+	}
+
+	logger.Info("CustomerPropertiesStatus.Version changed",
+		"old", existingServiceProviderCluster.Status.CustomerPropertiesStatus.Version,
+		"new", desiredStatusVersion)
+	existingServiceProviderCluster.Status.CustomerPropertiesStatus.Version = desiredStatusVersion
+
+	serviceProviderClustersCosmosClient := c.resourcesDBClient.ServiceProviderClusters(key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if _, err := serviceProviderClustersCosmosClient.Replace(ctx, existingServiceProviderCluster, nil); err != nil {
+		return utils.TrackError(fmt.Errorf("failed to replace ServiceProviderCluster: %w", err))
+	}
+	return nil
+}
+
+// latestAttemptedHostedClusterVersion returns the most recent version string
+// the HostedCluster has attempted to install, regardless of whether the
+// attempt completed. History is ordered newest-first, so the first entry
+// with a non-empty Version wins (Partial or Completed). It prefers
+// status.controlPlaneVersion.history (populated on 4.22+ clusters per
+// https://github.com/openshift/enhancements/pull/1950) and falls back to
+// status.version.history for older clusters. Returns "" if neither source
+// has a usable entry, so the caller can decline to overwrite existing status.
+func latestAttemptedHostedClusterVersion(hostedCluster *hsv1beta1.HostedCluster) string {
+	for _, entry := range hostedCluster.Status.ControlPlaneVersion.History {
+		if entry.Version != "" {
+			return entry.Version
+		}
+	}
+	if hostedCluster.Status.Version != nil {
+		for _, entry := range hostedCluster.Status.Version.History {
+			if entry.Version != "" {
+				return entry.Version
+			}
+		}
+	}
+	return ""
+}

--- a/internal/api/types_cluster.go
+++ b/internal/api/types_cluster.go
@@ -47,6 +47,16 @@ type HCPOpenShiftClusterStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 }
 
+type CustomerPropertiesStatus struct {
+	Version VersionProfileStatus `json:"version,omitempty"`
+}
+
+// VersionProfileStatus (and all status values) are separate structs because not every item is preserved.
+type VersionProfileStatus struct {
+	ID           string `json:"id,omitempty"`
+	ChannelGroup string `json:"channelGroup,omitempty"`
+}
+
 var _ arm.CosmosPersistable = &HCPOpenShiftCluster{}
 
 // HCPOpenShiftClusterCustomerProperties represents the property bag of a HCPOpenShiftCluster resource.

--- a/internal/api/types_serviceprovider_cluster.go
+++ b/internal/api/types_serviceprovider_cluster.go
@@ -129,6 +129,8 @@ type ServiceProviderClusterStatus struct {
 	// this HCP is placed on. Nil means placement has not been resolved yet.
 	// Once set, this field is immutable.
 	ManagementClusterResourceID *azcorearm.ResourceID `json:"managementClusterResourceID,omitempty"`
+
+	CustomerPropertiesStatus CustomerPropertiesStatus `json:"customerPropertiesStatus,omitempty"`
 }
 
 // ServiceProviderClusterStatusVersion contains the actual version information.


### PR DESCRIPTION
Before reporting a cluster update operation Succeeded, require that the customer-settable HCPOpenShiftClusterCustomerProperties fields match the observed values mirrored into ServiceProviderCluster.Status. While any desired field still differs from its observed counterpart, the update stays ProvisioningStateAccepted with a message listing the diverging fields, so callers can see exactly which intent has not yet landed.

Today this covers the version profile (id, channelGroup). The diff walker is structured per-struct (mirroring internal/validation) so we can extend the same pattern to the remaining user-settable fields as their observed counterparts are added to ServiceProviderCluster.Status.

/hold no tests