### PR TITLE
test combined resources cs async deletion in backend enablement

### DIFF
--- a/backend/pkg/controllers/clusterdeletion/cluster_child_resources_cleanup_controller.go
+++ b/backend/pkg/controllers/clusterdeletion/cluster_child_resources_cleanup_controller.go
@@ -202,6 +202,8 @@ func (c *clusterChildResourcesCleanupController) SyncOnce(ctx context.Context, k
 		return utils.TrackError(err)
 	}
 
+	logger.Info("all included cluster cosmos child resources deleted")
+
 	return nil
 }
 

--- a/backend/pkg/controllers/controllerutils/cooldown.go
+++ b/backend/pkg/controllers/controllerutils/cooldown.go
@@ -55,6 +55,10 @@ func (c *ActiveOperationBasedChecker) CanSync(ctx context.Context, key any) bool
 	switch castKey := key.(type) {
 	case HCPClusterKey:
 		activeOperations, err = c.activeOperationLister.ListActiveOperationsForCluster(ctx, castKey.SubscriptionID, castKey.ResourceGroupName, castKey.HCPClusterName)
+	case HCPNodePoolKey:
+		activeOperations, err = c.activeOperationLister.ListActiveOperationsForNodePool(ctx, castKey.SubscriptionID, castKey.ResourceGroupName, castKey.HCPClusterName, castKey.HCPNodePoolName)
+	case HCPExternalAuthKey:
+		activeOperations, err = c.activeOperationLister.ListActiveOperationsForExternalAuth(ctx, castKey.SubscriptionID, castKey.ResourceGroupName, castKey.HCPClusterName, castKey.HCPExternalAuthName)
 	case OperationKey:
 		ret := c.activeOperationTimer.CanSync(ctx, key)
 		return ret

--- a/backend/pkg/controllers/create_cluster_scoped_read_desires_controller.go
+++ b/backend/pkg/controllers/create_cluster_scoped_read_desires_controller.go
@@ -97,6 +97,9 @@ func (c *createClusterScopedReadDesiresSyncer) SyncOnce(ctx context.Context, key
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to get Cluster: %w", err))
 	}
+	if existingCluster.ServiceProviderProperties.DeletionTimestamp != nil {
+		return nil
+	}
 	if existingCluster.ServiceProviderProperties.ClusterServiceID == nil {
 		// We don't have a CS reference yet; we'll retrigger once it's set.
 		return nil

--- a/backend/pkg/controllers/create_nodepool_scoped_read_desires_controller.go
+++ b/backend/pkg/controllers/create_nodepool_scoped_read_desires_controller.go
@@ -84,6 +84,9 @@ func (c *createNodePoolScopedReadDesiresSyncer) SyncOnce(ctx context.Context, ke
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to get NodePool: %w", err))
 	}
+	if existingNodePool.ServiceProviderProperties.DeletionTimestamp != nil {
+		return nil
+	}
 	if existingNodePool.ServiceProviderProperties.ClusterServiceID == nil ||
 		len(existingNodePool.ServiceProviderProperties.ClusterServiceID.String()) == 0 {
 		return nil

--- a/backend/pkg/controllers/externalauthdeletion/external_auth_child_resources_cleanup_controller.go
+++ b/backend/pkg/controllers/externalauthdeletion/external_auth_child_resources_cleanup_controller.go
@@ -152,5 +152,7 @@ func (c *externalAuthChildResourcesCleanupController) SyncOnce(ctx context.Conte
 		return utils.TrackError(err)
 	}
 
+	logger.Info("all included external auth cosmos child resources deleted")
+
 	return nil
 }

--- a/backend/pkg/controllers/nodepooldeletion/node_pool_child_resources_cleanup_controller.go
+++ b/backend/pkg/controllers/nodepooldeletion/node_pool_child_resources_cleanup_controller.go
@@ -316,5 +316,7 @@ func (c *nodePoolChildResourcesCleanupController) ensureNodePoolScopedKubeApplie
 		return utils.TrackError(fmt.Errorf("error iterating nodepool-scoped kube-applier resources: %w", err))
 	}
 
+	logger.Info("all included nodepool cosmos child resources deleted")
+
 	return nil
 }

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_active_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_active_version_controller.go
@@ -81,12 +81,15 @@ func (c *controlPlaneActiveVersionSyncer) CooldownChecker() controllerutil.Coold
 // from the per-cluster ReadDesire's observed HostedCluster. Each active version
 // includes Version and State (Completed or Partial) and is persisted on replace.
 func (c *controlPlaneActiveVersionSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPClusterKey) error {
-	_, err := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).Get(ctx, key.HCPClusterName)
+	existingCluster, err := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).Get(ctx, key.HCPClusterName)
 	if database.IsNotFoundError(err) {
 		return nil
 	}
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to get Cluster: %w", err))
+	}
+	if existingCluster.ServiceProviderProperties.DeletionTimestamp != nil {
+		return nil
 	}
 
 	hostedCluster, err := maestrohelpers.GetCachedHostedClusterForCluster(ctx, c.readDesireLister, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
@@ -121,6 +121,9 @@ func (c *controlPlaneDesiredVersionSyncer) SyncOnce(ctx context.Context, key con
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to get Cluster: %w", err))
 	}
+	if existingCluster.ServiceProviderProperties.DeletionTimestamp != nil {
+		return nil
+	}
 	if existingCluster.ServiceProviderProperties.ClusterServiceID == nil {
 		// Currently, this is correct.  We will likely refactor and change this to separate the read of active versions from the determination
 		// of the next desired version: we'll need to choose a desired version even if there are no active versions.

--- a/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller.go
@@ -130,6 +130,9 @@ func (c *nodePoolVersionSyncer) SyncOnce(ctx context.Context, key controllerutil
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to get node pool from cosmos: %w", err))
 	}
+	if nodePool.ServiceProviderProperties.DeletionTimestamp != nil {
+		return nil
+	}
 	if nodePool.ServiceProviderProperties.ClusterServiceID == nil || len(nodePool.ServiceProviderProperties.ClusterServiceID.String()) == 0 {
 		// if we have no clusterservice nodepool, we have nothing to sync.
 		return nil

--- a/backend/pkg/controllers/upgradecontrollers/trigger_control_plane_upgrade_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/trigger_control_plane_upgrade_controller.go
@@ -94,6 +94,9 @@ func (c *triggerControlPlaneUpgradeSyncer) SyncOnce(ctx context.Context, key con
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to get Cluster: %w", err))
 	}
+	if existingCluster.ServiceProviderProperties.DeletionTimestamp != nil {
+		return nil
+	}
 	if existingCluster.ServiceProviderProperties.ClusterServiceID == nil {
 		// if we have no clusterService cluster, we have nothing to trigger.
 		return nil

--- a/backend/pkg/controllers/upgradecontrollers/trigger_node_pool_upgrade_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/trigger_node_pool_upgrade_controller.go
@@ -87,6 +87,9 @@ func (c *triggerNodePoolUpgradeSyncer) SyncOnce(ctx context.Context, key control
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to get NodePool: %w", err))
 	}
+	if existingNodePool.ServiceProviderProperties.DeletionTimestamp != nil {
+		return nil
+	}
 	// if we have no clusterservice nodepool, we have nothing to trigger.
 	if existingNodePool.ServiceProviderProperties.ClusterServiceID == nil || len(existingNodePool.ServiceProviderProperties.ClusterServiceID.String()) == 0 {
 		return nil

--- a/backend/pkg/controllers/validationcontrollers/cluster_validation_controller.go
+++ b/backend/pkg/controllers/validationcontrollers/cluster_validation_controller.go
@@ -81,6 +81,9 @@ func (c *clusterValidationSyncer) SyncOnce(ctx context.Context, key controllerut
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to get Cluster: %w", err))
 	}
+	if existingCluster.ServiceProviderProperties.DeletionTimestamp != nil {
+		return nil
+	}
 
 	existingServiceProviderCluster, err := database.GetOrCreateServiceProviderCluster(ctx, c.resourcesDBClient, key.GetResourceID())
 	if err != nil {

--- a/backend/pkg/informers/informers.go
+++ b/backend/pkg/informers/informers.go
@@ -592,6 +592,8 @@ func NewActiveOperationInformerWithRelistDuration(lister database.GlobalLister[a
 			Indexers: cache.Indexers{
 				listers.ByResourceGroup: activeOperationResourceGroupIndexFunc,
 				listers.ByCluster:       activeOperationClusterIndexFunc,
+				listers.ByNodePool:      activeOperationNodePoolIndexFunc,
+				listers.ByExternalAuth:  activeOperationExternalAuthIndexFunc,
 			},
 		},
 	)
@@ -685,6 +687,30 @@ func activeOperationClusterIndexFunc(obj interface{}) ([]string, error) {
 	}
 
 	return clusterResourceIDFromResourceID(op.ExternalID)
+}
+
+// activeOperationNodePoolIndexFunc indexes operations by their associated node
+// pool resource ID when ExternalID is a nodepool resource. Operations on other
+// resource types return no index entries.
+func activeOperationNodePoolIndexFunc(obj interface{}) ([]string, error) {
+	op, ok := obj.(*api.Operation)
+	if !ok {
+		return nil, fmt.Errorf("expected *api.Operation, got %T", obj)
+	}
+
+	return nodePoolResourceIDFromResourceID(op.ExternalID)
+}
+
+// activeOperationExternalAuthIndexFunc indexes operations by their associated
+// external auth resource ID when ExternalID is an external auth resource.
+// Operations on other resource types return no index entries.
+func activeOperationExternalAuthIndexFunc(obj interface{}) ([]string, error) {
+	op, ok := obj.(*api.Operation)
+	if !ok {
+		return nil, fmt.Errorf("expected *api.Operation, got %T", obj)
+	}
+
+	return externalAuthResourceIDFromResourceID(op.ExternalID)
 }
 
 // nodePoolResourceIDIndexFunc indexes objects by the node pool resource ID of their nearest

--- a/backend/pkg/listers/active_operation_lister.go
+++ b/backend/pkg/listers/active_operation_lister.go
@@ -27,6 +27,8 @@ type ActiveOperationLister interface {
 	List(ctx context.Context) ([]*api.Operation, error)
 	Get(ctx context.Context, subscriptionID, name string) (*api.Operation, error)
 	ListActiveOperationsForCluster(ctx context.Context, subscriptionName, resourceGroupName, clusterName string) ([]*api.Operation, error)
+	ListActiveOperationsForNodePool(ctx context.Context, subscriptionName, resourceGroupName, clusterName, nodePoolName string) ([]*api.Operation, error)
+	ListActiveOperationsForExternalAuth(ctx context.Context, subscriptionName, resourceGroupName, clusterName, externalAuthName string) ([]*api.Operation, error)
 }
 
 // activeOperationLister implements ActiveOperationLister backed by a SharedIndexInformer.
@@ -57,4 +59,14 @@ func (l *activeOperationLister) Get(ctx context.Context, subscriptionID, name st
 func (l *activeOperationLister) ListActiveOperationsForCluster(ctx context.Context, subscriptionName, resourceGroupName, clusterName string) ([]*api.Operation, error) {
 	key := api.ToClusterResourceIDString(subscriptionName, resourceGroupName, clusterName)
 	return listFromIndex[api.Operation](l.indexer, ByCluster, key)
+}
+
+func (l *activeOperationLister) ListActiveOperationsForNodePool(ctx context.Context, subscriptionName, resourceGroupName, clusterName, nodePoolName string) ([]*api.Operation, error) {
+	key := api.ToNodePoolResourceIDString(subscriptionName, resourceGroupName, clusterName, nodePoolName)
+	return listFromIndex[api.Operation](l.indexer, ByNodePool, key)
+}
+
+func (l *activeOperationLister) ListActiveOperationsForExternalAuth(ctx context.Context, subscriptionName, resourceGroupName, clusterName, externalAuthName string) ([]*api.Operation, error) {
+	key := api.ToExternalAuthResourceIDString(subscriptionName, resourceGroupName, clusterName, externalAuthName)
+	return listFromIndex[api.Operation](l.indexer, ByExternalAuth, key)
 }

--- a/backend/pkg/listertesting/db_listers.go
+++ b/backend/pkg/listertesting/db_listers.go
@@ -116,13 +116,27 @@ func (l *DBActiveOperationLister) Get(ctx context.Context, subscriptionID, name 
 
 func (l *DBActiveOperationLister) ListActiveOperationsForCluster(ctx context.Context, subscriptionID, resourceGroupName, clusterName string) ([]*api.Operation, error) {
 	clusterKey := api.ToClusterResourceIDString(subscriptionID, resourceGroupName, clusterName)
+	return l.listByPrefix(ctx, clusterKey)
+}
+
+func (l *DBActiveOperationLister) ListActiveOperationsForNodePool(ctx context.Context, subscriptionID, resourceGroupName, clusterName, nodePoolName string) ([]*api.Operation, error) {
+	nodePoolKey := api.ToNodePoolResourceIDString(subscriptionID, resourceGroupName, clusterName, nodePoolName)
+	return l.listByPrefix(ctx, nodePoolKey)
+}
+
+func (l *DBActiveOperationLister) ListActiveOperationsForExternalAuth(ctx context.Context, subscriptionID, resourceGroupName, clusterName, externalAuthName string) ([]*api.Operation, error) {
+	externalAuthKey := api.ToExternalAuthResourceIDString(subscriptionID, resourceGroupName, clusterName, externalAuthName)
+	return l.listByPrefix(ctx, externalAuthKey)
+}
+
+func (l *DBActiveOperationLister) listByPrefix(ctx context.Context, prefix string) ([]*api.Operation, error) {
 	all, err := l.List(ctx)
 	if err != nil {
 		return nil, err
 	}
 	var result []*api.Operation
 	for _, op := range all {
-		if op.ExternalID != nil && strings.HasPrefix(strings.ToLower(op.ExternalID.String()), strings.ToLower(clusterKey)) {
+		if op.ExternalID != nil && strings.HasPrefix(strings.ToLower(op.ExternalID.String()), strings.ToLower(prefix)) {
 			result = append(result, op)
 		}
 	}

--- a/backend/pkg/listertesting/slice_listers.go
+++ b/backend/pkg/listertesting/slice_listers.go
@@ -144,16 +144,30 @@ func (l *SliceActiveOperationLister) Get(ctx context.Context, subscriptionID, na
 
 func (l *SliceActiveOperationLister) ListActiveOperationsForCluster(ctx context.Context, subscriptionID, resourceGroupName, clusterName string) ([]*api.Operation, error) {
 	clusterKey := api.ToClusterResourceIDString(subscriptionID, resourceGroupName, clusterName)
+	return l.listByPrefix(clusterKey), nil
+}
+
+func (l *SliceActiveOperationLister) ListActiveOperationsForNodePool(ctx context.Context, subscriptionID, resourceGroupName, clusterName, nodePoolName string) ([]*api.Operation, error) {
+	nodePoolKey := api.ToNodePoolResourceIDString(subscriptionID, resourceGroupName, clusterName, nodePoolName)
+	return l.listByPrefix(nodePoolKey), nil
+}
+
+func (l *SliceActiveOperationLister) ListActiveOperationsForExternalAuth(ctx context.Context, subscriptionID, resourceGroupName, clusterName, externalAuthName string) ([]*api.Operation, error) {
+	externalAuthKey := api.ToExternalAuthResourceIDString(subscriptionID, resourceGroupName, clusterName, externalAuthName)
+	return l.listByPrefix(externalAuthKey), nil
+}
+
+func (l *SliceActiveOperationLister) listByPrefix(prefix string) []*api.Operation {
 	var result []*api.Operation
 	for _, op := range l.Operations {
 		if op.ExternalID == nil {
 			continue
 		}
-		if strings.HasPrefix(strings.ToLower(op.ExternalID.String()), strings.ToLower(clusterKey)) {
+		if strings.HasPrefix(strings.ToLower(op.ExternalID.String()), strings.ToLower(prefix)) {
 			result = append(result, op)
 		}
 	}
-	return result, nil
+	return result
 }
 
 // SliceExternalAuthLister implements listers.ExternalAuthLister backed by a slice.

--- a/frontend/pkg/frontend/cluster.go
+++ b/frontend/pkg/frontend/cluster.go
@@ -17,7 +17,6 @@ package frontend
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"maps"
 	"net/http"
@@ -31,8 +30,6 @@ import (
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
-
-	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
 
 	"github.com/Azure/ARO-HCP/internal/admission"
 	"github.com/Azure/ARO-HCP/internal/api"
@@ -787,27 +784,9 @@ func (f *Frontend) DeleteCluster(writer http.ResponseWriter, request *http.Reque
 }
 
 func (f *Frontend) addDeleteClusterToTransaction(ctx context.Context, writer http.ResponseWriter, request *http.Request, transaction database.DBTransaction, cluster *api.HCPOpenShiftCluster) error {
-	logger := utils.LoggerFromContext(ctx)
-
 	correlationData, err := CorrelationDataFromContext(ctx)
 	if err != nil {
 		return utils.TrackError(err)
-	}
-
-	if cluster.ServiceProviderProperties.ClusterServiceID != nil {
-		err = f.clusterServiceClient.DeleteCluster(ctx, *cluster.ServiceProviderProperties.ClusterServiceID)
-		var ocmError *ocmerrors.Error
-		if errors.As(err, &ocmError) && ocmError.Status() == http.StatusNotFound {
-			// StatusNotFound means we have stale data in Cosmos DB.
-			// This can happen in test environments if a user bypasses
-			// the RP to delete a resource (e.g. "ocm delete"). It can
-			// also happen if an asynchronous deletion operation fails.
-			// we will fall through and cancel all operations and go through as normal a deletion flow as we can to avoid
-			// leaking data related to the resource, like controller status.
-			logger.Info("clusterService cluster missing, trying to clean up", "err", err)
-		} else if err != nil {
-			return utils.TrackError(err)
-		}
 	}
 
 	// Cluster Service will take care of canceling any ongoing operations
@@ -825,19 +804,18 @@ func (f *Frontend) addDeleteClusterToTransaction(ctx context.Context, writer htt
 		return utils.TrackError(err)
 	}
 
-	clusterServiceID := api.InternalID{}
-	if cluster.ServiceProviderProperties.ClusterServiceID != nil {
-		clusterServiceID = *cluster.ServiceProviderProperties.ClusterServiceID
-	}
 	operationDoc := database.NewOperation(
 		database.OperationRequestDelete,
 		cluster.ID,
-		clusterServiceID,
+		api.InternalID{},
 		f.azureLocation,
 		"",
 		"",
 		"",
 		correlationData)
+	// TODO remove this once migration of the new cluster deletion from frontend to backend approach is fully completed in all ARO-HCP
+	// permanent environments, for all regions.
+	operationDoc.UsesNewClusterDeletionApproach = true
 	if request != nil {
 		// these are optional because when this is triggered via the subscription deletion flow, there is no
 		// deletion request containing these headers so these operations cannot be directly tracked.
@@ -856,6 +834,9 @@ func (f *Frontend) addDeleteClusterToTransaction(ctx context.Context, writer htt
 	}
 	cluster.ServiceProviderProperties.ActiveOperationID = operationDoc.ResourceID.Name
 	cluster.ServiceProviderProperties.ProvisioningState = operationDoc.Status
+	// TODO remove this once migration of the new cluster deletion from frontend to backend approach is fully completed in all ARO-HCP
+	// permanent environments, for all regions.
+	cluster.ServiceProviderProperties.UsesNewClusterDeletionApproach = true
 	_, err = f.resourcesDBClient.HCPClusters(cluster.ID.SubscriptionID, cluster.ID.ResourceGroupName).
 		AddReplaceToTransaction(ctx, transaction, cluster, nil)
 	if err != nil {

--- a/frontend/pkg/frontend/external_auth.go
+++ b/frontend/pkg/frontend/external_auth.go
@@ -17,7 +17,6 @@ package frontend
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -28,8 +27,6 @@ import (
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
-
-	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
 
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
@@ -581,26 +578,6 @@ func (f *Frontend) DeleteExternalAuth(writer http.ResponseWriter, request *http.
 
 	logger.Info(fmt.Sprintf("deleting resource %s", externalAuth.ID))
 
-	// Temporary check until creation and deletion interaction with CS is moved to the backend: if a delete arrives and the external
-	// auth has not been created in CS or the ClusterServiceID reference has not been persisted in Cosmos, return an error.
-	if externalAuth.ServiceProviderProperties.ClusterServiceID == nil || len(externalAuth.ServiceProviderProperties.ClusterServiceID.String()) == 0 {
-		return utils.TrackError(fmt.Errorf("serviceProviderProperties.clusterServiceID is required to delete an external auth"))
-	}
-
-	err = f.clusterServiceClient.DeleteExternalAuth(ctx, *externalAuth.ServiceProviderProperties.ClusterServiceID)
-	var ocmError *ocmerrors.Error
-	if errors.As(err, &ocmError) && ocmError.Status() == http.StatusNotFound {
-		// StatusNotFound means we have stale data in Cosmos DB.
-		// This can happen in test environments if a user bypasses
-		// the RP to delete a resource (e.g. "ocm delete"). It can
-		// also happen if an asynchronous deletion operation fails.
-		// we will fall through and cancel all operations and go through as normal a deletion flow as we can to avoid
-		// leaking data related to the resource, like controller status.
-		logger.Info("clusterService externalauth missing, trying to clean up", "err", err)
-	} else if err != nil {
-		return utils.TrackError(err)
-	}
-
 	transaction := f.resourcesDBClient.NewTransaction(externalAuth.ID.SubscriptionID)
 	if err := f.addDeleteExternalAuthToTransaction(ctx, writer, request, transaction, externalAuth); err != nil {
 		return utils.TrackError(err)
@@ -631,21 +608,18 @@ func (f *Frontend) addDeleteExternalAuthToTransaction(ctx context.Context, write
 		return utils.TrackError(err)
 	}
 
-	// Temporary check until creation and deletion interaction with CS is moved to the backend: if a delete arrives and the external
-	// auth has not been created in CS or the ClusterServiceID reference has not been persisted in Cosmos, return an error.
-	if externalAuth.ServiceProviderProperties.ClusterServiceID == nil || len(externalAuth.ServiceProviderProperties.ClusterServiceID.String()) == 0 {
-		return utils.TrackError(fmt.Errorf("serviceProviderProperties.clusterServiceID is required to delete an external auth"))
-	}
-
 	operationDoc := database.NewOperation(
 		database.OperationRequestDelete,
 		externalAuth.ID,
-		*externalAuth.ServiceProviderProperties.ClusterServiceID,
+		api.InternalID{},
 		f.azureLocation,
 		"",
 		"",
 		"",
 		correlationData)
+	// TODO remove this once migration of the new external auth deletion from frontend to backend approach is fully completed in all ARO-HCP
+	// permanent environments, for all regions.
+	operationDoc.UsesNewExternalAuthDeletionApproach = true
 	if request != nil {
 		// these are optional because when this is triggered via the subscription deletion flow, there is no
 		// deletion request containing these headers so these operations cannot be directly tracked.
@@ -664,6 +638,9 @@ func (f *Frontend) addDeleteExternalAuthToTransaction(ctx context.Context, write
 	}
 	externalAuth.ServiceProviderProperties.ActiveOperationID = operationDoc.ResourceID.Name
 	externalAuth.Properties.ProvisioningState = operationDoc.Status
+	// TODO remove this once migration of the new external auth deletion from frontend to backend approach is fully completed in all ARO-HCP
+	// permanent environments, for all regions.
+	externalAuth.ServiceProviderProperties.UsesNewExternalAuthDeletionApproach = true
 	_, err = f.resourcesDBClient.HCPClusters(externalAuth.ID.SubscriptionID, externalAuth.ID.ResourceGroupName).ExternalAuth(externalAuth.ID.Parent.Name).
 		AddReplaceToTransaction(ctx, transaction, externalAuth, nil)
 	if err != nil {

--- a/frontend/pkg/frontend/node_pool.go
+++ b/frontend/pkg/frontend/node_pool.go
@@ -17,7 +17,6 @@ package frontend
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"maps"
 	"net/http"
@@ -30,8 +29,6 @@ import (
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
-
-	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
 
 	"github.com/Azure/ARO-HCP/internal/admission"
 	"github.com/Azure/ARO-HCP/internal/api"
@@ -734,26 +731,6 @@ func (f *Frontend) DeleteNodePool(writer http.ResponseWriter, request *http.Requ
 		return utils.TrackError(err)
 	}
 
-	// Temporary check until creation and deletion interaction with CS is moved to the backend: if a delete arrives and the node
-	// pool has not been created in CS or the ClusterServiceID reference has not been persisted in Cosmos, return an error.
-	if nodePool.ServiceProviderProperties.ClusterServiceID == nil || len(nodePool.ServiceProviderProperties.ClusterServiceID.String()) == 0 {
-		return utils.TrackError(fmt.Errorf("serviceProviderProperties.clusterServiceID is required to delete a node pool"))
-	}
-
-	err = f.clusterServiceClient.DeleteNodePool(ctx, *nodePool.ServiceProviderProperties.ClusterServiceID)
-	var ocmError *ocmerrors.Error
-	if errors.As(err, &ocmError) && ocmError.Status() == http.StatusNotFound {
-		// StatusNotFound means we have stale data in Cosmos DB.
-		// This can happen in test environments if a user bypasses
-		// the RP to delete a resource (e.g. "ocm delete"). It can
-		// also happen if an asynchronous deletion operation fails.
-		// we will fall through and cancel all operations and go through as normal a deletion flow as we can to avoid
-		// leaking data related to the resource, like controller status.
-		logger.Info("clusterService nodepool missing, trying to clean up", "err", err)
-	} else if err != nil {
-		return utils.TrackError(err)
-	}
-
 	transaction := f.resourcesDBClient.NewTransaction(nodePool.ID.SubscriptionID)
 	if err := f.addDeleteNodePoolToTransaction(ctx, writer, request, transaction, nodePool); err != nil {
 		return utils.TrackError(err)
@@ -784,21 +761,18 @@ func (f *Frontend) addDeleteNodePoolToTransaction(ctx context.Context, writer ht
 		return utils.TrackError(err)
 	}
 
-	// Temporary check until creation and deletion interaction with CS is moved to the backend: if a delete arrives and the node pool
-	// has not been created in CS or the ClusterServiceID reference has not been persisted in Cosmos, return an error.
-	if nodePool.ServiceProviderProperties.ClusterServiceID == nil || len(nodePool.ServiceProviderProperties.ClusterServiceID.String()) == 0 {
-		return utils.TrackError(fmt.Errorf("serviceProviderProperties.clusterServiceID is required to delete a node pool"))
-	}
-
 	operationDoc := database.NewOperation(
 		database.OperationRequestDelete,
 		nodePool.ID,
-		*nodePool.ServiceProviderProperties.ClusterServiceID,
+		api.InternalID{},
 		f.azureLocation,
 		"",
 		"",
 		"",
 		correlationData)
+	// TODO remove this once migration of the new node pool deletion from frontend to backend approach is fully completed in all ARO-HCP
+	// permanent environments, for all regions.
+	operationDoc.UsesNewNodePoolDeletionApproach = true
 	if request != nil {
 		// these are optional because when this is triggered via the subscription deletion flow, there is no
 		// deletion request containing these headers so these operations cannot be directly tracked.
@@ -817,6 +791,9 @@ func (f *Frontend) addDeleteNodePoolToTransaction(ctx context.Context, writer ht
 	}
 	nodePool.ServiceProviderProperties.ActiveOperationID = operationDoc.ResourceID.Name
 	nodePool.Properties.ProvisioningState = operationDoc.Status
+	// TODO remove this once migration of the new node pool deletion from frontend to backend approach is fully completed in all ARO-HCP
+	// permanent environments, for all regions.
+	nodePool.ServiceProviderProperties.UsesNewNodePoolDeletionApproach = true
 	_, err = f.resourcesDBClient.HCPClusters(nodePool.ID.SubscriptionID, nodePool.ID.ResourceGroupName).NodePools(nodePool.ID.Parent.Name).
 		AddReplaceToTransaction(ctx, transaction, nodePool, nil)
 	if err != nil {

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-cluster-operation/03-cosmosCompare-final-state/cluster-test-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-cluster-operation/03-cosmosCompare-final-state/cluster-test-cluster.json
@@ -68,7 +68,7 @@
 			"managedIdentitiesDataPlaneIdentityURL": "https://dummyhost.identity.azure.net/otherinformation?aqueryarg=somevalue",
 			"platform": {},
 			"provisioningState": "Deleting",
-			"usesNewClusterDeletionApproach": false
+			"usesNewClusterDeletionApproach": true
 		},
 		"status": {},
 		"systemData": {

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-cluster-operation/03-cosmosCompare-final-state/operation-cluster-delete.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-cluster-operation/03-cosmosCompare-final-state/operation-cluster-delete.json
@@ -5,7 +5,7 @@
 		"request": "Delete",
 		"status": "Deleting",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewClusterDeletionApproach": false,
+		"usesNewClusterDeletionApproach": true,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/cluster-test-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/cluster-test-cluster.json
@@ -68,7 +68,7 @@
 			"managedIdentitiesDataPlaneIdentityURL": "https://dummyhost.identity.azure.net/otherinformation?aqueryarg=somevalue",
 			"platform": {},
 			"provisioningState": "Deleting",
-			"usesNewClusterDeletionApproach": false
+			"usesNewClusterDeletionApproach": true
 		},
 		"status": {},
 		"systemData": {

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/nodepool-test-nodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/nodepool-test-nodepool.json
@@ -42,7 +42,7 @@
 			}
 		},
 		"serviceProviderProperties": {
-			"usesNewNodePoolDeletionApproach": false
+			"usesNewNodePoolDeletionApproach": true
 		},
 		"status": {},
 		"systemData": {

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/operation-cluster-delete.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/operation-cluster-delete.json
@@ -5,7 +5,7 @@
 		"request": "Delete",
 		"status": "Deleting",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewClusterDeletionApproach": false,
+		"usesNewClusterDeletionApproach": true,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/operation-nodepool-delete.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/operation-nodepool-delete.json
@@ -6,7 +6,7 @@
 		"status": "Deleting",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
-		"usesNewNodePoolDeletionApproach": false
+		"usesNewNodePoolDeletionApproach": true
 	},
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",
 	"ttl": 604800

--- a/test/e2e/external_auth_list_and_verify.go
+++ b/test/e2e/external_auth_list_and_verify.go
@@ -17,13 +17,16 @@ package e2e
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"k8s.io/apimachinery/pkg/util/rand"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 
 	hcpsdk "github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
@@ -198,6 +201,40 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to get updated external auth config from cluster %s", clusterName)
 			Expect(*updatedResult.Properties.ProvisioningState).To(Equal(hcpsdk.ExternalAuthProvisioningStateSucceeded), "updated external auth provisioning state should be Succeeded")
 			Expect(*updatedResult.Properties.Claim.Mappings.Username.Prefix).To(Equal(*expectedExternalAuth.Properties.Claim.Mappings.Username.Prefix), "updated external auth Username.Prefix should match expected value")
+
+			By("deleting the external auth")
+			err = framework.DeleteExternalAuthAndWait20240610(
+				ctx,
+				externalAuthClient,
+				*resourceGroup.Name,
+				clusterName,
+				*expectedExternalAuth.Name,
+				framework.ExternalAuthDeletionTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to delete external auth config on cluster %s", clusterName)
+
+			By("confirming the external auth has been deleted")
+			_, getErr := framework.GetExternalAuth20240610(
+				ctx,
+				externalAuthClient,
+				*resourceGroup.Name,
+				clusterName,
+				*expectedExternalAuth.Name,
+			)
+			Expect(getErr).To(HaveOccurred(), "expected error when getting deleted external auth %s on cluster %s", *expectedExternalAuth.Name, clusterName)
+			var respErr *azcore.ResponseError
+			Expect(errors.As(getErr, &respErr)).To(BeTrue(), "expected azcore.ResponseError when getting deleted external auth %s", *expectedExternalAuth.Name)
+			Expect(respErr.StatusCode).To(Equal(http.StatusNotFound), "expected HTTP 404 when getting deleted external auth %s", *expectedExternalAuth.Name)
+
+			By("confirming list returns no external auth configs")
+			var extAuthCount int
+			pager = externalAuthClient.NewListByParentPager(*resourceGroup.Name, clusterName, nil)
+			for pager.More() {
+				page, err := pager.NextPage(ctx)
+				Expect(err).NotTo(HaveOccurred(), "failed to list external auth configs on cluster %s after delete", clusterName)
+				extAuthCount += len(page.Value)
+			}
+			Expect(extAuthCount).To(Equal(0), "expected no external auth configs on cluster %s after delete", clusterName)
 
 		})
 })

--- a/test/util/framework/constants.go
+++ b/test/util/framework/constants.go
@@ -28,7 +28,8 @@ const (
 
 // Deletion timeouts
 const (
-	HCPClusterDeletionTimeout = 45 * time.Minute
+	HCPClusterDeletionTimeout   = 45 * time.Minute
+	ExternalAuthDeletionTimeout = 25 * time.Minute
 )
 
 // Resource Update timeouts


### PR DESCRIPTION
MR that enables the deletion interaction with CS to be in the backend, for clusters, nodepools and externalauths combined.