### PR TITLE
Add node pool rollout warning to imageDigestMirrors doc comment

### DIFF
--- a/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
+++ b/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
@@ -93,6 +93,8 @@ model HcpOpenShiftClusterProperties {
 
   /** imageDigestMirrors is a set of rules to allow pulling images from a
    * mirrored registry by using digest specifications.
+   *
+   * WARNING: Updating this array will redeploy all node pools in the cluster.
    */
   @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
   @added(Versions.v2025_12_23_preview)

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2025-12-23-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2025-12-23-preview/openapi.json
@@ -2284,7 +2284,7 @@
         },
         "imageDigestMirrors": {
           "type": "array",
-          "description": "imageDigestMirrors is a set of rules to allow pulling images from a\nmirrored registry by using digest specifications.",
+          "description": "imageDigestMirrors is a set of rules to allow pulling images from a\nmirrored registry by using digest specifications.\n\nWARNING: Updating this array will redeploy all node pools in the cluster.",
           "maxItems": 240,
           "items": {
             "$ref": "#/definitions/ImageDigestMirror"
@@ -2357,7 +2357,7 @@
         },
         "imageDigestMirrors": {
           "type": "array",
-          "description": "imageDigestMirrors is a set of rules to allow pulling images from a\nmirrored registry by using digest specifications.",
+          "description": "imageDigestMirrors is a set of rules to allow pulling images from a\nmirrored registry by using digest specifications.\n\nWARNING: Updating this array will redeploy all node pools in the cluster.",
           "maxItems": 240,
           "items": {
             "$ref": "#/definitions/ImageDigestMirror"

--- a/internal/api/v20251223preview/generated/models.go
+++ b/internal/api/v20251223preview/generated/models.go
@@ -345,6 +345,7 @@ type HcpOpenShiftClusterProperties struct {
 	Etcd *EtcdProfile
 
 	// imageDigestMirrors is a set of rules to allow pulling images from a mirrored registry by using digest specifications.
+	// WARNING: Updating this array will redeploy all node pools in the cluster.
 	ImageDigestMirrors []*ImageDigestMirror
 
 	// Cluster network configuration
@@ -373,6 +374,7 @@ type HcpOpenShiftClusterPropertiesUpdate struct {
 	Autoscaling *ClusterAutoscalingProfile
 
 	// imageDigestMirrors is a set of rules to allow pulling images from a mirrored registry by using digest specifications.
+	// WARNING: Updating this array will redeploy all node pools in the cluster.
 	ImageDigestMirrors []*ImageDigestMirror
 
 	// nodeDrainTimeoutMinutes is the grace period for how long Pod Disruption Budget-protected workloads will be respected during


### PR DESCRIPTION
[ARO-27584](https://redhat.atlassian.net/browse/ARO-27584)

### What

Add a doc comment to the `imageDigestMirrors` field in the TypeSpec API model warning that any change to this value will trigger a rollout for all existing node pools in the cluster. Regenerated OpenAPI spec and Go models.

### Why

A customer incident revealed that adding new IDMS entries post-install caused an unexpected node rollout across all NodePools. The API spec did not mention this side effect. This aligns with how Hypershift documents the equivalent `imageContentSources` field, without exposing internal implementation details.

### Testing

Doc-only change — no behavioral change. Verified that `make generate` in `api/` produces a clean diff with no unexpected changes.

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge