### PR TITLE
fix: split HyperShift installer into CRD and resource phases

### DIFF
--- a/hypershiftoperator/deploy/templates/installer.job.yaml
+++ b/hypershiftoperator/deploy/templates/installer.job.yaml
@@ -21,29 +21,16 @@ spec:
         - |
           hypershift install \
             --outputs=crds \
-            --enable-conversion-webhook=false \
             --managed-service ARO-HCP \
-            --aro-hcp-key-vault-users-client-id {{ .Values.azureKeyVaultClientId }} \
-            --registry-overrides "{{ .Values.registryOverrides }}" \
-            --hypershift-image {{ .Values.image }}@{{ .Values.imageDigest }} \
-            --platform-monitoring=None \
-            --metrics-set=SRE \
-            --enable-size-tagging=true \
             --limit-crd-install=Azure \
-            {{- if .Values.operatorEnvVars.sharedIngressIPTag }}
-            --additional-operator-env-vars SHARED_INGRESS_AZURE_PIP_IP_TAGS={{ .Values.operatorEnvVars.sharedIngressIPTag }} \
-            {{- end }}
-            {{- if .Values.operatorEnvVars.sharedIngressImage }}
-            --additional-operator-env-vars IMAGE_SHARED_INGRESS_HAPROXY={{ .Values.operatorEnvVars.sharedIngressImage }} \
-            {{- end }}
-            {{ .Values.additionalArgs }}
+            --hypershift-image {{ .Values.image }}@{{ .Values.imageDigest }}
       restartPolicy: Never
       serviceAccountName: hypershift-installer
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: install-hypershift-resources
+  name: install-hypershift
   namespace: '{{ .Release.Namespace }}'
   annotations:
     "helm.sh/hook": post-install,post-upgrade

--- a/hypershiftoperator/deploy/templates/installer.job.yaml
+++ b/hypershiftoperator/deploy/templates/installer.job.yaml
@@ -19,11 +19,11 @@ spec:
         - /bin/sh
         - -c
         - |
-          hypershift install render \
-            --outputs=crds \
+          hypershift install \
+            --install-scope=crds \
             --managed-service ARO-HCP \
             --limit-crd-install=Azure \
-            --hypershift-image {{ .Values.image }}@{{ .Values.imageDigest }} | kubectl apply -f -
+            --hypershift-image {{ .Values.image }}@{{ .Values.imageDigest }}
       restartPolicy: Never
       serviceAccountName: hypershift-installer
 ---
@@ -48,8 +48,8 @@ spec:
         - /bin/sh
         - -c
         - |
-          hypershift install render \
-            --outputs=resources \
+          hypershift install \
+            --install-scope=resources \
             --enable-conversion-webhook=false \
             --managed-service ARO-HCP \
             --aro-hcp-key-vault-users-client-id {{ .Values.azureKeyVaultClientId }} \
@@ -65,6 +65,6 @@ spec:
             {{- if .Values.operatorEnvVars.sharedIngressImage }}
             --additional-operator-env-vars IMAGE_SHARED_INGRESS_HAPROXY={{ .Values.operatorEnvVars.sharedIngressImage }} \
             {{- end }}
-            {{ .Values.additionalArgs }} | kubectl apply -f -
+            {{ .Values.additionalArgs }}
       restartPolicy: Never
       serviceAccountName: hypershift-installer

--- a/hypershiftoperator/deploy/templates/installer.job.yaml
+++ b/hypershiftoperator/deploy/templates/installer.job.yaml
@@ -1,14 +1,13 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: install-hypershift
+  name: install-hypershift-crds
   namespace: '{{ .Release.Namespace }}'
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
-  # set deadline to 30min
   activeDeadlineSeconds: 1800
   backoffLimit: 1
   template:
@@ -21,6 +20,49 @@ spec:
         - -c
         - |
           hypershift install \
+            --outputs=crds \
+            --enable-conversion-webhook=false \
+            --managed-service ARO-HCP \
+            --aro-hcp-key-vault-users-client-id {{ .Values.azureKeyVaultClientId }} \
+            --registry-overrides "{{ .Values.registryOverrides }}" \
+            --hypershift-image {{ .Values.image }}@{{ .Values.imageDigest }} \
+            --platform-monitoring=None \
+            --metrics-set=SRE \
+            --enable-size-tagging=true \
+            --limit-crd-install=Azure \
+            {{- if .Values.operatorEnvVars.sharedIngressIPTag }}
+            --additional-operator-env-vars SHARED_INGRESS_AZURE_PIP_IP_TAGS={{ .Values.operatorEnvVars.sharedIngressIPTag }} \
+            {{- end }}
+            {{- if .Values.operatorEnvVars.sharedIngressImage }}
+            --additional-operator-env-vars IMAGE_SHARED_INGRESS_HAPROXY={{ .Values.operatorEnvVars.sharedIngressImage }} \
+            {{- end }}
+            {{ .Values.additionalArgs }}
+      restartPolicy: Never
+      serviceAccountName: hypershift-installer
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: install-hypershift-resources
+  namespace: '{{ .Release.Namespace }}'
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "3"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  activeDeadlineSeconds: 1800
+  backoffLimit: 1
+  template:
+    spec:
+      containers:
+      - name: install
+        image: "{{ .Values.image }}@{{ .Values.imageDigest }}"
+        command:
+        - /bin/sh
+        - -c
+        - |
+          hypershift install \
+            --outputs=resources \
             --enable-conversion-webhook=false \
             --managed-service ARO-HCP \
             --aro-hcp-key-vault-users-client-id {{ .Values.azureKeyVaultClientId }} \

--- a/hypershiftoperator/deploy/templates/installer.job.yaml
+++ b/hypershiftoperator/deploy/templates/installer.job.yaml
@@ -19,11 +19,11 @@ spec:
         - /bin/sh
         - -c
         - |
-          hypershift install \
+          hypershift install render \
             --outputs=crds \
             --managed-service ARO-HCP \
             --limit-crd-install=Azure \
-            --hypershift-image {{ .Values.image }}@{{ .Values.imageDigest }}
+            --hypershift-image {{ .Values.image }}@{{ .Values.imageDigest }} | kubectl apply -f -
       restartPolicy: Never
       serviceAccountName: hypershift-installer
 ---
@@ -48,7 +48,7 @@ spec:
         - /bin/sh
         - -c
         - |
-          hypershift install \
+          hypershift install render \
             --outputs=resources \
             --enable-conversion-webhook=false \
             --managed-service ARO-HCP \
@@ -65,6 +65,6 @@ spec:
             {{- if .Values.operatorEnvVars.sharedIngressImage }}
             --additional-operator-env-vars IMAGE_SHARED_INGRESS_HAPROXY={{ .Values.operatorEnvVars.sharedIngressImage }} \
             {{- end }}
-            {{ .Values.additionalArgs }}
+            {{ .Values.additionalArgs }} | kubectl apply -f -
       restartPolicy: Never
       serviceAccountName: hypershift-installer

--- a/hypershiftoperator/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_hypershift.yaml
+++ b/hypershiftoperator/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_hypershift.yaml
@@ -736,11 +736,11 @@ spec:
         - /bin/sh
         - -c
         - |
-          hypershift install render \
-            --outputs=crds \
+          hypershift install \
+            --install-scope=crds \
             --managed-service ARO-HCP \
             --limit-crd-install=Azure \
-            --hypershift-image arohcpsvcdev.azurecr.io/redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator@sha256:1234567890 | kubectl apply -f -
+            --hypershift-image arohcpsvcdev.azurecr.io/redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator@sha256:1234567890
       restartPolicy: Never
       serviceAccountName: hypershift-installer
 ---
@@ -766,8 +766,8 @@ spec:
         - /bin/sh
         - -c
         - |
-          hypershift install render \
-            --outputs=resources \
+          hypershift install \
+            --install-scope=resources \
             --enable-conversion-webhook=false \
             --managed-service ARO-HCP \
             --aro-hcp-key-vault-users-client-id __csiSecretStoreClientId__ \
@@ -778,7 +778,7 @@ spec:
             --enable-size-tagging=true \
             --limit-crd-install=Azure \
             --additional-operator-env-vars IMAGE_SHARED_INGRESS_HAPROXY=arohcpocpdev.azurecr.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main@sha256:1234567890 \
-            --enable-cpo-overrides | kubectl apply -f -
+            --enable-cpo-overrides
       restartPolicy: Never
       serviceAccountName: hypershift-installer
 ---

--- a/hypershiftoperator/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_hypershift.yaml
+++ b/hypershiftoperator/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_hypershift.yaml
@@ -718,14 +718,13 @@ subjects:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: install-hypershift
+  name: install-hypershift-crds
   namespace: 'hypershift'
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
-  # set deadline to 30min
   activeDeadlineSeconds: 1800
   backoffLimit: 1
   template:
@@ -738,6 +737,45 @@ spec:
         - -c
         - |
           hypershift install \
+            --outputs=crds \
+            --enable-conversion-webhook=false \
+            --managed-service ARO-HCP \
+            --aro-hcp-key-vault-users-client-id __csiSecretStoreClientId__ \
+            --registry-overrides "quay.io/openshift-release-dev/ocp-v4.0-art-dev=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-v4.0-art-dev,quay.io/openshift-release-dev/ocp-v5.0-art-dev=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-v5.0-art-dev,quay.io/openshift-release-dev/ocp-release=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-release,quay.io/openshift-release-dev/ocp-release-nightly=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-release-nightly,registry.redhat.io/redhat=arohcpocpdev.azurecr.io/redhat" \
+            --hypershift-image arohcpsvcdev.azurecr.io/redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator@sha256:1234567890 \
+            --platform-monitoring=None \
+            --metrics-set=SRE \
+            --enable-size-tagging=true \
+            --limit-crd-install=Azure \
+            --additional-operator-env-vars IMAGE_SHARED_INGRESS_HAPROXY=arohcpocpdev.azurecr.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main@sha256:1234567890 \
+            --enable-cpo-overrides
+      restartPolicy: Never
+      serviceAccountName: hypershift-installer
+---
+# Source: aro-hcp-hypershift-operator/templates/installer.job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: install-hypershift-resources
+  namespace: 'hypershift'
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "3"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  activeDeadlineSeconds: 1800
+  backoffLimit: 1
+  template:
+    spec:
+      containers:
+      - name: install
+        image: "arohcpsvcdev.azurecr.io/redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator@sha256:1234567890"
+        command:
+        - /bin/sh
+        - -c
+        - |
+          hypershift install \
+            --outputs=resources \
             --enable-conversion-webhook=false \
             --managed-service ARO-HCP \
             --aro-hcp-key-vault-users-client-id __csiSecretStoreClientId__ \

--- a/hypershiftoperator/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_hypershift.yaml
+++ b/hypershiftoperator/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_hypershift.yaml
@@ -738,17 +738,9 @@ spec:
         - |
           hypershift install \
             --outputs=crds \
-            --enable-conversion-webhook=false \
             --managed-service ARO-HCP \
-            --aro-hcp-key-vault-users-client-id __csiSecretStoreClientId__ \
-            --registry-overrides "quay.io/openshift-release-dev/ocp-v4.0-art-dev=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-v4.0-art-dev,quay.io/openshift-release-dev/ocp-v5.0-art-dev=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-v5.0-art-dev,quay.io/openshift-release-dev/ocp-release=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-release,quay.io/openshift-release-dev/ocp-release-nightly=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-release-nightly,registry.redhat.io/redhat=arohcpocpdev.azurecr.io/redhat" \
-            --hypershift-image arohcpsvcdev.azurecr.io/redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator@sha256:1234567890 \
-            --platform-monitoring=None \
-            --metrics-set=SRE \
-            --enable-size-tagging=true \
             --limit-crd-install=Azure \
-            --additional-operator-env-vars IMAGE_SHARED_INGRESS_HAPROXY=arohcpocpdev.azurecr.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main@sha256:1234567890 \
-            --enable-cpo-overrides
+            --hypershift-image arohcpsvcdev.azurecr.io/redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator@sha256:1234567890
       restartPolicy: Never
       serviceAccountName: hypershift-installer
 ---
@@ -756,7 +748,7 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: install-hypershift-resources
+  name: install-hypershift
   namespace: 'hypershift'
   annotations:
     "helm.sh/hook": post-install,post-upgrade

--- a/hypershiftoperator/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_hypershift.yaml
+++ b/hypershiftoperator/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_hypershift.yaml
@@ -736,11 +736,11 @@ spec:
         - /bin/sh
         - -c
         - |
-          hypershift install \
+          hypershift install render \
             --outputs=crds \
             --managed-service ARO-HCP \
             --limit-crd-install=Azure \
-            --hypershift-image arohcpsvcdev.azurecr.io/redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator@sha256:1234567890
+            --hypershift-image arohcpsvcdev.azurecr.io/redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator@sha256:1234567890 | kubectl apply -f -
       restartPolicy: Never
       serviceAccountName: hypershift-installer
 ---
@@ -766,7 +766,7 @@ spec:
         - /bin/sh
         - -c
         - |
-          hypershift install \
+          hypershift install render \
             --outputs=resources \
             --enable-conversion-webhook=false \
             --managed-service ARO-HCP \
@@ -778,7 +778,7 @@ spec:
             --enable-size-tagging=true \
             --limit-crd-install=Azure \
             --additional-operator-env-vars IMAGE_SHARED_INGRESS_HAPROXY=arohcpocpdev.azurecr.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main@sha256:1234567890 \
-            --enable-cpo-overrides
+            --enable-cpo-overrides | kubectl apply -f -
       restartPolicy: Never
       serviceAccountName: hypershift-installer
 ---

--- a/tooling/helmtest/settings.yaml
+++ b/tooling/helmtest/settings.yaml
@@ -31,6 +31,7 @@ ResourceRequestsAllowlist:
 - Job/finalize-mce/finalize
 - Job/finalize-mce-config/finalize
 - Job/install-hypershift/install
+- Job/install-hypershift-crds/install
 - Job/registration-*/python # registration job name varies by environment
 - Job/unannotate-default-sc/finalize
 - Job/velero-install/apply-manifest
@@ -85,6 +86,7 @@ ResourceMemoryLimitsAllowlist:
 - Job/finalize-mce/finalize
 - Job/finalize-mce-config/finalize
 - Job/install-hypershift/install
+- Job/install-hypershift-crds/install
 - Job/registration-*/python # registration job name varies by environment
 - Job/unannotate-default-sc/finalize
 - Job/velero-install/apply-manifest

--- a/tooling/helmtest/testrunner/node_rollout_config.go
+++ b/tooling/helmtest/testrunner/node_rollout_config.go
@@ -210,19 +210,19 @@ func extractInstallScript(manifest string) (string, error) {
 			}
 			continue
 		}
-		if job.Kind != "Job" || job.Name != "install-hypershift-resources" {
+		if job.Kind != "Job" || job.Name != "install-hypershift" {
 			continue
 		}
 		if len(job.Spec.Template.Spec.Containers) == 0 {
-			return "", fmt.Errorf("install-hypershift-resources Job has no containers")
+			return "", fmt.Errorf("install-hypershift Job has no containers")
 		}
 		cmd := job.Spec.Template.Spec.Containers[0].Command
 		if len(cmd) < 3 {
-			return "", fmt.Errorf("install-hypershift-resources Job command has fewer than 3 elements")
+			return "", fmt.Errorf("install-hypershift Job command has fewer than 3 elements")
 		}
 		return cmd[2], nil
 	}
-	return "", fmt.Errorf("install-hypershift-resources Job not found in rendered manifest")
+	return "", fmt.Errorf("install-hypershift Job not found in rendered manifest")
 }
 
 func extractFlag(script, flagName string) (string, bool) {

--- a/tooling/helmtest/testrunner/node_rollout_config.go
+++ b/tooling/helmtest/testrunner/node_rollout_config.go
@@ -74,7 +74,7 @@ var flagCategories = map[string]flagEffect{
 	"--enable-size-tagging":               flagSafe,
 	"--limit-crd-install":                 flagSafe,
 	"--hypershift-image":                  flagSafe,
-	"--outputs":                           flagSafe, // phase selector (crds vs resources), does not affect node config
+	"--install-scope":                     flagSafe, // phase selector (crds vs resources), does not affect node config
 
 	// Node-affecting: tracked in dedicated NodeRolloutConfig fields
 	"--registry-overrides": flagNodeAffecting,

--- a/tooling/helmtest/testrunner/node_rollout_config.go
+++ b/tooling/helmtest/testrunner/node_rollout_config.go
@@ -74,7 +74,7 @@ var flagCategories = map[string]flagEffect{
 	"--enable-size-tagging":               flagSafe,
 	"--limit-crd-install":                 flagSafe,
 	"--hypershift-image":                  flagSafe,
-	"--outputs":                           flagSafe,
+	"--outputs":                           flagSafe, // phase selector (crds vs resources), does not affect node config
 
 	// Node-affecting: tracked in dedicated NodeRolloutConfig fields
 	"--registry-overrides": flagNodeAffecting,

--- a/tooling/helmtest/testrunner/node_rollout_config.go
+++ b/tooling/helmtest/testrunner/node_rollout_config.go
@@ -74,6 +74,7 @@ var flagCategories = map[string]flagEffect{
 	"--enable-size-tagging":               flagSafe,
 	"--limit-crd-install":                 flagSafe,
 	"--hypershift-image":                  flagSafe,
+	"--outputs":                           flagSafe,
 
 	// Node-affecting: tracked in dedicated NodeRolloutConfig fields
 	"--registry-overrides": flagNodeAffecting,
@@ -209,19 +210,19 @@ func extractInstallScript(manifest string) (string, error) {
 			}
 			continue
 		}
-		if job.Kind != "Job" || job.Name != "install-hypershift" {
+		if job.Kind != "Job" || job.Name != "install-hypershift-resources" {
 			continue
 		}
 		if len(job.Spec.Template.Spec.Containers) == 0 {
-			return "", fmt.Errorf("install-hypershift Job has no containers")
+			return "", fmt.Errorf("install-hypershift-resources Job has no containers")
 		}
 		cmd := job.Spec.Template.Spec.Containers[0].Command
 		if len(cmd) < 3 {
-			return "", fmt.Errorf("install-hypershift Job command has fewer than 3 elements")
+			return "", fmt.Errorf("install-hypershift-resources Job command has fewer than 3 elements")
 		}
 		return cmd[2], nil
 	}
-	return "", fmt.Errorf("install-hypershift Job not found in rendered manifest")
+	return "", fmt.Errorf("install-hypershift-resources Job not found in rendered manifest")
 }
 
 func extractFlag(script, flagName string) (string, bool) {


### PR DESCRIPTION
## Summary

- Split the single `install-hypershift` Job into two ordered phases to fix a race condition ([AROSLSRE-313](https://redhat.atlassian.net/browse/AROSLSRE-313))
- Phase 1 (weight 1): `install-hypershift-crds` runs `hypershift install --install-scope=crds`
- Phase 2 (weight 2): `ClusterSizingConfiguration` CR is applied (unchanged)
- Phase 3 (weight 3): `install-hypershift` runs `hypershift install --install-scope=resources`

Depends on `--install-scope` from [openshift/hypershift#8725](https://github.com/openshift/hypershift/pull/8725) / [AROSLSRE-1158](https://redhat.atlassian.net/browse/AROSLSRE-1158), available in ARO-HCP after the image bump in [#5982](https://github.com/Azure/ARO-HCP/pull/5982).

## Problem

The HyperShift operator starts before Helm can apply the `ClusterSizingConfiguration` CR. The operator creates its own `ClusterSizingConfiguration` on startup, colliding with the Helm post-install hook and causing `Apply failed with 5 conflicts`.

## Fix

By splitting the installer into CRDs-only and resources-only phases, we ensure:
1. CRDs are installed first
2. Our `ClusterSizingConfiguration` CR is applied using those CRDs
3. The operator starts last, finding our CR already in place (no conflict)

## Test plan

- [x] Verify Helm template renders two separate Jobs with correct hook weights
- [x] Verify `ClusterSizingConfiguration` CR remains at weight 2
- [x] Run pers upgrade test (main → this PR) to confirm no `Apply failed with conflicts` error

Fixes: [AROSLSRE-313](https://redhat.atlassian.net/browse/AROSLSRE-313)