### PR TITLE
fix(prometheus-rules): preserve GenerateFromConfig API (AROSLSRE-1131)

### DIFF
--- a/tooling/prometheus-rules/main.go
+++ b/tooling/prometheus-rules/main.go
@@ -38,7 +38,7 @@ func main() {
 		logrus.WithError(err).Fatal("invalid options")
 	}
 
-	if err := prometheusrules.GenerateFromConfig(configFilePath, promtoolPath); err != nil {
+	if err := prometheusrules.GenerateFromConfig(configFilePath, false, promtoolPath); err != nil {
 		logrus.WithError(err).Fatal("error running generator")
 	}
 

--- a/tooling/prometheus-rules/main_test.go
+++ b/tooling/prometheus-rules/main_test.go
@@ -72,7 +72,7 @@ func TestPrometheusRules(t *testing.T) {
 			} {
 				require.NoError(t, copyFile(testfile, filepath.Join(tmpDir, "alerts")))
 			}
-			err := prometheusrules.GenerateFromConfig(filepath.Join(tmpDir, "config.yaml"), "promtool")
+			err := prometheusrules.GenerateFromConfig(filepath.Join(tmpDir, "config.yaml"), false, "promtool")
 			require.NoError(t, err)
 
 			generatedFile, err := os.ReadFile(filepath.Join(tmpDir, "zzz_generated_AlertingRules.bicep"))
@@ -100,7 +100,7 @@ func TestPrometheusRulesMissingTest(t *testing.T) {
 	} {
 		require.NoError(t, copyFile(testfile, filepath.Join(tmpDir, "alerts")))
 	}
-	err := prometheusrules.GenerateFromConfig(filepath.Join(tmpDir, "config.yaml"), "promtool")
+	err := prometheusrules.GenerateFromConfig(filepath.Join(tmpDir, "config.yaml"), false, "promtool")
 	require.ErrorContains(t, err, "missing testfile")
 }
 
@@ -139,7 +139,7 @@ tests: []
 
 	// Run the generator - it should handle mixed rules based on file type
 	// Since we're using AlertingRules filename, it should process only alerts
-	err = prometheusrules.GenerateFromConfig(filepath.Join(tmpDir, "config.yaml"), "promtool")
+	err = prometheusrules.GenerateFromConfig(filepath.Join(tmpDir, "config.yaml"), false, "promtool")
 	require.NoError(t, err)
 
 	// Verify the generated file exists and contains only alert rules

--- a/tooling/prometheus-rules/pkg/prometheusrules/prometheusrules.go
+++ b/tooling/prometheus-rules/pkg/prometheusrules/prometheusrules.go
@@ -36,7 +36,8 @@ func Validate(args []string, configFilePath, promtoolPath string) error {
 }
 
 // GenerateFromConfig validates and renders rule files into Bicep output.
-func GenerateFromConfig(configFilePath string, promtoolPath string) error {
+// forceInfoSeverity is kept for compatibility with external callers and is ignored.
+func GenerateFromConfig(configFilePath string, _ bool, promtoolPath string) error {
 	o := internal.NewOptions()
 
 	if err := o.Complete(configFilePath, promtoolPath); err != nil {


### PR DESCRIPTION
<!-- Link to Jira issue -->
https://issues.redhat.com/browse/AROSLSRE-1131

### What

Restore the exported `prometheusrules.GenerateFromConfig` signature to accept the previous `forceInfoSeverity` argument while keeping that argument ignored.

### Why

`sdp-pipelines` imports this package and the `bump-aro-hcp` job updates ARO-HCP tooling modules before rebuilding `tooling/aro`. After ARO-HCP PR #5460 removed the unused argument, the bumper started failing with a Go compile error in sdp-pipelines before it could create the normal bump PR.

### Testing

```text
go test ./tooling/prometheus-rules/...
```

### Special notes for your reviewer

This is intentionally a compatibility-only unblock. It does not reintroduce the removed CLI flag or change alert rendering behavior. Once the bumper has moved sdp-pipelines to this compatible ARO-HCP revision, a follow-up can remove the stale sdp wrapper option safely.

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
