### PR TITLE
Avoid unnecessary error/requeue on conflict.

### DIFF
--- a/backend/pkg/controllers/clusterpropertiescontroller/cluster_properties_sync.go
+++ b/backend/pkg/controllers/clusterpropertiescontroller/cluster_properties_sync.go
@@ -129,7 +129,11 @@ func (c *clusterPropertiesSyncer) SyncOnce(ctx context.Context, key controllerut
 		return nil
 	}
 
-	if _, err := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).Replace(ctx, replacement, nil); err != nil {
+	if _, err := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).Replace(ctx, replacement, nil); database.IsPreconditionFailedError(err) {
+		// if we have a conflict error, then we're guaranteed that our informer will eventually see an update and trigger us again.
+		// there is no need to report an error since the retry will happen when the reflector sees the update and puts an Update into the informer.
+		return nil
+	} else if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to replace Cluster: %w", err))
 	}
 


### PR DESCRIPTION
When cluster properties sync gets a conflict, it doesn't need to requeue since the informer will eventually observe the update in state and trigger the controller.

Fixes the excessive retries in CI that look like

> 	"msg": "Error syncing; requeuing for later retry",
> 	"err": "(wrapped at cluster_properties_sync.go:133) failed to replace Cluster: PUT https://arohcpci01-rp-j0297856-westus3.documents.azure.com:443/dbs/arohcpci01-rp-j0297856/colls/Resources/docs/686daff4-1742-55d9-8c6e-926f6a728fbd\n--------------------------------------------------------------------------------\nRESPONSE 412: 412 Precondition Failed\nERROR CODE: 412 Precondition Failed\n--------------------------------------------------------------------------------\n{\n  \"code\": \"PreconditionFailed\",\n  \"message\": \"Operation cannot be performed because one of the specified precondition is not met., \\r\\nRequestStartTime: 2026-06-10T13:04:51.1507101Z, RequestEndTime: 2026-06-10T13:04:51.1519557Z,  Number of regions attempted:1\\r\\n{\\\"systemHistory\\\":

ref https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/Azure_ARO-HCP/5584/pull-ci-Azure-ARO-HCP-main-e2e-parallel/2064672805890297856
