### PR TITLE
feat: alert when mgmt cluster user nodes have zero SWIFT NIC capacity

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedHCPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedHCPPrometheusAlertingRules.bicep
@@ -1683,6 +1683,35 @@ resource mgmtCapacityRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
             }
           }
         ]
+        alert: 'MgmtClusterNodeSwiftNICCapacityZero'
+        enabled: true
+        labels: {
+          severity: 'critical'
+          team: 'hcp-sl'
+        }
+        annotations: {
+          correlationId: 'MgmtClusterNodeSwiftNICCapacityZero/{{ $labels.cluster }}'
+          description: 'Node {{ $labels.node }} on management cluster {{ $labels.cluster }} has zero SWIFT NIC capacity. No HCPs can be scheduled on this node until NIC capacity is restored.'
+          info: 'Node {{ $labels.node }} on management cluster {{ $labels.cluster }} has zero SWIFT NIC capacity. No HCPs can be scheduled on this node until NIC capacity is restored.'
+          owning_team: 'hcp-sl'
+          runbook_url: 'https://portal.microsofticm.com/imp/v5/incidents/details/802529667'
+          summary: 'Management cluster node has zero SWIFT NIC capacity.'
+          title: 'Management cluster node has zero SWIFT NIC capacity.'
+        }
+        expression: 'kube_node_status_capacity{node=~"user.*", resource="aro_openshift_io_swift_nic"} == 0'
+        for: 'PT10M'
+        severity: 2
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
         alert: 'MgmtClusterHCPCapacityCritical'
         enabled: true
         labels: {

--- a/observability/alerts/mgmt-capacity-prometheusRule.yaml
+++ b/observability/alerts/mgmt-capacity-prometheusRule.yaml
@@ -25,6 +25,18 @@ spec:
       labels:
         severity: info
         team: hcp-sl
+    - alert: MgmtClusterNodeSwiftNICCapacityZero
+      annotations:
+        description: Node {{ $labels.node }} on management cluster {{ $labels.cluster }} has zero SWIFT NIC capacity. No HCPs can be scheduled on this node until NIC capacity is restored.
+        runbook_url: https://portal.microsofticm.com/imp/v5/incidents/details/802529667
+        summary: Management cluster node has zero SWIFT NIC capacity.
+        owning_team: hcp-sl
+      expr: |
+        kube_node_status_capacity{node=~"user.*", resource="aro_openshift_io_swift_nic"} == 0
+      for: 10m
+      labels:
+        severity: critical
+        team: hcp-sl
     - alert: MgmtClusterHCPCapacityCritical
       annotations:
         description: Management cluster {{ $labels.cluster }} is at {{ $value | humanizePercentage }} of its HCP capacity (60 HCP limit). Current count exceeds critical threshold of 85%. Immediate action required to provision additional management cluster capacity.

--- a/observability/alerts/mgmt-capacity-prometheusRule_test.yaml
+++ b/observability/alerts/mgmt-capacity-prometheusRule_test.yaml
@@ -2,6 +2,44 @@ rule_files:
 - mgmt-capacity-prometheusRule.yaml
 evaluation_interval: 1m
 tests:
+# Test SWIFT NIC capacity zero - alert fires when user node has 0 NIC capacity
+- interval: 1m
+  input_series:
+  - series: 'kube_node_status_capacity{cluster="mgmt-nic-zero", node="user-pool-node-1", resource="aro_openshift_io_swift_nic"}'
+    values: "0+0x10"
+  alert_rule_test:
+  - eval_time: 10m
+    alertname: MgmtClusterNodeSwiftNICCapacityZero
+    exp_alerts:
+    - exp_labels:
+        severity: critical
+        team: hcp-sl
+        cluster: mgmt-nic-zero
+        node: user-pool-node-1
+        resource: aro_openshift_io_swift_nic
+      exp_annotations:
+        summary: Management cluster node has zero SWIFT NIC capacity.
+        description: Node user-pool-node-1 on management cluster mgmt-nic-zero has zero SWIFT NIC capacity. No HCPs can be scheduled on this node until NIC capacity is restored.
+        runbook_url: https://portal.microsofticm.com/imp/v5/incidents/details/802529667
+        owning_team: hcp-sl
+# Test SWIFT NIC capacity zero - no alert when user node has NIC capacity > 0
+- interval: 1m
+  input_series:
+  - series: 'kube_node_status_capacity{cluster="mgmt-nic-ok", node="user-pool-node-1", resource="aro_openshift_io_swift_nic"}'
+    values: "7+0x15"
+  alert_rule_test:
+  - eval_time: 10m
+    alertname: MgmtClusterNodeSwiftNICCapacityZero
+    exp_alerts: []
+# Test SWIFT NIC capacity zero - no alert for non-user nodes
+- interval: 1m
+  input_series:
+  - series: 'kube_node_status_capacity{cluster="mgmt-nic-sys", node="system-pool-node-1", resource="aro_openshift_io_swift_nic"}'
+    values: "0+0x15"
+  alert_rule_test:
+  - eval_time: 10m
+    alertname: MgmtClusterNodeSwiftNICCapacityZero
+    exp_alerts: []
 # Test warning threshold (60%) - need 37 namespaces (37/60 = 61.6% > 60%)
 - interval: 1m
   input_series:


### PR DESCRIPTION
### What

A user node reporting zero NIC capacity is silently unschedulable for HCPs. An incident uncovered that secondary NICs on nodes can be provisioned without accelerated networking enabled, causing mgmt-agent's NIC counter to report zero capacity since it only counts accelerated NICs. This alert ensures we detect the condition immediately rather than discovering it through scheduling failures.

https://redhat.atlassian.net/browse/ARO-27695

### Why

<!-- Briefly explain why this change is needed -->

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
