### PR TITLE
Refine node pool version controllers

### DIFF
--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -624,7 +624,13 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 	)
 	nodePoolVersionController := upgradecontrollers.NewNodePoolVersionController(
 		b.options.ResourcesDBClient,
-		b.options.ClustersServiceClient,
+		activeOperationLister,
+		subscriptionLister,
+		backendInformers,
+		unionReadDesireLister,
+	)
+	nodePoolActiveVersionController := upgradecontrollers.NewNodePoolActiveVersionController(
+		b.options.ResourcesDBClient,
 		activeOperationLister,
 		backendInformers,
 		unionReadDesireLister,
@@ -753,6 +759,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 				go azureClusterResourceGroupExistenceValidationController.Run(ctx, 20)
 				go azureClusterManagedIdentitiesExistenceValidationController.Run(ctx, 20)
 				go nodePoolVersionController.Run(ctx, 20)
+				go nodePoolActiveVersionController.Run(ctx, 20)
 				go createClusterScopedReadDesiresController.Run(ctx, 20)
 				go createNodePoolScopedReadDesiresController.Run(ctx, 20)
 				go maestroDeleteOrphanedReadonlyBundlesController.Run(ctx, 20)

--- a/backend/pkg/controllers/upgradecontrollers/nodepool_active_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/nodepool_active_version_controller.go
@@ -1,0 +1,149 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upgradecontrollers
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/blang/semver/v4"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/backend/pkg/maestrohelpers"
+	"github.com/Azure/ARO-HCP/internal/api"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/database"
+	dblisters "github.com/Azure/ARO-HCP/internal/database/listers"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// nodePoolActiveVersionSyncer is a NodePool syncer that updates
+// ServiceProviderNodePool.Status.NodePoolVersion.ActiveVersions from the
+// per-node-pool ReadDesire kubeContent (the kube-applier's mirror of the
+// management cluster's Hypershift NodePool object). Reading from the cached
+// NodePool CR replaces the previous round-trip through Cluster Service.
+type nodePoolActiveVersionSyncer struct {
+	cooldownChecker               controllerutil.CooldownChecker
+	serviceProviderNodePoolLister listers.ServiceProviderNodePoolLister
+	resourcesDBClient             database.ResourcesDBClient
+	readDesireLister              dblisters.ReadDesireLister
+}
+
+var _ controllerutils.NodePoolSyncer = (*nodePoolActiveVersionSyncer)(nil)
+
+// NewNodePoolActiveVersionController creates a new controller that updates
+// Status.NodePoolVersion.ActiveVersions on the ServiceProviderNodePool from the
+// per-node-pool ReadDesire's observed Hypershift NodePool.
+func NewNodePoolActiveVersionController(
+	resourcesDBClient database.ResourcesDBClient,
+	activeOperationLister listers.ActiveOperationLister,
+	informers informers.BackendInformers,
+	readDesireLister dblisters.ReadDesireLister,
+) controllerutils.Controller {
+	_, serviceProviderNodePoolLister := informers.ServiceProviderNodePools()
+	syncer := &nodePoolActiveVersionSyncer{
+		cooldownChecker:               controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		serviceProviderNodePoolLister: serviceProviderNodePoolLister,
+		resourcesDBClient:             resourcesDBClient,
+		readDesireLister:              readDesireLister,
+	}
+
+	return controllerutils.NewNodePoolWatchingController(
+		"NodePoolActiveVersions",
+		resourcesDBClient,
+		informers,
+		5*time.Minute,
+		syncer,
+	)
+}
+
+func (c *nodePoolActiveVersionSyncer) CooldownChecker() controllerutil.CooldownChecker {
+	return c.cooldownChecker
+}
+
+// NeedsWork reports whether the controller has a ServiceProviderNodePool to
+// update. The actual decision of whether the active versions need rewriting
+// depends on the ReadDesire NodePool's Status.Version (compared to the SPNP's
+// current tip), which can only be evaluated after the ReadDesire fetch — so
+// here we only verify that an SPNP exists to write back to.
+func (c *nodePoolActiveVersionSyncer) NeedsWork(spnp *api.ServiceProviderNodePool) bool {
+	return spnp != nil
+}
+
+// SyncOnce updates ServiceProviderNodePool.Status.NodePoolVersion.ActiveVersions
+// from the per-node-pool ReadDesire's observed Hypershift NodePool's
+// Status.Version. The new version is prepended to the existing list when it
+// differs from the current tip, and the slice is capped at two entries (newest
+// first, previous one second) so we don't grow without bound.
+func (c *nodePoolActiveVersionSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPNodePoolKey) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	// Cheap cache check: skip when the ServiceProviderNodePool hasn't been
+	// created yet. Once a sibling controller seeds it, the informer will
+	// retrigger us.
+	cachedServiceProviderNodePool, err := c.serviceProviderNodePoolLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get ServiceProviderNodePool from cache: %w", err))
+	}
+	if !c.NeedsWork(cachedServiceProviderNodePool) {
+		return nil
+	}
+
+	hsNodePool, err := maestrohelpers.GetCachedNodePoolForNodePool(ctx, c.readDesireLister, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get NodePool from ReadDesire: %w", err))
+	}
+	if hsNodePool == nil {
+		// ReadDesire absent or kubeContent not yet observed; retrigger
+		// once the kube-applier writes status.
+		return nil
+	}
+	if len(hsNodePool.Status.Version) == 0 {
+		// Mirror exists but the Hypershift NodePool hasn't reported a
+		// version yet; nothing to record.
+		return nil
+	}
+
+	actualVersion, err := semver.ParseTolerant(hsNodePool.Status.Version)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to parse NodePool Status.Version %q: %w", hsNodePool.Status.Version, err))
+	}
+
+	oldActiveVersions := cachedServiceProviderNodePool.Status.NodePoolVersion.ActiveVersions
+	newActiveVersions := prependActiveVersionIfChanged(oldActiveVersions, actualVersion)
+	if slices.Equal(oldActiveVersions, newActiveVersions) {
+		return nil
+	}
+
+	logger.Info("Active versions changed", "oldActiveVersions", oldActiveVersions, "newActiveVersions", newActiveVersions)
+	replacement := cachedServiceProviderNodePool.DeepCopy()
+	replacement.Status.NodePoolVersion.ActiveVersions = newActiveVersions
+	_, err = c.resourcesDBClient.ServiceProviderNodePools(key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName).Replace(ctx, replacement, nil)
+	if database.IsPreconditionFailedError(err) {
+		// the cache will update eventually since we're out of date and we'll enter this controller again. No need to fail.
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to replace ServiceProviderNodePool: %w", err))
+	}
+	return nil
+}

--- a/backend/pkg/controllers/upgradecontrollers/nodepool_active_version_controller_test.go
+++ b/backend/pkg/controllers/upgradecontrollers/nodepool_active_version_controller_test.go
@@ -1,0 +1,305 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upgradecontrollers
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/blang/semver/v4"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kruntime "k8s.io/apimachinery/pkg/runtime"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
+	"github.com/Azure/ARO-HCP/backend/pkg/maestrohelpers"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/kubeapplier"
+	internallistertesting "github.com/Azure/ARO-HCP/internal/database/listertesting"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// nodePoolReadDesireResourceID returns the resource ID for the readonly
+// NodePool ReadDesire associated with the test node pool. The slice lister
+// matches on this ID to satisfy GetForNodePool.
+func nodePoolReadDesireResourceID(t *testing.T) *azcorearm.ResourceID {
+	t.Helper()
+	return api.Must(azcorearm.ParseResourceID(
+		kubeapplier.ToNodePoolScopedReadDesireResourceIDString(
+			testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName,
+			maestrohelpers.ReadDesireNameReadonlyNodePool)))
+}
+
+// newNodePoolReadDesireWithStatusVersion builds a ReadDesire whose
+// Status.KubeContent.Raw carries a marshaled Hypershift NodePool with the
+// given status.version. Use empty string to omit (simulating "kube-applier
+// observed the resource but the controller hasn't filled status yet").
+func newNodePoolReadDesireWithStatusVersion(t *testing.T, statusVersion string) *kubeapplier.ReadDesire {
+	t.Helper()
+	np := &v1beta1.NodePool{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "NodePool",
+			APIVersion: v1beta1.GroupVersion.String(),
+		},
+		Status: v1beta1.NodePoolStatus{
+			Version: statusVersion,
+		},
+	}
+	raw, err := json.Marshal(np)
+	require.NoError(t, err)
+	return &kubeapplier.ReadDesire{
+		CosmosMetadata: api.CosmosMetadata{ResourceID: nodePoolReadDesireResourceID(t)},
+		Status: kubeapplier.ReadDesireStatus{
+			KubeContent: &kruntime.RawExtension{Raw: raw},
+		},
+	}
+}
+
+// newNodePoolReadDesireMissingKubeContent simulates the ReadDesire existing but
+// the kube-applier not having observed the target yet (Status.KubeContent nil).
+func newNodePoolReadDesireMissingKubeContent(t *testing.T) *kubeapplier.ReadDesire {
+	t.Helper()
+	return &kubeapplier.ReadDesire{
+		CosmosMetadata: api.CosmosMetadata{ResourceID: nodePoolReadDesireResourceID(t)},
+		Status:         kubeapplier.ReadDesireStatus{},
+	}
+}
+
+func TestNodePoolActiveVersionSyncer_SyncOnce(t *testing.T) {
+	testKey := controllerutils.HCPNodePoolKey{
+		SubscriptionID:    testSubscriptionID,
+		ResourceGroupName: testResourceGroupName,
+		HCPClusterName:    testClusterName,
+		HCPNodePoolName:   testNodePoolName,
+	}
+
+	tests := []struct {
+		name                  string
+		seedDB                func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient)
+		desires               func(t *testing.T) []*kubeapplier.ReadDesire
+		expectedError         bool
+		expectedErrorContains string
+		// validateAfter inspects the SPNP after sync. nil means "no SPNP write expected".
+		validateAfter func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient)
+	}{
+		{
+			name: "ServiceProviderNodePool not in cache returns nil",
+			seedDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+				// Seed only the NodePool — the cached SPNP lookup will miss
+				// and NeedsWork should short-circuit before we touch the
+				// ReadDesire.
+				createTestNodePoolWithVersion(t, ctx, mockDB, "4.19.15")
+			},
+			desires: func(t *testing.T) []*kubeapplier.ReadDesire {
+				return []*kubeapplier.ReadDesire{newNodePoolReadDesireWithStatusVersion(t, "4.19.7")}
+			},
+		},
+		{
+			name: "ReadDesire absent leaves existing SPNP untouched",
+			seedDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+				createTestNodePoolWithVersion(t, ctx, mockDB, "4.19.15")
+				createServiceProviderNodePoolWithVersion(t, ctx, mockDB, "4.19.7")
+			},
+			validateAfter: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+				spnp, err := mockDB.ServiceProviderNodePools(testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName).
+					Get(ctx, api.ServiceProviderNodePoolResourceName)
+				require.NoError(t, err)
+				require.Len(t, spnp.Status.NodePoolVersion.ActiveVersions, 1)
+				assert.True(t, semver.MustParse("4.19.7").EQ(*spnp.Status.NodePoolVersion.ActiveVersions[0].Version))
+			},
+		},
+		{
+			name: "ReadDesire without kubeContent leaves existing SPNP untouched",
+			seedDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+				createTestNodePoolWithVersion(t, ctx, mockDB, "4.19.15")
+				createServiceProviderNodePoolWithVersion(t, ctx, mockDB, "4.19.7")
+			},
+			desires: func(t *testing.T) []*kubeapplier.ReadDesire {
+				return []*kubeapplier.ReadDesire{newNodePoolReadDesireMissingKubeContent(t)}
+			},
+		},
+		{
+			name: "NodePool Status.Version empty leaves existing SPNP untouched",
+			seedDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+				createTestNodePoolWithVersion(t, ctx, mockDB, "4.19.15")
+				createServiceProviderNodePoolWithVersion(t, ctx, mockDB, "4.19.7")
+			},
+			desires: func(t *testing.T) []*kubeapplier.ReadDesire {
+				return []*kubeapplier.ReadDesire{newNodePoolReadDesireWithStatusVersion(t, "")}
+			},
+		},
+		{
+			name: "NodePool Status.Version unparseable returns error",
+			seedDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+				createTestNodePoolWithVersion(t, ctx, mockDB, "4.19.15")
+				createServiceProviderNodePoolWithVersion(t, ctx, mockDB, "4.19.7")
+			},
+			desires: func(t *testing.T) []*kubeapplier.ReadDesire {
+				return []*kubeapplier.ReadDesire{newNodePoolReadDesireWithStatusVersion(t, "not-a-semver")}
+			},
+			expectedError:         true,
+			expectedErrorContains: "failed to parse NodePool Status.Version",
+		},
+		{
+			name: "version unchanged: no rewrite, active versions stable",
+			seedDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+				createTestNodePoolWithVersion(t, ctx, mockDB, "4.19.15")
+				createServiceProviderNodePoolWithVersion(t, ctx, mockDB, "4.19.7")
+			},
+			desires: func(t *testing.T) []*kubeapplier.ReadDesire {
+				return []*kubeapplier.ReadDesire{newNodePoolReadDesireWithStatusVersion(t, "4.19.7")}
+			},
+			validateAfter: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+				spnp, err := mockDB.ServiceProviderNodePools(testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName).
+					Get(ctx, api.ServiceProviderNodePoolResourceName)
+				require.NoError(t, err)
+				require.Len(t, spnp.Status.NodePoolVersion.ActiveVersions, 1)
+				assert.True(t, semver.MustParse("4.19.7").EQ(*spnp.Status.NodePoolVersion.ActiveVersions[0].Version))
+			},
+		},
+		{
+			name: "version changed: new tip prepended, previous kept as second entry",
+			seedDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+				createTestNodePoolWithVersion(t, ctx, mockDB, "4.19.15")
+				createServiceProviderNodePoolWithVersion(t, ctx, mockDB, "4.19.7")
+			},
+			desires: func(t *testing.T) []*kubeapplier.ReadDesire {
+				return []*kubeapplier.ReadDesire{newNodePoolReadDesireWithStatusVersion(t, "4.19.15")}
+			},
+			validateAfter: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+				spnp, err := mockDB.ServiceProviderNodePools(testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName).
+					Get(ctx, api.ServiceProviderNodePoolResourceName)
+				require.NoError(t, err)
+				require.Len(t, spnp.Status.NodePoolVersion.ActiveVersions, 2)
+				assert.True(t, semver.MustParse("4.19.15").EQ(*spnp.Status.NodePoolVersion.ActiveVersions[0].Version))
+				assert.True(t, semver.MustParse("4.19.7").EQ(*spnp.Status.NodePoolVersion.ActiveVersions[1].Version))
+			},
+		},
+		{
+			name: "ParseTolerant accepts non-strict semver from hypershift",
+			seedDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+				createTestNodePoolWithVersion(t, ctx, mockDB, "4.19.15")
+				createServiceProviderNodePoolWithVersion(t, ctx, mockDB, "4.19.7")
+			},
+			desires: func(t *testing.T) []*kubeapplier.ReadDesire {
+				// hypershift sometimes reports versions like "4.19" (no patch)
+				return []*kubeapplier.ReadDesire{newNodePoolReadDesireWithStatusVersion(t, "4.19")}
+			},
+			validateAfter: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+				spnp, err := mockDB.ServiceProviderNodePools(testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName).
+					Get(ctx, api.ServiceProviderNodePoolResourceName)
+				require.NoError(t, err)
+				require.Len(t, spnp.Status.NodePoolVersion.ActiveVersions, 2)
+				expected := api.Must(semver.ParseTolerant("4.19"))
+				assert.True(t, expected.EQ(*spnp.Status.NodePoolVersion.ActiveVersions[0].Version))
+				assert.True(t, semver.MustParse("4.19.7").EQ(*spnp.Status.NodePoolVersion.ActiveVersions[1].Version))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runCtx := utils.ContextWithLogger(context.Background(), logr.Discard())
+			mockDB := databasetesting.NewMockResourcesDBClient()
+			tt.seedDB(t, runCtx, mockDB)
+
+			var desires []*kubeapplier.ReadDesire
+			if tt.desires != nil {
+				desires = tt.desires(t)
+			}
+
+			syncer := &nodePoolActiveVersionSyncer{
+				cooldownChecker:               &alwaysSyncCooldownChecker{},
+				serviceProviderNodePoolLister: &listertesting.DBServiceProviderNodePoolLister{ResourcesDBClient: mockDB},
+				resourcesDBClient:             mockDB,
+				readDesireLister:              &internallistertesting.SliceReadDesireLister{Desires: desires},
+			}
+
+			err := syncer.SyncOnce(runCtx, testKey)
+			assertSyncResult(t, err, tt.expectedError, tt.expectedErrorContains)
+
+			if tt.validateAfter != nil && !tt.expectedError {
+				tt.validateAfter(t, runCtx, mockDB)
+			}
+		})
+	}
+}
+
+// TestNodePoolActiveVersionSyncer_NoReplaceWhenVersionsUnchanged is a
+// regression test ensuring we don't churn the SPNP fixture on every reconcile
+// when nothing has changed — preserves the existing _etag.
+func TestNodePoolActiveVersionSyncer_NoReplaceWhenVersionsUnchanged(t *testing.T) {
+	runCtx := utils.ContextWithLogger(context.Background(), logr.Discard())
+	mockDB := databasetesting.NewMockResourcesDBClient()
+
+	createTestNodePoolWithVersion(t, runCtx, mockDB, "4.19.15")
+	createServiceProviderNodePoolWithVersion(t, runCtx, mockDB, "4.19.7")
+
+	spnpCRUD := mockDB.ServiceProviderNodePools(testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName)
+	before, err := spnpCRUD.Get(runCtx, api.ServiceProviderNodePoolResourceName)
+	require.NoError(t, err)
+	beforeETag := before.CosmosETag
+
+	syncer := &nodePoolActiveVersionSyncer{
+		cooldownChecker:               &alwaysSyncCooldownChecker{},
+		serviceProviderNodePoolLister: &listertesting.DBServiceProviderNodePoolLister{ResourcesDBClient: mockDB},
+		resourcesDBClient:             mockDB,
+		readDesireLister: &internallistertesting.SliceReadDesireLister{
+			Desires: []*kubeapplier.ReadDesire{newNodePoolReadDesireWithStatusVersion(t, "4.19.7")},
+		},
+	}
+
+	require.NoError(t, syncer.SyncOnce(runCtx, controllerutils.HCPNodePoolKey{
+		SubscriptionID:    testSubscriptionID,
+		ResourceGroupName: testResourceGroupName,
+		HCPClusterName:    testClusterName,
+		HCPNodePoolName:   testNodePoolName,
+	}))
+
+	after, err := spnpCRUD.Get(runCtx, api.ServiceProviderNodePoolResourceName)
+	require.NoError(t, err)
+	assert.Equal(t, beforeETag, after.CosmosETag, "no write expected when active versions unchanged")
+}
+
+// TestNodePoolActiveVersionSyncer_NeedsWork exercises the predicate directly so
+// failure modes there don't depend on the SyncOnce control flow.
+func TestNodePoolActiveVersionSyncer_NeedsWork(t *testing.T) {
+	syncer := &nodePoolActiveVersionSyncer{}
+
+	assert.False(t, syncer.NeedsWork(nil), "nil SPNP should mean no work")
+	assert.True(t, syncer.NeedsWork(&api.ServiceProviderNodePool{}), "any non-nil SPNP is enough — the actual version delta is decided after the ReadDesire fetch")
+}

--- a/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller.go
@@ -17,7 +17,6 @@ package upgradecontrollers
 import (
 	"context"
 	"fmt"
-	"slices"
 	"time"
 
 	"github.com/blang/semver/v4"
@@ -35,42 +34,50 @@ import (
 	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/database"
 	dblisters "github.com/Azure/ARO-HCP/internal/database/listers"
-	"github.com/Azure/ARO-HCP/internal/ocm"
 	"github.com/Azure/ARO-HCP/internal/utils"
 	"github.com/Azure/ARO-HCP/internal/utils/apihelpers"
 	"github.com/Azure/ARO-HCP/internal/validation"
 )
 
-// nodePoolVersionSyncer is a nodePool syncer that synchronizes cluster information
-// from CS and internal and helps selecting a valid desiredVersion within the user's
-// desired
+// nodePoolVersionSyncer validates the customer's desired NodePool version and
+// stores it on the ServiceProviderNodePool. Active-version tracking moved to
+// nodePoolActiveVersionSyncer (sourced from the ReadDesire NodePool mirror) and
+// is no longer this controller's responsibility.
 type nodePoolVersionSyncer struct {
-	cooldownChecker      controllerutil.CooldownChecker
-	readDesireLister     dblisters.ReadDesireLister
-	resourcesDBClient    database.ResourcesDBClient
-	clusterServiceClient ocm.ClusterServiceClientSpec
+	cooldownChecker               controllerutil.CooldownChecker
+	nodePoolLister                listers.NodePoolLister
+	serviceProviderNodePoolLister listers.ServiceProviderNodePoolLister
+	serviceProviderClusterLister  listers.ServiceProviderClusterLister
+	subscriptionLister            listers.SubscriptionLister
+	readDesireLister              dblisters.ReadDesireLister
+	resourcesDBClient             database.ResourcesDBClient
 
 	cincinnatiClientCache cincinnati.ClientCache
 }
 
 var _ controllerutils.NodePoolSyncer = (*nodePoolVersionSyncer)(nil)
 
-// NewNodePoolVersionController creates a new syncer that reads node pool versions
-// from Cluster Service.
-// TODO: improve this description
+// NewNodePoolVersionController creates a new syncer that validates and persists
+// the customer's desired NodePool version on the ServiceProviderNodePool.
 func NewNodePoolVersionController(
 	resourcesDBClient database.ResourcesDBClient,
-	clusterServiceClient ocm.ClusterServiceClientSpec,
 	activeOperationLister listers.ActiveOperationLister,
+	subscriptionLister listers.SubscriptionLister,
 	informers informers.BackendInformers,
 	readDesireLister dblisters.ReadDesireLister,
 ) controllerutils.Controller {
+	_, nodePoolLister := informers.NodePools()
+	_, serviceProviderNodePoolLister := informers.ServiceProviderNodePools()
+	_, serviceProviderClusterLister := informers.ServiceProviderClusters()
 	syncer := &nodePoolVersionSyncer{
-		cooldownChecker:       controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
-		readDesireLister:      readDesireLister,
-		resourcesDBClient:     resourcesDBClient,
-		clusterServiceClient:  clusterServiceClient,
-		cincinnatiClientCache: cincinnati.NewClientCache(),
+		cooldownChecker:               controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		nodePoolLister:                nodePoolLister,
+		serviceProviderNodePoolLister: serviceProviderNodePoolLister,
+		serviceProviderClusterLister:  serviceProviderClusterLister,
+		subscriptionLister:            subscriptionLister,
+		readDesireLister:              readDesireLister,
+		resourcesDBClient:             resourcesDBClient,
+		cincinnatiClientCache:         cincinnati.NewClientCache(),
 	}
 
 	controller := controllerutils.NewNodePoolWatchingController(
@@ -84,71 +91,91 @@ func NewNodePoolVersionController(
 	return controller
 }
 
-// SyncOnce synchronizes node pool version information between Cluster Service
-// and the ServiceProviderNodePool in Cosmos DB.
+// NeedsWork reports whether this controller has anything to do for the given
+// NodePool. The work this controller does is persist the customer's desired
+// version onto the ServiceProviderNodePool, which is needed when:
+//   - the NodePool's customer-visible Properties.Version.ID is set, and
+//   - the ServiceProviderNodePool's Spec.NodePoolVersion.DesiredVersion does
+//     not already equal that value (otherwise nothing would change).
 //
-// The method performs two main operations:
+// Both arguments must be non-nil; SyncOnce gates the cache miss before calling
+// NeedsWork.
+func (c *nodePoolVersionSyncer) NeedsWork(nodePool *api.HCPOpenShiftClusterNodePool, serviceProviderNodePool *api.ServiceProviderNodePool) bool {
+	if len(nodePool.Properties.Version.ID) == 0 {
+		return false
+	}
+	if serviceProviderNodePool.Spec.NodePoolVersion.DesiredVersion == nil {
+		return true
+	}
+	customerDesiredVersion, err := semver.ParseTolerant(nodePool.Properties.Version.ID)
+	if err != nil {
+		// Unparseable version; let SyncOnce surface the parse error path —
+		// we don't suppress work just because we can't parse it here.
+		return true
+	}
+	return !customerDesiredVersion.EQ(*serviceProviderNodePool.Spec.NodePoolVersion.DesiredVersion)
+}
+
+// SyncOnce validates and persists the customer's desired node pool version on
+// the ServiceProviderNodePool in Cosmos DB.
 //
-// 1. Active Version Tracking:
-//   - Reads the current running version from Cluster Service (csNodePool.Version)
-//   - Stores it in ServiceProviderNodePool.Status.NodePoolVersion.ActiveVersions
-//   - Maintains up to 2 versions during version changes (newest first, then previous)
+//   - Reads the customer's desired version from HCPNodePool.Properties.Version.ID.
+//   - Validates it against version change constraints (see validateDesiredNodePoolVersion):
+//   - Exists as a known version in Cincinnati.
+//   - Upgrade: at most +2 minor versions from current, and cannot exceed lowest control plane version.
+//   - Downgrade: at most -2 minor versions from the highest control plane version.
+//   - Cross-major changes (either direction) require AFEC FeatureExperimentalReleaseFeatures.
+//   - NP version must be in the allowed skew map when CP and NP are on different majors.
+//   - If valid, stores it in ServiceProviderNodePool.Spec.NodePoolVersion.DesiredVersion.
 //
-// 2. Desired Version Validation and Storage:
-//   - Reads the customer's desired version from HCPNodePool.Properties.Version.ID
-//   - Validates it against version change constraints (see validateDesiredNodePoolVersion)
-//   - The desired version must satisfy:
-//   - Exist as a known version in Cincinnati
-//   - Upgrade: at most +2 minor versions from current, and cannot exceed lowest control plane version
-//   - Downgrade: at most -2 minor versions from the highest control plane version
-//   - Cross-major changes (either direction) require AFEC FeatureExperimentalReleaseFeatures
-//   - NP version must be in the allowed skew map when CP and NP are on different majors
-//   - If valid, stores it in ServiceProviderNodePool.Spec.NodePoolVersion.DesiredVersion
-//
-// If the desired version is already among the active versions, validation is skipped
-// (the upgrade is already in progress or complete).
+// Active version tracking lives in nodePoolActiveVersionSyncer, which reads the
+// Hypershift NodePool from the per-node-pool ReadDesire kubeContent rather than
+// round-tripping through Cluster Service.
 func (c *nodePoolVersionSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPNodePoolKey) error {
 	logger := utils.LoggerFromContext(ctx)
 
-	// Get node pool from Cosmos to get CS internal ID
-	nodePool, err := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).
-		NodePools(key.HCPClusterName).Get(ctx, key.HCPNodePoolName)
-
+	// Do the super cheap cache check first.
+	cachedNodePool, err := c.nodePoolLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
 	if database.IsNotFoundError(err) {
-		return nil // nodepool doesn't exists
+		// we'll be re-fired if it is created again
+		return nil
 	}
 	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to get node pool from cosmos: %w", err))
+		return utils.TrackError(fmt.Errorf("failed to get node pool from cache: %w", err))
 	}
-	if nodePool.ServiceProviderProperties.ClusterServiceID == nil || len(nodePool.ServiceProviderProperties.ClusterServiceID.String()) == 0 {
-		// if we have no clusterservice nodepool, we have nothing to sync.
+	// SPNP must be in cache. If a sibling controller hasn't created it yet,
+	// skip this sync; the informer will retrigger us when it lands.
+	cachedServiceProviderNodePool, err := c.serviceProviderNodePoolLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get ServiceProviderNodePool from cache: %w", err))
+	}
+	if !c.NeedsWork(cachedNodePool, cachedServiceProviderNodePool) {
+		// if the cache doesn't need work, then we'll be retriggered if those values change when the cache updates.
 		return nil
 	}
 
-	existingServiceProviderNodePool, err := database.GetOrCreateServiceProviderNodePool(ctx, c.resourcesDBClient, key.GetResourceID())
-	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to get or create ServiceProviderNodePool: %w", err))
-	}
+	customerDesiredVersion := semver.MustParse(cachedNodePool.Properties.Version.ID)
 
-	// Get the ServiceProviderCluster for control plane version validation
-	clusterResourceID := api.Must(api.ToClusterResourceID(key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName))
-	existingServiceProviderCluster, err := database.GetOrCreateServiceProviderCluster(ctx, c.resourcesDBClient, clusterResourceID)
-	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to get or create ServiceProviderCluster: %w", err))
-	}
-
-	// Get the cluster for Cincinnati client initialization
-	cluster, err := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).Get(ctx, key.HCPClusterName)
+	// Pull the ServiceProviderCluster and Subscription from cache rather than
+	// re-fetching live: validation only reads them, and if either isn't yet
+	// observed by the informer we'll be retriggered when it lands.
+	cachedServiceProviderCluster, err := c.serviceProviderClusterLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
 	if database.IsNotFoundError(err) {
-		return nil // cluster doesn't exist, no work to do
+		return nil
 	}
 	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to get cluster from cosmos: %w", err))
+		return utils.TrackError(fmt.Errorf("failed to get ServiceProviderCluster from cache: %w", err))
 	}
-	if cluster.ServiceProviderProperties.ClusterServiceID == nil {
-		// TODO this appears to only be used to look up a clusterservice cluster to get a UUID.  Once the billing changes merge,
-		// we'll have UID to key by and won't need this.
+
+	subscription, err := c.subscriptionLister.Get(ctx, key.SubscriptionID)
+	if database.IsNotFoundError(err) {
 		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get Subscription from cache: %w", err))
 	}
 
 	// Resolve the cluster UUID from the cached HostedCluster so we can build the Cincinnati client.
@@ -161,67 +188,19 @@ func (c *nodePoolVersionSyncer) SyncOnce(ctx context.Context, key controllerutil
 		logger.Info("missing cluster UUID, continuing with empty")
 	}
 
-	// Read node pool from Cluster Service
-	csNodePool, err := c.clusterServiceClient.GetNodePool(ctx, *nodePool.ServiceProviderProperties.ClusterServiceID)
-	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to get NodePool from CS: %w", err))
-	}
-
-	// For now we get the CS desired version
-	// In the future it should be good to use the node pool Status information from the node pool CR
-	version, ok := csNodePool.GetVersion()
-	if !ok {
-		return utils.TrackError(fmt.Errorf("node pool version not found in Cluster Service response"))
-	}
-
-	actualVersion := semver.MustParse(version.RawID())
-
-	oldActiveVersions := existingServiceProviderNodePool.Status.NodePoolVersion.ActiveVersions
-	existingServiceProviderNodePool.Status.NodePoolVersion.ActiveVersions = prependActiveVersionIfChanged(oldActiveVersions, actualVersion)
-
-	serviceProviderCosmosNodePoolClient := c.resourcesDBClient.ServiceProviderNodePools(key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
-	// check if actualVersion from node pool in clusterService is different that the active versions in serviceProviderNodePool
-	// if it is different update the ActualVersion in the serviceProviderNodePool
-	// TODO: This is a simple gathering of the node pool versions. We should implement this to get the correct information.
-	// Possible ways to get this information
-	//   - In CS
-	// 	 	- nodepool.version: latest version applied. When an upgrade policy completes correctly, this is set to that version.
-	//   	- upgradepolicy.targetVersion: if the policy has started this version is applying to the nodepool
-	//   - In Hypershift
-	//		- .Status.Version: shows the latest applied version https://github.com/openshift/hypershift/blob/main/api/hypershift/v1beta1/nodepool_types.go#L246-L251
-	if !slices.Equal(oldActiveVersions, existingServiceProviderNodePool.Status.NodePoolVersion.ActiveVersions) {
-		logger.Info("Active versions changed", "oldActiveVersions", oldActiveVersions, "newActiveVersions", existingServiceProviderNodePool.Status.NodePoolVersion.ActiveVersions)
-		existingServiceProviderNodePool, err = serviceProviderCosmosNodePoolClient.Replace(ctx, existingServiceProviderNodePool, nil)
-		if err != nil {
-			return utils.TrackError(fmt.Errorf("failed to replace ServiceProviderNodePool: %w", err))
-		}
-	}
-
-	// If there is no nodePool version do not validate and update the desired Version
-	if nodePool.Properties.Version.ID == "" {
-		return nil
-	}
-	customerDesiredVersion := semver.MustParse(nodePool.Properties.Version.ID)
-
-	// Short-circuit: skip validation if desired version hasn't changed
-	if existingServiceProviderNodePool.Spec.NodePoolVersion.DesiredVersion != nil &&
-		customerDesiredVersion.EQ(*existingServiceProviderNodePool.Spec.NodePoolVersion.DesiredVersion) {
-		return nil
-	}
-
-	subscription, err := c.resourcesDBClient.Subscriptions().Get(ctx, cluster.ID.SubscriptionID)
-	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to get subscription: %w", err))
-	}
-
 	// Validate the customer's desired version before setting it
-	if err := c.validateDesiredNodePoolVersion(ctx, &customerDesiredVersion, existingServiceProviderNodePool, existingServiceProviderCluster, subscription, nodePool.Properties.Version.ChannelGroup, clusterUUID); err != nil {
+	if err := c.validateDesiredNodePoolVersion(ctx, &customerDesiredVersion, cachedServiceProviderNodePool, cachedServiceProviderCluster, subscription, cachedNodePool.Properties.Version.ChannelGroup, clusterUUID); err != nil {
 		return utils.TrackError(fmt.Errorf("invalid desired version: %w", err))
 	}
 
 	// Update the serviceProviderNodePool DesiredVersion
-	existingServiceProviderNodePool.Spec.NodePoolVersion.DesiredVersion = &customerDesiredVersion
-	_, err = serviceProviderCosmosNodePoolClient.Replace(ctx, existingServiceProviderNodePool, nil)
+	replacement := cachedServiceProviderNodePool.DeepCopy()
+	replacement.Spec.NodePoolVersion.DesiredVersion = &customerDesiredVersion
+	_, err = c.resourcesDBClient.ServiceProviderNodePools(key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName).Replace(ctx, replacement, nil)
+	if database.IsPreconditionFailedError(err) {
+		// the cache will update eventually since we're out of date and we'll enter this controller again. No need to fail.
+		return nil
+	}
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to replace ServiceProviderNodePool: %w", err))
 	}

--- a/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller_test.go
+++ b/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller_test.go
@@ -17,7 +17,6 @@ package upgradecontrollers
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"testing"
 
 	"github.com/blang/semver/v4"
@@ -32,12 +31,12 @@ import (
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
-	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
 	configv1 "github.com/openshift/api/config/v1"
 	cvocincinnati "github.com/openshift/cluster-version-operator/pkg/cincinnati"
 	"github.com/openshift/hypershift/api/hypershift/v1beta1"
 
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
 	"github.com/Azure/ARO-HCP/backend/pkg/maestrohelpers"
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
@@ -47,7 +46,6 @@ import (
 	dblisters "github.com/Azure/ARO-HCP/internal/database/listers"
 	internallistertesting "github.com/Azure/ARO-HCP/internal/database/listertesting"
 	"github.com/Azure/ARO-HCP/internal/databasetesting"
-	"github.com/Azure/ARO-HCP/internal/ocm"
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
 
@@ -154,22 +152,6 @@ func createTestNodePoolWithVersion(t *testing.T, ctx context.Context, mockResour
 	require.NoError(t, err)
 }
 
-// newCSNodePool creates a Cluster Service node pool for testing.
-func newCSNodePool(t *testing.T, version string) *arohcpv1alpha1.NodePool {
-	t.Helper()
-
-	builder := arohcpv1alpha1.NewNodePool().
-		ID(testNodePoolName)
-
-	if version != "" {
-		builder = builder.Version(arohcpv1alpha1.NewVersion().RawID(version))
-	}
-
-	csNodePool, err := builder.Build()
-	require.NoError(t, err)
-	return csNodePool
-}
-
 // hostedClusterReadDesireResourceID returns the resource ID for the readonly
 // HostedCluster ReadDesire associated with the test cluster. The slice lister
 // matches on this ID to satisfy GetForCluster.
@@ -226,7 +208,6 @@ func TestNodePoolVersionSyncer_SyncOnce(t *testing.T) {
 	tests := []struct {
 		name                  string
 		seedDB                func(t *testing.T, ctx context.Context, mockResourcesDBClient *databasetesting.MockResourcesDBClient)
-		mockCS                func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec)
 		readDesireLister      func(t *testing.T) dblisters.ReadDesireLister
 		expectedError         bool
 		expectedErrorContains string
@@ -237,27 +218,7 @@ func TestNodePoolVersionSyncer_SyncOnce(t *testing.T) {
 				t.Helper()
 				// Don't seed any node pool - Get will fail with not found.
 			},
-			mockCS: func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec) {
-				t.Helper()
-				// No CS mock setup needed - we won't reach CS call.
-			},
 			expectedError: false,
-		},
-		{
-			name: "cluster service get nodepool call returns error",
-			seedDB: func(t *testing.T, ctx context.Context, mockResourcesDBClient *databasetesting.MockResourcesDBClient) {
-				t.Helper()
-				createTestNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.15")
-			},
-			mockCS: func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec) {
-				t.Helper()
-				mockCS.EXPECT().
-					GetNodePool(gomock.Any(), gomock.Any()).
-					Return(nil, errors.New("cluster service unavailable")).
-					Times(1)
-			},
-			expectedError:         true,
-			expectedErrorContains: "cluster service unavailable",
 		},
 		{
 			name: "missing NodePool's ClusterServiceID returns nil",
@@ -286,27 +247,7 @@ func TestNodePoolVersionSyncer_SyncOnce(t *testing.T) {
 					NodePools(testClusterName).Create(ctx, nodePool, nil)
 				require.NoError(t, err)
 			},
-			mockCS: func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec) {
-				t.Helper()
-			},
 			expectedError: false,
-		},
-		{
-			name: "missing version returns error",
-			seedDB: func(t *testing.T, ctx context.Context, mockResourcesDBClient *databasetesting.MockResourcesDBClient) {
-				t.Helper()
-				createTestNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.15")
-			},
-			mockCS: func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec) {
-				t.Helper()
-				csNodePool := newCSNodePool(t, "") // No version
-				mockCS.EXPECT().
-					GetNodePool(gomock.Any(), gomock.Any()).
-					Return(csNodePool, nil).
-					Times(1)
-			},
-			expectedError:         true,
-			expectedErrorContains: "node pool version not found in Cluster Service respons",
 		},
 	}
 
@@ -316,12 +257,10 @@ func TestNodePoolVersionSyncer_SyncOnce(t *testing.T) {
 			ctrl := gomock.NewController(t)
 
 			mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
-			mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
 			mockClientCache := cincinnati.NewMockClientCache(ctrl)
 			mockClientCache.EXPECT().GetOrCreateClient(gomock.Any()).Return(cincinnati.NewMockClient(ctrl)).AnyTimes()
 
 			tt.seedDB(t, ctx, mockResourcesDBClient)
-			tt.mockCS(t, mockCS)
 
 			contentLister := newValidHostedClusterReadDesireLister(t)
 			if tt.readDesireLister != nil {
@@ -329,11 +268,14 @@ func TestNodePoolVersionSyncer_SyncOnce(t *testing.T) {
 			}
 
 			syncer := &nodePoolVersionSyncer{
-				cooldownChecker:       &alwaysSyncCooldownChecker{},
-				readDesireLister:      contentLister,
-				resourcesDBClient:     mockResourcesDBClient,
-				clusterServiceClient:  mockCS,
-				cincinnatiClientCache: mockClientCache,
+				cooldownChecker:               &alwaysSyncCooldownChecker{},
+				nodePoolLister:                &listertesting.DBNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
+				serviceProviderNodePoolLister: &listertesting.DBServiceProviderNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
+				serviceProviderClusterLister:  &listertesting.DBServiceProviderClusterLister{ResourcesDBClient: mockResourcesDBClient},
+				subscriptionLister:            &listertesting.DBSubscriptionLister{ResourcesDBClient: mockResourcesDBClient},
+				readDesireLister:              contentLister,
+				resourcesDBClient:             mockResourcesDBClient,
+				cincinnatiClientCache:         mockClientCache,
 			}
 
 			ctx = utils.ContextWithLogger(ctx, logr.Discard())
@@ -354,6 +296,47 @@ func assertSyncResult(t *testing.T, err error, expectedError bool, expectedError
 	} else {
 		assert.NoError(t, err)
 	}
+}
+
+// TestNodePoolVersionSyncer_NeedsWork covers the cache-evaluable conditions
+// that decide whether the desired-version controller has anything to do.
+// The SyncOnce flow guarantees a non-nil ServiceProviderNodePool by the time
+// it calls NeedsWork (cache misses bail before that), so we only exercise
+// non-nil inputs here.
+func TestNodePoolVersionSyncer_NeedsWork(t *testing.T) {
+	syncer := &nodePoolVersionSyncer{}
+
+	npWith := func(customerVersion string) *api.HCPOpenShiftClusterNodePool {
+		return &api.HCPOpenShiftClusterNodePool{
+			Properties: api.HCPOpenShiftClusterNodePoolProperties{
+				Version: api.NodePoolVersionProfile{ID: customerVersion},
+			},
+		}
+	}
+	spnpWithDesired := func(desiredVersion string) *api.ServiceProviderNodePool {
+		spnp := &api.ServiceProviderNodePool{}
+		if desiredVersion != "" {
+			v := semver.MustParse(desiredVersion)
+			spnp.Spec.NodePoolVersion.DesiredVersion = &v
+		}
+		return spnp
+	}
+
+	t.Run("no customer desired version skips", func(t *testing.T) {
+		assert.False(t, syncer.NeedsWork(npWith(""), spnpWithDesired("")))
+	})
+	t.Run("SPNP without DesiredVersion needs work", func(t *testing.T) {
+		assert.True(t, syncer.NeedsWork(npWith("4.19.15"), spnpWithDesired("")))
+	})
+	t.Run("matching DesiredVersion skips", func(t *testing.T) {
+		assert.False(t, syncer.NeedsWork(npWith("4.19.15"), spnpWithDesired("4.19.15")))
+	})
+	t.Run("different DesiredVersion needs work", func(t *testing.T) {
+		assert.True(t, syncer.NeedsWork(npWith("4.19.15"), spnpWithDesired("4.19.10")))
+	})
+	t.Run("unparseable customer version conservatively needs work", func(t *testing.T) {
+		assert.True(t, syncer.NeedsWork(npWith("not-a-semver"), spnpWithDesired("4.19.15")))
+	})
 }
 
 func TestNodePoolVersionSyncer_ValidateDesiredNodePoolVersion(t *testing.T) {
@@ -834,23 +817,11 @@ func createServiceProviderNodePoolWithVersion(t *testing.T, ctx context.Context,
 	require.NoError(t, err)
 }
 
-func newCSNodePoolWithVersion(t *testing.T, version string) *arohcpv1alpha1.NodePool {
-	t.Helper()
-
-	csNodePool, err := arohcpv1alpha1.NewNodePool().
-		ID(testNodePoolName).
-		Version(arohcpv1alpha1.NewVersion().RawID(version)).
-		Build()
-	require.NoError(t, err)
-	return csNodePool
-}
-
 func TestNodePoolVersionSyncer_SyncOnce_DesiredExceedsControlPlaneFails(t *testing.T) {
 	ctx := context.Background()
 	ctrl := gomock.NewController(t)
 
 	mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
-	mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
 	mockClientCache := cincinnati.NewMockClientCache(ctrl)
 	mockClientCache.EXPECT().GetOrCreateClient(gomock.Any()).Return(cincinnati.NewMockClient(ctrl)).AnyTimes()
 
@@ -863,19 +834,15 @@ func TestNodePoolVersionSyncer_SyncOnce_DesiredExceedsControlPlaneFails(t *testi
 	// Create ServiceProviderNodePool with active version 4.19.5 (so desired is not already active)
 	createServiceProviderNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.5")
 
-	// CS returns node pool with current version 4.19.5
-	csNodePool := newCSNodePoolWithVersion(t, "4.19.5")
-	mockCS.EXPECT().
-		GetNodePool(gomock.Any(), gomock.Any()).
-		Return(csNodePool, nil).
-		Times(1)
-
 	syncer := &nodePoolVersionSyncer{
-		cooldownChecker:       &alwaysSyncCooldownChecker{},
-		readDesireLister:      newValidHostedClusterReadDesireLister(t),
-		resourcesDBClient:     mockResourcesDBClient,
-		clusterServiceClient:  mockCS,
-		cincinnatiClientCache: mockClientCache,
+		cooldownChecker:               &alwaysSyncCooldownChecker{},
+		nodePoolLister:                &listertesting.DBNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
+		serviceProviderNodePoolLister: &listertesting.DBServiceProviderNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
+		serviceProviderClusterLister:  &listertesting.DBServiceProviderClusterLister{ResourcesDBClient: mockResourcesDBClient},
+		subscriptionLister:            &listertesting.DBSubscriptionLister{ResourcesDBClient: mockResourcesDBClient},
+		readDesireLister:              newValidHostedClusterReadDesireLister(t),
+		resourcesDBClient:             mockResourcesDBClient,
+		cincinnatiClientCache:         mockClientCache,
 	}
 
 	testKey := controllerutils.HCPNodePoolKey{
@@ -897,7 +864,6 @@ func TestNodePoolVersionSyncer_SyncOnce_SucceedsWithoutCincinnatiEdge(t *testing
 	ctrl := gomock.NewController(t)
 
 	mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
-	mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
 	mockCincinnati := cincinnati.NewMockClient(ctrl)
 
 	// Create node pool with desired version 4.19.10
@@ -909,14 +875,6 @@ func TestNodePoolVersionSyncer_SyncOnce_SucceedsWithoutCincinnatiEdge(t *testing
 	// Create ServiceProviderNodePool with active version 4.19.7
 	createServiceProviderNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.7")
 
-	// CS returns node pool with current version 4.19.7
-	csNodePool := newCSNodePoolWithVersion(t, "4.19.7")
-	mockCS.EXPECT().
-		GetNodePool(gomock.Any(), gomock.Any()).
-		Return(csNodePool, nil).
-		Times(1)
-
-	// Cincinnati: version exists, no candidates
 	mockCincinnati.EXPECT().
 		GetUpdates(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Eq(semver.MustParse("4.19.10"))).
 		Return(
@@ -931,11 +889,14 @@ func TestNodePoolVersionSyncer_SyncOnce_SucceedsWithoutCincinnatiEdge(t *testing
 	mockClientCache.EXPECT().GetOrCreateClient(gomock.Any()).Return(mockCincinnati).AnyTimes()
 
 	syncer := &nodePoolVersionSyncer{
-		cooldownChecker:       &alwaysSyncCooldownChecker{},
-		readDesireLister:      newValidHostedClusterReadDesireLister(t),
-		resourcesDBClient:     mockResourcesDBClient,
-		clusterServiceClient:  mockCS,
-		cincinnatiClientCache: mockClientCache,
+		cooldownChecker:               &alwaysSyncCooldownChecker{},
+		nodePoolLister:                &listertesting.DBNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
+		serviceProviderNodePoolLister: &listertesting.DBServiceProviderNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
+		serviceProviderClusterLister:  &listertesting.DBServiceProviderClusterLister{ResourcesDBClient: mockResourcesDBClient},
+		subscriptionLister:            &listertesting.DBSubscriptionLister{ResourcesDBClient: mockResourcesDBClient},
+		readDesireLister:              newValidHostedClusterReadDesireLister(t),
+		resourcesDBClient:             mockResourcesDBClient,
+		cincinnatiClientCache:         mockClientCache,
 	}
 
 	testKey := controllerutils.HCPNodePoolKey{
@@ -965,7 +926,6 @@ func TestNodePoolVersionSyncer_SyncOnce_VersionNotInCincinnatiFails(t *testing.T
 	ctrl := gomock.NewController(t)
 
 	mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
-	mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
 	mockCincinnati := cincinnati.NewMockClient(ctrl)
 
 	// Create node pool with desired version 4.19.99 (does not exist in Cincinnati)
@@ -977,14 +937,6 @@ func TestNodePoolVersionSyncer_SyncOnce_VersionNotInCincinnatiFails(t *testing.T
 	// Create ServiceProviderNodePool with active version 4.19.7
 	createServiceProviderNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.7")
 
-	// CS returns node pool with current version 4.19.7
-	csNodePool := newCSNodePoolWithVersion(t, "4.19.7")
-	mockCS.EXPECT().
-		GetNodePool(gomock.Any(), gomock.Any()).
-		Return(csNodePool, nil).
-		Times(1)
-
-	// Cincinnati returns VersionNotFound for the desired version
 	mockCincinnati.EXPECT().
 		GetUpdates(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Eq(semver.MustParse("4.19.99"))).
 		Return(
@@ -999,11 +951,14 @@ func TestNodePoolVersionSyncer_SyncOnce_VersionNotInCincinnatiFails(t *testing.T
 	mockClientCache.EXPECT().GetOrCreateClient(gomock.Any()).Return(mockCincinnati).AnyTimes()
 
 	syncer := &nodePoolVersionSyncer{
-		cooldownChecker:       &alwaysSyncCooldownChecker{},
-		readDesireLister:      newValidHostedClusterReadDesireLister(t),
-		resourcesDBClient:     mockResourcesDBClient,
-		clusterServiceClient:  mockCS,
-		cincinnatiClientCache: mockClientCache,
+		cooldownChecker:               &alwaysSyncCooldownChecker{},
+		nodePoolLister:                &listertesting.DBNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
+		serviceProviderNodePoolLister: &listertesting.DBServiceProviderNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
+		serviceProviderClusterLister:  &listertesting.DBServiceProviderClusterLister{ResourcesDBClient: mockResourcesDBClient},
+		subscriptionLister:            &listertesting.DBSubscriptionLister{ResourcesDBClient: mockResourcesDBClient},
+		readDesireLister:              newValidHostedClusterReadDesireLister(t),
+		resourcesDBClient:             mockResourcesDBClient,
+		cincinnatiClientCache:         mockClientCache,
 	}
 
 	testKey := controllerutils.HCPNodePoolKey{
@@ -1025,7 +980,6 @@ func TestNodePoolVersionSyncer_SyncOnce_DowngradeVersionNotInCincinnatiFails(t *
 	ctrl := gomock.NewController(t)
 
 	mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
-	mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
 	mockCincinnati := cincinnati.NewMockClient(ctrl)
 
 	// Create node pool with desired version 4.19.99 (does not exist in Cincinnati)
@@ -1037,14 +991,6 @@ func TestNodePoolVersionSyncer_SyncOnce_DowngradeVersionNotInCincinnatiFails(t *
 	// Create ServiceProviderNodePool with active version 4.19.7
 	createServiceProviderNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.7")
 
-	// CS returns node pool with current version 4.19.7
-	csNodePool := newCSNodePoolWithVersion(t, "4.19.7")
-	mockCS.EXPECT().
-		GetNodePool(gomock.Any(), gomock.Any()).
-		Return(csNodePool, nil).
-		Times(1)
-
-	// Cincinnati returns VersionNotFound for the desired version
 	mockCincinnati.EXPECT().
 		GetUpdates(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Eq(semver.MustParse("4.19.99"))).
 		Return(
@@ -1059,11 +1005,14 @@ func TestNodePoolVersionSyncer_SyncOnce_DowngradeVersionNotInCincinnatiFails(t *
 	mockClientCache.EXPECT().GetOrCreateClient(gomock.Any()).Return(mockCincinnati).AnyTimes()
 
 	syncer := &nodePoolVersionSyncer{
-		cooldownChecker:       &alwaysSyncCooldownChecker{},
-		readDesireLister:      newValidHostedClusterReadDesireLister(t),
-		resourcesDBClient:     mockResourcesDBClient,
-		clusterServiceClient:  mockCS,
-		cincinnatiClientCache: mockClientCache,
+		cooldownChecker:               &alwaysSyncCooldownChecker{},
+		nodePoolLister:                &listertesting.DBNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
+		serviceProviderNodePoolLister: &listertesting.DBServiceProviderNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
+		serviceProviderClusterLister:  &listertesting.DBServiceProviderClusterLister{ResourcesDBClient: mockResourcesDBClient},
+		subscriptionLister:            &listertesting.DBSubscriptionLister{ResourcesDBClient: mockResourcesDBClient},
+		readDesireLister:              newValidHostedClusterReadDesireLister(t),
+		resourcesDBClient:             mockResourcesDBClient,
+		cincinnatiClientCache:         mockClientCache,
 	}
 
 	testKey := controllerutils.HCPNodePoolKey{
@@ -1085,7 +1034,6 @@ func TestNodePoolVersionSyncer_SyncOnce_DowngradeWithinSkewSucceeds(t *testing.T
 	ctrl := gomock.NewController(t)
 
 	mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
-	mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
 	mockCincinnati := cincinnati.NewMockClient(ctrl)
 
 	// Create node pool with desired version 4.19.5 (z-stream downgrade from 4.19.10)
@@ -1094,14 +1042,9 @@ func TestNodePoolVersionSyncer_SyncOnce_DowngradeWithinSkewSucceeds(t *testing.T
 	// Create ServiceProviderCluster with control plane at 4.20.0
 	createServiceProviderClusterWithVersion(t, ctx, mockResourcesDBClient, "4.20.0")
 
-	// CS returns node pool with current version 4.19.10
-	csNodePool := newCSNodePoolWithVersion(t, "4.19.10")
-	mockCS.EXPECT().
-		GetNodePool(gomock.Any(), gomock.Any()).
-		Return(csNodePool, nil).
-		Times(1)
+	// SPNP must exist in cache for SyncOnce to proceed.
+	createServiceProviderNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.10")
 
-	// Cincinnati: version exists
 	mockCincinnati.EXPECT().
 		GetUpdates(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Eq(semver.MustParse("4.19.5"))).
 		Return(
@@ -1116,11 +1059,14 @@ func TestNodePoolVersionSyncer_SyncOnce_DowngradeWithinSkewSucceeds(t *testing.T
 	mockClientCache.EXPECT().GetOrCreateClient(gomock.Any()).Return(mockCincinnati).AnyTimes()
 
 	syncer := &nodePoolVersionSyncer{
-		cooldownChecker:       &alwaysSyncCooldownChecker{},
-		readDesireLister:      newValidHostedClusterReadDesireLister(t),
-		resourcesDBClient:     mockResourcesDBClient,
-		clusterServiceClient:  mockCS,
-		cincinnatiClientCache: mockClientCache,
+		cooldownChecker:               &alwaysSyncCooldownChecker{},
+		nodePoolLister:                &listertesting.DBNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
+		serviceProviderNodePoolLister: &listertesting.DBServiceProviderNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
+		serviceProviderClusterLister:  &listertesting.DBServiceProviderClusterLister{ResourcesDBClient: mockResourcesDBClient},
+		subscriptionLister:            &listertesting.DBSubscriptionLister{ResourcesDBClient: mockResourcesDBClient},
+		readDesireLister:              newValidHostedClusterReadDesireLister(t),
+		resourcesDBClient:             mockResourcesDBClient,
+		cincinnatiClientCache:         mockClientCache,
 	}
 
 	testKey := controllerutils.HCPNodePoolKey{
@@ -1150,7 +1096,6 @@ func TestNodePoolVersionSyncer_SyncOnce_ValidUpgradeSucceeds(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
-	mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
 	mockCincinnati := cincinnati.NewMockClient(ctrl)
 
 	// Create node pool with desired version 4.19.15 (valid upgrade from 4.19.10)
@@ -1159,14 +1104,9 @@ func TestNodePoolVersionSyncer_SyncOnce_ValidUpgradeSucceeds(t *testing.T) {
 	// Create ServiceProviderCluster with control plane at 4.20.0
 	createServiceProviderClusterWithVersion(t, ctx, mockResourcesDBClient, "4.20.0")
 
-	// CS returns node pool with current version 4.19.10
-	csNodePool := newCSNodePoolWithVersion(t, "4.19.10")
-	mockCS.EXPECT().
-		GetNodePool(gomock.Any(), gomock.Any()).
-		Return(csNodePool, nil).
-		Times(1)
+	// SPNP must exist in cache for SyncOnce to proceed.
+	createServiceProviderNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.10")
 
-	// Cincinnati returns success for the desired version (version exists in the graph)
 	mockCincinnati.EXPECT().
 		GetUpdates(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(
@@ -1181,11 +1121,14 @@ func TestNodePoolVersionSyncer_SyncOnce_ValidUpgradeSucceeds(t *testing.T) {
 	mockClientCache.EXPECT().GetOrCreateClient(gomock.Any()).Return(mockCincinnati).AnyTimes()
 
 	syncer := &nodePoolVersionSyncer{
-		cooldownChecker:       &alwaysSyncCooldownChecker{},
-		readDesireLister:      newValidHostedClusterReadDesireLister(t),
-		resourcesDBClient:     mockResourcesDBClient,
-		clusterServiceClient:  mockCS,
-		cincinnatiClientCache: mockClientCache,
+		cooldownChecker:               &alwaysSyncCooldownChecker{},
+		nodePoolLister:                &listertesting.DBNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
+		serviceProviderNodePoolLister: &listertesting.DBServiceProviderNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
+		serviceProviderClusterLister:  &listertesting.DBServiceProviderClusterLister{ResourcesDBClient: mockResourcesDBClient},
+		subscriptionLister:            &listertesting.DBSubscriptionLister{ResourcesDBClient: mockResourcesDBClient},
+		readDesireLister:              newValidHostedClusterReadDesireLister(t),
+		resourcesDBClient:             mockResourcesDBClient,
+		cincinnatiClientCache:         mockClientCache,
 	}
 
 	testKey := controllerutils.HCPNodePoolKey{
@@ -1216,20 +1159,13 @@ func TestNodePoolVersionSyncer_SyncOnce_DesiredVersionUnchangedOnFailure_Changed
 	ctrl := gomock.NewController(t)
 
 	mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
-	mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
 
 	// Seed the database with a node pool
 	createTestNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.15")
 	createServiceProviderClusterWithVersion(t, ctx, mockResourcesDBClient, "4.19.99")
+	// SPNP must exist in cache for SyncOnce to proceed.
+	createServiceProviderNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.7")
 
-	// Setup CS mock to return a node pool with version
-	csNodePool := newCSNodePool(t, "4.19.10")
-	mockCS.EXPECT().
-		GetNodePool(gomock.Any(), gomock.Any()).
-		Return(csNodePool, nil).
-		Times(1)
-
-	// Phase 1: Cincinnati confirms the desired version exists
 	mockCincinnati := cincinnati.NewMockClient(ctrl)
 	mockCincinnati.EXPECT().
 		GetUpdates(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
@@ -1245,11 +1181,14 @@ func TestNodePoolVersionSyncer_SyncOnce_DesiredVersionUnchangedOnFailure_Changed
 	mockClientCache.EXPECT().GetOrCreateClient(gomock.Any()).Return(mockCincinnati).Times(1)
 
 	syncer := &nodePoolVersionSyncer{
-		cooldownChecker:       &alwaysSyncCooldownChecker{},
-		readDesireLister:      newValidHostedClusterReadDesireLister(t),
-		resourcesDBClient:     mockResourcesDBClient,
-		clusterServiceClient:  mockCS,
-		cincinnatiClientCache: mockClientCache,
+		cooldownChecker:               &alwaysSyncCooldownChecker{},
+		nodePoolLister:                &listertesting.DBNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
+		serviceProviderNodePoolLister: &listertesting.DBServiceProviderNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
+		serviceProviderClusterLister:  &listertesting.DBServiceProviderClusterLister{ResourcesDBClient: mockResourcesDBClient},
+		subscriptionLister:            &listertesting.DBSubscriptionLister{ResourcesDBClient: mockResourcesDBClient},
+		readDesireLister:              newValidHostedClusterReadDesireLister(t),
+		resourcesDBClient:             mockResourcesDBClient,
+		cincinnatiClientCache:         mockClientCache,
 	}
 
 	testKey := controllerutils.HCPNodePoolKey{
@@ -1269,14 +1208,7 @@ func TestNodePoolVersionSyncer_SyncOnce_DesiredVersionUnchangedOnFailure_Changed
 	).Get(ctx, api.ServiceProviderNodePoolResourceName)
 	require.NoError(t, err, "ServiceProviderNodePool should exist after sync")
 
-	expectedActiveVersion := semver.MustParse("4.19.10")
 	expectedDesiredVersion := semver.MustParse("4.19.15")
-
-	// Verify ActiveVersion was persisted (from Cluster Service)
-	require.NotNil(t, spnp.Status.NodePoolVersion.ActiveVersions,
-		"ActiveVersion should be set")
-	require.True(t, expectedActiveVersion.EQ(*spnp.Status.NodePoolVersion.ActiveVersions[0].Version),
-		"ActiveVersion should match CS version %s, got %s", "4.19.10", spnp.Status.NodePoolVersion.ActiveVersions[0].Version)
 
 	// Verify DesiredVersion was persisted (from customer's HCPNodePool)
 	require.NotNil(t, spnp.Spec.NodePoolVersion.DesiredVersion,
@@ -1296,11 +1228,6 @@ func TestNodePoolVersionSyncer_SyncOnce_DesiredVersionUnchangedOnFailure_Changed
 	require.NoError(t, err)
 
 	// Setup CS mocks for second sync
-	mockCS.EXPECT().
-		GetNodePool(gomock.Any(), gomock.Any()).
-		Return(csNodePool, nil).
-		Times(1)
-
 	// Cincinnati returns VersionNotFound — version doesn't exist
 	mockCincinnatiFailing := cincinnati.NewMockClient(ctrl)
 	mockCincinnatiFailing.EXPECT().
@@ -1342,11 +1269,6 @@ func TestNodePoolVersionSyncer_SyncOnce_DesiredVersionUnchangedOnFailure_Changed
 	require.NoError(t, err)
 
 	// Setup CS mocks for third sync
-	mockCS.EXPECT().
-		GetNodePool(gomock.Any(), gomock.Any()).
-		Return(csNodePool, nil).
-		Times(1)
-
 	// Cincinnati confirms the version exists
 	mockCincinnatiSucceeding := cincinnati.NewMockClient(ctrl)
 	mockCincinnatiSucceeding.EXPECT().

--- a/backend/pkg/listertesting/db_listers.go
+++ b/backend/pkg/listertesting/db_listers.go
@@ -95,6 +95,34 @@ func (l *DBNodePoolLister) ListForCluster(ctx context.Context, subscriptionID, r
 	return collectFromIterator(ctx, iter)
 }
 
+// DBServiceProviderNodePoolLister implements listers.ServiceProviderNodePoolLister backed by a database.ResourcesDBClient.
+type DBServiceProviderNodePoolLister struct {
+	ResourcesDBClient database.ResourcesDBClient
+}
+
+var _ listers.ServiceProviderNodePoolLister = &DBServiceProviderNodePoolLister{}
+
+func (l *DBServiceProviderNodePoolLister) List(ctx context.Context) ([]*api.ServiceProviderNodePool, error) {
+	iter, err := l.ResourcesDBClient.ResourcesGlobalListers().ServiceProviderNodePools().List(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	return collectFromIterator(ctx, iter)
+}
+
+func (l *DBServiceProviderNodePoolLister) Get(ctx context.Context, subscriptionID, resourceGroupName, clusterName, nodePoolName string) (*api.ServiceProviderNodePool, error) {
+	return l.ResourcesDBClient.ServiceProviderNodePools(subscriptionID, resourceGroupName, clusterName, nodePoolName).
+		Get(ctx, api.ServiceProviderNodePoolResourceName)
+}
+
+func (l *DBServiceProviderNodePoolLister) ListForNodePool(ctx context.Context, subscriptionID, resourceGroupName, clusterName, nodePoolName string) ([]*api.ServiceProviderNodePool, error) {
+	iter, err := l.ResourcesDBClient.ServiceProviderNodePools(subscriptionID, resourceGroupName, clusterName, nodePoolName).List(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	return collectFromIterator(ctx, iter)
+}
+
 // DBActiveOperationLister implements listers.ActiveOperationLister backed by a database.ResourcesDBClient.
 type DBActiveOperationLister struct {
 	ResourcesDBClient database.ResourcesDBClient

--- a/backend/pkg/maestrohelpers/nodepools.go
+++ b/backend/pkg/maestrohelpers/nodepools.go
@@ -1,0 +1,73 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package maestrohelpers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/json"
+
+	"github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/database"
+	dblisters "github.com/Azure/ARO-HCP/internal/database/listers"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// ReadDesireNameReadonlyNodePool is the well-known ReadDesire name the backend
+// writes the per-node-pool NodePool mirror under. Consumers look this up via a
+// ReadDesireLister.GetForNodePool call.
+//
+// The value is the lowercased form of
+// api.MaestroBundleInternalNameReadonlyHypershiftNodePool — the same derivation
+// the writer (create_nodepool_scoped_read_desires_controller.go) uses for its
+// desired ReadDesire name.
+var ReadDesireNameReadonlyNodePool = strings.ToLower(string(api.MaestroBundleInternalNameReadonlyHypershiftNodePool))
+
+// GetCachedNodePoolForNodePool reads the Hypershift NodePool mirror from the
+// per-node-pool ReadDesire. The ReadDesire's Status.KubeContent.Raw carries the
+// observed NodePool JSON; we decode it directly and return the typed object.
+//
+// Returns (nil, nil) when:
+//   - the ReadDesire has not been created yet (NotFound),
+//   - the ReadDesire exists but the kube-applier has not yet observed
+//     the target (Status.KubeContent is nil or empty).
+//
+// Returns a non-nil error only for hard failures: a non-NotFound lister error,
+// or unmarshal failure.
+func GetCachedNodePoolForNodePool(
+	ctx context.Context,
+	readDesireLister dblisters.ReadDesireLister,
+	subscriptionName, resourceGroupName, clusterName, nodePoolName string,
+) (*v1beta1.NodePool, error) {
+	readDesire, err := readDesireLister.GetForNodePool(ctx, subscriptionName, resourceGroupName, clusterName, nodePoolName, ReadDesireNameReadonlyNodePool)
+	if database.IsNotFoundError(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, utils.TrackError(fmt.Errorf("failed to get ReadDesire for NodePool: %w", err))
+	}
+	if readDesire.Status.KubeContent == nil || len(readDesire.Status.KubeContent.Raw) == 0 {
+		return nil, nil
+	}
+	nodePool := &v1beta1.NodePool{}
+	if err := json.Unmarshal(readDesire.Status.KubeContent.Raw, nodePool); err != nil {
+		return nil, utils.TrackError(fmt.Errorf("failed to unmarshal NodePool from ReadDesire kubeContent: %w", err))
+	}
+	return nodePool, nil
+}


### PR DESCRIPTION
This separates the responsibility of setting active versions from setting desired version.

This removes cluster-service from the active version and desired version flow.

This will resolve failures caused by cluster-service nodepools missing during deletion.

