### PR TITLE
fix: set kusto.location to eastus2 for eastus2euap prod region

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -48,6 +48,9 @@ clouds:
             audit:
               connectSocket: true
         regions:
+          eastus2euap:
+            kusto:
+              location: "eastus2"
           switzerlandnorth:
             kusto:
               kustoName: "hcp-prod-ch-2"


### PR DESCRIPTION
## Why

`kusto.location` defaults to `{{ .ctx.region }}`, which for `eastus2euap` renders as `eastus2euap`. However, `eastus2euap` is a canary subregion of `eastus2` — the geo-level Kusto cluster (`hcp-prod-usc`) actually lives in `eastus2`. This makes `kusto.location` incorrect for Bicep deployments that scope to the Kusto cluster's actual location (e.g. `audit-logs-data-connection.bicep`).