### PR TITLE
feat(prometheus-rules): add testDependencies config for cross-file promtool tests

### DIFF
--- a/observability/alerts-msft-services.yaml
+++ b/observability/alerts-msft-services.yaml
@@ -6,6 +6,8 @@ prometheusRules:
   - alerts/msi-credential-refresher-prometheusRule.yaml
   untestedRules:
   - alerts/kubernetesControlPlane-prometheusRule.yaml
+  testDependencies:
+  - recording-rules-services.yaml
   outputBicep: ../dev-infrastructure/modules/metrics/rules/generatedMsftPrometheusAlertingRules.bicep
   # Explicitly lists all alerts wanted to prevent new Red Hat alerts from automatically being included here
   # Make sure to include the alert under the correct groupName as defined in its prometheusRule file

--- a/observability/alerts-rp-services.yaml
+++ b/observability/alerts-rp-services.yaml
@@ -2,4 +2,6 @@ prometheusRules:
   rulesFolders:
   - alerts/nodepool-slo-prometheusRule.yaml
   untestedRules: []
+  testDependencies:
+  - recording-rules-services.yaml
   outputBicep: ../dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep

--- a/observability/alerts-sl-services.yaml
+++ b/observability/alerts-sl-services.yaml
@@ -15,6 +15,8 @@ prometheusRules:
   - ../observability/alerts/imageRegistryPolicy-prometheusRule.yaml
   - alerts/kusto-logs-age-prometheusRule.yaml
   untestedRules: []
+  testDependencies:
+  - recording-rules-services.yaml
   outputBicep: ../dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
   prometheusOperatorVersion: e02554298cb62b5533f3407c8eacc664e80bc74b
   outputReplacements:

--- a/observability/alerts-sre-hcps.yaml
+++ b/observability/alerts-sre-hcps.yaml
@@ -6,6 +6,8 @@ prometheusRules:
   - ../observability/alerts/HCPclusterHealth-prometheusRule.yaml
   untestedRules:
   - ../observability/alerts/kubernetesControlPlane-prometheusRule.yaml
+  testDependencies:
+  - recording-rules-hcps.yaml
   outputBicep: ../dev-infrastructure/modules/metrics/rules/generatedHCPPrometheusAlertingRules.bicep
   outputReplacements:
   - from: 'job="kube-scheduler"'

--- a/tooling/prometheus-rules/internal/generator.go
+++ b/tooling/prometheus-rules/internal/generator.go
@@ -15,6 +15,7 @@
 package internal
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"io/fs"
@@ -51,6 +52,7 @@ type alertingRuleFile struct {
 	TestFileBaseName          string
 	Rules                     monitoringv1.PrometheusRule
 	TestFileContent           []byte
+	testDependency            bool
 }
 
 type GroupAlerts struct {
@@ -72,6 +74,7 @@ type Options struct {
 type PrometheusRulesConfig struct {
 	RulesFolders              []string       `json:"rulesFolders"`
 	UntestedRules             []string       `json:"untestedRules,omitempty"`
+	TestDependencies          []string       `json:"testDependencies,omitempty"`
 	OutputBicep               string         `json:"outputBicep"`
 	IncludedAlertsByGroup     []GroupAlerts  `json:"includedAlertsByGroup,omitempty"` // Optional: Only alerts listed here are included; if empty, all alerts are included
 	LabelsToExtract           []string       `json:"labelsToExtract,omitempty"`
@@ -172,6 +175,42 @@ func (o *Options) Complete(configFilePath string, promtoolPath string) error {
 		})
 	}
 
+	for _, dep := range config.PrometheusRules.TestDependencies {
+		depPath := path.Join(baseDirectory, dep)
+		depRaw, err := os.ReadFile(depPath)
+		if err != nil {
+			return fmt.Errorf("error reading test dependency config %s: %w", depPath, err)
+		}
+		depConfig := &CliConfig{}
+		if err := yaml.Unmarshal(depRaw, depConfig); err != nil {
+			return fmt.Errorf("error unmarshaling test dependency config %s: %w", depPath, err)
+		}
+		depBase := path.Dir(depPath)
+		for _, rulesDir := range depConfig.PrometheusRules.RulesFolders {
+			err := filepath.WalkDir(path.Join(depBase, rulesDir), func(p string, d fs.DirEntry, err error) error {
+				if err != nil {
+					return err
+				}
+				if !d.Type().IsRegular() || strings.Contains(filepath.Base(p), "_test") {
+					return nil
+				}
+				rules, err := readRulesFile(p)
+				if err != nil {
+					return fmt.Errorf("error reading test dependency %s: %w", p, err)
+				}
+				o.ruleFiles = append(o.ruleFiles, alertingRuleFile{
+					FileBaseName:   filepath.Base(p),
+					Rules:          *rules,
+					testDependency: true,
+				})
+				return nil
+			})
+			if err != nil {
+				return fmt.Errorf("error loading test dependency rules from %s: %w", dep, err)
+			}
+		}
+	}
+
 	for _, rulesDir := range config.PrometheusRules.RulesFolders {
 		err = filepath.WalkDir(path.Join(baseDirectory, rulesDir), func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
@@ -235,20 +274,35 @@ func (o *Options) RunTests() error {
 
 	logrus.Debugf("Created tempdir %s", dir)
 
+	// Write all rule files to the temp dir so that cross-file references
+	// in test rule_files lists are resolvable by promtool.
+	written := map[string][]byte{}
 	for _, irf := range o.ruleFiles {
-		if irf.TestFileBaseName == "" {
+		if irf.FileBaseName == "" {
 			continue
 		}
 		ruleGroups, err := yaml.Marshal(irf.Rules.Spec)
 		if err != nil {
 			return fmt.Errorf("error Marshalling rule groups %v", err)
 		}
-
-		tmpFile := fmt.Sprintf("%s%s%s", dir, string(os.PathSeparator), irf.FileBaseName)
-
-		err = os.WriteFile(tmpFile, ruleGroups, 0644)
-		if err != nil {
+		base := filepath.Base(irf.FileBaseName)
+		if prev, exists := written[base]; exists {
+			if !bytes.Equal(prev, ruleGroups) {
+				return fmt.Errorf("basename conflict: multiple rule files named %q have different content", base)
+			}
+			continue
+		}
+		written[base] = ruleGroups
+		tmpFile := filepath.Join(dir, base)
+		if err = os.WriteFile(tmpFile, ruleGroups, 0644); err != nil {
 			return fmt.Errorf("error writing rule groups file %v", err)
+		}
+	}
+
+	// Run tests for files that have a test file.
+	for _, irf := range o.ruleFiles {
+		if irf.TestFileBaseName == "" {
+			continue
 		}
 
 		fileNameParts := strings.Split(irf.FileBaseName, ".")
@@ -257,8 +311,7 @@ func (o *Options) RunTests() error {
 		}
 
 		testFile := filepath.Join(dir, irf.TestFileBaseName)
-		err = os.WriteFile(testFile, irf.TestFileContent, 0644)
-		if err != nil {
+		if err = os.WriteFile(testFile, irf.TestFileContent, 0644); err != nil {
 			return fmt.Errorf("error writing rule groups test file %v", err)
 		}
 		logrus.Debugf("running test %s", irf.TestFileBaseName)
@@ -268,7 +321,6 @@ func (o *Options) RunTests() error {
 			logrus.Error(string(output))
 			return fmt.Errorf("error running promtool %v", err)
 		}
-
 	}
 
 	return nil
@@ -348,6 +400,9 @@ param location string = resourceGroup().location
 	}
 
 	for _, irf := range o.ruleFiles {
+		if irf.testDependency {
+			continue
+		}
 		for _, group := range irf.Rules.Spec.Groups {
 			// Skip this group if not in includedAlerts
 			if len(o.includedAlerts) > 0 {

--- a/tooling/prometheus-rules/internal/generator_test.go
+++ b/tooling/prometheus-rules/internal/generator_test.go
@@ -369,6 +369,49 @@ spec:
 				assert.Contains(t, opts.includedAlerts["other.rules"], "OtherAlert")
 			},
 		},
+		{
+			name:       "config with explicit deps for promtool",
+			configFile: "prometheusRules:\n  rulesFolders:\n  - alerts\n  testDependencies:\n  - recording-rules.yaml\n  outputBicep: generated.bicep\n",
+			setupFiles: func(tmpDir string) error {
+				alertsDir := filepath.Join(tmpDir, "alerts")
+				if err := os.Mkdir(alertsDir, 0755); err != nil {
+					return err
+				}
+				recDir := filepath.Join(tmpDir, "recording")
+				if err := os.Mkdir(recDir, 0755); err != nil {
+					return err
+				}
+
+				ruleContent := "apiVersion: monitoring.coreos.com/v1\nkind: PrometheusRule\nmetadata:\n  name: test-rules\nspec:\n  groups:\n  - name: test.rules\n    rules:\n    - alert: TestAlert\n      expr: up == 0\n"
+				testContent := "rule_files:\n- test.yaml\ntests: []\n"
+				recordContent := "apiVersion: monitoring.coreos.com/v1\nkind: PrometheusRule\nmetadata:\n  name: recording-rules\nspec:\n  groups:\n  - name: recording.rules\n    rules:\n    - record: my_recording_rule\n      expr: sum(up)\n"
+				recConfig := "prometheusRules:\n  rulesFolders:\n  - recording/record.yaml\n  untestedRules: []\n  outputBicep: out.bicep\n"
+
+				if err := os.WriteFile(filepath.Join(alertsDir, "test.yaml"), []byte(ruleContent), 0644); err != nil {
+					return err
+				}
+				if err := os.WriteFile(filepath.Join(alertsDir, "test_test.yaml"), []byte(testContent), 0644); err != nil {
+					return err
+				}
+				if err := os.WriteFile(filepath.Join(recDir, "record.yaml"), []byte(recordContent), 0644); err != nil {
+					return err
+				}
+				return os.WriteFile(filepath.Join(tmpDir, "recording-rules.yaml"), []byte(recConfig), 0644)
+			},
+			expectError: false,
+			validateFunc: func(t *testing.T, opts *Options) {
+				assert.Len(t, opts.ruleFiles, 2)
+				var hasDep bool
+				for _, rf := range opts.ruleFiles {
+					if rf.testDependency {
+						hasDep = true
+						assert.Equal(t, "record.yaml", rf.FileBaseName)
+						assert.Empty(t, rf.TestFileBaseName)
+					}
+				}
+				assert.True(t, hasDep, "expected a test dependency rule file")
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -686,6 +729,69 @@ func TestOptionsGenerate(t *testing.T) {
 
 		assert.Contains(t, generated, "title: 'NoSummaryAlert'")
 		assert.NotContains(t, generated, "title: 'NoSummaryAlert namespace:")
+	})
+
+	t.Run("deps excluded from output", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		outputFile := filepath.Join(tmpDir, "AlertingRules_output.bicep")
+
+		opts := &Options{
+			outputBicep: outputFile,
+			ruleFiles: []alertingRuleFile{
+				{
+					Rules: monitoringv1.PrometheusRule{
+						Spec: monitoringv1.PrometheusRuleSpec{
+							Groups: []monitoringv1.RuleGroup{
+								{
+									Name: "alert-group",
+									Rules: []monitoringv1.Rule{
+										{
+											Alert: "RealAlert",
+											Expr:  intstr.FromString("up == 0"),
+											Labels: map[string]string{
+												"severity": "critical",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					FileBaseName:   "recording.yaml",
+					testDependency: true,
+					Rules: monitoringv1.PrometheusRule{
+						Spec: monitoringv1.PrometheusRuleSpec{
+							Groups: []monitoringv1.RuleGroup{
+								{
+									Name: "recording-group",
+									Rules: []monitoringv1.Rule{
+										{
+											Alert: "DependencyAlert",
+											Expr:  intstr.FromString("sum(up)"),
+											Labels: map[string]string{
+												"severity": "warning",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := opts.Generate()
+		assert.NoError(t, err)
+
+		content, err := os.ReadFile(outputFile)
+		assert.NoError(t, err)
+		generated := string(content)
+
+		assert.Contains(t, generated, "alert: 'RealAlert'")
+		assert.NotContains(t, generated, "DependencyAlert")
 	})
 }
 


### PR DESCRIPTION
## Summary

- Adds `testDependencies` field to alerting lane configs. Each entry points at a companion config file (e.g. `recording-rules-hcps.yaml`), and the generator loads all its rule files into the promtool temp dir for testing. They are excluded from generated bicep output.
- Writes all rule files to the temp dir before running any tests, so cross-file `rule_files:` references resolve correctly.
- Adds `testDependencies` to all `alerts-*.yaml` configs.
- Once merged will make PRs like #5608 work

Alternative to #5606 (auto-discovery by naming convention). This version is explicit.


🤖 Generated with [Claude Code](https://claude.com/claude-code)