### PR TITLE
fix: reduce ControlPlaneActiveVersions reconcile interval to 1 minute

### DIFF
--- a/backend/pkg/controllers/upgradecontrollers/control_plane_active_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_active_version_controller.go
@@ -68,7 +68,7 @@ func NewControlPlaneActiveVersionController(
 		resourcesDBClient,
 		informers,
 		kubeApplierInformers,
-		5*time.Minute,
+		1*time.Minute,
 		syncer,
 	)
 }


### PR DESCRIPTION
## Summary

- Reduces the `ControlPlaneActiveVersions` controller reconcile interval from 5 minutes to 1 minute to speed up OCP version detection during cluster creation.
- The 5-minute interval causes an average 2.5-minute lag, contributing to >20-minute E2E test timeouts. With 1 minute, average detection lag drops to ~30 seconds.

Ref: [ARO-27484](https://redhat.atlassian.net/browse/ARO-27484)

## Test plan

- [x] Existing unit tests pass (`cd backend && go test ./...`)
- [x] E2E tests show improved cluster creation time (version detection no longer a bottleneck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)