### PR TITLE
test(e2e): use general-purpose Standard_D2s_v5 for authorized-CIDRs test VM (AROSLSRE-1156)

### DIFF
--- a/test/e2e-setup/bicep/modules/test-vm.bicep
+++ b/test/e2e-setup/bicep/modules/test-vm.bicep
@@ -14,7 +14,7 @@ param adminUsername string = 'azureuser'
 param sshPublicKey string
 
 @description('VM size')
-param vmSize string = 'Standard_B2s'
+param vmSize string = 'Standard_D2s_v5'
 
 @description('Location for the VM')
 param location string = resourceGroup().location

--- a/test/e2e/cluster_authorized_cidrs_connectivity.go
+++ b/test/e2e/cluster_authorized_cidrs_connectivity.go
@@ -95,10 +95,20 @@ var _ = Describe("Authorized CIDRs", func() {
 
 				By("deploying test VM")
 				vmName := fmt.Sprintf("%s-test-vm", clusterName)
+				// The test VM is a throwaway kubectl client: it only needs a public IP
+				// (used as the single authorized CIDR) and to make one API call to the
+				// cluster. We use the common general-purpose Standard_D2s_v5 (same 2-vCPU
+				// size as the old burstable Standard_B2s) because the burstable B-series
+				// is the SKU class most prone to regional SkuNotAvailable capacity
+				// restrictions, which is what flaked this test.
+				const vmSize = "Standard_D2s_v5"
 				var vmDeployment *armresources.DeploymentExtended
-				Eventually(func() error {
-					var err error
-					vmDeployment, err = tc.CreateBicepTemplateAndWait(ctx,
+				var deployErr error
+				// Bounded retry to absorb transient ARM errors, but fail fast on
+				// SkuNotAvailable: a regional capacity restriction is not transient, so
+				// re-submitting an identical request only burns the timeout budget.
+				for attempt := 0; attempt < 3; attempt++ {
+					vmDeployment, deployErr = tc.CreateBicepTemplateAndWait(ctx,
 						framework.WithTemplateFromFS(TestArtifactsFS, "test-artifacts/generated-test-artifacts/modules/test-vm.json"),
 						framework.WithDeploymentName("test-vm"),
 						framework.WithScope(framework.BicepDeploymentScopeResourceGroup),
@@ -108,11 +118,16 @@ var _ = Describe("Authorized CIDRs", func() {
 							"vnetName":     customerVnetName,
 							"subnetName":   customerVnetSubnetName,
 							"sshPublicKey": sshPublicKey,
+							"vmSize":       vmSize,
 						}),
 						framework.WithTimeout(30*time.Minute),
 					)
-					return err
-				}, 30*time.Minute, 20*time.Second).Should(Succeed())
+					if deployErr == nil || strings.Contains(deployErr.Error(), "SkuNotAvailable") {
+						break
+					}
+					time.Sleep(20 * time.Second)
+				}
+				Expect(deployErr).NotTo(HaveOccurred(), "failed to deploy test VM")
 
 				By("extracting VM public IP from deployment outputs")
 				vmPublicIP, err := framework.GetOutputValueString(vmDeployment, "publicIP")


### PR DESCRIPTION
[AROSLSRE-1156](https://redhat.atlassian.net/browse/AROSLSRE-1156)

### What

Stop the `Authorized CIDRs Connectivity` e2e spec from deploying its throwaway test VM on the burstable `Standard_B2s` SKU. The Bicep default and the value the test passes are now the common general-purpose `Standard_D2s_v5` (same 2 vCPU / 8 GB size). The deploy keeps a small bounded retry for transient ARM errors but now fails fast on `SkuNotAvailable` instead of re-submitting an identical request for the full 30-minute budget.

### Why

In a recent PR e2e run the test failed purely in its setup fixture — never reaching the ARO-HCP RP — because ARM rejected every VM deploy at preflight:

```
SkuNotAvailable: 'Standard_B2s' is currently not available in location 'WestUS3' (Capacity Restrictions)
```

The SKU was fixed and the deploy was wrapped in `Eventually(30m, 20s)`, so ~90 identical attempts all failed and the spec timed out after 1800s at `cluster_authorized_cidrs_connectivity.go:115`. Burstable B-series is the SKU class most prone to per-region capacity restrictions; `Standard_D2s_v5` is a broadly available general-purpose SKU. The VM is only a kubectl client (it needs a public IP + one API call), so the general-purpose SKU removes the capacity-restriction dependency, and failing fast on `SkuNotAvailable` stops wasting the timeout budget on an unrecoverable error.

### Testing

`go build ./e2e/...` and `go vet ./e2e/` pass. The generated `test-vm.json` is a gitignored build artifact regenerated from the Bicep (`make -C test update` / `az bicep build`); CI regenerates it, so it is not committed. The change is exercised by the existing `Authorized CIDRs Connectivity` e2e spec.

### Special notes for your reviewer

No behavioural change to the test other than the VM SKU and fail-fast-on-`SkuNotAvailable`. Other fixtures (e.g. nodepool `Standard_D8s_v3`) are intentionally unchanged. (Branch name still says "fallback" from an earlier iteration that tried multiple Dsv generations; that cross-SKU fallback was dropped as unnecessary — the single general-purpose SKU is the fix.)

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
