### PR TITLE
PoC nodepool updates based on CS sha calculation and management cluster state

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -32,6 +32,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.43.0
 	go.uber.org/mock v0.6.0
 	golang.org/x/sync v0.20.0
+	k8s.io/api v0.35.3
 	k8s.io/apimachinery v0.35.3
 	k8s.io/client-go v0.35.3
 	k8s.io/component-base v0.35.3
@@ -142,7 +143,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.35.3 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect

--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -45,6 +45,7 @@ import (
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/metricscontrollers"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/mismatchcontrollers"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/nodepooldeletion"
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/nodepoolupdate"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/operationcontrollers"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/upgradecontrollers"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/validationcontrollers"
@@ -466,6 +467,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		b.clock,
 		b.options.ResourcesDBClient,
 		b.options.ClustersServiceClient,
+		unionReadDesireLister,
 		http.DefaultClient,
 		activeOperationInformer,
 	)
@@ -650,6 +652,12 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		activeOperationLister,
 		backendInformers,
 	)
+	nodePoolClusterServiceUpdateDispatchController := nodepoolupdate.NewNodePoolClusterServiceUpdateDispatchController(
+		b.options.ResourcesDBClient,
+		b.options.ClustersServiceClient,
+		activeOperationLister,
+		backendInformers,
+	)
 	nodePoolClusterServiceIDClearerController := nodepooldeletion.NewNodePoolClusterServiceIDClearerController(
 		b.options.ResourcesDBClient,
 		b.options.ClustersServiceClient,
@@ -751,6 +759,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 				go cleanupLegacyMaestroReadonlyBundlesController.Run(ctx, 1)
 				go triggerNodePoolUpgradeController.Run(ctx, 20)
 				go nodePoolDeletionClusterServiceDeleteDispatchController.Run(ctx, 20)
+				go nodePoolClusterServiceUpdateDispatchController.Run(ctx, 20)
 				go nodePoolClusterServiceIDClearerController.Run(ctx, 20)
 				go nodePoolChildResourcesCleanupController.Run(ctx, 20)
 				go nodePoolDeletionController.Run(ctx, 20)

--- a/backend/pkg/controllers/nodepoolupdate/node_pool_cluster_service_update_dispatch_controller.go
+++ b/backend/pkg/controllers/nodepoolupdate/node_pool_cluster_service_update_dispatch_controller.go
@@ -1,0 +1,213 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodepoolupdate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/internal/api"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+type nodePoolClusterServiceUpdateDispatchSyncer struct {
+	cooldownChecker      controllerutil.CooldownChecker
+	nodePoolLister       listers.NodePoolLister
+	resourcesDBClient    database.ResourcesDBClient
+	clusterServiceClient ocm.ClusterServiceClientSpec
+}
+
+var _ controllerutils.NodePoolSyncer = (*nodePoolClusterServiceUpdateDispatchSyncer)(nil)
+
+func NewNodePoolClusterServiceUpdateDispatchController(
+	resourcesDBClient database.ResourcesDBClient,
+	clusterServiceClient ocm.ClusterServiceClientSpec,
+	activeOperationLister listers.ActiveOperationLister,
+	informers informers.BackendInformers,
+) controllerutils.Controller {
+	_, nodePoolLister := informers.NodePools()
+	syncer := &nodePoolClusterServiceUpdateDispatchSyncer{
+		cooldownChecker:      controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		nodePoolLister:       nodePoolLister,
+		resourcesDBClient:    resourcesDBClient,
+		clusterServiceClient: clusterServiceClient,
+	}
+
+	return controllerutils.NewNodePoolWatchingController(
+		"NodePoolClusterServiceUpdateDispatch",
+		resourcesDBClient,
+		informers,
+		time.Minute,
+		syncer,
+	)
+}
+
+func shouldProceed(nodePool *api.HCPOpenShiftClusterNodePool) bool {
+	if nodePool.ServiceProviderProperties.DeletionTimestamp != nil {
+		return false
+	}
+
+	// TODO remove this check but keep the inner one when all nodepools have been moved to the new update approach
+	// We guard it with this check because when the boolean is false we want to set the config hash in the ServiceProviderNodePool independently on
+	// whether CSID is set or not.
+	if nodePool.ServiceProviderProperties.UsesNewNodePoolUpdateApproach {
+		csID := nodePool.ServiceProviderProperties.ClusterServiceID
+		if csID == nil || len(csID.String()) == 0 {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (c *nodePoolClusterServiceUpdateDispatchSyncer) CooldownChecker() controllerutil.CooldownChecker {
+	return c.cooldownChecker
+}
+
+func (c *nodePoolClusterServiceUpdateDispatchSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPNodePoolKey) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	cachedNodePool, err := c.nodePoolLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get node pool from cache: %w", err))
+	}
+	if !shouldProceed(cachedNodePool) {
+		return nil
+	}
+
+	nodePoolCRUD := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).NodePools(key.HCPClusterName)
+	nodePool, err := nodePoolCRUD.Get(ctx, key.HCPNodePoolName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get node pool: %w", err))
+	}
+	if !shouldProceed(nodePool) {
+		return nil
+	}
+
+	desiredHash, err := ocm.NodePoolUpdatableConfigHash(nodePool)
+	if err != nil {
+		return err
+	}
+
+	serviceProviderNodePool, err := database.GetOrCreateServiceProviderNodePool(ctx, c.resourcesDBClient, nodePool.ID)
+	if err != nil {
+		return err
+	}
+
+	// For the old update approach, we introduce this mechanism to set the config hash in the ServiceProviderNodePool status when the controller runs
+	// so we can compute the hash for pre-existing node pools.
+	// TODO should we run this independently on CSID being set? if not, it means that once we enable the new approach it could be that we trigger
+	// an update because it didn't have the hash set yet because it was still creating.
+	if !nodePool.ServiceProviderProperties.UsesNewNodePoolUpdateApproach {
+		if serviceProviderNodePool.Status.ClusterServiceUpdatableConfigHashForUpdateDispatch != desiredHash {
+			logger.Info("using old update deletion approach, skipping Cluster Service update but setting config hash", "desiredHash", desiredHash)
+			serviceProviderNodePool.Status.ClusterServiceUpdatableConfigHashForUpdateDispatch = desiredHash
+			_, err = c.resourcesDBClient.ServiceProviderNodePools(
+				nodePool.ID.SubscriptionID,
+				nodePool.ID.ResourceGroupName,
+				nodePool.ID.Parent.Name,
+				nodePool.ID.Name,
+			).Replace(ctx, serviceProviderNodePool, nil)
+			if err != nil {
+				return utils.TrackError(fmt.Errorf("failed to replace ServiceProviderNodePool config hash: %w", err))
+			}
+			return nil
+		}
+	}
+
+	// If the config hash is empty it means that the corresponding creation controller that sets it hasn't run yet so
+	// we do not act until that occurs.
+	// TODO this means that this code cannot be merged until the nodepool creation approach is merged and running.
+	// TODO uncomment this
+	// if serviceProviderNodePool.Status.ClusterServiceUpdatableConfigHashForUpdateDispatch == "" {
+	// 	return nil
+	// }
+
+	// If the desired hash matches the stored hash, we don't need to send a NodePool CS update
+	if serviceProviderNodePool.Status.ClusterServiceUpdatableConfigHashForUpdateDispatch == desiredHash {
+		return nil
+	}
+
+	csNodePoolBuilder, err := ocm.BuildCSNodePool(ctx, nodePool, true)
+	if err != nil {
+		return err
+	}
+
+	nodePoolCSID := nodePool.ServiceProviderProperties.ClusterServiceID
+	logger.Info("dispatching node pool update to Cluster Service",
+		"clusterServiceID", nodePoolCSID.String(),
+		"previousHash", serviceProviderNodePool.Status.ClusterServiceUpdatableConfigHashForUpdateDispatch,
+		"desiredHash", desiredHash,
+	)
+
+	_, err = c.clusterServiceClient.UpdateNodePool(ctx, *nodePoolCSID, csNodePoolBuilder)
+	if err != nil {
+		var ocmError *ocmerrors.Error
+
+		switch {
+		case errors.As(err, &ocmError) && ocmError.Status() == http.StatusBadRequest &&
+			strings.Contains(ocmError.Reason(), "Node pools can only be") &&
+			strings.Contains(ocmError.Reason(), "on clusters in an updatable state"):
+			logger.Info("Cluster Service rejected node pool update because its parent cluster is not updatable. Retrying on next sync.",
+				"clusterServiceID", nodePoolCSID.String(),
+				"error", err.Error(),
+			)
+			return nil
+		case errors.As(err, &ocmError) && ocmError.Status() == http.StatusBadRequest &&
+			strings.Contains(ocmError.Reason(), "Node pool can only be updated in 'ready' state"):
+			logger.Info("Cluster Service rejected node pool update because it is not updatable. Retrying on next sync.",
+				"clusterServiceID", nodePoolCSID.String(),
+				"error", err.Error(),
+			)
+			return nil
+		default:
+			return utils.TrackError(fmt.Errorf("failed to update cluster-service NodePool: %w", err))
+		}
+	}
+
+	logger.Info("requested cluster-service NodePool update", "clusterServiceID", nodePoolCSID.String())
+
+	serviceProviderNodePool.Status.ClusterServiceUpdatableConfigHashForUpdateDispatch = desiredHash
+	_, err = c.resourcesDBClient.ServiceProviderNodePools(
+		nodePool.ID.SubscriptionID,
+		nodePool.ID.ResourceGroupName,
+		nodePool.ID.Parent.Name,
+		nodePool.ID.Name,
+	).Replace(ctx, serviceProviderNodePool, nil)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to replace ServiceProviderNodePool config hash: %w", err))
+	}
+
+	logger.Info("stored Cluster Service node pool updatable config hash", "hash", desiredHash)
+	return nil
+}

--- a/backend/pkg/controllers/operationcontrollers/operation_node_pool_update.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_node_pool_update.go
@@ -16,8 +16,10 @@ package operationcontrollers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -26,7 +28,9 @@ import (
 
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/database"
+	dblisters "github.com/Azure/ARO-HCP/internal/database/listers"
 	"github.com/Azure/ARO-HCP/internal/ocm"
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
@@ -35,6 +39,7 @@ type operationNodePoolUpdate struct {
 	clock                utilsclock.PassiveClock
 	resourcesDBClient    database.ResourcesDBClient
 	clusterServiceClient ocm.ClusterServiceClientSpec
+	readDesireLister     dblisters.ReadDesireLister
 	notificationClient   *http.Client
 }
 
@@ -56,6 +61,7 @@ func NewOperationNodePoolUpdateController(
 	clock utilsclock.PassiveClock,
 	resourcesDBClient database.ResourcesDBClient,
 	clusterServiceClient ocm.ClusterServiceClientSpec,
+	readDesireLister dblisters.ReadDesireLister,
 	notificationClient *http.Client,
 	activeOperationInformer cache.SharedIndexInformer,
 ) controllerutils.Controller {
@@ -63,6 +69,7 @@ func NewOperationNodePoolUpdateController(
 		clock:                clock,
 		resourcesDBClient:    resourcesDBClient,
 		clusterServiceClient: clusterServiceClient,
+		readDesireLister:     readDesireLister,
 		notificationClient:   notificationClient,
 	}
 
@@ -105,5 +112,77 @@ func (c *operationNodePoolUpdate) SynchronizeOperation(ctx context.Context, key 
 		return nil // no work to do
 	}
 
-	return pollNodePoolStatus(ctx, c.clock, c.resourcesDBClient, c.clusterServiceClient, operation, c.notificationClient)
+	cosmosNewOperationState, err := c.determineOperationStatus(ctx, operation)
+	if err != nil {
+		return utils.TrackError(err)
+	}
+	logger.Info("new status via cosmos", "newStatus", cosmosNewOperationState.provisioningState, "newOperationMessage", cosmosNewOperationState.message)
+
+	nodePoolStatus, err := c.clusterServiceClient.GetNodePoolStatus(ctx, operation.InternalID)
+	if err != nil {
+		return utils.TrackError(err)
+	}
+	newOperationStatus, opError, err := convertNodePoolStatus(operation, nodePoolStatus)
+	if err != nil {
+		return utils.TrackError(err)
+	}
+	logger.Info("new status via cluster-service", "newStatus", newOperationStatus, "newOperationError", opError)
+
+	if newOperationStatus == arm.ProvisioningStateSucceeded && cosmosNewOperationState.provisioningState != arm.ProvisioningStateSucceeded {
+		return fmt.Errorf("cosmos operation status is %q, but cluster-service operation status is %q", cosmosNewOperationState.provisioningState, newOperationStatus)
+	}
+
+	logger.Info("updating status")
+	err = UpdateOperationStatus(ctx, c.clock, c.resourcesDBClient, operation, newOperationStatus, opError, postAsyncNotificationFn(c.notificationClient))
+	if err != nil {
+		return utils.TrackError(err)
+	}
+
+	return nil
+}
+
+func (c *operationNodePoolUpdate) determineOperationStatus(ctx context.Context, operation *api.Operation) (*operationState, error) {
+	logger := utils.LoggerFromContext(ctx)
+
+	errs := []error{}
+	operationStates := []*operationState{}
+
+	clusterName := operation.ExternalID.Parent.Name
+	nodePoolName := operation.ExternalID.Name
+	nodePool, err := c.resourcesDBClient.HCPClusters(operation.ExternalID.SubscriptionID, operation.ExternalID.ResourceGroupName).NodePools(clusterName).Get(ctx, nodePoolName)
+	if err != nil {
+		return nil, utils.TrackError(fmt.Errorf("failed to get node pool from cosmos: %w", err))
+	}
+	if currState, err := c.hypershiftNodePoolOperationState(ctx, nodePool); err != nil {
+		errs = append(errs, utils.TrackError(err))
+	} else {
+		operationStates = append(operationStates, currState)
+	}
+
+	// Here in the future we could add a check that checks something in the cosmos resource itself, like:
+	//	if currState, err := c.cosmosOperationState(ctx, nodePool); err != nil {
+	//		errs = append(errs, utils.TrackError(err))
+	//	} else {
+	//		operationStates = append(operationStates, currState)
+	//	}
+
+	if err := errors.Join(errs...); err != nil {
+		return nil, err
+	}
+	if len(operationStates) == 0 {
+		return nil, errors.New("no operation states")
+	}
+	slices.SortStableFunc(operationStates, compareOperationState)
+	if operationStates[0] == nil {
+		return nil, errors.New("nil operation state")
+	}
+
+	logger.Info("determined node pool update operation status", "operationStates", operationStates)
+
+	picked, err := pickWorstOperationState(operationStates)
+	if err != nil {
+		return nil, utils.TrackError(err)
+	}
+	logger.Info("picked node pool update operation status", "provisioningState", picked.provisioningState, "message", picked.message)
+	return picked, nil
 }

--- a/backend/pkg/controllers/operationcontrollers/operation_node_pool_update_state_calculation.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_node_pool_update_state_calculation.go
@@ -1,0 +1,270 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operationcontrollers
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/maestrohelpers"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/api/kubeapplier"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+func (c *operationNodePoolUpdate) hypershiftNodePoolOperationState(ctx context.Context, nodePool *api.HCPOpenShiftClusterNodePool) (*operationState, error) {
+	logger := utils.LoggerFromContext(ctx)
+
+	readDesire, err := c.readDesireLister.GetForNodePool(
+		ctx,
+		nodePool.ID.SubscriptionID,
+		nodePool.ID.ResourceGroupName,
+		nodePool.ID.Parent.Name,
+		nodePool.ID.Name,
+		maestrohelpers.ReadDesireNameReadonlyNodePool,
+	)
+	if database.IsNotFoundError(err) {
+		return newOperationState(arm.ProvisioningStateUpdating, "ReadDesire for NodePool has not been created yet"), nil
+	}
+	if err != nil {
+		return nil, utils.TrackError(err)
+	}
+
+	if !meta.IsStatusConditionTrue(readDesire.Status.Conditions, kubeapplier.ConditionTypeSuccessful) {
+		message := "ReadDesire has not yet successfully observed the NodePool"
+		if successfulCondition := meta.FindStatusCondition(readDesire.Status.Conditions, kubeapplier.ConditionTypeSuccessful); successfulCondition != nil {
+			message = fmt.Sprintf("ReadDesire is not successful: %s: %s", successfulCondition.Reason, successfulCondition.Message)
+		}
+		logger.Info("ReadDesire is not successful", "readDesire.Status.Conditions", readDesire.Status.Conditions)
+		return newOperationState(arm.ProvisioningStateUpdating, message), nil
+	}
+
+	observedHypershiftNodePool, err := maestrohelpers.NodePoolFromReadDesire(readDesire)
+	if err != nil {
+		return nil, utils.TrackError(err)
+	}
+	if observedHypershiftNodePool == nil {
+		return newOperationState(arm.ProvisioningStateUpdating, "ReadDesire has no NodePool kube content"), nil
+	}
+
+	// TODO should we check this condition? might there be updates on the nodepool on hypershift that are not related
+	// to the updates triggered by us?
+	if c.conditionIsTrue(observedHypershiftNodePool.Status.Conditions, v1beta1.NodePoolUpdatingConfigConditionType) {
+		message := "hypershift NodePool config update in progress"
+		if updatingConfig := c.findCondition(observedHypershiftNodePool.Status.Conditions, v1beta1.NodePoolUpdatingConfigConditionType); updatingConfig != nil {
+			message = fmt.Sprintf("hypershift NodePool config update in progress: %s: %s", updatingConfig.Reason, updatingConfig.Message)
+		}
+		logger.Info("hypershift NodePool is updating config", "nodePool.Status.Conditions", observedHypershiftNodePool.Status.Conditions)
+		return newOperationState(arm.ProvisioningStateUpdating, message), nil
+	}
+
+	// We first check Hypershift's NodePool spec to see if it matches the desired cosmos configuration
+	if matches, message := c.hypershiftNodePoolSpecMatchesCosmosDesired(nodePool.Properties, observedHypershiftNodePool.Spec); !matches {
+		logger.Info("hypershift NodePool spec does not match cosmos desired configuration", "message", message)
+		return newOperationState(arm.ProvisioningStateUpdating, message), nil
+	}
+
+	// We then check Hypershift's NodePool status to see if it matches the desired cosmos configuration
+	if matches, message := c.hypershiftNodePoolStatusMatchesCosmosDesired(nodePool.Properties, observedHypershiftNodePool.Status); !matches {
+		logger.Info("hypershift NodePool status does not match desired configuration", "message", message)
+		return newOperationState(arm.ProvisioningStateUpdating, message), nil
+	}
+
+	return newOperationState(arm.ProvisioningStateSucceeded, ""), nil
+}
+
+// hypershiftNodePoolSpecMatchesCosmosDesired compares Cosmos desired properties against the Hypershift
+// NodePool spec fields that are relevant for the update operation.
+func (c *operationNodePoolUpdate) hypershiftNodePoolSpecMatchesCosmosDesired(desired api.HCPOpenShiftClusterNodePoolProperties, observed v1beta1.NodePoolSpec) (bool, string) {
+	if matches, message := c.scalingSpecMatchesDesired(desired, observed); !matches {
+		return false, message
+	}
+	if matches, message := c.labelsSpecMatchesDesired(desired.Labels, observed.NodeLabels); !matches {
+		return false, message
+	}
+	if matches, message := c.taintsSpecMatchesDesired(desired.Taints, observed.Taints); !matches {
+		return false, message
+	}
+	if matches, message := c.nodeDrainTimeoutSpecMatchesDesired(desired.NodeDrainTimeoutMinutes, observed.NodeDrainTimeout); !matches {
+		return false, message
+	}
+	return true, ""
+}
+
+func (c *operationNodePoolUpdate) scalingSpecMatchesDesired(desired api.HCPOpenShiftClusterNodePoolProperties, observed v1beta1.NodePoolSpec) (bool, string) {
+	if desired.AutoScaling != nil {
+		if observed.AutoScaling == nil {
+			return false, "hypershift NodePool has no autoscaling configuration"
+		}
+		if observed.AutoScaling.Min == nil {
+			return false, "hypershift NodePool autoscaling min is unset"
+		}
+		if *observed.AutoScaling.Min != desired.AutoScaling.Min {
+			return false, fmt.Sprintf("hypershift NodePool autoscaling min is %d, want %d", *observed.AutoScaling.Min, desired.AutoScaling.Min)
+		}
+		if observed.AutoScaling.Max != desired.AutoScaling.Max {
+			return false, fmt.Sprintf("hypershift NodePool autoscaling max is %d, want %d", observed.AutoScaling.Max, desired.AutoScaling.Max)
+		}
+		if observed.Replicas != nil {
+			return false, "hypershift NodePool has replicas set while autoscaling is enabled"
+		}
+		return true, ""
+	}
+
+	if observed.AutoScaling != nil {
+		return false, "hypershift NodePool still has autoscaling configuration"
+	}
+
+	observedReplicas := int32(0)
+	if observed.Replicas != nil {
+		observedReplicas = *observed.Replicas
+	}
+	if observedReplicas != desired.Replicas {
+		return false, fmt.Sprintf("hypershift NodePool replicas is %d, want %d", observedReplicas, desired.Replicas)
+	}
+	return true, ""
+}
+
+func (c *operationNodePoolUpdate) labelsSpecMatchesDesired(desired map[string]string, observed map[string]string) (bool, string) {
+	if len(desired) == 0 && len(observed) == 0 {
+		return true, ""
+	}
+	if !maps.Equal(desired, observed) {
+		return false, "hypershift NodePool nodeLabels do not match desired labels"
+	}
+	return true, ""
+}
+
+func (c *operationNodePoolUpdate) taintsSpecMatchesDesired(desired []api.Taint, observed []v1beta1.Taint) (bool, string) {
+	if len(desired) == 0 && len(observed) == 0 {
+		return true, ""
+	}
+	if len(desired) != len(observed) {
+		return false, fmt.Sprintf("hypershift NodePool has %d taints, want %d", len(observed), len(desired))
+	}
+
+	for i := range desired {
+		if c.apiTaintToHypershift(desired[i]) != observed[i] {
+			return false, "hypershift cluster NodePool taints do not match cosmos desired taints"
+		}
+	}
+	return true, ""
+}
+
+func (c *operationNodePoolUpdate) nodeDrainTimeoutSpecMatchesDesired(desiredMinutes *int32, observed *metav1.Duration) (bool, string) {
+	if desiredMinutes == nil {
+		if observed == nil {
+			return true, ""
+		}
+
+		return false, fmt.Sprintf("hypershift NodePool nodeDrainTimeout is %s, want unset", observed.Duration)
+	}
+
+	want := time.Duration(*desiredMinutes) * time.Minute
+
+	// In Hypershift NodeDrainTimeout is a *metav1.Duration. According to its documentation (as of 2026-06-10):
+	// "The default value is 0, meaning that the node can retry drain without any time limitations."
+	// We treat Hypershift's side nil as the same as zero because when CS receives a desired value of zero for it on the
+	// PATCH call we set the Hypershift side to nil.
+	if observed == nil {
+		if want == 0 {
+			return true, ""
+		}
+		return false, fmt.Sprintf("hypershift NodePool nodeDrainTimeout is unset, want %s", want)
+	}
+	if observed.Duration != want {
+		return false, fmt.Sprintf("hypershift NodePool nodeDrainTimeout is %s, want %s", observed.Duration, want)
+	}
+	return true, ""
+}
+
+func (c *operationNodePoolUpdate) apiTaintToHypershift(t api.Taint) v1beta1.Taint {
+	return v1beta1.Taint{
+		Key:    t.Key,
+		Value:  t.Value,
+		Effect: corev1.TaintEffect(t.Effect),
+	}
+}
+
+// hypershiftNodePoolStatusMatchesCosmosDesired compares elements of Hypershift's NodePool status against Cosmos desired.
+func (c *operationNodePoolUpdate) hypershiftNodePoolStatusMatchesCosmosDesired(desired api.HCPOpenShiftClusterNodePoolProperties, observed v1beta1.NodePoolStatus) (bool, string) {
+	observedReplicas := observed.Replicas
+	if desired.AutoScaling != nil {
+		if observedReplicas < desired.AutoScaling.Min {
+			return false, fmt.Sprintf(
+				"hypershift NodePool status replicas is %d, want at least %d",
+				observedReplicas, desired.AutoScaling.Min,
+			)
+		}
+		if observedReplicas > desired.AutoScaling.Max {
+			return false, fmt.Sprintf(
+				"hypershift NodePool status replicas is %d, want at most %d",
+				observedReplicas, desired.AutoScaling.Max,
+			)
+		}
+		if !c.conditionIsTrue(observed.Conditions, v1beta1.NodePoolAutoscalingEnabledConditionType) {
+			message := "hypershift NodePool autoscaling is not enabled"
+			if autoscalingCondition := c.findCondition(observed.Conditions, v1beta1.NodePoolAutoscalingEnabledConditionType); autoscalingCondition != nil {
+				message = fmt.Sprintf("hypershift NodePool autoscaling is not enabled: %s: %s", autoscalingCondition.Reason, autoscalingCondition.Message)
+			}
+			return false, message
+		}
+	} else if observedReplicas != desired.Replicas {
+		return false, fmt.Sprintf(
+			"hypershift NodePool status replicas is %d, want %d",
+			observed.Replicas, desired.Replicas,
+		)
+	}
+
+	// TODO should we check this condition? might we have the hypershift nodepool not ready because of changes non triggered
+	// by us?
+	if !c.conditionIsTrue(observed.Conditions, v1beta1.NodePoolReadyConditionType) {
+		message := "hypershift NodePool is not ready"
+		if readyCondition := c.findCondition(observed.Conditions, v1beta1.NodePoolReadyConditionType); readyCondition != nil {
+			message = fmt.Sprintf("hypershift NodePool is not ready: %s: %s", readyCondition.Reason, readyCondition.Message)
+		}
+		return false, message
+	}
+
+	return true, ""
+}
+
+func (c *operationNodePoolUpdate) conditionIsTrue(conditions []v1beta1.NodePoolCondition, conditionType string) bool {
+	for i := range conditions {
+		if conditions[i].Type == conditionType {
+			return conditions[i].Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+func (c *operationNodePoolUpdate) findCondition(conditions []v1beta1.NodePoolCondition, conditionType string) *v1beta1.NodePoolCondition {
+	for i := range conditions {
+		if conditions[i].Type == conditionType {
+			return &conditions[i]
+		}
+	}
+	return nil
+}

--- a/backend/pkg/controllers/operationcontrollers/operation_node_pool_update_state_calculation_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_node_pool_update_state_calculation_test.go
@@ -1,0 +1,355 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operationcontrollers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+)
+
+func TestNodePoolUpdateSpecMatchesDesired(t *testing.T) {
+	tests := []struct {
+		name     string
+		desired  api.HCPOpenShiftClusterNodePoolProperties
+		observed v1beta1.NodePoolSpec
+		want     bool
+		wantMsg  string
+	}{
+		{
+			name: "fixed replicas match",
+			desired: api.HCPOpenShiftClusterNodePoolProperties{
+				Replicas: 3,
+			},
+			observed: v1beta1.NodePoolSpec{
+				Replicas: ptr.To(int32(3)),
+			},
+			want: true,
+		},
+		{
+			name: "fixed replicas mismatch",
+			desired: api.HCPOpenShiftClusterNodePoolProperties{
+				Replicas: 3,
+			},
+			observed: v1beta1.NodePoolSpec{
+				Replicas: ptr.To(int32(2)),
+			},
+			want:    false,
+			wantMsg: "hypershift NodePool replicas is 2, want 3",
+		},
+		{
+			name: "autoscaling match",
+			desired: api.HCPOpenShiftClusterNodePoolProperties{
+				AutoScaling: &api.NodePoolAutoScaling{Min: 2, Max: 5},
+			},
+			observed: v1beta1.NodePoolSpec{
+				AutoScaling: &v1beta1.NodePoolAutoScaling{
+					Min: ptr.To(int32(2)),
+					Max: 5,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "autoscaling min mismatch",
+			desired: api.HCPOpenShiftClusterNodePoolProperties{
+				AutoScaling: &api.NodePoolAutoScaling{Min: 2, Max: 5},
+			},
+			observed: v1beta1.NodePoolSpec{
+				AutoScaling: &v1beta1.NodePoolAutoScaling{
+					Min: ptr.To(int32(1)),
+					Max: 5,
+				},
+			},
+			want:    false,
+			wantMsg: "hypershift NodePool autoscaling min is 1, want 2",
+		},
+		{
+			name: "desired autoscaling but observed fixed replicas",
+			desired: api.HCPOpenShiftClusterNodePoolProperties{
+				AutoScaling: &api.NodePoolAutoScaling{Min: 2, Max: 5},
+			},
+			observed: v1beta1.NodePoolSpec{
+				Replicas: ptr.To(int32(0)),
+			},
+			want:    false,
+			wantMsg: "hypershift NodePool has no autoscaling configuration",
+		},
+		{
+			name: "desired fixed replicas but observed autoscaling remains",
+			desired: api.HCPOpenShiftClusterNodePoolProperties{
+				Replicas: 3,
+			},
+			observed: v1beta1.NodePoolSpec{
+				AutoScaling: &v1beta1.NodePoolAutoScaling{
+					Min: ptr.To(int32(2)),
+					Max: 5,
+				},
+			},
+			want:    false,
+			wantMsg: "hypershift NodePool still has autoscaling configuration",
+		},
+		{
+			name: "labels match",
+			desired: api.HCPOpenShiftClusterNodePoolProperties{
+				Replicas: 1,
+				Labels:   map[string]string{"role": "worker", "env": "test"},
+			},
+			observed: v1beta1.NodePoolSpec{
+				Replicas:   ptr.To(int32(1)),
+				NodeLabels: map[string]string{"role": "worker", "env": "test"},
+			},
+			want: true,
+		},
+		{
+			name: "labels mismatch",
+			desired: api.HCPOpenShiftClusterNodePoolProperties{
+				Replicas: 1,
+				Labels:   map[string]string{"role": "worker"},
+			},
+			observed: v1beta1.NodePoolSpec{
+				Replicas:   ptr.To(int32(1)),
+				NodeLabels: map[string]string{"role": "infra"},
+			},
+			want:    false,
+			wantMsg: "hypershift NodePool nodeLabels do not match desired labels",
+		},
+		{
+			name: "taints match",
+			desired: api.HCPOpenShiftClusterNodePoolProperties{
+				Replicas: 1,
+				Taints: []api.Taint{
+					{Key: "k1", Value: "v1", Effect: api.EffectNoSchedule},
+				},
+			},
+			observed: v1beta1.NodePoolSpec{
+				Replicas: ptr.To(int32(1)),
+				Taints: []v1beta1.Taint{
+					{Key: "k1", Value: "v1", Effect: corev1.TaintEffectNoSchedule},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "taints mismatch",
+			desired: api.HCPOpenShiftClusterNodePoolProperties{
+				Replicas: 1,
+				Taints: []api.Taint{
+					{Key: "k1", Value: "v1", Effect: api.EffectNoSchedule},
+				},
+			},
+			observed: v1beta1.NodePoolSpec{
+				Replicas: ptr.To(int32(1)),
+				Taints:   []v1beta1.Taint{},
+			},
+			want:    false,
+			wantMsg: "hypershift NodePool has 0 taints, want 1",
+		},
+		{
+			name: "node drain timeout match",
+			desired: api.HCPOpenShiftClusterNodePoolProperties{
+				Replicas:                1,
+				NodeDrainTimeoutMinutes: ptr.To(int32(30)),
+			},
+			observed: v1beta1.NodePoolSpec{
+				Replicas:         ptr.To(int32(1)),
+				NodeDrainTimeout: &metav1.Duration{Duration: 30 * time.Minute},
+			},
+			want: true,
+		},
+		{
+			name: "node drain timeout mismatch",
+			desired: api.HCPOpenShiftClusterNodePoolProperties{
+				Replicas:                1,
+				NodeDrainTimeoutMinutes: ptr.To(int32(30)),
+			},
+			observed: v1beta1.NodePoolSpec{
+				Replicas:         ptr.To(int32(1)),
+				NodeDrainTimeout: &metav1.Duration{Duration: 15 * time.Minute},
+			},
+			want:    false,
+			wantMsg: "hypershift NodePool nodeDrainTimeout is 15m0s, want 30m0s",
+		},
+		{
+			name: "node drain timeout both nil",
+			desired: api.HCPOpenShiftClusterNodePoolProperties{
+				Replicas: 1,
+			},
+			observed: v1beta1.NodePoolSpec{
+				Replicas: ptr.To(int32(1)),
+			},
+			want: true,
+		},
+		{
+			name: "node drain timeout desired nil but observed set",
+			desired: api.HCPOpenShiftClusterNodePoolProperties{
+				Replicas: 1,
+			},
+			observed: v1beta1.NodePoolSpec{
+				Replicas:         ptr.To(int32(1)),
+				NodeDrainTimeout: &metav1.Duration{Duration: 10 * time.Minute},
+			},
+			want:    false,
+			wantMsg: "hypershift NodePool nodeDrainTimeout is 10m0s, want unset",
+		},
+		{
+			name: "node drain timeout desired zero and observed nil treated as match",
+			desired: api.HCPOpenShiftClusterNodePoolProperties{
+				Replicas:                1,
+				NodeDrainTimeoutMinutes: ptr.To(int32(0)),
+			},
+			observed: v1beta1.NodePoolSpec{
+				Replicas: ptr.To(int32(1)),
+			},
+			want: true,
+		},
+		{
+			name: "node drain timeout desired nonzero but observed nil",
+			desired: api.HCPOpenShiftClusterNodePoolProperties{
+				Replicas:                1,
+				NodeDrainTimeoutMinutes: ptr.To(int32(15)),
+			},
+			observed: v1beta1.NodePoolSpec{
+				Replicas: ptr.To(int32(1)),
+			},
+			want:    false,
+			wantMsg: "hypershift NodePool nodeDrainTimeout is unset, want 15m0s",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &operationNodePoolUpdate{}
+			got, msg := c.hypershiftNodePoolSpecMatchesCosmosDesired(tt.desired, tt.observed)
+			assert.Equal(t, tt.want, got)
+			if !tt.want {
+				assert.Equal(t, tt.wantMsg, msg)
+			}
+		})
+	}
+}
+
+func TestNodePoolUpdateStatusMatchesDesired(t *testing.T) {
+	tests := []struct {
+		name     string
+		desired  api.HCPOpenShiftClusterNodePoolProperties
+		observed v1beta1.NodePoolStatus
+		want     bool
+		wantMsg  string
+	}{
+		{
+			name: "fixed replicas match",
+			desired: api.HCPOpenShiftClusterNodePoolProperties{
+				Replicas: 3,
+			},
+			observed: v1beta1.NodePoolStatus{
+				Replicas: 3,
+				Conditions: []v1beta1.NodePoolCondition{
+					{Type: v1beta1.NodePoolReadyConditionType, Status: corev1.ConditionTrue},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "fixed replicas mismatch",
+			desired: api.HCPOpenShiftClusterNodePoolProperties{
+				Replicas: 3,
+			},
+			observed: v1beta1.NodePoolStatus{Replicas: 2},
+			want:     false,
+			wantMsg:  "hypershift NodePool status replicas is 2, want 3",
+		},
+		{
+			name: "autoscaling status within range",
+			desired: api.HCPOpenShiftClusterNodePoolProperties{
+				AutoScaling: &api.NodePoolAutoScaling{Min: 2, Max: 5},
+			},
+			observed: v1beta1.NodePoolStatus{
+				Replicas: 3,
+				Conditions: []v1beta1.NodePoolCondition{
+					{Type: v1beta1.NodePoolAutoscalingEnabledConditionType, Status: corev1.ConditionTrue},
+					{Type: v1beta1.NodePoolReadyConditionType, Status: corev1.ConditionTrue},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "autoscaling enabled condition false",
+			desired: api.HCPOpenShiftClusterNodePoolProperties{
+				AutoScaling: &api.NodePoolAutoScaling{Min: 2, Max: 5},
+			},
+			observed: v1beta1.NodePoolStatus{
+				Replicas: 3,
+				Conditions: []v1beta1.NodePoolCondition{
+					{Type: v1beta1.NodePoolAutoscalingEnabledConditionType, Status: corev1.ConditionFalse, Reason: "Disabled", Message: "waiting for autoscaler"},
+				},
+			},
+			want:    false,
+			wantMsg: "hypershift NodePool autoscaling is not enabled: Disabled: waiting for autoscaler",
+		},
+		{
+			name: "autoscaling status below min",
+			desired: api.HCPOpenShiftClusterNodePoolProperties{
+				AutoScaling: &api.NodePoolAutoScaling{Min: 2, Max: 5},
+			},
+			observed: v1beta1.NodePoolStatus{Replicas: 1},
+			want:     false,
+			wantMsg:  "hypershift NodePool status replicas is 1, want at least 2",
+		},
+		{
+			name: "autoscaling status above max",
+			desired: api.HCPOpenShiftClusterNodePoolProperties{
+				AutoScaling: &api.NodePoolAutoScaling{Min: 2, Max: 5},
+			},
+			observed: v1beta1.NodePoolStatus{Replicas: 6},
+			want:     false,
+			wantMsg:  "hypershift NodePool status replicas is 6, want at most 5",
+		},
+		{
+			name: "replicas match but not ready",
+			desired: api.HCPOpenShiftClusterNodePoolProperties{
+				Replicas: 3,
+			},
+			observed: v1beta1.NodePoolStatus{
+				Replicas: 3,
+				Conditions: []v1beta1.NodePoolCondition{
+					{Type: v1beta1.NodePoolReadyConditionType, Status: corev1.ConditionFalse, Reason: "NotReady", Message: "machines not ready"},
+				},
+			},
+			want:    false,
+			wantMsg: "hypershift NodePool is not ready: NotReady: machines not ready",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &operationNodePoolUpdate{}
+			got, msg := c.hypershiftNodePoolStatusMatchesCosmosDesired(tt.desired, tt.observed)
+			assert.Equal(t, tt.want, got)
+			if !tt.want {
+				assert.Equal(t, tt.wantMsg, msg)
+			}
+		})
+	}
+}

--- a/backend/pkg/controllers/operationcontrollers/operation_node_pool_update_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_node_pool_update_test.go
@@ -16,42 +16,100 @@ package operationcontrollers
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr/testr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kruntime "k8s.io/apimachinery/pkg/runtime"
 	utilsclock "k8s.io/utils/clock"
+	"k8s.io/utils/ptr"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
 	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+	"github.com/openshift/hypershift/api/hypershift/v1beta1"
 
+	"github.com/Azure/ARO-HCP/backend/pkg/maestrohelpers"
+	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/api/kubeapplier"
 	"github.com/Azure/ARO-HCP/internal/database"
+	internallistertesting "github.com/Azure/ARO-HCP/internal/database/listertesting"
 	"github.com/Azure/ARO-HCP/internal/databasetesting"
 	"github.com/Azure/ARO-HCP/internal/ocm"
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
 
+func newNodePoolReadDesire(t *testing.T, nodePool *v1beta1.NodePool, conditions ...metav1.Condition) *kubeapplier.ReadDesire {
+	t.Helper()
+	raw, err := json.Marshal(nodePool)
+	require.NoError(t, err)
+	if conditions == nil {
+		conditions = []metav1.Condition{
+			{Type: kubeapplier.ConditionTypeSuccessful, Status: metav1.ConditionTrue, Reason: kubeapplier.ConditionReasonNoErrors},
+		}
+	}
+
+	resourceID := api.Must(azcorearm.ParseResourceID(
+		kubeapplier.ToNodePoolScopedReadDesireResourceIDString(
+			testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName, maestrohelpers.ReadDesireNameReadonlyNodePool)))
+
+	return &kubeapplier.ReadDesire{
+		CosmosMetadata: api.CosmosMetadata{
+			ResourceID: resourceID,
+		},
+		Status: kubeapplier.ReadDesireStatus{
+			Conditions:  conditions,
+			KubeContent: &kruntime.RawExtension{Raw: raw},
+		},
+	}
+}
+
 func TestOperationNodePoolUpdate_SynchronizeOperation(t *testing.T) {
 	tests := []struct {
-		name          string
-		nodePoolState string
-		nodePoolMsg   string
-		expectError   bool
-		verify        func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture)
+		name             string
+		nodePoolState    string
+		nodePoolMsg      string
+		nodePoolProps    *api.HCPOpenShiftClusterNodePoolProperties
+		readDesireLister internallistertesting.SliceReadDesireLister
+		expectError      bool
+		verify           func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture)
 	}{
 		{
-			name:          "node pool ready transitions to succeeded",
+			name:          "node pool ready and management cluster spec and status match transitions to succeeded",
 			nodePoolState: string(NodePoolStateReady),
-			expectError:   false,
+			nodePoolProps: &api.HCPOpenShiftClusterNodePoolProperties{
+				ProvisioningState: arm.ProvisioningStateAccepted,
+				Replicas:          3,
+			},
+			readDesireLister: internallistertesting.SliceReadDesireLister{
+				Desires: []*kubeapplier.ReadDesire{
+					newNodePoolReadDesire(t, &v1beta1.NodePool{
+						Spec: v1beta1.NodePoolSpec{
+							Replicas: ptr.To(int32(3)),
+						},
+						Status: v1beta1.NodePoolStatus{
+							Replicas: 3,
+							Conditions: []v1beta1.NodePoolCondition{
+								{Type: v1beta1.NodePoolReadyConditionType, Status: corev1.ConditionTrue},
+							},
+						},
+					}),
+				},
+			},
+			expectError: false,
 			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateSucceeded, op.Status)
 
-				// Verify node pool provisioning state was also updated
 				nodePool, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).NodePools(testClusterName).Get(ctx, testNodePoolName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateSucceeded, nodePool.Properties.ProvisioningState)
@@ -59,15 +117,316 @@ func TestOperationNodePoolUpdate_SynchronizeOperation(t *testing.T) {
 			},
 		},
 		{
+			name:          "node pool ready with matching spec but status replicas mismatch returns gate error",
+			nodePoolState: string(NodePoolStateReady),
+			nodePoolProps: &api.HCPOpenShiftClusterNodePoolProperties{
+				ProvisioningState: arm.ProvisioningStateAccepted,
+				Replicas:          3,
+			},
+			readDesireLister: internallistertesting.SliceReadDesireLister{
+				Desires: []*kubeapplier.ReadDesire{
+					newNodePoolReadDesire(t, &v1beta1.NodePool{
+						Spec: v1beta1.NodePoolSpec{
+							Replicas: ptr.To(int32(3)),
+						},
+						Status: v1beta1.NodePoolStatus{
+							Replicas: 2,
+						},
+					}),
+				},
+			},
+			expectError: true,
+			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+			},
+		},
+		{
+			name:          "node pool ready with autoscaling spec and status in range transitions to succeeded",
+			nodePoolState: string(NodePoolStateReady),
+			nodePoolProps: &api.HCPOpenShiftClusterNodePoolProperties{
+				ProvisioningState: arm.ProvisioningStateAccepted,
+				AutoScaling:       &api.NodePoolAutoScaling{Min: 2, Max: 5},
+			},
+			readDesireLister: internallistertesting.SliceReadDesireLister{
+				Desires: []*kubeapplier.ReadDesire{
+					newNodePoolReadDesire(t, &v1beta1.NodePool{
+						Spec: v1beta1.NodePoolSpec{
+							AutoScaling: &v1beta1.NodePoolAutoScaling{
+								Min: ptr.To(int32(2)),
+								Max: 5,
+							},
+						},
+						Status: v1beta1.NodePoolStatus{
+							Replicas: 3,
+							Conditions: []v1beta1.NodePoolCondition{
+								{Type: v1beta1.NodePoolAutoscalingEnabledConditionType, Status: corev1.ConditionTrue},
+								{Type: v1beta1.NodePoolReadyConditionType, Status: corev1.ConditionTrue},
+							},
+						},
+					}),
+				},
+			},
+			expectError: false,
+			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateSucceeded, op.Status)
+			},
+		},
+		{
+			name:          "node pool ready with autoscaling spec match but status below min returns gate error",
+			nodePoolState: string(NodePoolStateReady),
+			nodePoolProps: &api.HCPOpenShiftClusterNodePoolProperties{
+				ProvisioningState: arm.ProvisioningStateAccepted,
+				AutoScaling:       &api.NodePoolAutoScaling{Min: 2, Max: 5},
+			},
+			readDesireLister: internallistertesting.SliceReadDesireLister{
+				Desires: []*kubeapplier.ReadDesire{
+					newNodePoolReadDesire(t, &v1beta1.NodePool{
+						Spec: v1beta1.NodePoolSpec{
+							AutoScaling: &v1beta1.NodePoolAutoScaling{
+								Min: ptr.To(int32(2)),
+								Max: 5,
+							},
+						},
+						Status: v1beta1.NodePoolStatus{
+							Replicas: 1,
+							Conditions: []v1beta1.NodePoolCondition{
+								{Type: v1beta1.NodePoolAutoscalingEnabledConditionType, Status: corev1.ConditionTrue},
+							},
+						},
+					}),
+				},
+			},
+			expectError: true,
+			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+			},
+		},
+		{
+			name:          "node pool ready with labels spec and status match transitions to succeeded",
+			nodePoolState: string(NodePoolStateReady),
+			nodePoolProps: &api.HCPOpenShiftClusterNodePoolProperties{
+				ProvisioningState: arm.ProvisioningStateAccepted,
+				Replicas:          1,
+				Labels:            map[string]string{"role": "worker"},
+			},
+			readDesireLister: internallistertesting.SliceReadDesireLister{
+				Desires: []*kubeapplier.ReadDesire{
+					newNodePoolReadDesire(t, &v1beta1.NodePool{
+						Spec: v1beta1.NodePoolSpec{
+							Replicas:   ptr.To(int32(1)),
+							NodeLabels: map[string]string{"role": "worker"},
+						},
+						Status: v1beta1.NodePoolStatus{
+							Replicas: 1,
+							Conditions: []v1beta1.NodePoolCondition{
+								{Type: v1beta1.NodePoolReadyConditionType, Status: corev1.ConditionTrue},
+							},
+						},
+					}),
+				},
+			},
+			expectError: false,
+			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateSucceeded, op.Status)
+			},
+		},
+		{
+			name:          "node pool ready with labels spec mismatch returns gate error",
+			nodePoolState: string(NodePoolStateReady),
+			nodePoolProps: &api.HCPOpenShiftClusterNodePoolProperties{
+				ProvisioningState: arm.ProvisioningStateAccepted,
+				Replicas:          1,
+				Labels:            map[string]string{"role": "worker"},
+			},
+			readDesireLister: internallistertesting.SliceReadDesireLister{
+				Desires: []*kubeapplier.ReadDesire{
+					newNodePoolReadDesire(t, &v1beta1.NodePool{
+						Spec: v1beta1.NodePoolSpec{
+							Replicas:   ptr.To(int32(1)),
+							NodeLabels: map[string]string{"role": "infra"},
+						},
+						Status: v1beta1.NodePoolStatus{
+							Replicas: 1,
+							Conditions: []v1beta1.NodePoolCondition{
+								{Type: v1beta1.NodePoolReadyConditionType, Status: corev1.ConditionTrue},
+							},
+						},
+					}),
+				},
+			},
+			expectError: true,
+			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+			},
+		},
+		{
+			name:          "node pool ready with taints spec mismatch returns gate error",
+			nodePoolState: string(NodePoolStateReady),
+			nodePoolProps: &api.HCPOpenShiftClusterNodePoolProperties{
+				ProvisioningState: arm.ProvisioningStateAccepted,
+				Replicas:          1,
+				Taints: []api.Taint{
+					{Key: "k1", Value: "v1", Effect: api.EffectNoSchedule},
+				},
+			},
+			readDesireLister: internallistertesting.SliceReadDesireLister{
+				Desires: []*kubeapplier.ReadDesire{
+					newNodePoolReadDesire(t, &v1beta1.NodePool{
+						Spec: v1beta1.NodePoolSpec{
+							Replicas: ptr.To(int32(1)),
+						},
+						Status: v1beta1.NodePoolStatus{
+							Replicas: 1,
+							Conditions: []v1beta1.NodePoolCondition{
+								{Type: v1beta1.NodePoolReadyConditionType, Status: corev1.ConditionTrue},
+							},
+						},
+					}),
+				},
+			},
+			expectError: true,
+			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+			},
+		},
+		{
+			name:          "node pool ready with node drain timeout spec mismatch returns gate error",
+			nodePoolState: string(NodePoolStateReady),
+			nodePoolProps: &api.HCPOpenShiftClusterNodePoolProperties{
+				ProvisioningState:       arm.ProvisioningStateAccepted,
+				Replicas:                1,
+				NodeDrainTimeoutMinutes: ptr.To(int32(30)),
+			},
+			readDesireLister: internallistertesting.SliceReadDesireLister{
+				Desires: []*kubeapplier.ReadDesire{
+					newNodePoolReadDesire(t, &v1beta1.NodePool{
+						Spec: v1beta1.NodePoolSpec{
+							Replicas:         ptr.To(int32(1)),
+							NodeDrainTimeout: &metav1.Duration{Duration: 15 * time.Minute},
+						},
+						Status: v1beta1.NodePoolStatus{
+							Replicas: 1,
+							Conditions: []v1beta1.NodePoolCondition{
+								{Type: v1beta1.NodePoolReadyConditionType, Status: corev1.ConditionTrue},
+							},
+						},
+					}),
+				},
+			},
+			expectError: true,
+			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+			},
+		},
+		{
+			name:          "node pool ready with UpdatingConfig condition returns gate error",
+			nodePoolState: string(NodePoolStateReady),
+			nodePoolProps: &api.HCPOpenShiftClusterNodePoolProperties{
+				ProvisioningState: arm.ProvisioningStateAccepted,
+				Replicas:          3,
+			},
+			readDesireLister: internallistertesting.SliceReadDesireLister{
+				Desires: []*kubeapplier.ReadDesire{
+					newNodePoolReadDesire(t, &v1beta1.NodePool{
+						Spec: v1beta1.NodePoolSpec{
+							Replicas: ptr.To(int32(3)),
+						},
+						Status: v1beta1.NodePoolStatus{
+							Replicas: 3,
+							Conditions: []v1beta1.NodePoolCondition{
+								{Type: v1beta1.NodePoolUpdatingConfigConditionType, Status: corev1.ConditionTrue},
+								{Type: v1beta1.NodePoolReadyConditionType, Status: corev1.ConditionTrue},
+							},
+						},
+					}),
+				},
+			},
+			expectError: true,
+			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+			},
+		},
+		{
+			name:          "node pool ready but management cluster spec mismatch returns gate error",
+			nodePoolState: string(NodePoolStateReady),
+			nodePoolProps: &api.HCPOpenShiftClusterNodePoolProperties{
+				ProvisioningState: arm.ProvisioningStateAccepted,
+				AutoScaling:       &api.NodePoolAutoScaling{Min: 2, Max: 5},
+			},
+			readDesireLister: internallistertesting.SliceReadDesireLister{
+				Desires: []*kubeapplier.ReadDesire{
+					newNodePoolReadDesire(t, &v1beta1.NodePool{
+						Spec: v1beta1.NodePoolSpec{
+							Replicas: ptr.To(int32(3)),
+						},
+					}),
+				},
+			},
+			expectError: true,
+			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+
+				nodePool, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).NodePools(testClusterName).Get(ctx, testNodePoolName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, nodePool.Properties.ProvisioningState)
+				assert.Equal(t, testOperationName, nodePool.ServiceProviderProperties.ActiveOperationID)
+			},
+		},
+		{
+			name:          "node pool ready but ReadDesire missing returns gate error",
+			nodePoolState: string(NodePoolStateReady),
+			nodePoolProps: &api.HCPOpenShiftClusterNodePoolProperties{
+				ProvisioningState: arm.ProvisioningStateAccepted,
+				Replicas:          3,
+			},
+			readDesireLister: internallistertesting.SliceReadDesireLister{},
+			expectError:      true,
+			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+			},
+		},
+		{
 			name:          "node pool updating transitions to updating",
 			nodePoolState: string(NodePoolStateUpdating),
-			expectError:   false,
+			nodePoolProps: &api.HCPOpenShiftClusterNodePoolProperties{
+				ProvisioningState: arm.ProvisioningStateAccepted,
+				Replicas:          3,
+			},
+			readDesireLister: internallistertesting.SliceReadDesireLister{
+				Desires: []*kubeapplier.ReadDesire{
+					newNodePoolReadDesire(t, &v1beta1.NodePool{
+						Spec: v1beta1.NodePoolSpec{
+							Replicas: ptr.To(int32(3)),
+						},
+					}),
+				},
+			},
+			expectError: false,
 			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateUpdating, op.Status)
 
-				// Verify node pool still has active operation
 				nodePool, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).NodePools(testClusterName).Get(ctx, testNodePoolName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateUpdating, nodePool.Properties.ProvisioningState)
@@ -77,7 +436,12 @@ func TestOperationNodePoolUpdate_SynchronizeOperation(t *testing.T) {
 		{
 			name:          "node pool validating_update stays accepted",
 			nodePoolState: string(NodePoolStateValidatingUpdate),
-			expectError:   false,
+			nodePoolProps: &api.HCPOpenShiftClusterNodePoolProperties{
+				ProvisioningState: arm.ProvisioningStateAccepted,
+				Replicas:          3,
+			},
+			readDesireLister: internallistertesting.SliceReadDesireLister{},
+			expectError:      false,
 			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
@@ -87,7 +451,12 @@ func TestOperationNodePoolUpdate_SynchronizeOperation(t *testing.T) {
 		{
 			name:          "node pool pending_update stays accepted",
 			nodePoolState: string(NodePoolStatePendingUpdate),
-			expectError:   false,
+			nodePoolProps: &api.HCPOpenShiftClusterNodePoolProperties{
+				ProvisioningState: arm.ProvisioningStateAccepted,
+				Replicas:          3,
+			},
+			readDesireLister: internallistertesting.SliceReadDesireLister{},
+			expectError:      false,
 			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
@@ -98,7 +467,12 @@ func TestOperationNodePoolUpdate_SynchronizeOperation(t *testing.T) {
 			name:          "node pool recoverable_error transitions to failed",
 			nodePoolState: string(NodePoolStateRecoverableError),
 			nodePoolMsg:   "temporary error occurred",
-			expectError:   false,
+			nodePoolProps: &api.HCPOpenShiftClusterNodePoolProperties{
+				ProvisioningState: arm.ProvisioningStateAccepted,
+				Replicas:          3,
+			},
+			readDesireLister: internallistertesting.SliceReadDesireLister{},
+			expectError:      false,
 			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
@@ -119,6 +493,9 @@ func TestOperationNodePoolUpdate_SynchronizeOperation(t *testing.T) {
 			fixture := newNodePoolTestFixture()
 			cluster := fixture.newCluster()
 			nodePool := fixture.newNodePool()
+			if tt.nodePoolProps != nil {
+				nodePool.Properties = *tt.nodePoolProps
+			}
 			operation := fixture.newOperation(database.OperationRequestUpdate)
 
 			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, []any{cluster, nodePool, operation})
@@ -141,6 +518,7 @@ func TestOperationNodePoolUpdate_SynchronizeOperation(t *testing.T) {
 				clock:                utilsclock.RealClock{},
 				resourcesDBClient:    mockResourcesDBClient,
 				clusterServiceClient: mockCSClient,
+				readDesireLister:     &tt.readDesireLister,
 				notificationClient:   nil,
 			}
 

--- a/backend/pkg/maestrohelpers/nodepools.go
+++ b/backend/pkg/maestrohelpers/nodepools.go
@@ -1,0 +1,80 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package maestrohelpers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/json"
+
+	"github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/kubeapplier"
+	"github.com/Azure/ARO-HCP/internal/database"
+	dblisters "github.com/Azure/ARO-HCP/internal/database/listers"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// ReadDesireNameReadonlyNodePool is the well-known ReadDesire name the backend
+// writes the per-node-pool NodePool mirror under. Consumers look this up via a
+// ReadDesireLister.GetForNodePool call.
+//
+// The value is the lowercased form of
+// api.MaestroBundleInternalNameReadonlyHypershiftNodePool — the same derivation
+// the writer (create_nodepool_scoped_read_desires_controller.go) uses for its
+// desired ReadDesire name.
+var ReadDesireNameReadonlyNodePool = strings.ToLower(string(api.MaestroBundleInternalNameReadonlyHypershiftNodePool))
+
+// GetCachedNodePoolForNodePool reads the NodePool mirror from the per-node-pool
+// ReadDesire. The ReadDesire's Status.KubeContent.Raw carries the observed
+// NodePool JSON; we decode it directly and return the typed object.
+//
+// Returns (nil, nil) when:
+//   - the ReadDesire has not been created yet (NotFound),
+//   - the ReadDesire exists but the kube-applier has not yet observed
+//     the target (Status.KubeContent is nil or empty).
+//
+// Returns a non-nil error only for hard failures: a non-NotFound lister
+// error, or unmarshal failure.
+func GetCachedNodePoolForNodePool(
+	ctx context.Context,
+	readDesireLister dblisters.ReadDesireLister,
+	subscriptionName, resourceGroupName, clusterName, nodePoolName string,
+) (*v1beta1.NodePool, error) {
+	readDesire, err := readDesireLister.GetForNodePool(ctx, subscriptionName, resourceGroupName, clusterName, nodePoolName, ReadDesireNameReadonlyNodePool)
+	if database.IsNotFoundError(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, utils.TrackError(fmt.Errorf("failed to get ReadDesire for NodePool: %w", err))
+	}
+	return NodePoolFromReadDesire(readDesire)
+}
+
+// NodePoolFromReadDesire decodes the Hypershift NodePool carried in
+// readDesire.Status.KubeContent. Returns (nil, nil) when kube content is absent.
+func NodePoolFromReadDesire(readDesire *kubeapplier.ReadDesire) (*v1beta1.NodePool, error) {
+	if readDesire.Status.KubeContent == nil || len(readDesire.Status.KubeContent.Raw) == 0 {
+		return nil, nil
+	}
+	nodePool := &v1beta1.NodePool{}
+	if err := json.Unmarshal(readDesire.Status.KubeContent.Raw, nodePool); err != nil {
+		return nil, utils.TrackError(fmt.Errorf("failed to unmarshal NodePool from ReadDesire kubeContent: %w", err))
+	}
+	return nodePool, nil
+}

--- a/frontend/pkg/frontend/node_pool.go
+++ b/frontend/pkg/frontend/node_pool.go
@@ -593,33 +593,21 @@ func (f *Frontend) updateNodePoolInCosmos(ctx context.Context, writer http.Respo
 		return utils.TrackError(err)
 	}
 
-	// Temporary check until creation and update interaction with CS is moved to the backend: If an update arrives after the node pool
-	// has been created in Cosmos but before it exists in CS, or before its ClusterServiceID has been persisted in Cosmos, return an error.
+	// Temporary check until update interaction with CS is fully handled by the backend:
+	// If an update arrives after the node pool has been created in Cosmos but before it exists in CS,
+	// or before its ClusterServiceID has been persisted in Cosmos, return an error.
 	if oldInternalNodePool.ServiceProviderProperties.ClusterServiceID == nil || len(oldInternalNodePool.ServiceProviderProperties.ClusterServiceID.String()) == 0 {
 		return utils.TrackError(fmt.Errorf("serviceProviderProperties.clusterServiceID is required to update a node pool"))
 	}
 
-	csNodePoolBuilder, err := ocm.BuildCSNodePool(ctx, newInternalNodePool, true)
-	if err != nil {
-		return utils.TrackError(err)
-	}
 	logger.Info(fmt.Sprintf("updating resource %s", oldInternalNodePool.ID))
-	_, err = f.clusterServiceClient.UpdateNodePool(ctx, *oldInternalNodePool.ServiceProviderProperties.ClusterServiceID, csNodePoolBuilder)
-	if err != nil {
-		return utils.TrackError(err)
-	}
-
-	// The cosmos representation the new desired version
 	// The controllers will take care of handle the upgrade
 
 	transaction := f.resourcesDBClient.NewTransaction(oldInternalNodePool.ID.SubscriptionID)
 
 	// Always create an operation, even for version-only changes. This provides consistent
 	// ARM API behavior and avoids the complexity of detecting what changed.
-	// For version-only updates, CS receives a no-op PATCH
-	// (version is excluded in BuildCSNodePool for updates) and stays ready, so the
-	// operation resolves on the next poll cycle (~10s). The actual version upgrade is
-	// handled transparently by backend controllers using the desired version stored above.
+	// Cluster Service update dispatch and version upgrade are handled by backend controllers.
 	nodePoolUpdateOperation := database.NewOperation(
 		database.OperationRequestUpdate,
 		newInternalNodePool.ID,
@@ -639,7 +627,7 @@ func (f *Frontend) updateNodePoolInCosmos(ctx context.Context, writer http.Respo
 	// TODO once we we have separate creation/validation of operation documents, this can be done ahead of time.
 	newInternalNodePool.ServiceProviderProperties.ActiveOperationID = nodePoolUpdateOperation.ResourceID.Name
 	newInternalNodePool.Properties.ProvisioningState = nodePoolUpdateOperation.Status
-
+	newInternalNodePool.ServiceProviderProperties.UsesNewNodePoolUpdateApproach = true
 	_, err = f.resourcesDBClient.HCPClusters(newInternalNodePool.ID.SubscriptionID, newInternalNodePool.ID.ResourceGroupName).
 		NodePools(newInternalNodePool.ID.Parent.Name).
 		AddReplaceToTransaction(ctx, transaction, newInternalNodePool, nil)

--- a/internal/api/types_nodepool.go
+++ b/internal/api/types_nodepool.go
@@ -93,6 +93,13 @@ type HCPOpenShiftClusterNodePoolServiceProviderProperties struct {
 	// This will be removed once all nodepools whose deletion was triggered before the new approach is fully rolled out have been
 	// fully deleted in all ARO-HCP permanent environments, for all regions.
 	UsesNewNodePoolDeletionApproach bool `json:"usesNewNodePoolDeletionApproach"`
+
+	// TODO Temporary field to track whether the node pool is using the new update approach.
+	// We are migrating from the node pool cs update synchronous in frontend to the backend, to be fully asynchronous
+	// This boolean is true for NodePool update operations that are created with new update approach.
+	// This will be removed once all nodepools whose update was triggered before the new approach is fully rolled out have been
+	// fully updated in all ARO-HCP permanent environments, for all regions.
+	UsesNewNodePoolUpdateApproach bool `json:"usesNewNodePoolUpdateApproach"`
 }
 
 // NodePoolVersionProfile represents the worker node pool version.

--- a/internal/api/types_serviceprovider_nodepool.go
+++ b/internal/api/types_serviceprovider_nodepool.go
@@ -102,6 +102,12 @@ type ServiceProviderNodePoolStatus struct {
 	// The reference contains a mapping between the logical name we give to the Maestro bundle internally
 	// and the Maestro Bundle Name and ID at the Maestro API level.
 	MaestroReadonlyBundles MaestroBundleReferenceList `json:"maestroReadonlyBundles,omitempty"`
+
+	// ClusterServiceUpdatableConfigHashForUpdateDispatch is a SHA-256 hex digest of the internal/ocm.nodePoolUpdatableConfig struct,
+	// when serialized as a json map. This hash is used by the nodepool update dispatch controller to determine if a CS PATCH call is needed.
+	// Note: this hash does not necessarily include all the fields that can be updated via the CS API, just the ones
+	// that are to be considered by the nodepool update dispatch controller to determine if a CS PATCH call is needed.
+	ClusterServiceUpdatableConfigHashForUpdateDispatch string `json:"clusterServiceUpdatableConfigHashForUpdateDispatch"`
 }
 
 // ServiceProviderNodePoolStatusVersion contains the actual version information.

--- a/internal/api/v20240610preview/conversion_fuzz_test.go
+++ b/internal/api/v20240610preview/conversion_fuzz_test.go
@@ -95,6 +95,8 @@ func TestRoundTripInternalExternalInternal(t *testing.T) {
 			j.ClusterServiceID = nil
 			// UsesNewNodePoolDeletionApproach does not roundtrip through the external type because it is purely an internal detail
 			j.UsesNewNodePoolDeletionApproach = false
+			// UsesNewNodePoolUpdateApproach does not roundtrip through the external type because it is purely an internal detail
+			j.UsesNewNodePoolUpdateApproach = false
 		},
 		func(j *api.OSDiskProfile, c randfill.Continue) {
 			c.FillNoCustom(j)

--- a/internal/api/v20251223preview/conversion_fuzz_test.go
+++ b/internal/api/v20251223preview/conversion_fuzz_test.go
@@ -93,6 +93,8 @@ func TestRoundTripInternalExternalInternal(t *testing.T) {
 			j.ClusterServiceID = nil
 			// UsesNewNodePoolDeletionApproach does not roundtrip through the external type because it is purely an internal detail
 			j.UsesNewNodePoolDeletionApproach = false
+			// UsesNewNodePoolUpdateApproach does not roundtrip through the external type because it is purely an internal detail
+			j.UsesNewNodePoolUpdateApproach = false
 		},
 		func(j *api.HCPOpenShiftClusterExternalAuthServiceProviderProperties, c randfill.Continue) {
 			c.FillNoCustom(j)

--- a/internal/ocm/convert.go
+++ b/internal/ocm/convert.go
@@ -553,33 +553,7 @@ func BuildCSNodePool(ctx context.Context, nodePool *api.HCPOpenShiftClusterNodeP
 			AutoRepair(nodePool.Properties.AutoRepair)
 	}
 
-	nodePoolBuilder.Labels(nodePool.Properties.Labels)
-
-	if nodePool.Properties.AutoScaling != nil {
-		nodePoolBuilder.Autoscaling(arohcpv1alpha1.NewNodePoolAutoscaling().
-			MinReplica(int(nodePool.Properties.AutoScaling.Min)).
-			MaxReplica(int(nodePool.Properties.AutoScaling.Max)))
-	} else {
-		nodePoolBuilder.Replicas(int(nodePool.Properties.Replicas))
-	}
-
-	if nodePool.Properties.Taints != nil {
-		taintBuilders := []*arohcpv1alpha1.TaintBuilder{}
-		for _, t := range nodePool.Properties.Taints {
-			newTaintBuilder := arohcpv1alpha1.NewTaint().
-				Effect(string(t.Effect)).
-				Key(t.Key).
-				Value(t.Value)
-			taintBuilders = append(taintBuilders, newTaintBuilder)
-		}
-		nodePoolBuilder.Taints(taintBuilders...)
-	}
-
-	if nodePool.Properties.NodeDrainTimeoutMinutes != nil {
-		nodePoolBuilder.NodeDrainGracePeriod(arohcpv1alpha1.NewValue().
-			Unit(csNodeDrainGracePeriodUnit).
-			Value(float64(*nodePool.Properties.NodeDrainTimeoutMinutes)))
-	}
+	applyNodePoolUpdatableConfig(nodePoolBuilder, NodePoolUpdatableConfigFromProperties(nodePool.Properties))
 
 	return nodePoolBuilder, nil
 }

--- a/internal/ocm/nodepool_updatable_config.go
+++ b/internal/ocm/nodepool_updatable_config.go
@@ -1,0 +1,143 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocm
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// nodePoolUpdatableConfig is the canonical representation of node pool properties
+// hashed by NodePoolUpdatableConfigHash and applied to Cluster Service by
+// applyNodePoolUpdatableConfig (via BuildCSNodePool). Add or remove fields here
+// and update NodePoolUpdatableConfigFromProperties plus applyNodePoolUpdatableConfig
+// in the same change.
+//
+// The digest is stored on the node pool as ClusterServiceUpdatableConfigHashForUpdateDispatch and
+// compared by the nodepool update dispatch controller: a mismatch triggers a CS PATCH and
+// hash replacement. It is also stamped during nodepool creation.
+//
+// Changing this struct has deploy-time effects:
+//   - Removing a field (in the top-level or nested) changes the digest for every node pool that had that field marshalled. The marshalling of the
+//     field depends on whether omitempty was set for the field and the actual value of the field for the corresponding NodePool.
+//   - Adding a field (in the top-level or nested) changes the digest for every node pool that would start marshalling the field. The marshalling of
+//     the field depends on whether omitempty is set for it and the actual value of the field for the corresponding NodePool.
+//   - Renaming a json tag (in the top-level or nested) changes the digest for every node pool that had the field marshalled. The marshalling of the
+//     field depends on whether omitempty was set for the field and the actual value of the field for the corresponding NodePool.
+//
+// In all of those cases, a change of digest implies a CS PATCH and hash replacement.
+// Note: If in the future we consider that the previous behavior is too risky, we can consider having some sort of versioning of the config hash
+// where we can control the digest changes and only allow changes that we want to allow.
+//
+// Note: This does not necessarily include all the fields that can be updated via the CS API, just the ones
+// that are considered during an ARM NodePool update call and processed by the CS NodePool update dispatch controller.
+type nodePoolUpdatableConfig struct {
+	Labels                  map[string]string        `json:"labels,omitempty"`
+	AutoScaling             *api.NodePoolAutoScaling `json:"autoScaling,omitempty"`
+	Replicas                *int32                   `json:"replicas,omitempty"`
+	Taints                  []api.Taint              `json:"taints,omitempty"`
+	NodeDrainTimeoutMinutes *int32                   `json:"nodeDrainTimeoutMinutes,omitempty"`
+}
+
+// NodePoolUpdatableConfigFromProperties extracts the canonical updatable node pool
+// configuration from internal API properties.
+func NodePoolUpdatableConfigFromProperties(properties api.HCPOpenShiftClusterNodePoolProperties) *nodePoolUpdatableConfig {
+	config := &nodePoolUpdatableConfig{
+		Labels:                  properties.Labels,
+		Taints:                  properties.Taints,
+		NodeDrainTimeoutMinutes: properties.NodeDrainTimeoutMinutes,
+	}
+
+	if properties.AutoScaling != nil {
+		autoScaling := *properties.AutoScaling
+		config.AutoScaling = &autoScaling
+	} else {
+		replicas := properties.Replicas
+		config.Replicas = &replicas
+	}
+
+	return config
+}
+
+// NodePoolUpdatableConfigHash returns a SHA-256 hex digest of
+// nodePoolUpdatableConfig built from the node pool properties marshaled as a json map.
+func NodePoolUpdatableConfigHash(nodePool *api.HCPOpenShiftClusterNodePool) (string, error) {
+	config := NodePoolUpdatableConfigFromProperties(nodePool.Properties)
+
+	raw, err := nodePoolUpdatableConfigJSONForHash(config)
+	if err != nil {
+		return "", err
+	}
+
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// nodePoolUpdatableConfigJSONForHash returns canonical JSON for hashing. The struct
+// is marshaled first so json tags and omitempty apply, then round-tripped through
+// map[string]any so object keys are emitted in sorted order at every level.
+func nodePoolUpdatableConfigJSONForHash(config *nodePoolUpdatableConfig) ([]byte, error) {
+	raw, err := json.Marshal(config)
+	if err != nil {
+		return nil, utils.TrackError(fmt.Errorf("failed to marshal node pool updatable config: %w", err))
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return nil, utils.TrackError(fmt.Errorf("failed to unmarshal node pool updatable config: %w", err))
+	}
+
+	raw, err = json.Marshal(payload)
+	if err != nil {
+		return nil, utils.TrackError(fmt.Errorf("failed to marshal node pool updatable config payload: %w", err))
+	}
+	return raw, nil
+}
+
+func applyNodePoolUpdatableConfig(nodePoolBuilder *arohcpv1alpha1.NodePoolBuilder, config *nodePoolUpdatableConfig) {
+	nodePoolBuilder.Labels(config.Labels)
+
+	if config.AutoScaling != nil {
+		nodePoolBuilder.Autoscaling(arohcpv1alpha1.NewNodePoolAutoscaling().
+			MinReplica(int(config.AutoScaling.Min)).
+			MaxReplica(int(config.AutoScaling.Max)))
+	} else if config.Replicas != nil {
+		nodePoolBuilder.Replicas(int(*config.Replicas))
+	}
+
+	if config.Taints != nil {
+		taintBuilders := make([]*arohcpv1alpha1.TaintBuilder, 0, len(config.Taints))
+		for _, t := range config.Taints {
+			taintBuilders = append(taintBuilders, arohcpv1alpha1.NewTaint().
+				Effect(string(t.Effect)).
+				Key(t.Key).
+				Value(t.Value))
+		}
+		nodePoolBuilder.Taints(taintBuilders...)
+	}
+
+	if config.NodeDrainTimeoutMinutes != nil {
+		nodePoolBuilder.NodeDrainGracePeriod(arohcpv1alpha1.NewValue().
+			Unit(csNodeDrainGracePeriodUnit).
+			Value(float64(*config.NodeDrainTimeoutMinutes)))
+	}
+}

--- a/internal/ocm/nodepool_updatable_config_test.go
+++ b/internal/ocm/nodepool_updatable_config_test.go
@@ -1,0 +1,149 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocm
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/utils/ptr"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+)
+
+func TestNodePoolUpdatableConfigHash(t *testing.T) {
+	base := &api.HCPOpenShiftClusterNodePool{
+		Properties: api.HCPOpenShiftClusterNodePoolProperties{
+			Replicas: 3,
+			Labels:   map[string]string{"role": "worker"},
+		},
+	}
+
+	hash1, err := NodePoolUpdatableConfigHash(base)
+	require.NoError(t, err)
+	require.NotEmpty(t, hash1)
+
+	hash2, err := NodePoolUpdatableConfigHash(base)
+	require.NoError(t, err)
+	assert.Equal(t, hash1, hash2)
+
+	withTaintOrder := &api.HCPOpenShiftClusterNodePool{
+		Properties: api.HCPOpenShiftClusterNodePoolProperties{
+			Replicas: 1,
+			Taints: []api.Taint{
+				{Key: "b", Value: "v2", Effect: api.EffectNoSchedule},
+				{Key: "a", Value: "v1", Effect: api.EffectNoExecute},
+			},
+		},
+	}
+	reordered := &api.HCPOpenShiftClusterNodePool{
+		Properties: api.HCPOpenShiftClusterNodePoolProperties{
+			Replicas: 1,
+			Taints: []api.Taint{
+				{Key: "a", Value: "v1", Effect: api.EffectNoExecute},
+				{Key: "b", Value: "v2", Effect: api.EffectNoSchedule},
+			},
+		},
+	}
+
+	hashA, err := NodePoolUpdatableConfigHash(withTaintOrder)
+	require.NoError(t, err)
+	hashB, err := NodePoolUpdatableConfigHash(reordered)
+	require.NoError(t, err)
+	assert.NotEqual(t, hashA, hashB)
+
+	autoscaling := &api.HCPOpenShiftClusterNodePool{
+		Properties: api.HCPOpenShiftClusterNodePoolProperties{
+			Replicas:    99,
+			AutoScaling: &api.NodePoolAutoScaling{Min: 2, Max: 5},
+		},
+	}
+	autoscalingHash, err := NodePoolUpdatableConfigHash(autoscaling)
+	require.NoError(t, err)
+
+	fixedReplicas := &api.HCPOpenShiftClusterNodePool{
+		Properties: api.HCPOpenShiftClusterNodePoolProperties{
+			Replicas: 99,
+		},
+	}
+	fixedReplicasHash, err := NodePoolUpdatableConfigHash(fixedReplicas)
+	require.NoError(t, err)
+	assert.NotEqual(t, autoscalingHash, fixedReplicasHash)
+
+	withDrainTimeout := &api.HCPOpenShiftClusterNodePool{
+		Properties: api.HCPOpenShiftClusterNodePoolProperties{
+			Replicas:                1,
+			NodeDrainTimeoutMinutes: ptr.To(int32(30)),
+		},
+	}
+	drainHash, err := NodePoolUpdatableConfigHash(withDrainTimeout)
+	require.NoError(t, err)
+	assert.NotEqual(t, fixedReplicasHash, drainHash)
+}
+
+func TestNodePoolUpdatableConfigJSONForHashIsCanonical(t *testing.T) {
+	config := NodePoolUpdatableConfigFromProperties(api.HCPOpenShiftClusterNodePoolProperties{
+		Replicas:                2,
+		Labels:                  map[string]string{"role": "worker"},
+		NodeDrainTimeoutMinutes: ptr.To(int32(15)),
+		Taints: []api.Taint{
+			{Key: "k", Value: "v", Effect: api.EffectNoSchedule},
+		},
+	})
+
+	raw, err := nodePoolUpdatableConfigJSONForHash(config)
+	require.NoError(t, err)
+
+	keys, err := topLevelJSONKeys(raw)
+	require.NoError(t, err)
+	assert.True(t, slices.IsSorted(keys), "top-level JSON keys must be sorted: %v", keys)
+	assert.Equal(t, []string{"labels", "nodeDrainTimeoutMinutes", "replicas", "taints"}, keys)
+}
+
+func topLevelJSONKeys(raw []byte) ([]string, error) {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	tok, err := dec.Token()
+	if err != nil {
+		return nil, err
+	}
+	if delim, ok := tok.(json.Delim); !ok || delim != '{' {
+		return nil, fmt.Errorf("expected JSON object, got %v", tok)
+	}
+
+	var keys []string
+	for dec.More() {
+		tok, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		key, ok := tok.(string)
+		if !ok {
+			return nil, fmt.Errorf("expected object key, got %v", tok)
+		}
+		keys = append(keys, key)
+
+		var skip json.RawMessage
+		if err := dec.Decode(&skip); err != nil {
+			return nil, err
+		}
+	}
+	return keys, nil
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/nodepool-test-nodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/nodepool-test-nodepool.json
@@ -56,7 +56,8 @@
 				},
 				"serviceProviderProperties": {
 					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"usesNewNodePoolDeletionApproach": false,
+					"usesNewNodePoolUpdateApproach": false
 				},
 				"status": {},
 				"systemData": {
@@ -104,7 +105,8 @@
 			}
 		},
 		"serviceProviderProperties": {
-			"usesNewNodePoolDeletionApproach": false
+			"usesNewNodePoolDeletionApproach": false,
+			"usesNewNodePoolUpdateApproach": false
 		},
 		"status": {},
 		"systemData": {

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/nodepool-basic-node-pool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/nodepool-basic-node-pool.json
@@ -58,7 +58,8 @@
 				"serviceProviderProperties": {
 					"activeOperationId": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
 					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"usesNewNodePoolDeletionApproach": false,
+					"usesNewNodePoolUpdateApproach": false
 				},
 				"status": {},
 				"systemData": {
@@ -105,7 +106,8 @@
 		"serviceProviderProperties": {
 			"activeOperationId": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
 			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s",
-			"usesNewNodePoolDeletionApproach": false
+			"usesNewNodePoolDeletionApproach": false,
+			"usesNewNodePoolUpdateApproach": false
 		},
 		"status": {},
 		"systemData": {

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/nodepool-node-pool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/nodepool-node-pool-02.json
@@ -58,7 +58,8 @@
 				"serviceProviderProperties": {
 					"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
 					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"usesNewNodePoolDeletionApproach": false,
+					"usesNewNodePoolUpdateApproach": false
 				},
 				"status": {},
 				"systemData": {
@@ -105,7 +106,8 @@
 		"serviceProviderProperties": {
 			"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
 			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4",
-			"usesNewNodePoolDeletionApproach": false
+			"usesNewNodePoolDeletionApproach": false,
+			"usesNewNodePoolUpdateApproach": false
 		},
 		"status": {},
 		"systemData": {

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/nodepool-basic-node-pool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/nodepool-basic-node-pool.json
@@ -62,7 +62,8 @@
 				"serviceProviderProperties": {
 					"activeOperationId": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
 					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"usesNewNodePoolDeletionApproach": false,
+					"usesNewNodePoolUpdateApproach": false
 				},
 				"status": {},
 				"systemData": {
@@ -110,7 +111,8 @@
 		"serviceProviderProperties": {
 			"activeOperationId": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
 			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s",
-			"usesNewNodePoolDeletionApproach": false
+			"usesNewNodePoolDeletionApproach": false,
+			"usesNewNodePoolUpdateApproach": false
 		},
 		"status": {},
 		"systemData": {

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/nodepool-node-pool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/nodepool-node-pool-02.json
@@ -62,7 +62,8 @@
 				"serviceProviderProperties": {
 					"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
 					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"usesNewNodePoolDeletionApproach": false,
+					"usesNewNodePoolUpdateApproach": false
 				},
 				"status": {},
 				"systemData": {
@@ -110,7 +111,8 @@
 		"serviceProviderProperties": {
 			"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
 			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4",
-			"usesNewNodePoolDeletionApproach": false
+			"usesNewNodePoolDeletionApproach": false,
+			"usesNewNodePoolUpdateApproach": false
 		},
 		"status": {},
 		"systemData": {

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/nodepool-basic-node-pool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/nodepool-basic-node-pool.json
@@ -58,7 +58,8 @@
 				"serviceProviderProperties": {
 					"activeOperationId": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
 					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"usesNewNodePoolDeletionApproach": false,
+					"usesNewNodePoolUpdateApproach": false
 				},
 				"status": {},
 				"systemData": {
@@ -105,7 +106,8 @@
 		"serviceProviderProperties": {
 			"activeOperationId": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
 			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s",
-			"usesNewNodePoolDeletionApproach": false
+			"usesNewNodePoolDeletionApproach": false,
+			"usesNewNodePoolUpdateApproach": false
 		},
 		"status": {},
 		"systemData": {

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/nodepool-node-pool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/nodepool-node-pool-02.json
@@ -58,7 +58,8 @@
 				"serviceProviderProperties": {
 					"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
 					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"usesNewNodePoolDeletionApproach": false,
+					"usesNewNodePoolUpdateApproach": false
 				},
 				"status": {},
 				"systemData": {
@@ -105,7 +106,8 @@
 		"serviceProviderProperties": {
 			"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
 			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4",
-			"usesNewNodePoolDeletionApproach": false
+			"usesNewNodePoolDeletionApproach": false,
+			"usesNewNodePoolUpdateApproach": false
 		},
 		"status": {},
 		"systemData": {

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/nodepool-basic-node-pool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/nodepool-basic-node-pool.json
@@ -58,7 +58,8 @@
 				"serviceProviderProperties": {
 					"activeOperationId": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
 					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"usesNewNodePoolDeletionApproach": false,
+					"usesNewNodePoolUpdateApproach": false
 				},
 				"status": {},
 				"systemData": {
@@ -105,7 +106,8 @@
 		"serviceProviderProperties": {
 			"activeOperationId": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
 			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s",
-			"usesNewNodePoolDeletionApproach": false
+			"usesNewNodePoolDeletionApproach": false,
+			"usesNewNodePoolUpdateApproach": false
 		},
 		"status": {},
 		"systemData": {

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/nodepool-node-pool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/nodepool-node-pool-02.json
@@ -56,7 +56,8 @@
 				},
 				"serviceProviderProperties": {
 					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"usesNewNodePoolDeletionApproach": false,
+					"usesNewNodePoolUpdateApproach": false
 				},
 				"status": {},
 				"systemData": {
@@ -103,7 +104,8 @@
 		},
 		"serviceProviderProperties": {
 			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4",
-			"usesNewNodePoolDeletionApproach": false
+			"usesNewNodePoolDeletionApproach": false,
+			"usesNewNodePoolUpdateApproach": false
 		},
 		"status": {},
 		"systemData": {

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/create-current/06-cosmosCompare-confirm-content/nodepool-basic-node-pool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/create-current/06-cosmosCompare-confirm-content/nodepool-basic-node-pool.json
@@ -64,7 +64,8 @@
 				"serviceProviderProperties": {
 					"activeOperationId": "bf643e76-55fe-48a0-a752-f5c5a2db72ad",
 					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"usesNewNodePoolDeletionApproach": false,
+					"usesNewNodePoolUpdateApproach": false
 				},
 				"status": {},
 				"systemData": {
@@ -114,7 +115,8 @@
 		"serviceProviderProperties": {
 			"activeOperationId": "bf643e76-55fe-48a0-a752-f5c5a2db72ad",
 			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/dl7f9px2f2/node_pools/82npf9hxmk",
-			"usesNewNodePoolDeletionApproach": false
+			"usesNewNodePoolDeletionApproach": false,
+			"usesNewNodePoolUpdateApproach": false
 		},
 		"status": {},
 		"systemData": {

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/create-current/06-cosmosCompare-confirm-content/nodepool-node-pool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/create-current/06-cosmosCompare-confirm-content/nodepool-node-pool-02.json
@@ -64,7 +64,8 @@
 				"serviceProviderProperties": {
 					"activeOperationId": "25e4713b-44b5-4799-9e60-894a132c6674",
 					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"usesNewNodePoolDeletionApproach": false,
+					"usesNewNodePoolUpdateApproach": false
 				},
 				"status": {},
 				"systemData": {
@@ -114,7 +115,8 @@
 		"serviceProviderProperties": {
 			"activeOperationId": "25e4713b-44b5-4799-9e60-894a132c6674",
 			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/dl7f9px2f2/node_pools/5zdc9grtvf",
-			"usesNewNodePoolDeletionApproach": false
+			"usesNewNodePoolDeletionApproach": false,
+			"usesNewNodePoolUpdateApproach": false
 		},
 		"status": {},
 		"systemData": {

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/nodepool-basic-node-pool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/nodepool-basic-node-pool.json
@@ -58,7 +58,8 @@
 				"serviceProviderProperties": {
 					"activeOperationId": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
 					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"usesNewNodePoolDeletionApproach": false,
+					"usesNewNodePoolUpdateApproach": false
 				},
 				"status": {},
 				"systemData": {
@@ -105,7 +106,8 @@
 		"serviceProviderProperties": {
 			"activeOperationId": "cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
 			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s",
-			"usesNewNodePoolDeletionApproach": false
+			"usesNewNodePoolDeletionApproach": false,
+			"usesNewNodePoolUpdateApproach": false
 		},
 		"status": {},
 		"systemData": {

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/nodepool-node-pool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/nodepool-node-pool-02.json
@@ -58,7 +58,8 @@
 				"serviceProviderProperties": {
 					"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
 					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"usesNewNodePoolDeletionApproach": false,
+					"usesNewNodePoolUpdateApproach": false
 				},
 				"status": {},
 				"systemData": {
@@ -105,7 +106,8 @@
 		"serviceProviderProperties": {
 			"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
 			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4",
-			"usesNewNodePoolDeletionApproach": false
+			"usesNewNodePoolDeletionApproach": false,
+			"usesNewNodePoolUpdateApproach": false
 		},
 		"status": {},
 		"systemData": {

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/nodepool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/nodepool-02.json
@@ -58,7 +58,8 @@
 				"serviceProviderProperties": {
 					"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
 					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"usesNewNodePoolDeletionApproach": false,
+					"usesNewNodePoolUpdateApproach": false
 				},
 				"status": {},
 				"systemData": {
@@ -105,7 +106,8 @@
 		"serviceProviderProperties": {
 			"activeOperationId": "4067756a-fcc1-4732-a211-d785d888203c",
 			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/v4lx7rv2r4",
-			"usesNewNodePoolDeletionApproach": false
+			"usesNewNodePoolDeletionApproach": false,
+			"usesNewNodePoolUpdateApproach": false
 		},
 		"status": {},
 		"systemData": {

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/nodepool-basic-node-pool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/nodepool-basic-node-pool.json
@@ -62,7 +62,8 @@
 				"serviceProviderProperties": {
 					"activeOperationId": "9e244879-591b-4693-823a-4412b4200f4d",
 					"clusterServiceID": "",
-					"usesNewNodePoolDeletionApproach": false
+					"usesNewNodePoolDeletionApproach": false,
+					"usesNewNodePoolUpdateApproach": true
 				},
 				"status": {},
 				"systemData": {
@@ -110,7 +111,8 @@
 		"serviceProviderProperties": {
 			"activeOperationId": "9e244879-591b-4693-823a-4412b4200f4d",
 			"clusterServiceID": "/api/clusters_mgmt/v1/clusters/9p2sk955gj/node_pools/59mkgdzg9s",
-			"usesNewNodePoolDeletionApproach": false
+			"usesNewNodePoolDeletionApproach": false,
+			"usesNewNodePoolUpdateApproach": true
 		},
 		"status": {},
 		"systemData": {


### PR DESCRIPTION
Move Cluster Service node pool PATCH out of the frontend. ARM updates now only persist desired state in Cosmos and create an update operation. Backend controllers reconcile the rest.

Add a node pool updatable config hash (labels, scaling, taints, nodeDrainTimeoutMinutes) and store it on ServiceProviderNodePoolStatus.

A new NodePoolClusterServiceUpdateDispatch controller compares the hash against Cosmos desired state and calls UpdateNodePool when it changes, retrying transient CS 400 rejections when the cluster or node pool is not yet updatable.

Extend the node pool update operation controller to follow the cluster create pattern: poll Cluster Service status, gate on Cosmos/MC readiness (ReadDesire NodePool mirror, spec/status match, rollout conditions), and only mark the operation Succeeded when all layers agree.

Also add helpers for decoding the per-node-pool NodePool ReadDesire

<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

### Why

<!-- Briefly explain why this change is needed -->

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
