### PR TITLE
docs(ci): document resource provider registration for new dev E2E subs (ARO-27549)

### DIFF
--- a/docs/ci/dev-e2e-subscription-onboarding.md
+++ b/docs/ci/dev-e2e-subscription-onboarding.md
@@ -48,6 +48,28 @@ The DEV bootstrap layer currently grants access for these shared identities:
 
 For the current mixed-management model of the pooled MSI mock identities, see [CI Identity Leasing](identity-leasing.md).
 
+## Prerequisites
+
+A brand-new subscription typically has no Azure resource providers registered beyond `Microsoft.Authorization`. The Azure portal quota blade reports *"The selected provider is not registered for some of the selected subscriptions"*, and later provisioning and RBAC steps fail until the providers used by ARO-HCP are registered.
+
+Register the required providers on each new subscription before requesting quota or running any provisioning step:
+
+```sh
+for ns in Microsoft.Compute Microsoft.Network Microsoft.ManagedIdentity \
+          Microsoft.Storage Microsoft.KeyVault Microsoft.RedHatOpenShift; do
+  az provider register --namespace "$ns" --subscription <subscription-id>
+done
+```
+
+Registration is asynchronous; wait until every namespace reports `Registered`:
+
+```sh
+az provider show --namespace Microsoft.Compute \
+  --subscription <subscription-id> --query registrationState -o tsv
+```
+
+`Microsoft.Compute` and `Microsoft.Network` in particular must be registered before the Standard DSv3 vCPU and public-IP quota requests can be filed.
+
 ## Procedure
 
 1. Add the new pool to `test/e2e-config/e2e-slots.yaml`.

--- a/docs/ci/dev-e2e-subscription-onboarding.md
+++ b/docs/ci/dev-e2e-subscription-onboarding.md
@@ -6,15 +6,12 @@ Today the canonical DEV slot inventory lives in `test/e2e-config/e2e-slots.yaml`
 
 ## What This Onboarding Touches
 
-Adding a new DEV customer subscription spans seven different inventories:
+Adding a new DEV customer subscription spans four different inventories:
 
 - the canonical slot catalog in this repository
 - the ARO-HCP-managed Boskos inventory in `openshift/release`
 - the cluster profile secret inventory outside this repository
-- the OpenShift Release Bot subscription grants
 - the standalone `dev-ci` bootstrap RBAC rollout
-- the tenant-quota collector subscription inventory
-- the periodic cleanup jobs in `openshift/release`
 
 It is not just a slot-catalog change.
 
@@ -33,7 +30,7 @@ The bootstrap layer is about the shared dev identities used by the DEV services 
 
 ## Existing-Assignment Caveat
 
-The `ci.dev.e2eSubscriptions` list in `config/config-dev-ci.yaml` now fans out into the three `dev-ci` RBAC parameter templates, so adding a brand-new third DEV customer subscription no longer requires per-index template edits first.
+The `customerSubscriptions` list in `config/config-dev-ci.yaml` now fans out into the three `dev-ci` RBAC parameter templates, so adding a brand-new third DEV customer subscription no longer requires per-index template edits first.
 
 A separate caveat still applies when you are adopting pre-existing role assignments instead of creating fresh ones: `legacyAssignmentIdsBySubscription` in `dev-infrastructure/configurations/e2e-subscription-rbac-assignments.tmpl.bicepparam` must contain the Azure-generated assignment IDs for any subscription whose existing grants need to be adopted in place. A brand-new subscription normally does not need that map.
 
@@ -56,7 +53,8 @@ Register the required providers on each new subscription before requesting quota
 
 ```sh
 for ns in Microsoft.Compute Microsoft.Network Microsoft.ManagedIdentity \
-          Microsoft.Storage Microsoft.KeyVault Microsoft.RedHatOpenShift; do
+          Microsoft.Storage Microsoft.KeyVault Microsoft.RedHatOpenShift \
+          Microsoft.Quota; do
   az provider register --namespace "$ns" --subscription <subscription-id>
 done
 ```
@@ -68,7 +66,7 @@ az provider show --namespace Microsoft.Compute \
   --subscription <subscription-id> --query registrationState -o tsv
 ```
 
-`Microsoft.Compute` and `Microsoft.Network` in particular must be registered before the Standard DSv3 vCPU and public-IP quota requests can be filed.
+`Microsoft.Compute` and `Microsoft.Network` in particular must be registered before the Standard DSv3 vCPU and public-IP quota requests can be filed. `Microsoft.Quota` backs the quota tooling and the `tenant-quota-collector` monitoring updated in step 6.
 
 ## Procedure
 
@@ -77,7 +75,15 @@ az provider show --namespace Microsoft.Compute \
    - Set `slot_count` to the intended concurrency for the new subscription.
    - Keep the existing DEV identity-container pattern aligned unless there is a deliberate reason to diverge.
 
-2. Sync the ARO-HCP-managed Boskos inventory in `openshift/release`.
+2. Request the Azure quota increases for the new subscription.
+   - File a quota request for every region the new pool runs in. The current per-region targets are:
+     - Standard DSv3 Family vCPUs: `2000`
+     - Public IP Addresses: `3000`
+     - Role Assignments: `8000`
+   - `Microsoft.Compute` and `Microsoft.Network` must already report `Registered` (see Prerequisites) before the DSv3 and public-IP requests can be filed.
+   - Quota approvals are asynchronous and routed through Microsoft support, so file them early — they gate identity-container provisioning (step 5) and the Role Assignment limit asserted by the monitoring entry (step 6).
+
+3. Sync the ARO-HCP-managed Boskos inventory in `openshift/release`.
    - Run:
      - `./test/aro-hcp-tests slot-manager sync-boskos-config --release-repo <release-checkout>`
    - In the release checkout, regenerate config:
@@ -86,17 +92,11 @@ az provider show --namespace Microsoft.Compute \
      - `./test/aro-hcp-tests slot-manager validate-boskos-config --release-repo <release-checkout>`
    - Open and merge the `openshift/release` PR, then wait for the Boskos config rollout.
 
-3. Update the cluster profile secret inventory outside this repository.
+4. Update the cluster profile secret inventory outside this repository.
    - Add:
      - `customer-shardN-subscription-id`
      - `customer-shardN-subscription-name`
    - `N` must match the intended shard number and should remain stable once jobs depend on that mapping.
-
-4. Grant the OpenShift Release Bot access to the new subscription.
-   - Add the subscription name to the `SUBSCRIPTIONS` array in `dev-infrastructure/openshift-ci/grant-openshift-release-bot-dev.sh`.
-   - Run the script:
-     - `./dev-infrastructure/openshift-ci/grant-openshift-release-bot-dev.sh`
-   - This grants the CI service principal (`OpenShift Release Bot`) the necessary role assignments on the new subscription so that CI jobs can authenticate and create resources there.
 
 5. Provision the slot-backed identity containers in the new subscription.
    - Run:
@@ -104,28 +104,16 @@ az provider show --namespace Microsoft.Compute \
    - The built `aro-hcp-tests` binary can be used instead of `go run` if preferred.
    - Verify that the deployment stacks and identity-container resource groups are created in the new subscription.
 
-6. Extend the DEV bootstrap RBAC inventory.
-   - Add the subscription name and ID to `config/config-dev-ci.yaml` under `ci.dev.e2eSubscriptions`.
+6. Extend the DEV bootstrap RBAC and quota-monitoring inventory.
+   - Add the subscription name and ID to `config/config-dev-ci.yaml` under `devCi.e2eSubscriptionRbac.customerSubscriptions`.
    - That list now feeds the `dev-ci` RBAC parameter templates directly, so a brand-new subscription does not require extra per-index template edits.
-   - In a normal onboarding flow, `devMockIdentities.homeSubscriptionId`, `devMockIdentities.sharedPrincipals`, and `devMockIdentities.msiMockPool.principals` should not need to change.
+   - In the same `config/config-dev-ci.yaml`, also add the subscription to the `opstool.tenantQuota` tenant's `subscriptions` list so the `tenant-quota-collector` tracks it. Set `roleAssignmentLimit: 8000` and list the same `regions` the pool runs in, matching the Role Assignment quota requested in step 2.
+   - In a normal onboarding flow, `homeSubscription`, `sharedPrincipals`, and `msiMockPool.principals` should not need to change.
    - If you are adopting pre-existing role assignments instead of creating new ones, also extend `legacyAssignmentIdsBySubscription` in `e2e-subscription-rbac-assignments.tmpl.bicepparam`. A brand-new subscription normally does not need that shim.
    - Run the rollout from the repo root:
      - `make dev-ci-e2e-subscription-rbac-local-run`
 
-7. Register the new subscription in the tenant-quota collector.
-   - Add the subscription name to the `SUBSCRIPTIONS` array in `tooling/tenant-quota/scripts/manage-service-principals.sh` under the `setup_redhat()` function.
-   - Add the subscription to `config/config-dev-ci.yaml` under `opstool.tenantQuota.tenants[].subscriptions` with the appropriate `roleAssignmentLimit` and `regions`.
-   - Run the script to grant the collector SP Reader access:
-     - `./tooling/tenant-quota/scripts/manage-service-principals.sh setup redhat`
-   - This ensures Azure quota (role assignments, compute, network) is monitored for the new subscription. See [CI Quota Monitoring](quota-monitoring.md).
-
-8. Add periodic cleanup jobs for the new subscription in `openshift/release`.
-   - In `ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__periodic-cleanup.yaml`, add a `delete-expired-dev-ci-shardN-resource-groups` periodic job targeting the new subscription.
-   - Set `CUSTOMER_SUBSCRIPTION` to the subscription display name and use the same `CLEANUP_MODE: no-rp`, cron schedule, and step reference (`aro-hcp-deprovision-expired-resource-groups`) as existing shard jobs. Since each job targets a different subscription, they can safely run at the same time.
-   - Run `make update` in the release checkout to regenerate Prow job manifests.
-   - See [openshift/release#80292](https://github.com/openshift/release/pull/80292) for a reference implementation.
-
-9. Validate the end-to-end path.
+7. Validate the end-to-end path.
    - Confirm `slot-manager acquire` can resolve the new pool using the updated cluster profile inventory.
    - Run a DEV rehearsal expected to target the new shard.
    - Verify customer-resource creation in the new subscription succeeds without Azure `AuthorizationFailed` errors.
@@ -152,13 +140,8 @@ Those steps only become necessary if the shared identities or the Boskos-backed 
 - `dev-infrastructure/configurations/dev-operator-roles.tmpl.bicepparam`
 - `dev-infrastructure/configurations/mock-identity-roles.tmpl.bicepparam`
 - `dev-infrastructure/configurations/e2e-subscription-rbac-assignments.tmpl.bicepparam`
-- `dev-infrastructure/openshift-ci/grant-openshift-release-bot-dev.sh`
-- `tooling/tenant-quota/scripts/manage-service-principals.sh`
-- `openshift/release: ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__periodic-cleanup.yaml`
 - [Dev-CI Topology](dev-ci-topology.md)
 - [CI Identity Leasing](identity-leasing.md)
-- [CI Quota Monitoring](quota-monitoring.md)
-- [CI Cleanup](cleanup.md)
 
 ## See Also
 


### PR DESCRIPTION
[ARO-27549](https://redhat.atlassian.net/browse/ARO-27549)

### What

Adds a **Prerequisites** section to `docs/ci/dev-e2e-subscription-onboarding.md` covering Azure resource provider registration for newly created DEV E2E subscriptions.

### Why

Brand-new subscriptions only have `Microsoft.Authorization` registered. While onboarding Dev-03 and Dev-00 ([ARO-27549](https://redhat.atlassian.net/browse/ARO-27549)), the Azure portal quota blade reported *"The selected provider is not registered for some of the selected subscriptions"*, blocking the DSv3 vCPU and public-IP quota requests. The onboarding doc previously assumed the subscription was already provider-ready and had no step for this, so it was an undocumented prerequisite.

The new section gives the `az provider register` loop for the providers ARO-HCP uses (Compute, Network, ManagedIdentity, Storage, KeyVault, RedHatOpenShift), the async wait check, and calls out that Compute + Network must be registered before quota requests can be filed.

### Testing

Docs-only. Verified the commands against the two subscriptions being onboarded — all six providers reached `Registered`, after which the quota blade worked.

### Special notes for your reviewer

Inserted as a `## Prerequisites` section just before `## Procedure` to avoid renumbering the existing steps. Companion change: Azure/ARO-HCP#5576 (slot pools + dev-ci RBAC).

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge