### PR TITLE
test: cross-file recording rule dependency (expected to fail without testDependencies)

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedHCPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedHCPPrometheusAlertingRules.bicep
@@ -1908,3 +1908,40 @@ This usually indicates critical operators (Network, API, etc.) are down.
     ]
   }
 }
+
+resource fakeAlertRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'fake-alert-rules'
+  location: location
+  properties: {
+    interval: 'PT1M'
+    rules: [
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'FakeHighErrorRate'
+        enabled: true
+        labels: {
+          severity: 'critical'
+        }
+        annotations: {
+          correlationId: 'FakeHighErrorRate/{{ $labels.cluster }}'
+          summary: 'High error rate detected'
+          title: 'High error rate detected'
+        }
+        expression: 'fake:error_rate:5m > 0.05'
+        for: 'PT5M'
+        severity: 2
+      }
+    ]
+    scopes: [
+      azureMonitoring
+    ]
+  }
+}

--- a/observability/alerts-sre-hcps.yaml
+++ b/observability/alerts-sre-hcps.yaml
@@ -4,6 +4,7 @@ prometheusRules:
   - ../observability/alerts/HCPkasRecord-prometheusRule-KSM.yaml
   - ../observability/alerts/HCPkasMonitor-prometheusRule-KSM.yaml
   - ../observability/alerts/HCPclusterHealth-prometheusRule.yaml
+  - ../observability/alerts/fake-alert-prometheusRule.yaml
   untestedRules:
   - ../observability/alerts/kubernetesControlPlane-prometheusRule.yaml
   testDependencies:

--- a/observability/alerts/fake-alert-prometheusRule.yaml
+++ b/observability/alerts/fake-alert-prometheusRule.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: fake-alert-rules
+  namespace: prometheus
+spec:
+  groups:
+  - name: fake-alert-rules
+    rules:
+    - alert: FakeHighErrorRate
+      expr: fake:error_rate:5m > 0.05
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        summary: "High error rate detected"

--- a/observability/alerts/fake-alert-prometheusRule_test.yaml
+++ b/observability/alerts/fake-alert-prometheusRule_test.yaml
@@ -1,0 +1,19 @@
+rule_files:
+- fake-record-prometheusRule.yaml
+- fake-alert-prometheusRule.yaml
+evaluation_interval: 1m
+tests:
+- interval: 1m
+  input_series:
+  - series: 'http_errors_total{namespace="test", cluster="c1"}'
+    values: "100+100x20"
+  alert_rule_test:
+  - eval_time: 10m
+    alertname: FakeHighErrorRate
+    exp_alerts:
+    - exp_labels:
+        severity: critical
+        namespace: test
+        cluster: c1
+      exp_annotations:
+        summary: "High error rate detected"

--- a/observability/alerts/fake-record-prometheusRule.yaml
+++ b/observability/alerts/fake-record-prometheusRule.yaml
@@ -1,0 +1,11 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: fake-recording-rules
+  namespace: prometheus
+spec:
+  groups:
+  - name: fake-recording-rules
+    rules:
+    - record: fake:error_rate:5m
+      expr: sum(rate(http_errors_total[5m])) by (namespace, cluster)

--- a/observability/alerts/fake-record-prometheusRule_test.yaml
+++ b/observability/alerts/fake-record-prometheusRule_test.yaml
@@ -1,0 +1,4 @@
+rule_files:
+- fake-record-prometheusRule.yaml
+evaluation_interval: 1m
+tests: []

--- a/observability/recording-rules-hcps.yaml
+++ b/observability/recording-rules-hcps.yaml
@@ -3,5 +3,6 @@ prometheusRules:
   - ../observability/alerts/HCPkasRecord-prometheusRule-KSM.yaml
   - ../observability/alerts/HCPkasRecord-prometheusRule-apiserver-requests.yaml
   - ../observability/alerts/HCPkasRecord-prometheusRule-latency.yaml
+  - ../observability/alerts/fake-record-prometheusRule.yaml
   untestedRules: []
   outputBicep: ../dev-infrastructure/modules/metrics/rules/generatedHCPRecordingRules.bicep


### PR DESCRIPTION
## Summary

Adds a recording rule to `recording-rules-hcps.yaml` and an alert in `alerts-sre-hcps.yaml` that depends on it. The alert's promtool test references the recording rule file via `rule_files:`.

**This PR is expected to fail.** The generator currently doesn't make recording rule files from companion configs available during alerting rule tests. The fix is in #5606 (auto-discovery) or #5607 (explicit `testDependencies`).

```
WARNING: no file match pattern .../fake-record-prometheusRule.yaml
FAILED: alertname: FakeHighErrorRate, time: 10m, exp:[...], got:[]
```


🤖 Generated with [Claude Code](https://claude.com/claude-code)