### PR TITLE
update component images, hold back MCE/ACM bundles

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -118,7 +118,7 @@ defaults:
       image:
         registry: mcr.microsoft.com
         repository: oss/v2/fluent/fluent-bit
-        digest: sha256:8544418cd26754f68d1ef13e98d77357e3b5bf9d88f1b93a7b400152fb58ae05 # v5.0.4 (2026-05-21 21:36)
+        digest: sha256:f1bd17579ed4044d7d06a404aeb6d7662510de6e57e695dba36cc5cc679f1a40 # v5.0.4 (2026-06-09 10:56)
       resources:
         requests:
           cpu: 100m
@@ -167,7 +167,7 @@ defaults:
     image:
       registry: arohcpsvcdev.azurecr.io
       repository: arohcpmetrics
-      digest: sha256:2476efd096b031e1fd98bec5f028cd358022523342f00316d05d36247c4189ae # 7d5b858 (2026-06-08 14:11)
+      digest: sha256:81912673248ea41c42502d9ff50c0a57e8f542d5a0a4fed28489a47e40276c15 # fecedb7 (2026-06-10 02:54)
   # Mgmt Agent Controller
   mgmtAgent:
     managedIdentityName: mgmt-agent
@@ -317,7 +317,7 @@ defaults:
     image:
       registry: quay.io
       repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
-      digest: sha256:caea1a9e4d7cd7b270dc1b28895b571a44fbcb6b97c810683764a0f247ab13cf # a101e6697af02eba43e6cfd04fc4c00277b72a64 (2026-06-05 23:06)
+      digest: sha256:c8b031e426ae224d5bebca597d0deaab1fb62060d20d1dc150cd581cc6381f4c # 832b8480e72020b3d6d6477e7aba90c7c2f2ddfb (2026-06-09 16:41)
     namespace: hypershift
     additionalInstallArg: '--enable-cpo-overrides'
     # By default we set it to empty as this tag is only required for msft environments. We override
@@ -947,7 +947,7 @@ defaults:
     image:
       registry: quay.io
       repository: app-sre/aro-hcp-clusters-service
-      digest: sha256:31fe1839cc3bd62fad4d9f5848f1269f3083c33686c328904a182a5011b4e4ff # f285788692fa9198f37cd298760832ed5b7b8b0e (2026-06-05 15:56)
+      digest: sha256:0e369c753925e8d18e47ed45c9f70bf68cf35e0b833794fda8c7212cc298d006 # dcb97edc3a5de24cbaf1c8593a923b7fa94dac23 (2026-06-09 15:40)
     # controls how many HCPs can be placed on an MC, sadly not configurable per MC
     provisionShardClusterLimit: 100
     provisionShardStatus: active
@@ -1007,7 +1007,7 @@ defaults:
       image:
         registry: arohcpsvcdev.azurecr.io
         repository: image-sync/oc-mirror
-        digest: sha256:883eae8e2c6d90a1c754ae7c75183812bf47437cfbb37a7c1d9fa84213280aa4 # 7d5b858 (2026-06-08 14:12)
+        digest: sha256:bd75091889a904335a6b6ff81bc425a514620351773674ec2b72e21de965d99e # fecedb7 (2026-06-10 02:55)
       pullSecretName: ocmirror-pull-secret
       operatorVersionsToMirror: "4.18,4.19,4.20,4.21,4.22"
   # Automation Account

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -65,7 +65,7 @@ armHelperTenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
 arobit:
   forwarder:
     image:
-      digest: sha256:8544418cd26754f68d1ef13e98d77357e3b5bf9d88f1b93a7b400152fb58ae05
+      digest: sha256:f1bd17579ed4044d7d06a404aeb6d7662510de6e57e695dba36cc5cc679f1a40
       registry: mcr.microsoft.com
       repository: oss/v2/fluent/fluent-bit
     resources:
@@ -164,7 +164,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpci00
   image:
-    digest: sha256:31fe1839cc3bd62fad4d9f5848f1269f3083c33686c328904a182a5011b4e4ff
+    digest: sha256:0e369c753925e8d18e47ed45c9f70bf68cf35e0b833794fda8c7212cc298d006
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:
@@ -207,7 +207,7 @@ clustersService:
 customExporter:
   enabledCollectors: service-tag-usage,kusto-logs-current
   image:
-    digest: sha256:2476efd096b031e1fd98bec5f028cd358022523342f00316d05d36247c4189ae
+    digest: sha256:81912673248ea41c42502d9ff50c0a57e8f542d5a0a4fed28489a47e40276c15
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpmetrics
   k8s:
@@ -423,7 +423,7 @@ hcpRecovery:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides
   image:
-    digest: sha256:caea1a9e4d7cd7b270dc1b28895b571a44fbcb6b97c810683764a0f247ab13cf
+    digest: sha256:c8b031e426ae224d5bebca597d0deaab1fb62060d20d1dc150cd581cc6381f4c
     registry: quay.io
     repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
   limitClusterSizes: true
@@ -441,7 +441,7 @@ imageSync:
   ocMirror:
     enabled: true
     image:
-      digest: sha256:883eae8e2c6d90a1c754ae7c75183812bf47437cfbb37a7c1d9fa84213280aa4
+      digest: sha256:bd75091889a904335a6b6ff81bc425a514620351773674ec2b72e21de965d99e
       registry: arohcpsvcdev.azurecr.io
       repository: image-sync/oc-mirror
     jobNamePrefix: ""

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -65,7 +65,7 @@ armHelperTenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
 arobit:
   forwarder:
     image:
-      digest: sha256:8544418cd26754f68d1ef13e98d77357e3b5bf9d88f1b93a7b400152fb58ae05
+      digest: sha256:f1bd17579ed4044d7d06a404aeb6d7662510de6e57e695dba36cc5cc679f1a40
       registry: mcr.microsoft.com
       repository: oss/v2/fluent/fluent-bit
     resources:
@@ -164,7 +164,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpci01
   image:
-    digest: sha256:31fe1839cc3bd62fad4d9f5848f1269f3083c33686c328904a182a5011b4e4ff
+    digest: sha256:0e369c753925e8d18e47ed45c9f70bf68cf35e0b833794fda8c7212cc298d006
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:
@@ -207,7 +207,7 @@ clustersService:
 customExporter:
   enabledCollectors: service-tag-usage,kusto-logs-current
   image:
-    digest: sha256:2476efd096b031e1fd98bec5f028cd358022523342f00316d05d36247c4189ae
+    digest: sha256:81912673248ea41c42502d9ff50c0a57e8f542d5a0a4fed28489a47e40276c15
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpmetrics
   k8s:
@@ -423,7 +423,7 @@ hcpRecovery:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides
   image:
-    digest: sha256:caea1a9e4d7cd7b270dc1b28895b571a44fbcb6b97c810683764a0f247ab13cf
+    digest: sha256:c8b031e426ae224d5bebca597d0deaab1fb62060d20d1dc150cd581cc6381f4c
     registry: quay.io
     repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
   limitClusterSizes: true
@@ -441,7 +441,7 @@ imageSync:
   ocMirror:
     enabled: true
     image:
-      digest: sha256:883eae8e2c6d90a1c754ae7c75183812bf47437cfbb37a7c1d9fa84213280aa4
+      digest: sha256:bd75091889a904335a6b6ff81bc425a514620351773674ec2b72e21de965d99e
       registry: arohcpsvcdev.azurecr.io
       repository: image-sync/oc-mirror
     jobNamePrefix: ""

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -65,7 +65,7 @@ armHelperTenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
 arobit:
   forwarder:
     image:
-      digest: sha256:8544418cd26754f68d1ef13e98d77357e3b5bf9d88f1b93a7b400152fb58ae05
+      digest: sha256:f1bd17579ed4044d7d06a404aeb6d7662510de6e57e695dba36cc5cc679f1a40
       registry: mcr.microsoft.com
       repository: oss/v2/fluent/fluent-bit
     resources:
@@ -164,7 +164,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpcspr
   image:
-    digest: sha256:31fe1839cc3bd62fad4d9f5848f1269f3083c33686c328904a182a5011b4e4ff
+    digest: sha256:0e369c753925e8d18e47ed45c9f70bf68cf35e0b833794fda8c7212cc298d006
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:
@@ -207,7 +207,7 @@ clustersService:
 customExporter:
   enabledCollectors: service-tag-usage,kusto-logs-current
   image:
-    digest: sha256:2476efd096b031e1fd98bec5f028cd358022523342f00316d05d36247c4189ae
+    digest: sha256:81912673248ea41c42502d9ff50c0a57e8f542d5a0a4fed28489a47e40276c15
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpmetrics
   k8s:
@@ -423,7 +423,7 @@ hcpRecovery:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides
   image:
-    digest: sha256:caea1a9e4d7cd7b270dc1b28895b571a44fbcb6b97c810683764a0f247ab13cf
+    digest: sha256:c8b031e426ae224d5bebca597d0deaab1fb62060d20d1dc150cd581cc6381f4c
     registry: quay.io
     repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
   limitClusterSizes: true
@@ -441,7 +441,7 @@ imageSync:
   ocMirror:
     enabled: true
     image:
-      digest: sha256:883eae8e2c6d90a1c754ae7c75183812bf47437cfbb37a7c1d9fa84213280aa4
+      digest: sha256:bd75091889a904335a6b6ff81bc425a514620351773674ec2b72e21de965d99e
       registry: arohcpsvcdev.azurecr.io
       repository: image-sync/oc-mirror
     jobNamePrefix: ""

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -65,7 +65,7 @@ armHelperTenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
 arobit:
   forwarder:
     image:
-      digest: sha256:8544418cd26754f68d1ef13e98d77357e3b5bf9d88f1b93a7b400152fb58ae05
+      digest: sha256:f1bd17579ed4044d7d06a404aeb6d7662510de6e57e695dba36cc5cc679f1a40
       registry: mcr.microsoft.com
       repository: oss/v2/fluent/fluent-bit
     resources:
@@ -164,7 +164,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpdev
   image:
-    digest: sha256:31fe1839cc3bd62fad4d9f5848f1269f3083c33686c328904a182a5011b4e4ff
+    digest: sha256:0e369c753925e8d18e47ed45c9f70bf68cf35e0b833794fda8c7212cc298d006
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:
@@ -207,7 +207,7 @@ clustersService:
 customExporter:
   enabledCollectors: service-tag-usage,kusto-logs-current
   image:
-    digest: sha256:2476efd096b031e1fd98bec5f028cd358022523342f00316d05d36247c4189ae
+    digest: sha256:81912673248ea41c42502d9ff50c0a57e8f542d5a0a4fed28489a47e40276c15
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpmetrics
   k8s:
@@ -423,7 +423,7 @@ hcpRecovery:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides
   image:
-    digest: sha256:caea1a9e4d7cd7b270dc1b28895b571a44fbcb6b97c810683764a0f247ab13cf
+    digest: sha256:c8b031e426ae224d5bebca597d0deaab1fb62060d20d1dc150cd581cc6381f4c
     registry: quay.io
     repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
   limitClusterSizes: true
@@ -441,7 +441,7 @@ imageSync:
   ocMirror:
     enabled: true
     image:
-      digest: sha256:883eae8e2c6d90a1c754ae7c75183812bf47437cfbb37a7c1d9fa84213280aa4
+      digest: sha256:bd75091889a904335a6b6ff81bc425a514620351773674ec2b72e21de965d99e
       registry: arohcpsvcdev.azurecr.io
       repository: image-sync/oc-mirror
     jobNamePrefix: ""

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -65,7 +65,7 @@ armHelperTenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
 arobit:
   forwarder:
     image:
-      digest: sha256:8544418cd26754f68d1ef13e98d77357e3b5bf9d88f1b93a7b400152fb58ae05
+      digest: sha256:f1bd17579ed4044d7d06a404aeb6d7662510de6e57e695dba36cc5cc679f1a40
       registry: mcr.microsoft.com
       repository: oss/v2/fluent/fluent-bit
     resources:
@@ -164,7 +164,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpperf
   image:
-    digest: sha256:31fe1839cc3bd62fad4d9f5848f1269f3083c33686c328904a182a5011b4e4ff
+    digest: sha256:0e369c753925e8d18e47ed45c9f70bf68cf35e0b833794fda8c7212cc298d006
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:
@@ -207,7 +207,7 @@ clustersService:
 customExporter:
   enabledCollectors: service-tag-usage,kusto-logs-current
   image:
-    digest: sha256:2476efd096b031e1fd98bec5f028cd358022523342f00316d05d36247c4189ae
+    digest: sha256:81912673248ea41c42502d9ff50c0a57e8f542d5a0a4fed28489a47e40276c15
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpmetrics
   k8s:
@@ -423,7 +423,7 @@ hcpRecovery:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides
   image:
-    digest: sha256:caea1a9e4d7cd7b270dc1b28895b571a44fbcb6b97c810683764a0f247ab13cf
+    digest: sha256:c8b031e426ae224d5bebca597d0deaab1fb62060d20d1dc150cd581cc6381f4c
     registry: quay.io
     repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
   limitClusterSizes: true
@@ -441,7 +441,7 @@ imageSync:
   ocMirror:
     enabled: true
     image:
-      digest: sha256:883eae8e2c6d90a1c754ae7c75183812bf47437cfbb37a7c1d9fa84213280aa4
+      digest: sha256:bd75091889a904335a6b6ff81bc425a514620351773674ec2b72e21de965d99e
       registry: arohcpsvcdev.azurecr.io
       repository: image-sync/oc-mirror
     jobNamePrefix: ""

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -65,7 +65,7 @@ armHelperTenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
 arobit:
   forwarder:
     image:
-      digest: sha256:8544418cd26754f68d1ef13e98d77357e3b5bf9d88f1b93a7b400152fb58ae05
+      digest: sha256:f1bd17579ed4044d7d06a404aeb6d7662510de6e57e695dba36cc5cc679f1a40
       registry: mcr.microsoft.com
       repository: oss/v2/fluent/fluent-bit
     resources:
@@ -164,7 +164,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcppers
   image:
-    digest: sha256:31fe1839cc3bd62fad4d9f5848f1269f3083c33686c328904a182a5011b4e4ff
+    digest: sha256:0e369c753925e8d18e47ed45c9f70bf68cf35e0b833794fda8c7212cc298d006
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:
@@ -207,7 +207,7 @@ clustersService:
 customExporter:
   enabledCollectors: service-tag-usage,kusto-logs-current
   image:
-    digest: sha256:2476efd096b031e1fd98bec5f028cd358022523342f00316d05d36247c4189ae
+    digest: sha256:81912673248ea41c42502d9ff50c0a57e8f542d5a0a4fed28489a47e40276c15
     registry: arohcpsvcdev.azurecr.io
     repository: arohcpmetrics
   k8s:
@@ -423,7 +423,7 @@ hcpRecovery:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides
   image:
-    digest: sha256:caea1a9e4d7cd7b270dc1b28895b571a44fbcb6b97c810683764a0f247ab13cf
+    digest: sha256:c8b031e426ae224d5bebca597d0deaab1fb62060d20d1dc150cd581cc6381f4c
     registry: quay.io
     repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
   limitClusterSizes: true
@@ -441,7 +441,7 @@ imageSync:
   ocMirror:
     enabled: true
     image:
-      digest: sha256:883eae8e2c6d90a1c754ae7c75183812bf47437cfbb37a7c1d9fa84213280aa4
+      digest: sha256:bd75091889a904335a6b6ff81bc425a514620351773674ec2b72e21de965d99e
       registry: arohcpsvcdev.azurecr.io
       repository: image-sync/oc-mirror
     jobNamePrefix: ""

--- a/tooling/image-updater/config.yaml
+++ b/tooling/image-updater/config.yaml
@@ -79,7 +79,7 @@ images:
     group: hypershift-stack
     source:
       image: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
-      tagPattern: "^v\\d+\\.\\d+\\.\\d+-\\d+$"
+      tag: "v2.16.2-450" # PINNED: v2.16.2-452 has klusterlet registration regression
       repoVersionUpgrade:
         repoPrefix: "acm-operator-bundle-acm-"
     targets:
@@ -89,7 +89,7 @@ images:
     group: hypershift-stack
     source:
       image: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211
-      tagPattern: "^v\\d+\\.\\d+\\.\\d+-\\d+$"
+      tag: "v2.11.2-506" # PINNED: v2.11.2-508 has klusterlet registration regression
       repoVersionUpgrade:
         repoPrefix: "mce-operator-bundle-mce-"
     targets:


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-1145

## Summary

Update image digests for all components except MCE and ACM bundles, which are held back due to a klusterlet registration regression.

Automated image updater - https://github.com/Azure/ARO-HCP/pull/5565

| Name | Old Digest | New Digest | Tag | Date | Status |
| --- | --- | --- | --- | --- | --- |
| arobit-forwarder | 8544418cd267… | f1bd17579ed4… | v5.0.4 | 2026-06-09 10:56 | updated |
| aro-hcp-exporter | 2476efd096b0… | 81912673248e… | fecedb7 | 2026-06-10 02:54 | updated |
| hypershift | caea1a9e4d7c… | c8b031e426ae… | latest | 2026-06-09 16:41 | updated |
| clusters-service | 31fe1839cc3b… | 0e369c753925… | latest | 2026-06-09 15:40 | updated |
| imageSync | 883eae8e2c6d… | bd75091889a9… | fecedb7 | 2026-06-10 02:55 | updated |
| **acm-operator** | ea8fd7e65469… | — | **v2.16.2-450** | — | **held back** |
| **acm-mce** | beb1ebcf6243… | — | **v2.11.2-506** | — | **held back** |

### Why are MCE/ACM bundles held back?

MCE v2.11.2-508 has a **klusterlet registration regression** identified as the root cause of all 50 e2e test failures in PR #5565. The `external-managed-kubeconfig` secret is never created on the management cluster.

**Root cause from Kusto logs (scoped to our CI run's management cluster):**

1. HCP control plane bootstraps successfully — `ControlPlaneReady = True` at T+5:22
2. All components deployed by T+5:53
3. MCE klusterlet operator fails: `secrets "external-managed-kubeconfig" not found` — continuously for 14+ minutes
4. ManagedCluster stuck at `AvailableUnknown` — "connection check from managed cluster to hub has failed"
5. CS stays in `installing` → 20-min timeout → all tests fail

**18 of 18 clusters** on our management cluster hit this error with **zero recoveries** — a total failure of the registration flow.

ACM v2.16.2-452 is also held back since its addon controllers participate in the same registration flow.

## Test plan

- [ ] Verify e2e-parallel tests pass with MCE v2.11.2-506 / ACM v2.16.2-450
- [ ] Report registration regression to MCE/ACM team
- [ ] Re-enable MCE/ACM bundle updates after fix is confirmed upstream