### PR TITLE
feat: add new Management Cluster Triage Grafana SRE dashboard

### DIFF
--- a/observability/grafana-dashboards/sre/user-journey/mgmt-cluster-triage.json
+++ b/observability/grafana-dashboards/sre/user-journey/mgmt-cluster-triage.json
@@ -1725,7 +1725,7 @@
     "to": "now"
   },
   "timepicker": {},
-  "timezone": "browser",
+  "timezone": "utc",
   "title": "Management Cluster Triage",
   "uid": "mgmt-cluster-triage",
   "version": 1,

--- a/observability/grafana-dashboards/sre/user-journey/mgmt-cluster-triage.json
+++ b/observability/grafana-dashboards/sre/user-journey/mgmt-cluster-triage.json
@@ -506,8 +506,8 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (instance) (rate(container_cpu_usage_seconds_total{cluster=\"$cluster\", container!=\"\", container!=\"POD\"}[5m]))\n/ on(instance)\nmax by (instance) (label_replace(kube_node_status_allocatable{cluster=\"$cluster\", resource=\"cpu\"}, \"instance\", \"$1\", \"node\", \"(.+)\"))\n* 100",
-          "legendFormat": "{{instance}}",
+          "expr": "sum by (node) (label_replace(rate(container_cpu_usage_seconds_total{cluster=\"$cluster\", container!=\"\", container!=\"POD\"}[5m]), \"node\", \"$1\", \"instance\", \"(.+)\"))\n/ on(node)\nmax by (node) (kube_node_status_allocatable{cluster=\"$cluster\", resource=\"cpu\"})\n* 100",
+          "legendFormat": "{{node}}",
           "range": true,
           "refId": "A"
         }
@@ -610,8 +610,8 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (instance) (container_memory_working_set_bytes{cluster=\"$cluster\", container!=\"\", container!=\"POD\"})\n/ on(instance)\nmax by (instance) (label_replace(kube_node_status_allocatable{cluster=\"$cluster\", resource=\"memory\"}, \"instance\", \"$1\", \"node\", \"(.+)\"))\n* 100",
-          "legendFormat": "{{instance}}",
+          "expr": "sum by (node) (label_replace(container_memory_working_set_bytes{cluster=\"$cluster\", container!=\"\", container!=\"POD\"}, \"node\", \"$1\", \"instance\", \"(.+)\"))\n/ on(node)\nmax by (node) (kube_node_status_allocatable{cluster=\"$cluster\", resource=\"memory\"})\n* 100",
+          "legendFormat": "{{node}}",
           "range": true,
           "refId": "A"
         }
@@ -1532,7 +1532,7 @@
             "uid": "${hcp_datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99,\n  sum by (namespace, le) (\n    rate(etcd_disk_wal_fsync_duration_seconds_bucket{cluster=\"$cluster\"}[5m])\n  )\n)",
+          "expr": "histogram_quantile(0.99,\n  sum by (namespace, le) (\n    rate(etcd_disk_wal_fsync_duration_seconds_bucket{cluster=\"$cluster\", namespace=~\"$hcp_namespace\"}[5m])\n  )\n)",
           "legendFormat": "{{namespace}}",
           "range": true,
           "refId": "A"
@@ -1632,7 +1632,7 @@
             "uid": "${hcp_datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (namespace) (increase(etcd_server_leader_changes_seen_total{cluster=\"$cluster\"}[1h]))",
+          "expr": "sum by (namespace) (increase(etcd_server_leader_changes_seen_total{cluster=\"$cluster\", namespace=~\"$hcp_namespace\"}[1h]))",
           "legendFormat": "{{namespace}}",
           "range": true,
           "refId": "A"

--- a/observability/grafana-dashboards/sre/user-journey/mgmt-cluster-triage.json
+++ b/observability/grafana-dashboards/sre/user-journey/mgmt-cluster-triage.json
@@ -1546,7 +1546,7 @@
         "type": "prometheus",
         "uid": "${hcp_datasource}"
       },
-      "description": "Rate of etcd leader changes per HCP namespace. Frequent leader elections indicate etcd instability.",
+      "description": "Number of etcd leader changes per HCP namespace over the last hour. Any value above 0 indicates leader churn worth investigating.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1632,13 +1632,13 @@
             "uid": "${hcp_datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (namespace) (rate(etcd_server_leader_changes_seen_total{cluster=\"$cluster\"}[5m]))",
+          "expr": "sum by (namespace) (increase(etcd_server_leader_changes_seen_total{cluster=\"$cluster\"}[1h]))",
           "legendFormat": "{{namespace}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "etcd Leader Changes",
+      "title": "etcd Leader Changes (Last 1h)",
       "type": "timeseries"
     }
   ],

--- a/observability/grafana-dashboards/sre/user-journey/mgmt-cluster-triage.json
+++ b/observability/grafana-dashboards/sre/user-journey/mgmt-cluster-triage.json
@@ -1,0 +1,1719 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 7,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "### Management Cluster Triage\n\nIncident triage starting point for KAS availability alerts on management clusters. Quickly identify whether the root cause is node-level, workload-level, or a noisy-neighbor HCP.\n\n**Sections:**\n- **Node Health** — node status, CPU/memory vs allocatable, pressure conditions\n- **Workload Stability** — OOMKills, restart rate, evictions, CrashLoopBackOff, pending pods\n- **Noisy Neighbor** — top HCP namespaces by CPU, memory, and network\n- **etcd Early Warning** — WAL fsync latency and leader changes (fires 3-5 min before KAS degrades)\n\n**Datasources:**\n- Node, workload, and noisy-neighbor panels use **SVC AMW** (`Managed_Prometheus_services-*`).\n- etcd panels use **HCP AMW** (`Managed_Prometheus_hcps-*`).\n\n**Notes:**\n- HCP pods have resource REQUESTS only (no limits). This dashboard uses usage vs node allocatable.\n- For deep-dive into a specific HCP, use the HCP Namespace Deep Dive dashboard.",
+        "mode": "markdown"
+      },
+      "pluginVersion": "11.6.9",
+      "title": "Dashboard Info",
+      "type": "text"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 2,
+      "panels": [],
+      "title": "Node Health",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Number of nodes in Ready state",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "none",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 0,
+        "y": 11
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "count(kube_node_status_condition{cluster=\"$cluster\", condition=\"Ready\", status=\"true\"} == 1) or vector(0)",
+          "instant": true,
+          "range": false,
+          "legendFormat": "Ready",
+          "refId": "A"
+        }
+      ],
+      "title": "Nodes Ready",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Number of nodes in NotReady state",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 5,
+        "y": 11
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "count(kube_node_status_condition{cluster=\"$cluster\", condition=\"Ready\", status=\"false\"} == 1) or vector(0)",
+          "instant": true,
+          "range": false,
+          "legendFormat": "NotReady",
+          "refId": "A"
+        }
+      ],
+      "title": "Nodes NotReady",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Number of nodes with scheduling disabled (cordoned)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 10,
+        "y": 11
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "count(kube_node_spec_unschedulable{cluster=\"$cluster\"} == 1) or vector(0)",
+          "instant": true,
+          "range": false,
+          "legendFormat": "SchedulingDisabled",
+          "refId": "A"
+        }
+      ],
+      "title": "Nodes SchedulingDisabled",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Number of nodes reporting DiskPressure condition",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 15,
+        "y": 11
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "count(kube_node_status_condition{cluster=\"$cluster\", condition=\"DiskPressure\", status=\"true\"} == 1) or vector(0)",
+          "instant": true,
+          "range": false,
+          "legendFormat": "DiskPressure",
+          "refId": "A"
+        }
+      ],
+      "title": "Disk Pressure",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Number of nodes reporting PIDPressure condition",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 11
+      },
+      "id": 7,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "count(kube_node_status_condition{cluster=\"$cluster\", condition=\"PIDPressure\", status=\"true\"} == 1) or vector(0)",
+          "instant": true,
+          "range": false,
+          "legendFormat": "PIDPressure",
+          "refId": "A"
+        }
+      ],
+      "title": "PID Pressure",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "CPU utilization per node as percentage of allocatable capacity",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 15
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (instance) (rate(container_cpu_usage_seconds_total{cluster=\"$cluster\", container!=\"\"}[5m]))\n/ on(instance)\nmax by (instance) (label_replace(kube_node_status_allocatable{cluster=\"$cluster\", resource=\"cpu\"}, \"instance\", \"$1\", \"node\", \"(.+)\"))\n* 100",
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "CPU Utilization per Node (% of Allocatable)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Memory utilization per node as percentage of allocatable capacity",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 15
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (instance) (container_memory_working_set_bytes{cluster=\"$cluster\", container!=\"\"})\n/ on(instance)\nmax by (instance) (label_replace(kube_node_status_allocatable{cluster=\"$cluster\", resource=\"memory\"}, \"instance\", \"$1\", \"node\", \"(.+)\"))\n* 100",
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Memory Utilization per Node (% of Allocatable)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "id": 10,
+      "panels": [],
+      "title": "Workload Stability",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Current count of containers whose last termination was OOMKilled, grouped by namespace (top 10)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "topk(10, sum by (namespace) (kube_pod_container_status_last_terminated_reason{cluster=\"$cluster\", reason=\"OOMKilled\"}))",
+          "legendFormat": "{{namespace}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "OOMKilled Containers by Namespace (Top 10)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Rate of pod container restarts per namespace (top 10)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "topk(10, sum by (namespace) (increase(kube_pod_container_status_restarts_total{cluster=\"$cluster\"}[1h])))",
+          "legendFormat": "{{namespace}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Pod Restart Rate by Namespace (Top 10, 1h window)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Current count of pods in CrashLoopBackOff state by namespace (top 10)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 32
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "topk(10, sum by (namespace) (kube_pod_container_status_waiting_reason{cluster=\"$cluster\", reason=\"CrashLoopBackOff\"}))",
+          "legendFormat": "{{namespace}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Pods in CrashLoopBackOff by Namespace (Top 10)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Current count of pods in Pending phase by namespace (top 10)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "orange",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 32
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "topk(10, sum by (namespace) (kube_pod_status_phase{cluster=\"$cluster\", phase=\"Pending\"} == 1))",
+          "legendFormat": "{{namespace}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Pods Pending by Namespace (Top 10)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Current count of evicted pods by namespace (top 10)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 32
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "topk(10, sum by (namespace) (kube_pod_status_reason{cluster=\"$cluster\", reason=\"Evicted\"}))",
+          "legendFormat": "{{namespace}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Evicted Pods by Namespace (Top 10)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 40
+      },
+      "id": 16,
+      "panels": [],
+      "title": "Noisy Neighbor",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Top 10 HCP namespaces by total CPU usage (cores). HCP namespaces match ocm-*.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "cores",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 41
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "topk(10, sum by (namespace) (rate(container_cpu_usage_seconds_total{cluster=\"$cluster\", namespace=~\"ocm-.*\", container!=\"\"}[5m])))",
+          "legendFormat": "{{namespace}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Top 10 HCP Namespaces by CPU Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Top 10 HCP namespaces by memory working set. HCP namespaces match ocm-*.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 41
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "topk(10, sum by (namespace) (container_memory_working_set_bytes{cluster=\"$cluster\", namespace=~\"ocm-.*\", container!=\"\"}))",
+          "legendFormat": "{{namespace}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Top 10 HCP Namespaces by Memory Working Set",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Top 10 HCP namespaces by total network I/O (receive + transmit). HCP namespaces match ocm-*.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 41
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "topk(10, sum by (namespace) (\n  rate(container_network_receive_bytes_total{cluster=\"$cluster\", namespace=~\"ocm-.*\"}[5m])\n  + rate(container_network_transmit_bytes_total{cluster=\"$cluster\", namespace=~\"ocm-.*\"}[5m])\n))",
+          "legendFormat": "{{namespace}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Top 10 HCP Namespaces by Network I/O",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 49
+      },
+      "id": 20,
+      "panels": [],
+      "title": "etcd Early Warning",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${hcp_datasource}"
+      },
+      "description": "etcd WAL fsync duration p99 per HCP namespace. Elevated latency (>10ms) often fires 3-5 minutes before KAS availability degrades.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line+area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "transparent"
+              },
+              {
+                "color": "red",
+                "value": 0.01
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 50
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${hcp_datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99,\n  sum by (namespace, le) (\n    rate(etcd_disk_wal_fsync_duration_seconds_bucket{cluster=\"$cluster\"}[5m])\n  )\n)",
+          "legendFormat": "{{namespace}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "etcd WAL Fsync Latency p99",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${hcp_datasource}"
+      },
+      "description": "Rate of etcd leader changes per HCP namespace. Frequent leader elections indicate etcd instability.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line+area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "transparent"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 50
+      },
+      "id": 22,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${hcp_datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (namespace) (rate(etcd_server_leader_changes_seen_total{cluster=\"$cluster\"}[5m]))",
+          "legendFormat": "{{namespace}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "etcd Leader Changes",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "refresh": "30s",
+  "schemaVersion": 41,
+  "tags": [
+    "sre",
+    "triage",
+    "management-cluster"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "SVC Datasource",
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "^Managed_Prometheus_services-.*$",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "HCP Datasource",
+        "name": "hcp_datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "^Managed_Prometheus_hcps-.*$",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(up, cluster)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Cluster",
+        "multi": false,
+        "name": "cluster",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(up, cluster)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "^.*-mgmt-\\d+$",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Management Cluster Triage",
+  "uid": "mgmt-cluster-triage",
+  "version": 1,
+  "weekStart": ""
+}

--- a/observability/grafana-dashboards/sre/user-journey/mgmt-cluster-triage.json
+++ b/observability/grafana-dashboards/sre/user-journey/mgmt-cluster-triage.json
@@ -736,7 +736,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Rate of pod container restarts per namespace (top 10)",
+      "description": "Total pod container restarts per namespace in the last hour (top 10)",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -827,7 +827,7 @@
           "refId": "A"
         }
       ],
-      "title": "Pod Restart Rate by Namespace (Top 10, 1h window)",
+      "title": "Pod Restarts by Namespace (Top 10, Last 1h)",
       "type": "timeseries"
     },
     {
@@ -1227,7 +1227,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "topk(10, sum by (namespace) (rate(container_cpu_usage_seconds_total{cluster=\"$cluster\", namespace=~\"ocm-.*\", container!=\"\"}[5m])))",
+          "expr": "topk(10, sum by (namespace) (rate(container_cpu_usage_seconds_total{cluster=\"$cluster\", namespace=~\"$hcp_namespace\", container!=\"\"}[5m])))",
           "legendFormat": "{{namespace}}",
           "range": true,
           "refId": "A"
@@ -1323,7 +1323,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "topk(10, sum by (namespace) (container_memory_working_set_bytes{cluster=\"$cluster\", namespace=~\"ocm-.*\", container!=\"\"}))",
+          "expr": "topk(10, sum by (namespace) (container_memory_working_set_bytes{cluster=\"$cluster\", namespace=~\"$hcp_namespace\", container!=\"\"}))",
           "legendFormat": "{{namespace}}",
           "range": true,
           "refId": "A"
@@ -1419,7 +1419,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "topk(10, sum by (namespace) (\n  rate(container_network_receive_bytes_total{cluster=\"$cluster\", namespace=~\"ocm-.*\"}[5m])\n  + rate(container_network_transmit_bytes_total{cluster=\"$cluster\", namespace=~\"ocm-.*\"}[5m])\n))",
+          "expr": "topk(10, sum by (namespace) (\n  rate(container_network_receive_bytes_total{cluster=\"$cluster\", namespace=~\"$hcp_namespace\"}[5m])\n  + rate(container_network_transmit_bytes_total{cluster=\"$cluster\", namespace=~\"$hcp_namespace\"}[5m])\n))",
           "legendFormat": "{{namespace}}",
           "range": true,
           "refId": "A"
@@ -1703,6 +1703,20 @@
         "skipUrlSync": false,
         "sort": 0,
         "type": "query"
+      },
+      {
+        "current": {
+          "text": "ocm-.*",
+          "value": "ocm-.*"
+        },
+        "description": "Regex pattern for HCP namespaces (default: ocm-.*)",
+        "hide": 0,
+        "label": "HCP Namespace Pattern",
+        "name": "hcp_namespace",
+        "options": [],
+        "query": "ocm-.*",
+        "skipUrlSync": false,
+        "type": "textbox"
       }
     ]
   },

--- a/observability/grafana-dashboards/sre/user-journey/mgmt-cluster-triage.json
+++ b/observability/grafana-dashboards/sre/user-journey/mgmt-cluster-triage.json
@@ -506,7 +506,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (instance) (rate(container_cpu_usage_seconds_total{cluster=\"$cluster\", container!=\"\"}[5m]))\n/ on(instance)\nmax by (instance) (label_replace(kube_node_status_allocatable{cluster=\"$cluster\", resource=\"cpu\"}, \"instance\", \"$1\", \"node\", \"(.+)\"))\n* 100",
+          "expr": "sum by (instance) (rate(container_cpu_usage_seconds_total{cluster=\"$cluster\", container!=\"\", container!=\"POD\"}[5m]))\n/ on(instance)\nmax by (instance) (label_replace(kube_node_status_allocatable{cluster=\"$cluster\", resource=\"cpu\"}, \"instance\", \"$1\", \"node\", \"(.+)\"))\n* 100",
           "legendFormat": "{{instance}}",
           "range": true,
           "refId": "A"
@@ -610,7 +610,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (instance) (container_memory_working_set_bytes{cluster=\"$cluster\", container!=\"\"})\n/ on(instance)\nmax by (instance) (label_replace(kube_node_status_allocatable{cluster=\"$cluster\", resource=\"memory\"}, \"instance\", \"$1\", \"node\", \"(.+)\"))\n* 100",
+          "expr": "sum by (instance) (container_memory_working_set_bytes{cluster=\"$cluster\", container!=\"\", container!=\"POD\"})\n/ on(instance)\nmax by (instance) (label_replace(kube_node_status_allocatable{cluster=\"$cluster\", resource=\"memory\"}, \"instance\", \"$1\", \"node\", \"(.+)\"))\n* 100",
           "legendFormat": "{{instance}}",
           "range": true,
           "refId": "A"
@@ -1227,7 +1227,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "topk(10, sum by (namespace) (rate(container_cpu_usage_seconds_total{cluster=\"$cluster\", namespace=~\"$hcp_namespace\", container!=\"\"}[5m])))",
+          "expr": "topk(10, sum by (namespace) (rate(container_cpu_usage_seconds_total{cluster=\"$cluster\", namespace=~\"$hcp_namespace\", container!=\"\", container!=\"POD\"}[5m])))",
           "legendFormat": "{{namespace}}",
           "range": true,
           "refId": "A"
@@ -1323,7 +1323,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "topk(10, sum by (namespace) (container_memory_working_set_bytes{cluster=\"$cluster\", namespace=~\"$hcp_namespace\", container!=\"\"}))",
+          "expr": "topk(10, sum by (namespace) (container_memory_working_set_bytes{cluster=\"$cluster\", namespace=~\"$hcp_namespace\", container!=\"\", container!=\"POD\"}))",
           "legendFormat": "{{namespace}}",
           "range": true,
           "refId": "A"

--- a/observability/grafana-dashboards/sre/user-journey/mgmt-cluster-triage.json
+++ b/observability/grafana-dashboards/sre/user-journey/mgmt-cluster-triage.json
@@ -637,7 +637,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Current count of containers whose last termination was OOMKilled, grouped by namespace (top 10)",
+      "description": "Current count of containers whose last termination was OOMKilled, grouped by namespace (top 10). Intentionally unscoped to show all namespaces including platform/system.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -736,7 +736,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Total pod container restarts per namespace in the last hour (top 10)",
+      "description": "Total pod container restarts per namespace in the last hour (top 10). Intentionally unscoped to show all namespaces including platform/system.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -835,7 +835,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Current count of pods in CrashLoopBackOff state by namespace (top 10)",
+      "description": "Current count of pods in CrashLoopBackOff state by namespace (top 10). Intentionally unscoped to show all namespaces including platform/system.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -934,7 +934,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Current count of pods in Pending phase by namespace (top 10)",
+      "description": "Current count of pods in Pending phase by namespace (top 10). Intentionally unscoped to show all namespaces including platform/system.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1033,7 +1033,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Current count of evicted pods by namespace (top 10)",
+      "description": "Current count of evicted pods by namespace (top 10). Intentionally unscoped to show all namespaces including platform/system.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1705,18 +1705,29 @@
         "type": "query"
       },
       {
-        "current": {
-          "text": "ocm-.*",
-          "value": "ocm-.*"
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
         },
-        "description": "Regex pattern for HCP namespaces (default: ocm-.*)",
+        "definition": "label_values(kube_pod_info{cluster=\"$cluster\"}, namespace)",
+        "description": "HCP namespaces on the selected management cluster",
         "hide": 0,
-        "label": "HCP Namespace Pattern",
+        "includeAll": true,
+        "label": "HCP Namespace",
+        "multi": true,
         "name": "hcp_namespace",
         "options": [],
-        "query": "ocm-.*",
+        "query": {
+          "qryType": 1,
+          "query": "label_values(kube_pod_info{cluster=\"$cluster\"}, namespace)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "^ocm-.*$",
         "skipUrlSync": false,
-        "type": "textbox"
+        "sort": 1,
+        "type": "query"
       }
     ]
   },

--- a/observability/grafana-dashboards/sre/user-journey/mgmt-cluster-triage.json
+++ b/observability/grafana-dashboards/sre/user-journey/mgmt-cluster-triage.json
@@ -506,7 +506,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (node) (label_replace(rate(container_cpu_usage_seconds_total{cluster=\"$cluster\", container!=\"\", container!=\"POD\"}[5m]), \"node\", \"$1\", \"instance\", \"(.+)\"))\n/ on(node)\nmax by (node) (kube_node_status_allocatable{cluster=\"$cluster\", resource=\"cpu\"})\n* 100",
+          "expr": "sum by (node) (label_replace(rate(container_cpu_usage_seconds_total{cluster=\"$cluster\", container!=\"\", container!=\"POD\"}[5m]), \"node\", \"$1\", \"instance\", \"([^:]+)(:.*)?\"))\n/ on(node)\nmax by (node) (kube_node_status_allocatable{cluster=\"$cluster\", resource=\"cpu\"})\n* 100",
           "legendFormat": "{{node}}",
           "range": true,
           "refId": "A"
@@ -610,7 +610,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (node) (label_replace(container_memory_working_set_bytes{cluster=\"$cluster\", container!=\"\", container!=\"POD\"}, \"node\", \"$1\", \"instance\", \"(.+)\"))\n/ on(node)\nmax by (node) (kube_node_status_allocatable{cluster=\"$cluster\", resource=\"memory\"})\n* 100",
+          "expr": "sum by (node) (label_replace(container_memory_working_set_bytes{cluster=\"$cluster\", container!=\"\", container!=\"POD\"}, \"node\", \"$1\", \"instance\", \"([^:]+)(:.*)?\"))\n/ on(node)\nmax by (node) (kube_node_status_allocatable{cluster=\"$cluster\", resource=\"memory\"})\n* 100",
           "legendFormat": "{{node}}",
           "range": true,
           "refId": "A"
@@ -1643,7 +1643,7 @@
     }
   ],
   "preload": false,
-  "refresh": "30s",
+  "refresh": "",
   "schemaVersion": 41,
   "tags": [
     "sre",
@@ -1710,7 +1710,7 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(kube_pod_info{cluster=\"$cluster\"}, namespace)",
+        "definition": "label_values(kube_pod_info{cluster=\"$cluster\", namespace=~\"ocm-.*\"}, namespace)",
         "description": "HCP namespaces on the selected management cluster",
         "hide": 0,
         "includeAll": true,
@@ -1720,11 +1720,11 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(kube_pod_info{cluster=\"$cluster\"}, namespace)",
+          "query": "label_values(kube_pod_info{cluster=\"$cluster\", namespace=~\"ocm-.*\"}, namespace)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
-        "regex": "^ocm-.*$",
+        "regex": "",
         "skipUrlSync": false,
         "sort": 1,
         "type": "query"


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-26980

### What

<!-- Briefly describe what this PR does -->

Adds a new Grafana Dashboard for basic resource utilization and top talker metrics for mgmt clusters.

### Why

<!-- Briefly explain why this change is needed -->

This will help the team identify noisy neighbors, problematic nodes or pods, and other basic metrics at a glance.

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

The Grafana dashboard was served locally first to confirm functionality. Then, it was tested against the arohcp-dev Grafana instance with a personal dev env (containing 5 HCPs) to confirm functionality of the queries.

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if graph/UI/metrics changes) - Please see [management_cluster_triage_3.pdf](https://github.com/user-attachments/files/28756921/management_cluster_triage_3.pdf)
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [x] All comment threads resolved before merge
