### PR TITLE
feat: expose cluster control plane version state in backend Prometheus metrics

### DIFF
--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -400,7 +400,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		"ClusterMetrics", clusterInformer, clusterHandler)
 
 	serviceProviderClusterInformer, _ := backendInformers.ServiceProviderClusters()
-	clusterVersionMetricsHandler := metricscontrollers.NewClusterVersionMetricsHandler(b.options.MetricsRegisterer)
+	clusterVersionMetricsHandler := metricscontrollers.NewClusterVersionMetricsHandler(b.options.MetricsRegisterer, unionReadDesireLister)
 	clusterVersionMetricsController := metricscontrollers.NewController(
 		"ClusterVersionMetrics", serviceProviderClusterInformer, clusterVersionMetricsHandler)
 

--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -395,9 +395,14 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 	_, unionReadDesireLister := unionKubeApplierInformers.ReadDesires()
 
 	clusterInformer, clusterLister := backendInformers.Clusters()
-	clusterHandler := metricscontrollers.NewClusterMetricsHandler(b.options.MetricsRegisterer, b.options.ResourcesDBClient)
+	clusterHandler := metricscontrollers.NewClusterMetricsHandler(b.options.MetricsRegisterer)
 	clusterMetricsController := metricscontrollers.NewController(
 		"ClusterMetrics", clusterInformer, clusterHandler)
+
+	serviceProviderClusterInformer, _ := backendInformers.ServiceProviderClusters()
+	clusterVersionMetricsHandler := metricscontrollers.NewClusterVersionMetricsHandler(b.options.MetricsRegisterer)
+	clusterVersionMetricsController := metricscontrollers.NewController(
+		"ClusterVersionMetrics", serviceProviderClusterInformer, clusterVersionMetricsHandler)
 
 	_, billingLister := backendInformers.BillingDocs()
 
@@ -801,6 +806,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 				go clusterDeletionController.Run(ctx, 20)
 				go operationPhaseMetricsController.Run(ctx, 1)
 				go clusterMetricsController.Run(ctx, 1)
+				go clusterVersionMetricsController.Run(ctx, 1)
 				go nodePoolMetricsController.Run(ctx, 1)
 				go externalAuthMetricsController.Run(ctx, 1)
 				go placementSyncController.Run(ctx, 20)

--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -395,7 +395,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 	_, unionReadDesireLister := unionKubeApplierInformers.ReadDesires()
 
 	clusterInformer, clusterLister := backendInformers.Clusters()
-	clusterHandler := metricscontrollers.NewClusterMetricsHandler(b.options.MetricsRegisterer)
+	clusterHandler := metricscontrollers.NewClusterMetricsHandler(b.options.MetricsRegisterer, b.options.ResourcesDBClient)
 	clusterMetricsController := metricscontrollers.NewController(
 		"ClusterMetrics", clusterInformer, clusterHandler)
 

--- a/backend/pkg/controllers/metricscontrollers/cluster_version_metrics_handler.go
+++ b/backend/pkg/controllers/metricscontrollers/cluster_version_metrics_handler.go
@@ -109,17 +109,21 @@ func (metricsHandler *clusterVersionMetricsHandler) clusterUUIDMetricLabel(
 func (metricsHandler *clusterVersionMetricsHandler) versionStatesFromServiceProviderCluster(serviceProviderCluster *api.ServiceProviderCluster) map[string]string {
 	versionStates := make(map[string]string)
 
-	// Desired is emitted only when the target z-stream is not yet active. Active versions
-	// (partial or completed) override desired for the same version string.
-	if serviceProviderCluster.Spec.ControlPlaneVersion.DesiredVersion != nil {
-		versionStates[serviceProviderCluster.Spec.ControlPlaneVersion.DesiredVersion.String()] = "desired"
-	}
-
 	for _, activeVersion := range serviceProviderCluster.Status.ControlPlaneVersion.ActiveVersions {
-		if activeVersion.Version == nil {
+		version := activeVersion.Version.String()
+		// ActiveVersions is newest-first; skip duplicates that can appear after a rollback to the same z-stream.
+		if _, ok := versionStates[version]; ok {
 			continue
 		}
-		versionStates[activeVersion.Version.String()] = strings.ToLower(string(activeVersion.State))
+		versionStates[version] = strings.ToLower(string(activeVersion.State))
+	}
+
+	// Desired is emitted only when the target z-stream is not yet active.
+	if serviceProviderCluster.Spec.ControlPlaneVersion.DesiredVersion != nil {
+		desiredVersion := serviceProviderCluster.Spec.ControlPlaneVersion.DesiredVersion.String()
+		if _, ok := versionStates[desiredVersion]; !ok {
+			versionStates[desiredVersion] = "desired"
+		}
 	}
 
 	return versionStates

--- a/backend/pkg/controllers/metricscontrollers/cluster_version_metrics_handler.go
+++ b/backend/pkg/controllers/metricscontrollers/cluster_version_metrics_handler.go
@@ -42,7 +42,7 @@ func NewClusterVersionMetricsHandler(
 		readDesireLister: readDesireLister,
 		clusterVersionInfo: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "backend_cluster_version_info",
-			Help: "Information about cluster versions. Value is 1 when version is in the specified state. States: desired (target selected, upgrade not started), partial (upgrade in progress), completed (upgrade finished). Use partial and completed for fleet and upgrade-progress metrics; desired is pre-upgrade only.",
+			Help: "Information about cluster versions. Value is 1 when version is in the specified state. States: desired (target selected, but version hasn't reflected in the cluster active versions), partial (upgrade in progress), completed (upgrade finished). Use partial and completed for fleet and upgrade-progress metrics.",
 		}, []string{"resource_id", "subscription_id", "cluster_uuid", "version", "state"}),
 	}
 	prometheusRegisterer.MustRegister(metricsHandler.clusterVersionInfo)
@@ -94,11 +94,11 @@ func (metricsHandler *clusterVersionMetricsHandler) clusterUUIDMetricLabel(
 	)
 	if err != nil {
 		logger := utils.LoggerFromContext(ctx)
-		logger.Info("error getting cluster UUID, continuing with empty", "err", err.Error())
+		logger.Error(utils.TrackError(err), "error getting cluster UUID, continuing with empty")
 	}
 	if !found {
 		logger := utils.LoggerFromContext(ctx)
-		logger.Info("missing cluster UUID, continuing with empty")
+		logger.V(1).Info("missing cluster UUID, continuing with empty")
 	}
 	if err != nil || !found {
 		return ""

--- a/backend/pkg/controllers/metricscontrollers/cluster_version_metrics_handler.go
+++ b/backend/pkg/controllers/metricscontrollers/cluster_version_metrics_handler.go
@@ -1,0 +1,118 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metricscontrollers
+
+import (
+	"context"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+type clusterVersionMetricsHandler struct {
+	clusterVersionInfo *prometheus.GaugeVec
+	resourcesDBClient  database.ResourcesDBClient
+}
+
+func newClusterVersionMetricsHandler(
+	prometheusRegisterer prometheus.Registerer,
+	resourcesDBClient database.ResourcesDBClient,
+) *clusterVersionMetricsHandler {
+	metricsHandler := &clusterVersionMetricsHandler{
+		clusterVersionInfo: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "backend_cluster_version_info",
+			Help: "Information about cluster versions. Value is 1 when version is in the specified state. States: desired (target selected, upgrade not started), partial (upgrade in progress), completed (upgrade finished). Use partial and completed for fleet and upgrade-progress metrics; desired is pre-upgrade only.",
+		}, []string{"resource_id", "subscription_id", "version", "state"}),
+		resourcesDBClient: resourcesDBClient,
+	}
+	prometheusRegisterer.MustRegister(metricsHandler.clusterVersionInfo)
+	return metricsHandler
+}
+
+func (metricsHandler *clusterVersionMetricsHandler) Sync(ctx context.Context, clusterVersionObject clusterMetricsObject) {
+	clusterResourceID := clusterVersionObject.ResourceID()
+	resourceID := resourceIDMetricLabel(clusterResourceID)
+	if len(resourceID) == 0 {
+		return
+	}
+	subscriptionID := subscriptionIDMetricLabel(clusterResourceID)
+
+	serviceProviderCluster, err := metricsHandler.resourcesDBClient.ServiceProviderClusters(
+		clusterResourceID.SubscriptionID,
+		clusterResourceID.ResourceGroupName,
+		clusterResourceID.Name,
+	).Get(ctx, api.ServiceProviderClusterResourceName)
+	if err != nil {
+		if database.IsNotFoundError(err) {
+			metricsHandler.clusterVersionInfo.DeletePartialMatch(prometheus.Labels{"resource_id": resourceID})
+		} else {
+			utils.LoggerFromContext(ctx).Error(err, "failed to get ServiceProviderCluster for cluster version metrics; retaining previous metrics",
+				"resource_id", resourceID)
+		}
+		return
+	}
+
+	metricsHandler.clusterVersionInfo.DeletePartialMatch(prometheus.Labels{"resource_id": resourceID})
+
+	for version, state := range versionStatesFromServiceProviderCluster(serviceProviderCluster) {
+		metricsHandler.clusterVersionInfo.With(prometheus.Labels{
+			"resource_id":     resourceID,
+			"subscription_id": subscriptionID,
+			"version":         version,
+			"state":           state,
+		}).Set(1.0)
+	}
+}
+
+func (metricsHandler *clusterVersionMetricsHandler) Delete(resourceIDKey string) {
+	if len(resourceIDKey) == 0 {
+		return
+	}
+
+	metricsHandler.clusterVersionInfo.DeletePartialMatch(prometheus.Labels{"resource_id": resourceIDKey})
+}
+
+func versionStatesFromServiceProviderCluster(serviceProviderCluster *api.ServiceProviderCluster) map[string]string {
+	versionStates := make(map[string]string)
+	if serviceProviderCluster == nil {
+		return versionStates
+	}
+
+	// Desired is emitted only when the target z-stream is not yet active. Active versions
+	// (partial or completed) override desired for the same version string.
+	if serviceProviderCluster.Spec.ControlPlaneVersion.DesiredVersion != nil {
+		versionStates[serviceProviderCluster.Spec.ControlPlaneVersion.DesiredVersion.String()] = "desired"
+	}
+
+	for _, activeVersion := range serviceProviderCluster.Status.ControlPlaneVersion.ActiveVersions {
+		if activeVersion.Version == nil {
+			continue
+		}
+
+		state := "completed"
+		if activeVersion.State == configv1.PartialUpdate {
+			state = "partial"
+		}
+
+		versionStates[activeVersion.Version.String()] = state
+	}
+
+	return versionStates
+}

--- a/backend/pkg/controllers/metricscontrollers/cluster_version_metrics_handler.go
+++ b/backend/pkg/controllers/metricscontrollers/cluster_version_metrics_handler.go
@@ -95,8 +95,7 @@ func (metricsHandler *clusterVersionMetricsHandler) clusterUUIDMetricLabel(
 	if err != nil {
 		logger := utils.LoggerFromContext(ctx)
 		logger.Error(utils.TrackError(err), "error getting cluster UUID, continuing with empty")
-	}
-	if !found {
+	} else if !found {
 		logger := utils.LoggerFromContext(ctx)
 		logger.V(1).Info("missing cluster UUID, continuing with empty")
 	}

--- a/backend/pkg/controllers/metricscontrollers/cluster_version_metrics_handler.go
+++ b/backend/pkg/controllers/metricscontrollers/cluster_version_metrics_handler.go
@@ -16,62 +16,38 @@ package metricscontrollers
 
 import (
 	"context"
+	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	configv1 "github.com/openshift/api/config/v1"
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
 	"github.com/Azure/ARO-HCP/internal/api"
-	"github.com/Azure/ARO-HCP/internal/database"
-	"github.com/Azure/ARO-HCP/internal/utils"
 )
 
 type clusterVersionMetricsHandler struct {
 	clusterVersionInfo *prometheus.GaugeVec
-	resourcesDBClient  database.ResourcesDBClient
 }
 
-func newClusterVersionMetricsHandler(
-	prometheusRegisterer prometheus.Registerer,
-	resourcesDBClient database.ResourcesDBClient,
-) *clusterVersionMetricsHandler {
+// NewClusterVersionMetricsHandler creates a metrics handler for cluster version metrics.
+func NewClusterVersionMetricsHandler(prometheusRegisterer prometheus.Registerer) Handler[*api.ServiceProviderCluster] {
 	metricsHandler := &clusterVersionMetricsHandler{
 		clusterVersionInfo: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "backend_cluster_version_info",
 			Help: "Information about cluster versions. Value is 1 when version is in the specified state. States: desired (target selected, upgrade not started), partial (upgrade in progress), completed (upgrade finished). Use partial and completed for fleet and upgrade-progress metrics; desired is pre-upgrade only.",
 		}, []string{"resource_id", "subscription_id", "version", "state"}),
-		resourcesDBClient: resourcesDBClient,
 	}
 	prometheusRegisterer.MustRegister(metricsHandler.clusterVersionInfo)
 	return metricsHandler
 }
 
-func (metricsHandler *clusterVersionMetricsHandler) Sync(ctx context.Context, clusterVersionObject clusterMetricsObject) {
-	clusterResourceID := clusterVersionObject.ResourceID()
-	resourceID := resourceIDMetricLabel(clusterResourceID)
-	if len(resourceID) == 0 {
-		return
-	}
-	subscriptionID := subscriptionIDMetricLabel(clusterResourceID)
-
-	serviceProviderCluster, err := metricsHandler.resourcesDBClient.ServiceProviderClusters(
-		clusterResourceID.SubscriptionID,
-		clusterResourceID.ResourceGroupName,
-		clusterResourceID.Name,
-	).Get(ctx, api.ServiceProviderClusterResourceName)
-	if err != nil {
-		if database.IsNotFoundError(err) {
-			metricsHandler.clusterVersionInfo.DeletePartialMatch(prometheus.Labels{"resource_id": resourceID})
-		} else {
-			utils.LoggerFromContext(ctx).Error(err, "failed to get ServiceProviderCluster for cluster version metrics; retaining previous metrics",
-				"resource_id", resourceID)
-		}
-		return
-	}
+func (metricsHandler *clusterVersionMetricsHandler) Sync(_ context.Context, serviceProviderCluster *api.ServiceProviderCluster) {
+	resourceID := resourceIDMetricLabel(serviceProviderCluster.ResourceID.Parent)
+	subscriptionID := subscriptionIDMetricLabel(serviceProviderCluster.ResourceID.Parent)
 
 	metricsHandler.clusterVersionInfo.DeletePartialMatch(prometheus.Labels{"resource_id": resourceID})
 
-	for version, state := range versionStatesFromServiceProviderCluster(serviceProviderCluster) {
+	for version, state := range metricsHandler.versionStatesFromServiceProviderCluster(serviceProviderCluster) {
 		metricsHandler.clusterVersionInfo.With(prometheus.Labels{
 			"resource_id":     resourceID,
 			"subscription_id": subscriptionID,
@@ -81,19 +57,22 @@ func (metricsHandler *clusterVersionMetricsHandler) Sync(ctx context.Context, cl
 	}
 }
 
-func (metricsHandler *clusterVersionMetricsHandler) Delete(resourceIDKey string) {
-	if len(resourceIDKey) == 0 {
+func (metricsHandler *clusterVersionMetricsHandler) Delete(serviceProviderClusterKey string) {
+	if len(serviceProviderClusterKey) == 0 {
+		return
+	}
+	serviceProviderClusterResourceID, err := azcorearm.ParseResourceID(serviceProviderClusterKey)
+	if err != nil {
 		return
 	}
 
-	metricsHandler.clusterVersionInfo.DeletePartialMatch(prometheus.Labels{"resource_id": resourceIDKey})
+	metricsHandler.clusterVersionInfo.DeletePartialMatch(prometheus.Labels{
+		"resource_id": resourceIDMetricLabel(serviceProviderClusterResourceID.Parent),
+	})
 }
 
-func versionStatesFromServiceProviderCluster(serviceProviderCluster *api.ServiceProviderCluster) map[string]string {
+func (metricsHandler *clusterVersionMetricsHandler) versionStatesFromServiceProviderCluster(serviceProviderCluster *api.ServiceProviderCluster) map[string]string {
 	versionStates := make(map[string]string)
-	if serviceProviderCluster == nil {
-		return versionStates
-	}
 
 	// Desired is emitted only when the target z-stream is not yet active. Active versions
 	// (partial or completed) override desired for the same version string.
@@ -105,13 +84,7 @@ func versionStatesFromServiceProviderCluster(serviceProviderCluster *api.Service
 		if activeVersion.Version == nil {
 			continue
 		}
-
-		state := "completed"
-		if activeVersion.State == configv1.PartialUpdate {
-			state = "partial"
-		}
-
-		versionStates[activeVersion.Version.String()] = state
+		versionStates[activeVersion.Version.String()] = strings.ToLower(string(activeVersion.State))
 	}
 
 	return versionStates

--- a/backend/pkg/controllers/metricscontrollers/cluster_version_metrics_handler.go
+++ b/backend/pkg/controllers/metricscontrollers/cluster_version_metrics_handler.go
@@ -109,7 +109,13 @@ func (metricsHandler *clusterVersionMetricsHandler) clusterUUIDMetricLabel(
 func (metricsHandler *clusterVersionMetricsHandler) versionStatesFromServiceProviderCluster(serviceProviderCluster *api.ServiceProviderCluster) map[string]string {
 	versionStates := make(map[string]string)
 
-	for _, activeVersion := range serviceProviderCluster.Status.ControlPlaneVersion.ActiveVersions {
+	activeVersions := serviceProviderCluster.Status.ControlPlaneVersion.ActiveVersions
+	// Bound concurrent version time series per cluster: the version we are on or moving to and the two previous versions.
+	const maxReportedActiveVersions = 3
+	if len(activeVersions) > maxReportedActiveVersions {
+		activeVersions = activeVersions[:maxReportedActiveVersions]
+	}
+	for _, activeVersion := range activeVersions {
 		version := activeVersion.Version.String()
 		// ActiveVersions is newest-first; skip duplicates that can appear after a rollback to the same z-stream.
 		if _, ok := versionStates[version]; ok {

--- a/backend/pkg/controllers/metricscontrollers/cluster_version_metrics_handler.go
+++ b/backend/pkg/controllers/metricscontrollers/cluster_version_metrics_handler.go
@@ -22,28 +22,37 @@ import (
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
+	"github.com/Azure/ARO-HCP/backend/pkg/maestrohelpers"
 	"github.com/Azure/ARO-HCP/internal/api"
+	dblisters "github.com/Azure/ARO-HCP/internal/database/listers"
+	"github.com/Azure/ARO-HCP/internal/utils"
 )
 
 type clusterVersionMetricsHandler struct {
 	clusterVersionInfo *prometheus.GaugeVec
+	readDesireLister   dblisters.ReadDesireLister
 }
 
 // NewClusterVersionMetricsHandler creates a metrics handler for cluster version metrics.
-func NewClusterVersionMetricsHandler(prometheusRegisterer prometheus.Registerer) Handler[*api.ServiceProviderCluster] {
+func NewClusterVersionMetricsHandler(
+	prometheusRegisterer prometheus.Registerer,
+	readDesireLister dblisters.ReadDesireLister,
+) Handler[*api.ServiceProviderCluster] {
 	metricsHandler := &clusterVersionMetricsHandler{
+		readDesireLister: readDesireLister,
 		clusterVersionInfo: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "backend_cluster_version_info",
 			Help: "Information about cluster versions. Value is 1 when version is in the specified state. States: desired (target selected, upgrade not started), partial (upgrade in progress), completed (upgrade finished). Use partial and completed for fleet and upgrade-progress metrics; desired is pre-upgrade only.",
-		}, []string{"resource_id", "subscription_id", "version", "state"}),
+		}, []string{"resource_id", "subscription_id", "cluster_uuid", "version", "state"}),
 	}
 	prometheusRegisterer.MustRegister(metricsHandler.clusterVersionInfo)
 	return metricsHandler
 }
 
-func (metricsHandler *clusterVersionMetricsHandler) Sync(_ context.Context, serviceProviderCluster *api.ServiceProviderCluster) {
+func (metricsHandler *clusterVersionMetricsHandler) Sync(ctx context.Context, serviceProviderCluster *api.ServiceProviderCluster) {
 	resourceID := resourceIDMetricLabel(serviceProviderCluster.ResourceID.Parent)
 	subscriptionID := subscriptionIDMetricLabel(serviceProviderCluster.ResourceID.Parent)
+	clusterUUID := metricsHandler.clusterUUIDMetricLabel(ctx, serviceProviderCluster.ResourceID.Parent)
 
 	metricsHandler.clusterVersionInfo.DeletePartialMatch(prometheus.Labels{"resource_id": resourceID})
 
@@ -51,6 +60,7 @@ func (metricsHandler *clusterVersionMetricsHandler) Sync(_ context.Context, serv
 		metricsHandler.clusterVersionInfo.With(prometheus.Labels{
 			"resource_id":     resourceID,
 			"subscription_id": subscriptionID,
+			"cluster_uuid":    clusterUUID,
 			"version":         version,
 			"state":           state,
 		}).Set(1.0)
@@ -69,6 +79,31 @@ func (metricsHandler *clusterVersionMetricsHandler) Delete(serviceProviderCluste
 	metricsHandler.clusterVersionInfo.DeletePartialMatch(prometheus.Labels{
 		"resource_id": resourceIDMetricLabel(serviceProviderClusterResourceID.Parent),
 	})
+}
+
+func (metricsHandler *clusterVersionMetricsHandler) clusterUUIDMetricLabel(
+	ctx context.Context,
+	clusterResourceID *azcorearm.ResourceID,
+) string {
+	clusterUUID, found, err := maestrohelpers.GetCachedHostedClusterUUIDForCluster(
+		ctx,
+		metricsHandler.readDesireLister,
+		clusterResourceID.SubscriptionID,
+		clusterResourceID.ResourceGroupName,
+		clusterResourceID.Name,
+	)
+	if err != nil {
+		logger := utils.LoggerFromContext(ctx)
+		logger.Info("error getting cluster UUID, continuing with empty", "err", err.Error())
+	}
+	if !found {
+		logger := utils.LoggerFromContext(ctx)
+		logger.Info("missing cluster UUID, continuing with empty")
+	}
+	if err != nil || !found {
+		return ""
+	}
+	return strings.ToLower(clusterUUID.String())
 }
 
 func (metricsHandler *clusterVersionMetricsHandler) versionStatesFromServiceProviderCluster(serviceProviderCluster *api.ServiceProviderCluster) map[string]string {

--- a/backend/pkg/controllers/metricscontrollers/cluster_version_metrics_handler_test.go
+++ b/backend/pkg/controllers/metricscontrollers/cluster_version_metrics_handler_test.go
@@ -16,7 +16,6 @@ package metricscontrollers
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -26,6 +25,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/utils/ptr"
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
@@ -34,21 +34,16 @@ import (
 
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
-	"github.com/Azure/ARO-HCP/internal/database"
-	"github.com/Azure/ARO-HCP/internal/databasetesting"
 )
 
-func seedTestServiceProviderCluster(
+func newTestServiceProviderCluster(
 	t *testing.T,
-	ctx context.Context,
-	mockResourcesDBClient *databasetesting.MockResourcesDBClient,
-	clusterName string,
+	cluster *api.HCPOpenShiftCluster,
 	desiredVersion string,
 	activeVersions []api.HCPClusterActiveVersion,
-) *api.HCPOpenShiftCluster {
+) *api.ServiceProviderCluster {
 	t.Helper()
 
-	cluster := newTestCluster(t, clusterName, arm.ProvisioningStateSucceeded, nil)
 	clusterResourceID := cluster.ID
 	serviceProviderClusterResourceID := api.Must(azcorearm.ParseResourceID(
 		clusterResourceID.String() + "/" + api.ServiceProviderClusterResourceTypeName + "/" + api.ServiceProviderClusterResourceName,
@@ -66,27 +61,20 @@ func seedTestServiceProviderCluster(
 		serviceProviderCluster.Spec.ControlPlaneVersion.DesiredVersion = ptr.To(semver.MustParse(desiredVersion))
 	}
 
-	_, err := mockResourcesDBClient.ServiceProviderClusters(
-		clusterResourceID.SubscriptionID,
-		clusterResourceID.ResourceGroupName,
-		clusterResourceID.Name,
-	).Create(ctx, serviceProviderCluster, nil)
-	require.NoError(t, err)
-
-	return cluster
+	return serviceProviderCluster
 }
 
 func TestClusterVersionMetricsHandler_SetsDesiredAndActiveVersions(t *testing.T) {
 	ctx := context.Background()
-	mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
 	prometheusRegistry := prometheus.NewRegistry()
-	versionMetricsHandler := newClusterVersionMetricsHandler(prometheusRegistry, mockResourcesDBClient)
+	handler := NewClusterVersionMetricsHandler(prometheusRegistry)
 
-	cluster := seedTestServiceProviderCluster(t, ctx, mockResourcesDBClient, "cluster-1", "4.19.20", []api.HCPClusterActiveVersion{
+	cluster := newTestCluster(t, "cluster-1", arm.ProvisioningStateSucceeded, nil)
+	serviceProviderCluster := newTestServiceProviderCluster(t, cluster, "4.19.20", []api.HCPClusterActiveVersion{
 		{Version: ptr.To(semver.MustParse("4.19.19")), State: configv1.CompletedUpdate},
 		{Version: ptr.To(semver.MustParse("4.19.20")), State: configv1.PartialUpdate},
 	})
-	versionMetricsHandler.Sync(ctx, clusterMetricsObject{cluster})
+	handler.Sync(ctx, serviceProviderCluster)
 
 	resourceID := resourceIDMetricLabel(cluster.ID)
 	subscriptionID := subscriptionIDMetricLabel(cluster.ID)
@@ -101,14 +89,14 @@ backend_cluster_version_info{resource_id="%s",state="partial",subscription_id="%
 
 func TestClusterVersionMetricsHandler_ReplacesDesiredWhenVersionBecomesActive(t *testing.T) {
 	ctx := context.Background()
-	mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
 	prometheusRegistry := prometheus.NewRegistry()
-	versionMetricsHandler := newClusterVersionMetricsHandler(prometheusRegistry, mockResourcesDBClient)
+	handler := NewClusterVersionMetricsHandler(prometheusRegistry)
 
-	cluster := seedTestServiceProviderCluster(t, ctx, mockResourcesDBClient, "cluster-1", "4.19.20", []api.HCPClusterActiveVersion{
+	cluster := newTestCluster(t, "cluster-1", arm.ProvisioningStateSucceeded, nil)
+	serviceProviderCluster := newTestServiceProviderCluster(t, cluster, "4.19.20", []api.HCPClusterActiveVersion{
 		{Version: ptr.To(semver.MustParse("4.19.20")), State: configv1.CompletedUpdate},
 	})
-	versionMetricsHandler.Sync(ctx, clusterMetricsObject{cluster})
+	handler.Sync(ctx, serviceProviderCluster)
 
 	resourceID := resourceIDMetricLabel(cluster.ID)
 	subscriptionID := subscriptionIDMetricLabel(cluster.ID)
@@ -122,83 +110,42 @@ backend_cluster_version_info{resource_id="%s",state="completed",subscription_id=
 
 func TestClusterVersionMetricsHandler_DeleteCleansUpMetrics(t *testing.T) {
 	ctx := context.Background()
-	mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
 	prometheusRegistry := prometheus.NewRegistry()
-	versionMetricsHandler := newClusterVersionMetricsHandler(prometheusRegistry, mockResourcesDBClient)
-
-	cluster := seedTestServiceProviderCluster(t, ctx, mockResourcesDBClient, "cluster-1", "4.19.20", nil)
-	versionMetricsHandler.Sync(ctx, clusterMetricsObject{cluster})
-	versionMetricsHandler.Delete(resourceIDMetricLabel(cluster.ID))
-
-	require.NoError(t, testutil.GatherAndCompare(prometheusRegistry, strings.NewReader(""), "backend_cluster_version_info"))
-}
-
-func TestClusterVersionMetricsHandler_NoMetricsWhenServiceProviderClusterMissing(t *testing.T) {
-	ctx := context.Background()
-	mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
-	prometheusRegistry := prometheus.NewRegistry()
-	versionMetricsHandler := newClusterVersionMetricsHandler(prometheusRegistry, mockResourcesDBClient)
+	handler := NewClusterVersionMetricsHandler(prometheusRegistry)
 
 	cluster := newTestCluster(t, "cluster-1", arm.ProvisioningStateSucceeded, nil)
-	versionMetricsHandler.Sync(ctx, clusterMetricsObject{cluster})
+	serviceProviderCluster := newTestServiceProviderCluster(t, cluster, "4.19.20", nil)
+	handler.Sync(ctx, serviceProviderCluster)
 
-	require.NoError(t, testutil.GatherAndCompare(prometheusRegistry, strings.NewReader(""), "backend_cluster_version_info"))
-}
-
-func TestClusterVersionMetricsHandler_ClearsMetricsWhenServiceProviderClusterDeleted(t *testing.T) {
-	ctx := context.Background()
-	mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
-	prometheusRegistry := prometheus.NewRegistry()
-	versionMetricsHandler := newClusterVersionMetricsHandler(prometheusRegistry, mockResourcesDBClient)
-
-	cluster := seedTestServiceProviderCluster(t, ctx, mockResourcesDBClient, "cluster-1", "4.19.20", nil)
-	versionMetricsHandler.Sync(ctx, clusterMetricsObject{cluster})
-
-	err := mockResourcesDBClient.ServiceProviderClusters(
-		cluster.ID.SubscriptionID,
-		cluster.ID.ResourceGroupName,
-		cluster.ID.Name,
-	).Delete(ctx, api.ServiceProviderClusterResourceName)
+	spcKey, err := resourceIDStoreKey(serviceProviderCluster)
 	require.NoError(t, err)
-
-	versionMetricsHandler.Sync(ctx, clusterMetricsObject{cluster})
+	handler.Delete(spcKey)
 
 	require.NoError(t, testutil.GatherAndCompare(prometheusRegistry, strings.NewReader(""), "backend_cluster_version_info"))
 }
 
-// Stubs below simulate a transient ServiceProviderCluster Get failure for
-// TestClusterVersionMetricsHandler_RetainsMetricsOnTransientGetError.
-type getErrorServiceProviderClusterCRUD struct {
-	database.ServiceProviderClusterCRUD
-	getErr error
-}
-
-func (c *getErrorServiceProviderClusterCRUD) Get(ctx context.Context, resourceID string) (*api.ServiceProviderCluster, error) {
-	return nil, c.getErr
-}
-
-type serviceProviderClusterGetErrorDBClient struct {
-	*databasetesting.MockResourcesDBClient
-	getErr error
-}
-
-func (c *serviceProviderClusterGetErrorDBClient) ServiceProviderClusters(subscriptionID, resourceGroupName, clusterName string) database.ServiceProviderClusterCRUD {
-	return &getErrorServiceProviderClusterCRUD{
-		ServiceProviderClusterCRUD: c.MockResourcesDBClient.ServiceProviderClusters(subscriptionID, resourceGroupName, clusterName),
-		getErr:                     c.getErr,
-	}
-}
-
-func TestClusterVersionMetricsHandler_RetainsMetricsOnTransientGetError(t *testing.T) {
+func TestClusterVersionMetricsController_SyncResource(t *testing.T) {
 	ctx := context.Background()
-	mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
 	prometheusRegistry := prometheus.NewRegistry()
-	versionMetricsHandler := newClusterVersionMetricsHandler(prometheusRegistry, mockResourcesDBClient)
+	handler := NewClusterVersionMetricsHandler(prometheusRegistry)
 
-	cluster := seedTestServiceProviderCluster(t, ctx, mockResourcesDBClient, "cluster-1", "4.19.20", []api.HCPClusterActiveVersion{
+	cluster := newTestCluster(t, "cluster-1", arm.ProvisioningStateSucceeded, nil)
+	serviceProviderCluster := newTestServiceProviderCluster(t, cluster, "4.19.20", []api.HCPClusterActiveVersion{
 		{Version: ptr.To(semver.MustParse("4.19.20")), State: configv1.CompletedUpdate},
 	})
-	versionMetricsHandler.Sync(ctx, clusterMetricsObject{cluster})
+
+	indexer := cache.NewIndexer(resourceIDStoreKeyForObject, cache.Indexers{})
+	require.NoError(t, indexer.Add(serviceProviderCluster))
+
+	controller := &Controller[*api.ServiceProviderCluster]{
+		name:    "ClusterVersionMetrics",
+		indexer: indexer,
+		handler: handler,
+	}
+
+	key, err := resourceIDStoreKeyForObject(serviceProviderCluster)
+	require.NoError(t, err)
+	require.NoError(t, controller.syncResource(ctx, key))
 
 	resourceID := resourceIDMetricLabel(cluster.ID)
 	subscriptionID := subscriptionIDMetricLabel(cluster.ID)
@@ -206,12 +153,33 @@ func TestClusterVersionMetricsHandler_RetainsMetricsOnTransientGetError(t *testi
 # TYPE backend_cluster_version_info gauge
 backend_cluster_version_info{resource_id="%s",state="completed",subscription_id="%s",version="4.19.20"} 1
 `, resourceID, subscriptionID)
-
-	versionMetricsHandler.resourcesDBClient = &serviceProviderClusterGetErrorDBClient{
-		MockResourcesDBClient: mockResourcesDBClient,
-		getErr:                errors.New("transient database error"),
-	}
-	versionMetricsHandler.Sync(ctx, clusterMetricsObject{cluster})
-
 	require.NoError(t, testutil.GatherAndCompare(prometheusRegistry, strings.NewReader(expected), "backend_cluster_version_info"))
+}
+
+func TestClusterVersionMetricsController_DeletesMetricsWhenResourceRemoved(t *testing.T) {
+	ctx := context.Background()
+	prometheusRegistry := prometheus.NewRegistry()
+	handler := NewClusterVersionMetricsHandler(prometheusRegistry)
+
+	cluster := newTestCluster(t, "cluster-1", arm.ProvisioningStateSucceeded, nil)
+	serviceProviderCluster := newTestServiceProviderCluster(t, cluster, "4.19.20", []api.HCPClusterActiveVersion{
+		{Version: ptr.To(semver.MustParse("4.19.20")), State: configv1.CompletedUpdate},
+	})
+
+	indexer := cache.NewIndexer(resourceIDStoreKeyForObject, cache.Indexers{})
+	require.NoError(t, indexer.Add(serviceProviderCluster))
+
+	controller := &Controller[*api.ServiceProviderCluster]{
+		name:    "ClusterVersionMetrics",
+		indexer: indexer,
+		handler: handler,
+	}
+
+	key, err := resourceIDStoreKeyForObject(serviceProviderCluster)
+	require.NoError(t, err)
+	require.NoError(t, controller.syncResource(ctx, key))
+	require.NoError(t, indexer.Delete(serviceProviderCluster))
+	require.NoError(t, controller.syncResource(ctx, key))
+
+	require.NoError(t, testutil.GatherAndCompare(prometheusRegistry, strings.NewReader(""), "backend_cluster_version_info"))
 }

--- a/backend/pkg/controllers/metricscontrollers/cluster_version_metrics_handler_test.go
+++ b/backend/pkg/controllers/metricscontrollers/cluster_version_metrics_handler_test.go
@@ -44,7 +44,11 @@ import (
 	internallistertesting "github.com/Azure/ARO-HCP/internal/database/listertesting"
 )
 
-const testClusterUUID = "11111111-1111-1111-1111-111111111111"
+func expectedBackendClusterVersionInfoMetricHeader() string {
+	return `# HELP backend_cluster_version_info Information about cluster versions. Value is 1 when version is in the specified state. States: desired (target selected, but version hasn't reflected in the cluster active versions), partial (upgrade in progress), completed (upgrade finished). Use partial and completed for fleet and upgrade-progress metrics.
+# TYPE backend_cluster_version_info gauge
+`
+}
 
 func newTestClusterVersionMetricsHandler(t *testing.T, prometheusRegistry *prometheus.Registry, readDesireLister dblisters.ReadDesireLister) Handler[*api.ServiceProviderCluster] {
 	t.Helper()
@@ -118,7 +122,7 @@ func newTestServiceProviderCluster(
 func TestClusterVersionMetricsHandler_SetsDesiredAndActiveVersions(t *testing.T) {
 	ctx := context.Background()
 	prometheusRegistry := prometheus.NewRegistry()
-	handler := newTestClusterVersionMetricsHandler(t, prometheusRegistry, newTestHostedClusterReadDesireLister(t, testClusterUUID))
+	handler := newTestClusterVersionMetricsHandler(t, prometheusRegistry, newTestHostedClusterReadDesireLister(t, "11111111-1111-1111-1111-111111111111"))
 
 	cluster := newTestCluster(t, "cluster-1", arm.ProvisioningStateSucceeded, nil)
 	serviceProviderCluster := newTestServiceProviderCluster(t, cluster, "4.19.20", []api.HCPClusterActiveVersion{
@@ -130,18 +134,33 @@ func TestClusterVersionMetricsHandler_SetsDesiredAndActiveVersions(t *testing.T)
 	resourceID := resourceIDMetricLabel(cluster.ID)
 	subscriptionID := subscriptionIDMetricLabel(cluster.ID)
 
-	expected := fmt.Sprintf(`# HELP backend_cluster_version_info Information about cluster versions. Value is 1 when version is in the specified state. States: desired (target selected, upgrade not started), partial (upgrade in progress), completed (upgrade finished). Use partial and completed for fleet and upgrade-progress metrics; desired is pre-upgrade only.
-# TYPE backend_cluster_version_info gauge
-backend_cluster_version_info{cluster_uuid="%s",resource_id="%s",state="completed",subscription_id="%s",version="4.19.19"} 1
+	expected := expectedBackendClusterVersionInfoMetricHeader() + fmt.Sprintf(`backend_cluster_version_info{cluster_uuid="%s",resource_id="%s",state="completed",subscription_id="%s",version="4.19.19"} 1
 backend_cluster_version_info{cluster_uuid="%s",resource_id="%s",state="partial",subscription_id="%s",version="4.19.20"} 1
-`, testClusterUUID, resourceID, subscriptionID, testClusterUUID, resourceID, subscriptionID)
+`, "11111111-1111-1111-1111-111111111111", resourceID, subscriptionID, "11111111-1111-1111-1111-111111111111", resourceID, subscriptionID)
+	require.NoError(t, testutil.GatherAndCompare(prometheusRegistry, strings.NewReader(expected), "backend_cluster_version_info"))
+}
+
+func TestClusterVersionMetricsHandler_EmitsDesiredWhenNotYetActive(t *testing.T) {
+	ctx := context.Background()
+	prometheusRegistry := prometheus.NewRegistry()
+	handler := newTestClusterVersionMetricsHandler(t, prometheusRegistry, newTestHostedClusterReadDesireLister(t, "11111111-1111-1111-1111-111111111111"))
+
+	cluster := newTestCluster(t, "cluster-1", arm.ProvisioningStateSucceeded, nil)
+	serviceProviderCluster := newTestServiceProviderCluster(t, cluster, "4.19.20", nil)
+	handler.Sync(ctx, serviceProviderCluster)
+
+	resourceID := resourceIDMetricLabel(cluster.ID)
+	subscriptionID := subscriptionIDMetricLabel(cluster.ID)
+
+	expected := expectedBackendClusterVersionInfoMetricHeader() + fmt.Sprintf(`backend_cluster_version_info{cluster_uuid="%s",resource_id="%s",state="desired",subscription_id="%s",version="4.19.20"} 1
+`, "11111111-1111-1111-1111-111111111111", resourceID, subscriptionID)
 	require.NoError(t, testutil.GatherAndCompare(prometheusRegistry, strings.NewReader(expected), "backend_cluster_version_info"))
 }
 
 func TestClusterVersionMetricsHandler_ReplacesDesiredWhenVersionBecomesActive(t *testing.T) {
 	ctx := context.Background()
 	prometheusRegistry := prometheus.NewRegistry()
-	handler := newTestClusterVersionMetricsHandler(t, prometheusRegistry, newTestHostedClusterReadDesireLister(t, testClusterUUID))
+	handler := newTestClusterVersionMetricsHandler(t, prometheusRegistry, newTestHostedClusterReadDesireLister(t, "11111111-1111-1111-1111-111111111111"))
 
 	cluster := newTestCluster(t, "cluster-1", arm.ProvisioningStateSucceeded, nil)
 	serviceProviderCluster := newTestServiceProviderCluster(t, cluster, "4.19.20", []api.HCPClusterActiveVersion{
@@ -152,17 +171,41 @@ func TestClusterVersionMetricsHandler_ReplacesDesiredWhenVersionBecomesActive(t 
 	resourceID := resourceIDMetricLabel(cluster.ID)
 	subscriptionID := subscriptionIDMetricLabel(cluster.ID)
 
-	expected := fmt.Sprintf(`# HELP backend_cluster_version_info Information about cluster versions. Value is 1 when version is in the specified state. States: desired (target selected, upgrade not started), partial (upgrade in progress), completed (upgrade finished). Use partial and completed for fleet and upgrade-progress metrics; desired is pre-upgrade only.
-# TYPE backend_cluster_version_info gauge
+	expected := expectedBackendClusterVersionInfoMetricHeader() + fmt.Sprintf(`backend_cluster_version_info{cluster_uuid="%s",resource_id="%s",state="completed",subscription_id="%s",version="4.19.20"} 1
+`, "11111111-1111-1111-1111-111111111111", resourceID, subscriptionID)
+	require.NoError(t, testutil.GatherAndCompare(prometheusRegistry, strings.NewReader(expected), "backend_cluster_version_info"))
+}
+
+func TestClusterVersionMetricsHandler_VersionStateTransitionDeletesOldSeries(t *testing.T) {
+	ctx := context.Background()
+	prometheusRegistry := prometheus.NewRegistry()
+	handler := newTestClusterVersionMetricsHandler(t, prometheusRegistry, newTestHostedClusterReadDesireLister(t, "11111111-1111-1111-1111-111111111111"))
+
+	cluster := newTestCluster(t, "cluster-1", arm.ProvisioningStateSucceeded, nil)
+	serviceProviderCluster := newTestServiceProviderCluster(t, cluster, "4.19.20", []api.HCPClusterActiveVersion{
+		{Version: ptr.To(semver.MustParse("4.19.19")), State: configv1.CompletedUpdate},
+		{Version: ptr.To(semver.MustParse("4.19.20")), State: configv1.PartialUpdate},
+	})
+	handler.Sync(ctx, serviceProviderCluster)
+
+	serviceProviderCluster.Status.ControlPlaneVersion.ActiveVersions = []api.HCPClusterActiveVersion{
+		{Version: ptr.To(semver.MustParse("4.19.19")), State: configv1.CompletedUpdate},
+		{Version: ptr.To(semver.MustParse("4.19.20")), State: configv1.CompletedUpdate},
+	}
+	handler.Sync(ctx, serviceProviderCluster)
+
+	resourceID := resourceIDMetricLabel(cluster.ID)
+	subscriptionID := subscriptionIDMetricLabel(cluster.ID)
+	expected := expectedBackendClusterVersionInfoMetricHeader() + fmt.Sprintf(`backend_cluster_version_info{cluster_uuid="%s",resource_id="%s",state="completed",subscription_id="%s",version="4.19.19"} 1
 backend_cluster_version_info{cluster_uuid="%s",resource_id="%s",state="completed",subscription_id="%s",version="4.19.20"} 1
-`, testClusterUUID, resourceID, subscriptionID)
+`, "11111111-1111-1111-1111-111111111111", resourceID, subscriptionID, "11111111-1111-1111-1111-111111111111", resourceID, subscriptionID)
 	require.NoError(t, testutil.GatherAndCompare(prometheusRegistry, strings.NewReader(expected), "backend_cluster_version_info"))
 }
 
 func TestClusterVersionMetricsHandler_DeleteCleansUpMetrics(t *testing.T) {
 	ctx := context.Background()
 	prometheusRegistry := prometheus.NewRegistry()
-	handler := newTestClusterVersionMetricsHandler(t, prometheusRegistry, newTestHostedClusterReadDesireLister(t, testClusterUUID))
+	handler := newTestClusterVersionMetricsHandler(t, prometheusRegistry, newTestHostedClusterReadDesireLister(t, "11111111-1111-1111-1111-111111111111"))
 
 	cluster := newTestCluster(t, "cluster-1", arm.ProvisioningStateSucceeded, nil)
 	serviceProviderCluster := newTestServiceProviderCluster(t, cluster, "4.19.20", nil)
@@ -178,7 +221,7 @@ func TestClusterVersionMetricsHandler_DeleteCleansUpMetrics(t *testing.T) {
 func TestClusterVersionMetricsController_SyncResource(t *testing.T) {
 	ctx := context.Background()
 	prometheusRegistry := prometheus.NewRegistry()
-	handler := newTestClusterVersionMetricsHandler(t, prometheusRegistry, newTestHostedClusterReadDesireLister(t, testClusterUUID))
+	handler := newTestClusterVersionMetricsHandler(t, prometheusRegistry, newTestHostedClusterReadDesireLister(t, "11111111-1111-1111-1111-111111111111"))
 
 	cluster := newTestCluster(t, "cluster-1", arm.ProvisioningStateSucceeded, nil)
 	serviceProviderCluster := newTestServiceProviderCluster(t, cluster, "4.19.20", []api.HCPClusterActiveVersion{
@@ -200,17 +243,15 @@ func TestClusterVersionMetricsController_SyncResource(t *testing.T) {
 
 	resourceID := resourceIDMetricLabel(cluster.ID)
 	subscriptionID := subscriptionIDMetricLabel(cluster.ID)
-	expected := fmt.Sprintf(`# HELP backend_cluster_version_info Information about cluster versions. Value is 1 when version is in the specified state. States: desired (target selected, upgrade not started), partial (upgrade in progress), completed (upgrade finished). Use partial and completed for fleet and upgrade-progress metrics; desired is pre-upgrade only.
-# TYPE backend_cluster_version_info gauge
-backend_cluster_version_info{cluster_uuid="%s",resource_id="%s",state="completed",subscription_id="%s",version="4.19.20"} 1
-`, testClusterUUID, resourceID, subscriptionID)
+	expected := expectedBackendClusterVersionInfoMetricHeader() + fmt.Sprintf(`backend_cluster_version_info{cluster_uuid="%s",resource_id="%s",state="completed",subscription_id="%s",version="4.19.20"} 1
+`, "11111111-1111-1111-1111-111111111111", resourceID, subscriptionID)
 	require.NoError(t, testutil.GatherAndCompare(prometheusRegistry, strings.NewReader(expected), "backend_cluster_version_info"))
 }
 
 func TestClusterVersionMetricsController_DeletesMetricsWhenResourceRemoved(t *testing.T) {
 	ctx := context.Background()
 	prometheusRegistry := prometheus.NewRegistry()
-	handler := newTestClusterVersionMetricsHandler(t, prometheusRegistry, newTestHostedClusterReadDesireLister(t, testClusterUUID))
+	handler := newTestClusterVersionMetricsHandler(t, prometheusRegistry, newTestHostedClusterReadDesireLister(t, "11111111-1111-1111-1111-111111111111"))
 
 	cluster := newTestCluster(t, "cluster-1", arm.ProvisioningStateSucceeded, nil)
 	serviceProviderCluster := newTestServiceProviderCluster(t, cluster, "4.19.20", []api.HCPClusterActiveVersion{

--- a/backend/pkg/controllers/metricscontrollers/cluster_version_metrics_handler_test.go
+++ b/backend/pkg/controllers/metricscontrollers/cluster_version_metrics_handler_test.go
@@ -178,6 +178,32 @@ func TestClusterVersionMetricsHandler_SkipsDuplicateActiveVersionsAfterRollback(
 	require.NoError(t, testutil.GatherAndCompare(prometheusRegistry, strings.NewReader(expected), "backend_cluster_version_info"))
 }
 
+func TestClusterVersionMetricsHandler_CapsReportedActiveVersions(t *testing.T) {
+	ctx := context.Background()
+	prometheusRegistry := prometheus.NewRegistry()
+	handler := newTestClusterVersionMetricsHandler(t, prometheusRegistry, newTestHostedClusterReadDesireLister(t, "11111111-1111-1111-1111-111111111111"))
+
+	cluster := newTestCluster(t, "cluster-1", arm.ProvisioningStateSucceeded, nil)
+	// ActiveVersions is newest-first; only the three newest history entries are reported.
+	serviceProviderCluster := newTestServiceProviderCluster(t, cluster, "", []api.HCPClusterActiveVersion{
+		{Version: ptr.To(semver.MustParse("4.19.22")), State: configv1.PartialUpdate},
+		{Version: ptr.To(semver.MustParse("4.19.21")), State: configv1.PartialUpdate},
+		{Version: ptr.To(semver.MustParse("4.19.20")), State: configv1.PartialUpdate},
+		{Version: ptr.To(semver.MustParse("4.19.19")), State: configv1.CompletedUpdate},
+	})
+	handler.Sync(ctx, serviceProviderCluster)
+
+	resourceID := resourceIDMetricLabel(cluster.ID)
+	subscriptionID := subscriptionIDMetricLabel(cluster.ID)
+	clusterUUID := "11111111-1111-1111-1111-111111111111"
+
+	expected := expectedBackendClusterVersionInfoMetricHeader() + fmt.Sprintf(`backend_cluster_version_info{cluster_uuid="%s",resource_id="%s",state="partial",subscription_id="%s",version="4.19.22"} 1
+backend_cluster_version_info{cluster_uuid="%s",resource_id="%s",state="partial",subscription_id="%s",version="4.19.21"} 1
+backend_cluster_version_info{cluster_uuid="%s",resource_id="%s",state="partial",subscription_id="%s",version="4.19.20"} 1
+`, clusterUUID, resourceID, subscriptionID, clusterUUID, resourceID, subscriptionID, clusterUUID, resourceID, subscriptionID)
+	require.NoError(t, testutil.GatherAndCompare(prometheusRegistry, strings.NewReader(expected), "backend_cluster_version_info"))
+}
+
 func TestClusterVersionMetricsHandler_ReplacesDesiredWhenVersionBecomesActive(t *testing.T) {
 	ctx := context.Background()
 	prometheusRegistry := prometheus.NewRegistry()

--- a/backend/pkg/controllers/metricscontrollers/cluster_version_metrics_handler_test.go
+++ b/backend/pkg/controllers/metricscontrollers/cluster_version_metrics_handler_test.go
@@ -1,0 +1,217 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metricscontrollers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/blang/semver/v4"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/utils/ptr"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+)
+
+func seedTestServiceProviderCluster(
+	t *testing.T,
+	ctx context.Context,
+	mockResourcesDBClient *databasetesting.MockResourcesDBClient,
+	clusterName string,
+	desiredVersion string,
+	activeVersions []api.HCPClusterActiveVersion,
+) *api.HCPOpenShiftCluster {
+	t.Helper()
+
+	cluster := newTestCluster(t, clusterName, arm.ProvisioningStateSucceeded, nil)
+	clusterResourceID := cluster.ID
+	serviceProviderClusterResourceID := api.Must(azcorearm.ParseResourceID(
+		clusterResourceID.String() + "/" + api.ServiceProviderClusterResourceTypeName + "/" + api.ServiceProviderClusterResourceName,
+	))
+
+	serviceProviderCluster := &api.ServiceProviderCluster{
+		CosmosMetadata: api.CosmosMetadata{ResourceID: serviceProviderClusterResourceID},
+		Status: api.ServiceProviderClusterStatus{
+			ControlPlaneVersion: api.ServiceProviderClusterStatusVersion{
+				ActiveVersions: activeVersions,
+			},
+		},
+	}
+	if desiredVersion != "" {
+		serviceProviderCluster.Spec.ControlPlaneVersion.DesiredVersion = ptr.To(semver.MustParse(desiredVersion))
+	}
+
+	_, err := mockResourcesDBClient.ServiceProviderClusters(
+		clusterResourceID.SubscriptionID,
+		clusterResourceID.ResourceGroupName,
+		clusterResourceID.Name,
+	).Create(ctx, serviceProviderCluster, nil)
+	require.NoError(t, err)
+
+	return cluster
+}
+
+func TestClusterVersionMetricsHandler_SetsDesiredAndActiveVersions(t *testing.T) {
+	ctx := context.Background()
+	mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
+	prometheusRegistry := prometheus.NewRegistry()
+	versionMetricsHandler := newClusterVersionMetricsHandler(prometheusRegistry, mockResourcesDBClient)
+
+	cluster := seedTestServiceProviderCluster(t, ctx, mockResourcesDBClient, "cluster-1", "4.19.20", []api.HCPClusterActiveVersion{
+		{Version: ptr.To(semver.MustParse("4.19.19")), State: configv1.CompletedUpdate},
+		{Version: ptr.To(semver.MustParse("4.19.20")), State: configv1.PartialUpdate},
+	})
+	versionMetricsHandler.Sync(ctx, clusterMetricsObject{cluster})
+
+	resourceID := resourceIDMetricLabel(cluster.ID)
+	subscriptionID := subscriptionIDMetricLabel(cluster.ID)
+
+	expected := fmt.Sprintf(`# HELP backend_cluster_version_info Information about cluster versions. Value is 1 when version is in the specified state. States: desired (target selected, upgrade not started), partial (upgrade in progress), completed (upgrade finished). Use partial and completed for fleet and upgrade-progress metrics; desired is pre-upgrade only.
+# TYPE backend_cluster_version_info gauge
+backend_cluster_version_info{resource_id="%s",state="completed",subscription_id="%s",version="4.19.19"} 1
+backend_cluster_version_info{resource_id="%s",state="partial",subscription_id="%s",version="4.19.20"} 1
+`, resourceID, subscriptionID, resourceID, subscriptionID)
+	require.NoError(t, testutil.GatherAndCompare(prometheusRegistry, strings.NewReader(expected), "backend_cluster_version_info"))
+}
+
+func TestClusterVersionMetricsHandler_ReplacesDesiredWhenVersionBecomesActive(t *testing.T) {
+	ctx := context.Background()
+	mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
+	prometheusRegistry := prometheus.NewRegistry()
+	versionMetricsHandler := newClusterVersionMetricsHandler(prometheusRegistry, mockResourcesDBClient)
+
+	cluster := seedTestServiceProviderCluster(t, ctx, mockResourcesDBClient, "cluster-1", "4.19.20", []api.HCPClusterActiveVersion{
+		{Version: ptr.To(semver.MustParse("4.19.20")), State: configv1.CompletedUpdate},
+	})
+	versionMetricsHandler.Sync(ctx, clusterMetricsObject{cluster})
+
+	resourceID := resourceIDMetricLabel(cluster.ID)
+	subscriptionID := subscriptionIDMetricLabel(cluster.ID)
+
+	expected := fmt.Sprintf(`# HELP backend_cluster_version_info Information about cluster versions. Value is 1 when version is in the specified state. States: desired (target selected, upgrade not started), partial (upgrade in progress), completed (upgrade finished). Use partial and completed for fleet and upgrade-progress metrics; desired is pre-upgrade only.
+# TYPE backend_cluster_version_info gauge
+backend_cluster_version_info{resource_id="%s",state="completed",subscription_id="%s",version="4.19.20"} 1
+`, resourceID, subscriptionID)
+	require.NoError(t, testutil.GatherAndCompare(prometheusRegistry, strings.NewReader(expected), "backend_cluster_version_info"))
+}
+
+func TestClusterVersionMetricsHandler_DeleteCleansUpMetrics(t *testing.T) {
+	ctx := context.Background()
+	mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
+	prometheusRegistry := prometheus.NewRegistry()
+	versionMetricsHandler := newClusterVersionMetricsHandler(prometheusRegistry, mockResourcesDBClient)
+
+	cluster := seedTestServiceProviderCluster(t, ctx, mockResourcesDBClient, "cluster-1", "4.19.20", nil)
+	versionMetricsHandler.Sync(ctx, clusterMetricsObject{cluster})
+	versionMetricsHandler.Delete(resourceIDMetricLabel(cluster.ID))
+
+	require.NoError(t, testutil.GatherAndCompare(prometheusRegistry, strings.NewReader(""), "backend_cluster_version_info"))
+}
+
+func TestClusterVersionMetricsHandler_NoMetricsWhenServiceProviderClusterMissing(t *testing.T) {
+	ctx := context.Background()
+	mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
+	prometheusRegistry := prometheus.NewRegistry()
+	versionMetricsHandler := newClusterVersionMetricsHandler(prometheusRegistry, mockResourcesDBClient)
+
+	cluster := newTestCluster(t, "cluster-1", arm.ProvisioningStateSucceeded, nil)
+	versionMetricsHandler.Sync(ctx, clusterMetricsObject{cluster})
+
+	require.NoError(t, testutil.GatherAndCompare(prometheusRegistry, strings.NewReader(""), "backend_cluster_version_info"))
+}
+
+func TestClusterVersionMetricsHandler_ClearsMetricsWhenServiceProviderClusterDeleted(t *testing.T) {
+	ctx := context.Background()
+	mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
+	prometheusRegistry := prometheus.NewRegistry()
+	versionMetricsHandler := newClusterVersionMetricsHandler(prometheusRegistry, mockResourcesDBClient)
+
+	cluster := seedTestServiceProviderCluster(t, ctx, mockResourcesDBClient, "cluster-1", "4.19.20", nil)
+	versionMetricsHandler.Sync(ctx, clusterMetricsObject{cluster})
+
+	err := mockResourcesDBClient.ServiceProviderClusters(
+		cluster.ID.SubscriptionID,
+		cluster.ID.ResourceGroupName,
+		cluster.ID.Name,
+	).Delete(ctx, api.ServiceProviderClusterResourceName)
+	require.NoError(t, err)
+
+	versionMetricsHandler.Sync(ctx, clusterMetricsObject{cluster})
+
+	require.NoError(t, testutil.GatherAndCompare(prometheusRegistry, strings.NewReader(""), "backend_cluster_version_info"))
+}
+
+// Stubs below simulate a transient ServiceProviderCluster Get failure for
+// TestClusterVersionMetricsHandler_RetainsMetricsOnTransientGetError.
+type getErrorServiceProviderClusterCRUD struct {
+	database.ServiceProviderClusterCRUD
+	getErr error
+}
+
+func (c *getErrorServiceProviderClusterCRUD) Get(ctx context.Context, resourceID string) (*api.ServiceProviderCluster, error) {
+	return nil, c.getErr
+}
+
+type serviceProviderClusterGetErrorDBClient struct {
+	*databasetesting.MockResourcesDBClient
+	getErr error
+}
+
+func (c *serviceProviderClusterGetErrorDBClient) ServiceProviderClusters(subscriptionID, resourceGroupName, clusterName string) database.ServiceProviderClusterCRUD {
+	return &getErrorServiceProviderClusterCRUD{
+		ServiceProviderClusterCRUD: c.MockResourcesDBClient.ServiceProviderClusters(subscriptionID, resourceGroupName, clusterName),
+		getErr:                     c.getErr,
+	}
+}
+
+func TestClusterVersionMetricsHandler_RetainsMetricsOnTransientGetError(t *testing.T) {
+	ctx := context.Background()
+	mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
+	prometheusRegistry := prometheus.NewRegistry()
+	versionMetricsHandler := newClusterVersionMetricsHandler(prometheusRegistry, mockResourcesDBClient)
+
+	cluster := seedTestServiceProviderCluster(t, ctx, mockResourcesDBClient, "cluster-1", "4.19.20", []api.HCPClusterActiveVersion{
+		{Version: ptr.To(semver.MustParse("4.19.20")), State: configv1.CompletedUpdate},
+	})
+	versionMetricsHandler.Sync(ctx, clusterMetricsObject{cluster})
+
+	resourceID := resourceIDMetricLabel(cluster.ID)
+	subscriptionID := subscriptionIDMetricLabel(cluster.ID)
+	expected := fmt.Sprintf(`# HELP backend_cluster_version_info Information about cluster versions. Value is 1 when version is in the specified state. States: desired (target selected, upgrade not started), partial (upgrade in progress), completed (upgrade finished). Use partial and completed for fleet and upgrade-progress metrics; desired is pre-upgrade only.
+# TYPE backend_cluster_version_info gauge
+backend_cluster_version_info{resource_id="%s",state="completed",subscription_id="%s",version="4.19.20"} 1
+`, resourceID, subscriptionID)
+
+	versionMetricsHandler.resourcesDBClient = &serviceProviderClusterGetErrorDBClient{
+		MockResourcesDBClient: mockResourcesDBClient,
+		getErr:                errors.New("transient database error"),
+	}
+	versionMetricsHandler.Sync(ctx, clusterMetricsObject{cluster})
+
+	require.NoError(t, testutil.GatherAndCompare(prometheusRegistry, strings.NewReader(expected), "backend_cluster_version_info"))
+}

--- a/backend/pkg/controllers/metricscontrollers/cluster_version_metrics_handler_test.go
+++ b/backend/pkg/controllers/metricscontrollers/cluster_version_metrics_handler_test.go
@@ -157,6 +157,27 @@ func TestClusterVersionMetricsHandler_EmitsDesiredWhenNotYetActive(t *testing.T)
 	require.NoError(t, testutil.GatherAndCompare(prometheusRegistry, strings.NewReader(expected), "backend_cluster_version_info"))
 }
 
+func TestClusterVersionMetricsHandler_SkipsDuplicateActiveVersionsAfterRollback(t *testing.T) {
+	ctx := context.Background()
+	prometheusRegistry := prometheus.NewRegistry()
+	handler := newTestClusterVersionMetricsHandler(t, prometheusRegistry, newTestHostedClusterReadDesireLister(t, "11111111-1111-1111-1111-111111111111"))
+
+	cluster := newTestCluster(t, "cluster-1", arm.ProvisioningStateSucceeded, nil)
+	// ActiveVersions is newest-first; the same z-stream can appear twice after a rollback.
+	serviceProviderCluster := newTestServiceProviderCluster(t, cluster, "", []api.HCPClusterActiveVersion{
+		{Version: ptr.To(semver.MustParse("4.19.19")), State: configv1.PartialUpdate},
+		{Version: ptr.To(semver.MustParse("4.19.19")), State: configv1.CompletedUpdate},
+	})
+	handler.Sync(ctx, serviceProviderCluster)
+
+	resourceID := resourceIDMetricLabel(cluster.ID)
+	subscriptionID := subscriptionIDMetricLabel(cluster.ID)
+
+	expected := expectedBackendClusterVersionInfoMetricHeader() + fmt.Sprintf(`backend_cluster_version_info{cluster_uuid="%s",resource_id="%s",state="partial",subscription_id="%s",version="4.19.19"} 1
+`, "11111111-1111-1111-1111-111111111111", resourceID, subscriptionID)
+	require.NoError(t, testutil.GatherAndCompare(prometheusRegistry, strings.NewReader(expected), "backend_cluster_version_info"))
+}
+
 func TestClusterVersionMetricsHandler_ReplacesDesiredWhenVersionBecomesActive(t *testing.T) {
 	ctx := context.Background()
 	prometheusRegistry := prometheus.NewRegistry()

--- a/backend/pkg/controllers/metricscontrollers/cluster_version_metrics_handler_test.go
+++ b/backend/pkg/controllers/metricscontrollers/cluster_version_metrics_handler_test.go
@@ -16,6 +16,7 @@ package metricscontrollers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -25,16 +26,66 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/utils/ptr"
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
 	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/hypershift/api/hypershift/v1beta1"
 
+	"github.com/Azure/ARO-HCP/backend/pkg/maestrohelpers"
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/api/kubeapplier"
+	dblisters "github.com/Azure/ARO-HCP/internal/database/listers"
+	internallistertesting "github.com/Azure/ARO-HCP/internal/database/listertesting"
 )
+
+const testClusterUUID = "11111111-1111-1111-1111-111111111111"
+
+func newTestClusterVersionMetricsHandler(t *testing.T, prometheusRegistry *prometheus.Registry, readDesireLister dblisters.ReadDesireLister) Handler[*api.ServiceProviderCluster] {
+	t.Helper()
+	if readDesireLister == nil {
+		readDesireLister = &internallistertesting.SliceReadDesireLister{}
+	}
+	return NewClusterVersionMetricsHandler(prometheusRegistry, readDesireLister)
+}
+
+func newTestHostedClusterReadDesireLister(t *testing.T, clusterUUID string) dblisters.ReadDesireLister {
+	t.Helper()
+
+	hostedCluster := &v1beta1.HostedCluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "HostedCluster",
+			APIVersion: v1beta1.GroupVersion.String(),
+		},
+		Spec: v1beta1.HostedClusterSpec{
+			ClusterID: clusterUUID,
+		},
+	}
+	raw, err := json.Marshal(hostedCluster)
+	require.NoError(t, err)
+
+	readDesireResourceID := api.Must(azcorearm.ParseResourceID(
+		kubeapplier.ToClusterScopedReadDesireResourceIDString(
+			"sub-1", "rg", "cluster-1", maestrohelpers.ReadDesireNameReadonlyHostedCluster,
+		),
+	))
+
+	return &internallistertesting.SliceReadDesireLister{
+		Desires: []*kubeapplier.ReadDesire{
+			{
+				CosmosMetadata: api.CosmosMetadata{ResourceID: readDesireResourceID},
+				Status: kubeapplier.ReadDesireStatus{
+					KubeContent: &kruntime.RawExtension{Raw: raw},
+				},
+			},
+		},
+	}
+}
 
 func newTestServiceProviderCluster(
 	t *testing.T,
@@ -67,7 +118,7 @@ func newTestServiceProviderCluster(
 func TestClusterVersionMetricsHandler_SetsDesiredAndActiveVersions(t *testing.T) {
 	ctx := context.Background()
 	prometheusRegistry := prometheus.NewRegistry()
-	handler := NewClusterVersionMetricsHandler(prometheusRegistry)
+	handler := newTestClusterVersionMetricsHandler(t, prometheusRegistry, newTestHostedClusterReadDesireLister(t, testClusterUUID))
 
 	cluster := newTestCluster(t, "cluster-1", arm.ProvisioningStateSucceeded, nil)
 	serviceProviderCluster := newTestServiceProviderCluster(t, cluster, "4.19.20", []api.HCPClusterActiveVersion{
@@ -81,16 +132,16 @@ func TestClusterVersionMetricsHandler_SetsDesiredAndActiveVersions(t *testing.T)
 
 	expected := fmt.Sprintf(`# HELP backend_cluster_version_info Information about cluster versions. Value is 1 when version is in the specified state. States: desired (target selected, upgrade not started), partial (upgrade in progress), completed (upgrade finished). Use partial and completed for fleet and upgrade-progress metrics; desired is pre-upgrade only.
 # TYPE backend_cluster_version_info gauge
-backend_cluster_version_info{resource_id="%s",state="completed",subscription_id="%s",version="4.19.19"} 1
-backend_cluster_version_info{resource_id="%s",state="partial",subscription_id="%s",version="4.19.20"} 1
-`, resourceID, subscriptionID, resourceID, subscriptionID)
+backend_cluster_version_info{cluster_uuid="%s",resource_id="%s",state="completed",subscription_id="%s",version="4.19.19"} 1
+backend_cluster_version_info{cluster_uuid="%s",resource_id="%s",state="partial",subscription_id="%s",version="4.19.20"} 1
+`, testClusterUUID, resourceID, subscriptionID, testClusterUUID, resourceID, subscriptionID)
 	require.NoError(t, testutil.GatherAndCompare(prometheusRegistry, strings.NewReader(expected), "backend_cluster_version_info"))
 }
 
 func TestClusterVersionMetricsHandler_ReplacesDesiredWhenVersionBecomesActive(t *testing.T) {
 	ctx := context.Background()
 	prometheusRegistry := prometheus.NewRegistry()
-	handler := NewClusterVersionMetricsHandler(prometheusRegistry)
+	handler := newTestClusterVersionMetricsHandler(t, prometheusRegistry, newTestHostedClusterReadDesireLister(t, testClusterUUID))
 
 	cluster := newTestCluster(t, "cluster-1", arm.ProvisioningStateSucceeded, nil)
 	serviceProviderCluster := newTestServiceProviderCluster(t, cluster, "4.19.20", []api.HCPClusterActiveVersion{
@@ -103,15 +154,15 @@ func TestClusterVersionMetricsHandler_ReplacesDesiredWhenVersionBecomesActive(t 
 
 	expected := fmt.Sprintf(`# HELP backend_cluster_version_info Information about cluster versions. Value is 1 when version is in the specified state. States: desired (target selected, upgrade not started), partial (upgrade in progress), completed (upgrade finished). Use partial and completed for fleet and upgrade-progress metrics; desired is pre-upgrade only.
 # TYPE backend_cluster_version_info gauge
-backend_cluster_version_info{resource_id="%s",state="completed",subscription_id="%s",version="4.19.20"} 1
-`, resourceID, subscriptionID)
+backend_cluster_version_info{cluster_uuid="%s",resource_id="%s",state="completed",subscription_id="%s",version="4.19.20"} 1
+`, testClusterUUID, resourceID, subscriptionID)
 	require.NoError(t, testutil.GatherAndCompare(prometheusRegistry, strings.NewReader(expected), "backend_cluster_version_info"))
 }
 
 func TestClusterVersionMetricsHandler_DeleteCleansUpMetrics(t *testing.T) {
 	ctx := context.Background()
 	prometheusRegistry := prometheus.NewRegistry()
-	handler := NewClusterVersionMetricsHandler(prometheusRegistry)
+	handler := newTestClusterVersionMetricsHandler(t, prometheusRegistry, newTestHostedClusterReadDesireLister(t, testClusterUUID))
 
 	cluster := newTestCluster(t, "cluster-1", arm.ProvisioningStateSucceeded, nil)
 	serviceProviderCluster := newTestServiceProviderCluster(t, cluster, "4.19.20", nil)
@@ -127,7 +178,7 @@ func TestClusterVersionMetricsHandler_DeleteCleansUpMetrics(t *testing.T) {
 func TestClusterVersionMetricsController_SyncResource(t *testing.T) {
 	ctx := context.Background()
 	prometheusRegistry := prometheus.NewRegistry()
-	handler := NewClusterVersionMetricsHandler(prometheusRegistry)
+	handler := newTestClusterVersionMetricsHandler(t, prometheusRegistry, newTestHostedClusterReadDesireLister(t, testClusterUUID))
 
 	cluster := newTestCluster(t, "cluster-1", arm.ProvisioningStateSucceeded, nil)
 	serviceProviderCluster := newTestServiceProviderCluster(t, cluster, "4.19.20", []api.HCPClusterActiveVersion{
@@ -151,15 +202,15 @@ func TestClusterVersionMetricsController_SyncResource(t *testing.T) {
 	subscriptionID := subscriptionIDMetricLabel(cluster.ID)
 	expected := fmt.Sprintf(`# HELP backend_cluster_version_info Information about cluster versions. Value is 1 when version is in the specified state. States: desired (target selected, upgrade not started), partial (upgrade in progress), completed (upgrade finished). Use partial and completed for fleet and upgrade-progress metrics; desired is pre-upgrade only.
 # TYPE backend_cluster_version_info gauge
-backend_cluster_version_info{resource_id="%s",state="completed",subscription_id="%s",version="4.19.20"} 1
-`, resourceID, subscriptionID)
+backend_cluster_version_info{cluster_uuid="%s",resource_id="%s",state="completed",subscription_id="%s",version="4.19.20"} 1
+`, testClusterUUID, resourceID, subscriptionID)
 	require.NoError(t, testutil.GatherAndCompare(prometheusRegistry, strings.NewReader(expected), "backend_cluster_version_info"))
 }
 
 func TestClusterVersionMetricsController_DeletesMetricsWhenResourceRemoved(t *testing.T) {
 	ctx := context.Background()
 	prometheusRegistry := prometheus.NewRegistry()
-	handler := NewClusterVersionMetricsHandler(prometheusRegistry)
+	handler := newTestClusterVersionMetricsHandler(t, prometheusRegistry, newTestHostedClusterReadDesireLister(t, testClusterUUID))
 
 	cluster := newTestCluster(t, "cluster-1", arm.ProvisioningStateSucceeded, nil)
 	serviceProviderCluster := newTestServiceProviderCluster(t, cluster, "4.19.20", []api.HCPClusterActiveVersion{

--- a/backend/pkg/controllers/metricscontrollers/resource_metrics_controller.go
+++ b/backend/pkg/controllers/metricscontrollers/resource_metrics_controller.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
-	"github.com/Azure/ARO-HCP/internal/database"
 )
 
 type resourceStateMetricsObject interface {
@@ -124,11 +123,10 @@ func (o clusterMetricsObject) CreatedAt() *time.Time {
 
 type clusterMetricsHandler struct {
 	*resourceStateMetricsHandler[clusterMetricsObject]
-	clusterVersionMetrics *clusterVersionMetricsHandler
 }
 
 // NewClusterMetricsHandler creates a metrics handler for cluster metrics.
-func NewClusterMetricsHandler(r prometheus.Registerer, resourcesDBClient database.ResourcesDBClient) Handler[*api.HCPOpenShiftCluster] {
+func NewClusterMetricsHandler(r prometheus.Registerer) Handler[*api.HCPOpenShiftCluster] {
 	return &clusterMetricsHandler{
 		resourceStateMetricsHandler: newResourceStateMetricsHandler[clusterMetricsObject](
 			r,
@@ -137,19 +135,11 @@ func NewClusterMetricsHandler(r prometheus.Registerer, resourcesDBClient databas
 			"backend_cluster_created_time_seconds",
 			"Unix timestamp when the cluster was created.",
 		),
-		clusterVersionMetrics: newClusterVersionMetricsHandler(r, resourcesDBClient),
 	}
 }
 
 func (h *clusterMetricsHandler) Sync(ctx context.Context, cluster *api.HCPOpenShiftCluster) {
-	obj := clusterMetricsObject{cluster}
-	h.resourceStateMetricsHandler.Sync(ctx, obj)
-	h.clusterVersionMetrics.Sync(ctx, obj)
-}
-
-func (h *clusterMetricsHandler) Delete(key string) {
-	h.resourceStateMetricsHandler.Delete(key)
-	h.clusterVersionMetrics.Delete(key)
+	h.resourceStateMetricsHandler.Sync(ctx, clusterMetricsObject{cluster})
 }
 
 type nodePoolMetricsObject struct {

--- a/backend/pkg/controllers/metricscontrollers/resource_metrics_controller.go
+++ b/backend/pkg/controllers/metricscontrollers/resource_metrics_controller.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/database"
 )
 
 type resourceStateMetricsObject interface {
@@ -123,23 +124,32 @@ func (o clusterMetricsObject) CreatedAt() *time.Time {
 
 type clusterMetricsHandler struct {
 	*resourceStateMetricsHandler[clusterMetricsObject]
+	clusterVersionMetrics *clusterVersionMetricsHandler
 }
 
 // NewClusterMetricsHandler creates a metrics handler for cluster metrics.
-func NewClusterMetricsHandler(r prometheus.Registerer) Handler[*api.HCPOpenShiftCluster] {
+func NewClusterMetricsHandler(r prometheus.Registerer, resourcesDBClient database.ResourcesDBClient) Handler[*api.HCPOpenShiftCluster] {
 	return &clusterMetricsHandler{
-		newResourceStateMetricsHandler[clusterMetricsObject](
+		resourceStateMetricsHandler: newResourceStateMetricsHandler[clusterMetricsObject](
 			r,
 			"backend_cluster_provision_state",
 			"Current provisioning state of the cluster (value is always 1).",
 			"backend_cluster_created_time_seconds",
 			"Unix timestamp when the cluster was created.",
 		),
+		clusterVersionMetrics: newClusterVersionMetricsHandler(r, resourcesDBClient),
 	}
 }
 
 func (h *clusterMetricsHandler) Sync(ctx context.Context, cluster *api.HCPOpenShiftCluster) {
-	h.resourceStateMetricsHandler.Sync(ctx, clusterMetricsObject{cluster})
+	obj := clusterMetricsObject{cluster}
+	h.resourceStateMetricsHandler.Sync(ctx, obj)
+	h.clusterVersionMetrics.Sync(ctx, obj)
+}
+
+func (h *clusterMetricsHandler) Delete(key string) {
+	h.resourceStateMetricsHandler.Delete(key)
+	h.clusterVersionMetrics.Delete(key)
 }
 
 type nodePoolMetricsObject struct {

--- a/backend/pkg/controllers/metricscontrollers/resource_metrics_controller_test.go
+++ b/backend/pkg/controllers/metricscontrollers/resource_metrics_controller_test.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
-	"github.com/Azure/ARO-HCP/internal/databasetesting"
 )
 
 func newTestCluster(t *testing.T, name string, state arm.ProvisioningState, createdAt *time.Time) *api.HCPOpenShiftCluster {
@@ -61,7 +60,7 @@ func newTestCluster(t *testing.T, name string, state arm.ProvisioningState, crea
 func TestClusterMetricsHandler_SetsProvisionStateAndCreatedTime(t *testing.T) {
 	now := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	reg := prometheus.NewRegistry()
-	handler := NewClusterMetricsHandler(reg, databasetesting.NewMockResourcesDBClient())
+	handler := NewClusterMetricsHandler(reg)
 
 	cluster := newTestCluster(t, "cluster-1", arm.ProvisioningStateProvisioning, &now)
 	handler.Sync(context.Background(), cluster)
@@ -85,7 +84,7 @@ backend_cluster_created_time_seconds{resource_id="%s",subscription_id="%s"} %d
 func TestClusterMetricsHandler_PhaseTransitionDeletesOldSeries(t *testing.T) {
 	now := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	reg := prometheus.NewRegistry()
-	handler := NewClusterMetricsHandler(reg, databasetesting.NewMockResourcesDBClient())
+	handler := NewClusterMetricsHandler(reg)
 
 	cluster := newTestCluster(t, "cluster-1", arm.ProvisioningStateAccepted, &now)
 	handler.Sync(context.Background(), cluster)
@@ -104,7 +103,7 @@ backend_cluster_provision_state{phase="provisioning",resource_id="%s",subscripti
 
 func TestClusterMetricsHandler_NilCreatedAt(t *testing.T) {
 	reg := prometheus.NewRegistry()
-	handler := NewClusterMetricsHandler(reg, databasetesting.NewMockResourcesDBClient())
+	handler := NewClusterMetricsHandler(reg)
 
 	cluster := newTestCluster(t, "cluster-1", arm.ProvisioningStateAccepted, nil)
 	handler.Sync(context.Background(), cluster)
@@ -122,7 +121,7 @@ backend_cluster_provision_state{phase="accepted",resource_id="%s",subscription_i
 func TestClusterMetricsHandler_DeleteCleansUpAllGauges(t *testing.T) {
 	now := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	reg := prometheus.NewRegistry()
-	handler := NewClusterMetricsHandler(reg, databasetesting.NewMockResourcesDBClient())
+	handler := NewClusterMetricsHandler(reg)
 
 	cluster := newTestCluster(t, "cluster-1", arm.ProvisioningStateSucceeded, &now)
 	handler.Sync(context.Background(), cluster)
@@ -204,7 +203,7 @@ backend_externalauth_created_time_seconds{resource_id="%s",subscription_id="%s"}
 func TestResourceControllerSyncResource_SetsMetricsFromIndexer(t *testing.T) {
 	now := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	reg := prometheus.NewRegistry()
-	handler := NewClusterMetricsHandler(reg, databasetesting.NewMockResourcesDBClient())
+	handler := NewClusterMetricsHandler(reg)
 	cluster := newTestCluster(t, "cluster-1", arm.ProvisioningStateSucceeded, &now)
 
 	indexer := cache.NewIndexer(resourceIDStoreKeyForObject, cache.Indexers{})
@@ -232,7 +231,7 @@ backend_cluster_provision_state{phase="succeeded",resource_id="%s",subscription_
 func TestResourceControllerSyncResource_DeletesMetricsWhenResourceRemoved(t *testing.T) {
 	now := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	reg := prometheus.NewRegistry()
-	handler := NewClusterMetricsHandler(reg, databasetesting.NewMockResourcesDBClient())
+	handler := NewClusterMetricsHandler(reg)
 	cluster := newTestCluster(t, "cluster-1", arm.ProvisioningStateSucceeded, &now)
 
 	indexer := cache.NewIndexer(resourceIDStoreKeyForObject, cache.Indexers{})

--- a/backend/pkg/controllers/metricscontrollers/resource_metrics_controller_test.go
+++ b/backend/pkg/controllers/metricscontrollers/resource_metrics_controller_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
 )
 
 func newTestCluster(t *testing.T, name string, state arm.ProvisioningState, createdAt *time.Time) *api.HCPOpenShiftCluster {
@@ -60,7 +61,7 @@ func newTestCluster(t *testing.T, name string, state arm.ProvisioningState, crea
 func TestClusterMetricsHandler_SetsProvisionStateAndCreatedTime(t *testing.T) {
 	now := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	reg := prometheus.NewRegistry()
-	handler := NewClusterMetricsHandler(reg)
+	handler := NewClusterMetricsHandler(reg, databasetesting.NewMockResourcesDBClient())
 
 	cluster := newTestCluster(t, "cluster-1", arm.ProvisioningStateProvisioning, &now)
 	handler.Sync(context.Background(), cluster)
@@ -84,7 +85,7 @@ backend_cluster_created_time_seconds{resource_id="%s",subscription_id="%s"} %d
 func TestClusterMetricsHandler_PhaseTransitionDeletesOldSeries(t *testing.T) {
 	now := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	reg := prometheus.NewRegistry()
-	handler := NewClusterMetricsHandler(reg)
+	handler := NewClusterMetricsHandler(reg, databasetesting.NewMockResourcesDBClient())
 
 	cluster := newTestCluster(t, "cluster-1", arm.ProvisioningStateAccepted, &now)
 	handler.Sync(context.Background(), cluster)
@@ -103,7 +104,7 @@ backend_cluster_provision_state{phase="provisioning",resource_id="%s",subscripti
 
 func TestClusterMetricsHandler_NilCreatedAt(t *testing.T) {
 	reg := prometheus.NewRegistry()
-	handler := NewClusterMetricsHandler(reg)
+	handler := NewClusterMetricsHandler(reg, databasetesting.NewMockResourcesDBClient())
 
 	cluster := newTestCluster(t, "cluster-1", arm.ProvisioningStateAccepted, nil)
 	handler.Sync(context.Background(), cluster)
@@ -121,7 +122,7 @@ backend_cluster_provision_state{phase="accepted",resource_id="%s",subscription_i
 func TestClusterMetricsHandler_DeleteCleansUpAllGauges(t *testing.T) {
 	now := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	reg := prometheus.NewRegistry()
-	handler := NewClusterMetricsHandler(reg)
+	handler := NewClusterMetricsHandler(reg, databasetesting.NewMockResourcesDBClient())
 
 	cluster := newTestCluster(t, "cluster-1", arm.ProvisioningStateSucceeded, &now)
 	handler.Sync(context.Background(), cluster)
@@ -203,7 +204,7 @@ backend_externalauth_created_time_seconds{resource_id="%s",subscription_id="%s"}
 func TestResourceControllerSyncResource_SetsMetricsFromIndexer(t *testing.T) {
 	now := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	reg := prometheus.NewRegistry()
-	handler := NewClusterMetricsHandler(reg)
+	handler := NewClusterMetricsHandler(reg, databasetesting.NewMockResourcesDBClient())
 	cluster := newTestCluster(t, "cluster-1", arm.ProvisioningStateSucceeded, &now)
 
 	indexer := cache.NewIndexer(resourceIDStoreKeyForObject, cache.Indexers{})
@@ -231,7 +232,7 @@ backend_cluster_provision_state{phase="succeeded",resource_id="%s",subscription_
 func TestResourceControllerSyncResource_DeletesMetricsWhenResourceRemoved(t *testing.T) {
 	now := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	reg := prometheus.NewRegistry()
-	handler := NewClusterMetricsHandler(reg)
+	handler := NewClusterMetricsHandler(reg, databasetesting.NewMockResourcesDBClient())
 	cluster := newTestCluster(t, "cluster-1", arm.ProvisioningStateSucceeded, &now)
 
 	indexer := cache.NewIndexer(resourceIDStoreKeyForObject, cache.Indexers{})


### PR DESCRIPTION
### What

feat: expose cluster control plane version state in backend Prometheus metrics

### Why

Add backend_cluster_version_info so fleet and upgrade dashboards (to be added as followup) can track each cluster's target and active OpenShift versions from ServiceProviderCluster data.

The cluster metrics handler now reads desired and active control plane versions on sync, emits one time series per version/state pair, and cleans up series when a cluster is deleted. Active versions take precedence over desired for the same version string.

Example metric

1. 4.19.20 is desired
```
backend_cluster_version_info{
  resource_id="/subscriptions/aabbccdd-1111-2222-3333-444455556666/resourcegroups/my-rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/my-cluster",
  subscription_id="aabbccdd-1111-2222-3333-444455556666",
  version="4.19.20",
  state="desired"
} 1
```
2. it becomes partial: active version in the cluster but partially upgraded to

```
backend_cluster_version_info{
  resource_id="/subscriptions/aabbccdd-1111-2222-3333-444455556666/resourcegroups/my-rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/my-cluster",
  subscription_id="aabbccdd-1111-2222-3333-444455556666",
  version="4.19.20",
  state="partial"
} 1
```

3. once completed: the upgrade is complete

```
backend_cluster_version_info{
  resource_id="/subscriptions/aabbccdd-1111-2222-3333-444455556666/resourcegroups/my-rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/my-cluster",
  subscription_id="aabbccdd-1111-2222-3333-444455556666",
  version="4.19.20",
  state="`completed"
} 1
```


### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
