### PR TITLE
workaround: skip nightly nodepool upgrade/downgrade tests (ARO-27344)

### DIFF
--- a/test/e2e/nodepool_version_upgrade.go
+++ b/test/e2e/nodepool_version_upgrade.go
@@ -382,6 +382,13 @@ var _ = Describe("Customer", func() {
 		func(ctx context.Context, nodePoolMinor string, targetMinor string) {
 			channelGroup := framework.DefaultOpenshiftChannelGroup()
 
+			// Workaround: skip on nightly until CS fixes the nightly→ACR image substitution
+			// on the nodepool upgrade path (PatchNodePoolCR writes quay.io instead of ACR).
+			// See ARO-27344.
+			if channelGroup == "nightly" {
+				Skip("nightly nodepool upgrade blocked by CS image substitution bug; see ARO-27344")
+			}
+
 			nodePoolInstallVersion, err := framework.GetLatestVersionInMinor(ctx, channelGroup, nodePoolMinor)
 			if cincinnati.IsCincinnatiVersionNotFoundError(err) {
 				Skip(fmt.Sprintf("Cincinnati returned version not found for minor %s on channel %s", nodePoolMinor, channelGroup))
@@ -642,6 +649,13 @@ var _ = Describe("Customer", func() {
 	DescribeTable("should downgrade a nodepool to a lower minor version",
 		func(ctx context.Context, cpMinor string, targetMinor string) {
 			channelGroup := framework.DefaultOpenshiftChannelGroup()
+
+			// Workaround: skip on nightly until CS fixes the nightly→ACR image substitution
+			// on the nodepool upgrade path (PatchNodePoolCR writes quay.io instead of ACR).
+			// See ARO-27344.
+			if channelGroup == "nightly" {
+				Skip("nightly nodepool downgrade blocked by CS image substitution bug; see ARO-27344")
+			}
 
 			clusterInstallVersion, err := framework.GetLatestVersionInMinor(ctx, channelGroup, cpMinor)
 			if cincinnati.IsCincinnatiVersionNotFoundError(err) {


### PR DESCRIPTION
CS's nightly→ACR image substitution in PatchNodePoolCR (`node_pool_cr_helpers.go:57-68`) is dead code on the upgrade path — it mutates a JSON-roundtripped copy that's never written back to the ManifestWork. HyperShift receives the unpullable quay.io URL and the upgrade stalls silently.

Skip these 2 tests on nightly until the CS fix is deployed. Revert this commit once CS MR lands and rolls out to staging.

<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

### Why

<!-- Briefly explain why this change is needed -->

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
