### PR TITLE
feat: grant Grafana MI Monitoring Reader on global/svc/mgmt subscriptions

### DIFF
--- a/dev-infrastructure/configurations/grafana-monitoring-reader.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/grafana-monitoring-reader.tmpl.bicepparam
@@ -1,0 +1,3 @@
+using '../templates/grafana-monitoring-reader.bicep'
+
+param grafanaPrincipalId = '__grafanaPrincipalId__'

--- a/dev-infrastructure/global-pipeline.yaml
+++ b/dev-infrastructure/global-pipeline.yaml
@@ -49,6 +49,20 @@ resourceGroups:
     dependsOn:
     - resourceGroup: singleton
       step: infra
+  - name: grafana-monitoring-reader
+    action: ARM
+    template: templates/grafana-monitoring-reader.bicep
+    parameters: configurations/grafana-monitoring-reader.tmpl.bicepparam
+    deploymentLevel: Subscription
+    variables:
+    - name: grafanaPrincipalId
+      input:
+        resourceGroup: singleton
+        step: output
+        name: grafanaPrincipalId
+    dependsOn:
+    - resourceGroup: singleton
+      step: output
   - name: global-kv-private-issuer
     action: SetCertificateIssuer
     secretKeyVault:

--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -95,6 +95,17 @@ resourceGroups:
   resourceGroup: '{{ .mgmt.rg }}'
   subscription: '{{ .mgmt.subscription.key }}'
   steps:
+  - name: grafana-monitoring-reader
+    action: ARM
+    template: templates/grafana-monitoring-reader.bicep
+    parameters: configurations/grafana-monitoring-reader.tmpl.bicepparam
+    deploymentLevel: Subscription
+    variables:
+    - name: grafanaPrincipalId
+      input:
+        resourceGroup: global
+        step: output
+        name: grafanaPrincipalId
   - name: subscription-output
     action: ARM
     template: templates/subscription-lookup.bicep

--- a/dev-infrastructure/svc-pipeline.yaml
+++ b/dev-infrastructure/svc-pipeline.yaml
@@ -84,6 +84,17 @@ resourceGroups:
   resourceGroup: '{{ .svc.rg }}'
   subscription: '{{ .svc.subscription.key }}'
   steps:
+  - name: grafana-monitoring-reader
+    action: ARM
+    template: templates/grafana-monitoring-reader.bicep
+    parameters: configurations/grafana-monitoring-reader.tmpl.bicepparam
+    deploymentLevel: Subscription
+    variables:
+    - name: grafanaPrincipalId
+      input:
+        resourceGroup: global
+        step: output
+        name: grafanaPrincipalId
   # Create SVC KV
   - name: infra
     action: ARM

--- a/dev-infrastructure/templates/grafana-monitoring-reader.bicep
+++ b/dev-infrastructure/templates/grafana-monitoring-reader.bicep
@@ -1,0 +1,24 @@
+targetScope = 'subscription'
+
+@description('The principal ID of the global Grafana managed identity')
+param grafanaPrincipalId string
+
+// Monitoring Reader lets the Grafana managed identity read Azure Monitor
+// platform metrics (the built-in azure-monitor-oob datasource) for every
+// resource in this subscription. Granting at subscription scope avoids a
+// per-resource role assignment for each new metric source.
+// https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#monitoring-reader
+var monitoringReaderRoleId = subscriptionResourceId(
+  'Microsoft.Authorization/roleDefinitions',
+  '43d0d8ad-25c7-4714-9337-8ba259a9fe05'
+)
+
+resource grafanaMonitoringReader 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(subscription().id, grafanaPrincipalId, monitoringReaderRoleId)
+  scope: subscription()
+  properties: {
+    principalId: grafanaPrincipalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: monitoringReaderRoleId
+  }
+}


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-973

### What

Grants the global Grafana managed identity the **Monitoring Reader** built-in role at **subscription scope** across the **global**, **svc**, and **mgmt** subscriptions.

Adds:
- `dev-infrastructure/templates/grafana-monitoring-reader.bicep` (`targetScope = 'subscription'`) + its `.tmpl.bicepparam`
- A `deploymentLevel: Subscription` ARM step in `global-pipeline.yaml`, `svc-pipeline.yaml`, and `mgmt-pipeline.yaml`, each sourcing `grafanaPrincipalId` from the existing global `output` step.

No dashboards, no `grafanactl`, no datasource-creation code.

### Why

Azure Managed Grafana **auto-provisions** the built-in Azure Monitor datasource (`azure-monitor-oob`) when the Grafana resource is created. Nothing in this repo "registers" that datasource — the only thing standing between Grafana and Azure Monitor platform metrics is **RBAC**. Without a Monitoring Reader grant the datasource exists but every query returns 403; with it, the same datasource can read metrics for every resource in scope.

Granting once per subscription (rather than per-resource) means any future Azure Monitor use case — Front Door, PostgreSQL Flexible Server, storage, AKS, etc. — works with no further role-assignment PRs.

This implements the review feedback on #5327 (janboll: grant Monitoring access to the global, svc and mgmt subscriptions; "We will have plenty of usecases for this").

### Design notes for reviewers

- **Why a new template, not an extension of `observability-permissions.bicep`?** That module is resource-group-scoped (its AFD grant uses `scope: resourceGroup()`), and a Bicep file may declare only one `targetScope`. A subscription-scoped grant therefore needs its own file. This follows the existing subscription-scoped permission convention (`exporter-permissions.bicep`, `pipeline-msi-reader-permissions.bicep`).
- **Idempotency:** the role-assignment name is `guid(subscription().id, grafanaPrincipalId, roleDefinitionId)` — deterministic, so redeploys are no-ops rather than 409s.
- **Placement:** the global grant lives in the `singleton`/global-subscription block right after the `output` step (same block that creates Grafana), so it shares Grafana's execution constraints. The svc and mgmt grants live in their respective subscription blocks.

### Testing

- `bicep build dev-infrastructure/templates/grafana-monitoring-reader.bicep` — builds clean as a subscription deployment, no warnings.
- `make validate-config-pipelines ONLY_CHANGED=--only-changed` — passes for all three edited pipelines.

### PR Checklist

- [x] PR is scoped to a single task
- [x] Title follows Conventional Commits
- [x] Summary explains the "Why"
- [x] Linked to relevant context (#5327)
- [x] Self-reviewed the diff
