### PR TITLE
feat: enable externalauth delete from frontend to backend

### DIFF
--- a/frontend/pkg/frontend/external_auth.go
+++ b/frontend/pkg/frontend/external_auth.go
@@ -17,7 +17,6 @@ package frontend
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -28,8 +27,6 @@ import (
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
-
-	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
 
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
@@ -581,26 +578,6 @@ func (f *Frontend) DeleteExternalAuth(writer http.ResponseWriter, request *http.
 
 	logger.Info(fmt.Sprintf("deleting resource %s", externalAuth.ID))
 
-	// Temporary check until creation and deletion interaction with CS is moved to the backend: if a delete arrives and the external
-	// auth has not been created in CS or the ClusterServiceID reference has not been persisted in Cosmos, return an error.
-	if externalAuth.ServiceProviderProperties.ClusterServiceID == nil || len(externalAuth.ServiceProviderProperties.ClusterServiceID.String()) == 0 {
-		return utils.TrackError(fmt.Errorf("serviceProviderProperties.clusterServiceID is required to delete an external auth"))
-	}
-
-	err = f.clusterServiceClient.DeleteExternalAuth(ctx, *externalAuth.ServiceProviderProperties.ClusterServiceID)
-	var ocmError *ocmerrors.Error
-	if errors.As(err, &ocmError) && ocmError.Status() == http.StatusNotFound {
-		// StatusNotFound means we have stale data in Cosmos DB.
-		// This can happen in test environments if a user bypasses
-		// the RP to delete a resource (e.g. "ocm delete"). It can
-		// also happen if an asynchronous deletion operation fails.
-		// we will fall through and cancel all operations and go through as normal a deletion flow as we can to avoid
-		// leaking data related to the resource, like controller status.
-		logger.Info("clusterService externalauth missing, trying to clean up", "err", err)
-	} else if err != nil {
-		return utils.TrackError(err)
-	}
-
 	transaction := f.resourcesDBClient.NewTransaction(externalAuth.ID.SubscriptionID)
 	if err := f.addDeleteExternalAuthToTransaction(ctx, writer, request, transaction, externalAuth); err != nil {
 		return utils.TrackError(err)
@@ -631,21 +608,18 @@ func (f *Frontend) addDeleteExternalAuthToTransaction(ctx context.Context, write
 		return utils.TrackError(err)
 	}
 
-	// Temporary check until creation and deletion interaction with CS is moved to the backend: if a delete arrives and the external
-	// auth has not been created in CS or the ClusterServiceID reference has not been persisted in Cosmos, return an error.
-	if externalAuth.ServiceProviderProperties.ClusterServiceID == nil || len(externalAuth.ServiceProviderProperties.ClusterServiceID.String()) == 0 {
-		return utils.TrackError(fmt.Errorf("serviceProviderProperties.clusterServiceID is required to delete an external auth"))
-	}
-
 	operationDoc := database.NewOperation(
 		database.OperationRequestDelete,
 		externalAuth.ID,
-		*externalAuth.ServiceProviderProperties.ClusterServiceID,
+		api.InternalID{},
 		f.azureLocation,
 		"",
 		"",
 		"",
 		correlationData)
+	// TODO remove this once migration of the new external auth deletion from frontend to backend approach is fully completed in all ARO-HCP
+	// permanent environments, for all regions.
+	operationDoc.UsesNewExternalAuthDeletionApproach = true
 	if request != nil {
 		// these are optional because when this is triggered via the subscription deletion flow, there is no
 		// deletion request containing these headers so these operations cannot be directly tracked.
@@ -664,6 +638,9 @@ func (f *Frontend) addDeleteExternalAuthToTransaction(ctx context.Context, write
 	}
 	externalAuth.ServiceProviderProperties.ActiveOperationID = operationDoc.ResourceID.Name
 	externalAuth.Properties.ProvisioningState = operationDoc.Status
+	// TODO remove this once migration of the new external auth deletion from frontend to backend approach is fully completed in all ARO-HCP
+	// permanent environments, for all regions.
+	externalAuth.ServiceProviderProperties.UsesNewExternalAuthDeletionApproach = true
 	_, err = f.resourcesDBClient.HCPClusters(externalAuth.ID.SubscriptionID, externalAuth.ID.ResourceGroupName).ExternalAuth(externalAuth.ID.Parent.Name).
 		AddReplaceToTransaction(ctx, transaction, externalAuth, nil)
 	if err != nil {

--- a/test/e2e/external_auth_list_and_verify.go
+++ b/test/e2e/external_auth_list_and_verify.go
@@ -17,13 +17,16 @@ package e2e
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"k8s.io/apimachinery/pkg/util/rand"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 
 	hcpsdk "github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
@@ -198,6 +201,40 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to get updated external auth config from cluster %s", clusterName)
 			Expect(*updatedResult.Properties.ProvisioningState).To(Equal(hcpsdk.ExternalAuthProvisioningStateSucceeded), "updated external auth provisioning state should be Succeeded")
 			Expect(*updatedResult.Properties.Claim.Mappings.Username.Prefix).To(Equal(*expectedExternalAuth.Properties.Claim.Mappings.Username.Prefix), "updated external auth Username.Prefix should match expected value")
+
+			By("deleting the external auth")
+			err = framework.DeleteExternalAuthAndWait20240610(
+				ctx,
+				externalAuthClient,
+				*resourceGroup.Name,
+				clusterName,
+				*expectedExternalAuth.Name,
+				framework.ExternalAuthDeletionTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to delete external auth config on cluster %s", clusterName)
+
+			By("confirming the external auth has been deleted")
+			_, getErr := framework.GetExternalAuth20240610(
+				ctx,
+				externalAuthClient,
+				*resourceGroup.Name,
+				clusterName,
+				*expectedExternalAuth.Name,
+			)
+			Expect(getErr).To(HaveOccurred(), "expected error when getting deleted external auth %s on cluster %s", *expectedExternalAuth.Name, clusterName)
+			var respErr *azcore.ResponseError
+			Expect(errors.As(getErr, &respErr)).To(BeTrue(), "expected azcore.ResponseError when getting deleted external auth %s", *expectedExternalAuth.Name)
+			Expect(respErr.StatusCode).To(Equal(http.StatusNotFound), "expected HTTP 404 when getting deleted external auth %s", *expectedExternalAuth.Name)
+
+			By("confirming list returns no external auth configs")
+			var extAuthCount int
+			pager = externalAuthClient.NewListByParentPager(*resourceGroup.Name, clusterName, nil)
+			for pager.More() {
+				page, err := pager.NextPage(ctx)
+				Expect(err).NotTo(HaveOccurred(), "failed to list external auth configs on cluster %s after delete", clusterName)
+				extAuthCount += len(page.Value)
+			}
+			Expect(extAuthCount).To(Equal(0), "expected no external auth configs on cluster %s after delete", clusterName)
 
 		})
 })

--- a/test/util/framework/constants.go
+++ b/test/util/framework/constants.go
@@ -28,7 +28,8 @@ const (
 
 // Deletion timeouts
 const (
-	HCPClusterDeletionTimeout = 45 * time.Minute
+	HCPClusterDeletionTimeout   = 45 * time.Minute
+	ExternalAuthDeletionTimeout = 25 * time.Minute
 )
 
 // Resource Update timeouts


### PR DESCRIPTION
Move Cluster Service interaction out of the frontend delete path and hand it off to the backend's async external auth deletion controllers.

The frontend now only:
- Creates a delete operation with UsesNewExternalAuthDeletionApproach set to true
- Sets DeletionTimestamp and sets UsesNewExternalAuthDeletionApproach to true in the ExternalAuth
- Returns 202 Accepted immediately

Removed from the frontend:
- Direct clusterServiceClient.DeleteExternalAuth() call
- Requirement that ClusterServiceID must exist before delete is allowed
- Stale-data 404 handling, which is now handled in the backend side too

External Auth Delete operations no longer set an InternalID as it is not needed anymore when using the new external auth deletion approach in backend.

Legacy deletion (operations without UsesNewExternalAuthDeletionApproach) is unchanged and still handled by OperationExternalAuthDeleteController.