### PR TITLE
fix(mgmtclustermigratin): set KubeApplierCosmosContainerName on update

### DIFF
--- a/backend/pkg/controllers/managementclustercontrollers/management_cluster_migration.go
+++ b/backend/pkg/controllers/managementclustercontrollers/management_cluster_migration.go
@@ -162,6 +162,12 @@ func (c *managementClusterMigrationController) syncProvisionShard(ctx context.Co
 	for _, cond := range convertedManagementCluster.Status.Conditions {
 		apimeta.SetStatusCondition(&managementClusterToWrite.Status.Conditions, cond)
 	}
+
+	// Backfill KubeApplierCosmosContainerName for management clusters created
+	// before this field was introduced.
+	if len(managementClusterToWrite.Status.KubeApplierCosmosContainerName) == 0 {
+		managementClusterToWrite.Status.KubeApplierCosmosContainerName = convertedManagementCluster.Status.KubeApplierCosmosContainerName
+	}
 	if equality.Semantic.DeepEqual(existing, managementClusterToWrite) {
 		logger.V(1).Info("management cluster unchanged, skipping update")
 		return nil

--- a/backend/pkg/controllers/managementclustercontrollers/management_cluster_migration_test.go
+++ b/backend/pkg/controllers/managementclustercontrollers/management_cluster_migration_test.go
@@ -16,6 +16,7 @@ package managementclustercontrollers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -336,6 +337,55 @@ func TestSyncOnce(t *testing.T) {
 				require.NotNil(t, readyCond, "Ready condition must exist")
 				assert.Equal(t, metav1.ConditionTrue, readyCond.Status, "Ready condition should be True")
 				assert.Equal(t, string(fleet.ManagementClusterConditionReasonProvisionShardActive), readyCond.Reason)
+			},
+		},
+		{
+			name: "existing management cluster with empty KubeApplierCosmosContainerName is backfilled",
+			setup: func(t *testing.T, ctrl *gomock.Controller) (ocm.ClusterServiceClientSpec, *databasetesting.MockFleetDBClient, dblisters.StampLister, dblisters.ManagementClusterLister) {
+				t.Helper()
+				mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
+				fleetClient := databasetesting.NewMockFleetDBClient()
+
+				shard := buildTestProvisionShard(t, testShardID, "test-consumer", "test-westus3-mgmt-1", "active")
+				existing, err := ocm.ConvertCSManagementClusterToInternal(shard)
+				require.NoError(t, err)
+				existing.Spec.SchedulingPolicy = fleet.ManagementClusterSchedulingPolicyUnschedulable
+				_, err = fleetClient.Stamps().ManagementClusters("1").Create(t.Context(), existing, nil)
+				require.NoError(t, err)
+
+				// Simulate a pre-migration record that was created before
+				// KubeApplierCosmosContainerName was introduced: blank the
+				// field both in the DB and on the lister copy.
+				for cosmosID, raw := range fleetClient.GetAllDocuments() {
+					var doc map[string]any
+					require.NoError(t, json.Unmarshal(raw, &doc))
+					props, ok := doc["properties"].(map[string]any)
+					if !ok {
+						continue
+					}
+					status, ok := props["status"].(map[string]any)
+					if !ok {
+						continue
+					}
+					if _, has := status["kubeApplierCosmosContainerName"]; !has {
+						continue
+					}
+					delete(status, "kubeApplierCosmosContainerName")
+					patched, err := json.Marshal(doc)
+					require.NoError(t, err)
+					fleetClient.StoreDocument(cosmosID, patched)
+				}
+				existing.Status.KubeApplierCosmosContainerName = ""
+
+				mockCS.EXPECT().ListProvisionShards().Return(
+					ocm.NewSimpleProvisionShardListIterator([]*arohcpv1alpha1.ProvisionShard{shard}, nil),
+				)
+				return mockCS, fleetClient, &listertesting.SliceStampLister{}, &listertesting.SliceManagementClusterLister{ManagementClusters: []*fleet.ManagementCluster{existing}}
+			},
+			validate: func(t *testing.T, ctx context.Context, client *databasetesting.MockFleetDBClient) {
+				t.Helper()
+				doc := getManagementCluster(t, ctx, client, "1")
+				assert.Equal(t, "Manifests-MC-1", doc.Status.KubeApplierCosmosContainerName)
 			},
 		},
 		{


### PR DESCRIPTION
### What

make sure we set the KubeApplierCosmosContainerName on mgmt cluster cosmosdb documents also on update
added a test to verify

### Why

<!-- Briefly explain why this change is needed -->

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
