### PR TITLE
feat(e2e): onboard dev shard2 and shard3 customer subscriptions (ARO-27549)

### DIFF
--- a/config/config-dev-ci.yaml
+++ b/config/config-dev-ci.yaml
@@ -172,13 +172,13 @@ clouds:
               - westus3
               - centralus
               - canadacentral
-            - name: "ARO HCP E2E Hosted Clusters - Dev - 03"
+            - name: "ARO HCP E2E Hosted Clusters - Dev - 02"
               roleAssignmentLimit: 8000
               regions:
               - westus3
               - centralus
               - canadacentral
-            - name: "ARO HCP E2E Hosted Clusters - Dev - 00"
+            - name: "ARO HCP E2E Hosted Clusters - Dev - 03"
               roleAssignmentLimit: 8000
               regions:
               - westus3
@@ -227,9 +227,9 @@ clouds:
             id: "974ebd46-8ad3-41e3-afef-7ef25fd5c371"
           - name: "ARO HCP E2E Hosted Clusters 2 (EA Subscription)"
             id: "e8c5a115-842d-4d7e-98ad-cfb2c50b209e"
-          - name: "ARO HCP E2E Hosted Clusters - Dev - 03"
+          - name: "ARO HCP E2E Hosted Clusters - Dev - 02"
             id: "e627aa70-36a3-40b0-8e68-975269e39d7b"
-          - name: "ARO HCP E2E Hosted Clusters - Dev - 00"
+          - name: "ARO HCP E2E Hosted Clusters - Dev - 03"
             id: "6ed122d1-7e03-4a01-baae-9020abf350d4"
           sharedPrincipals:
             firstParty:

--- a/config/config-dev-ci.yaml
+++ b/config/config-dev-ci.yaml
@@ -215,6 +215,10 @@ clouds:
             id: "974ebd46-8ad3-41e3-afef-7ef25fd5c371"
           - name: "ARO HCP E2E Hosted Clusters 2 (EA Subscription)"
             id: "e8c5a115-842d-4d7e-98ad-cfb2c50b209e"
+          - name: "ARO HCP E2E Hosted Clusters - Dev - 03"
+            id: "e627aa70-36a3-40b0-8e68-975269e39d7b"
+          - name: "ARO HCP E2E Hosted Clusters - Dev - 00"
+            id: "6ed122d1-7e03-4a01-baae-9020abf350d4"
           sharedPrincipals:
             firstParty:
               principalId: "47f69502-0065-4d9a-b19b-d403e183d2f4"

--- a/config/config-dev-ci.yaml
+++ b/config/config-dev-ci.yaml
@@ -172,6 +172,18 @@ clouds:
               - westus3
               - centralus
               - canadacentral
+            - name: "ARO HCP E2E Hosted Clusters - Dev - 03"
+              roleAssignmentLimit: 8000
+              regions:
+              - westus3
+              - centralus
+              - canadacentral
+            - name: "ARO HCP E2E Hosted Clusters - Dev - 00"
+              roleAssignmentLimit: 8000
+              regions:
+              - westus3
+              - centralus
+              - canadacentral
             - name: "ARO HCP E2E Infrastructure (EA Subscription)"
               roleAssignmentLimit: 4000
               regions:

--- a/dev-infrastructure/openshift-ci/grant-openshift-release-bot-dev.sh
+++ b/dev-infrastructure/openshift-ci/grant-openshift-release-bot-dev.sh
@@ -5,7 +5,9 @@ APPLICATION_NAME="OpenShift Release Bot"
 SUBSCRIPTIONS=(
     "ARO HCP E2E Infrastructure (EA Subscription)"
     "ARO HCP E2E Hosted Clusters (EA Subscription)"
-    "ARO HCP E2E Management Clusters (EA Subscription)"
+    "ARO HCP E2E Hosted Clusters 2 (EA Subscription)"
+    "ARO HCP E2E Hosted Clusters - Dev - 02"
+    "ARO HCP E2E Hosted Clusters - Dev - 03"
     "ARO Hosted Control Planes (EA Subscription 1)"
 )
 GLOBAL_SUBSCRIPTION_NAME="ARO Hosted Control Planes (EA Subscription 1)"

--- a/docs/ci/dev-e2e-subscription-onboarding.md
+++ b/docs/ci/dev-e2e-subscription-onboarding.md
@@ -6,12 +6,15 @@ Today the canonical DEV slot inventory lives in `test/e2e-config/e2e-slots.yaml`
 
 ## What This Onboarding Touches
 
-Adding a new DEV customer subscription spans four different inventories:
+Adding a new DEV customer subscription spans seven different inventories:
 
 - the canonical slot catalog in this repository
 - the ARO-HCP-managed Boskos inventory in `openshift/release`
 - the cluster profile secret inventory outside this repository
+- the OpenShift Release Bot subscription grants
 - the standalone `dev-ci` bootstrap RBAC rollout
+- the tenant-quota collector subscription inventory
+- the periodic cleanup jobs in `openshift/release`
 
 It is not just a slot-catalog change.
 
@@ -67,13 +70,19 @@ For the current mixed-management model of the pooled MSI mock identities, see [C
      - `customer-shardN-subscription-name`
    - `N` must match the intended shard number and should remain stable once jobs depend on that mapping.
 
-4. Provision the slot-backed identity containers in the new subscription.
+4. Grant the OpenShift Release Bot access to the new subscription.
+   - Add the subscription name to the `SUBSCRIPTIONS` array in `dev-infrastructure/openshift-ci/grant-openshift-release-bot-dev.sh`.
+   - Run the script:
+     - `./dev-infrastructure/openshift-ci/grant-openshift-release-bot-dev.sh`
+   - This grants the CI service principal (`OpenShift Release Bot`) the necessary role assignments on the new subscription so that CI jobs can authenticate and create resources there.
+
+5. Provision the slot-backed identity containers in the new subscription.
    - Run:
      - `go run ./test/cmd/aro-hcp-tests slot-manager apply-identity-pool --environment dev`
    - The built `aro-hcp-tests` binary can be used instead of `go run` if preferred.
    - Verify that the deployment stacks and identity-container resource groups are created in the new subscription.
 
-5. Extend the DEV bootstrap RBAC inventory.
+6. Extend the DEV bootstrap RBAC inventory.
    - Add the subscription name and ID to `config/config-dev-ci.yaml` under `devCi.e2eSubscriptionRbac.customerSubscriptions`.
    - That list now feeds the `dev-ci` RBAC parameter templates directly, so a brand-new subscription does not require extra per-index template edits.
    - In a normal onboarding flow, `homeSubscription`, `sharedPrincipals`, and `msiMockPool.principals` should not need to change.
@@ -81,7 +90,20 @@ For the current mixed-management model of the pooled MSI mock identities, see [C
    - Run the rollout from the repo root:
      - `make dev-ci-e2e-subscription-rbac-local-run`
 
-6. Validate the end-to-end path.
+7. Register the new subscription in the tenant-quota collector.
+   - Add the subscription name to the `SUBSCRIPTIONS` array in `tooling/tenant-quota/scripts/manage-service-principals.sh` under the `setup_redhat()` function.
+   - Add the subscription to `config/config-dev-ci.yaml` under `devCi.tenantQuota.subscriptions` with the appropriate `roleAssignmentLimit` and `regions`.
+   - Run the script to grant the collector SP Reader access:
+     - `./tooling/tenant-quota/scripts/manage-service-principals.sh setup redhat`
+   - This ensures Azure quota (role assignments, compute, network) is monitored for the new subscription. See [CI Quota Monitoring](quota-monitoring.md).
+
+8. Add periodic cleanup jobs for the new subscription in `openshift/release`.
+   - In `ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__periodic-cleanup.yaml`, add a `delete-expired-dev-ci-shardN-resource-groups` periodic job targeting the new subscription.
+   - Set `CUSTOMER_SUBSCRIPTION` to the subscription display name and use the same `CLEANUP_MODE: no-rp`, cron schedule, and step reference (`aro-hcp-deprovision-expired-resource-groups`) as existing shard jobs. Since each job targets a different subscription, they can safely run at the same time.
+   - Run `make update` in the release checkout to regenerate Prow job manifests.
+   - See [openshift/release#80292](https://github.com/openshift/release/pull/80292) for a reference implementation.
+
+9. Validate the end-to-end path.
    - Confirm `slot-manager acquire` can resolve the new pool using the updated cluster profile inventory.
    - Run a DEV rehearsal expected to target the new shard.
    - Verify customer-resource creation in the new subscription succeeds without Azure `AuthorizationFailed` errors.
@@ -108,8 +130,13 @@ Those steps only become necessary if the shared identities or the Boskos-backed 
 - `dev-infrastructure/configurations/dev-operator-roles.tmpl.bicepparam`
 - `dev-infrastructure/configurations/mock-identity-roles.tmpl.bicepparam`
 - `dev-infrastructure/configurations/e2e-subscription-rbac-assignments.tmpl.bicepparam`
+- `dev-infrastructure/openshift-ci/grant-openshift-release-bot-dev.sh`
+- `tooling/tenant-quota/scripts/manage-service-principals.sh`
+- `openshift/release: ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__periodic-cleanup.yaml`
 - [Dev-CI Topology](dev-ci-topology.md)
 - [CI Identity Leasing](identity-leasing.md)
+- [CI Quota Monitoring](quota-monitoring.md)
+- [CI Cleanup](cleanup.md)
 
 ## See Also
 

--- a/test/e2e-config/e2e-slots.yaml
+++ b/test/e2e-config/e2e-slots.yaml
@@ -24,6 +24,26 @@ environments:
       slot_count: 15
       identity_container_prefix: aro-hcp-msi-container-dev-shard0
       identity_container_count: 20
+    # shard2: dedicated dev capacity on the third customer subscription.
+    # identity_container_count is higher than shard0/shard1 (40 vs 20) because this
+    # single-tenant subscription is sized to run the full DEV E2E suite in parallel.
+    - subscription_name: "ARO HCP E2E Hosted Clusters - Dev - 03"
+      region: westus3
+      region_mode: runtime-selected
+      resource_type: aro-hcp-dev-shard2-slot
+      slot_count: 1
+      identity_container_prefix: aro-hcp-msi-container-dev-shard2
+      identity_container_count: 40
+    # shard3: dedicated dev capacity on the fourth customer subscription.
+    # identity_container_count is higher than shard0/shard1 (40 vs 20) because this
+    # single-tenant subscription is sized to run the full DEV E2E suite in parallel.
+    - subscription_name: "ARO HCP E2E Hosted Clusters - Dev - 00"
+      region: westus3
+      region_mode: runtime-selected
+      resource_type: aro-hcp-dev-shard3-slot
+      slot_count: 1
+      identity_container_prefix: aro-hcp-msi-container-dev-shard3
+      identity_container_count: 40
 
 # int:
 #   deploy_envs:

--- a/test/e2e-config/e2e-slots.yaml
+++ b/test/e2e-config/e2e-slots.yaml
@@ -27,7 +27,7 @@ environments:
     # shard2: dedicated dev capacity on the third customer subscription.
     # identity_container_count is higher than shard0/shard1 (40 vs 20) because this
     # single-tenant subscription is sized to run the full DEV E2E suite in parallel.
-    - subscription_name: "ARO HCP E2E Hosted Clusters - Dev - 03"
+    - subscription_name: "ARO HCP E2E Hosted Clusters - Dev - 02"
       region: westus3
       region_mode: runtime-selected
       resource_type: aro-hcp-dev-shard2-slot
@@ -37,7 +37,7 @@ environments:
     # shard3: dedicated dev capacity on the fourth customer subscription.
     # identity_container_count is higher than shard0/shard1 (40 vs 20) because this
     # single-tenant subscription is sized to run the full DEV E2E suite in parallel.
-    - subscription_name: "ARO HCP E2E Hosted Clusters - Dev - 00"
+    - subscription_name: "ARO HCP E2E Hosted Clusters - Dev - 03"
       region: westus3
       region_mode: runtime-selected
       resource_type: aro-hcp-dev-shard3-slot

--- a/tooling/tenant-quota/scripts/manage-service-principals.sh
+++ b/tooling/tenant-quota/scripts/manage-service-principals.sh
@@ -111,8 +111,11 @@ setup_redhat() {
     local DIRECTORY_QUOTA=true
     local SUBSCRIPTIONS=(
         "ARO Hosted Control Planes (EA Subscription 1)"
-        "ARO HCP E2E Hosted Clusters (EA Subscription)"
         "ARO HCP E2E Infrastructure (EA Subscription)"
+        "ARO HCP E2E Hosted Clusters (EA Subscription)"
+        "ARO HCP E2E Hosted Clusters 2 (EA Subscription)"
+        "ARO HCP E2E Hosted Clusters - Dev - 02"
+        "ARO HCP E2E Hosted Clusters - Dev - 03"
         "ARO SRE Team - INT (EA Subscription 3)"
     )
 


### PR DESCRIPTION
[ARO-27549](https://redhat.atlassian.net/browse/ARO-27549)

### What

Onboards two new DEV E2E customer subscriptions into the slot-based fleet as `shard2` and `shard3`:

| Shard | Subscription | ID | slot_count |
| --- | --- | --- | --- |
| shard2 | `ARO HCP E2E Hosted Clusters - Dev - 02` | `e627aa70-36a3-40b0-8e68-975269e39d7b` | 1 |
| shard3 | `ARO HCP E2E Hosted Clusters - Dev - 03` | `6ed122d1-7e03-4a01-baae-9020abf350d4` | 1 |

> The subscription display names were realigned in Azure so the numeric suffix matches the shard they back (`shard2 -> Dev - 02`, `shard3 -> Dev - 03`). GUIDs are unchanged; only the display strings used for name-based resolution were updated.

- `test/e2e-config/e2e-slots.yaml`: adds `aro-hcp-dev-shard2-slot` and `aro-hcp-dev-shard3-slot` pools (westus3, `runtime-selected`, 40 identity containers each). The higher count (vs shard0/shard1's 20) is intentional — these dedicated subscriptions are sized to run the full E2E suite in parallel.
- `config/config-dev-ci.yaml`: adds both subscriptions to `devCi.e2eSubscriptionRbac.customerSubscriptions` so the dev-ci bootstrap RBAC templates grant the shared dev identities (first-party, ARM-helper, MSI-mock + pool) on both subscriptions.
- `config/config-dev-ci.yaml`: also registers both subscriptions in `tenantQuota.tenants[].subscriptions` with `roleAssignmentLimit: 8000` (vs the 4000 default) so the tenant-quota tool monitors RA usage from day one. The raised limit is tracked in [ARO-27560](https://issues.redhat.com/browse/ARO-27560).

These are brand-new subscriptions, so no `legacyAssignmentIdsBySubscription` adoption shim is required.

### Why

Adds dedicated DEV E2E capacity on two newly provisioned customer subscriptions (June 5 capacity meeting, epic ARO-25833; follows [ARO-27238](https://redhat.atlassian.net/browse/ARO-27238)). Without the slot pool + bootstrap grants, jobs cannot lease slots on these subscriptions and customer-resource creation fails with `AuthorizationFailed`.

### Testing

- `python3 -c "yaml.safe_load(...)"` on both edited files — valid.
- `make -C config validate` and `make -C config detect-change` pass (no materialized drift from the name realignment).
- Built `aro-hcp-tests` and regenerated the Boskos inventory in a fresh `openshift/release` checkout via `slot-manager sync-boskos-config` + `generate-boskos.py`; `slot-manager validate-boskos-config` passes. Companion PR: openshift/release adds `aro-hcp-dev-shard2-slot-00` / `aro-hcp-dev-shard3-slot-00`.
- Identity-pool provisioning (`apply-identity-pool`) and the dev-ci RBAC rollout (`make dev-ci-e2e-subscription-rbac-local-run`) are Azure-side operator steps run after the Boskos rollout merges; tracked on [ARO-27549](https://redhat.atlassian.net/browse/ARO-27549).

### Special notes for your reviewer

Follows `docs/ci/dev-e2e-subscription-onboarding.md`. The Boskos PR in `openshift/release` should merge and roll out before the Azure-side identity-pool and RBAC steps. The cluster-profile secret inventory (`customer-shardN-subscription-id/name`) and Azure quota/policy items from the Jira AC are handled outside this repo. Subscription resolution is by display name, so the realigned names above must match what the slot pools and tenant-quota collector reference (they do).

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
