### PR TITLE
fix(backend): add 4.23 and 5.0 to minVersionsWithValidSuccessCondition (AROSLSRE-1152)

### DIFF
--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_create.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_create.go
@@ -229,6 +229,7 @@ var minVersionsWithValidSuccessCondition = map[string]semver.Version{
 	"4.20": api.Must(semver.Parse("4.20.999")),
 	"4.21": api.Must(semver.Parse("4.21.999")),
 	"4.22": api.Must(semver.Parse("4.22.999")),
+	"4.23": api.Must(semver.Parse("4.23.999")),
 	"5.0":  api.Must(semver.Parse("5.0.999")),
 }
 

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_create.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_create.go
@@ -222,7 +222,7 @@ func (c *operationClusterCreate) clusterOperationStatus(ctx context.Context, ope
 	return newOperationState(arm.ProvisioningStateSucceeded, ""), nil
 }
 
-// minVersionsWithValidSuccessCondition maps from <major>.<micro> to the first z-stream version that includes the fix for
+// minVersionsWithValidSuccessCondition maps from <major>.<minor> to the first z-stream version that includes the fix for
 // control plane validation success.
 var minVersionsWithValidSuccessCondition = map[string]semver.Version{
 	"4.19": api.Must(semver.Parse("4.19.999")),

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_create.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_create.go
@@ -229,6 +229,7 @@ var minVersionsWithValidSuccessCondition = map[string]semver.Version{
 	"4.20": api.Must(semver.Parse("4.20.999")),
 	"4.21": api.Must(semver.Parse("4.21.999")),
 	"4.22": api.Must(semver.Parse("4.22.999")),
+	"5.0":  api.Must(semver.Parse("5.0.999")),
 }
 
 func (c *operationClusterCreate) hostedClusterOperationStatus(ctx context.Context, operation *api.Operation) (*operationState, error) {

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_create_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_create_test.go
@@ -301,6 +301,34 @@ func TestDetermineOperationStatus(t *testing.T) {
 			expectedMessage: "",
 		},
 		{
+			name: "4.23 bypass: Available=False with 4.23.0 history → Succeeded",
+			clusterLister: &listertesting.SliceClusterLister{
+				Clusters: []*api.HCPOpenShiftCluster{newClusterWithAPIURL("https://api.example.com")},
+			},
+			readDesireLister: &internallistertesting.SliceReadDesireLister{
+				Desires: []*kubeapplier.ReadDesire{
+					newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+						Status: v1beta1.HostedClusterStatus{
+							Conditions: []metav1.Condition{
+								{Type: string(v1beta1.HostedClusterAvailable), Status: metav1.ConditionFalse, Reason: "ComponentsNotAvailable", Message: "Waiting for components to be available: router"},
+							},
+							ControlPlaneVersion: v1beta1.ControlPlaneVersionStatus{
+								History: []v1beta1.ControlPlaneUpdateHistory{
+									{Version: "4.23.0", State: configv1.PartialUpdate},
+								},
+							},
+							ControlPlaneEndpoint: v1beta1.APIEndpoint{
+								Host: "api.example.com",
+								Port: 6443,
+							},
+						},
+					}),
+				},
+			},
+			expectedState:   arm.ProvisioningStateSucceeded,
+			expectedMessage: "",
+		},
+		{
 			name: "cluster API URL empty → Provisioning (lowest priority wins)",
 			clusterLister: &listertesting.SliceClusterLister{
 				Clusters: []*api.HCPOpenShiftCluster{newClusterWithAPIURL("")},
@@ -406,7 +434,7 @@ func TestDetermineOperationStatus(t *testing.T) {
 							},
 							ControlPlaneVersion: v1beta1.ControlPlaneVersionStatus{
 								History: []v1beta1.ControlPlaneUpdateHistory{
-									{Version: "4.23.0", State: configv1.PartialUpdate},
+									{Version: "4.24.0", State: configv1.PartialUpdate},
 								},
 							},
 						},
@@ -481,7 +509,7 @@ func TestDetermineOperationStatus(t *testing.T) {
 							},
 							ControlPlaneVersion: v1beta1.ControlPlaneVersionStatus{
 								History: []v1beta1.ControlPlaneUpdateHistory{
-									{Version: "4.23.0", State: configv1.PartialUpdate},
+									{Version: "4.24.0", State: configv1.PartialUpdate},
 								},
 							},
 							ControlPlaneEndpoint: v1beta1.APIEndpoint{

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_create_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_create_test.go
@@ -273,6 +273,34 @@ func TestDetermineOperationStatus(t *testing.T) {
 			expectedMessage: "",
 		},
 		{
+			name: "5.0 bypass: Available=False with 5.0.0 history → Succeeded",
+			clusterLister: &listertesting.SliceClusterLister{
+				Clusters: []*api.HCPOpenShiftCluster{newClusterWithAPIURL("https://api.example.com")},
+			},
+			readDesireLister: &internallistertesting.SliceReadDesireLister{
+				Desires: []*kubeapplier.ReadDesire{
+					newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+						Status: v1beta1.HostedClusterStatus{
+							Conditions: []metav1.Condition{
+								{Type: string(v1beta1.HostedClusterAvailable), Status: metav1.ConditionFalse, Reason: "NotReady", Message: "cluster is not ready"},
+							},
+							ControlPlaneVersion: v1beta1.ControlPlaneVersionStatus{
+								History: []v1beta1.ControlPlaneUpdateHistory{
+									{Version: "5.0.0", State: configv1.PartialUpdate},
+								},
+							},
+							ControlPlaneEndpoint: v1beta1.APIEndpoint{
+								Host: "api.example.com",
+								Port: 6443,
+							},
+						},
+					}),
+				},
+			},
+			expectedState:   arm.ProvisioningStateSucceeded,
+			expectedMessage: "",
+		},
+		{
 			name: "cluster API URL empty → Provisioning (lowest priority wins)",
 			clusterLister: &listertesting.SliceClusterLister{
 				Clusters: []*api.HCPOpenShiftCluster{newClusterWithAPIURL("")},


### PR DESCRIPTION
<!-- [AROSLSRE-1152](https://redhat.atlassian.net/browse/AROSLSRE-1152) -->

### What

Add `4.23` and `5.0` entries to `minVersionsWithValidSuccessCondition` in `backend/pkg/controllers/operationcontrollers/operation_cluster_create.go`, mirroring the existing `4.19`–`4.22` sentinel-.999 pattern.

```go
var minVersionsWithValidSuccessCondition = map[string]semver.Version{
    "4.19": api.Must(semver.Parse("4.19.999")),
    "4.20": api.Must(semver.Parse("4.20.999")),
    "4.21": api.Must(semver.Parse("4.21.999")),
    "4.22": api.Must(semver.Parse("4.22.999")),
    "4.23": api.Must(semver.Parse("4.23.999")),   // <-- added
    "5.0":  api.Must(semver.Parse("5.0.999")),    // <-- added
}
```

Also fixes a pre-existing typo in the map comment (`<major>.<micro>` → `<major>.<minor>`; code uses `currVersion.Major`/`Minor`).

### Why

`4.23` and `5.0` cluster creation deadlocks in `OperationClusterCreate` even after the HostedCluster reports `Available=True` and Clusters Service marks the cluster `ready`. The async operation never reaches a terminal state and the multiversion E2E `for 4.23` / `for 5.0` cases in `prod-e2e-parallel` time out after 20 minutes.

The chicken-and-egg:

- The strict path needs at least one `ControlPlaneVersion.History` entry in `state=CompletedUpdate`.
- `CompletedUpdate` needs cluster operators (router, console, dns, image-registry, ingress, insights, …) `Available=True`.
- Those operators need worker nodes to run.
- The test workflow only creates the node pool **after** cluster creation completes.

Prod-canary (`hcp-prod-usc.eastus2`) `ServiceLogs.backendLogs` over the last 7 days confirms both minors are wedged on the same condition with the same message — "router" is the most common blocker:

| Version | "ComponentsNotAvailable: …router…" hits (7d) |
|---|---|
| 4.23 | 41 |
| 5.0  | 40 |

The map is the existing mechanism for opting a minor out of the strict check while its control-plane-only success condition is unreliable. `4.19`–`4.22` already opt out via `.999` sentinel; `4.23` and `5.0` were simply missing.

### Testing

- `cd backend && go build ./...` — clean
- `go test ./pkg/controllers/operationcontrollers/...` — pass
- Added focused unit tests for both `5.0` and `4.23` bypass paths in `TestDetermineOperationStatus` (HostedCluster with `5.0.0`/`4.23.0` History entry + `HostedClusterAvailable=False` + populated endpoint → `Succeeded`).
- Negative-control verified locally for both: removing either map entry makes the corresponding test fail with `Provisioning`, so the tests guard exactly the new behavior.
- Reproduced root cause for 5.0 with `hcpctl snapshot analyze` against prow job `2064790437436067840` and two earlier prod-BR snapshots; all three independently land on the same missing-map-entry conclusion. Confirmed 4.23 exhibits the same pattern via the prod-canary log query above.
- Two pre-existing `TestDetermineOperationStatus` cases used `4.23.0` in History fixtures to exercise the strict path; bumped them to `4.24.0` so they still exercise the strict (non-bypass) path now that `4.23` is in the map.

### Special notes for your reviewer

- `5.1`–`5.11` are not in the map; the multiversion E2E for those minors passes today.
- Once `4.23` / `5.0` have a real release with a reliable success condition, swap the `.999` sentinel for that z-stream — same pattern `4.19`–`4.22` are queued to follow.

### PR Checklist

- [x] Tests added/updated where applicable (new bypass cases + fixture bumps for the two pre-existing strict-path cases)
- [x] Documentation updated (n/a — internal map only; map's own doc comment typo corrected as a drive-by)
- [x] Linked Jira ([AROSLSRE-1152](https://issues.redhat.com/browse/AROSLSRE-1152))
