### PR TITLE
read actual node versions from hypershift nodepool

### DIFF
--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -603,6 +603,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		controllerLister,
 		activeOperationLister,
 		backendInformers,
+		unionKubeApplierInformers,
 		b.clock,
 	)
 	externalAuthDegradedAggregatorController := statuscontrollers.NewExternalAuthDegradedAggregatorController(

--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -682,12 +682,14 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		activeOperationLister,
 		subscriptionLister,
 		backendInformers,
+		unionKubeApplierInformers,
 		unionReadDesireLister,
 	)
 	nodePoolActiveVersionController := upgradecontrollers.NewNodePoolActiveVersionController(
 		b.options.ResourcesDBClient,
 		activeOperationLister,
 		backendInformers,
+		unionKubeApplierInformers,
 		unionReadDesireLister,
 	)
 	triggerNodePoolUpgradeController := upgradecontrollers.NewTriggerNodePoolUpgradeController(
@@ -695,6 +697,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		b.options.ClustersServiceClient,
 		activeOperationLister,
 		backendInformers,
+		unionKubeApplierInformers,
 	)
 	placementSyncController := managementclustercontrollers.NewManagementClusterPlacementSyncController(
 		b.options.ResourcesDBClient,
@@ -711,23 +714,27 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		b.options.ClustersServiceClient,
 		activeOperationLister,
 		backendInformers,
+		unionKubeApplierInformers,
 	)
 	nodePoolClusterServiceIDClearerController := nodepooldeletion.NewNodePoolClusterServiceIDClearerController(
 		b.options.ResourcesDBClient,
 		b.options.ClustersServiceClient,
 		activeOperationLister,
 		backendInformers,
+		unionKubeApplierInformers,
 	)
 	nodePoolChildResourcesCleanupController := nodepooldeletion.NewNodePoolChildResourcesCleanupController(
 		b.options.ResourcesDBClient,
 		b.options.KubeApplierDBClients,
 		activeOperationLister,
 		backendInformers,
+		unionKubeApplierInformers,
 	)
 	nodePoolDeletionController := nodepooldeletion.NewNodePoolDeletionController(
 		b.options.ResourcesDBClient,
 		activeOperationLister,
 		backendInformers,
+		unionKubeApplierInformers,
 	)
 
 	externalAuthDeletionClusterServiceDeleteDispatchController := externalauthdeletion.NewExternalAuthClusterServiceDeleteDispatchController(

--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -678,11 +678,16 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 	)
 	nodePoolVersionController := upgradecontrollers.NewNodePoolVersionController(
 		b.options.ResourcesDBClient,
-		b.options.ClustersServiceClient,
+		activeOperationLister,
+		subscriptionLister,
+		backendInformers,
+		unionReadDesireLister,
+	)
+	nodePoolActiveVersionController := upgradecontrollers.NewNodePoolActiveVersionController(
+		b.options.ResourcesDBClient,
 		activeOperationLister,
 		backendInformers,
 		unionReadDesireLister,
-		subscriptionLister,
 	)
 	triggerNodePoolUpgradeController := upgradecontrollers.NewTriggerNodePoolUpgradeController(
 		b.options.ResourcesDBClient,
@@ -839,6 +844,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 				go azureClusterResourceGroupExistenceValidationController.Run(ctx, 20)
 				go azureClusterManagedIdentitiesExistenceValidationController.Run(ctx, 20)
 				go nodePoolVersionController.Run(ctx, 20)
+				go nodePoolActiveVersionController.Run(ctx, 20)
 				go createClusterScopedReadDesiresController.Run(ctx, 20)
 				go createNodePoolScopedReadDesiresController.Run(ctx, 20)
 				go maestroDeleteOrphanedReadonlyBundlesController.Run(ctx, 20)

--- a/backend/pkg/controllers/controllerutils/nodepool_watching_controller.go
+++ b/backend/pkg/controllers/controllerutils/nodepool_watching_controller.go
@@ -27,6 +27,7 @@ import (
 	"github.com/Azure/ARO-HCP/internal/api"
 	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/database"
+	unionkubeapplierinformers "github.com/Azure/ARO-HCP/internal/database/unioninformers/kubeapplier"
 )
 
 type NodePoolSyncer interface {
@@ -46,10 +47,18 @@ type nodePoolWatchingController struct {
 // Since our detection of change is coarse, we are being triggered every few second without new information.
 // Until we get a changefeed, the cooldownDuration value is effectively the min resync time.
 // This does NOT prevent us from re-executing on errors, so errors will continue to trigger fast checks as expected.
+//
+// kubeApplierInformers is optional: when non-nil, the controller also enqueues
+// on ReadDesire events from the union kube-applier informer surface. The
+// status that the kube-applier writes back lives on the ReadDesire, so a
+// ReadDesire update is how this controller learns "the kube-applier
+// reported something new about a node pool". Apply/Delete desires are not
+// wired in because their status doesn't carry node-pool-state signal.
 func NewNodePoolWatchingController(
 	name string,
 	resourcesDBClient database.ResourcesDBClient,
 	informers informers.BackendInformers,
+	kubeApplierInformers *unionkubeapplierinformers.UnionKubeApplierInformers,
 	resyncDuration time.Duration,
 	syncer NodePoolSyncer,
 ) Controller {
@@ -73,6 +82,18 @@ func NewNodePoolWatchingController(
 		// Limit the max depth of ManagementClusterContent to 1 to only consider the nodepool-scoped ManagementClusterContents
 		err = nodePoolController.QueueForInformersWithMaxDepth(resyncDuration, 1, managementClusterContentInformer)
 		if err != nil {
+			panic(err) // coding error
+		}
+	}
+
+	if kubeApplierInformers != nil {
+		// Node-pool-scoped ReadDesires sit one level below the node pool
+		// (.../nodePools/<np>/readDesires/<name>), so a maxDepth of 1
+		// reaches the node pool and stops there. Cluster-scoped ReadDesires
+		// live above the node pool and are ignored on purpose — this
+		// controller is "nodepool-scoped only".
+		readDesireInformer, _ := kubeApplierInformers.ReadDesires()
+		if err := nodePoolController.QueueForInformersWithMaxDepth(resyncDuration, 1, readDesireInformer); err != nil {
 			panic(err) // coding error
 		}
 	}

--- a/backend/pkg/controllers/create_nodepool_scoped_read_desires_controller.go
+++ b/backend/pkg/controllers/create_nodepool_scoped_read_desires_controller.go
@@ -71,6 +71,7 @@ func NewCreateNodePoolScopedReadDesiresController(
 		"CreateNodePoolScopedReadDesires",
 		resourcesDBClient,
 		informers,
+		nil, // do not fire on ReadDesires this controller itself creates
 		1*time.Minute,
 		syncer,
 	)

--- a/backend/pkg/controllers/nodepooldeletion/node_pool_child_resources_cleanup_controller.go
+++ b/backend/pkg/controllers/nodepooldeletion/node_pool_child_resources_cleanup_controller.go
@@ -28,6 +28,7 @@ import (
 	"github.com/Azure/ARO-HCP/internal/api"
 	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/database"
+	unionkubeapplierinformers "github.com/Azure/ARO-HCP/internal/database/unioninformers/kubeapplier"
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
 
@@ -52,6 +53,7 @@ func NewNodePoolChildResourcesCleanupController(
 	kubeApplierDBClients database.KubeApplierDBClients,
 	activeOperationLister listers.ActiveOperationLister,
 	informers informers.BackendInformers,
+	kubeApplierInformers *unionkubeapplierinformers.UnionKubeApplierInformers,
 ) controllerutils.Controller {
 	_, nodePoolLister := informers.NodePools()
 	syncer := &nodePoolChildResourcesCleanupController{
@@ -65,6 +67,7 @@ func NewNodePoolChildResourcesCleanupController(
 		"NodePoolChildResourcesCleanupController",
 		resourcesDBClient,
 		informers,
+		kubeApplierInformers,
 		time.Minute,
 		syncer,
 	)

--- a/backend/pkg/controllers/nodepooldeletion/node_pool_cluster_service_delete_dispatch_controller.go
+++ b/backend/pkg/controllers/nodepooldeletion/node_pool_cluster_service_delete_dispatch_controller.go
@@ -34,6 +34,7 @@ import (
 	"github.com/Azure/ARO-HCP/internal/api"
 	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/database"
+	unionkubeapplierinformers "github.com/Azure/ARO-HCP/internal/database/unioninformers/kubeapplier"
 	"github.com/Azure/ARO-HCP/internal/ocm"
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
@@ -78,6 +79,7 @@ func NewNodePoolClusterServiceDeleteDispatchController(
 	clusterServiceClient ocm.ClusterServiceClientSpec,
 	activeOperationLister listers.ActiveOperationLister,
 	informers informers.BackendInformers,
+	kubeApplierInformers *unionkubeapplierinformers.UnionKubeApplierInformers,
 ) controllerutils.Controller {
 	_, nodePoolLister := informers.NodePools()
 	syncer := &nodePoolClusterServiceDeleteDispatchSyncer{
@@ -93,6 +95,7 @@ func NewNodePoolClusterServiceDeleteDispatchController(
 		"NodePoolClusterServiceDeleteDispatch",
 		resourcesDBClient,
 		informers,
+		kubeApplierInformers,
 		time.Minute,
 		syncer,
 	)

--- a/backend/pkg/controllers/nodepooldeletion/node_pool_cluster_service_id_clearer.go
+++ b/backend/pkg/controllers/nodepooldeletion/node_pool_cluster_service_id_clearer.go
@@ -29,6 +29,7 @@ import (
 	"github.com/Azure/ARO-HCP/internal/api"
 	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/database"
+	unionkubeapplierinformers "github.com/Azure/ARO-HCP/internal/database/unioninformers/kubeapplier"
 	"github.com/Azure/ARO-HCP/internal/ocm"
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
@@ -53,6 +54,7 @@ func NewNodePoolClusterServiceIDClearerController(
 	clusterServiceClient ocm.ClusterServiceClientSpec,
 	activeOperationLister listers.ActiveOperationLister,
 	informers informers.BackendInformers,
+	kubeApplierInformers *unionkubeapplierinformers.UnionKubeApplierInformers,
 ) controllerutils.Controller {
 	_, nodePoolLister := informers.NodePools()
 	syncer := &nodePoolClusterServiceIDClearer{
@@ -66,6 +68,7 @@ func NewNodePoolClusterServiceIDClearerController(
 		"NodePoolDeletionClusterServiceIDClearer",
 		resourcesDBClient,
 		informers,
+		kubeApplierInformers,
 		time.Minute,
 		syncer,
 	)

--- a/backend/pkg/controllers/nodepooldeletion/node_pool_deletion_controller.go
+++ b/backend/pkg/controllers/nodepooldeletion/node_pool_deletion_controller.go
@@ -26,6 +26,7 @@ import (
 	"github.com/Azure/ARO-HCP/internal/api"
 	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/database"
+	unionkubeapplierinformers "github.com/Azure/ARO-HCP/internal/database/unioninformers/kubeapplier"
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
 
@@ -47,6 +48,7 @@ func NewNodePoolDeletionController(
 	resourcesDBClient database.ResourcesDBClient,
 	activeOperationLister listers.ActiveOperationLister,
 	informers informers.BackendInformers,
+	kubeApplierInformers *unionkubeapplierinformers.UnionKubeApplierInformers,
 ) controllerutils.Controller {
 	_, nodePoolLister := informers.NodePools()
 	_, serviceProviderNodePoolLister := informers.ServiceProviderNodePools()
@@ -61,6 +63,7 @@ func NewNodePoolDeletionController(
 		"NodePoolDeletionController",
 		resourcesDBClient,
 		informers,
+		kubeApplierInformers,
 		time.Minute,
 		syncer,
 	)

--- a/backend/pkg/controllers/statuscontrollers/nodepool_degraded_aggregator.go
+++ b/backend/pkg/controllers/statuscontrollers/nodepool_degraded_aggregator.go
@@ -29,6 +29,7 @@ import (
 	"github.com/Azure/ARO-HCP/backend/pkg/listers"
 	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/database"
+	unionkubeapplierinformers "github.com/Azure/ARO-HCP/internal/database/unioninformers/kubeapplier"
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
 
@@ -68,6 +69,7 @@ func NewNodePoolDegradedAggregatorController(
 	controllerLister listers.ControllerLister,
 	activeOperationLister listers.ActiveOperationLister,
 	informers informers.BackendInformers,
+	kubeApplierInformers *unionkubeapplierinformers.UnionKubeApplierInformers,
 	clock utilsclock.PassiveClock,
 ) controllerutils.Controller {
 	if clock == nil {
@@ -86,6 +88,7 @@ func NewNodePoolDegradedAggregatorController(
 		"NodePoolDegradedAggregator",
 		resourcesDBClient,
 		informers,
+		kubeApplierInformers,
 		1*time.Minute,
 		syncer,
 	)

--- a/backend/pkg/controllers/upgradecontrollers/artifacts/TestNodePoolActiveVersionSyncer_RealCosmosFixture/cluster.json
+++ b/backend/pkg/controllers/upgradecontrollers/artifacts/TestNodePoolActiveVersionSyncer_RealCosmosFixture/cluster.json
@@ -1,0 +1,398 @@
+{
+  "_attachments": "attachments/",
+  "_etag": "\"0000a625-0000-4d00-0000-6a29fae10000\"",
+  "_rid": "deIlAKL5A1hVBQAAAAAAAA==",
+  "_self": "dbs/deIlAA==/colls/deIlAKL5A1g=/docs/deIlAKL5A1hVBQAAAAAAAA==/",
+  "_ts": 1781136097,
+  "id": "7b628620-95db-5631-9c44-15c5dc774dfc",
+  "partitionKey": "e8c5a115-842d-4d7e-98ad-cfb2c50b209e",
+  "properties": {
+    "cosmosMetadata": {
+      "etag": "\"0000bc1d-0000-4d00-0000-6a29ec4f0000\"",
+      "resourceID": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/rg-np-version-upgrade-pckjw8-79qhmc/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/np-version-upgrade-cluster-pckjw8"
+    },
+    "customerProperties": {
+      "api": {
+        "visibility": "Public"
+      },
+      "autoscaling": {
+        "maxNodeProvisionTimeSeconds": 900,
+        "maxPodGracePeriodSeconds": 600,
+        "podPriorityThreshold": -10
+      },
+      "clusterImageRegistry": {
+        "state": "Enabled"
+      },
+      "dns": {
+        "baseDomainPrefix": "x8y5p7r4g6j9e3v"
+      },
+      "etcd": {
+        "dataEncryption": {
+          "customerManaged": {
+            "encryptionType": "KMS",
+            "kms": {
+              "activeKey": {
+                "name": "etcd-data-kms-encryption-key",
+                "vaultName": "cust-kv-nwb7s2fhiity4",
+                "version": "0ac571d3970149dfb69e433820082616"
+              },
+              "visibility": "Public"
+            }
+          },
+          "keyManagementMode": "CustomerManaged"
+        }
+      },
+      "network": {
+        "hostPrefix": 23,
+        "machineCidr": "10.0.0.0/16",
+        "networkType": "OVNKubernetes",
+        "podCidr": "10.128.0.0/14",
+        "serviceCidr": "172.30.0.0/16"
+      },
+      "platform": {
+        "managedResourceGroup": "rg-np-version-upgrade-pckjw8-79qhmc-np-upgrade-pckjw8--managed",
+        "networkSecurityGroupId": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/rg-np-version-upgrade-pckjw8-79qhmc/providers/Microsoft.Network/networkSecurityGroups/customer-nsg-np-upgrade-pckjw8",
+        "operatorsAuthentication": {
+          "userAssignedIdentities": {
+            "controlPlaneOperators": {
+              "cloud-controller-manager": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/cloud-controller-manager",
+              "cloud-network-config": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/cloud-network-config",
+              "cluster-api-azure": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/cluster-api-azure",
+              "control-plane": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/control-plane",
+              "disk-csi-driver": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/disk-csi-driver",
+              "file-csi-driver": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/file-csi-driver",
+              "image-registry": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/image-registry",
+              "ingress": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ingress",
+              "kms": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/kms"
+            },
+            "dataPlaneOperators": {
+              "disk-csi-driver": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/dp-disk-csi-driver",
+              "file-csi-driver": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/dp-file-csi-driver",
+              "image-registry": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/dp-image-registry"
+            },
+            "serviceManagedIdentity": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/service"
+          }
+        },
+        "outboundType": "LoadBalancer",
+        "subnetId": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/rg-np-version-upgrade-pckjw8-79qhmc/providers/Microsoft.Network/virtualNetworks/customer-vnet-np-upgrade-pckjw8/subnets/customer-vnet-subnet-np-upgrade-pckjw8"
+      },
+      "version": {
+        "channelGroup": "candidate",
+        "id": "4.21.19"
+      }
+    },
+    "id": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/rg-np-version-upgrade-pckjw8-79qhmc/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/np-version-upgrade-cluster-pckjw8",
+    "identity": {
+      "type": "UserAssigned",
+      "userAssignedIdentities": {
+        "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/cloud-controller-manager": {
+          "clientId": "8c088886-a118-4973-8168-0d7ae1493aa7",
+          "principalId": "ccbf438f-08ec-4e2b-ae4e-219ce7dc3762"
+        },
+        "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/cloud-network-config": {
+          "clientId": "8c088886-a118-4973-8168-0d7ae1493aa7",
+          "principalId": "ccbf438f-08ec-4e2b-ae4e-219ce7dc3762"
+        },
+        "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/cluster-api-azure": {
+          "clientId": "8c088886-a118-4973-8168-0d7ae1493aa7",
+          "principalId": "ccbf438f-08ec-4e2b-ae4e-219ce7dc3762"
+        },
+        "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/control-plane": {
+          "clientId": "8c088886-a118-4973-8168-0d7ae1493aa7",
+          "principalId": "ccbf438f-08ec-4e2b-ae4e-219ce7dc3762"
+        },
+        "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/disk-csi-driver": {
+          "clientId": "8c088886-a118-4973-8168-0d7ae1493aa7",
+          "principalId": "ccbf438f-08ec-4e2b-ae4e-219ce7dc3762"
+        },
+        "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/file-csi-driver": {
+          "clientId": "8c088886-a118-4973-8168-0d7ae1493aa7",
+          "principalId": "ccbf438f-08ec-4e2b-ae4e-219ce7dc3762"
+        },
+        "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/image-registry": {
+          "clientId": "8c088886-a118-4973-8168-0d7ae1493aa7",
+          "principalId": "ccbf438f-08ec-4e2b-ae4e-219ce7dc3762"
+        },
+        "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ingress": {
+          "clientId": "8c088886-a118-4973-8168-0d7ae1493aa7",
+          "principalId": "ccbf438f-08ec-4e2b-ae4e-219ce7dc3762"
+        },
+        "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/kms": {
+          "clientId": "8c088886-a118-4973-8168-0d7ae1493aa7",
+          "principalId": "ccbf438f-08ec-4e2b-ae4e-219ce7dc3762"
+        },
+        "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/service": {
+          "clientId": "8c088886-a118-4973-8168-0d7ae1493aa7",
+          "principalId": "ccbf438f-08ec-4e2b-ae4e-219ce7dc3762"
+        }
+      }
+    },
+    "intermediateResourceDoc": {
+      "activeOperationId": "be3c078c-1f8c-45bd-aaef-13c0cafcbc65",
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/cloud-controller-manager": {
+            "clientId": "8c088886-a118-4973-8168-0d7ae1493aa7",
+            "principalId": "ccbf438f-08ec-4e2b-ae4e-219ce7dc3762"
+          },
+          "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/cloud-network-config": {
+            "clientId": "8c088886-a118-4973-8168-0d7ae1493aa7",
+            "principalId": "ccbf438f-08ec-4e2b-ae4e-219ce7dc3762"
+          },
+          "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/cluster-api-azure": {
+            "clientId": "8c088886-a118-4973-8168-0d7ae1493aa7",
+            "principalId": "ccbf438f-08ec-4e2b-ae4e-219ce7dc3762"
+          },
+          "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/control-plane": {
+            "clientId": "8c088886-a118-4973-8168-0d7ae1493aa7",
+            "principalId": "ccbf438f-08ec-4e2b-ae4e-219ce7dc3762"
+          },
+          "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/disk-csi-driver": {
+            "clientId": "8c088886-a118-4973-8168-0d7ae1493aa7",
+            "principalId": "ccbf438f-08ec-4e2b-ae4e-219ce7dc3762"
+          },
+          "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/file-csi-driver": {
+            "clientId": "8c088886-a118-4973-8168-0d7ae1493aa7",
+            "principalId": "ccbf438f-08ec-4e2b-ae4e-219ce7dc3762"
+          },
+          "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/image-registry": {
+            "clientId": "8c088886-a118-4973-8168-0d7ae1493aa7",
+            "principalId": "ccbf438f-08ec-4e2b-ae4e-219ce7dc3762"
+          },
+          "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ingress": {
+            "clientId": "8c088886-a118-4973-8168-0d7ae1493aa7",
+            "principalId": "ccbf438f-08ec-4e2b-ae4e-219ce7dc3762"
+          },
+          "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/kms": {
+            "clientId": "8c088886-a118-4973-8168-0d7ae1493aa7",
+            "principalId": "ccbf438f-08ec-4e2b-ae4e-219ce7dc3762"
+          },
+          "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/service": {
+            "clientId": "8c088886-a118-4973-8168-0d7ae1493aa7",
+            "principalId": "ccbf438f-08ec-4e2b-ae4e-219ce7dc3762"
+          }
+        }
+      },
+      "internalId": "/api/aro_hcp/v1alpha1/clusters/2qrppk0otds3rdmdcojqcqkqq8f0s591",
+      "provisioningState": "Deleting",
+      "resourceId": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/rg-np-version-upgrade-pckjw8-79qhmc/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/np-version-upgrade-cluster-pckjw8",
+      "systemData": {
+        "createdAt": "2026-06-10T22:53:03.0000000Z",
+        "createdBy": "e2e-test",
+        "createdByType": "Application",
+        "lastModifiedAt": "2026-06-10T22:53:04.3799969Z",
+        "lastModifiedBy": "Unknown-ARO-HCP-frontend",
+        "lastModifiedByType": "Application"
+      },
+      "tags": {
+        "aro-hcp.experimental.cluster.size-override": "Minimal"
+      }
+    },
+    "internalState": {
+      "internalAPI": {
+        "cosmosMetadata": {
+          "resourceID": null
+        },
+        "customerProperties": {
+          "api": {
+            "visibility": "Public"
+          },
+          "autoscaling": {
+            "maxNodeProvisionTimeSeconds": 900,
+            "maxPodGracePeriodSeconds": 600,
+            "podPriorityThreshold": -10
+          },
+          "clusterImageRegistry": {
+            "state": "Enabled"
+          },
+          "dns": {
+            "baseDomainPrefix": "x8y5p7r4g6j9e3v"
+          },
+          "etcd": {
+            "dataEncryption": {
+              "customerManaged": {
+                "encryptionType": "KMS",
+                "kms": {
+                  "activeKey": {
+                    "name": "etcd-data-kms-encryption-key",
+                    "vaultName": "cust-kv-nwb7s2fhiity4",
+                    "version": "0ac571d3970149dfb69e433820082616"
+                  },
+                  "visibility": "Public"
+                }
+              },
+              "keyManagementMode": "CustomerManaged"
+            }
+          },
+          "network": {
+            "hostPrefix": 23,
+            "machineCidr": "10.0.0.0/16",
+            "networkType": "OVNKubernetes",
+            "podCidr": "10.128.0.0/14",
+            "serviceCidr": "172.30.0.0/16"
+          },
+          "platform": {
+            "managedResourceGroup": "rg-np-version-upgrade-pckjw8-79qhmc-np-upgrade-pckjw8--managed",
+            "networkSecurityGroupId": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/rg-np-version-upgrade-pckjw8-79qhmc/providers/Microsoft.Network/networkSecurityGroups/customer-nsg-np-upgrade-pckjw8",
+            "operatorsAuthentication": {
+              "userAssignedIdentities": {
+                "controlPlaneOperators": {
+                  "cloud-controller-manager": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/cloud-controller-manager",
+                  "cloud-network-config": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/cloud-network-config",
+                  "cluster-api-azure": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/cluster-api-azure",
+                  "control-plane": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/control-plane",
+                  "disk-csi-driver": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/disk-csi-driver",
+                  "file-csi-driver": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/file-csi-driver",
+                  "image-registry": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/image-registry",
+                  "ingress": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ingress",
+                  "kms": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/kms"
+                },
+                "dataPlaneOperators": {
+                  "disk-csi-driver": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/dp-disk-csi-driver",
+                  "file-csi-driver": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/dp-file-csi-driver",
+                  "image-registry": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/dp-image-registry"
+                },
+                "serviceManagedIdentity": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/service"
+              }
+            },
+            "outboundType": "LoadBalancer",
+            "subnetId": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/rg-np-version-upgrade-pckjw8-79qhmc/providers/Microsoft.Network/virtualNetworks/customer-vnet-np-upgrade-pckjw8/subnets/customer-vnet-subnet-np-upgrade-pckjw8"
+          },
+          "version": {
+            "channelGroup": "candidate",
+            "id": "4.21.19"
+          }
+        },
+        "id": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/rg-np-version-upgrade-pckjw8-79qhmc/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/np-version-upgrade-cluster-pckjw8",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/cloud-controller-manager": {
+              "clientId": "8c088886-a118-4973-8168-0d7ae1493aa7",
+              "principalId": "ccbf438f-08ec-4e2b-ae4e-219ce7dc3762"
+            },
+            "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/cloud-network-config": {
+              "clientId": "8c088886-a118-4973-8168-0d7ae1493aa7",
+              "principalId": "ccbf438f-08ec-4e2b-ae4e-219ce7dc3762"
+            },
+            "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/cluster-api-azure": {
+              "clientId": "8c088886-a118-4973-8168-0d7ae1493aa7",
+              "principalId": "ccbf438f-08ec-4e2b-ae4e-219ce7dc3762"
+            },
+            "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/control-plane": {
+              "clientId": "8c088886-a118-4973-8168-0d7ae1493aa7",
+              "principalId": "ccbf438f-08ec-4e2b-ae4e-219ce7dc3762"
+            },
+            "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/disk-csi-driver": {
+              "clientId": "8c088886-a118-4973-8168-0d7ae1493aa7",
+              "principalId": "ccbf438f-08ec-4e2b-ae4e-219ce7dc3762"
+            },
+            "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/file-csi-driver": {
+              "clientId": "8c088886-a118-4973-8168-0d7ae1493aa7",
+              "principalId": "ccbf438f-08ec-4e2b-ae4e-219ce7dc3762"
+            },
+            "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/image-registry": {
+              "clientId": "8c088886-a118-4973-8168-0d7ae1493aa7",
+              "principalId": "ccbf438f-08ec-4e2b-ae4e-219ce7dc3762"
+            },
+            "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ingress": {
+              "clientId": "8c088886-a118-4973-8168-0d7ae1493aa7",
+              "principalId": "ccbf438f-08ec-4e2b-ae4e-219ce7dc3762"
+            },
+            "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/kms": {
+              "clientId": "8c088886-a118-4973-8168-0d7ae1493aa7",
+              "principalId": "ccbf438f-08ec-4e2b-ae4e-219ce7dc3762"
+            },
+            "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/aro-hcp-msi-container-dev-shard1-01-03/providers/Microsoft.ManagedIdentity/userAssignedIdentities/service": {
+              "clientId": "8c088886-a118-4973-8168-0d7ae1493aa7",
+              "principalId": "ccbf438f-08ec-4e2b-ae4e-219ce7dc3762"
+            }
+          }
+        },
+        "location": "westus3",
+        "name": "np-version-upgrade-cluster-pckjw8",
+        "serviceProviderProperties": {
+          "activeOperationId": "be3c078c-1f8c-45bd-aaef-13c0cafcbc65",
+          "api": {
+            "url": "https://api.x8y5p7r4g6j9e3v.ucwa.j0750976.hcp.osadev.cloud:443"
+          },
+          "billingDocumentCosmosID": "aa80adef-0fa4-4fe3-8d7e-86b5c9534e29",
+          "clusterServiceID": "/api/aro_hcp/v1alpha1/clusters/2qrppk0otds3rdmdcojqcqkqq8f0s591",
+          "clusterUID": "aa80adef-0fa4-4fe3-8d7e-86b5c9534e29",
+          "console": {
+            "url": "https://console-openshift-console.apps.aro.x8y5p7r4g6j9e3v.ucwa.j0750976.hcp.osadev.cloud"
+          },
+          "deletionTimestamp": "2026-06-11T00:01:37.0000000Z",
+          "dns": {
+            "baseDomain": "ucwa.j0750976.hcp.osadev.cloud"
+          },
+          "experimentalFeatures": {
+            "sizeOverride": "Minimal"
+          },
+          "managedIdentitiesDataPlaneIdentityURL": "https://dummyhost.identity.azure.net",
+          "platform": {
+            "issuerUrl": "https://arohcpci01oidcj0750976.z1.web.core.windows.net/64dc69e4-d083-49fc-9569-ebece1dd1408/2qrppk0otds3rdmdcojqcqkqq8f0s591"
+          },
+          "provisioningState": "Deleting",
+          "usesNewClusterDeletionApproach": false
+        },
+        "status": {},
+        "systemData": {
+          "createdAt": "2026-06-10T22:53:03.0000000Z",
+          "createdBy": "e2e-test",
+          "createdByType": "Application",
+          "lastModifiedAt": "2026-06-10T22:53:04.3799969Z",
+          "lastModifiedBy": "Unknown-ARO-HCP-frontend",
+          "lastModifiedByType": "Application"
+        },
+        "tags": {
+          "aro-hcp.experimental.cluster.size-override": "Minimal"
+        },
+        "type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters"
+      }
+    },
+    "location": "westus3",
+    "name": "np-version-upgrade-cluster-pckjw8",
+    "serviceProviderProperties": {
+      "activeOperationId": "be3c078c-1f8c-45bd-aaef-13c0cafcbc65",
+      "api": {
+        "url": "https://api.x8y5p7r4g6j9e3v.ucwa.j0750976.hcp.osadev.cloud:443"
+      },
+      "billingDocumentCosmosID": "aa80adef-0fa4-4fe3-8d7e-86b5c9534e29",
+      "clusterServiceID": "/api/aro_hcp/v1alpha1/clusters/2qrppk0otds3rdmdcojqcqkqq8f0s591",
+      "clusterUID": "aa80adef-0fa4-4fe3-8d7e-86b5c9534e29",
+      "console": {
+        "url": "https://console-openshift-console.apps.aro.x8y5p7r4g6j9e3v.ucwa.j0750976.hcp.osadev.cloud"
+      },
+      "deletionTimestamp": "2026-06-11T00:01:37.0000000Z",
+      "dns": {
+        "baseDomain": "ucwa.j0750976.hcp.osadev.cloud"
+      },
+      "experimentalFeatures": {
+        "sizeOverride": "Minimal"
+      },
+      "managedIdentitiesDataPlaneIdentityURL": "https://dummyhost.identity.azure.net",
+      "platform": {
+        "issuerUrl": "https://arohcpci01oidcj0750976.z1.web.core.windows.net/64dc69e4-d083-49fc-9569-ebece1dd1408/2qrppk0otds3rdmdcojqcqkqq8f0s591"
+      },
+      "provisioningState": "Deleting",
+      "usesNewClusterDeletionApproach": false
+    },
+    "status": {},
+    "systemData": {
+      "createdAt": "2026-06-10T22:53:03.0000000Z",
+      "createdBy": "e2e-test",
+      "createdByType": "Application",
+      "lastModifiedAt": "2026-06-10T22:53:04.3799969Z",
+      "lastModifiedBy": "Unknown-ARO-HCP-frontend",
+      "lastModifiedByType": "Application"
+    },
+    "tags": {
+      "aro-hcp.experimental.cluster.size-override": "Minimal"
+    },
+    "type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters"
+  },
+  "resourceID": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/rg-np-version-upgrade-pckjw8-79qhmc/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/np-version-upgrade-cluster-pckjw8",
+  "resourceType": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters"
+}

--- a/backend/pkg/controllers/upgradecontrollers/artifacts/TestNodePoolActiveVersionSyncer_RealCosmosFixture/nodepool.json
+++ b/backend/pkg/controllers/upgradecontrollers/artifacts/TestNodePoolActiveVersionSyncer_RealCosmosFixture/nodepool.json
@@ -1,0 +1,116 @@
+{
+  "_attachments": "attachments/",
+  "_etag": "\"0000a825-0000-4d00-0000-6a29fae10000\"",
+  "_rid": "deIlAKL5A1gUBgAAAAAAAA==",
+  "_self": "dbs/deIlAA==/colls/deIlAKL5A1g=/docs/deIlAKL5A1gUBgAAAAAAAA==/",
+  "_ts": 1781136097,
+  "id": "91023779-455a-57f3-bbf0-e47c90179dac",
+  "partitionKey": "e8c5a115-842d-4d7e-98ad-cfb2c50b209e",
+  "properties": {
+    "cosmosMetadata": {
+      "etag": "\"00002f23-0000-4d00-0000-6a29f03c0000\"",
+      "resourceID": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/rg-np-version-upgrade-pckjw8-79qhmc/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/np-version-upgrade-cluster-pckjw8/nodePools/npupgrade-4-20"
+    },
+    "id": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/rg-np-version-upgrade-pckjw8-79qhmc/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/np-version-upgrade-cluster-pckjw8/nodePools/npupgrade-4-20",
+    "intermediateResourceDoc": {
+      "activeOperationId": "66c481f6-0ee9-4fcb-9b23-78489a50e220",
+      "internalId": "/api/aro_hcp/v1alpha1/clusters/2qrppk0otds3rdmdcojqcqkqq8f0s591/node_pools/npupgrade-4-20",
+      "provisioningState": "Deleting",
+      "resourceId": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/rg-np-version-upgrade-pckjw8-79qhmc/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/np-version-upgrade-cluster-pckjw8/nodePools/npupgrade-4-20",
+      "systemData": {
+        "createdAt": "2026-06-10T22:59:18.0000000Z",
+        "createdBy": "e2e-test",
+        "createdByType": "Application",
+        "lastModifiedAt": "2026-06-10T23:09:27.6415755Z",
+        "lastModifiedBy": "Unknown-ARO-HCP-frontend",
+        "lastModifiedByType": "Application"
+      }
+    },
+    "internalState": {
+      "internalAPI": {
+        "cosmosMetadata": {
+          "resourceID": null
+        },
+        "id": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/rg-np-version-upgrade-pckjw8-79qhmc/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/np-version-upgrade-cluster-pckjw8/nodePools/npupgrade-4-20",
+        "location": "westus3",
+        "name": "npupgrade-4-20",
+        "properties": {
+          "autoRepair": true,
+          "nodeDrainTimeoutMinutes": 10,
+          "platform": {
+            "enableEncryptionAtHost": false,
+            "osDisk": {
+              "diskStorageAccountType": "StandardSSD_LRS",
+              "diskType": "Managed",
+              "sizeGiB": 64
+            },
+            "subnetId": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/rg-np-version-upgrade-pckjw8-79qhmc/providers/Microsoft.Network/virtualNetworks/customer-vnet-np-upgrade-pckjw8/subnets/customer-vnet-subnet-np-upgrade-pckjw8",
+            "vmSize": "Standard_D8s_v3"
+          },
+          "provisioningState": "Deleting",
+          "replicas": 3,
+          "version": {
+            "channelGroup": "candidate",
+            "id": "4.21.19"
+          }
+        },
+        "serviceProviderProperties": {
+          "activeOperationId": "66c481f6-0ee9-4fcb-9b23-78489a50e220",
+          "clusterServiceID": "/api/aro_hcp/v1alpha1/clusters/2qrppk0otds3rdmdcojqcqkqq8f0s591/node_pools/npupgrade-4-20",
+          "deletionTimestamp": "2026-06-11T00:01:37.0000000Z",
+          "usesNewNodePoolDeletionApproach": false
+        },
+        "status": {},
+        "systemData": {
+          "createdAt": "2026-06-10T22:59:18.0000000Z",
+          "createdBy": "e2e-test",
+          "createdByType": "Application",
+          "lastModifiedAt": "2026-06-10T23:09:27.6415755Z",
+          "lastModifiedBy": "Unknown-ARO-HCP-frontend",
+          "lastModifiedByType": "Application"
+        },
+        "type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
+      }
+    },
+    "location": "westus3",
+    "name": "npupgrade-4-20",
+    "properties": {
+      "autoRepair": true,
+      "nodeDrainTimeoutMinutes": 10,
+      "platform": {
+        "enableEncryptionAtHost": false,
+        "osDisk": {
+          "diskStorageAccountType": "StandardSSD_LRS",
+          "diskType": "Managed",
+          "sizeGiB": 64
+        },
+        "subnetId": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/rg-np-version-upgrade-pckjw8-79qhmc/providers/Microsoft.Network/virtualNetworks/customer-vnet-np-upgrade-pckjw8/subnets/customer-vnet-subnet-np-upgrade-pckjw8",
+        "vmSize": "Standard_D8s_v3"
+      },
+      "provisioningState": "Deleting",
+      "replicas": 3,
+      "version": {
+        "channelGroup": "candidate",
+        "id": "4.21.19"
+      }
+    },
+    "serviceProviderProperties": {
+      "activeOperationId": "66c481f6-0ee9-4fcb-9b23-78489a50e220",
+      "clusterServiceID": "/api/aro_hcp/v1alpha1/clusters/2qrppk0otds3rdmdcojqcqkqq8f0s591/node_pools/npupgrade-4-20",
+      "deletionTimestamp": "2026-06-11T00:01:37.0000000Z",
+      "usesNewNodePoolDeletionApproach": false
+    },
+    "status": {},
+    "systemData": {
+      "createdAt": "2026-06-10T22:59:18.0000000Z",
+      "createdBy": "e2e-test",
+      "createdByType": "Application",
+      "lastModifiedAt": "2026-06-10T23:09:27.6415755Z",
+      "lastModifiedBy": "Unknown-ARO-HCP-frontend",
+      "lastModifiedByType": "Application"
+    },
+    "type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
+  },
+  "resourceID": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/rg-np-version-upgrade-pckjw8-79qhmc/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/np-version-upgrade-cluster-pckjw8/nodePools/npupgrade-4-20",
+  "resourceType": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
+}

--- a/backend/pkg/controllers/upgradecontrollers/artifacts/TestNodePoolActiveVersionSyncer_RealCosmosFixture/readonlyhypershiftnodepool.json
+++ b/backend/pkg/controllers/upgradecontrollers/artifacts/TestNodePoolActiveVersionSyncer_RealCosmosFixture/readonlyhypershiftnodepool.json
@@ -1,0 +1,406 @@
+{
+  "_attachments": "attachments/",
+  "_etag": "\"0000f32e-0000-4d00-0000-6a29fb670000\"",
+  "_rid": "deIlAOPdPfpBAAAAAAAAAA==",
+  "_self": "dbs/deIlAA==/colls/deIlAOPdPfo=/docs/deIlAOPdPfpBAAAAAAAAAA==/",
+  "_ts": 1781136231,
+  "id": "c52c6d67-3e54-5426-8d83-cd60445f039e",
+  "partitionKey": "/providers/microsoft.redhatopenshift/stamps/1/managementclusters/default",
+  "properties": {
+    "cosmosMetadata": {
+      "etag": "\"0000b42a-0000-4d00-0000-6a29f0000000\"",
+      "resourceID": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/rg-np-version-upgrade-pckjw8-79qhmc/providers/microsoft.redhatopenshift/hcpopenshiftclusters/np-version-upgrade-cluster-pckjw8/nodepools/npupgrade-4-20/readdesires/readonlyhypershiftnodepool"
+    },
+    "spec": {
+      "managementCluster": "/providers/microsoft.redhatopenshift/stamps/1/managementclusters/default",
+      "targetItem": {
+        "group": "hypershift.openshift.io",
+        "name": "x8y5p7r4g6j9e3v-npupgrade-4-20",
+        "namespace": "ocm-arohcpci01-2qrppk0otds3rdmdcojqcqkqq8f0s591",
+        "resource": "nodepools",
+        "version": "v1beta1"
+      }
+    },
+    "status": {
+      "conditions": [
+        {
+          "lastTransitionTime": "2026-06-10T22:59:58.0000000Z",
+          "message": "As expected.",
+          "reason": "NoErrors",
+          "status": "True",
+          "type": "Successful"
+        }
+      ],
+      "kubeContent": {
+        "apiVersion": "hypershift.openshift.io/v1beta1",
+        "kind": "NodePool",
+        "metadata": {
+          "annotations": {
+            "hypershift.openshift.io/nodePoolCurrentConfig": "f467d67c",
+            "hypershift.openshift.io/nodePoolCurrentConfigVersion": "63caebc0",
+            "hypershift.openshift.io/nodePoolPlatformMachineTemplate": "x8y5p7r4g6j9e3v-npupgrade-4-20-b6b9e397"
+          },
+          "creationTimestamp": "2026-06-10T22:59:30.0000000Z",
+          "deletionGracePeriodSeconds": 0,
+          "deletionTimestamp": "2026-06-11T00:03:51.0000000Z",
+          "finalizers": [
+            "hypershift.openshift.io/finalizer"
+          ],
+          "generation": 4,
+          "labels": {
+            "api.openshift.com/environment": "arohcpci01",
+            "api.openshift.com/id": "2qrppk0otds3rdmdcojqcqkqq8f0s591",
+            "api.openshift.com/name": "np-version-upgrade-cluster-pckjw8"
+          },
+          "managedFields": [
+            {
+              "apiVersion": "hypershift.openshift.io/v1beta1",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:metadata": {
+                  "f:labels": {
+                    "f:api.openshift.com/environment": {},
+                    "f:api.openshift.com/id": {},
+                    "f:api.openshift.com/name": {}
+                  }
+                },
+                "f:spec": {
+                  "f:clusterName": {},
+                  "f:management": {
+                    "f:autoRepair": {},
+                    "f:replace": {
+                      "f:rollingUpdate": {
+                        "f:maxSurge": {},
+                        "f:maxUnavailable": {}
+                      },
+                      "f:strategy": {}
+                    },
+                    "f:upgradeType": {}
+                  },
+                  "f:nodeDrainTimeout": {},
+                  "f:platform": {
+                    "f:azure": {
+                      "f:diagnostics": {
+                        "f:storageAccountType": {}
+                      },
+                      "f:encryptionAtHost": {},
+                      "f:image": {
+                        "f:azureMarketplace": {
+                          "f:imageGeneration": {}
+                        },
+                        "f:type": {}
+                      },
+                      "f:osDisk": {
+                        "f:diskStorageAccountType": {},
+                        "f:persistence": {},
+                        "f:sizeGiB": {}
+                      },
+                      "f:subnetID": {},
+                      "f:vmSize": {}
+                    },
+                    "f:type": {}
+                  },
+                  "f:release": {
+                    "f:image": {}
+                  },
+                  "f:replicas": {}
+                }
+              },
+              "manager": "work-agent",
+              "operation": "Apply",
+              "time": "2026-06-10T23:09:33.0000000Z"
+            },
+            {
+              "apiVersion": "hypershift.openshift.io/v1beta1",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:metadata": {
+                  "f:ownerReferences": {
+                    ".": {},
+                    "k:{\"uid\":\"60158c0f-dbda-48d4-8d3d-5fb2a7b34476\"}": {}
+                  }
+                }
+              },
+              "manager": "work-agent",
+              "operation": "Update",
+              "time": "2026-06-10T22:59:30.0000000Z"
+            },
+            {
+              "apiVersion": "hypershift.openshift.io/v1beta1",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:metadata": {
+                  "f:annotations": {
+                    ".": {},
+                    "f:hypershift.openshift.io/nodePoolCurrentConfig": {},
+                    "f:hypershift.openshift.io/nodePoolCurrentConfigVersion": {},
+                    "f:hypershift.openshift.io/nodePoolPlatformMachineTemplate": {}
+                  },
+                  "f:finalizers": {
+                    ".": {},
+                    "v:\"hypershift.openshift.io/finalizer\"": {}
+                  },
+                  "f:ownerReferences": {
+                    "k:{\"uid\":\"6828189d-0a12-401e-ad4f-9381ea5ee8e8\"}": {}
+                  }
+                },
+                "f:spec": {
+                  "f:platform": {
+                    "f:azure": {
+                      "f:image": {
+                        "f:azureMarketplace": {
+                          "f:offer": {},
+                          "f:publisher": {},
+                          "f:sku": {},
+                          "f:version": {}
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "manager": "hypershift-operator-manager",
+              "operation": "Update",
+              "time": "2026-06-10T23:05:40.0000000Z"
+            },
+            {
+              "apiVersion": "hypershift.openshift.io/v1beta1",
+              "fieldsType": "FieldsV1",
+              "fieldsV1": {
+                "f:status": {
+                  ".": {},
+                  "f:conditions": {},
+                  "f:nodesInfo": {
+                    ".": {},
+                    "f:nodeVersions": {}
+                  },
+                  "f:replicas": {},
+                  "f:version": {}
+                }
+              },
+              "manager": "hypershift-operator-manager",
+              "operation": "Update",
+              "subresource": "status",
+              "time": "2026-06-10T23:15:12.0000000Z"
+            }
+          ],
+          "name": "x8y5p7r4g6j9e3v-npupgrade-4-20",
+          "namespace": "ocm-arohcpci01-2qrppk0otds3rdmdcojqcqkqq8f0s591",
+          "ownerReferences": [
+            {
+              "apiVersion": "work.open-cluster-management.io/v1",
+              "kind": "AppliedManifestWork",
+              "name": "1710ce7a0d4dfc0db490b6b6747644ffbb86e00748dd9562d4bee835e077b083-2qrppk0otds3rdmdcojqcqkqq8f0s591-npupgrade-4-20",
+              "uid": "60158c0f-dbda-48d4-8d3d-5fb2a7b34476"
+            },
+            {
+              "apiVersion": "hypershift.openshift.io/v1beta1",
+              "kind": "HostedCluster",
+              "name": "x8y5p7r4g6j9e3v",
+              "uid": "6828189d-0a12-401e-ad4f-9381ea5ee8e8"
+            }
+          ],
+          "resourceVersion": "504321",
+          "uid": "01b8fda7-7c0f-49c8-a741-b081f0e777e6"
+        },
+        "spec": {
+          "arch": "amd64",
+          "clusterName": "x8y5p7r4g6j9e3v",
+          "management": {
+            "autoRepair": true,
+            "replace": {
+              "rollingUpdate": {
+                "maxSurge": 1,
+                "maxUnavailable": 0
+              },
+              "strategy": "RollingUpdate"
+            },
+            "upgradeType": "Replace"
+          },
+          "nodeDrainTimeout": "10m0s",
+          "platform": {
+            "azure": {
+              "diagnostics": {
+                "storageAccountType": "Managed"
+              },
+              "encryptionAtHost": "Disabled",
+              "image": {
+                "azureMarketplace": {
+                  "imageGeneration": "Gen2",
+                  "offer": "aro4",
+                  "publisher": "azureopenshift",
+                  "sku": "420-v2",
+                  "version": "9.6.20251015"
+                },
+                "type": "AzureMarketplace"
+              },
+              "osDisk": {
+                "diskStorageAccountType": "StandardSSD_LRS",
+                "persistence": "Persistent",
+                "sizeGiB": 64
+              },
+              "subnetID": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/rg-np-version-upgrade-pckjw8-79qhmc/providers/Microsoft.Network/virtualNetworks/customer-vnet-np-upgrade-pckjw8/subnets/customer-vnet-subnet-np-upgrade-pckjw8",
+              "vmSize": "Standard_D8s_v3"
+            },
+            "type": "Azure"
+          },
+          "release": {
+            "image": "quay.io/openshift-release-dev/ocp-release@sha256:a65e099f04964491ac8b98692b2bc5c4599b0b534ffc042d020f3f90153fccf2"
+          },
+          "replicas": 3
+        },
+        "status": {
+          "conditions": [
+            {
+              "lastTransitionTime": "2026-06-10T22:59:30.0000000Z",
+              "observedGeneration": 3,
+              "reason": "AsExpected",
+              "status": "False",
+              "type": "AutoscalingEnabled"
+            },
+            {
+              "lastTransitionTime": "2026-06-10T22:59:30.0000000Z",
+              "observedGeneration": 3,
+              "reason": "AsExpected",
+              "status": "True",
+              "type": "UpdateManagementEnabled"
+            },
+            {
+              "lastTransitionTime": "2026-06-10T22:59:30.0000000Z",
+              "message": "Using release image: quay.io/openshift-release-dev/ocp-release@sha256:a65e099f04964491ac8b98692b2bc5c4599b0b534ffc042d020f3f90153fccf2",
+              "observedGeneration": 3,
+              "reason": "AsExpected",
+              "status": "True",
+              "type": "ValidReleaseImage"
+            },
+            {
+              "lastTransitionTime": "2026-06-10T22:59:30.0000000Z",
+              "observedGeneration": 3,
+              "reason": "AsExpected",
+              "status": "True",
+              "type": "ValidArchPlatform"
+            },
+            {
+              "lastTransitionTime": "2026-06-10T22:59:30.0000000Z",
+              "message": "Reconciliation active on resource",
+              "observedGeneration": 3,
+              "reason": "ReconciliationActive",
+              "status": "True",
+              "type": "ReconciliationActive"
+            },
+            {
+              "lastTransitionTime": "2026-06-10T22:59:30.0000000Z",
+              "message": "Release image version is valid",
+              "observedGeneration": 3,
+              "reason": "AsExpected",
+              "status": "True",
+              "type": "SupportedVersionSkew"
+            },
+            {
+              "lastTransitionTime": "2026-06-10T22:59:30.0000000Z",
+              "observedGeneration": 3,
+              "reason": "AsExpected",
+              "status": "True",
+              "type": "ValidMachineConfig"
+            },
+            {
+              "lastTransitionTime": "2026-06-10T23:05:40.0000000Z",
+              "observedGeneration": 3,
+              "reason": "AsExpected",
+              "status": "False",
+              "type": "UpdatingConfig"
+            },
+            {
+              "lastTransitionTime": "2026-06-10T23:05:40.0000000Z",
+              "observedGeneration": 3,
+              "reason": "AsExpected",
+              "status": "False",
+              "type": "UpdatingVersion"
+            },
+            {
+              "lastTransitionTime": "2026-06-10T23:00:03.0000000Z",
+              "message": "Payload generated successfully",
+              "observedGeneration": 3,
+              "reason": "AsExpected",
+              "status": "True",
+              "type": "ValidGeneratedPayload"
+            },
+            {
+              "lastTransitionTime": "2026-06-10T23:00:10.0000000Z",
+              "observedGeneration": 3,
+              "reason": "AsExpected",
+              "status": "True",
+              "type": "ReachedIgnitionEndpoint"
+            },
+            {
+              "lastTransitionTime": "2026-06-10T23:10:27.0000000Z",
+              "message": "All is well",
+              "observedGeneration": 3,
+              "reason": "AsExpected",
+              "status": "True",
+              "type": "AllMachinesReady"
+            },
+            {
+              "lastTransitionTime": "2026-06-10T23:15:12.0000000Z",
+              "message": "All is well",
+              "observedGeneration": 3,
+              "reason": "AsExpected",
+              "status": "True",
+              "type": "AllNodesHealthy"
+            },
+            {
+              "lastTransitionTime": "2026-06-10T22:59:30.0000000Z",
+              "message": "All is well",
+              "observedGeneration": 3,
+              "reason": "AsExpected",
+              "status": "True",
+              "type": "ValidPlatformConfig"
+            },
+            {
+              "lastTransitionTime": "2026-06-10T22:59:30.0000000Z",
+              "observedGeneration": 3,
+              "reason": "AsExpected",
+              "status": "True",
+              "type": "ValidTuningConfig"
+            },
+            {
+              "lastTransitionTime": "2026-06-10T23:05:40.0000000Z",
+              "observedGeneration": 3,
+              "reason": "AsExpected",
+              "status": "False",
+              "type": "UpdatingPlatformMachineTemplate"
+            },
+            {
+              "lastTransitionTime": "2026-06-10T23:15:12.0000000Z",
+              "observedGeneration": 3,
+              "reason": "AsExpected",
+              "status": "True",
+              "type": "Ready"
+            },
+            {
+              "lastTransitionTime": "2026-06-10T23:00:10.0000000Z",
+              "observedGeneration": 3,
+              "reason": "AsExpected",
+              "status": "True",
+              "type": "AutorepairEnabled"
+            }
+          ],
+          "nodesInfo": {
+            "nodeVersions": [
+              {
+                "kubeletVersion": "v1.33.12",
+                "ocpVersion": "4.20.24",
+                "readyNodeCount": 3,
+                "unreadyNodeCount": 0
+              }
+            ]
+          },
+          "replicas": 3,
+          "version": "4.20.24"
+        }
+      }
+    }
+  },
+  "resourceID": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/rg-np-version-upgrade-pckjw8-79qhmc/providers/microsoft.redhatopenshift/hcpopenshiftclusters/np-version-upgrade-cluster-pckjw8/nodepools/npupgrade-4-20/readdesires/readonlyhypershiftnodepool",
+  "resourceType": "microsoft.redhatopenshift/hcpopenshiftclusters/nodepools/readdesires"
+}

--- a/backend/pkg/controllers/upgradecontrollers/artifacts/TestNodePoolActiveVersionSyncer_RealCosmosFixture/serviceprovidernodepool.json
+++ b/backend/pkg/controllers/upgradecontrollers/artifacts/TestNodePoolActiveVersionSyncer_RealCosmosFixture/serviceprovidernodepool.json
@@ -1,0 +1,22 @@
+{
+  "_attachments": "attachments/",
+  "_etag": "\"0000cb1d-0000-4d00-0000-6a29ec660000\"",
+  "_rid": "deIlAKL5A1gfBgAAAAAAAA==",
+  "_self": "dbs/deIlAA==/colls/deIlAKL5A1g=/docs/deIlAKL5A1gfBgAAAAAAAA==/",
+  "_ts": 1781132390,
+  "id": "b4708efa-616d-5bec-8b92-aa01bb72f15e",
+  "partitionKey": "e8c5a115-842d-4d7e-98ad-cfb2c50b209e",
+  "properties": {
+    "cosmosMetadata": {
+      "resourceID": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/rg-np-version-upgrade-pckjw8-79qhmc/providers/microsoft.redhatopenshift/hcpopenshiftclusters/np-version-upgrade-cluster-pckjw8/nodepools/npupgrade-4-20/serviceProviderNodePools/default"
+    },
+    "spec": {
+      "nodePoolVersion": {}
+    },
+    "status": {
+      "nodePoolVersion": {}
+    }
+  },
+  "resourceID": "/subscriptions/e8c5a115-842d-4d7e-98ad-cfb2c50b209e/resourceGroups/rg-np-version-upgrade-pckjw8-79qhmc/providers/microsoft.redhatopenshift/hcpopenshiftclusters/np-version-upgrade-cluster-pckjw8/nodepools/npupgrade-4-20/serviceProviderNodePools/default",
+  "resourceType": "microsoft.redhatopenshift/hcpopenshiftclusters/nodepools/serviceProviderNodePools"
+}

--- a/backend/pkg/controllers/upgradecontrollers/nodepool_active_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/nodepool_active_version_controller.go
@@ -32,6 +32,7 @@ import (
 	internalcontrollerutils "github.com/Azure/ARO-HCP/internal/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/database"
 	dblisters "github.com/Azure/ARO-HCP/internal/database/listers"
+	unionkubeapplierinformers "github.com/Azure/ARO-HCP/internal/database/unioninformers/kubeapplier"
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
 
@@ -58,6 +59,7 @@ func NewNodePoolActiveVersionController(
 	resourcesDBClient database.ResourcesDBClient,
 	activeOperationLister listers.ActiveOperationLister,
 	informers informers.BackendInformers,
+	kubeApplierInformers *unionkubeapplierinformers.UnionKubeApplierInformers,
 	readDesireLister dblisters.ReadDesireLister,
 ) controllerutils.Controller {
 	_, serviceProviderNodePoolLister := informers.ServiceProviderNodePools()
@@ -72,6 +74,7 @@ func NewNodePoolActiveVersionController(
 		NodePoolActiveVersionsControllerName,
 		resourcesDBClient,
 		informers,
+		kubeApplierInformers,
 		5*time.Minute,
 		syncer,
 	)

--- a/backend/pkg/controllers/upgradecontrollers/nodepool_active_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/nodepool_active_version_controller.go
@@ -1,0 +1,149 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upgradecontrollers
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/blang/semver/v4"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/backend/pkg/maestrohelpers"
+	"github.com/Azure/ARO-HCP/internal/api"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/database"
+	dblisters "github.com/Azure/ARO-HCP/internal/database/listers"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// nodePoolActiveVersionSyncer is a NodePool syncer that updates
+// ServiceProviderNodePool.Status.NodePoolVersion.ActiveVersions from the
+// per-node-pool ReadDesire kubeContent (the kube-applier's mirror of the
+// management cluster's Hypershift NodePool object). Reading from the cached
+// NodePool CR replaces the previous round-trip through Cluster Service.
+type nodePoolActiveVersionSyncer struct {
+	cooldownChecker               controllerutil.CooldownChecker
+	serviceProviderNodePoolLister listers.ServiceProviderNodePoolLister
+	resourcesDBClient             database.ResourcesDBClient
+	readDesireLister              dblisters.ReadDesireLister
+}
+
+var _ controllerutils.NodePoolSyncer = (*nodePoolActiveVersionSyncer)(nil)
+
+// NewNodePoolActiveVersionController creates a new controller that updates
+// Status.NodePoolVersion.ActiveVersions on the ServiceProviderNodePool from the
+// per-node-pool ReadDesire's observed Hypershift NodePool.
+func NewNodePoolActiveVersionController(
+	resourcesDBClient database.ResourcesDBClient,
+	activeOperationLister listers.ActiveOperationLister,
+	informers informers.BackendInformers,
+	readDesireLister dblisters.ReadDesireLister,
+) controllerutils.Controller {
+	_, serviceProviderNodePoolLister := informers.ServiceProviderNodePools()
+	syncer := &nodePoolActiveVersionSyncer{
+		cooldownChecker:               controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		serviceProviderNodePoolLister: serviceProviderNodePoolLister,
+		resourcesDBClient:             resourcesDBClient,
+		readDesireLister:              readDesireLister,
+	}
+
+	return controllerutils.NewNodePoolWatchingController(
+		"NodePoolActiveVersions",
+		resourcesDBClient,
+		informers,
+		5*time.Minute,
+		syncer,
+	)
+}
+
+func (c *nodePoolActiveVersionSyncer) CooldownChecker() controllerutil.CooldownChecker {
+	return c.cooldownChecker
+}
+
+// NeedsWork reports whether the controller has a ServiceProviderNodePool to
+// update. The actual decision of whether the active versions need rewriting
+// depends on the ReadDesire NodePool's Status.Version (compared to the SPNP's
+// current tip), which can only be evaluated after the ReadDesire fetch — so
+// here we only verify that an SPNP exists to write back to.
+func (c *nodePoolActiveVersionSyncer) NeedsWork(spnp *api.ServiceProviderNodePool) bool {
+	return spnp != nil
+}
+
+// SyncOnce updates ServiceProviderNodePool.Status.NodePoolVersion.ActiveVersions
+// from the per-node-pool ReadDesire's observed Hypershift NodePool's
+// Status.Version. The new version is prepended to the existing list when it
+// differs from the current tip, and the slice is capped at two entries (newest
+// first, previous one second) so we don't grow without bound.
+func (c *nodePoolActiveVersionSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPNodePoolKey) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	// Cheap cache check: skip when the ServiceProviderNodePool hasn't been
+	// created yet. Once a sibling controller seeds it, the informer will
+	// retrigger us.
+	cachedServiceProviderNodePool, err := c.serviceProviderNodePoolLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get ServiceProviderNodePool from cache: %w", err))
+	}
+	if !c.NeedsWork(cachedServiceProviderNodePool) {
+		return nil
+	}
+
+	hsNodePool, err := maestrohelpers.GetCachedNodePoolForNodePool(ctx, c.readDesireLister, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get NodePool from ReadDesire: %w", err))
+	}
+	if hsNodePool == nil {
+		// ReadDesire absent or kubeContent not yet observed; retrigger
+		// once the kube-applier writes status.
+		return nil
+	}
+	if len(hsNodePool.Status.Version) == 0 {
+		// Mirror exists but the Hypershift NodePool hasn't reported a
+		// version yet; nothing to record.
+		return nil
+	}
+
+	actualVersion, err := semver.ParseTolerant(hsNodePool.Status.Version)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to parse NodePool Status.Version %q: %w", hsNodePool.Status.Version, err))
+	}
+
+	oldActiveVersions := cachedServiceProviderNodePool.Status.NodePoolVersion.ActiveVersions
+	newActiveVersions := prependActiveVersionIfChanged(oldActiveVersions, actualVersion)
+	if slices.Equal(oldActiveVersions, newActiveVersions) {
+		return nil
+	}
+
+	logger.Info("Active versions changed", "oldActiveVersions", oldActiveVersions, "newActiveVersions", newActiveVersions)
+	replacement := cachedServiceProviderNodePool.DeepCopy()
+	replacement.Status.NodePoolVersion.ActiveVersions = newActiveVersions
+	_, err = c.resourcesDBClient.ServiceProviderNodePools(key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName).Replace(ctx, replacement, nil)
+	if database.IsPreconditionFailedError(err) {
+		// the cache will update eventually since we're out of date and we'll enter this controller again. No need to fail.
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to replace ServiceProviderNodePool: %w", err))
+	}
+	return nil
+}

--- a/backend/pkg/controllers/upgradecontrollers/nodepool_active_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/nodepool_active_version_controller.go
@@ -22,16 +22,20 @@ import (
 
 	"github.com/blang/semver/v4"
 
+	hsv1beta1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
 	"github.com/Azure/ARO-HCP/backend/pkg/informers"
 	"github.com/Azure/ARO-HCP/backend/pkg/listers"
 	"github.com/Azure/ARO-HCP/backend/pkg/maestrohelpers"
 	"github.com/Azure/ARO-HCP/internal/api"
-	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
+	internalcontrollerutils "github.com/Azure/ARO-HCP/internal/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/database"
 	dblisters "github.com/Azure/ARO-HCP/internal/database/listers"
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
+
+const NodePoolActiveVersionsControllerName = "NodePoolActiveVersions"
 
 // nodePoolActiveVersionSyncer is a NodePool syncer that updates
 // ServiceProviderNodePool.Status.NodePoolVersion.ActiveVersions from the
@@ -39,7 +43,7 @@ import (
 // management cluster's Hypershift NodePool object). Reading from the cached
 // NodePool CR replaces the previous round-trip through Cluster Service.
 type nodePoolActiveVersionSyncer struct {
-	cooldownChecker               controllerutil.CooldownChecker
+	cooldownChecker               internalcontrollerutils.CooldownChecker
 	serviceProviderNodePoolLister listers.ServiceProviderNodePoolLister
 	resourcesDBClient             database.ResourcesDBClient
 	readDesireLister              dblisters.ReadDesireLister
@@ -65,7 +69,7 @@ func NewNodePoolActiveVersionController(
 	}
 
 	return controllerutils.NewNodePoolWatchingController(
-		"NodePoolActiveVersions",
+		NodePoolActiveVersionsControllerName,
 		resourcesDBClient,
 		informers,
 		5*time.Minute,
@@ -73,7 +77,7 @@ func NewNodePoolActiveVersionController(
 	)
 }
 
-func (c *nodePoolActiveVersionSyncer) CooldownChecker() controllerutil.CooldownChecker {
+func (c *nodePoolActiveVersionSyncer) CooldownChecker() internalcontrollerutils.CooldownChecker {
 	return c.cooldownChecker
 }
 
@@ -87,10 +91,11 @@ func (c *nodePoolActiveVersionSyncer) NeedsWork(spnp *api.ServiceProviderNodePoo
 }
 
 // SyncOnce updates ServiceProviderNodePool.Status.NodePoolVersion.ActiveVersions
-// from the per-node-pool ReadDesire's observed Hypershift NodePool's
-// Status.Version. The new version is prepended to the existing list when it
-// differs from the current tip, and the slice is capped at two entries (newest
-// first, previous one second) so we don't grow without bound.
+// to the distinct set of OCPVersions reported by the Hypershift NodePool's
+// Status.NodesInfo.NodeVersions. During an in-progress upgrade NodeVersions
+// will hold one entry per (OCPVersion, KubeletVersion) tuple that any node is
+// running; we dedupe on OCPVersion and order newest-semver first so the SPNP
+// reflects exactly what is live on the management cluster.
 func (c *nodePoolActiveVersionSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPNodePoolKey) error {
 	logger := utils.LoggerFromContext(ctx)
 
@@ -117,24 +122,29 @@ func (c *nodePoolActiveVersionSyncer) SyncOnce(ctx context.Context, key controll
 		// once the kube-applier writes status.
 		return nil
 	}
-	if len(hsNodePool.Status.Version) == 0 {
-		// Mirror exists but the Hypershift NodePool hasn't reported a
-		// version yet; nothing to record.
+	if len(hsNodePool.Status.NodesInfo.NodeVersions) == 0 {
+		// Mirror exists but the Hypershift NodePool hasn't reported any
+		// node versions yet; nothing to record.
 		return nil
 	}
 
-	actualVersion, err := semver.ParseTolerant(hsNodePool.Status.Version)
+	newActiveVersions, err := activeVersionsFromNodeVersions(ctx, hsNodePool.Status.NodesInfo.NodeVersions)
 	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to parse NodePool Status.Version %q: %w", hsNodePool.Status.Version, err))
+		return utils.TrackError(err)
 	}
-
-	oldActiveVersions := cachedServiceProviderNodePool.Status.NodePoolVersion.ActiveVersions
-	newActiveVersions := prependActiveVersionIfChanged(oldActiveVersions, actualVersion)
-	if slices.Equal(oldActiveVersions, newActiveVersions) {
+	if len(newActiveVersions) == 0 {
+		// Every NodeVersions entry had an empty/unparseable OCPVersion;
+		// nothing usable to record, wait for the next reconcile.
 		return nil
 	}
 
-	logger.Info("Active versions changed", "oldActiveVersions", oldActiveVersions, "newActiveVersions", newActiveVersions)
+	if !internalcontrollerutils.NeedsUpdate(cachedServiceProviderNodePool.Status.NodePoolVersion.ActiveVersions, newActiveVersions) {
+		return nil
+	}
+
+	logger.Info("Active versions changed",
+		"oldActiveVersions", cachedServiceProviderNodePool.Status.NodePoolVersion.ActiveVersions,
+		"newActiveVersions", newActiveVersions)
 	replacement := cachedServiceProviderNodePool.DeepCopy()
 	replacement.Status.NodePoolVersion.ActiveVersions = newActiveVersions
 	_, err = c.resourcesDBClient.ServiceProviderNodePools(key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName).Replace(ctx, replacement, nil)
@@ -146,4 +156,40 @@ func (c *nodePoolActiveVersionSyncer) SyncOnce(ctx context.Context, key controll
 		return utils.TrackError(fmt.Errorf("failed to replace ServiceProviderNodePool: %w", err))
 	}
 	return nil
+}
+
+// activeVersionsFromNodeVersions reduces a list of Hypershift NodeVersion entries
+// to the distinct, semver-sorted (newest first) set of OCPVersions. Multiple
+// NodeVersion entries may share the same OCPVersion (they differ on
+// KubeletVersion / readiness counts), so we dedupe; entries whose OCPVersion is
+// empty or unparseable are skipped with an Info log so a single malformed row
+// doesn't poison the rest of the list.
+func activeVersionsFromNodeVersions(ctx context.Context, nodeVersions []hsv1beta1.NodeVersion) ([]api.HCPNodePoolActiveVersion, error) {
+	logger := utils.LoggerFromContext(ctx)
+	seen := map[string]struct{}{}
+	parsed := []semver.Version{}
+	for _, nv := range nodeVersions {
+		if len(nv.OCPVersion) == 0 {
+			continue
+		}
+		if _, ok := seen[nv.OCPVersion]; ok {
+			continue
+		}
+		v, err := semver.ParseTolerant(nv.OCPVersion)
+		if err != nil {
+			logger.Info("skipping NodeVersions entry with unparseable OCPVersion", "ocpVersion", nv.OCPVersion, "err", err.Error())
+			continue
+		}
+		seen[nv.OCPVersion] = struct{}{}
+		parsed = append(parsed, v)
+	}
+	// Newest first.
+	semver.Sort(parsed)
+	slices.Reverse(parsed)
+
+	out := make([]api.HCPNodePoolActiveVersion, 0, len(parsed))
+	for i := range parsed {
+		out = append(out, api.HCPNodePoolActiveVersion{Version: &parsed[i]})
+	}
+	return out, nil
 }

--- a/backend/pkg/controllers/upgradecontrollers/nodepool_active_version_controller_test.go
+++ b/backend/pkg/controllers/upgradecontrollers/nodepool_active_version_controller_test.go
@@ -52,19 +52,26 @@ func nodePoolReadDesireResourceID(t *testing.T) *azcorearm.ResourceID {
 			maestrohelpers.ReadDesireNameReadonlyNodePool)))
 }
 
-// newNodePoolReadDesireWithStatusVersion builds a ReadDesire whose
-// Status.KubeContent.Raw carries a marshaled Hypershift NodePool with the
-// given status.version. Use empty string to omit (simulating "kube-applier
-// observed the resource but the controller hasn't filled status yet").
-func newNodePoolReadDesireWithStatusVersion(t *testing.T, statusVersion string) *kubeapplier.ReadDesire {
+// newNodePoolReadDesireWithNodeVersions builds a ReadDesire whose
+// Status.KubeContent.Raw carries a marshaled Hypershift NodePool whose
+// Status.NodesInfo.NodeVersions lists the given OCP versions (one entry per
+// argument). Pass no arguments to simulate "kube-applier observed the resource
+// but no node versions have been reported yet."
+func newNodePoolReadDesireWithNodeVersions(t *testing.T, ocpVersions ...string) *kubeapplier.ReadDesire {
 	t.Helper()
+	var nvs []v1beta1.NodeVersion
+	for _, v := range ocpVersions {
+		nvs = append(nvs, v1beta1.NodeVersion{OCPVersion: v})
+	}
 	np := &v1beta1.NodePool{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "NodePool",
 			APIVersion: v1beta1.GroupVersion.String(),
 		},
 		Status: v1beta1.NodePoolStatus{
-			Version: statusVersion,
+			NodesInfo: v1beta1.NodePoolNodesInfo{
+				NodeVersions: nvs,
+			},
 		},
 	}
 	raw, err := json.Marshal(np)
@@ -114,7 +121,7 @@ func TestNodePoolActiveVersionSyncer_SyncOnce(t *testing.T) {
 				createTestNodePoolWithVersion(t, ctx, mockDB, "4.19.15")
 			},
 			desires: func(t *testing.T) []*kubeapplier.ReadDesire {
-				return []*kubeapplier.ReadDesire{newNodePoolReadDesireWithStatusVersion(t, "4.19.7")}
+				return []*kubeapplier.ReadDesire{newNodePoolReadDesireWithNodeVersions(t, "4.19.7")}
 			},
 		},
 		{
@@ -145,28 +152,26 @@ func TestNodePoolActiveVersionSyncer_SyncOnce(t *testing.T) {
 			},
 		},
 		{
-			name: "NodePool Status.Version empty leaves existing SPNP untouched",
+			name: "empty NodeVersions leaves existing SPNP untouched",
 			seedDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
 				t.Helper()
 				createTestNodePoolWithVersion(t, ctx, mockDB, "4.19.15")
 				createServiceProviderNodePoolWithVersion(t, ctx, mockDB, "4.19.7")
 			},
 			desires: func(t *testing.T) []*kubeapplier.ReadDesire {
-				return []*kubeapplier.ReadDesire{newNodePoolReadDesireWithStatusVersion(t, "")}
+				return []*kubeapplier.ReadDesire{newNodePoolReadDesireWithNodeVersions(t)}
 			},
 		},
 		{
-			name: "NodePool Status.Version unparseable returns error",
+			name: "NodeVersions entries all empty/unparseable leaves SPNP untouched",
 			seedDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
 				t.Helper()
 				createTestNodePoolWithVersion(t, ctx, mockDB, "4.19.15")
 				createServiceProviderNodePoolWithVersion(t, ctx, mockDB, "4.19.7")
 			},
 			desires: func(t *testing.T) []*kubeapplier.ReadDesire {
-				return []*kubeapplier.ReadDesire{newNodePoolReadDesireWithStatusVersion(t, "not-a-semver")}
+				return []*kubeapplier.ReadDesire{newNodePoolReadDesireWithNodeVersions(t, "", "not-a-semver")}
 			},
-			expectedError:         true,
-			expectedErrorContains: "failed to parse NodePool Status.Version",
 		},
 		{
 			name: "version unchanged: no rewrite, active versions stable",
@@ -176,7 +181,7 @@ func TestNodePoolActiveVersionSyncer_SyncOnce(t *testing.T) {
 				createServiceProviderNodePoolWithVersion(t, ctx, mockDB, "4.19.7")
 			},
 			desires: func(t *testing.T) []*kubeapplier.ReadDesire {
-				return []*kubeapplier.ReadDesire{newNodePoolReadDesireWithStatusVersion(t, "4.19.7")}
+				return []*kubeapplier.ReadDesire{newNodePoolReadDesireWithNodeVersions(t, "4.19.7")}
 			},
 			validateAfter: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
 				t.Helper()
@@ -188,14 +193,33 @@ func TestNodePoolActiveVersionSyncer_SyncOnce(t *testing.T) {
 			},
 		},
 		{
-			name: "version changed: new tip prepended, previous kept as second entry",
+			name: "single new version replaces the previous one",
 			seedDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
 				t.Helper()
 				createTestNodePoolWithVersion(t, ctx, mockDB, "4.19.15")
 				createServiceProviderNodePoolWithVersion(t, ctx, mockDB, "4.19.7")
 			},
 			desires: func(t *testing.T) []*kubeapplier.ReadDesire {
-				return []*kubeapplier.ReadDesire{newNodePoolReadDesireWithStatusVersion(t, "4.19.15")}
+				return []*kubeapplier.ReadDesire{newNodePoolReadDesireWithNodeVersions(t, "4.19.15")}
+			},
+			validateAfter: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+				spnp, err := mockDB.ServiceProviderNodePools(testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName).
+					Get(ctx, api.ServiceProviderNodePoolResourceName)
+				require.NoError(t, err)
+				require.Len(t, spnp.Status.NodePoolVersion.ActiveVersions, 1)
+				assert.True(t, semver.MustParse("4.19.15").EQ(*spnp.Status.NodePoolVersion.ActiveVersions[0].Version))
+			},
+		},
+		{
+			name: "in-progress upgrade: both versions surfaced, newest first",
+			seedDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+				createTestNodePoolWithVersion(t, ctx, mockDB, "4.19.15")
+				createServiceProviderNodePoolWithVersion(t, ctx, mockDB, "4.19.7")
+			},
+			desires: func(t *testing.T) []*kubeapplier.ReadDesire {
+				return []*kubeapplier.ReadDesire{newNodePoolReadDesireWithNodeVersions(t, "4.19.7", "4.19.15")}
 			},
 			validateAfter: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
 				t.Helper()
@@ -208,6 +232,46 @@ func TestNodePoolActiveVersionSyncer_SyncOnce(t *testing.T) {
 			},
 		},
 		{
+			name: "duplicate OCPVersion entries are deduped",
+			seedDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+				createTestNodePoolWithVersion(t, ctx, mockDB, "4.19.15")
+				createServiceProviderNodePoolWithVersion(t, ctx, mockDB, "4.19.7")
+			},
+			desires: func(t *testing.T) []*kubeapplier.ReadDesire {
+				// Two NodeVersion entries with the same OCPVersion (different
+				// KubeletVersion in real life) must collapse to one entry.
+				return []*kubeapplier.ReadDesire{newNodePoolReadDesireWithNodeVersions(t, "4.19.15", "4.19.15")}
+			},
+			validateAfter: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+				spnp, err := mockDB.ServiceProviderNodePools(testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName).
+					Get(ctx, api.ServiceProviderNodePoolResourceName)
+				require.NoError(t, err)
+				require.Len(t, spnp.Status.NodePoolVersion.ActiveVersions, 1)
+				assert.True(t, semver.MustParse("4.19.15").EQ(*spnp.Status.NodePoolVersion.ActiveVersions[0].Version))
+			},
+		},
+		{
+			name: "unparseable entries are skipped, parseable ones still recorded",
+			seedDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+				createTestNodePoolWithVersion(t, ctx, mockDB, "4.19.15")
+				createServiceProviderNodePoolWithVersion(t, ctx, mockDB, "4.19.7")
+			},
+			desires: func(t *testing.T) []*kubeapplier.ReadDesire {
+				return []*kubeapplier.ReadDesire{newNodePoolReadDesireWithNodeVersions(t, "4.19.15", "not-a-semver")}
+			},
+			validateAfter: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+				spnp, err := mockDB.ServiceProviderNodePools(testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName).
+					Get(ctx, api.ServiceProviderNodePoolResourceName)
+				require.NoError(t, err)
+				require.Len(t, spnp.Status.NodePoolVersion.ActiveVersions, 1)
+				assert.True(t, semver.MustParse("4.19.15").EQ(*spnp.Status.NodePoolVersion.ActiveVersions[0].Version))
+			},
+		},
+		{
 			name: "ParseTolerant accepts non-strict semver from hypershift",
 			seedDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
 				t.Helper()
@@ -216,17 +280,16 @@ func TestNodePoolActiveVersionSyncer_SyncOnce(t *testing.T) {
 			},
 			desires: func(t *testing.T) []*kubeapplier.ReadDesire {
 				// hypershift sometimes reports versions like "4.19" (no patch)
-				return []*kubeapplier.ReadDesire{newNodePoolReadDesireWithStatusVersion(t, "4.19")}
+				return []*kubeapplier.ReadDesire{newNodePoolReadDesireWithNodeVersions(t, "4.19")}
 			},
 			validateAfter: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
 				t.Helper()
 				spnp, err := mockDB.ServiceProviderNodePools(testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName).
 					Get(ctx, api.ServiceProviderNodePoolResourceName)
 				require.NoError(t, err)
-				require.Len(t, spnp.Status.NodePoolVersion.ActiveVersions, 2)
+				require.Len(t, spnp.Status.NodePoolVersion.ActiveVersions, 1)
 				expected := api.Must(semver.ParseTolerant("4.19"))
 				assert.True(t, expected.EQ(*spnp.Status.NodePoolVersion.ActiveVersions[0].Version))
-				assert.True(t, semver.MustParse("4.19.7").EQ(*spnp.Status.NodePoolVersion.ActiveVersions[1].Version))
 			},
 		},
 	}
@@ -279,7 +342,7 @@ func TestNodePoolActiveVersionSyncer_NoReplaceWhenVersionsUnchanged(t *testing.T
 		serviceProviderNodePoolLister: &listertesting.DBServiceProviderNodePoolLister{ResourcesDBClient: mockDB},
 		resourcesDBClient:             mockDB,
 		readDesireLister: &internallistertesting.SliceReadDesireLister{
-			Desires: []*kubeapplier.ReadDesire{newNodePoolReadDesireWithStatusVersion(t, "4.19.7")},
+			Desires: []*kubeapplier.ReadDesire{newNodePoolReadDesireWithNodeVersions(t, "4.19.7")},
 		},
 	}
 

--- a/backend/pkg/controllers/upgradecontrollers/nodepool_active_version_controller_test.go
+++ b/backend/pkg/controllers/upgradecontrollers/nodepool_active_version_controller_test.go
@@ -1,0 +1,305 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upgradecontrollers
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/blang/semver/v4"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kruntime "k8s.io/apimachinery/pkg/runtime"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
+	"github.com/Azure/ARO-HCP/backend/pkg/maestrohelpers"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/kubeapplier"
+	internallistertesting "github.com/Azure/ARO-HCP/internal/database/listertesting"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// nodePoolReadDesireResourceID returns the resource ID for the readonly
+// NodePool ReadDesire associated with the test node pool. The slice lister
+// matches on this ID to satisfy GetForNodePool.
+func nodePoolReadDesireResourceID(t *testing.T) *azcorearm.ResourceID {
+	t.Helper()
+	return api.Must(azcorearm.ParseResourceID(
+		kubeapplier.ToNodePoolScopedReadDesireResourceIDString(
+			testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName,
+			maestrohelpers.ReadDesireNameReadonlyNodePool)))
+}
+
+// newNodePoolReadDesireWithStatusVersion builds a ReadDesire whose
+// Status.KubeContent.Raw carries a marshaled Hypershift NodePool with the
+// given status.version. Use empty string to omit (simulating "kube-applier
+// observed the resource but the controller hasn't filled status yet").
+func newNodePoolReadDesireWithStatusVersion(t *testing.T, statusVersion string) *kubeapplier.ReadDesire {
+	t.Helper()
+	np := &v1beta1.NodePool{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "NodePool",
+			APIVersion: v1beta1.GroupVersion.String(),
+		},
+		Status: v1beta1.NodePoolStatus{
+			Version: statusVersion,
+		},
+	}
+	raw, err := json.Marshal(np)
+	require.NoError(t, err)
+	return &kubeapplier.ReadDesire{
+		CosmosMetadata: api.CosmosMetadata{ResourceID: nodePoolReadDesireResourceID(t)},
+		Status: kubeapplier.ReadDesireStatus{
+			KubeContent: &kruntime.RawExtension{Raw: raw},
+		},
+	}
+}
+
+// newNodePoolReadDesireMissingKubeContent simulates the ReadDesire existing but
+// the kube-applier not having observed the target yet (Status.KubeContent nil).
+func newNodePoolReadDesireMissingKubeContent(t *testing.T) *kubeapplier.ReadDesire {
+	t.Helper()
+	return &kubeapplier.ReadDesire{
+		CosmosMetadata: api.CosmosMetadata{ResourceID: nodePoolReadDesireResourceID(t)},
+		Status:         kubeapplier.ReadDesireStatus{},
+	}
+}
+
+func TestNodePoolActiveVersionSyncer_SyncOnce(t *testing.T) {
+	testKey := controllerutils.HCPNodePoolKey{
+		SubscriptionID:    testSubscriptionID,
+		ResourceGroupName: testResourceGroupName,
+		HCPClusterName:    testClusterName,
+		HCPNodePoolName:   testNodePoolName,
+	}
+
+	tests := []struct {
+		name                  string
+		seedDB                func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient)
+		desires               func(t *testing.T) []*kubeapplier.ReadDesire
+		expectedError         bool
+		expectedErrorContains string
+		// validateAfter inspects the SPNP after sync. nil means "no SPNP write expected".
+		validateAfter func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient)
+	}{
+		{
+			name: "ServiceProviderNodePool not in cache returns nil",
+			seedDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+				// Seed only the NodePool — the cached SPNP lookup will miss
+				// and NeedsWork should short-circuit before we touch the
+				// ReadDesire.
+				createTestNodePoolWithVersion(t, ctx, mockDB, "4.19.15")
+			},
+			desires: func(t *testing.T) []*kubeapplier.ReadDesire {
+				return []*kubeapplier.ReadDesire{newNodePoolReadDesireWithStatusVersion(t, "4.19.7")}
+			},
+		},
+		{
+			name: "ReadDesire absent leaves existing SPNP untouched",
+			seedDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+				createTestNodePoolWithVersion(t, ctx, mockDB, "4.19.15")
+				createServiceProviderNodePoolWithVersion(t, ctx, mockDB, "4.19.7")
+			},
+			validateAfter: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+				spnp, err := mockDB.ServiceProviderNodePools(testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName).
+					Get(ctx, api.ServiceProviderNodePoolResourceName)
+				require.NoError(t, err)
+				require.Len(t, spnp.Status.NodePoolVersion.ActiveVersions, 1)
+				assert.True(t, semver.MustParse("4.19.7").EQ(*spnp.Status.NodePoolVersion.ActiveVersions[0].Version))
+			},
+		},
+		{
+			name: "ReadDesire without kubeContent leaves existing SPNP untouched",
+			seedDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+				createTestNodePoolWithVersion(t, ctx, mockDB, "4.19.15")
+				createServiceProviderNodePoolWithVersion(t, ctx, mockDB, "4.19.7")
+			},
+			desires: func(t *testing.T) []*kubeapplier.ReadDesire {
+				return []*kubeapplier.ReadDesire{newNodePoolReadDesireMissingKubeContent(t)}
+			},
+		},
+		{
+			name: "NodePool Status.Version empty leaves existing SPNP untouched",
+			seedDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+				createTestNodePoolWithVersion(t, ctx, mockDB, "4.19.15")
+				createServiceProviderNodePoolWithVersion(t, ctx, mockDB, "4.19.7")
+			},
+			desires: func(t *testing.T) []*kubeapplier.ReadDesire {
+				return []*kubeapplier.ReadDesire{newNodePoolReadDesireWithStatusVersion(t, "")}
+			},
+		},
+		{
+			name: "NodePool Status.Version unparseable returns error",
+			seedDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+				createTestNodePoolWithVersion(t, ctx, mockDB, "4.19.15")
+				createServiceProviderNodePoolWithVersion(t, ctx, mockDB, "4.19.7")
+			},
+			desires: func(t *testing.T) []*kubeapplier.ReadDesire {
+				return []*kubeapplier.ReadDesire{newNodePoolReadDesireWithStatusVersion(t, "not-a-semver")}
+			},
+			expectedError:         true,
+			expectedErrorContains: "failed to parse NodePool Status.Version",
+		},
+		{
+			name: "version unchanged: no rewrite, active versions stable",
+			seedDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+				createTestNodePoolWithVersion(t, ctx, mockDB, "4.19.15")
+				createServiceProviderNodePoolWithVersion(t, ctx, mockDB, "4.19.7")
+			},
+			desires: func(t *testing.T) []*kubeapplier.ReadDesire {
+				return []*kubeapplier.ReadDesire{newNodePoolReadDesireWithStatusVersion(t, "4.19.7")}
+			},
+			validateAfter: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+				spnp, err := mockDB.ServiceProviderNodePools(testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName).
+					Get(ctx, api.ServiceProviderNodePoolResourceName)
+				require.NoError(t, err)
+				require.Len(t, spnp.Status.NodePoolVersion.ActiveVersions, 1)
+				assert.True(t, semver.MustParse("4.19.7").EQ(*spnp.Status.NodePoolVersion.ActiveVersions[0].Version))
+			},
+		},
+		{
+			name: "version changed: new tip prepended, previous kept as second entry",
+			seedDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+				createTestNodePoolWithVersion(t, ctx, mockDB, "4.19.15")
+				createServiceProviderNodePoolWithVersion(t, ctx, mockDB, "4.19.7")
+			},
+			desires: func(t *testing.T) []*kubeapplier.ReadDesire {
+				return []*kubeapplier.ReadDesire{newNodePoolReadDesireWithStatusVersion(t, "4.19.15")}
+			},
+			validateAfter: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+				spnp, err := mockDB.ServiceProviderNodePools(testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName).
+					Get(ctx, api.ServiceProviderNodePoolResourceName)
+				require.NoError(t, err)
+				require.Len(t, spnp.Status.NodePoolVersion.ActiveVersions, 2)
+				assert.True(t, semver.MustParse("4.19.15").EQ(*spnp.Status.NodePoolVersion.ActiveVersions[0].Version))
+				assert.True(t, semver.MustParse("4.19.7").EQ(*spnp.Status.NodePoolVersion.ActiveVersions[1].Version))
+			},
+		},
+		{
+			name: "ParseTolerant accepts non-strict semver from hypershift",
+			seedDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+				createTestNodePoolWithVersion(t, ctx, mockDB, "4.19.15")
+				createServiceProviderNodePoolWithVersion(t, ctx, mockDB, "4.19.7")
+			},
+			desires: func(t *testing.T) []*kubeapplier.ReadDesire {
+				// hypershift sometimes reports versions like "4.19" (no patch)
+				return []*kubeapplier.ReadDesire{newNodePoolReadDesireWithStatusVersion(t, "4.19")}
+			},
+			validateAfter: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+				spnp, err := mockDB.ServiceProviderNodePools(testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName).
+					Get(ctx, api.ServiceProviderNodePoolResourceName)
+				require.NoError(t, err)
+				require.Len(t, spnp.Status.NodePoolVersion.ActiveVersions, 2)
+				expected := api.Must(semver.ParseTolerant("4.19"))
+				assert.True(t, expected.EQ(*spnp.Status.NodePoolVersion.ActiveVersions[0].Version))
+				assert.True(t, semver.MustParse("4.19.7").EQ(*spnp.Status.NodePoolVersion.ActiveVersions[1].Version))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runCtx := utils.ContextWithLogger(context.Background(), logr.Discard())
+			mockDB := databasetesting.NewMockResourcesDBClient()
+			tt.seedDB(t, runCtx, mockDB)
+
+			var desires []*kubeapplier.ReadDesire
+			if tt.desires != nil {
+				desires = tt.desires(t)
+			}
+
+			syncer := &nodePoolActiveVersionSyncer{
+				cooldownChecker:               &alwaysSyncCooldownChecker{},
+				serviceProviderNodePoolLister: &listertesting.DBServiceProviderNodePoolLister{ResourcesDBClient: mockDB},
+				resourcesDBClient:             mockDB,
+				readDesireLister:              &internallistertesting.SliceReadDesireLister{Desires: desires},
+			}
+
+			err := syncer.SyncOnce(runCtx, testKey)
+			assertSyncResult(t, err, tt.expectedError, tt.expectedErrorContains)
+
+			if tt.validateAfter != nil && !tt.expectedError {
+				tt.validateAfter(t, runCtx, mockDB)
+			}
+		})
+	}
+}
+
+// TestNodePoolActiveVersionSyncer_NoReplaceWhenVersionsUnchanged is a
+// regression test ensuring we don't churn the SPNP fixture on every reconcile
+// when nothing has changed — preserves the existing _etag.
+func TestNodePoolActiveVersionSyncer_NoReplaceWhenVersionsUnchanged(t *testing.T) {
+	runCtx := utils.ContextWithLogger(context.Background(), logr.Discard())
+	mockDB := databasetesting.NewMockResourcesDBClient()
+
+	createTestNodePoolWithVersion(t, runCtx, mockDB, "4.19.15")
+	createServiceProviderNodePoolWithVersion(t, runCtx, mockDB, "4.19.7")
+
+	spnpCRUD := mockDB.ServiceProviderNodePools(testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName)
+	before, err := spnpCRUD.Get(runCtx, api.ServiceProviderNodePoolResourceName)
+	require.NoError(t, err)
+	beforeETag := before.CosmosETag
+
+	syncer := &nodePoolActiveVersionSyncer{
+		cooldownChecker:               &alwaysSyncCooldownChecker{},
+		serviceProviderNodePoolLister: &listertesting.DBServiceProviderNodePoolLister{ResourcesDBClient: mockDB},
+		resourcesDBClient:             mockDB,
+		readDesireLister: &internallistertesting.SliceReadDesireLister{
+			Desires: []*kubeapplier.ReadDesire{newNodePoolReadDesireWithStatusVersion(t, "4.19.7")},
+		},
+	}
+
+	require.NoError(t, syncer.SyncOnce(runCtx, controllerutils.HCPNodePoolKey{
+		SubscriptionID:    testSubscriptionID,
+		ResourceGroupName: testResourceGroupName,
+		HCPClusterName:    testClusterName,
+		HCPNodePoolName:   testNodePoolName,
+	}))
+
+	after, err := spnpCRUD.Get(runCtx, api.ServiceProviderNodePoolResourceName)
+	require.NoError(t, err)
+	assert.Equal(t, beforeETag, after.CosmosETag, "no write expected when active versions unchanged")
+}
+
+// TestNodePoolActiveVersionSyncer_NeedsWork exercises the predicate directly so
+// failure modes there don't depend on the SyncOnce control flow.
+func TestNodePoolActiveVersionSyncer_NeedsWork(t *testing.T) {
+	syncer := &nodePoolActiveVersionSyncer{}
+
+	assert.False(t, syncer.NeedsWork(nil), "nil SPNP should mean no work")
+	assert.True(t, syncer.NeedsWork(&api.ServiceProviderNodePool{}), "any non-nil SPNP is enough — the actual version delta is decided after the ReadDesire fetch")
+}

--- a/backend/pkg/controllers/upgradecontrollers/nodepool_active_version_real_cosmos_test.go
+++ b/backend/pkg/controllers/upgradecontrollers/nodepool_active_version_real_cosmos_test.go
@@ -1,0 +1,170 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upgradecontrollers
+
+import (
+	"context"
+	"embed"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/blang/semver/v4"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/utils/ptr"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/api/kubeapplier"
+	internallistertesting "github.com/Azure/ARO-HCP/internal/database/listertesting"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// nodePoolActiveVersionRealCosmosFS holds JSON documents captured directly
+// from CosmosDB on a real cluster (subscription
+// e8c5a115-842d-4d7e-98ad-cfb2c50b209e, resource group
+// rg-np-version-upgrade-pckjw8-79qhmc, cluster
+// np-version-upgrade-cluster-pckjw8, node pool npupgrade-4-20) where the
+// ServiceProviderNodePool's status.nodePoolVersion stayed empty even though
+// the kube-applier-mirrored Hypershift NodePool reported
+// status.nodesInfo.nodeVersions[].ocpVersion = "4.20.24". Embedding the
+// exact documents lets this test serve as a regression check against the
+// shape of the observed inputs.
+//
+//go:embed artifacts/TestNodePoolActiveVersionSyncer_RealCosmosFixture/*.json
+var nodePoolActiveVersionRealCosmosFS embed.FS
+
+// loadCosmosResource reads an embedded Cosmos JSON document
+// (`{"properties": {...resource fields...}}`) and unmarshals the
+// `properties` subtree into *T. Cosmos infrastructure fields (_etag, _rid,
+// _self, etc.) live outside `properties` and are ignored.
+func loadCosmosResource[T any](t *testing.T, fsys embed.FS, path string) *T {
+	t.Helper()
+	raw, err := fsys.ReadFile(path)
+	require.NoError(t, err, "read embedded fixture %s", path)
+	var doc struct {
+		Properties json.RawMessage `json:"properties"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &doc), "outer parse of %s", path)
+	out := new(T)
+	require.NoError(t, json.Unmarshal(doc.Properties, out), "properties parse of %s", path)
+	return out
+}
+
+// seedSubscription inserts a minimal registered subscription. The Cosmos
+// capture in /tmp/nodeversionfail did not include the subscription document
+// (subscriptions live in a separate container we did not snapshot), so this
+// is the only piece of the parent chain we still synthesize.
+func seedSubscription(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient, subscriptionID string) {
+	t.Helper()
+	subscriptionRID := api.Must(azcorearm.ParseResourceID("/subscriptions/" + subscriptionID))
+	_, err := mockDB.Subscriptions().Create(ctx, &arm.Subscription{
+		CosmosMetadata: arm.CosmosMetadata{
+			ResourceID:   subscriptionRID,
+			PartitionKey: strings.ToLower(subscriptionRID.SubscriptionID),
+		},
+		ResourceID: subscriptionRID,
+		State:      arm.SubscriptionStateRegistered,
+		Properties: &arm.SubscriptionProperties{TenantId: ptr.To("test-tenant-id")},
+	}, nil)
+	require.NoError(t, err)
+}
+
+// TestNodePoolActiveVersionSyncer_RealCosmosFixture is a regression test built
+// from Cosmos documents captured on a real cluster. The captured SPNP had an
+// empty status.nodePoolVersion despite the kube-applier-mirrored Hypershift
+// NodePool reporting ocpVersion=4.20.24 in status.nodesInfo.nodeVersions.
+// Replaying those two documents through the syncer must produce
+// ActiveVersions=[{Version: 4.20.24}] — anything else means we have
+// regressed on the parsing path that handles real-world payloads.
+func TestNodePoolActiveVersionSyncer_RealCosmosFixture(t *testing.T) {
+	const artifactsRoot = "artifacts/TestNodePoolActiveVersionSyncer_RealCosmosFixture"
+
+	runCtx := utils.ContextWithLogger(context.Background(), logr.Discard())
+	mockDB := databasetesting.NewMockResourcesDBClient()
+
+	cluster := loadCosmosResource[api.HCPOpenShiftCluster](t, nodePoolActiveVersionRealCosmosFS, artifactsRoot+"/cluster.json")
+	nodePool := loadCosmosResource[api.HCPOpenShiftClusterNodePool](t, nodePoolActiveVersionRealCosmosFS, artifactsRoot+"/nodepool.json")
+	spnp := loadCosmosResource[api.ServiceProviderNodePool](t, nodePoolActiveVersionRealCosmosFS, artifactsRoot+"/serviceprovidernodepool.json")
+	readDesire := loadCosmosResource[kubeapplier.ReadDesire](t, nodePoolActiveVersionRealCosmosFS, artifactsRoot+"/readonlyhypershiftnodepool.json")
+
+	// Sanity-check the inputs match what was captured: empty active versions
+	// going in, NodeVersions present on the mirrored Hypershift NodePool.
+	require.Empty(t, spnp.Status.NodePoolVersion.ActiveVersions, "captured SPNP must start with no active versions")
+	require.NotNil(t, readDesire.Status.KubeContent, "captured ReadDesire must have a kubeContent body")
+
+	require.NotNil(t, spnp.ResourceID)
+	nodePoolRID := spnp.ResourceID.Parent
+	clusterRID := nodePoolRID.Parent
+
+	// Subscription is the only piece of the parent chain we synthesize —
+	// see seedSubscription. Cluster, NodePool, and SPNP are inserted
+	// verbatim from the captured Cosmos JSON.
+	seedSubscription(t, runCtx, mockDB, clusterRID.SubscriptionID)
+
+	// The captured Cosmos JSON does not carry PartitionKey on the embedded
+	// CosmosMetadata; populate it here so the mock CRUD (which mirrors the
+	// real one) accepts the documents.
+	partitionKey := strings.ToLower(clusterRID.SubscriptionID)
+	cluster.PartitionKey = partitionKey
+	nodePool.PartitionKey = partitionKey
+	spnp.PartitionKey = partitionKey
+
+	_, err := mockDB.HCPClusters(clusterRID.SubscriptionID, clusterRID.ResourceGroupName).Create(runCtx, cluster, nil)
+	require.NoError(t, err, "create cluster from captured cosmos doc")
+
+	_, err = mockDB.HCPClusters(clusterRID.SubscriptionID, clusterRID.ResourceGroupName).
+		NodePools(clusterRID.Name).Create(runCtx, nodePool, nil)
+	require.NoError(t, err, "create node pool from captured cosmos doc")
+
+	_, err = mockDB.ServiceProviderNodePools(
+		clusterRID.SubscriptionID, clusterRID.ResourceGroupName, clusterRID.Name, nodePoolRID.Name,
+	).Create(runCtx, spnp, nil)
+	require.NoError(t, err, "create ServiceProviderNodePool from captured cosmos doc")
+
+	syncer := &nodePoolActiveVersionSyncer{
+		cooldownChecker:               &alwaysSyncCooldownChecker{},
+		serviceProviderNodePoolLister: &listertesting.DBServiceProviderNodePoolLister{ResourcesDBClient: mockDB},
+		resourcesDBClient:             mockDB,
+		readDesireLister: &internallistertesting.SliceReadDesireLister{
+			Desires: []*kubeapplier.ReadDesire{readDesire},
+		},
+	}
+
+	require.NoError(t, syncer.SyncOnce(runCtx, controllerutils.HCPNodePoolKey{
+		SubscriptionID:    clusterRID.SubscriptionID,
+		ResourceGroupName: clusterRID.ResourceGroupName,
+		HCPClusterName:    clusterRID.Name,
+		HCPNodePoolName:   nodePoolRID.Name,
+	}))
+
+	after, err := mockDB.ServiceProviderNodePools(
+		clusterRID.SubscriptionID, clusterRID.ResourceGroupName, clusterRID.Name, nodePoolRID.Name,
+	).Get(runCtx, api.ServiceProviderNodePoolResourceName)
+	require.NoError(t, err)
+	require.Len(t, after.Status.NodePoolVersion.ActiveVersions, 1,
+		"expected the single observed OCPVersion to be promoted into ActiveVersions")
+	expected := semver.MustParse("4.20.24")
+	assert.True(t, expected.EQ(*after.Status.NodePoolVersion.ActiveVersions[0].Version),
+		"expected ActiveVersions[0] to be 4.20.24, got %s", after.Status.NodePoolVersion.ActiveVersions[0].Version)
+}

--- a/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"slices"
 	"time"
 
 	"github.com/blang/semver/v4"
@@ -39,48 +38,53 @@ import (
 	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/database"
 	dblisters "github.com/Azure/ARO-HCP/internal/database/listers"
-	"github.com/Azure/ARO-HCP/internal/ocm"
 	"github.com/Azure/ARO-HCP/internal/utils"
 	"github.com/Azure/ARO-HCP/internal/utils/apihelpers"
 	"github.com/Azure/ARO-HCP/internal/validation"
 )
 
-// nodepoolVersionControllerName is the Cosmos controller document ID for this syncer.
+// NodepoolVersionControllerName is the Cosmos controller document ID for this syncer.
 const NodepoolVersionControllerName = "NodePoolVersion"
 
-// nodePoolVersionSyncer is a nodePool syncer that synchronizes cluster information
-// from CS and internal and helps selecting a valid desiredVersion within the user's
-// desired
+// nodePoolVersionSyncer validates the customer's desired NodePool version and
+// stores it on the ServiceProviderNodePool. Active-version tracking moved to
+// nodePoolActiveVersionSyncer (sourced from the ReadDesire NodePool mirror) and
+// is no longer this controller's responsibility.
 type nodePoolVersionSyncer struct {
-	cooldownChecker      controllerutil.CooldownChecker
-	readDesireLister     dblisters.ReadDesireLister
-	resourcesDBClient    database.ResourcesDBClient
-	clusterServiceClient ocm.ClusterServiceClientSpec
-	subscriptionLister   listers.SubscriptionLister
+	cooldownChecker               controllerutil.CooldownChecker
+	nodePoolLister                listers.NodePoolLister
+	serviceProviderNodePoolLister listers.ServiceProviderNodePoolLister
+	serviceProviderClusterLister  listers.ServiceProviderClusterLister
+	subscriptionLister            listers.SubscriptionLister
+	readDesireLister              dblisters.ReadDesireLister
+	resourcesDBClient             database.ResourcesDBClient
 
 	cincinnatiClientCache cincinnati.ClientCache
 }
 
 var _ controllerutils.NodePoolSyncer = (*nodePoolVersionSyncer)(nil)
 
-// NewNodePoolVersionController creates a new syncer that reads node pool versions
-// from Cluster Service.
-// TODO: improve this description
+// NewNodePoolVersionController creates a new syncer that validates and persists
+// the customer's desired NodePool version on the ServiceProviderNodePool.
 func NewNodePoolVersionController(
 	resourcesDBClient database.ResourcesDBClient,
-	clusterServiceClient ocm.ClusterServiceClientSpec,
 	activeOperationLister listers.ActiveOperationLister,
+	subscriptionLister listers.SubscriptionLister,
 	informers informers.BackendInformers,
 	readDesireLister dblisters.ReadDesireLister,
-	subscriptionLister listers.SubscriptionLister,
 ) controllerutils.Controller {
+	_, nodePoolLister := informers.NodePools()
+	_, serviceProviderNodePoolLister := informers.ServiceProviderNodePools()
+	_, serviceProviderClusterLister := informers.ServiceProviderClusters()
 	syncer := &nodePoolVersionSyncer{
-		cooldownChecker:       controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
-		readDesireLister:      readDesireLister,
-		resourcesDBClient:     resourcesDBClient,
-		clusterServiceClient:  clusterServiceClient,
-		cincinnatiClientCache: cincinnati.NewClientCache(),
-		subscriptionLister:    subscriptionLister,
+		cooldownChecker:               controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		nodePoolLister:                nodePoolLister,
+		serviceProviderNodePoolLister: serviceProviderNodePoolLister,
+		serviceProviderClusterLister:  serviceProviderClusterLister,
+		subscriptionLister:            subscriptionLister,
+		readDesireLister:              readDesireLister,
+		resourcesDBClient:             resourcesDBClient,
+		cincinnatiClientCache:         cincinnati.NewClientCache(),
 	}
 
 	controller := controllerutils.NewNodePoolWatchingController(
@@ -94,74 +98,91 @@ func NewNodePoolVersionController(
 	return controller
 }
 
-// SyncOnce synchronizes node pool version information between Cluster Service
-// and the ServiceProviderNodePool in Cosmos DB.
+// NeedsWork reports whether this controller has anything to do for the given
+// NodePool. The work this controller does is persist the customer's desired
+// version onto the ServiceProviderNodePool, which is needed when:
+//   - the NodePool's customer-visible Properties.Version.ID is set, and
+//   - the ServiceProviderNodePool's Spec.NodePoolVersion.DesiredVersion does
+//     not already equal that value (otherwise nothing would change).
 //
-// The method performs two main operations:
+// Both arguments must be non-nil; SyncOnce gates the cache miss before calling
+// NeedsWork.
+func (c *nodePoolVersionSyncer) NeedsWork(nodePool *api.HCPOpenShiftClusterNodePool, serviceProviderNodePool *api.ServiceProviderNodePool) bool {
+	if len(nodePool.Properties.Version.ID) == 0 {
+		return false
+	}
+	if serviceProviderNodePool.Spec.NodePoolVersion.DesiredVersion == nil {
+		return true
+	}
+	customerDesiredVersion, err := semver.ParseTolerant(nodePool.Properties.Version.ID)
+	if err != nil {
+		// Unparseable version; let SyncOnce surface the parse error path —
+		// we don't suppress work just because we can't parse it here.
+		return true
+	}
+	return !customerDesiredVersion.EQ(*serviceProviderNodePool.Spec.NodePoolVersion.DesiredVersion)
+}
+
+// SyncOnce validates and persists the customer's desired node pool version on
+// the ServiceProviderNodePool in Cosmos DB.
 //
-// 1. Active Version Tracking:
-//   - Reads the current running version from Cluster Service (csNodePool.Version)
-//   - Stores it in ServiceProviderNodePool.Status.NodePoolVersion.ActiveVersions
-//   - Maintains up to 2 versions during version changes (newest first, then previous)
+//   - Reads the customer's desired version from HCPNodePool.Properties.Version.ID.
+//   - Validates it against version change constraints (see validateDesiredNodePoolVersion):
+//   - Exists as a known version in Cincinnati.
+//   - Upgrade: at most +2 minor versions from current, and cannot exceed lowest control plane version.
+//   - Downgrade: at most -2 minor versions from the highest control plane version.
+//   - Cross-major changes (either direction) require AFEC FeatureExperimentalReleaseFeatures.
+//   - NP version must be in the allowed skew map when CP and NP are on different majors.
+//   - If valid, stores it in ServiceProviderNodePool.Spec.NodePoolVersion.DesiredVersion.
 //
-// 2. Desired Version Validation and Storage:
-//   - Reads the customer's desired version from HCPNodePool.Properties.Version.ID
-//   - Validates it against version change constraints (see validateDesiredNodePoolVersion)
-//   - The desired version must satisfy:
-//   - Exist as a known version in Cincinnati
-//   - Upgrade: at most +2 minor versions from current, and cannot exceed lowest control plane version
-//   - Downgrade: at most -2 minor versions from the highest control plane version
-//   - Cross-major changes (either direction) require AFEC FeatureExperimentalReleaseFeatures
-//   - NP version must be in the allowed skew map when CP and NP are on different majors
-//   - If valid, stores it in ServiceProviderNodePool.Spec.NodePoolVersion.DesiredVersion
-//
-// If the desired version is already among the active versions, validation is skipped
-// (the upgrade is already in progress or complete).
+// Active version tracking lives in nodePoolActiveVersionSyncer, which reads the
+// Hypershift NodePool from the per-node-pool ReadDesire kubeContent rather than
+// round-tripping through Cluster Service.
 func (c *nodePoolVersionSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPNodePoolKey) error {
 	logger := utils.LoggerFromContext(ctx)
 
-	// Get node pool from Cosmos to get CS internal ID
-	nodePool, err := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).
-		NodePools(key.HCPClusterName).Get(ctx, key.HCPNodePoolName)
-
+	// Do the super cheap cache check first.
+	cachedNodePool, err := c.nodePoolLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
 	if database.IsNotFoundError(err) {
-		return nil // nodepool doesn't exists
-	}
-	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to get node pool from cosmos: %w", err))
-	}
-	if nodePool.ServiceProviderProperties.DeletionTimestamp != nil {
+		// we'll be re-fired if it is created again
 		return nil
 	}
-	if nodePool.ServiceProviderProperties.ClusterServiceID == nil || len(nodePool.ServiceProviderProperties.ClusterServiceID.String()) == 0 {
-		// if we have no clusterservice nodepool, we have nothing to sync.
-		return nil
-	}
-
-	existingServiceProviderNodePool, err := database.GetOrCreateServiceProviderNodePool(ctx, c.resourcesDBClient, key.GetResourceID())
 	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to get or create ServiceProviderNodePool: %w", err))
+		return utils.TrackError(fmt.Errorf("failed to get node pool from cache: %w", err))
 	}
-
-	// Get the ServiceProviderCluster for control plane version validation
-	clusterResourceID := api.Must(api.ToClusterResourceID(key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName))
-	existingServiceProviderCluster, err := database.GetOrCreateServiceProviderCluster(ctx, c.resourcesDBClient, clusterResourceID)
-	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to get or create ServiceProviderCluster: %w", err))
-	}
-
-	// Get the cluster for Cincinnati client initialization
-	cluster, err := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).Get(ctx, key.HCPClusterName)
+	// SPNP must be in cache. If a sibling controller hasn't created it yet,
+	// skip this sync; the informer will retrigger us when it lands.
+	cachedServiceProviderNodePool, err := c.serviceProviderNodePoolLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
 	if database.IsNotFoundError(err) {
-		return nil // cluster doesn't exist, no work to do
+		return nil
 	}
 	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to get cluster from cosmos: %w", err))
+		return utils.TrackError(fmt.Errorf("failed to get ServiceProviderNodePool from cache: %w", err))
 	}
-	if cluster.ServiceProviderProperties.ClusterServiceID == nil {
-		// TODO this appears to only be used to look up a clusterservice cluster to get a UUID.  Once the billing changes merge,
-		// we'll have UID to key by and won't need this.
+	if !c.NeedsWork(cachedNodePool, cachedServiceProviderNodePool) {
+		// if the cache doesn't need work, then we'll be retriggered if those values change when the cache updates.
 		return nil
+	}
+
+	customerDesiredVersion := semver.MustParse(cachedNodePool.Properties.Version.ID)
+
+	// Pull the ServiceProviderCluster and Subscription from cache rather than
+	// re-fetching live: validation only reads them, and if either isn't yet
+	// observed by the informer we'll be retriggered when it lands.
+	cachedServiceProviderCluster, err := c.serviceProviderClusterLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get ServiceProviderCluster from cache: %w", err))
+	}
+
+	subscription, err := c.subscriptionLister.Get(ctx, key.SubscriptionID)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get Subscription from cache: %w", err))
 	}
 
 	// Resolve the cluster UUID from the cached HostedCluster so we can build the Cincinnati client.
@@ -174,69 +195,13 @@ func (c *nodePoolVersionSyncer) SyncOnce(ctx context.Context, key controllerutil
 		logger.Info("missing cluster UUID, continuing with empty")
 	}
 
-	// Read node pool from Cluster Service
-	csNodePool, err := c.clusterServiceClient.GetNodePool(ctx, *nodePool.ServiceProviderProperties.ClusterServiceID)
-	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to get NodePool from CS: %w", err))
-	}
-
-	// For now we get the CS desired version
-	// In the future it should be good to use the node pool Status information from the node pool CR
-	version, ok := csNodePool.GetVersion()
-	if !ok {
-		return utils.TrackError(fmt.Errorf("node pool version not found in Cluster Service response"))
-	}
-
-	actualVersion := semver.MustParse(version.RawID())
-
-	oldActiveVersions := existingServiceProviderNodePool.Status.NodePoolVersion.ActiveVersions
-	newActiveVersions := prependActiveVersionIfChanged(oldActiveVersions, actualVersion)
-
-	serviceProviderCosmosNodePoolClient := c.resourcesDBClient.ServiceProviderNodePools(key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
-	// check if actualVersion from node pool in clusterService is different that the active versions in serviceProviderNodePool
-	// if it is different update the ActualVersion in the serviceProviderNodePool
-	// TODO: This is a simple gathering of the node pool versions. We should implement this to get the correct information.
-	// Possible ways to get this information
-	//   - In CS
-	// 	 	- nodepool.version: latest version applied. When an upgrade policy completes correctly, this is set to that version.
-	//   	- upgradepolicy.targetVersion: if the policy has started this version is applying to the nodepool
-	//   - In Hypershift
-	//		- .Status.Version: shows the latest applied version https://github.com/openshift/hypershift/blob/main/api/hypershift/v1beta1/nodepool_types.go#L246-L251
-	if !slices.Equal(oldActiveVersions, newActiveVersions) {
-		logger.Info("Active versions changed", "oldActiveVersions", oldActiveVersions, "newActiveVersions", newActiveVersions)
-		replacement := existingServiceProviderNodePool.DeepCopy()
-		replacement.Status.NodePoolVersion.ActiveVersions = newActiveVersions
-		existingServiceProviderNodePool, err = serviceProviderCosmosNodePoolClient.Replace(ctx, replacement, nil)
-		if err != nil {
-			return utils.TrackError(fmt.Errorf("failed to replace ServiceProviderNodePool: %w", err))
-		}
-	}
-
-	// If there is no nodePool version do not validate and update the desired Version
-	if nodePool.Properties.Version.ID == "" {
-		return nil
-	}
-	customerDesiredVersion := semver.MustParse(nodePool.Properties.Version.ID)
-
-	// Short-circuit: skip validation if desired version hasn't changed
-	if existingServiceProviderNodePool.Spec.NodePoolVersion.DesiredVersion != nil &&
-		customerDesiredVersion.EQ(*existingServiceProviderNodePool.Spec.NodePoolVersion.DesiredVersion) {
-		return nil
-	}
-
-	subscription, err := c.subscriptionLister.Get(ctx, cluster.ID.SubscriptionID)
-	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to get subscription: %w", err))
-	}
 	op := operation.Operation{
-		Type:    operation.Update,
 		Options: validation.AFECsToValidationOptions(subscription.GetRegisteredFeatures()),
 	}
 
 	// Validate the customer's desired version before setting it
-	err = c.validateDesiredNodePoolVersion(ctx, &customerDesiredVersion, existingServiceProviderNodePool, existingServiceProviderCluster, nodePool.Properties.Version.ChannelGroup, clusterUUID,
+	err = c.validateDesiredNodePoolVersion(ctx, &customerDesiredVersion, cachedServiceProviderNodePool, cachedServiceProviderCluster, cachedNodePool.Properties.Version.ChannelGroup, clusterUUID,
 		op.HasOption(api.FeatureExperimentalReleaseFeatures))
-
 	if err != nil {
 		// Persist IntentFailed on the controller document for Cincinnati VersionNotFound or any non-Cincinnati resolution error.
 		// Other Cincinnati errors are treated as transient graph or transport issues.
@@ -263,9 +228,13 @@ func (c *nodePoolVersionSyncer) SyncOnce(ctx context.Context, key controllerutil
 	}
 
 	// Update the serviceProviderNodePool DesiredVersion
-	replacement := existingServiceProviderNodePool.DeepCopy()
+	replacement := cachedServiceProviderNodePool.DeepCopy()
 	replacement.Spec.NodePoolVersion.DesiredVersion = &customerDesiredVersion
-	_, err = serviceProviderCosmosNodePoolClient.Replace(ctx, replacement, nil)
+	_, err = c.resourcesDBClient.ServiceProviderNodePools(key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName).Replace(ctx, replacement, nil)
+	if database.IsPreconditionFailedError(err) {
+		// the cache will update eventually since we're out of date and we'll enter this controller again. No need to fail.
+		return nil
+	}
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to replace ServiceProviderNodePool: %w", err))
 	}

--- a/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller.go
@@ -38,6 +38,7 @@ import (
 	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/database"
 	dblisters "github.com/Azure/ARO-HCP/internal/database/listers"
+	unionkubeapplierinformers "github.com/Azure/ARO-HCP/internal/database/unioninformers/kubeapplier"
 	"github.com/Azure/ARO-HCP/internal/utils"
 	"github.com/Azure/ARO-HCP/internal/utils/apihelpers"
 	"github.com/Azure/ARO-HCP/internal/validation"
@@ -71,6 +72,7 @@ func NewNodePoolVersionController(
 	activeOperationLister listers.ActiveOperationLister,
 	subscriptionLister listers.SubscriptionLister,
 	informers informers.BackendInformers,
+	kubeApplierInformers *unionkubeapplierinformers.UnionKubeApplierInformers,
 	readDesireLister dblisters.ReadDesireLister,
 ) controllerutils.Controller {
 	_, nodePoolLister := informers.NodePools()
@@ -91,6 +93,7 @@ func NewNodePoolVersionController(
 		NodepoolVersionControllerName,
 		resourcesDBClient,
 		informers,
+		kubeApplierInformers,
 		5*time.Minute, // Check for upgrades every 5 minutes
 		syncer,
 	)

--- a/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller.go
@@ -164,7 +164,10 @@ func (c *nodePoolVersionSyncer) SyncOnce(ctx context.Context, key controllerutil
 		return nil
 	}
 
-	customerDesiredVersion := semver.MustParse(cachedNodePool.Properties.Version.ID)
+	customerDesiredVersion, err := semver.Parse(cachedNodePool.Properties.Version.ID)
+	if err != nil {
+		return utils.TrackError(err)
+	}
 
 	// Pull the ServiceProviderCluster and Subscription from cache rather than
 	// re-fetching live: validation only reads them, and if either isn't yet
@@ -260,24 +263,6 @@ func (c *nodePoolVersionSyncer) SyncOnce(ctx context.Context, key controllerutil
 
 func (c *nodePoolVersionSyncer) CooldownChecker() controllerutil.CooldownChecker {
 	return c.cooldownChecker
-}
-
-// prependActiveVersionIfChanged takes a slice of active versions and returns an updated slice
-// with the new version prepended if it differs from the most recent version.
-// If the most recent version matches the new version, returns the original slice unchanged.
-// The returned slice is capped to the 2 most recent versions.
-func prependActiveVersionIfChanged(currentVersions []api.HCPNodePoolActiveVersion, newVersion semver.Version) []api.HCPNodePoolActiveVersion {
-	// Check if the tip (most recent version) is already the new version
-	if len(currentVersions) > 0 && currentVersions[0].Version != nil && currentVersions[0].Version.EQ(newVersion) {
-		return currentVersions
-	}
-
-	// Create new list with at most 2 versions: new version + most recent old version
-	newVersions := []api.HCPNodePoolActiveVersion{{Version: &newVersion}}
-	if len(currentVersions) > 0 {
-		newVersions = append(newVersions, currentVersions[0])
-	}
-	return newVersions
 }
 
 // validateDesiredNodePoolVersion checks that the desired node pool version is a valid change.

--- a/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller_test.go
+++ b/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller_test.go
@@ -17,7 +17,6 @@ package upgradecontrollers
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"strings"
 	"testing"
 
@@ -34,7 +33,6 @@ import (
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
-	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
 	configv1 "github.com/openshift/api/config/v1"
 	cvocincinnati "github.com/openshift/cluster-version-operator/pkg/cincinnati"
 	"github.com/openshift/hypershift/api/hypershift/v1beta1"
@@ -51,7 +49,6 @@ import (
 	dblisters "github.com/Azure/ARO-HCP/internal/database/listers"
 	internallistertesting "github.com/Azure/ARO-HCP/internal/database/listertesting"
 	"github.com/Azure/ARO-HCP/internal/databasetesting"
-	"github.com/Azure/ARO-HCP/internal/ocm"
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
 
@@ -161,22 +158,6 @@ func createTestNodePoolWithVersion(t *testing.T, ctx context.Context, mockResour
 	require.NoError(t, err)
 }
 
-// newCSNodePool creates a Cluster Service node pool for testing.
-func newCSNodePool(t *testing.T, version string) *arohcpv1alpha1.NodePool {
-	t.Helper()
-
-	builder := arohcpv1alpha1.NewNodePool().
-		ID(testNodePoolName)
-
-	if version != "" {
-		builder = builder.Version(arohcpv1alpha1.NewVersion().RawID(version))
-	}
-
-	csNodePool, err := builder.Build()
-	require.NoError(t, err)
-	return csNodePool
-}
-
 // hostedClusterReadDesireResourceID returns the resource ID for the readonly
 // HostedCluster ReadDesire associated with the test cluster. The slice lister
 // matches on this ID to satisfy GetForCluster.
@@ -233,7 +214,6 @@ func TestNodePoolVersionSyncer_SyncOnce(t *testing.T) {
 	tests := []struct {
 		name                  string
 		seedDB                func(t *testing.T, ctx context.Context, mockResourcesDBClient *databasetesting.MockResourcesDBClient)
-		mockCS                func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec)
 		readDesireLister      func(t *testing.T) dblisters.ReadDesireLister
 		expectedError         bool
 		expectedErrorContains string
@@ -244,27 +224,7 @@ func TestNodePoolVersionSyncer_SyncOnce(t *testing.T) {
 				t.Helper()
 				// Don't seed any node pool - Get will fail with not found.
 			},
-			mockCS: func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec) {
-				t.Helper()
-				// No CS mock setup needed - we won't reach CS call.
-			},
 			expectedError: false,
-		},
-		{
-			name: "cluster service get nodepool call returns error",
-			seedDB: func(t *testing.T, ctx context.Context, mockResourcesDBClient *databasetesting.MockResourcesDBClient) {
-				t.Helper()
-				createTestNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.15")
-			},
-			mockCS: func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec) {
-				t.Helper()
-				mockCS.EXPECT().
-					GetNodePool(gomock.Any(), gomock.Any()).
-					Return(nil, errors.New("cluster service unavailable")).
-					Times(1)
-			},
-			expectedError:         true,
-			expectedErrorContains: "cluster service unavailable",
 		},
 		{
 			name: "missing NodePool's ClusterServiceID returns nil",
@@ -294,27 +254,7 @@ func TestNodePoolVersionSyncer_SyncOnce(t *testing.T) {
 					NodePools(testClusterName).Create(ctx, nodePool, nil)
 				require.NoError(t, err)
 			},
-			mockCS: func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec) {
-				t.Helper()
-			},
 			expectedError: false,
-		},
-		{
-			name: "missing version returns error",
-			seedDB: func(t *testing.T, ctx context.Context, mockResourcesDBClient *databasetesting.MockResourcesDBClient) {
-				t.Helper()
-				createTestNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.15")
-			},
-			mockCS: func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec) {
-				t.Helper()
-				csNodePool := newCSNodePool(t, "") // No version
-				mockCS.EXPECT().
-					GetNodePool(gomock.Any(), gomock.Any()).
-					Return(csNodePool, nil).
-					Times(1)
-			},
-			expectedError:         true,
-			expectedErrorContains: "node pool version not found in Cluster Service respons",
 		},
 	}
 
@@ -324,12 +264,10 @@ func TestNodePoolVersionSyncer_SyncOnce(t *testing.T) {
 			ctrl := gomock.NewController(t)
 
 			mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
-			mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
 			mockClientCache := cincinnati.NewMockClientCache(ctrl)
 			mockClientCache.EXPECT().GetOrCreateClient(gomock.Any()).Return(cincinnati.NewMockClient(ctrl)).AnyTimes()
 
 			tt.seedDB(t, ctx, mockResourcesDBClient)
-			tt.mockCS(t, mockCS)
 
 			contentLister := newValidHostedClusterReadDesireLister(t)
 			if tt.readDesireLister != nil {
@@ -337,11 +275,14 @@ func TestNodePoolVersionSyncer_SyncOnce(t *testing.T) {
 			}
 
 			syncer := &nodePoolVersionSyncer{
-				cooldownChecker:       &alwaysSyncCooldownChecker{},
-				readDesireLister:      contentLister,
-				resourcesDBClient:     mockResourcesDBClient,
-				clusterServiceClient:  mockCS,
-				cincinnatiClientCache: mockClientCache,
+				cooldownChecker:               &alwaysSyncCooldownChecker{},
+				nodePoolLister:                &listertesting.DBNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
+				serviceProviderNodePoolLister: &listertesting.DBServiceProviderNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
+				serviceProviderClusterLister:  &listertesting.DBServiceProviderClusterLister{ResourcesDBClient: mockResourcesDBClient},
+				subscriptionLister:            &listertesting.DBSubscriptionLister{ResourcesDBClient: mockResourcesDBClient},
+				readDesireLister:              contentLister,
+				resourcesDBClient:             mockResourcesDBClient,
+				cincinnatiClientCache:         mockClientCache,
 			}
 
 			ctx = utils.ContextWithLogger(ctx, logr.Discard())
@@ -541,17 +482,10 @@ func TestNodePoolVersionSyncer_SyncOnce_IntentFailed(t *testing.T) {
 			ctx := utils.ContextWithLogger(context.Background(), logr.Discard())
 			ctrl := gomock.NewController(t)
 			mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
-			mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
 
 			createTestNodePoolWithVersion(t, ctx, mockResourcesDBClient, tt.customerVersion)
 			createServiceProviderNodePoolWithVersion(t, ctx, mockResourcesDBClient, tt.nodePoolVersion)
 			createServiceProviderClusterWithVersion(t, ctx, mockResourcesDBClient, tt.controlPlaneVersion)
-
-			csNodePool := newCSNodePoolWithVersion(t, tt.nodePoolVersion)
-			mockCS.EXPECT().
-				GetNodePool(gomock.Any(), gomock.Any()).
-				Return(csNodePool, nil).
-				Times(1)
 
 			mockCincinnati := cincinnati.NewMockClient(ctrl)
 			tt.setupCincinnati(mockCincinnati)
@@ -560,12 +494,14 @@ func TestNodePoolVersionSyncer_SyncOnce_IntentFailed(t *testing.T) {
 			mockClientCache.EXPECT().GetOrCreateClient(gomock.Any()).Return(mockCincinnati).AnyTimes()
 
 			syncer := &nodePoolVersionSyncer{
-				cooldownChecker:       &alwaysSyncCooldownChecker{},
-				readDesireLister:      newValidHostedClusterReadDesireLister(t),
-				resourcesDBClient:     mockResourcesDBClient,
-				clusterServiceClient:  mockCS,
-				subscriptionLister:    subscriptionLister,
-				cincinnatiClientCache: mockClientCache,
+				cooldownChecker:               &alwaysSyncCooldownChecker{},
+				nodePoolLister:                &listertesting.DBNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
+				serviceProviderNodePoolLister: &listertesting.DBServiceProviderNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
+				serviceProviderClusterLister:  &listertesting.DBServiceProviderClusterLister{ResourcesDBClient: mockResourcesDBClient},
+				subscriptionLister:            subscriptionLister,
+				readDesireLister:              newValidHostedClusterReadDesireLister(t),
+				resourcesDBClient:             mockResourcesDBClient,
+				cincinnatiClientCache:         mockClientCache,
 			}
 
 			err := syncer.SyncOnce(ctx, testKey)
@@ -581,6 +517,47 @@ func TestNodePoolVersionSyncer_SyncOnce_IntentFailed(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestNodePoolVersionSyncer_NeedsWork covers the cache-evaluable conditions
+// that decide whether the desired-version controller has anything to do.
+// The SyncOnce flow guarantees a non-nil ServiceProviderNodePool by the time
+// it calls NeedsWork (cache misses bail before that), so we only exercise
+// non-nil inputs here.
+func TestNodePoolVersionSyncer_NeedsWork(t *testing.T) {
+	syncer := &nodePoolVersionSyncer{}
+
+	npWith := func(customerVersion string) *api.HCPOpenShiftClusterNodePool {
+		return &api.HCPOpenShiftClusterNodePool{
+			Properties: api.HCPOpenShiftClusterNodePoolProperties{
+				Version: api.NodePoolVersionProfile{ID: customerVersion},
+			},
+		}
+	}
+	spnpWithDesired := func(desiredVersion string) *api.ServiceProviderNodePool {
+		spnp := &api.ServiceProviderNodePool{}
+		if desiredVersion != "" {
+			v := semver.MustParse(desiredVersion)
+			spnp.Spec.NodePoolVersion.DesiredVersion = &v
+		}
+		return spnp
+	}
+
+	t.Run("no customer desired version skips", func(t *testing.T) {
+		assert.False(t, syncer.NeedsWork(npWith(""), spnpWithDesired("")))
+	})
+	t.Run("SPNP without DesiredVersion needs work", func(t *testing.T) {
+		assert.True(t, syncer.NeedsWork(npWith("4.19.15"), spnpWithDesired("")))
+	})
+	t.Run("matching DesiredVersion skips", func(t *testing.T) {
+		assert.False(t, syncer.NeedsWork(npWith("4.19.15"), spnpWithDesired("4.19.15")))
+	})
+	t.Run("different DesiredVersion needs work", func(t *testing.T) {
+		assert.True(t, syncer.NeedsWork(npWith("4.19.15"), spnpWithDesired("4.19.10")))
+	})
+	t.Run("unparseable customer version conservatively needs work", func(t *testing.T) {
+		assert.True(t, syncer.NeedsWork(npWith("not-a-semver"), spnpWithDesired("4.19.15")))
+	})
 }
 
 func TestNodePoolVersionSyncer_ValidateDesiredNodePoolVersion(t *testing.T) {
@@ -994,25 +971,355 @@ func TestNodePoolVersionSyncer_ValidateDesiredNodePoolVersion(t *testing.T) {
 	}
 }
 
+func TestNodePoolVersionSyncer_SyncOnce_DesiredExceedsControlPlaneFails(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+
+	mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
+	mockClientCache := cincinnati.NewMockClientCache(ctrl)
+	mockClientCache.EXPECT().GetOrCreateClient(gomock.Any()).Return(cincinnati.NewMockClient(ctrl)).AnyTimes()
+
+	// Create node pool with desired version 4.19.15 (exceeds control plane 4.19.10)
+	createTestNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.15")
+
+	// Create ServiceProviderCluster with control plane at 4.19.10 (lower than desired)
+	createServiceProviderClusterWithVersion(t, ctx, mockResourcesDBClient, "4.19.10")
+
+	// Create ServiceProviderNodePool with active version 4.19.5 (so desired is not already active)
+	createServiceProviderNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.5")
+
+	syncer := &nodePoolVersionSyncer{
+		cooldownChecker:               &alwaysSyncCooldownChecker{},
+		nodePoolLister:                &listertesting.DBNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
+		serviceProviderNodePoolLister: &listertesting.DBServiceProviderNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
+		serviceProviderClusterLister:  &listertesting.DBServiceProviderClusterLister{ResourcesDBClient: mockResourcesDBClient},
+		subscriptionLister:            &listertesting.DBSubscriptionLister{ResourcesDBClient: mockResourcesDBClient},
+		readDesireLister:              newValidHostedClusterReadDesireLister(t),
+		resourcesDBClient:             mockResourcesDBClient,
+		cincinnatiClientCache:         mockClientCache,
+	}
+
+	testKey := controllerutils.HCPNodePoolKey{
+		SubscriptionID:    testSubscriptionID,
+		ResourceGroupName: testResourceGroupName,
+		HCPClusterName:    testClusterName,
+		HCPNodePoolName:   testNodePoolName,
+	}
+
+	ctx = utils.ContextWithLogger(ctx, logr.Discard())
+	err := syncer.SyncOnce(ctx, testKey)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot exceed control plane version")
+}
+
+func TestNodePoolVersionSyncer_SyncOnce_SucceedsWithoutCincinnatiEdge(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+
+	mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
+	mockCincinnati := cincinnati.NewMockClient(ctrl)
+
+	// Create node pool with desired version 4.19.10
+	createTestNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.10")
+
+	// Create ServiceProviderCluster with control plane at 4.20.0 (allows the desired version)
+	createServiceProviderClusterWithVersion(t, ctx, mockResourcesDBClient, "4.20.0")
+
+	// Create ServiceProviderNodePool with active version 4.19.7
+	createServiceProviderNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.7")
+
+	mockCincinnati.EXPECT().
+		GetUpdates(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Eq(semver.MustParse("4.19.10"))).
+		Return(
+			configv1.Release{Version: "4.19.10"},
+			[]configv1.Release{},
+			nil,
+			nil,
+		).
+		Times(1)
+
+	mockClientCache := cincinnati.NewMockClientCache(ctrl)
+	mockClientCache.EXPECT().GetOrCreateClient(gomock.Any()).Return(mockCincinnati).AnyTimes()
+
+	syncer := &nodePoolVersionSyncer{
+		cooldownChecker:               &alwaysSyncCooldownChecker{},
+		nodePoolLister:                &listertesting.DBNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
+		serviceProviderNodePoolLister: &listertesting.DBServiceProviderNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
+		serviceProviderClusterLister:  &listertesting.DBServiceProviderClusterLister{ResourcesDBClient: mockResourcesDBClient},
+		subscriptionLister:            &listertesting.DBSubscriptionLister{ResourcesDBClient: mockResourcesDBClient},
+		readDesireLister:              newValidHostedClusterReadDesireLister(t),
+		resourcesDBClient:             mockResourcesDBClient,
+		cincinnatiClientCache:         mockClientCache,
+	}
+
+	testKey := controllerutils.HCPNodePoolKey{
+		SubscriptionID:    testSubscriptionID,
+		ResourceGroupName: testResourceGroupName,
+		HCPClusterName:    testClusterName,
+		HCPNodePoolName:   testNodePoolName,
+	}
+
+	ctx = utils.ContextWithLogger(ctx, logr.Discard())
+	err := syncer.SyncOnce(ctx, testKey)
+
+	require.NoError(t, err)
+
+	// Verify the ServiceProviderNodePool DesiredVersion was updated
+	spnp, err := mockResourcesDBClient.ServiceProviderNodePools(
+		testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName,
+	).Get(ctx, api.ServiceProviderNodePoolResourceName)
+	require.NoError(t, err)
+	require.NotNil(t, spnp.Spec.NodePoolVersion.DesiredVersion)
+	expectedDesiredVersion := semver.MustParse("4.19.10")
+	require.True(t, expectedDesiredVersion.EQ(*spnp.Spec.NodePoolVersion.DesiredVersion))
+}
+
+func TestNodePoolVersionSyncer_SyncOnce_VersionNotInCincinnatiFails(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+
+	mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
+	mockCincinnati := cincinnati.NewMockClient(ctrl)
+
+	// Create node pool with desired version 4.19.99 (does not exist in Cincinnati)
+	createTestNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.99")
+
+	// Create ServiceProviderCluster with control plane at 4.20.0
+	createServiceProviderClusterWithVersion(t, ctx, mockResourcesDBClient, "4.20.0")
+
+	// Create ServiceProviderNodePool with active version 4.19.7
+	createServiceProviderNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.7")
+
+	mockCincinnati.EXPECT().
+		GetUpdates(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Eq(semver.MustParse("4.19.99"))).
+		Return(
+			configv1.Release{},
+			nil,
+			nil,
+			&cvocincinnati.Error{Reason: "VersionNotFound", Message: "version 4.19.99 not found"},
+		).
+		Times(1)
+
+	mockClientCache := cincinnati.NewMockClientCache(ctrl)
+	mockClientCache.EXPECT().GetOrCreateClient(gomock.Any()).Return(mockCincinnati).AnyTimes()
+
+	syncer := &nodePoolVersionSyncer{
+		cooldownChecker:               &alwaysSyncCooldownChecker{},
+		nodePoolLister:                &listertesting.DBNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
+		serviceProviderNodePoolLister: &listertesting.DBServiceProviderNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
+		serviceProviderClusterLister:  &listertesting.DBServiceProviderClusterLister{ResourcesDBClient: mockResourcesDBClient},
+		subscriptionLister:            &listertesting.DBSubscriptionLister{ResourcesDBClient: mockResourcesDBClient},
+		readDesireLister:              newValidHostedClusterReadDesireLister(t),
+		resourcesDBClient:             mockResourcesDBClient,
+		cincinnatiClientCache:         mockClientCache,
+	}
+
+	testKey := controllerutils.HCPNodePoolKey{
+		SubscriptionID:    testSubscriptionID,
+		ResourceGroupName: testResourceGroupName,
+		HCPClusterName:    testClusterName,
+		HCPNodePoolName:   testNodePoolName,
+	}
+
+	ctx = utils.ContextWithLogger(ctx, logr.Discard())
+	err := syncer.SyncOnce(ctx, testKey)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found in Cincinnati")
+}
+
+func TestNodePoolVersionSyncer_SyncOnce_DowngradeVersionNotInCincinnatiFails(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+
+	mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
+	mockCincinnati := cincinnati.NewMockClient(ctrl)
+
+	// Create node pool with desired version 4.19.99 (does not exist in Cincinnati)
+	createTestNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.99")
+
+	// Create ServiceProviderCluster with control plane at 4.20.0
+	createServiceProviderClusterWithVersion(t, ctx, mockResourcesDBClient, "4.20.0")
+
+	// Create ServiceProviderNodePool with active version 4.19.7
+	createServiceProviderNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.7")
+
+	mockCincinnati.EXPECT().
+		GetUpdates(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Eq(semver.MustParse("4.19.99"))).
+		Return(
+			configv1.Release{},
+			nil,
+			nil,
+			&cvocincinnati.Error{Reason: "VersionNotFound", Message: "version 4.19.99 not found"},
+		).
+		Times(1)
+
+	mockClientCache := cincinnati.NewMockClientCache(ctrl)
+	mockClientCache.EXPECT().GetOrCreateClient(gomock.Any()).Return(mockCincinnati).AnyTimes()
+
+	syncer := &nodePoolVersionSyncer{
+		cooldownChecker:               &alwaysSyncCooldownChecker{},
+		nodePoolLister:                &listertesting.DBNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
+		serviceProviderNodePoolLister: &listertesting.DBServiceProviderNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
+		serviceProviderClusterLister:  &listertesting.DBServiceProviderClusterLister{ResourcesDBClient: mockResourcesDBClient},
+		subscriptionLister:            &listertesting.DBSubscriptionLister{ResourcesDBClient: mockResourcesDBClient},
+		readDesireLister:              newValidHostedClusterReadDesireLister(t),
+		resourcesDBClient:             mockResourcesDBClient,
+		cincinnatiClientCache:         mockClientCache,
+	}
+
+	testKey := controllerutils.HCPNodePoolKey{
+		SubscriptionID:    testSubscriptionID,
+		ResourceGroupName: testResourceGroupName,
+		HCPClusterName:    testClusterName,
+		HCPNodePoolName:   testNodePoolName,
+	}
+
+	ctx = utils.ContextWithLogger(ctx, logr.Discard())
+	err := syncer.SyncOnce(ctx, testKey)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found in Cincinnati")
+}
+
+func TestNodePoolVersionSyncer_SyncOnce_DowngradeWithinSkewSucceeds(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+
+	mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
+	mockCincinnati := cincinnati.NewMockClient(ctrl)
+
+	// Create node pool with desired version 4.19.5 (z-stream downgrade from 4.19.10)
+	createTestNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.5")
+
+	// Create ServiceProviderCluster with control plane at 4.20.0
+	createServiceProviderClusterWithVersion(t, ctx, mockResourcesDBClient, "4.20.0")
+
+	// SPNP must exist in cache for SyncOnce to proceed.
+	createServiceProviderNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.10")
+
+	mockCincinnati.EXPECT().
+		GetUpdates(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Eq(semver.MustParse("4.19.5"))).
+		Return(
+			configv1.Release{Version: "4.19.5"},
+			[]configv1.Release{},
+			nil,
+			nil,
+		).
+		Times(1)
+
+	mockClientCache := cincinnati.NewMockClientCache(ctrl)
+	mockClientCache.EXPECT().GetOrCreateClient(gomock.Any()).Return(mockCincinnati).AnyTimes()
+
+	syncer := &nodePoolVersionSyncer{
+		cooldownChecker:               &alwaysSyncCooldownChecker{},
+		nodePoolLister:                &listertesting.DBNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
+		serviceProviderNodePoolLister: &listertesting.DBServiceProviderNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
+		serviceProviderClusterLister:  &listertesting.DBServiceProviderClusterLister{ResourcesDBClient: mockResourcesDBClient},
+		subscriptionLister:            &listertesting.DBSubscriptionLister{ResourcesDBClient: mockResourcesDBClient},
+		readDesireLister:              newValidHostedClusterReadDesireLister(t),
+		resourcesDBClient:             mockResourcesDBClient,
+		cincinnatiClientCache:         mockClientCache,
+	}
+
+	testKey := controllerutils.HCPNodePoolKey{
+		SubscriptionID:    testSubscriptionID,
+		ResourceGroupName: testResourceGroupName,
+		HCPClusterName:    testClusterName,
+		HCPNodePoolName:   testNodePoolName,
+	}
+
+	ctx = utils.ContextWithLogger(ctx, logr.Discard())
+	err := syncer.SyncOnce(ctx, testKey)
+
+	require.NoError(t, err)
+
+	// Verify the ServiceProviderNodePool DesiredVersion was updated to the downgrade target
+	spnp, err := mockResourcesDBClient.ServiceProviderNodePools(
+		testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName,
+	).Get(ctx, api.ServiceProviderNodePoolResourceName)
+	require.NoError(t, err)
+	require.NotNil(t, spnp.Spec.NodePoolVersion.DesiredVersion)
+	expectedDesiredVersion := semver.MustParse("4.19.5")
+	require.True(t, expectedDesiredVersion.EQ(*spnp.Spec.NodePoolVersion.DesiredVersion))
+}
+
+func TestNodePoolVersionSyncer_SyncOnce_ValidUpgradeSucceeds(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+
+	mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
+	mockCincinnati := cincinnati.NewMockClient(ctrl)
+
+	// Create node pool with desired version 4.19.15 (valid upgrade from 4.19.10)
+	createTestNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.15")
+
+	// Create ServiceProviderCluster with control plane at 4.20.0
+	createServiceProviderClusterWithVersion(t, ctx, mockResourcesDBClient, "4.20.0")
+
+	// SPNP must exist in cache for SyncOnce to proceed.
+	createServiceProviderNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.10")
+
+	mockCincinnati.EXPECT().
+		GetUpdates(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(
+			configv1.Release{Version: "4.19.15"},
+			[]configv1.Release{},
+			nil,
+			nil,
+		).
+		Times(1)
+
+	mockClientCache := cincinnati.NewMockClientCache(ctrl)
+	mockClientCache.EXPECT().GetOrCreateClient(gomock.Any()).Return(mockCincinnati).AnyTimes()
+
+	syncer := &nodePoolVersionSyncer{
+		cooldownChecker:               &alwaysSyncCooldownChecker{},
+		nodePoolLister:                &listertesting.DBNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
+		serviceProviderNodePoolLister: &listertesting.DBServiceProviderNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
+		serviceProviderClusterLister:  &listertesting.DBServiceProviderClusterLister{ResourcesDBClient: mockResourcesDBClient},
+		subscriptionLister:            &listertesting.DBSubscriptionLister{ResourcesDBClient: mockResourcesDBClient},
+		readDesireLister:              newValidHostedClusterReadDesireLister(t),
+		resourcesDBClient:             mockResourcesDBClient,
+		cincinnatiClientCache:         mockClientCache,
+	}
+
+	testKey := controllerutils.HCPNodePoolKey{
+		SubscriptionID:    testSubscriptionID,
+		ResourceGroupName: testResourceGroupName,
+		HCPClusterName:    testClusterName,
+		HCPNodePoolName:   testNodePoolName,
+	}
+
+	ctx = utils.ContextWithLogger(ctx, logr.Discard())
+	err := syncer.SyncOnce(ctx, testKey)
+	require.NoError(t, err)
+
+	// Verify the ServiceProviderNodePool was updated correctly
+	spnp, err := mockResourcesDBClient.ServiceProviderNodePools(
+		testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName,
+	).Get(ctx, api.ServiceProviderNodePoolResourceName)
+	require.NoError(t, err)
+
+	// Verify DesiredVersion was persisted
+	require.NotNil(t, spnp.Spec.NodePoolVersion.DesiredVersion)
+	expectedDesiredVersion := semver.MustParse("4.19.15")
+	require.True(t, expectedDesiredVersion.EQ(*spnp.Spec.NodePoolVersion.DesiredVersion))
+}
+
 func TestNodePoolVersionSyncer_SyncOnce_DesiredVersionUnchangedOnFailure_ChangedOnSuccess(t *testing.T) {
 	ctx := context.Background()
 	ctrl := gomock.NewController(t)
 
 	mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
-	mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
 
 	// Seed the database with a node pool
 	createTestNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.15")
 	createServiceProviderClusterWithVersion(t, ctx, mockResourcesDBClient, "4.19.99")
+	// SPNP must exist in cache for SyncOnce to proceed.
+	createServiceProviderNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.7")
 
-	// Setup CS mock to return a node pool with version
-	csNodePool := newCSNodePool(t, "4.19.10")
-	mockCS.EXPECT().
-		GetNodePool(gomock.Any(), gomock.Any()).
-		Return(csNodePool, nil).
-		Times(1)
-
-	// Phase 1: Cincinnati confirms the desired version exists
 	mockCincinnati := cincinnati.NewMockClient(ctrl)
 	mockCincinnati.EXPECT().
 		GetUpdates(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
@@ -1028,12 +1335,14 @@ func TestNodePoolVersionSyncer_SyncOnce_DesiredVersionUnchangedOnFailure_Changed
 	mockClientCache.EXPECT().GetOrCreateClient(gomock.Any()).Return(mockCincinnati).Times(1)
 
 	syncer := &nodePoolVersionSyncer{
-		cooldownChecker:       &alwaysSyncCooldownChecker{},
-		readDesireLister:      newValidHostedClusterReadDesireLister(t),
-		resourcesDBClient:     mockResourcesDBClient,
-		clusterServiceClient:  mockCS,
-		subscriptionLister:    newTestSubscriptionLister(),
-		cincinnatiClientCache: mockClientCache,
+		cooldownChecker:               &alwaysSyncCooldownChecker{},
+		nodePoolLister:                &listertesting.DBNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
+		serviceProviderNodePoolLister: &listertesting.DBServiceProviderNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
+		serviceProviderClusterLister:  &listertesting.DBServiceProviderClusterLister{ResourcesDBClient: mockResourcesDBClient},
+		subscriptionLister:            &listertesting.DBSubscriptionLister{ResourcesDBClient: mockResourcesDBClient},
+		readDesireLister:              newValidHostedClusterReadDesireLister(t),
+		resourcesDBClient:             mockResourcesDBClient,
+		cincinnatiClientCache:         mockClientCache,
 	}
 
 	testKey := controllerutils.HCPNodePoolKey{
@@ -1053,14 +1362,7 @@ func TestNodePoolVersionSyncer_SyncOnce_DesiredVersionUnchangedOnFailure_Changed
 	).Get(ctx, api.ServiceProviderNodePoolResourceName)
 	require.NoError(t, err, "ServiceProviderNodePool should exist after sync")
 
-	expectedActiveVersion := semver.MustParse("4.19.10")
 	expectedDesiredVersion := semver.MustParse("4.19.15")
-
-	// Verify ActiveVersion was persisted (from Cluster Service)
-	require.NotNil(t, spnp.Status.NodePoolVersion.ActiveVersions,
-		"ActiveVersion should be set")
-	require.True(t, expectedActiveVersion.EQ(*spnp.Status.NodePoolVersion.ActiveVersions[0].Version),
-		"ActiveVersion should match CS version %s, got %s", "4.19.10", spnp.Status.NodePoolVersion.ActiveVersions[0].Version)
 
 	// Verify DesiredVersion was persisted (from customer's HCPNodePool)
 	require.NotNil(t, spnp.Spec.NodePoolVersion.DesiredVersion,
@@ -1080,11 +1382,6 @@ func TestNodePoolVersionSyncer_SyncOnce_DesiredVersionUnchangedOnFailure_Changed
 	require.NoError(t, err)
 
 	// Setup CS mocks for second sync
-	mockCS.EXPECT().
-		GetNodePool(gomock.Any(), gomock.Any()).
-		Return(csNodePool, nil).
-		Times(1)
-
 	// Cincinnati returns VersionNotFound — version doesn't exist
 	mockCincinnatiFailing := cincinnati.NewMockClient(ctrl)
 	mockCincinnatiFailing.EXPECT().
@@ -1125,11 +1422,6 @@ func TestNodePoolVersionSyncer_SyncOnce_DesiredVersionUnchangedOnFailure_Changed
 	require.NoError(t, err)
 
 	// Setup CS mocks for third sync
-	mockCS.EXPECT().
-		GetNodePool(gomock.Any(), gomock.Any()).
-		Return(csNodePool, nil).
-		Times(1)
-
 	// Cincinnati confirms the version exists
 	mockCincinnatiSucceeding := cincinnati.NewMockClient(ctrl)
 	mockCincinnatiSucceeding.EXPECT().
@@ -1237,15 +1529,4 @@ func newTestSubscriptionLister() *listertesting.SliceSubscriptionLister {
 			Properties:     &arm.SubscriptionProperties{},
 		}},
 	}
-}
-
-func newCSNodePoolWithVersion(t *testing.T, version string) *arohcpv1alpha1.NodePool {
-	t.Helper()
-
-	csNodePool, err := arohcpv1alpha1.NewNodePool().
-		ID(testNodePoolName).
-		Version(arohcpv1alpha1.NewVersion().RawID(version)).
-		Build()
-	require.NoError(t, err)
-	return csNodePool
 }

--- a/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller_test.go
+++ b/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller_test.go
@@ -1009,8 +1009,13 @@ func TestNodePoolVersionSyncer_SyncOnce_DesiredExceedsControlPlaneFails(t *testi
 	ctx = utils.ContextWithLogger(ctx, logr.Discard())
 	err := syncer.SyncOnce(ctx, testKey)
 
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "cannot exceed control plane version")
+	// Validation failure persists IntentFailed and SyncOnce returns nil.
+	require.NoError(t, err)
+	spnp, err := mockResourcesDBClient.ServiceProviderNodePools(
+		testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName,
+	).Get(ctx, api.ServiceProviderNodePoolResourceName)
+	require.NoError(t, err)
+	assert.Nil(t, spnp.Spec.NodePoolVersion.DesiredVersion, "desired version must not be persisted when validation fails")
 }
 
 func TestNodePoolVersionSyncer_SyncOnce_SucceedsWithoutCincinnatiEdge(t *testing.T) {
@@ -1125,8 +1130,13 @@ func TestNodePoolVersionSyncer_SyncOnce_VersionNotInCincinnatiFails(t *testing.T
 	ctx = utils.ContextWithLogger(ctx, logr.Discard())
 	err := syncer.SyncOnce(ctx, testKey)
 
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not found in Cincinnati")
+	// Cincinnati VersionNotFound persists IntentFailed; SyncOnce returns nil.
+	require.NoError(t, err)
+	spnp, err := mockResourcesDBClient.ServiceProviderNodePools(
+		testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName,
+	).Get(ctx, api.ServiceProviderNodePoolResourceName)
+	require.NoError(t, err)
+	assert.Nil(t, spnp.Spec.NodePoolVersion.DesiredVersion, "desired version must not be persisted when validation fails")
 }
 
 func TestNodePoolVersionSyncer_SyncOnce_DowngradeVersionNotInCincinnatiFails(t *testing.T) {
@@ -1179,8 +1189,13 @@ func TestNodePoolVersionSyncer_SyncOnce_DowngradeVersionNotInCincinnatiFails(t *
 	ctx = utils.ContextWithLogger(ctx, logr.Discard())
 	err := syncer.SyncOnce(ctx, testKey)
 
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not found in Cincinnati")
+	// Cincinnati VersionNotFound persists IntentFailed; SyncOnce returns nil.
+	require.NoError(t, err)
+	spnp, err := mockResourcesDBClient.ServiceProviderNodePools(
+		testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName,
+	).Get(ctx, api.ServiceProviderNodePoolResourceName)
+	require.NoError(t, err)
+	assert.Nil(t, spnp.Spec.NodePoolVersion.DesiredVersion, "desired version must not be persisted when validation fails")
 }
 
 func TestNodePoolVersionSyncer_SyncOnce_DowngradeWithinSkewSucceeds(t *testing.T) {

--- a/backend/pkg/controllers/upgradecontrollers/trigger_node_pool_upgrade_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/trigger_node_pool_upgrade_controller.go
@@ -29,6 +29,7 @@ import (
 	"github.com/Azure/ARO-HCP/internal/api"
 	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/database"
+	unionkubeapplierinformers "github.com/Azure/ARO-HCP/internal/database/unioninformers/kubeapplier"
 	"github.com/Azure/ARO-HCP/internal/ocm"
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
@@ -50,6 +51,7 @@ func NewTriggerNodePoolUpgradeController(
 	clusterServiceClient ocm.ClusterServiceClientSpec,
 	activeOperationLister listers.ActiveOperationLister,
 	informers informers.BackendInformers,
+	kubeApplierInformers *unionkubeapplierinformers.UnionKubeApplierInformers,
 ) controllerutils.Controller {
 	syncer := &triggerNodePoolUpgradeSyncer{
 		cooldownChecker:      controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
@@ -61,6 +63,7 @@ func NewTriggerNodePoolUpgradeController(
 		"TriggerNodePoolUpgrade",
 		resourcesDBClient,
 		informers,
+		kubeApplierInformers,
 		5*time.Minute,
 		syncer,
 	)

--- a/backend/pkg/controllers/validationcontrollers/nodepool_validation_controller.go
+++ b/backend/pkg/controllers/validationcontrollers/nodepool_validation_controller.go
@@ -29,6 +29,7 @@ import (
 	"github.com/Azure/ARO-HCP/internal/api"
 	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/database"
+	unionkubeapplierinformers "github.com/Azure/ARO-HCP/internal/database/unioninformers/kubeapplier"
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
 
@@ -51,6 +52,7 @@ func NewNodePoolValidationController(
 	activeOperationLister listers.ActiveOperationLister,
 	resourcesDBClient database.ResourcesDBClient,
 	informers informers.BackendInformers,
+	kubeApplierInformers *unionkubeapplierinformers.UnionKubeApplierInformers,
 ) controllerutils.Controller {
 
 	syncer := &nodePoolValidationSyncer{
@@ -63,6 +65,7 @@ func NewNodePoolValidationController(
 		fmt.Sprintf("NodePoolValidation%s", validation.Name()),
 		resourcesDBClient,
 		informers,
+		kubeApplierInformers,
 		1*time.Minute,
 		syncer,
 	)

--- a/backend/pkg/listertesting/db_listers.go
+++ b/backend/pkg/listertesting/db_listers.go
@@ -95,6 +95,34 @@ func (l *DBNodePoolLister) ListForCluster(ctx context.Context, subscriptionID, r
 	return collectFromIterator(ctx, iter)
 }
 
+// DBServiceProviderNodePoolLister implements listers.ServiceProviderNodePoolLister backed by a database.ResourcesDBClient.
+type DBServiceProviderNodePoolLister struct {
+	ResourcesDBClient database.ResourcesDBClient
+}
+
+var _ listers.ServiceProviderNodePoolLister = &DBServiceProviderNodePoolLister{}
+
+func (l *DBServiceProviderNodePoolLister) List(ctx context.Context) ([]*api.ServiceProviderNodePool, error) {
+	iter, err := l.ResourcesDBClient.ResourcesGlobalListers().ServiceProviderNodePools().List(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	return collectFromIterator(ctx, iter)
+}
+
+func (l *DBServiceProviderNodePoolLister) Get(ctx context.Context, subscriptionID, resourceGroupName, clusterName, nodePoolName string) (*api.ServiceProviderNodePool, error) {
+	return l.ResourcesDBClient.ServiceProviderNodePools(subscriptionID, resourceGroupName, clusterName, nodePoolName).
+		Get(ctx, api.ServiceProviderNodePoolResourceName)
+}
+
+func (l *DBServiceProviderNodePoolLister) ListForNodePool(ctx context.Context, subscriptionID, resourceGroupName, clusterName, nodePoolName string) ([]*api.ServiceProviderNodePool, error) {
+	iter, err := l.ResourcesDBClient.ServiceProviderNodePools(subscriptionID, resourceGroupName, clusterName, nodePoolName).List(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	return collectFromIterator(ctx, iter)
+}
+
 // DBActiveOperationLister implements listers.ActiveOperationLister backed by a database.ResourcesDBClient.
 type DBActiveOperationLister struct {
 	ResourcesDBClient database.ResourcesDBClient

--- a/backend/pkg/maestrohelpers/nodepools.go
+++ b/backend/pkg/maestrohelpers/nodepools.go
@@ -1,0 +1,73 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package maestrohelpers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/json"
+
+	"github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/database"
+	dblisters "github.com/Azure/ARO-HCP/internal/database/listers"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// ReadDesireNameReadonlyNodePool is the well-known ReadDesire name the backend
+// writes the per-node-pool NodePool mirror under. Consumers look this up via a
+// ReadDesireLister.GetForNodePool call.
+//
+// The value is the lowercased form of
+// api.MaestroBundleInternalNameReadonlyHypershiftNodePool — the same derivation
+// the writer (create_nodepool_scoped_read_desires_controller.go) uses for its
+// desired ReadDesire name.
+var ReadDesireNameReadonlyNodePool = strings.ToLower(string(api.MaestroBundleInternalNameReadonlyHypershiftNodePool))
+
+// GetCachedNodePoolForNodePool reads the Hypershift NodePool mirror from the
+// per-node-pool ReadDesire. The ReadDesire's Status.KubeContent.Raw carries the
+// observed NodePool JSON; we decode it directly and return the typed object.
+//
+// Returns (nil, nil) when:
+//   - the ReadDesire has not been created yet (NotFound),
+//   - the ReadDesire exists but the kube-applier has not yet observed
+//     the target (Status.KubeContent is nil or empty).
+//
+// Returns a non-nil error only for hard failures: a non-NotFound lister error,
+// or unmarshal failure.
+func GetCachedNodePoolForNodePool(
+	ctx context.Context,
+	readDesireLister dblisters.ReadDesireLister,
+	subscriptionName, resourceGroupName, clusterName, nodePoolName string,
+) (*v1beta1.NodePool, error) {
+	readDesire, err := readDesireLister.GetForNodePool(ctx, subscriptionName, resourceGroupName, clusterName, nodePoolName, ReadDesireNameReadonlyNodePool)
+	if database.IsNotFoundError(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, utils.TrackError(fmt.Errorf("failed to get ReadDesire for NodePool: %w", err))
+	}
+	if readDesire.Status.KubeContent == nil || len(readDesire.Status.KubeContent.Raw) == 0 {
+		return nil, nil
+	}
+	nodePool := &v1beta1.NodePool{}
+	if err := json.Unmarshal(readDesire.Status.KubeContent.Raw, nodePool); err != nil {
+		return nil, utils.TrackError(fmt.Errorf("failed to unmarshal NodePool from ReadDesire kubeContent: %w", err))
+	}
+	return nodePool, nil
+}

--- a/internal/api/types_cosmosdata.go
+++ b/internal/api/types_cosmosdata.go
@@ -25,6 +25,13 @@ import (
 
 type CosmosMetadata = arm.CosmosMetadata
 
+// The ToXxxResourceIDString helpers form ARM resource ID strings by
+// delegating to the parent helper and appending the final segment. The
+// segment uses the leaf type name (Types[len-1]) for nested types so that
+// the provider namespace is added exactly once at the top of the chain.
+// Authoring each level via its parent makes it impossible to accidentally
+// produce a non-canonical key — which the cache uses to look up objects.
+
 func ToResourceGroupResourceIDString(subscriptionName, resourceGroupName string) string {
 	return strings.ToLower(path.Join("/subscriptions", subscriptionName, "resourceGroups", resourceGroupName))
 }
@@ -39,8 +46,7 @@ func ToClusterResourceID(subscriptionName, resourceGroupName, clusterName string
 
 func ToClusterResourceIDString(subscriptionName, resourceGroupName, clusterName string) string {
 	return strings.ToLower(path.Join(
-		"/subscriptions", subscriptionName,
-		"resourceGroups", resourceGroupName,
+		ToResourceGroupResourceIDString(subscriptionName, resourceGroupName),
 		"providers", ClusterResourceType.String(), clusterName,
 	))
 }
@@ -51,10 +57,8 @@ func ToNodePoolResourceID(subscriptionName, resourceGroupName, clusterName, node
 
 func ToNodePoolResourceIDString(subscriptionName, resourceGroupName, clusterName, nodePoolName string) string {
 	return strings.ToLower(path.Join(
-		"/subscriptions", subscriptionName,
-		"resourceGroups", resourceGroupName,
-		"providers", ClusterResourceType.String(), clusterName,
-		NodePoolResourceType.Types[len(NodePoolResourceType.Types)-1], nodePoolName,
+		ToClusterResourceIDString(subscriptionName, resourceGroupName, clusterName),
+		leafTypeName(NodePoolResourceType), nodePoolName,
 	))
 }
 
@@ -64,19 +68,15 @@ func ToExternalAuthResourceID(subscriptionName, resourceGroupName, clusterName, 
 
 func ToExternalAuthResourceIDString(subscriptionName, resourceGroupName, clusterName, externalAuthName string) string {
 	return strings.ToLower(path.Join(
-		"/subscriptions", subscriptionName,
-		"resourceGroups", resourceGroupName,
-		"providers", ClusterResourceType.String(), clusterName,
-		ExternalAuthResourceType.Types[len(ExternalAuthResourceType.Types)-1], externalAuthName,
+		ToClusterResourceIDString(subscriptionName, resourceGroupName, clusterName),
+		leafTypeName(ExternalAuthResourceType), externalAuthName,
 	))
 }
 
 func ToServiceProviderClusterResourceIDString(subscriptionName, resourceGroupName, clusterName string) string {
 	return strings.ToLower(path.Join(
-		"/subscriptions", subscriptionName,
-		"resourceGroups", resourceGroupName,
-		"providers", ClusterResourceType.String(), clusterName,
-		ServiceProviderClusterResourceType.Types[len(ServiceProviderClusterResourceType.Types)-1], ServiceProviderClusterResourceName,
+		ToClusterResourceIDString(subscriptionName, resourceGroupName, clusterName),
+		leafTypeName(ServiceProviderClusterResourceType), ServiceProviderClusterResourceName,
 	))
 }
 
@@ -89,19 +89,23 @@ func ToOperationResourceIDString(subscriptionName, operationName string) string 
 
 func ToManagementClusterContentResourceIDString(subscriptionName, resourceGroupName, clusterName, managementClusterContentName string) string {
 	return strings.ToLower(path.Join(
-		"/subscriptions", subscriptionName,
-		"resourceGroups", resourceGroupName,
-		"providers", ClusterResourceType.String(), clusterName,
+		ToClusterResourceIDString(subscriptionName, resourceGroupName, clusterName),
 		ManagementClusterContentResourceTypeName, managementClusterContentName,
 	))
 }
 
 func ToServiceProviderNodePoolResourceIDString(subscriptionName, resourceGroupName, clusterName, nodePoolName string) string {
 	return strings.ToLower(path.Join(
-		"/subscriptions", subscriptionName,
-		"resourceGroups", resourceGroupName,
-		"providers", ClusterResourceType.String(), clusterName,
-		NodePoolResourceType.String(), nodePoolName,
-		ServiceProviderNodePoolResourceType.Types[len(ServiceProviderNodePoolResourceType.Types)-1], ServiceProviderNodePoolResourceName,
+		ToNodePoolResourceIDString(subscriptionName, resourceGroupName, clusterName, nodePoolName),
+		leafTypeName(ServiceProviderNodePoolResourceType), ServiceProviderNodePoolResourceName,
 	))
+}
+
+// leafTypeName returns the trailing segment of an ARM ResourceType (the
+// part after the last slash). Using it in the per-level helpers prevents
+// callers from accidentally embedding the full `namespace/type/...` form
+// twice in the same ID — see the original ToServiceProviderNodePoolResourceIDString
+// bug.
+func leafTypeName(rt azcorearm.ResourceType) string {
+	return rt.Types[len(rt.Types)-1]
 }

--- a/test-integration/frontend/informer_test.go
+++ b/test-integration/frontend/informer_test.go
@@ -29,6 +29,7 @@ import (
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
 	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/database"
@@ -672,4 +673,142 @@ func activeOperationInformerIntegrationTestCase() informerIntegrationTestCase {
 			}, 45*time.Second, 200*time.Millisecond, "expected add event for op-3")
 		},
 	}
+}
+
+// TestServiceProviderNodePoolLister verifies that after seeding a
+// ServiceProviderNodePool in cosmos and starting the SPNP informer with a
+// very short relist duration, the serviceProviderNodePoolLister built from
+// the informer's indexer eventually surfaces the SPNP via both List and Get.
+func TestServiceProviderNodePoolLister(t *testing.T) {
+	integrationutils.WithAndWithoutCosmos(t, testServiceProviderNodePoolLister)
+}
+
+func testServiceProviderNodePoolLister(t *testing.T, withMock bool) {
+	const (
+		subscriptionID    = "00000000-0000-0000-0000-000000000004"
+		resourceGroupName = "test-rg"
+		clusterName       = "spnp-cluster"
+		nodePoolName      = "spnp-np"
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	var storageInfo integrationutils.StorageIntegrationTestInfo
+	var err error
+	if withMock {
+		storageInfo, err = integrationutils.NewMockCosmosFromTestingEnv(ctx, t)
+	} else {
+		storageInfo, err = integrationutils.NewCosmosFromTestingEnv(ctx, t)
+	}
+	require.NoError(t, err)
+	defer storageInfo.Cleanup(context.Background())
+
+	resourcesDBClient := storageInfo.ResourcesDBClient()
+
+	// Seed the parent cluster, parent node pool, and the SPNP.
+	clusterResourceID := mustParseResourceID(t,
+		"/subscriptions/"+subscriptionID+
+			"/resourceGroups/"+resourceGroupName+
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/"+clusterName)
+	clusterInternalID, err := api.NewInternalID("/api/clusters_mgmt/v1/clusters/" + clusterName)
+	require.NoError(t, err)
+	cluster := &api.HCPOpenShiftCluster{
+		CosmosMetadata: arm.CosmosMetadata{
+			ResourceID:   clusterResourceID,
+			PartitionKey: strings.ToLower(clusterResourceID.SubscriptionID),
+		},
+		TrackedResource: arm.TrackedResource{
+			Resource: arm.Resource{
+				ID:   clusterResourceID,
+				Name: clusterName,
+				Type: api.ClusterResourceType.String(),
+			},
+			Location: "eastus",
+		},
+		ServiceProviderProperties: api.HCPOpenShiftClusterServiceProviderProperties{
+			ProvisioningState: arm.ProvisioningStateSucceeded,
+			ClusterServiceID:  &clusterInternalID,
+		},
+	}
+	_, err = resourcesDBClient.HCPClusters(subscriptionID, resourceGroupName).Create(ctx, cluster, nil)
+	require.NoError(t, err, "failed to seed parent cluster")
+
+	npResourceID := mustParseResourceID(t,
+		"/subscriptions/"+subscriptionID+
+			"/resourceGroups/"+resourceGroupName+
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/"+clusterName+
+			"/nodePools/"+nodePoolName)
+	npInternalID := api.Ptr(api.Must(api.NewInternalID("/api/aro_hcp/v1alpha1/clusters/" + clusterName + "/node_pools/" + nodePoolName)))
+	nodePool := &api.HCPOpenShiftClusterNodePool{
+		CosmosMetadata: arm.CosmosMetadata{
+			ResourceID:   npResourceID,
+			PartitionKey: strings.ToLower(npResourceID.SubscriptionID),
+		},
+		TrackedResource: arm.TrackedResource{
+			Resource: arm.Resource{
+				ID:   npResourceID,
+				Name: nodePoolName,
+				Type: api.NodePoolResourceType.String(),
+			},
+			Location: "eastus",
+		},
+		Properties: api.HCPOpenShiftClusterNodePoolProperties{
+			ProvisioningState: arm.ProvisioningStateSucceeded,
+			Replicas:          1,
+		},
+		ServiceProviderProperties: api.HCPOpenShiftClusterNodePoolServiceProviderProperties{
+			ClusterServiceID: npInternalID,
+		},
+	}
+	_, err = resourcesDBClient.HCPClusters(subscriptionID, resourceGroupName).NodePools(clusterName).Create(ctx, nodePool, nil)
+	require.NoError(t, err, "failed to seed parent node pool")
+
+	spnpResourceID := mustParseResourceID(t,
+		"/subscriptions/"+subscriptionID+
+			"/resourceGroups/"+resourceGroupName+
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/"+clusterName+
+			"/nodePools/"+nodePoolName+
+			"/serviceProviderNodePools/"+api.ServiceProviderNodePoolResourceName)
+	spnp := &api.ServiceProviderNodePool{
+		CosmosMetadata: arm.CosmosMetadata{
+			ResourceID:   spnpResourceID,
+			PartitionKey: strings.ToLower(spnpResourceID.SubscriptionID),
+		},
+	}
+	_, err = resourcesDBClient.ServiceProviderNodePools(subscriptionID, resourceGroupName, clusterName, nodePoolName).Create(ctx, spnp, nil)
+	require.NoError(t, err, "failed to seed service provider node pool")
+
+	// Start the SPNP informer with a very short relist duration so the cache
+	// observes the seeded object quickly.
+	informer := informers.NewServiceProviderNodePoolInformerWithRelistDuration(
+		resourcesDBClient.ResourcesGlobalListers().ServiceProviderNodePools(),
+		1*time.Second)
+	go informer.Run(ctx.Done())
+	require.True(t, cache.WaitForCacheSync(ctx.Done(), informer.HasSynced), "timed out waiting for service provider node pool informer cache sync")
+
+	lister := listers.NewServiceProviderNodePoolLister(informer.GetIndexer())
+
+	// Wait up to 30s for the SPNP to be visible via List.
+	require.Eventually(t, func() bool {
+		all, err := lister.List(ctx)
+		if err != nil {
+			return false
+		}
+		for _, item := range all {
+			if item.ResourceID != nil && strings.EqualFold(item.ResourceID.String(), spnpResourceID.String()) {
+				return true
+			}
+		}
+		return false
+	}, 30*time.Second, 200*time.Millisecond, "service provider node pool never appeared in lister.List output")
+
+	// Wait up to 30s for the SPNP to be visible via Get.
+	require.Eventually(t, func() bool {
+		got, err := lister.Get(ctx, subscriptionID, resourceGroupName, clusterName, nodePoolName)
+		if err != nil {
+			return false
+		}
+		return got != nil && got.ResourceID != nil && strings.EqualFold(got.ResourceID.String(), spnpResourceID.String())
+	}, 30*time.Second, 200*time.Millisecond, "service provider node pool never appeared in lister.Get output")
 }


### PR DESCRIPTION
builds on https://github.com/Azure/ARO-HCP/pull/5600

Fixes the nodepool active versions to be accurate.

/assign @ahitacat 