### PR TITLE
Fix create ACR replication script

### DIFF
--- a/dev-infrastructure/scripts/manage-acr-replication.sh
+++ b/dev-infrastructure/scripts/manage-acr-replication.sh
@@ -60,7 +60,7 @@ create_replication() {
         --resource-group "$RESOURCE_GROUP" \
         --location "$REPLICATION_REGION" \
         --name "$REPLICATION_REGION" \
-        --region-endpoint-enabled true
+        --global-endpoint-routing true
 
     echo "Successfully created replication $REPLICATION_REGION for ACR $ACR_NAME in region $REPLICATION_REGION"
 }


### PR DESCRIPTION
Azure CLI 2.86.0 renamed `--region-endpoint-enabled` to `--global-endpoint-routing`
on `az acr replication create/update` ([azure-cli#32954](https://github.com/Azure/azure-cli/pull/32954)),
and Azure CLI 2.87.0 (June 2026) completed the breaking change by removing the
deprecated flag entirely ([azure-cli#33173](https://github.com/Azure/azure-cli/pull/33173)).

Our CI image now ships 2.87.0+, so any code path that calls `az acr replication create`
with the old flag fails.

### Why this wasn't caught earlier

The `create_replication` function is only invoked when no replication exists in the
target region (or when an existing one is in `Failed` state). For regions that were
already provisioned (`westus3`, `centralus`), the script exits early after finding the
existing healthy replication — never exercising the broken flag. The issue surfaced
when provisioning `canadacentral` for the first time.

### Fix

Replace `--region-endpoint-enabled true` with `--global-endpoint-routing true`.
The semantics are equivalent for our use case: include the newly created replica
in global endpoint routing.

References:
- [Azure CLI release notes — breaking change](https://github.com/MicrosoftDocs/azure-docs-cli/blob/main/docs-ref-conceptual/Latest-version/release-notes-azure-cli.md)
- [Microsoft Learn — Geo-replication in ACR](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-geo-replication)