### PR TITLE
test: improve poller timeout verbosity

### DIFF
--- a/test/e2e/cluster_authorized_cidrs_connectivity.go
+++ b/test/e2e/cluster_authorized_cidrs_connectivity.go
@@ -416,12 +416,13 @@ var _ = Describe("Authorized CIDRs", func() {
 				)
 				Expect(err).NotTo(HaveOccurred(), "failed to begin updating cluster %q authorized CIDRs", clusterName)
 
-				pollCtx, pollCancel := context.WithTimeout(ctx, 10*time.Minute)
+				const pollTimeout = 10 * time.Minute
+				pollCtx, pollCancel := context.WithTimeout(ctx, pollTimeout)
 				defer pollCancel()
 				_, err = poller.PollUntilDone(pollCtx, &runtime.PollUntilDoneOptions{
 					Frequency: framework.StandardPollInterval,
 				})
-				Expect(err).NotTo(HaveOccurred(), "failed to poll cluster %q authorized CIDRs update to completion", clusterName)
+				Expect(err).NotTo(HaveOccurred(), "failed to poll cluster %q authorized CIDRs update to completion (timeout '%f' minutes)", clusterName, pollTimeout.Minutes())
 
 				By("verifying VM is now blocked from API access")
 				output, err := framework.RunVMCommand(ctx, tc, *resourceGroup.Name, vmName, connectivityTest, 2*time.Minute)

--- a/test/e2e/clusters_sharing_resgroup.go
+++ b/test/e2e/clusters_sharing_resgroup.go
@@ -128,14 +128,14 @@ var _ = Describe("Customer", func() {
 			_, err = poller1.PollUntilDone(pollCtx, &runtime.PollUntilDoneOptions{
 				Frequency: framework.StandardPollInterval,
 			})
-			Expect(err).NotTo(HaveOccurred(), "failed to wait for first cluster %q to complete creation", customerClusterName)
+			Expect(err).NotTo(HaveOccurred(), "failed to wait for first cluster %q to complete creation (timeout '%f' minutes)", customerClusterName, framework.ClusterCreationTimeout.Minutes())
 
 			By("waiting for second cluster to complete creation")
 
 			_, err = poller2.PollUntilDone(pollCtx, &runtime.PollUntilDoneOptions{
 				Frequency: framework.StandardPollInterval,
 			})
-			Expect(err).NotTo(HaveOccurred(), "failed to wait for second cluster %q to complete creation", customerClusterName2)
+			Expect(err).NotTo(HaveOccurred(), "failed to wait for second cluster %q to complete creation (timeout '%f' minutes)", customerClusterName2, framework.ClusterCreationTimeout.Minutes())
 
 			// Third cluster (should fail)
 			By("creating customer infrastructure and managed identities for third cluster")

--- a/test/e2e/mise_routing.go
+++ b/test/e2e/mise_routing.go
@@ -139,7 +139,7 @@ var _ = Describe("MISE Routing", func() {
 			_, err = delPoller.PollUntilDone(delCtx, &runtime.PollUntilDoneOptions{
 				Frequency: framework.StandardPollInterval,
 			})
-			Expect(err).NotTo(HaveOccurred(), "failed to poll HCP cluster deletion to completion")
+			Expect(err).NotTo(HaveOccurred(), "failed to poll HCP cluster %q deletion (timeout '%f' minutes)", clusterParams.ClusterName, framework.HCPClusterDeletionTimeout.Minutes())
 
 			Expect(validator.mismatches).To(BeEmpty(), "x-ms-served-by header mismatches detected")
 			Expect(validator.requestCount).To(BeNumerically(">", 0), "expected at least one HCP API request")

--- a/test/e2e/shoebox_logs.go
+++ b/test/e2e/shoebox_logs.go
@@ -106,6 +106,8 @@ func pollVerifier(ctx context.Context, name string, verifier shoeboxLogVerifier,
 }
 
 func createStorageAccount(ctx context.Context, subscriptionID string, creds azcore.TokenCredential, resourceGroupName, location string) (*storageAccountResult, error) {
+	const pollTimeout = 10 * time.Minute
+
 	storageAccountName := "shoebox" + rand.String(6)
 
 	storageClient, err := armstorage.NewAccountsClient(subscriptionID, creds, nil)
@@ -124,13 +126,13 @@ func createStorageAccount(ctx context.Context, subscriptionID string, creds azco
 		return nil, fmt.Errorf("failed to begin storage account creation: %w", err)
 	}
 
-	pollCtx, pollCancel := context.WithTimeout(ctx, 10*time.Minute)
+	pollCtx, pollCancel := context.WithTimeout(ctx, pollTimeout)
 	defer pollCancel()
 	storageAccount, err := storagePoller.PollUntilDone(pollCtx, &runtime.PollUntilDoneOptions{
 		Frequency: 10 * time.Second,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create storage account: %w", err)
+		return nil, fmt.Errorf("failed to create storage account %s in resource group %s (timeout '%f' minutes): %w", storageAccountName, resourceGroupName, pollTimeout.Minutes(), err)
 	}
 
 	return &storageAccountResult{
@@ -150,6 +152,7 @@ func createEventHub(ctx context.Context, subscriptionID string, creds azcore.Tok
 		namespaceName = "shoebox-eh-ns"
 		hubName       = "shoebox-eh"
 		authRuleName  = "shoebox-eh-auth"
+		pollTimeout   = 10 * time.Minute
 	)
 
 	nsClient, err := armeventhub.NewNamespacesClient(subscriptionID, creds, nil)
@@ -168,13 +171,13 @@ func createEventHub(ctx context.Context, subscriptionID string, creds azcore.Tok
 		return nil, fmt.Errorf("failed to begin Event Hub namespace creation: %w", err)
 	}
 
-	pollCtx, pollCancel := context.WithTimeout(ctx, 10*time.Minute)
+	pollCtx, pollCancel := context.WithTimeout(ctx, pollTimeout)
 	defer pollCancel()
 	_, err = nsPoller.PollUntilDone(pollCtx, &runtime.PollUntilDoneOptions{
 		Frequency: 10 * time.Second,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create Event Hub namespace: %w", err)
+		return nil, fmt.Errorf("failed to create Event Hub namespace %s in resource group %s (timeout '%f' minutes): %w", namespaceName, resourceGroupName, pollTimeout.Minutes(), err)
 	}
 
 	hubClient, err := armeventhub.NewEventHubsClient(subscriptionID, creds, nil)


### PR DESCRIPTION
[ARO-27303](https://redhat.atlassian.net/browse/ARO-27303)

### What

Add logging to include exact timeout (and relevant resource names) in the error message.

4 test cases affected:

- test/e2e/cluster_authorized_cidrs_connectivity.go (auth CIDRs update timeout)
- test/e2e/clusters_sharing_resgroup.go (2x cluster creation timeout)
- test/e2e/mise_routing.go (cluster deletion timeout, clusterName)
- test/e2e/shoebox_logs.go (timeouts, storageAccountName, namespaceName, resourceGroupName)

### Why

1. Exact timeout value readable immediately from error message
2. Maintain consistency with timeout reporting in framework helpers (e.g. CreateHCPClusterFromParam20240610) for tests that call PollUntilDone() directly

### Testing

Modifies test timeout logging.

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
