### PR TITLE
ARO-27686 | feat(observability): expose subscription_id on KSM HostedCluster metrics

### DIFF
--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arohcp_monitor.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arohcp_monitor.yaml
@@ -67656,6 +67656,11 @@ data:
           namespace:
           - metadata
           - namespace
+          subscription_id:
+          - spec
+          - platform
+          - azure
+          - subscriptionID
         metricNamePrefix: hostedClusterAPI
         metrics:
         - each:

--- a/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_mgmt_resources.yaml
+++ b/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_mgmt_resources.yaml
@@ -67656,6 +67656,11 @@ data:
           namespace:
           - metadata
           - namespace
+          subscription_id:
+          - spec
+          - platform
+          - azure
+          - subscriptionID
         metricNamePrefix: hostedClusterAPI
         metrics:
         - each:

--- a/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_mgmt_resources_unset.yaml
+++ b/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_mgmt_resources_unset.yaml
@@ -67656,6 +67656,11 @@ data:
           namespace:
           - metadata
           - namespace
+          subscription_id:
+          - spec
+          - platform
+          - azure
+          - subscriptionID
         metricNamePrefix: hostedClusterAPI
         metrics:
         - each:

--- a/observability/prometheus/values-mgmt.yaml
+++ b/observability/prometheus/values-mgmt.yaml
@@ -101,6 +101,7 @@ kube-prometheus-stack:
               namespace: [metadata, namespace]
               api_url: [spec, services, "[service=APIServer]", servicePublishingStrategy, route, hostname]
               _id: [spec, clusterID]
+              subscription_id: [spec, platform, azure, subscriptionID]
             metrics:
             - name: "kubeapiserver_available"
               help: "KubeAPIServer availability condition"


### PR DESCRIPTION
<!-- Link to Jira issue -->
https://redhat.atlassian.net/browse/ARO-27686

### What

Add `subscription_id` to the KSM custom-resource-state config for HostedCluster CRDs, mapping `HostedCluster.Spec.Platform.Azure.SubscriptionID` as a label on all `hostedClusterAPI_*` metrics.

### Why

Downstream alert filtering and dashboards need `subscription_id` to distinguish internal/dev subscriptions from customer subscriptions. This label is the foundation for excluding internal subs from RP lane alerting (generator changes in a follow-up PR).

### Testing

Helm test fixtures regenerated via `UPDATE=true go test ./tooling/helmtest/...`, all existing tests pass.