### PR TITLE
feat(e2e): onboard Prod-00 + Prod-01 subscriptions and activate prod slot pool (ARO-27547)

### DIFF
--- a/config/config-dev-ci.yaml
+++ b/config/config-dev-ci.yaml
@@ -182,6 +182,14 @@ clouds:
               roleAssignmentLimit: 4000
               regions:
               - uksouth
+            - name: "ARO HCP E2E Hosted Clusters - Prod - 00"
+              roleAssignmentLimit: 8000
+              regions:
+              - westus3
+            - name: "ARO HCP E2E Hosted Clusters - Prod - 01"
+              roleAssignmentLimit: 8000
+              regions:
+              - westus3
           # Test Test Azure Red Hat OpenShift (Microsoft E2E tenant); directory quota off — subscription ARM only.
           - tenantId: "93b21e64-4824-439a-b893-46c9b2a51082"
             tenantName: "TestTestARO"

--- a/test/e2e-config/e2e-slots.yaml
+++ b/test/e2e-config/e2e-slots.yaml
@@ -49,14 +49,26 @@ environments:
 #       identity_container_prefix: aro-hcp-msi-container-stg
 #       identity_container_count: 30
 
-# prod:
-#   deploy_envs:
-#     - prod
-#   pools:
-#     - subscription_name: "ARO HCP E2E"
-#       region: uksouth
-#       region_mode: runtime-selected
-#       resource_type: aro-hcp-prod-shard0-slot
-#       slot_count: 1
-#       identity_container_prefix: aro-hcp-msi-container-prod
-#       identity_container_count: 15
+  prod:
+    deploy_envs:
+    - prod
+    pools:
+    # shard0: Prod-00 customer subscription. Jobs choose the runtime region;
+    # `region` is only the default when no runtime override is provided.
+    # identity_container_count set to 40 (matching Stage-00) so a single-slot
+    # pool can run the full E2E suite in parallel.
+    - subscription_name: "ARO HCP E2E Hosted Clusters - Prod - 00"
+      region: westus3
+      region_mode: runtime-selected
+      resource_type: aro-hcp-prod-shard0-slot
+      slot_count: 1
+      identity_container_prefix: aro-hcp-msi-container-prod-shard0
+      identity_container_count: 40
+    # shard1: Prod-01 customer subscription for additional prod capacity.
+    - subscription_name: "ARO HCP E2E Hosted Clusters - Prod - 01"
+      region: westus3
+      region_mode: runtime-selected
+      resource_type: aro-hcp-prod-shard1-slot
+      slot_count: 1
+      identity_container_prefix: aro-hcp-msi-container-prod-shard1
+      identity_container_count: 40

--- a/test/e2e-config/e2e-slots.yaml
+++ b/test/e2e-config/e2e-slots.yaml
@@ -24,30 +24,28 @@ environments:
       slot_count: 15
       identity_container_prefix: aro-hcp-msi-container-dev-shard0
       identity_container_count: 20
-
-# int:
-#   deploy_envs:
-#     - int
-#   pools:
-#     - subscription_name: "ARO SRE Team - INT (EA Subscription 3)"
-#       region: uksouth
-#       region_mode: fixed
-#       resource_type: aro-hcp-int-uksouth-slot
-#       slot_count: 1
-#       identity_container_prefix: aro-hcp-msi-container-int
-#       identity_container_count: 20
-
-# stg:
-#   deploy_envs:
-#     - stg
-#   pools:
-#     - subscription_name: "ARO HCP E2E - Staging"
-#       region: uksouth
-#       region_mode: fixed
-#       resource_type: aro-hcp-stg-uksouth-slot
-#       slot_count: 1
-#       identity_container_prefix: aro-hcp-msi-container-stg
-#       identity_container_count: 30
+      # int:
+      #   deploy_envs:
+      #     - int
+      #   pools:
+      #     - subscription_name: "ARO SRE Team - INT (EA Subscription 3)"
+      #       region: uksouth
+      #       region_mode: fixed
+      #       resource_type: aro-hcp-int-uksouth-slot
+      #       slot_count: 1
+      #       identity_container_prefix: aro-hcp-msi-container-int
+      #       identity_container_count: 20
+  # stg:
+  #   deploy_envs:
+  #     - stg
+  #   pools:
+  #     - subscription_name: "ARO HCP E2E - Staging"
+  #       region: uksouth
+  #       region_mode: fixed
+  #       resource_type: aro-hcp-stg-uksouth-slot
+  #       slot_count: 1
+  #       identity_container_prefix: aro-hcp-msi-container-stg
+  #       identity_container_count: 30
 
   prod:
     deploy_envs:


### PR DESCRIPTION
[ARO-27547](https://redhat.atlassian.net/browse/ARO-27547)

### What

Activates the `prod` slot environment by onboarding the two new dedicated **Prod** customer subscriptions:

- `test/e2e-config/e2e-slots.yaml`: uncomment and activate the `prod` environment block with two pools:
  - **shard0** → `ARO HCP E2E Hosted Clusters - Prod - 00` (`8d696692-794f-4cdb-ba25-9250c9e9ec4c`)
  - **shard1** → `ARO HCP E2E Hosted Clusters - Prod - 01` (`ec435068-e722-475f-8504-c91b72a5dc51`)

  Both use `region_mode: runtime-selected` (default `westus3`), `slot_count: 1`, and `identity_container_count: 40`.
- `config/config-dev-ci.yaml`: add both Prod subscriptions to the `RedHat0` tenant `tenantQuota` subscriptions (`roleAssignmentLimit: 8000`, region `westus3`) for quota monitoring.

### Why

Prod E2E needs dedicated Red Hat EA subscriptions with a managed quota-escalation path, mirroring the DEV/Stage setup. Two shards provide additional parallel prod capacity across the two customer subscriptions.

`identity_container_count: 40` matches **Stage-00** (PR #5579). Both prod pools are single-slot (`slot_count: 1`), like Stage — all parallelism comes from containers within the one slot, so 40 is needed to run the full E2E suite in parallel against a single shard. (The DEV shard0/shard1 pools use 20 because they have 7–15 slots and spread parallelism across slots — a different topology.)

### Testing

- `cd config; make materialize` — no rendered-config diff (tenantQuota is runtime-consumed, consistent with the Stage-00 PR #5579).
- `apply-identity-pool --environment prod` — **run and verified**; deployment stacks `succeeded` on both subs with 40 containers each:
  - `aro-hcp-slot-msi-pool-aro-hcp-prod-shard0-slot-00` (Prod-00) → `succeeded`
  - `aro-hcp-slot-msi-pool-aro-hcp-prod-shard1-slot-00` (Prod-01) → `succeeded`
- Providers registered on both subs (Compute, Network, ManagedIdentity, Storage, KeyVault, RedHatOpenShift, Quota).

### Special notes for your reviewer

- **tenantQuota region**: I used `westus3` (the identity-provisioning region) for both entries, mirroring the existing DEV shard0/shard1 entries which also list only `westus3` despite running `runtime-selected`. The onboarding handoff mentioned "all 9 prod regions" — that refers to per-region VM/PubIP quota, not the `tenantQuota` role-assignment tracking which follows the provisioning region. Flagging in case reviewers prefer the full region list here.
- **Draft**: the companion openshift/release PR (switch `prod-e2e-parallel*` jobs from `aro-hcp-prod-quota-slice` static leases to the `aro-hcp-persistent-e2e` workflow + Boskos slot pool) is **not yet created**. Also pending: RA 8000 tickets ([ARO-27555](https://redhat.atlassian.net/browse/ARO-27555)), DSv3 support tickets, and EUAP onboarding ([ARO-27665](https://redhat.atlassian.net/browse/ARO-27665)). Keeping this as a draft until the companion PR lands.

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
