### PR TITLE
fix(hcpctl): bump copilot-sdk to v1.0.1 for CLI 1.0.61 compatibility (AROSLSRE-1149)

### DIFF
--- a/tooling/hcpctl/go.mod
+++ b/tooling/hcpctl/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.9.0
 	github.com/Azure/kubelogin v0.2.9
 	github.com/dusted-go/logging v1.3.0
-	github.com/github/copilot-sdk/go v0.3.0
+	github.com/github/copilot-sdk/go v1.0.1
 	github.com/go-logr/logr v1.4.3
 	github.com/google/go-cmp v0.7.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510

--- a/tooling/hcpctl/go.sum
+++ b/tooling/hcpctl/go.sum
@@ -117,8 +117,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/github/copilot-sdk/go v0.3.0 h1:LPMpoJzUTfrPbr/5e7s5QKvi66PMmREnbZ9kRxPe6ls=
-github.com/github/copilot-sdk/go v0.3.0/go.mod h1:uGWkjVYcp2DV9DgtqYihh5tEoJjNqxIFaUNnrwY4FxM=
+github.com/github/copilot-sdk/go v1.0.1 h1:Do6tV22Ip3oSVCga1RaJtV/XI97IbV2vjfMLCeNN9KU=
+github.com/github/copilot-sdk/go v1.0.1/go.mod h1:I6YKZQzUXhHZd8a2TkSOcBa8FMVL34QiEg2yxiaXghw=
 github.com/go-errors/errors v1.5.1 h1:ZwEMSLRCapFLflTpT7NKaAc7ukJ8ZPEjzlxt8rPN8bk=
 github.com/go-errors/errors v1.5.1/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=

--- a/tooling/hcpctl/pkg/agent/agent.go
+++ b/tooling/hcpctl/pkg/agent/agent.go
@@ -158,7 +158,7 @@ func (c *CopilotClient) CreateSession(ctx context.Context, logger logr.Logger, c
 		OnPermissionRequest: copilot.PermissionHandler.ApproveAll,
 		// Disable config discovery — we don't want to pick up .mcp.json or
 		// AGENTS.md from the analysis workspace.
-		EnableConfigDiscovery: false,
+		EnableConfigDiscovery: copilot.Bool(false),
 	}
 
 	// Apply the configured model if the caller didn't override.
@@ -285,7 +285,7 @@ func (s *Session) Delete(ctx context.Context) error {
 // caches it locally. If the RPC fails (e.g. process is dying), the last
 // successful snapshot is preserved.
 func (s *Session) snapshotMessages() {
-	events, err := s.inner.GetMessages(context.Background())
+	events, err := s.inner.GetEvents(context.Background())
 	if err != nil {
 		s.logger.Error(err, "Failed to snapshot session messages.")
 		return


### PR DESCRIPTION
<!-- Link to Jira issue -->
Fixes [AROSLSRE-1149](https://issues.redhat.com/browse/AROSLSRE-1149)

### What

Bump `github.com/github/copilot-sdk/go` from `v0.3.0` to `v1.0.1` in `tooling/hcpctl`, plus the two source touch-ups needed by the new SDK API surface:

- `SessionConfig.EnableConfigDiscovery` is now `*bool` (tri-state) — use `copilot.Bool(false)`.
- `Session.GetMessages` was renamed to `Session.GetEvents` (same `[]SessionEvent` return type).

### Why

`hcpctl snapshot analyze` fails to even open a Copilot session on any machine with `@github/copilot >= 1.0.61` installed:

```
failed to create Copilot session: failed to create copilot session:
  json: cannot unmarshal string into Go struct field PingResponse.timestamp of type int64
```

Timeline:

- `copilot-sdk/go v0.3.0` (Apr 2026) types `PingResponse.timestamp` as `int64`.
- `@github/copilot` CLI `1.0.61` (2026-06-09) changed several timestamp fields on the wire from `int64` to `string`.
- `copilot-sdk/go v1.0.1` (2026-06-10) ships the schema that matches CLI 1.0.61.

Anyone who runs `copilot update` past `1.0.60` (released 2026-06-05) hits this on next invocation. Currently the only workaround is `npm i -g @github/copilot@1.0.60`, which silently breaks again on the next CLI bump.

### Testing

In `tooling/hcpctl/`:

```
go mod tidy        # clean
go build ./...     # clean
go test  ./...     # all packages pass
hcpctl snapshot analyze --help   # binary launches without the PingResponse error
```

Local repro of the original bug against CLI `1.0.61` reproduces; same invocation on the patched build proceeds past `session.create`.

### Special notes for your reviewer

- Diff is intentionally minimal — only the two API breaks that the new SDK requires. No event-handler refactor, no adoption of post-`v0.3.0` SDK features (canvases / elicitation / command handlers / etc.) — out of scope.
- The CLI version (`@github/copilot`) is a user-installed dependency. This PR pins the *SDK*, which is the only side we control. The wire format is now back in sync.

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
