### PR TITLE
fix(recreate-broken-pools): remediate delete-only nodepool deadlock (AROSLSRE-1133)

### DIFF
--- a/dev-infrastructure/scripts/recreate-broken-pools/main.go
+++ b/dev-infrastructure/scripts/recreate-broken-pools/main.go
@@ -542,6 +542,11 @@ func forcedEvidencePath(ctx context.Context, cfg *config, orch orchestrator, tar
 	}
 
 	if err := orch.triggerPoolReconcile(ctx, target, live); err != nil {
+		if isDeletionInitiatedErr(err) {
+			logf("pool %s rejected scale-up: deletion has been initiated; confirming as broken (remediation will delete+recreate)", target.name)
+			target.suspected = false
+			return &target, nil
+		}
 		logf("WARN: triggerPoolReconcile for %s failed: %v; treating as no-op", target.name, err)
 		return nil, nil
 	}
@@ -818,6 +823,21 @@ func (c *clients) bootstrapKube(ctx context.Context, mc armcs.ManagedCluster) er
 	}
 	c.kube = kc
 	return nil
+}
+
+// isDeletionInitiatedErr reports whether err is an ARM OperationNotAllowed
+// response indicating that AKS has marked the pool for deletion and refuses
+// all operations except retrying the delete. This state is reached when a
+// previous delete was initiated but did not complete.
+func isDeletionInitiatedErr(err error) bool {
+	var re *azcore.ResponseError
+	if !errors.As(err, &re) {
+		return false
+	}
+	if re.ErrorCode != "OperationNotAllowed" {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "deletion has been initiated")
 }
 
 // isNotFoundErr reports whether err is an azcore HTTP 404 ResponseError

--- a/dev-infrastructure/scripts/recreate-broken-pools/main.go
+++ b/dev-infrastructure/scripts/recreate-broken-pools/main.go
@@ -230,10 +230,11 @@ const (
 const nodePoolRoleLabel = "aro-hcp.azure.com/role"
 
 type nodePoolTarget struct {
-	name        string
-	vmssPrefix  string
-	nrpFailures int
-	suspected   bool
+	name              string
+	vmssPrefix        string
+	nrpFailures       int
+	suspected         bool
+	deletionInitiated bool
 }
 
 func poolVMSSPrefix(poolName string) string {
@@ -451,6 +452,19 @@ func runWith(ctx context.Context, cfg *config, orch orchestrator) error {
 		return nil
 	}
 
+	// Remember which pools were confirmed via deletion-initiated before
+	// re-running detection. The post-LRO detect queries the activity log
+	// from scratch and will see 0 NRP-KVS events for these pools (the
+	// trigger was rejected, so no events were generated). Without this
+	// carry-forward, those pools would be reclassified as suspected and
+	// filtered out, deadlocking the remediation.
+	deletionInitiatedPools := map[string]bool{}
+	for _, t := range targets {
+		if t.deletionInitiated {
+			deletionInitiatedPools[t.name] = true
+		}
+	}
+
 	logBanner("STEP 2b :: re-check detection guards after LRO handling")
 	targets, reason, err = orch.detect(ctx)
 	if err != nil {
@@ -459,6 +473,11 @@ func runWith(ctx context.Context, cfg *config, orch orchestrator) error {
 	var postConfirmed []nodePoolTarget
 	for _, target := range targets {
 		if !target.suspected {
+			postConfirmed = append(postConfirmed, target)
+		} else if deletionInitiatedPools[target.name] {
+			target.suspected = false
+			target.deletionInitiated = true
+			logf("pool %s: carrying forward deletion-initiated confirmation from pre-LRO detection", target.name)
 			postConfirmed = append(postConfirmed, target)
 		}
 	}
@@ -545,6 +564,7 @@ func forcedEvidencePath(ctx context.Context, cfg *config, orch orchestrator, tar
 		if isDeletionInitiatedErr(err) {
 			logf("pool %s rejected scale-up: deletion has been initiated; confirming as broken (remediation will delete+recreate)", target.name)
 			target.suspected = false
+			target.deletionInitiated = true
 			return &target, nil
 		}
 		logf("WARN: triggerPoolReconcile for %s failed: %v; treating as no-op", target.name, err)

--- a/dev-infrastructure/scripts/recreate-broken-pools/main_test.go
+++ b/dev-infrastructure/scripts/recreate-broken-pools/main_test.go
@@ -1660,6 +1660,32 @@ func TestIsActivityLogAuthorizationError(t *testing.T) {
 	}
 }
 
+func TestIsDeletionInitiatedErr(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"plain_error", errors.New("boom"), false},
+		{"operation_not_allowed_deletion", fmt.Errorf("begin trigger: %w",
+			fmt.Errorf("deletion has been initiated: %w",
+				&azcore.ResponseError{StatusCode: http.StatusBadRequest, ErrorCode: "OperationNotAllowed"})), true},
+		{"operation_not_allowed_other_reason", fmt.Errorf("quota exceeded: %w",
+			&azcore.ResponseError{StatusCode: http.StatusBadRequest, ErrorCode: "OperationNotAllowed"}), false},
+		{"different_error_code_with_deletion_text", fmt.Errorf("deletion has been initiated: %w",
+			&azcore.ResponseError{StatusCode: http.StatusBadRequest, ErrorCode: "BadRequest"}), false},
+		{"not_response_error", fmt.Errorf("deletion has been initiated: %w", errors.New("not azcore")), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isDeletionInitiatedErr(tc.err); got != tc.want {
+				t.Errorf("got %t want %t", got, tc.want)
+			}
+		})
+	}
+}
+
 // =============================================================================
 // evalPoolWedge  (per-pool provisioningState == "Failed")
 // =============================================================================
@@ -2046,6 +2072,34 @@ func TestRunWith(t *testing.T) {
 			wantCalls: []string{
 				"ensureCluster", "dumpPreflight", "detect:1",
 				"snapshotSystem", "triggerSystemReconcile",
+			},
+		},
+		{
+			name: "guard1_fail_trigger_deletion_initiated_confirms",
+			cfg:  &config{clusterName: "c", resourceGroup: "rg", subscriptionID: "sub", cpVersion: "1.30.0", threshold: 10, forcedEvidenceTimeoutMin: 20, forcedEvidenceThreshold: 3},
+			setup: func(m *mockOrchestrator) {
+				m.detectFn = func(_ context.Context, n int) (bool, string, error) {
+					if n == 1 {
+						return false, "NRP-KVS storm FAIL: only 0 NRP failures < 10", nil
+					}
+					return true, "", nil
+				}
+				m.triggerSystemReconcileFn = func(context.Context, *armcs.AgentPool) error {
+					return fmt.Errorf("begin trigger pool scale-up system: %w",
+						fmt.Errorf("Cannot run operation on node pool system because deletion has been initiated: %w",
+							&azcore.ResponseError{StatusCode: http.StatusBadRequest, ErrorCode: "OperationNotAllowed"}))
+				}
+			},
+			wantCalls: []string{
+				"ensureCluster", "dumpPreflight", "detect:1",
+				"snapshotSystem", "triggerSystemReconcile",
+				"bootstrapKube", "dumpPreflight",
+				"snapshotSystem", "maybeAbortLRO", "detect:2", "adoptLeftoverTempPool:system", "snapshotSystem",
+				"addTempPool:system",
+				"drainPool:system", "deletePool:system",
+				"recreateSystem",
+				"drainPool:" + tmpSystem, "deletePool:" + tmpSystem,
+				"reconcileTagPut", "dumpPostflight",
 			},
 		},
 		{

--- a/dev-infrastructure/scripts/recreate-broken-pools/main_test.go
+++ b/dev-infrastructure/scripts/recreate-broken-pools/main_test.go
@@ -2075,14 +2075,16 @@ func TestRunWith(t *testing.T) {
 			},
 		},
 		{
+			// Deletion-initiated: detect:1 sees 0 NRP events (suspected),
+			// forced evidence trigger is rejected with OperationNotAllowed
+			// "deletion has been initiated", pool is confirmed. detect:2
+			// also sees 0 NRP events (suspected again), but the
+			// deletion-initiated flag carries forward through Step 2b.
 			name: "guard1_fail_trigger_deletion_initiated_confirms",
 			cfg:  &config{clusterName: "c", resourceGroup: "rg", subscriptionID: "sub", cpVersion: "1.30.0", threshold: 10, forcedEvidenceTimeoutMin: 20, forcedEvidenceThreshold: 3},
 			setup: func(m *mockOrchestrator) {
-				m.detectFn = func(_ context.Context, n int) (bool, string, error) {
-					if n == 1 {
-						return false, "NRP-KVS storm FAIL: only 0 NRP failures < 10", nil
-					}
-					return true, "", nil
+				m.detectFn = func(_ context.Context, _ int) (bool, string, error) {
+					return false, "NRP-KVS storm FAIL: only 0 NRP failures < 10", nil
 				}
 				m.triggerSystemReconcileFn = func(context.Context, *armcs.AgentPool) error {
 					return fmt.Errorf("begin trigger pool scale-up system: %w",


### PR DESCRIPTION
[AROSLSRE-1133](https://redhat.atlassian.net/browse/AROSLSRE-1133)

### What

  main.go:
  - Added deletionInitiated bool field to nodePoolTarget
  - Added isDeletionInitiatedErr helper — matches ARM OperationNotAllowed with "deletion has been initiated" (both conditions required)
  - In forcedEvidencePath: when triggerPoolReconcile fails with deletion-initiated, sets both suspected = false and deletionInitiated = true, returns confirmed target
  - Before Step 2b: builds a deletionInitiatedPools set from the pre-LRO confirmed targets
  - In Step 2b filtering: carries forward deletion-initiated targets that detect:2 would otherwise reclassify as suspected

  main_test.go:
  - TestIsDeletionInitiatedErr: 6 cases (nil, plain error, correct match, wrong message, wrong error code, non-ResponseError)
  - TestRunWith/guard1_fail_trigger_deletion_initiated_confirms: end-to-end flow where detect:1 AND detect:2 both return suspected (matching reality — 0 NRP events on both passes), but the deletion-initiated flag carries through to full remediation

### Why

When a previous pool delete is initiated but doesn't complete (e.g. the script crashes after drain but before delete, or an external operation partially deletes the pool), AKS marks the pool as delete-only — it rejects all PUTs with OperationNotAllowed: "deletion has been initiated". The script's forced-evidence path tries to trigger a scale-up PUT to generate NRP-KVS activity log entries, but that PUT is rejected. The script treats any trigger failure as "inconclusive" and exits no-op. Since no operation can ever generate the NRP-KVS evidence the script requires, and the script is the only thing that deletes these pools, the pool is permanently deadlocked — every future run exits no-op, the pool stays in Failed, and the cluster loses that pool's capacity indefinitely.

### Testing

added unit test, e2e.

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
