### PR TITLE
fix: add seriesToRows before merge in Mixed-datasource panels

### DIFF
--- a/observability/grafana-dashboards/sre/user-journey/cluster-provisioning-slo.json
+++ b/observability/grafana-dashboards/sre/user-journey/cluster-provisioning-slo.json
@@ -118,6 +118,10 @@
           "options": {}
         },
         {
+          "id": "merge",
+          "options": {}
+        },
+        {
           "id": "groupBy",
           "options": {
             "fields": {
@@ -217,6 +221,10 @@
       ],
       "title": "Completed Create Attempts (Window)",
       "transformations": [
+        {
+          "id": "seriesToRows",
+          "options": {}
+        },
         {
           "id": "merge",
           "options": {}
@@ -320,6 +328,10 @@
       "transformations": [
         {
           "id": "seriesToRows",
+          "options": {}
+        },
+        {
+          "id": "merge",
           "options": {}
         },
         {
@@ -444,6 +456,10 @@
       "title": "Failed / Canceled Create Attempts (Window)",
       "transformations": [
         {
+          "id": "seriesToRows",
+          "options": {}
+        },
+        {
           "id": "merge",
           "options": {}
         },
@@ -559,6 +575,10 @@
       "transformations": [
         {
           "id": "seriesToRows",
+          "options": {}
+        },
+        {
+          "id": "merge",
           "options": {}
         },
         {
@@ -1010,6 +1030,10 @@
       "title": "Clusters by Provisioning State",
       "transformations": [
         {
+          "id": "seriesToRows",
+          "options": {}
+        },
+        {
           "id": "merge",
           "options": {}
         }
@@ -1089,6 +1113,10 @@
       ],
       "title": "Create Ops Stuck > 20 min",
       "transformations": [
+        {
+          "id": "seriesToRows",
+          "options": {}
+        },
         {
           "id": "merge",
           "options": {}
@@ -1210,6 +1238,10 @@
       "transformations": [
         {
           "id": "seriesToRows",
+          "options": {}
+        },
+        {
+          "id": "merge",
           "options": {}
         },
         {
@@ -1837,6 +1869,10 @@
       "transformations": [
         {
           "id": "seriesToRows",
+          "options": {}
+        },
+        {
+          "id": "merge",
           "options": {}
         }
       ],

--- a/observability/grafana-dashboards/sre/user-journey/etcd-availability.json
+++ b/observability/grafana-dashboards/sre/user-journey/etcd-availability.json
@@ -123,6 +123,10 @@
       "title": "Fleet Total Stable Clusters (24h)",
       "transformations": [
         {
+          "id": "seriesToRows",
+          "options": {}
+        },
+        {
           "id": "merge",
           "options": {}
         },
@@ -214,6 +218,10 @@
       "title": "Fleet Total Leader Changes (24h)",
       "transformations": [
         {
+          "id": "seriesToRows",
+          "options": {}
+        },
+        {
           "id": "merge",
           "options": {}
         },
@@ -295,6 +303,10 @@
       ],
       "title": "Fleet Clusters Monitored",
       "transformations": [
+        {
+          "id": "seriesToRows",
+          "options": {}
+        },
         {
           "id": "merge",
           "options": {}
@@ -386,6 +398,10 @@
       "title": "Worst Cluster P99 WAL Fsync (5m)",
       "transformations": [
         {
+          "id": "seriesToRows",
+          "options": {}
+        },
+        {
           "id": "merge",
           "options": {}
         },
@@ -475,6 +491,10 @@
       ],
       "title": "Worst Cluster P99 Backend Commit (5m)",
       "transformations": [
+        {
+          "id": "seriesToRows",
+          "options": {}
+        },
         {
           "id": "merge",
           "options": {}
@@ -566,6 +586,10 @@
       "title": "Worst Cluster P99 Peer RTT (5m)",
       "transformations": [
         {
+          "id": "seriesToRows",
+          "options": {}
+        },
+        {
           "id": "merge",
           "options": {}
         },
@@ -655,6 +679,10 @@
       ],
       "title": "Fleet Worst Cluster DB Size",
       "transformations": [
+        {
+          "id": "seriesToRows",
+          "options": {}
+        },
         {
           "id": "merge",
           "options": {}


### PR DESCRIPTION
[ARO-27611](https://redhat.atlassian.net/browse/ARO-27611)

### What
Add `seriesToRows` before `merge` in all Mixed-datasource stat/chart panels across both dashboards.

### Why
Without `seriesToRows`, each regional Prometheus workspace produces its own frame and stat panels render N tiles instead of one aggregated number when `datasource=All`. Same fix pattern as commit e4c0ec6c2 (p50/p95/p99 panels).

### Dashboards fixed
- `cluster-provisioning-slo.json`: 9 panels
- `etcd-availability.json`: 7 panels

### Testing
Verified in dev Grafana with datasource=All.

### PR Checklist
- [x] PR is scoped to a single task
- [x] Title follows Conventional Commits format
- [x] Summary explains the "Why"
- [x] Linked to relevant ticket/issue
- [x] Self-reviewed the diff
- [x] Commit history is clean