### PR TITLE
Ad-hoc run 2026-06-08

### DIFF
--- a/test/cmd/aro-hcp-tests/main.go
+++ b/test/cmd/aro-hcp-tests/main.go
@@ -222,7 +222,7 @@ func setupCli() *cobra.Command {
 	// 	specs = specs.AddLabel("SLOW")
 
 	// Specs can be globally filtered...
-	// specs = specs.MustFilter([]string{`name.contains("filter")`})
+	specs = specs.MustFilter([]string{`name.contains("create an HCP cluster and validate TLS certificates")`})
 
 	// Or walked...
 	// specs = specs.Walk(func(spec *extensiontests.ExtensionTestSpec) {

--- a/test/util/framework/per_invocation_framework.go
+++ b/test/util/framework/per_invocation_framework.go
@@ -307,8 +307,7 @@ func msiPoolStateFilePath() string {
 }
 
 func skipCleanup() bool {
-	ret, _ := strconv.ParseBool(os.Getenv("ARO_E2E_SKIP_CLEANUP"))
-	return ret
+	return true
 }
 
 // artifactDir returns the value of ARTIFACT_DIR environment variable, which is spot to save info in CI


### PR DESCRIPTION
### What

- selects one full (a cluster with a node pool) and simple (no special use cases, just checks) use case
- disables teardown

### Why

To schedule ad-hoc test run.

### Testing

One particular test case is selected as expected:

```
$ ./aro-hcp-tests list | jq '.[].name'
"Customer should create an HCP cluster and validate TLS certificates"
```

### Special notes for your reviewer

Do not merge.
