### PR TITLE
Avoid operation_create when racing the cache update

### DIFF
--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_create.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_create.go
@@ -210,6 +210,11 @@ func (c *operationClusterCreate) determineOperationStatus(ctx context.Context, o
 
 func (c *operationClusterCreate) clusterOperationStatus(ctx context.Context, operation *api.Operation) (*operationState, error) {
 	cluster, err := c.clusterLister.Get(ctx, operation.ExternalID.SubscriptionID, operation.ExternalID.ResourceGroupName, operation.ExternalID.Name)
+	if database.IsNotFoundError(err) {
+		// if the cache doesn't have the cosmos cluster yet, we'll eventually recheck when we resync. Currently 10s for
+		// active operations.  No need to fail and trigger an extra check.
+		return newOperationState(arm.ProvisioningStateProvisioning, "cluster state not cached yet"), nil
+	}
 	if err != nil {
 		return nil, utils.TrackError(err)
 	}
@@ -239,7 +244,7 @@ func (c *operationClusterCreate) hostedClusterOperationStatus(ctx context.Contex
 	// don't need to know which management cluster the HostedCluster is on.
 	readDesire, err := c.readDesireLister.GetForCluster(ctx, operation.ExternalID.SubscriptionID, operation.ExternalID.ResourceGroupName, operation.ExternalID.Name, maestrohelpers.ReadDesireNameReadonlyHostedCluster)
 	if database.IsNotFoundError(err) {
-		return newOperationState(arm.ProvisioningStateProvisioning, ""), nil
+		return newOperationState(arm.ProvisioningStateProvisioning, "hosted cluster state not cached yet"), nil
 	}
 	if err != nil {
 		return nil, utils.TrackError(err)


### PR DESCRIPTION
We don't need to fail since we're going to requeue.  Instead we can return a reasonable operation status that indicates we're accepted, but have no real status.  Corrects failures like

	"err": "(wrapped at operation_cluster_create.go:146) (wrapped at operation_cluster_create.go:184) (wrapped at operation_cluster_create.go:214) Missing RawResponse\n--------------------------------------------------------------------------------\nERROR CODE: 404 Not Found\n--------------------------------------------------------------------------------\n",

Seen in https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/Azure_ARO-HCP/5584/pull-ci-Azure-ARO-HCP-main-e2e-parallel/2064672805890297856
