### PR TITLE
Use the HostedClusterAvailable condition

### DIFF
--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_create.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_create.go
@@ -231,9 +231,9 @@ func (c *operationClusterCreate) clusterOperationStatus(ctx context.Context, ope
 // control plane validation success.
 var minVersionsWithValidSuccessCondition = map[string]semver.Version{
 	"4.19": api.Must(semver.Parse("4.19.999")),
-	"4.20": api.Must(semver.Parse("4.20.999")),
-	"4.21": api.Must(semver.Parse("4.21.999")),
-	"4.22": api.Must(semver.Parse("4.22.999")),
+	"4.20": api.Must(semver.Parse("4.20.15")),
+	"4.21": api.Must(semver.Parse("4.21.1")),
+	"4.22": api.Must(semver.Parse("4.22.0")),
 }
 
 func (c *operationClusterCreate) hostedClusterOperationStatus(ctx context.Context, operation *api.Operation) (*operationState, error) {


### PR DESCRIPTION
hypershift#7434 merged to improve thsi condition. It was backported

- 4.22 — #7434 (original). Fix version 4.22.0.
- 4.21 — #7604 cherry-pick.
- 4.20 — #7616 (slightly refined title: "check components are available before setting HostedCluster available").

- 4.21 — shipped in 4.21.1 via RHSA-2026:2129 (2026-02-10)  https://access.redhat.com/errata/RHSA-2026:2129
- 4.20 — shipped in 4.20.15 via RHBA-2026:2987 (2026-02-25) https://access.redhat.com/errata/RHBA-2026:2987

