### PR TITLE
feat(prometheus-rules): auto-load recording rules for promtool tests

### DIFF
--- a/tooling/prometheus-rules/internal/generator.go
+++ b/tooling/prometheus-rules/internal/generator.go
@@ -51,6 +51,7 @@ type alertingRuleFile struct {
 	TestFileBaseName          string
 	Rules                     monitoringv1.PrometheusRule
 	TestFileContent           []byte
+	testDependency            bool
 }
 
 type GroupAlerts struct {
@@ -88,6 +89,66 @@ type CliConfig struct {
 func NewOptions() *Options {
 	o := &Options{}
 	return o
+}
+
+// loadRecordingRuleDeps automatically discovers and loads recording rule files
+// as test-only dependencies based on config file naming convention.
+// alerts-*-hcps.yaml loads rule files from recording-rules-hcps.yaml,
+// alerts-*-services.yaml loads from recording-rules-services.yaml, etc.
+func (o *Options) loadRecordingRuleDeps(configFilePath string, baseDirectory string) error {
+	configBase := filepath.Base(configFilePath)
+
+	// Extract the suffix: alerts-sre-hcps.yaml -> hcps
+	if !strings.HasPrefix(configBase, "alerts-") {
+		return nil
+	}
+	suffix := strings.TrimPrefix(configBase, "alerts-")
+	suffix = strings.TrimSuffix(suffix, filepath.Ext(suffix))
+	parts := strings.SplitN(suffix, "-", 2)
+	if len(parts) < 2 {
+		return nil
+	}
+	lane := parts[len(parts)-1]
+
+	recordingConfigPath := filepath.Join(filepath.Dir(configFilePath), fmt.Sprintf("recording-rules-%s%s", lane, filepath.Ext(configFilePath)))
+	if _, err := os.Stat(recordingConfigPath); err != nil {
+		return nil
+	}
+
+	cfgRaw, err := os.ReadFile(recordingConfigPath)
+	if err != nil {
+		return fmt.Errorf("error reading recording rules config %s: %v", recordingConfigPath, err)
+	}
+	recConfig := &CliConfig{}
+	if err := yaml.Unmarshal(cfgRaw, recConfig); err != nil {
+		return fmt.Errorf("error unmarshaling recording rules config %s: %v", recordingConfigPath, err)
+	}
+
+	recBaseDirectory := filepath.Dir(recordingConfigPath)
+	for _, rulesDir := range recConfig.PrometheusRules.RulesFolders {
+		err := filepath.WalkDir(path.Join(recBaseDirectory, rulesDir), func(p string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if !d.Type().IsRegular() || strings.Contains(filepath.Base(p), "_test") {
+				return nil
+			}
+			rules, err := readRulesFile(p)
+			if err != nil {
+				return fmt.Errorf("error reading recording rule dependency %s: %v", p, err)
+			}
+			o.ruleFiles = append(o.ruleFiles, alertingRuleFile{
+				FileBaseName:   filepath.Base(p),
+				Rules:          *rules,
+				testDependency: true,
+			})
+			return nil
+		})
+		if err != nil {
+			return fmt.Errorf("error loading recording rule dependencies from %s: %w", recordingConfigPath, err)
+		}
+	}
+	return nil
 }
 
 func readRulesFile(filename string) (*monitoringv1.PrometheusRule, error) {
@@ -172,6 +233,14 @@ func (o *Options) Complete(configFilePath string, promtoolPath string) error {
 		})
 	}
 
+	// Automatically load recording rules as test dependencies based on
+	// config file naming convention: alerts-*-hcps.yaml pairs with
+	// recording-rules-hcps.yaml, alerts-*-services.yaml pairs with
+	// recording-rules-services.yaml, etc.
+	if err := o.loadRecordingRuleDeps(configFilePath, baseDirectory); err != nil {
+		return err
+	}
+
 	for _, rulesDir := range config.PrometheusRules.RulesFolders {
 		err = filepath.WalkDir(path.Join(baseDirectory, rulesDir), func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
@@ -235,20 +304,26 @@ func (o *Options) RunTests() error {
 
 	logrus.Debugf("Created tempdir %s", dir)
 
+	// Write all rule files to the temp dir so that cross-file references
+	// in test rule_files lists are resolvable by promtool.
 	for _, irf := range o.ruleFiles {
-		if irf.TestFileBaseName == "" {
+		if irf.FileBaseName == "" {
 			continue
 		}
 		ruleGroups, err := yaml.Marshal(irf.Rules.Spec)
 		if err != nil {
 			return fmt.Errorf("error Marshalling rule groups %v", err)
 		}
-
-		tmpFile := fmt.Sprintf("%s%s%s", dir, string(os.PathSeparator), irf.FileBaseName)
-
-		err = os.WriteFile(tmpFile, ruleGroups, 0644)
-		if err != nil {
+		tmpFile := filepath.Join(dir, filepath.Base(irf.FileBaseName))
+		if err = os.WriteFile(tmpFile, ruleGroups, 0644); err != nil {
 			return fmt.Errorf("error writing rule groups file %v", err)
+		}
+	}
+
+	// Run tests for files that have a test file.
+	for _, irf := range o.ruleFiles {
+		if irf.TestFileBaseName == "" {
+			continue
 		}
 
 		fileNameParts := strings.Split(irf.FileBaseName, ".")
@@ -257,8 +332,7 @@ func (o *Options) RunTests() error {
 		}
 
 		testFile := filepath.Join(dir, irf.TestFileBaseName)
-		err = os.WriteFile(testFile, irf.TestFileContent, 0644)
-		if err != nil {
+		if err = os.WriteFile(testFile, irf.TestFileContent, 0644); err != nil {
 			return fmt.Errorf("error writing rule groups test file %v", err)
 		}
 		logrus.Debugf("running test %s", irf.TestFileBaseName)
@@ -268,7 +342,6 @@ func (o *Options) RunTests() error {
 			logrus.Error(string(output))
 			return fmt.Errorf("error running promtool %v", err)
 		}
-
 	}
 
 	return nil
@@ -348,6 +421,9 @@ param location string = resourceGroup().location
 	}
 
 	for _, irf := range o.ruleFiles {
+		if irf.testDependency {
+			continue
+		}
 		for _, group := range irf.Rules.Spec.Groups {
 			// Skip this group if not in includedAlerts
 			if len(o.includedAlerts) > 0 {

--- a/tooling/prometheus-rules/internal/generator_test.go
+++ b/tooling/prometheus-rules/internal/generator_test.go
@@ -111,12 +111,13 @@ spec: {}
 
 func TestOptionsComplete(t *testing.T) {
 	tests := []struct {
-		name         string
-		configFile   string
-		setupFiles   func(tmpDir string) error
-		expectError  bool
-		errorMsg     string
-		validateFunc func(t *testing.T, opts *Options)
+		name           string
+		configFile     string
+		configFileName string // defaults to "config.yaml"
+		setupFiles     func(tmpDir string) error
+		expectError    bool
+		errorMsg       string
+		validateFunc   func(t *testing.T, opts *Options)
 	}{
 		{
 			name: "valid config with rules folders",
@@ -327,6 +328,51 @@ spec:
 			},
 		},
 		{
+			name: "auto loads recording rule deps from naming convention",
+			configFile:     "prometheusRules:\n  rulesFolders:\n  - alerts\n  outputBicep: generated.bicep\n",
+			configFileName: "alerts-sre-hcps.yaml",
+			setupFiles: func(tmpDir string) error {
+				alertsDir := filepath.Join(tmpDir, "alerts")
+				if err := os.Mkdir(alertsDir, 0755); err != nil {
+					return err
+				}
+				recDir := filepath.Join(tmpDir, "recording")
+				if err := os.Mkdir(recDir, 0755); err != nil {
+					return err
+				}
+
+				ruleContent := "apiVersion: monitoring.coreos.com/v1\nkind: PrometheusRule\nmetadata:\n  name: test-rules\nspec:\n  groups:\n  - name: test.rules\n    rules:\n    - alert: TestAlert\n      expr: up == 0\n"
+				testContent := "rule_files:\n- test.yaml\ntests: []\n"
+				recordContent := "apiVersion: monitoring.coreos.com/v1\nkind: PrometheusRule\nmetadata:\n  name: recording-rules\nspec:\n  groups:\n  - name: recording.rules\n    rules:\n    - record: my_recording_rule\n      expr: sum(up)\n"
+				recConfig := "prometheusRules:\n  rulesFolders:\n  - recording/record.yaml\n  untestedRules: []\n  outputBicep: generated.bicep\n"
+
+				if err := os.WriteFile(filepath.Join(alertsDir, "test.yaml"), []byte(ruleContent), 0644); err != nil {
+					return err
+				}
+				if err := os.WriteFile(filepath.Join(alertsDir, "test_test.yaml"), []byte(testContent), 0644); err != nil {
+					return err
+				}
+				if err := os.WriteFile(filepath.Join(recDir, "record.yaml"), []byte(recordContent), 0644); err != nil {
+					return err
+				}
+				// The companion recording rules config
+				return os.WriteFile(filepath.Join(tmpDir, "recording-rules-hcps.yaml"), []byte(recConfig), 0644)
+			},
+			expectError: false,
+			validateFunc: func(t *testing.T, opts *Options) {
+				assert.Len(t, opts.ruleFiles, 2)
+				var hasDep bool
+				for _, rf := range opts.ruleFiles {
+					if rf.testDependency {
+						hasDep = true
+						assert.Equal(t, "record.yaml", rf.FileBaseName)
+						assert.Empty(t, rf.TestFileBaseName)
+					}
+				}
+				assert.True(t, hasDep, "expected a test dependency rule file")
+			},
+		},
+		{
 			name: "config with includedAlertsByGroup (multiple groups)",
 			configFile: `
 prometheusRules:
@@ -374,7 +420,11 @@ spec:
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
-			configPath := filepath.Join(tmpDir, "config.yaml")
+			cfgName := tt.configFileName
+			if cfgName == "" {
+				cfgName = "config.yaml"
+			}
+			configPath := filepath.Join(tmpDir, cfgName)
 
 			if tt.configFile != "" {
 				require.NoError(t, os.WriteFile(configPath, []byte(tt.configFile), 0644))
@@ -686,6 +736,69 @@ func TestOptionsGenerate(t *testing.T) {
 
 		assert.Contains(t, generated, "title: 'NoSummaryAlert'")
 		assert.NotContains(t, generated, "title: 'NoSummaryAlert namespace:")
+	})
+
+	t.Run("test dependencies excluded from output", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		outputFile := filepath.Join(tmpDir, "AlertingRules_output.bicep")
+
+		opts := &Options{
+			outputBicep: outputFile,
+			ruleFiles: []alertingRuleFile{
+				{
+					Rules: monitoringv1.PrometheusRule{
+						Spec: monitoringv1.PrometheusRuleSpec{
+							Groups: []monitoringv1.RuleGroup{
+								{
+									Name: "alert-group",
+									Rules: []monitoringv1.Rule{
+										{
+											Alert: "RealAlert",
+											Expr:  intstr.FromString("up == 0"),
+											Labels: map[string]string{
+												"severity": "critical",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					FileBaseName:   "recording.yaml",
+					testDependency: true,
+					Rules: monitoringv1.PrometheusRule{
+						Spec: monitoringv1.PrometheusRuleSpec{
+							Groups: []monitoringv1.RuleGroup{
+								{
+									Name: "recording-group",
+									Rules: []monitoringv1.Rule{
+										{
+											Alert: "DependencyAlert",
+											Expr:  intstr.FromString("sum(up)"),
+											Labels: map[string]string{
+												"severity": "warning",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := opts.Generate()
+		assert.NoError(t, err)
+
+		content, err := os.ReadFile(outputFile)
+		assert.NoError(t, err)
+		generated := string(content)
+
+		assert.Contains(t, generated, "alert: 'RealAlert'")
+		assert.NotContains(t, generated, "DependencyAlert")
 	})
 }
 


### PR DESCRIPTION
## Summary

- When processing an alerting config (e.g. `alerts-sre-hcps.yaml`), the generator now automatically discovers and loads rule files from the companion recording rules config (`recording-rules-hcps.yaml`) as test-only dependencies. The pairing is by naming convention: `alerts-*-{lane}.yaml` pairs with `recording-rules-{lane}.yaml`.
- Splits `RunTests()` into two passes: write all rule files to the temp dir first, then run tests — so cross-file `rule_files:` references in promtool test YAMLs resolve correctly.
- Recording rule dependencies are excluded from the generated bicep output.

This means new alerting configs that reference recording rules in their tests just work — no need to manually list the recording rule files in `rulesFolders` or any other config field.


🤖 Generated with [Claude Code](https://claude.com/claude-code)