### PR TITLE
ARO-27591 | add node pool validation controller

### DIFF
--- a/backend/pkg/controllers/validationcontrollers/nodepool_validation_controller.go
+++ b/backend/pkg/controllers/validationcontrollers/nodepool_validation_controller.go
@@ -1,0 +1,141 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validationcontrollers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/validationcontrollers/validations"
+	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/internal/api"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// nodePoolValidationSyncer is a NodePool syncer that performs a NodePool
+// validation.
+type nodePoolValidationSyncer struct {
+	cooldownChecker   controllerutil.CooldownChecker
+	resourcesDBClient database.ResourcesDBClient
+
+	// validation is the validation to perform on the node pool.
+	validation validations.NodePoolValidation
+}
+
+var _ controllerutils.NodePoolSyncer = (*nodePoolValidationSyncer)(nil)
+
+// NewNodePoolValidationController creates a new controller that
+// executes the provided NodePool validation on each node pool.
+func NewNodePoolValidationController(
+	validation validations.NodePoolValidation,
+	activeOperationLister listers.ActiveOperationLister,
+	resourcesDBClient database.ResourcesDBClient,
+	informers informers.BackendInformers,
+) controllerutils.Controller {
+
+	syncer := &nodePoolValidationSyncer{
+		cooldownChecker:   controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		resourcesDBClient: resourcesDBClient,
+		validation:        validation,
+	}
+
+	controller := controllerutils.NewNodePoolWatchingController(
+		fmt.Sprintf("NodePoolValidation%s", validation.Name()),
+		resourcesDBClient,
+		informers,
+		1*time.Minute,
+		syncer,
+	)
+
+	return controller
+}
+
+func (c *nodePoolValidationSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPNodePoolKey) error {
+	existingCluster, err := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).Get(ctx, key.HCPClusterName)
+	if database.IsNotFoundError(err) {
+		return nil // cluster doesn't exist, no work to do
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get Cluster: %w", err))
+	}
+
+	existingNodePool, err := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).NodePools(key.HCPClusterName).Get(ctx, key.HCPNodePoolName)
+	if database.IsNotFoundError(err) {
+		return nil // node pool doesn't exist, no work to do
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get NodePool: %w", err))
+	}
+
+	existingServiceProviderNodePool, err := database.GetOrCreateServiceProviderNodePool(ctx, c.resourcesDBClient, key.GetResourceID())
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get or create ServiceProviderNodePool: %w", err))
+	}
+
+	shouldProcess := c.shouldProcess(existingServiceProviderNodePool)
+	if !shouldProcess {
+		return nil // no work to do
+	}
+	subscription, err := c.resourcesDBClient.Subscriptions().Get(ctx, existingNodePool.ID.SubscriptionID)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get Subscription: %w", err))
+	}
+
+	// We store the validation error in a separate variable and we use that as the
+	// error to return to the caller. This allows us to perform other remaining
+	// tasks in the syncer even if the validation fails, and we ultimately
+	// drive the behavior of its controller through the outcome of the validation.
+	validationErr := c.validation.Validate(ctx, existingCluster, subscription, existingNodePool)
+
+	validationCondition := metav1.Condition{
+		Type: c.validation.Name(),
+	}
+	if validationErr != nil {
+		validationCondition.Status = metav1.ConditionFalse
+		validationCondition.Reason = "Failed"
+		validationCondition.Message = fmt.Sprintf("Validation failed: %s", validationErr.Error())
+	} else {
+		validationCondition.Status = metav1.ConditionTrue
+		validationCondition.Reason = "Succeeded"
+		validationCondition.Message = "Validation succeeded"
+	}
+	meta.SetStatusCondition(&existingServiceProviderNodePool.Status.Validations, validationCondition)
+
+	serviceProviderNodePoolsCosmosClient := c.resourcesDBClient.ServiceProviderNodePools(key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
+	_, err = serviceProviderNodePoolsCosmosClient.Replace(ctx, existingServiceProviderNodePool, nil)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to replace ServiceProviderNodePool: %w", err))
+	}
+
+	return validationErr
+}
+
+// shouldProcess returns true when the condition associated to the validation does not exist or when it exists but
+// it failed to run successfully in a previous attempt.
+func (c *nodePoolValidationSyncer) shouldProcess(serviceProviderNodePool *api.ServiceProviderNodePool) bool {
+	return !meta.IsStatusConditionTrue(serviceProviderNodePool.Status.Validations, c.validation.Name())
+}
+
+func (c *nodePoolValidationSyncer) CooldownChecker() controllerutil.CooldownChecker {
+	return c.cooldownChecker
+}

--- a/backend/pkg/controllers/validationcontrollers/nodepool_validation_controller_test.go
+++ b/backend/pkg/controllers/validationcontrollers/nodepool_validation_controller_test.go
@@ -1,0 +1,260 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validationcontrollers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/validationcontrollers/validations"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+const (
+	testSubscriptionID = "00000000-0000-0000-0000-000000000000"
+	testResourceGroup  = "test-rg"
+	testClusterName    = "test-cluster"
+	testNodePoolName   = "test-nodepool"
+	testValidationName = "TestValidation"
+)
+
+func newTestNodePoolKey() controllerutils.HCPNodePoolKey {
+	return controllerutils.HCPNodePoolKey{
+		SubscriptionID:    testSubscriptionID,
+		ResourceGroupName: testResourceGroup,
+		HCPClusterName:    testClusterName,
+		HCPNodePoolName:   testNodePoolName,
+	}
+}
+
+func newTestCluster(t *testing.T) *api.HCPOpenShiftCluster {
+	t.Helper()
+	resourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroup +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName))
+	return &api.HCPOpenShiftCluster{
+		CosmosMetadata: arm.CosmosMetadata{ResourceID: resourceID},
+		TrackedResource: arm.TrackedResource{
+			Resource: arm.Resource{
+				ID:   resourceID,
+				Name: testClusterName,
+				Type: api.ClusterResourceType.String(),
+			},
+			Location: "eastus",
+		},
+	}
+}
+
+func newTestNodePool(t *testing.T) *api.HCPOpenShiftClusterNodePool {
+	t.Helper()
+	resourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroup +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+			"/nodePools/" + testNodePoolName))
+	return &api.HCPOpenShiftClusterNodePool{
+		CosmosMetadata: arm.CosmosMetadata{ResourceID: resourceID},
+		TrackedResource: arm.TrackedResource{
+			Resource: arm.Resource{
+				ID:   resourceID,
+				Name: testNodePoolName,
+				Type: api.NodePoolResourceType.String(),
+			},
+			Location: "eastus",
+		},
+	}
+}
+
+func newTestSubscription() *arm.Subscription {
+	subResourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID))
+	return &arm.Subscription{
+		CosmosMetadata: api.CosmosMetadata{ResourceID: subResourceID},
+		ResourceID:     subResourceID,
+		State:          arm.SubscriptionStateRegistered,
+	}
+}
+
+// alwaysSyncCooldownChecker always allows syncing.
+type alwaysSyncCooldownChecker struct{}
+
+func (a *alwaysSyncCooldownChecker) CanSync(_ context.Context, _ any) bool { return true }
+
+var _ controllerutil.CooldownChecker = (*alwaysSyncCooldownChecker)(nil)
+
+// mockNodePoolValidation implements validations.NodePoolValidation for tests.
+type mockNodePoolValidation struct {
+	name        string
+	validateErr error
+}
+
+var _ validations.NodePoolValidation = (*mockNodePoolValidation)(nil)
+
+func (m *mockNodePoolValidation) Name() string { return m.name }
+
+func (m *mockNodePoolValidation) Validate(_ context.Context, _ *api.HCPOpenShiftCluster, _ *arm.Subscription, _ *api.HCPOpenShiftClusterNodePool) error {
+	return m.validateErr
+}
+
+func TestNodePoolValidationSyncer_SyncOnce(t *testing.T) {
+
+	defaultSetupDB := func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
+		t.Helper()
+		_, err := mockDB.HCPClusters(testSubscriptionID, testResourceGroup).Create(ctx, newTestCluster(t), nil)
+		require.NoError(t, err)
+		_, err = mockDB.HCPClusters(testSubscriptionID, testResourceGroup).NodePools(testClusterName).Create(ctx, newTestNodePool(t), nil)
+		require.NoError(t, err)
+		_, err = mockDB.Subscriptions().Create(ctx, newTestSubscription(), nil)
+		require.NoError(t, err)
+	}
+
+	testCases := []struct {
+		name                string
+		setupDB             func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient)
+		validation          *mockNodePoolValidation
+		wantErr             bool
+		wantConditionStatus *metav1.ConditionStatus
+	}{
+		{
+			name: "cluster not found -- no-op",
+			setupDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+				_, err := mockDB.HCPClusters(testSubscriptionID, testResourceGroup).NodePools(testClusterName).Create(ctx, newTestNodePool(t), nil)
+				require.NoError(t, err)
+				_, err = mockDB.Subscriptions().Create(ctx, newTestSubscription(), nil)
+				require.NoError(t, err)
+			},
+			validation: &mockNodePoolValidation{name: testValidationName},
+		},
+		{
+			name: "node pool not found -- no-op",
+			setupDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+				_, err := mockDB.HCPClusters(testSubscriptionID, testResourceGroup).Create(ctx, newTestCluster(t), nil)
+				require.NoError(t, err)
+				_, err = mockDB.Subscriptions().Create(ctx, newTestSubscription(), nil)
+				require.NoError(t, err)
+			},
+			validation: &mockNodePoolValidation{name: testValidationName},
+		},
+		{
+			name:    "validation succeeds -- condition set to True",
+			setupDB: defaultSetupDB,
+			validation: &mockNodePoolValidation{
+				name: testValidationName,
+			},
+			wantConditionStatus: api.Ptr(metav1.ConditionTrue),
+		},
+		{
+			name:    "validation fails -- condition set to False and error returned",
+			setupDB: defaultSetupDB,
+			validation: &mockNodePoolValidation{
+				name:        testValidationName,
+				validateErr: fmt.Errorf("quota exceeded"),
+			},
+			wantErr:             true,
+			wantConditionStatus: api.Ptr(metav1.ConditionFalse),
+		},
+		{
+			name: "already-succeeded validation -- skipped",
+			setupDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+				defaultSetupDB(t, ctx, mockDB)
+				spnpResourceID := api.Must(azcorearm.ParseResourceID(
+					"/subscriptions/" + testSubscriptionID +
+						"/resourceGroups/" + testResourceGroup +
+						"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+						"/nodePools/" + testNodePoolName +
+						"/serviceProviderNodePools/default"))
+				spnp := &api.ServiceProviderNodePool{
+					CosmosMetadata: arm.CosmosMetadata{ResourceID: spnpResourceID},
+					Status: api.ServiceProviderNodePoolStatus{
+						Validations: []metav1.Condition{
+							{
+								Type:   testValidationName,
+								Status: metav1.ConditionTrue,
+								Reason: "Succeeded",
+							},
+						},
+					},
+				}
+				_, err := mockDB.ServiceProviderNodePools(testSubscriptionID, testResourceGroup, testClusterName, testNodePoolName).Create(ctx, spnp, nil)
+				require.NoError(t, err)
+			},
+			validation: &mockNodePoolValidation{
+				name:        testValidationName,
+				validateErr: fmt.Errorf("should not be called"),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+
+			mockDB := databasetesting.NewMockResourcesDBClient()
+			if tc.setupDB != nil {
+				tc.setupDB(t, ctx, mockDB)
+			}
+
+			syncer := &nodePoolValidationSyncer{
+				cooldownChecker:   &alwaysSyncCooldownChecker{},
+				resourcesDBClient: mockDB,
+				validation:        tc.validation,
+			}
+
+			err := syncer.SyncOnce(ctx, newTestNodePoolKey())
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			if tc.wantConditionStatus != nil {
+				spnp, spnpErr := mockDB.ServiceProviderNodePools(
+					testSubscriptionID, testResourceGroup, testClusterName, testNodePoolName,
+				).Get(ctx, "default")
+				require.NoError(t, spnpErr)
+
+				cond := meta.FindStatusCondition(spnp.Status.Validations, testValidationName)
+				require.NotNil(t, cond, "expected validation condition to be set")
+				assert.Equal(t, *tc.wantConditionStatus, cond.Status)
+
+				if tc.validation.validateErr != nil {
+					assert.Equal(t, "Failed", cond.Reason)
+					assert.Contains(t, cond.Message, tc.validation.validateErr.Error())
+				} else {
+					assert.Equal(t, "Succeeded", cond.Reason)
+				}
+			}
+		})
+	}
+}

--- a/backend/pkg/controllers/validationcontrollers/validations/nodepool_validation.go
+++ b/backend/pkg/controllers/validationcontrollers/validations/nodepool_validation.go
@@ -1,0 +1,30 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validations
+
+import (
+	"context"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+)
+
+// NodePoolValidation represents a validation that can be performed on a node pool.
+type NodePoolValidation interface {
+	// Name returns the name of the validation.
+	Name() string
+	// Validate validates the NodePool. It returns nil if the validation succeeds and an error otherwise.
+	Validate(ctx context.Context, cluster *api.HCPOpenShiftCluster, nodePoolSubscription *arm.Subscription, nodePool *api.HCPOpenShiftClusterNodePool) error
+}

--- a/internal/api/types_serviceprovider_nodepool.go
+++ b/internal/api/types_serviceprovider_nodepool.go
@@ -97,6 +97,13 @@ type ServiceProviderNodePoolStatus struct {
 	// }
 	NodePoolVersion ServiceProviderNodePoolStatusVersion `json:"nodePoolVersion,omitempty"`
 
+	// Validations is a list of conditions that tracks the status of each node pool validation.
+	// Each Condition Type represents a validation and it should be unique among all validations.
+	// A Condition Status of True means that the validation passed successfully, and a Condition Status of False means that the validation failed.
+	// The Condition Reason and Message are used to provide more details about the validation status.
+	// The Condition LastTransitionTime is used to track the last time the validation transitioned from one status to another.
+	Validations []metav1.Condition `json:"validations,omitempty"`
+
 	// MaestroReadonlyBundles contains a list of Maestro readonly bundles references.
 	// These bundles are used to retrieve particular K8s resources from the Management Cluster.
 	// The reference contains a mapping between the logical name we give to the Maestro bundle internally

--- a/internal/api/zz_generated.deepcopy.go
+++ b/internal/api/zz_generated.deepcopy.go
@@ -1617,6 +1617,13 @@ func (in *ServiceProviderNodePoolStatus) DeepCopyInto(out *ServiceProviderNodePo
 		}
 	}
 	in.NodePoolVersion.DeepCopyInto(&out.NodePoolVersion)
+	if in.Validations != nil {
+		in, out := &in.Validations, &out.Validations
+		*out = make([]v1.Condition, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.MaestroReadonlyBundles != nil {
 		in, out := &in.MaestroReadonlyBundles, &out.MaestroReadonlyBundles
 		*out = make(MaestroBundleReferenceList, len(*in))


### PR DESCRIPTION
[ARO-27591](https://redhat.atlassian.net/browse/ARO-27591)

### What

Introduce a reusable NodePoolValidation controller modeled after the existing cluster validation controller. Validations run per node pool, persist results on ServiceProviderNodePool.Status.Validations, and requeue until they succeed.
- Add NodePoolValidationController and NodePoolValidation interface
- Add AlwaysSuccessNodePoolValidation placeholder for plumbing
- Add Validations conditions to ServiceProviderNodePoolStatus
- Register and start AlwaysSuccessNodePoolValidationController in backend
