### PR TITLE
feat: add acrPullIdentity field to ARM API (ARO-24037)

### DIFF
--- a/api/redhatopenshift/HcpCluster.Management/examples/2025-12-23-preview/HcpOpenShiftClusters_CreateOrUpdate_MaximumSet_Gen.json
+++ b/api/redhatopenshift/HcpCluster.Management/examples/2025-12-23-preview/HcpOpenShiftClusters_CreateOrUpdate_MaximumSet_Gen.json
@@ -39,7 +39,8 @@
             "userAssignedIdentities": {
               "controlPlaneOperators": {},
               "dataPlaneOperators": {},
-              "serviceManagedIdentity": "/subscriptions/FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/serviceMI"
+              "serviceManagedIdentity": "/subscriptions/FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/serviceMI",
+              "acrPullIdentity": "/subscriptions/FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/acrPullMI"
             }
           }
         },
@@ -132,7 +133,8 @@
               "userAssignedIdentities": {
                 "controlPlaneOperators": {},
                 "dataPlaneOperators": {},
-                "serviceManagedIdentity": "/subscriptions/FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/serviceMI"
+                "serviceManagedIdentity": "/subscriptions/FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/serviceMI",
+                "acrPullIdentity": "/subscriptions/FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/acrPullMI"
               }
             },
             "issuerUrl": "https://oidc.contoso.com"
@@ -246,7 +248,8 @@
               "userAssignedIdentities": {
                 "controlPlaneOperators": {},
                 "dataPlaneOperators": {},
-                "serviceManagedIdentity": "/subscriptions/FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/serviceMI"
+                "serviceManagedIdentity": "/subscriptions/FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/serviceMI",
+                "acrPullIdentity": "/subscriptions/FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/acrPullMI"
               }
             },
             "issuerUrl": "https://oidc.contoso.com"

--- a/api/redhatopenshift/HcpCluster.Management/examples/2025-12-23-preview/HcpOpenShiftClusters_Get_MaximumSet_Gen.json
+++ b/api/redhatopenshift/HcpCluster.Management/examples/2025-12-23-preview/HcpOpenShiftClusters_Get_MaximumSet_Gen.json
@@ -44,7 +44,8 @@
               "userAssignedIdentities": {
                 "controlPlaneOperators": {},
                 "dataPlaneOperators": {},
-                "serviceManagedIdentity": "/subscriptions/FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/serviceMI"
+                "serviceManagedIdentity": "/subscriptions/FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/serviceMI",
+                "acrPullIdentity": "/subscriptions/FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/acrPullMI"
               }
             },
             "issuerUrl": "https://oidc.contoso.com"

--- a/api/redhatopenshift/HcpCluster.Management/examples/2025-12-23-preview/HcpOpenShiftClusters_ListByResourceGroup_MaximumSet_Gen.json
+++ b/api/redhatopenshift/HcpCluster.Management/examples/2025-12-23-preview/HcpOpenShiftClusters_ListByResourceGroup_MaximumSet_Gen.json
@@ -45,7 +45,8 @@
                   "userAssignedIdentities": {
                     "controlPlaneOperators": {},
                     "dataPlaneOperators": {},
-                    "serviceManagedIdentity": "/subscriptions/FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/serviceMI"
+                    "serviceManagedIdentity": "/subscriptions/FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/serviceMI",
+                    "acrPullIdentity": "/subscriptions/FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/acrPullMI"
                   }
                 },
                 "issuerUrl": "https://oidc.contoso.com"

--- a/api/redhatopenshift/HcpCluster.Management/examples/2025-12-23-preview/HcpOpenShiftClusters_ListBySubscription_MaximumSet_Gen.json
+++ b/api/redhatopenshift/HcpCluster.Management/examples/2025-12-23-preview/HcpOpenShiftClusters_ListBySubscription_MaximumSet_Gen.json
@@ -44,7 +44,8 @@
                   "userAssignedIdentities": {
                     "controlPlaneOperators": {},
                     "dataPlaneOperators": {},
-                    "serviceManagedIdentity": "/subscriptions/FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/serviceMI"
+                    "serviceManagedIdentity": "/subscriptions/FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/serviceMI",
+                    "acrPullIdentity": "/subscriptions/FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/acrPullMI"
                   }
                 },
                 "issuerUrl": "https://oidc.contoso.com"

--- a/api/redhatopenshift/HcpCluster.Management/examples/2025-12-23-preview/HcpOpenShiftClusters_Update_MaximumSet_Gen.json
+++ b/api/redhatopenshift/HcpCluster.Management/examples/2025-12-23-preview/HcpOpenShiftClusters_Update_MaximumSet_Gen.json
@@ -55,7 +55,8 @@
               "userAssignedIdentities": {
                 "controlPlaneOperators": {},
                 "dataPlaneOperators": {},
-                "serviceManagedIdentity": "/subscriptions/FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/serviceMI"
+                "serviceManagedIdentity": "/subscriptions/FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/serviceMI",
+                "acrPullIdentity": "/subscriptions/FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/acrPullMI"
               }
             },
             "issuerUrl": "https://oidc.contoso.com"

--- a/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
+++ b/api/redhatopenshift/HcpCluster.Management/hcpCluster-models.tsp
@@ -495,6 +495,12 @@ model UserAssignedIdentitiesProfile {
    * purpose is to perform service level actions. */
   @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
   serviceManagedIdentity: UserAssignedIdentityResourceId;
+
+  /** Represents the information associated to an Azure User-Assigned Managed Identity whose
+   * purpose is to perform image pulls from Azure Container Registries. */
+  @added(Versions.v2025_12_23_preview)
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
+  acrPullIdentity?: UserAssignedIdentityResourceId;
 }
 
 scalar UserAssignedIdentityResourceId

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2025-12-23-preview/examples/HcpOpenShiftClusters_CreateOrUpdate_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2025-12-23-preview/examples/HcpOpenShiftClusters_CreateOrUpdate_MaximumSet_Gen.json
@@ -39,7 +39,8 @@
             "userAssignedIdentities": {
               "controlPlaneOperators": {},
               "dataPlaneOperators": {},
-              "serviceManagedIdentity": "/subscriptions/FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/serviceMI"
+              "serviceManagedIdentity": "/subscriptions/FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/serviceMI",
+              "acrPullIdentity": "/subscriptions/FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/acrPullMI"
             }
           }
         },
@@ -132,7 +133,8 @@
               "userAssignedIdentities": {
                 "controlPlaneOperators": {},
                 "dataPlaneOperators": {},
-                "serviceManagedIdentity": "/subscriptions/FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/serviceMI"
+                "serviceManagedIdentity": "/subscriptions/FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/serviceMI",
+                "acrPullIdentity": "/subscriptions/FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/acrPullMI"
               }
             },
             "issuerUrl": "https://oidc.contoso.com"
@@ -246,7 +248,8 @@
               "userAssignedIdentities": {
                 "controlPlaneOperators": {},
                 "dataPlaneOperators": {},
-                "serviceManagedIdentity": "/subscriptions/FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/serviceMI"
+                "serviceManagedIdentity": "/subscriptions/FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/serviceMI",
+                "acrPullIdentity": "/subscriptions/FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/acrPullMI"
               }
             },
             "issuerUrl": "https://oidc.contoso.com"

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2025-12-23-preview/examples/HcpOpenShiftClusters_Get_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2025-12-23-preview/examples/HcpOpenShiftClusters_Get_MaximumSet_Gen.json
@@ -44,7 +44,8 @@
               "userAssignedIdentities": {
                 "controlPlaneOperators": {},
                 "dataPlaneOperators": {},
-                "serviceManagedIdentity": "/subscriptions/FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/serviceMI"
+                "serviceManagedIdentity": "/subscriptions/FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/serviceMI",
+                "acrPullIdentity": "/subscriptions/FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/acrPullMI"
               }
             },
             "issuerUrl": "https://oidc.contoso.com"

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2025-12-23-preview/examples/HcpOpenShiftClusters_ListByResourceGroup_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2025-12-23-preview/examples/HcpOpenShiftClusters_ListByResourceGroup_MaximumSet_Gen.json
@@ -45,7 +45,8 @@
                   "userAssignedIdentities": {
                     "controlPlaneOperators": {},
                     "dataPlaneOperators": {},
-                    "serviceManagedIdentity": "/subscriptions/FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/serviceMI"
+                    "serviceManagedIdentity": "/subscriptions/FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/serviceMI",
+                    "acrPullIdentity": "/subscriptions/FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/acrPullMI"
                   }
                 },
                 "issuerUrl": "https://oidc.contoso.com"

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2025-12-23-preview/examples/HcpOpenShiftClusters_ListBySubscription_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2025-12-23-preview/examples/HcpOpenShiftClusters_ListBySubscription_MaximumSet_Gen.json
@@ -44,7 +44,8 @@
                   "userAssignedIdentities": {
                     "controlPlaneOperators": {},
                     "dataPlaneOperators": {},
-                    "serviceManagedIdentity": "/subscriptions/FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/serviceMI"
+                    "serviceManagedIdentity": "/subscriptions/FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/serviceMI",
+                    "acrPullIdentity": "/subscriptions/FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/acrPullMI"
                   }
                 },
                 "issuerUrl": "https://oidc.contoso.com"

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2025-12-23-preview/examples/HcpOpenShiftClusters_Update_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2025-12-23-preview/examples/HcpOpenShiftClusters_Update_MaximumSet_Gen.json
@@ -55,7 +55,8 @@
               "userAssignedIdentities": {
                 "controlPlaneOperators": {},
                 "dataPlaneOperators": {},
-                "serviceManagedIdentity": "/subscriptions/FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/serviceMI"
+                "serviceManagedIdentity": "/subscriptions/FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/serviceMI",
+                "acrPullIdentity": "/subscriptions/FDEA43EA-0230-4A7D-BDEE-F3AFF2183B1D/resourceGroups/rgopenapi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/acrPullMI"
               }
             },
             "issuerUrl": "https://oidc.contoso.com"

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2025-12-23-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpclusters/preview/2025-12-23-preview/openapi.json
@@ -3692,6 +3692,15 @@
             "update",
             "create"
           ]
+        },
+        "acrPullIdentity": {
+          "$ref": "#/definitions/UserAssignedIdentityResourceId",
+          "description": "Represents the information associated to an Azure User-Assigned Managed Identity whose\npurpose is to perform image pulls from Azure Container Registries.",
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
         }
       },
       "required": [
@@ -3731,6 +3740,15 @@
         "serviceManagedIdentity": {
           "$ref": "#/definitions/UserAssignedIdentityResourceId",
           "description": "Represents the information associated to an Azure User-Assigned Managed Identity whose\npurpose is to perform service level actions.",
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        },
+        "acrPullIdentity": {
+          "$ref": "#/definitions/UserAssignedIdentityResourceId",
+          "description": "Represents the information associated to an Azure User-Assigned Managed Identity whose\npurpose is to perform image pulls from Azure Container Registries.",
           "x-ms-mutability": [
             "read",
             "update",

--- a/internal/api/types_cluster.go
+++ b/internal/api/types_cluster.go
@@ -232,6 +232,7 @@ type UserAssignedIdentitiesProfile struct {
 	ControlPlaneOperators  map[string]*azcorearm.ResourceID `json:"controlPlaneOperators,omitempty"`
 	DataPlaneOperators     map[string]*azcorearm.ResourceID `json:"dataPlaneOperators,omitempty"`
 	ServiceManagedIdentity *azcorearm.ResourceID            `json:"serviceManagedIdentity,omitempty"`
+	AcrPullIdentity        *azcorearm.ResourceID            `json:"acrPullIdentity,omitempty"`
 }
 
 // ClusterImageRegistryProfile - OpenShift cluster image registry

--- a/internal/api/v20240610preview/conversion_fuzz_test.go
+++ b/internal/api/v20240610preview/conversion_fuzz_test.go
@@ -117,6 +117,12 @@ func TestRoundTripInternalExternalInternal(t *testing.T) {
 			// VnetIntegrationSubnetID was added in v2025_12_23_preview and does not exist in v2024_06_10_preview
 			j.VnetIntegrationSubnetID = nil
 		},
+		func(j *api.UserAssignedIdentitiesProfile, c randfill.Continue) {
+			c.FillNoCustom(j)
+			// AcrPullIdentity was added in v2025_12_23_preview and does not exist in v2024_06_10_preview.
+			// Cross-version preservation is handled by preserveUnknownClusterFields.
+			j.AcrPullIdentity = nil
+		},
 		func(j *api.KmsEncryptionProfile, c randfill.Continue) {
 			c.FillNoCustom(j)
 			// Visibility was added in v2025_12_23_preview and does not exist in v2024_06_10_preview

--- a/internal/api/v20240610preview/hcpopenshiftclusters_methods.go
+++ b/internal/api/v20240610preview/hcpopenshiftclusters_methods.go
@@ -438,6 +438,9 @@ func preserveUnknownClusterFields(from, to *api.HCPOpenShiftCluster) {
 	}
 	// VnetIntegrationSubnetID was added in v2025_12_23_preview.
 	to.CustomerProperties.Platform.VnetIntegrationSubnetID = from.CustomerProperties.Platform.VnetIntegrationSubnetID
+	// AcrPullIdentity was added in v2025_12_23_preview.
+	to.CustomerProperties.Platform.OperatorsAuthentication.UserAssignedIdentities.AcrPullIdentity =
+		from.CustomerProperties.Platform.OperatorsAuthentication.UserAssignedIdentities.AcrPullIdentity
 	// Visibility was added in v2025_12_23_preview.
 	if from.CustomerProperties.Etcd.DataEncryption.CustomerManaged != nil && from.CustomerProperties.Etcd.DataEncryption.CustomerManaged.Kms != nil {
 		if to.CustomerProperties.Etcd.DataEncryption.CustomerManaged == nil {

--- a/internal/api/v20251223preview/generated/models.go
+++ b/internal/api/v20251223preview/generated/models.go
@@ -1055,11 +1055,19 @@ type UserAssignedIdentitiesProfile struct {
 	// REQUIRED; Represents the information associated to an Azure User-Assigned Managed Identity whose purpose is to perform
 	// service level actions.
 	ServiceManagedIdentity *string
+
+	// Represents the information associated to an Azure User-Assigned Managed Identity whose purpose is to perform image pulls
+	// from Azure Container Registries.
+	AcrPullIdentity *string
 }
 
 // UserAssignedIdentitiesProfileUpdate - Represents the information related to Azure User-Assigned managed identities needed
 // to perform Operators authentication based on Azure User-Assigned Managed Identities
 type UserAssignedIdentitiesProfileUpdate struct {
+	// Represents the information associated to an Azure User-Assigned Managed Identity whose purpose is to perform image pulls
+	// from Azure Container Registries.
+	AcrPullIdentity *string
+
 	// The set of Azure User-Assigned Managed Identities leveraged for the Control Plane operators of the cluster. The set of
 	// required managed identities is dependent on the Cluster's OpenShift version.
 	ControlPlaneOperators map[string]*string

--- a/internal/api/v20251223preview/generated/models_serde.go
+++ b/internal/api/v20251223preview/generated/models_serde.go
@@ -2569,6 +2569,7 @@ func (t *TokenRequiredClaim) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type UserAssignedIdentitiesProfile.
 func (u UserAssignedIdentitiesProfile) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
+	populate(objectMap, "acrPullIdentity", u.AcrPullIdentity)
 	populate(objectMap, "controlPlaneOperators", u.ControlPlaneOperators)
 	populate(objectMap, "dataPlaneOperators", u.DataPlaneOperators)
 	populate(objectMap, "serviceManagedIdentity", u.ServiceManagedIdentity)
@@ -2584,6 +2585,9 @@ func (u *UserAssignedIdentitiesProfile) UnmarshalJSON(data []byte) error {
 	for key, val := range rawMsg {
 		var err error
 		switch key {
+		case "acrPullIdentity":
+			err = unpopulate(val, "AcrPullIdentity", &u.AcrPullIdentity)
+			delete(rawMsg, key)
 		case "controlPlaneOperators":
 			err = unpopulate(val, "ControlPlaneOperators", &u.ControlPlaneOperators)
 			delete(rawMsg, key)
@@ -2606,6 +2610,7 @@ func (u *UserAssignedIdentitiesProfile) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type UserAssignedIdentitiesProfileUpdate.
 func (u UserAssignedIdentitiesProfileUpdate) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
+	populate(objectMap, "acrPullIdentity", u.AcrPullIdentity)
 	populate(objectMap, "controlPlaneOperators", u.ControlPlaneOperators)
 	populate(objectMap, "dataPlaneOperators", u.DataPlaneOperators)
 	populate(objectMap, "serviceManagedIdentity", u.ServiceManagedIdentity)
@@ -2621,6 +2626,9 @@ func (u *UserAssignedIdentitiesProfileUpdate) UnmarshalJSON(data []byte) error {
 	for key, val := range rawMsg {
 		var err error
 		switch key {
+		case "acrPullIdentity":
+			err = unpopulate(val, "AcrPullIdentity", &u.AcrPullIdentity)
+			delete(rawMsg, key)
 		case "controlPlaneOperators":
 			err = unpopulate(val, "ControlPlaneOperators", &u.ControlPlaneOperators)
 			delete(rawMsg, key)

--- a/internal/api/v20251223preview/hcpopenshiftclusters_methods.go
+++ b/internal/api/v20251223preview/hcpopenshiftclusters_methods.go
@@ -286,6 +286,7 @@ func newUserAssignedIdentitiesProfile(from *api.UserAssignedIdentitiesProfile) g
 		ControlPlaneOperators:  api.ResourceIDMapToStringPtrMap(from.ControlPlaneOperators),
 		DataPlaneOperators:     api.ResourceIDMapToStringPtrMap(from.DataPlaneOperators),
 		ServiceManagedIdentity: api.ResourceIDToStringPtr(from.ServiceManagedIdentity),
+		AcrPullIdentity:        api.ResourceIDToStringPtr(from.AcrPullIdentity),
 	}
 }
 
@@ -687,6 +688,13 @@ func normalizeUserAssignedIdentities(fldPath *field.Path, p *generated.UserAssig
 			errs = append(errs, field.Invalid(fldPath.Child("serviceManagedIdentity"), *p.ServiceManagedIdentity, err.Error()))
 		} else {
 			out.ServiceManagedIdentity = resourceID
+		}
+	}
+	if p.AcrPullIdentity != nil && len(*p.AcrPullIdentity) > 0 {
+		if resourceID, err := azcorearm.ParseResourceID(*p.AcrPullIdentity); err != nil {
+			errs = append(errs, field.Invalid(fldPath.Child("acrPullIdentity"), *p.AcrPullIdentity, err.Error()))
+		} else {
+			out.AcrPullIdentity = resourceID
 		}
 	}
 	return errs

--- a/internal/api/zz_generated.deepcopy.go
+++ b/internal/api/zz_generated.deepcopy.go
@@ -1879,6 +1879,10 @@ func (in *UserAssignedIdentitiesProfile) DeepCopyInto(out *UserAssignedIdentitie
 		in, out := &in.ServiceManagedIdentity, &out.ServiceManagedIdentity
 		*out = arm.DeepCopyResourceID(*in)
 	}
+	if in.AcrPullIdentity != nil {
+		in, out := &in.AcrPullIdentity, &out.AcrPullIdentity
+		*out = arm.DeepCopyResourceID(*in)
+	}
 	return
 }
 

--- a/internal/validation/validate_cluster.go
+++ b/internal/validation/validate_cluster.go
@@ -190,7 +190,6 @@ func validateResourceIDsAgainstClusterID(ctx context.Context, op operation.Opera
 		field.NewPath("customerProperties", "platform", "operatorsAuthentication", "userAssignedIdentities", "serviceManagedIdentity"),
 		newCluster.CustomerProperties.Platform.OperatorsAuthentication.UserAssignedIdentities.ServiceManagedIdentity, nil,
 		newCluster.ID.SubscriptionID, newCluster.CustomerProperties.Platform.ManagedResourceGroup)...)
-
 	return errs
 }
 
@@ -609,7 +608,7 @@ func validateCustomerPlatformProfile(ctx context.Context, op operation.Operation
 	errs = append(errs, RestrictedResourceIDWithResourceGroup(ctx, op, fldPath.Child("networkSecurityGroupId"), newObj.NetworkSecurityGroupID, safe.Field(oldObj, toPlatformNetworkSecurityGroupID), "Microsoft.Network/networkSecurityGroups")...)
 
 	//OperatorsAuthentication OperatorsAuthenticationProfile `json:"operatorsAuthentication,omitempty"`
-	errs = append(errs, immutableByReflect(ctx, op, fldPath.Child("operatorsAuthentication"), &newObj.OperatorsAuthentication, safe.Field(oldObj, toPlatformOperatorsAuthentication))...)
+	errs = append(errs, immutableAuthExcludingAcr(ctx, op, fldPath.Child("operatorsAuthentication"), &newObj.OperatorsAuthentication, safe.Field(oldObj, toPlatformOperatorsAuthentication))...)
 	errs = append(errs, validateOperatorsAuthenticationProfile(ctx, op, fldPath.Child("operatorsAuthentication"), &newObj.OperatorsAuthentication, safe.Field(oldObj, toPlatformOperatorsAuthentication))...)
 
 	return errs
@@ -639,7 +638,7 @@ func validateOperatorsAuthenticationProfile(ctx context.Context, op operation.Op
 	errs := field.ErrorList{}
 
 	//UserAssignedIdentities UserAssignedIdentitiesProfile `json:"userAssignedIdentities,omitempty"`
-	errs = append(errs, immutableByReflect(ctx, op, fldPath.Child("userAssignedIdentities"), &newObj.UserAssignedIdentities, safe.Field(oldObj, toAuthenticationUserAssignedIdentities))...)
+	errs = append(errs, immutableUAIExcludingAcr(ctx, op, fldPath.Child("userAssignedIdentities"), &newObj.UserAssignedIdentities, safe.Field(oldObj, toAuthenticationUserAssignedIdentities))...)
 	errs = append(errs, validateUserAssignedIdentitiesProfile(ctx, op, fldPath.Child("userAssignedIdentities"), &newObj.UserAssignedIdentities, safe.Field(oldObj, toAuthenticationUserAssignedIdentities))...)
 
 	return errs
@@ -654,6 +653,9 @@ var (
 	}
 	toUserAssignedIdentitiesServiceManagedIdentity = func(oldObj *api.UserAssignedIdentitiesProfile) *azcorearm.ResourceID {
 		return oldObj.ServiceManagedIdentity
+	}
+	toUserAssignedIdentitiesAcrPullIdentity = func(oldObj *api.UserAssignedIdentitiesProfile) *azcorearm.ResourceID {
+		return oldObj.AcrPullIdentity
 	}
 )
 
@@ -700,7 +702,34 @@ func validateUserAssignedIdentitiesProfile(ctx context.Context, op operation.Ope
 	errs = append(errs, immutableByReflect(ctx, op, fldPath.Child("serviceManagedIdentity"), newObj.ServiceManagedIdentity, safe.Field(oldObj, toUserAssignedIdentitiesServiceManagedIdentity))...)
 	errs = append(errs, RestrictedResourceIDWithResourceGroup(ctx, op, fldPath.Child("serviceManagedIdentity"), newObj.ServiceManagedIdentity, safe.Field(oldObj, toUserAssignedIdentitiesServiceManagedIdentity), "Microsoft.ManagedIdentity/userAssignedIdentities")...)
 
+	//AcrPullIdentity — Day-2 mutable, no immutableByReflect.
+	errs = append(errs, RestrictedResourceIDWithResourceGroup(ctx, op, fldPath.Child("acrPullIdentity"), newObj.AcrPullIdentity, safe.Field(oldObj, toUserAssignedIdentitiesAcrPullIdentity), "Microsoft.ManagedIdentity/userAssignedIdentities")...)
+
 	return errs
+}
+
+func immutableAuthExcludingAcr(ctx context.Context, op operation.Operation, fldPath *field.Path, newObj *api.OperatorsAuthenticationProfile, oldObj *api.OperatorsAuthenticationProfile) field.ErrorList {
+	newCopy := *newObj
+	newCopy.UserAssignedIdentities.AcrPullIdentity = nil
+	var oldCopy *api.OperatorsAuthenticationProfile
+	if oldObj != nil {
+		tmp := *oldObj
+		tmp.UserAssignedIdentities.AcrPullIdentity = nil
+		oldCopy = &tmp
+	}
+	return immutableByReflect(ctx, op, fldPath, &newCopy, oldCopy)
+}
+
+func immutableUAIExcludingAcr(ctx context.Context, op operation.Operation, fldPath *field.Path, newObj *api.UserAssignedIdentitiesProfile, oldObj *api.UserAssignedIdentitiesProfile) field.ErrorList {
+	newCopy := *newObj
+	newCopy.AcrPullIdentity = nil
+	var oldCopy *api.UserAssignedIdentitiesProfile
+	if oldObj != nil {
+		tmp := *oldObj
+		tmp.AcrPullIdentity = nil
+		oldCopy = &tmp
+	}
+	return immutableByReflect(ctx, op, fldPath, &newCopy, oldCopy)
 }
 
 var (


### PR DESCRIPTION
Add acrPullIdentity to UserAssignedIdentitiesProfile in the v2025-12-23-preview API version. This field allows customers to specify a user-assigned managed identity for cluster-wide ACR image pulls.

The field is Day-2 mutable (set, change, remove after cluster creation). Validation enforces resource ID format only — no subscription/resource-group constraints since HyperShift allows cross-subscription and cross-RG identities. The existing immutableByReflect checks are updated to exclude acrPullIdentity so other identity fields remain immutable while this one allows updates.

[ARO-25900](https://redhat.atlassian.net/browse/ARO-25900)

What

Add acrPullIdentity field to the ARM API (UserAssignedIdentitiesProfile) for v2025-12-23-preview. Includes TypeSpec definition, generated OpenAPI/Go models, conversion methods, cross-version preservation for v2024-06-10-preview, and validation.

Why

[ARO-24037](https://redhat.atlassian.net/browse/ARO-24037) requires worker nodes to pull images from ACR using a user-assigned managed identity instead of image pull secrets. The ARM API needs a field for customers to provide the identity's resource ID so it can flow through CS to HyperShift, which attaches it to worker VMSS and writes it into cloud.conf.

Testing

- Existing fuzz tests (TestRoundTripInternalExternalInternal) updated — v2024-06-10-preview fuzzer zeroes out the field since it doesn't exist in that version
- Deep copy test passes with regenerated zz_generated.deepcopy.go
- Validation tests pass
- make generate, make lint-openapi, make validate-examples all pass

OCM conversion code is out of scope (blocked on OCM SDK release after ocm-api-model#1164).

Special notes for your reviewer

- The field is not tallied against ARM envelope identities — unlike operator MIs, the ACR pull identity is attached to worker VMSS by CAPZ, not managed through ARM's identity system
- No subscription/RG location validation — HyperShift PR #8472 explicitly allows cross-subscription and cross-RG identities
- Two helper functions (immutableAuthExcludingAcr, immutableUAIExcludingAcr) zero the mutable field before immutableByReflect comparison

PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows Conventional Commits format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge