### PR TITLE
feat: stagger e2e starts

### DIFF
--- a/test/util/framework/constants.go
+++ b/test/util/framework/constants.go
@@ -14,7 +14,11 @@
 
 package framework
 
-import "time"
+import (
+	"os"
+	"strconv"
+	"time"
+)
 
 // When updating timeouts, see test/e2e/README.md#updating-e2e-timeouts.
 
@@ -43,3 +47,18 @@ const (
 const (
 	IdentityContainerAssignmentRetryInterval = 60 * time.Second
 )
+
+// ClusterCreateStaggerInterval returns the stagger delay between successive
+// cluster creation starts, read from E2E_CLUSTER_CREATE_STAGGER_SECONDS.
+// Returns 0 (disabled) when the env var is unset or empty.
+func ClusterCreateStaggerInterval() time.Duration {
+	s := os.Getenv("E2E_CLUSTER_CREATE_STAGGER_SECONDS")
+	if s == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil || n <= 0 {
+		return 0
+	}
+	return time.Duration(n) * time.Second
+}

--- a/test/util/framework/constants.go
+++ b/test/util/framework/constants.go
@@ -54,7 +54,7 @@ const (
 func ClusterCreateStaggerInterval() time.Duration {
 	s := os.Getenv("E2E_CLUSTER_CREATE_STAGGER_SECONDS")
 	if s == "" {
-		return 0
+		return 15 * time.Second
 	}
 	n, err := strconv.Atoi(s)
 	if err != nil || n <= 0 {

--- a/test/util/framework/constants.go
+++ b/test/util/framework/constants.go
@@ -54,7 +54,7 @@ const (
 func ClusterCreateStaggerInterval() time.Duration {
 	s := os.Getenv("E2E_CLUSTER_CREATE_STAGGER_SECONDS")
 	if s == "" {
-		return 30 * time.Second
+		return 60 * time.Second
 	}
 	n, err := strconv.Atoi(s)
 	if err != nil || n <= 0 {

--- a/test/util/framework/constants.go
+++ b/test/util/framework/constants.go
@@ -54,7 +54,7 @@ const (
 func ClusterCreateStaggerInterval() time.Duration {
 	s := os.Getenv("E2E_CLUSTER_CREATE_STAGGER_SECONDS")
 	if s == "" {
-		return 15 * time.Second
+		return 30 * time.Second
 	}
 	n, err := strconv.Atoi(s)
 	if err != nil || n <= 0 {

--- a/test/util/framework/identities_helper.go
+++ b/test/util/framework/identities_helper.go
@@ -273,10 +273,24 @@ func (tc *perItOrDescribeTestContext) AssignIdentityContainers(ctx context.Conte
 	attempt := 0
 	for {
 		attempt++
-		err := state.assignNTo(specID(), count)
+		ordinal, err := state.assignNTo(specID(), count)
 		if err == nil {
 			ginkgo.GinkgoLogr.Info("Successfully assigned identity containers",
 				"count", count, "attempt", attempt, "elapsed", time.Since(startTime).Round(time.Second))
+
+			if stagger := ClusterCreateStaggerInterval(); stagger > 0 {
+				delay := time.Duration(ordinal) * stagger
+				if delay > 0 {
+					ginkgo.GinkgoLogr.Info("Staggering cluster creation start",
+						"ordinal", ordinal, "staggerInterval", stagger, "delay", delay)
+					select {
+					case <-ctx.Done():
+						return fmt.Errorf("context cancelled during stagger delay: %w", ctx.Err())
+					case <-time.After(delay):
+					}
+				}
+			}
+
 			return nil
 		}
 		if !errors.Is(err, ErrNotEnoughFreeIdentityContainers) {
@@ -909,10 +923,11 @@ func (state *leasedIdentityPoolState) useNextAssigned(me string) (string, error)
 // assignNTo attempts to assign n free identity containers to the caller by marking
 // them as "assigned". It does not perform any waiting or retries: if there are
 // fewer than n free entries, it returns an error and leaves the state
-// unchanged.
-func (state *leasedIdentityPoolState) assignNTo(me string, n uint8) error {
+// unchanged. On success it returns the number of non-free entries that existed
+// before this assignment (i.e. the caller's ordinal position in the pool).
+func (state *leasedIdentityPoolState) assignNTo(me string, n uint8) (int, error) {
 	if err := state.lock(); err != nil {
-		return fmt.Errorf("failed to acquire managed identities pool state file lock: %w", err)
+		return 0, fmt.Errorf("failed to acquire managed identities pool state file lock: %w", err)
 	}
 	defer func() {
 		if err := state.unlock(); err != nil {
@@ -921,7 +936,14 @@ func (state *leasedIdentityPoolState) assignNTo(me string, n uint8) error {
 	}()
 
 	if err := state.readUnlocked(); err != nil {
-		return fmt.Errorf("failed to read managed identities pool state file: %w", err)
+		return 0, fmt.Errorf("failed to read managed identities pool state file: %w", err)
+	}
+
+	alreadyAssigned := 0
+	for i := range state.entries {
+		if !state.entries[i].isFree() {
+			alreadyAssigned++
+		}
 	}
 
 	count := 0
@@ -937,14 +959,14 @@ func (state *leasedIdentityPoolState) assignNTo(me string, n uint8) error {
 
 	if count < int(n) {
 		// return and don't persist the partial in-memory state to file
-		return fmt.Errorf("%w: requested %d identity containers but only %d are assigned", ErrNotEnoughFreeIdentityContainers, n, count)
+		return 0, fmt.Errorf("%w: requested %d identity containers but only %d are assigned", ErrNotEnoughFreeIdentityContainers, n, count)
 	}
 
 	if err := state.writeUnlocked(); err != nil {
-		return fmt.Errorf("failed to write managed identities pool state file: %w", err)
+		return 0, fmt.Errorf("failed to write managed identities pool state file: %w", err)
 	}
 
-	return nil
+	return alreadyAssigned, nil
 }
 
 // releaseByContainerName releases the identity container by the given name.


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

test/util/framework/constants.go — Added ClusterCreateStaggerInterval() function that reads E2E_CLUSTER_CREATE_STAGGER_SECONDS env var and returns a time.Duration. Returns 0 (disabled) when unset.

test/util/framework/identities_helper.go — Two changes:
  1. assignNTo() now returns (int, error) instead of error. The int is the count of already-assigned containers before this assignment — the caller's ordinal position in the pool.
  2. AssignIdentityContainers() uses the ordinal to compute a stagger delay (ordinal * staggerInterval) and sleeps before returning, with context cancellation support and logging.

### Why

With E2E_CLUSTER_CREATE_STAGGER_SECONDS=15 and 20 MSI containers, the first test starts immediately, the second waits 15s, the third waits 30s, ..., the 20th waits ~5 minutes. This spreads the CosmosDB write load across the provisioning window instead of a single burst.

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
