### PR TITLE
feat(tenant-quota): detect expired e2e resource groups via configurable collector

### DIFF
--- a/tooling/tenant-quota/.gitignore
+++ b/tooling/tenant-quota/.gitignore
@@ -1,2 +1,5 @@
 _output
 tenant-quota-collector
+
+# Override ignored directories from the root directory's .gitignore
+!pkg/resourcegroups/

--- a/tooling/tenant-quota/alerting.bicep
+++ b/tooling/tenant-quota/alerting.bicep
@@ -13,6 +13,11 @@ param alertingEnabled bool = true
 // Usage/limit ratio excluding Network Watchers
 var azureQuotaUsageRatioFiltered = 'azure_quota_usage{localized_name!~"(?i)^network watchers$"} / azure_quota_limit{localized_name!~"(?i)^network watchers$"}'
 
+// E2E resource group alert thresholds — relaxed initially; see TODOs on each rule
+var e2eExpiredCountInfoThreshold = 10 // TODO: tighten to 0 once cleanup-sweeper reliably clears expired RGs
+var e2eExpiredCountEscalationThreshold = 25 // TODO: tighten to 5 once cleanup-sweeper baseline improves
+var e2eMaxExpiredAgeSeconds = 604800 // 7 days; TODO: tighten to 86400 (1 day)
+
 // Prometheus Rule Group for tenant-quota alerts
 resource tenantQuotaAlerts 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
   name: 'tenant-quota-alerts'
@@ -249,5 +254,112 @@ resource subscriptionQuotaAlerts 'Microsoft.AlertsManagement/prometheusRuleGroup
   }
 }
 
+resource e2eExpiredRGAlerts 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'e2e-expired-resource-group-alerts'
+  location: resourceGroup().location
+  properties: {
+    enabled: alertingEnabled
+    interval: 'PT1M'
+    scopes: [
+      azureMonitorWorkspaceId
+    ]
+    rules: [
+      {
+        alert: 'E2EExpiredResourceGroupsInfo'
+        enabled: true
+        expression: 'count by (subscription_id, subscription_name) (e2e_resource_group_expiry_timestamp < time()) > ${e2eExpiredCountInfoThreshold}'
+        for: 'PT2H'
+        severity: 4
+        labels: {
+          severity: 'info'
+        }
+        annotations: {
+          summary: 'Expired E2E resource groups detected'
+          description: '{{ $value }} E2E resource groups past their deleteAfter TTL in {{ $labels.subscription_name }}. Check the cleanup-sweeper and periodic cleanup job.'
+        }
+        actions: [
+          {
+            actionGroupId: sharedActionGroupId
+          }
+        ]
+        resolveConfiguration: {
+          autoResolved: true
+          timeToResolve: 'PT10M'
+        }
+      }
+      {
+        alert: 'E2EExpiredResourceGroupsEscalation'
+        enabled: true
+        expression: 'count by (subscription_id, subscription_name) (e2e_resource_group_expiry_timestamp < time()) > ${e2eExpiredCountEscalationThreshold}'
+        for: 'PT2H'
+        severity: 4
+        labels: {
+          severity: 'info'
+        }
+        annotations: {
+          summary: 'Many expired E2E resource groups detected'
+          description: '{{ $value }} E2E resource groups past their deleteAfter TTL in {{ $labels.subscription_name }}. Resource cleanup is likely broken.'
+        }
+        actions: [
+          {
+            actionGroupId: sharedActionGroupId
+          }
+        ]
+        resolveConfiguration: {
+          autoResolved: true
+          timeToResolve: 'PT10M'
+        }
+      }
+      {
+        alert: 'E2EExpiredResourceGroupStale'
+        enabled: true
+        expression: 'max by (subscription_id, subscription_name) (time() - (e2e_resource_group_expiry_timestamp < time())) > ${e2eMaxExpiredAgeSeconds}'
+        for: 'PT15M'
+        severity: 4
+        labels: {
+          severity: 'info'
+        }
+        annotations: {
+          summary: 'E2E resource group expired for over {{ $value | humanizeDuration }}'
+          description: 'Oldest expired E2E resource group in {{ $labels.subscription_name }} has been past its TTL for {{ $value | humanizeDuration }}. Manual cleanup may be required.'
+        }
+        actions: [
+          {
+            actionGroupId: sharedActionGroupId
+          }
+        ]
+        resolveConfiguration: {
+          autoResolved: true
+          timeToResolve: 'PT10M'
+        }
+      }
+      {
+        alert: 'E2EResourceGroupMetricsStale'
+        enabled: true
+        expression: 'absent(e2e_resource_group_expiry_timestamp)'
+        for: 'PT30M'
+        severity: 2
+        labels: {
+          severity: 'critical'
+        }
+        annotations: {
+          summary: 'E2E resource group metrics are stale'
+          description: 'No e2e_resource_group_expiry_timestamp metrics received for 30 minutes. The resource group collector may have stopped. Check the tenant-quota-collector pod status and Prometheus scrape target health.'
+        }
+        actions: [
+          {
+            actionGroupId: sharedActionGroupId
+          }
+        ]
+        resolveConfiguration: {
+          autoResolved: true
+          timeToResolve: 'PT10M'
+        }
+      }
+    ]
+  }
+}
+
 output alertRuleGroupId string = tenantQuotaAlerts.id
 output subscriptionAlertRuleGroupId string = subscriptionQuotaAlerts.id
+output e2eExpiredRGAlertRuleGroupId string = e2eExpiredRGAlerts.id

--- a/tooling/tenant-quota/go.mod
+++ b/tooling/tenant-quota/go.mod
@@ -9,8 +9,10 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6 v6.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6 v6.2.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.3.0
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/apimachinery v0.35.3
 )
@@ -18,6 +20,7 @@ require (
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v3 v3.1.1 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups v1.2.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v3 v3.0.1 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.7.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -30,7 +33,6 @@ require (
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect

--- a/tooling/tenant-quota/go.sum
+++ b/tooling/tenant-quota/go.sum
@@ -17,6 +17,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0 h1:PTFG
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0/go.mod h1:LRr2FzBTQlONPPa5HREE5+RjSCTXl7BwOvYOaWTqCaI=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v3 v3.1.1 h1:1kpY4qe+BGAH2ykv4baVSqyx+AY5VjXeJ15SldlU6hs=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v3 v3.1.1/go.mod h1:nT6cWpWdUt+g81yuKmjeYPUtI73Ak3yQIT4PVVsCEEQ=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups v1.2.0 h1:akP6VpxJGgQRpDR1P462piz/8OhYLRCreDj48AyNabc=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups v1.2.0/go.mod h1:8wzvopPfyZYPaQUoKW87Zfdul7jmJMDfp/k7YY3oJyA=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6 v6.2.0 h1:HYGD75g0bQ3VO/Omedm54v4LrD3B1cGImuRF3AJ5wLo=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6 v6.2.0/go.mod h1:ulHyBFJOI0ONiRL4vcJTmS7rx18jQQlEPmAgo80cRdM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armdeployments v0.2.0 h1:bYq3jfB2x36hslKMHyge3+esWzROtJNk/4dCjsKlrl4=

--- a/tooling/tenant-quota/main.go
+++ b/tooling/tenant-quota/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/Azure/ARO-HCP/internal/version"
 	"github.com/Azure/ARO-HCP/tooling/tenant-quota/pkg/config"
 	"github.com/Azure/ARO-HCP/tooling/tenant-quota/pkg/credentials"
+	"github.com/Azure/ARO-HCP/tooling/tenant-quota/pkg/resourcegroups"
 	"github.com/Azure/ARO-HCP/tooling/tenant-quota/pkg/subscriptionquota"
 	"github.com/Azure/ARO-HCP/tooling/tenant-quota/pkg/tenantquota"
 )
@@ -89,6 +90,10 @@ func run(logger *slog.Logger) error {
 		subCollector := subscriptionquota.NewCollector(cfg, logger, credProvider, cfg.GetCacheTTL())
 		registry.MustRegister(subCollector)
 		go subCollector.Start(ctx)
+
+		e2eRGCollector := resourcegroups.NewCollector(resourcegroups.E2ECollectorConfig, cfg, logger, credProvider)
+		registry.MustRegister(e2eRGCollector)
+		go e2eRGCollector.Start(ctx)
 	}
 
 	mux := http.NewServeMux()

--- a/tooling/tenant-quota/pkg/resourcegroups/collector.go
+++ b/tooling/tenant-quota/pkg/resourcegroups/collector.go
@@ -1,0 +1,196 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourcegroups
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
+	"github.com/Azure/ARO-HCP/tooling/tenant-quota/pkg/config"
+	"github.com/Azure/ARO-HCP/tooling/tenant-quota/pkg/credentials"
+)
+
+// Collector tracks resource groups matching a tag filter across configured
+// subscriptions and exposes a per-resource-group Prometheus gauge with the
+// deleteAfter TTL timestamp. Consumers derive expired counts, max staleness,
+// etc. via PromQL. Azure API calls happen only in the background collection
+// loop; scrapes read from cached metric values.
+type Collector struct {
+	collectorCfg CollectorConfig
+	config       *config.Config
+	logger       *slog.Logger
+	credProvider *credentials.Provider
+	lister       ResourceGroupLister
+	expiryDesc   *prometheus.Desc
+	mu           sync.RWMutex
+	metrics      []prometheus.Metric
+}
+
+func NewCollector(collectorCfg CollectorConfig, cfg *config.Config, logger *slog.Logger, credProvider *credentials.Provider, lister ...ResourceGroupLister) *Collector {
+	var l ResourceGroupLister
+	if len(lister) > 0 {
+		l = lister[0]
+	}
+	return &Collector{
+		collectorCfg: collectorCfg,
+		config:       cfg,
+		logger:       logger,
+		credProvider: credProvider,
+		lister:       l,
+		expiryDesc: prometheus.NewDesc(
+			fmt.Sprintf("%s_expiry_timestamp", collectorCfg.MetricPrefix),
+			fmt.Sprintf("Unix timestamp of the deleteAfter TTL tag for each %s", collectorCfg.Name),
+			[]string{"resource_group", "region", "subscription_id", "subscription_name"}, nil,
+		),
+	}
+}
+
+func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.expiryDesc
+}
+
+func (c *Collector) Collect(ch chan<- prometheus.Metric) {
+	c.mu.RLock()
+	metrics := c.metrics
+	c.mu.RUnlock()
+	for _, m := range metrics {
+		ch <- m
+	}
+}
+
+// Start runs the background collection loop. It collects immediately on
+// startup, then on every interval tick.
+func (c *Collector) Start(ctx context.Context) {
+	defer utilruntime.HandleCrash()
+	interval := c.config.GetInterval()
+	c.logger.Info("Starting resource group collection",
+		"collector", c.collectorCfg.Name,
+		"interval", interval)
+
+	c.collectAll(ctx)
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			c.logger.Info("Stopping resource group collection", "collector", c.collectorCfg.Name)
+			return
+		case <-ticker.C:
+			c.collectAll(ctx)
+		}
+	}
+}
+
+func (c *Collector) collectAll(ctx context.Context) {
+	var metrics []prometheus.Metric
+
+	for _, tenant := range c.config.Tenants {
+		if len(tenant.Subscriptions) == 0 {
+			continue
+		}
+
+		var lister ResourceGroupLister
+		if c.lister != nil {
+			lister = c.lister
+		} else {
+			cred, err := c.credProvider.GetCredential(tenant)
+			if err != nil {
+				c.logger.Error("Failed to get credential for tenant",
+					"tenant", tenant.GetDisplayName(),
+					"error", err)
+				continue
+			}
+			lister = &AzureResourceGroupLister{cred: cred, filter: c.collectorCfg.TagFilter}
+		}
+
+		for _, sub := range tenant.Subscriptions {
+			subMetrics := c.collectSubscription(ctx, lister, sub)
+			metrics = append(metrics, subMetrics...)
+		}
+	}
+
+	c.mu.Lock()
+	c.metrics = metrics
+	c.mu.Unlock()
+}
+
+func (c *Collector) collectSubscription(ctx context.Context, lister ResourceGroupLister, sub config.SubscriptionConfig) []prometheus.Metric {
+	collectCtx, cancel := context.WithTimeout(ctx, c.config.GetTimeout())
+	defer cancel()
+
+	rgs, err := lister.ListResourceGroups(collectCtx, sub.SubscriptionID)
+	if err != nil {
+		c.logger.Error("Failed to list resource groups",
+			"collector", c.collectorCfg.Name,
+			"subscription", sub.Name,
+			"error", err)
+		// Return nil so this subscription contributes no metrics to the
+		// current cycle. The full metrics slice is replaced atomically in
+		// collectAll, so the subscription's gauges disappear until the next
+		// successful collection rather than persisting stale values.
+		return nil
+	}
+
+	var metrics []prometheus.Metric
+
+	ttlKey := c.collectorCfg.TTLTagKey
+	for _, rg := range rgs {
+		rgName := ""
+		if rg.Name != nil {
+			rgName = *rg.Name
+		}
+		region := ""
+		if rg.Location != nil {
+			region = *rg.Location
+		}
+
+		expiryTag := rg.Tags[ttlKey]
+		if expiryTag == nil {
+			continue
+		}
+
+		expiry, err := time.Parse(time.RFC3339, *expiryTag)
+		if err != nil {
+			c.logger.Warn("Failed to parse TTL tag",
+				"resourceGroup", rgName,
+				"tagKey", ttlKey,
+				"value", *expiryTag,
+				"error", err)
+			continue
+		}
+
+		metrics = append(metrics, prometheus.MustNewConstMetric(
+			c.expiryDesc, prometheus.GaugeValue, float64(expiry.Unix()),
+			rgName, region, sub.SubscriptionID, sub.Name,
+		))
+	}
+
+	c.logger.Info("Collected resource group metrics",
+		"collector", c.collectorCfg.Name,
+		"subscription", sub.Name,
+		"totalRGs", len(rgs),
+		"rgsWithTTL", len(metrics))
+
+	return metrics
+}

--- a/tooling/tenant-quota/pkg/resourcegroups/collector_test.go
+++ b/tooling/tenant-quota/pkg/resourcegroups/collector_test.go
@@ -1,0 +1,341 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourcegroups
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+
+	"github.com/Azure/ARO-HCP/tooling/tenant-quota/pkg/config"
+)
+
+type fakeLister struct {
+	rgs map[string][]*armresources.ResourceGroup
+	err error
+}
+
+func (f *fakeLister) ListResourceGroups(_ context.Context, subscriptionID string) ([]*armresources.ResourceGroup, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.rgs[subscriptionID], nil
+}
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func testConfig(subs ...config.SubscriptionConfig) *config.Config {
+	cfg := &config.Config{
+		Interval: "1m",
+		Timeout:  "10s",
+		Tenants: []config.TenantConfig{
+			{
+				TenantID:                 "test-tenant",
+				ServicePrincipalClientId: "test-sp",
+				KeyVaultSecretName:       "test-secret",
+				Subscriptions:            subs,
+			},
+		},
+	}
+	if err := cfg.Validate(); err != nil {
+		panic(fmt.Sprintf("invalid test config: %v", err))
+	}
+	return cfg
+}
+
+func makeRG(name, location string, tags map[string]*string) *armresources.ResourceGroup {
+	return &armresources.ResourceGroup{
+		Name:     to.Ptr(name),
+		Location: to.Ptr(location),
+		Tags:     tags,
+	}
+}
+
+func collectMetrics(c *Collector) []prometheus.Metric {
+	ch := make(chan prometheus.Metric)
+	go func() {
+		c.Collect(ch)
+		close(ch)
+	}()
+	var metrics []prometheus.Metric
+	for m := range ch {
+		metrics = append(metrics, m)
+	}
+	return metrics
+}
+
+type metricInfo struct {
+	resourceGroup    string
+	region           string
+	subscriptionID   string
+	subscriptionName string
+	timestamp        float64
+}
+
+func parseMetric(t *testing.T, m prometheus.Metric) metricInfo {
+	t.Helper()
+	metric := &dto.Metric{}
+	if err := m.Write(metric); err != nil {
+		t.Fatalf("write metric: %v", err)
+	}
+	info := metricInfo{timestamp: metric.GetGauge().GetValue()}
+	for _, lp := range metric.GetLabel() {
+		switch lp.GetName() {
+		case "resource_group":
+			info.resourceGroup = lp.GetValue()
+		case "region":
+			info.region = lp.GetValue()
+		case "subscription_id":
+			info.subscriptionID = lp.GetValue()
+		case "subscription_name":
+			info.subscriptionName = lp.GetValue()
+		}
+	}
+	return info
+}
+
+func TestCollectSubscription_PerRGTimestamps(t *testing.T) {
+	twoHoursAgo := time.Date(2026, 6, 8, 10, 0, 0, 0, time.UTC)
+	oneHourAgo := time.Date(2026, 6, 8, 11, 0, 0, 0, time.UTC)
+	inFuture := time.Date(2026, 6, 8, 14, 0, 0, 0, time.UTC)
+
+	ttlKey := E2ECollectorConfig.TTLTagKey
+	subCfg := config.SubscriptionConfig{
+		Name:           "sub-a",
+		SubscriptionID: "sub-id",
+		Regions:        []string{"eastus"},
+	}
+
+	type expectedMetric struct {
+		resourceGroup string
+		region        string
+		timestamp     float64
+	}
+
+	testCases := []struct {
+		name        string
+		rgs         []*armresources.ResourceGroup
+		wantMetrics []expectedMetric
+	}{
+		{
+			name:        "no resource groups produces no metrics",
+			rgs:         nil,
+			wantMetrics: nil,
+		},
+		{
+			name: "RG with valid TTL tag produces one metric",
+			rgs: []*armresources.ResourceGroup{
+				makeRG("rg-active-1", "eastus", map[string]*string{
+					ttlKey: to.Ptr(inFuture.Format(time.RFC3339)),
+				}),
+			},
+			wantMetrics: []expectedMetric{
+				{resourceGroup: "rg-active-1", region: "eastus", timestamp: float64(inFuture.Unix())},
+			},
+		},
+		{
+			name: "expired and active RGs each produce one metric",
+			rgs: []*armresources.ResourceGroup{
+				makeRG("rg-expired-1", "eastus", map[string]*string{
+					ttlKey: to.Ptr(twoHoursAgo.Format(time.RFC3339)),
+				}),
+				makeRG("rg-expired-2", "eastus", map[string]*string{
+					ttlKey: to.Ptr(oneHourAgo.Format(time.RFC3339)),
+				}),
+				makeRG("rg-active", "eastus", map[string]*string{
+					ttlKey: to.Ptr(inFuture.Format(time.RFC3339)),
+				}),
+			},
+			wantMetrics: []expectedMetric{
+				{resourceGroup: "rg-expired-1", region: "eastus", timestamp: float64(twoHoursAgo.Unix())},
+				{resourceGroup: "rg-expired-2", region: "eastus", timestamp: float64(oneHourAgo.Unix())},
+				{resourceGroup: "rg-active", region: "eastus", timestamp: float64(inFuture.Unix())},
+			},
+		},
+		{
+			name: "RGs missing TTL tag produce no metric",
+			rgs: []*armresources.ResourceGroup{
+				makeRG("rg-no-tag", "westus", map[string]*string{}),
+			},
+			wantMetrics: nil,
+		},
+		{
+			name: "RGs with unparseable TTL tag produce no metric",
+			rgs: []*armresources.ResourceGroup{
+				makeRG("rg-bad-tag", "westus", map[string]*string{
+					ttlKey: to.Ptr("not-a-timestamp"),
+				}),
+			},
+			wantMetrics: nil,
+		},
+		{
+			name: "RGs across multiple regions each get their own time series",
+			rgs: []*armresources.ResourceGroup{
+				makeRG("rg-east-1", "eastus", map[string]*string{
+					ttlKey: to.Ptr(twoHoursAgo.Format(time.RFC3339)),
+				}),
+				makeRG("rg-west-1", "westus", map[string]*string{
+					ttlKey: to.Ptr(oneHourAgo.Format(time.RFC3339)),
+				}),
+			},
+			wantMetrics: []expectedMetric{
+				{resourceGroup: "rg-east-1", region: "eastus", timestamp: float64(twoHoursAgo.Unix())},
+				{resourceGroup: "rg-west-1", region: "westus", timestamp: float64(oneHourAgo.Unix())},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			lister := &fakeLister{
+				rgs: map[string][]*armresources.ResourceGroup{
+					"sub-id": tc.rgs,
+				},
+			}
+
+			cfg := testConfig(subCfg)
+			c := NewCollector(E2ECollectorConfig, cfg, testLogger(), nil, lister)
+			c.collectAll(context.Background())
+
+			metrics := collectMetrics(c)
+
+			if len(metrics) != len(tc.wantMetrics) {
+				t.Fatalf("got %d metrics, want %d", len(metrics), len(tc.wantMetrics))
+			}
+
+			actual := make(map[string]metricInfo)
+			for _, m := range metrics {
+				info := parseMetric(t, m)
+				actual[info.resourceGroup] = info
+			}
+
+			for _, want := range tc.wantMetrics {
+				got, ok := actual[want.resourceGroup]
+				if !ok {
+					t.Errorf("missing metric for resource_group=%s", want.resourceGroup)
+					continue
+				}
+				if got.region != want.region {
+					t.Errorf("resource_group=%s: region=%s, want %s", want.resourceGroup, got.region, want.region)
+				}
+				if got.timestamp != want.timestamp {
+					t.Errorf("resource_group=%s: timestamp=%v, want %v", want.resourceGroup, got.timestamp, want.timestamp)
+				}
+				if got.subscriptionID != "sub-id" {
+					t.Errorf("resource_group=%s: subscription_id=%s, want sub-id", want.resourceGroup, got.subscriptionID)
+				}
+				if got.subscriptionName != "sub-a" {
+					t.Errorf("resource_group=%s: subscription_name=%s, want sub-a", want.resourceGroup, got.subscriptionName)
+				}
+			}
+		})
+	}
+}
+
+func TestCollectAll_ListError(t *testing.T) {
+	subCfg := config.SubscriptionConfig{
+		Name:           "sub-a",
+		SubscriptionID: "sub-id",
+		Regions:        []string{"eastus"},
+	}
+	lister := &fakeLister{err: fmt.Errorf("azure API error")}
+	cfg := testConfig(subCfg)
+
+	c := NewCollector(E2ECollectorConfig, cfg, testLogger(), nil, lister)
+	c.collectAll(context.Background())
+
+	metrics := collectMetrics(c)
+	if len(metrics) != 0 {
+		t.Errorf("expected 0 metrics on error, got %d", len(metrics))
+	}
+}
+
+func TestCollectAll_NoRGs(t *testing.T) {
+	subCfg := config.SubscriptionConfig{
+		Name:           "sub-a",
+		SubscriptionID: "sub-id",
+		Regions:        []string{"eastus"},
+	}
+	lister := &fakeLister{rgs: map[string][]*armresources.ResourceGroup{}}
+	cfg := testConfig(subCfg)
+
+	c := NewCollector(E2ECollectorConfig, cfg, testLogger(), nil, lister)
+	c.collectAll(context.Background())
+
+	metrics := collectMetrics(c)
+	if len(metrics) != 0 {
+		t.Errorf("expected 0 metrics, got %d", len(metrics))
+	}
+}
+
+func TestCollectAll_SkipsTenantWithoutSubscriptions(t *testing.T) {
+	cfg := &config.Config{
+		Interval: "1m",
+		Timeout:  "10s",
+		Tenants: []config.TenantConfig{
+			{
+				TenantID:                 "test-tenant",
+				ServicePrincipalClientId: "test-sp",
+				KeyVaultSecretName:       "test-secret",
+			},
+		},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("invalid config: %v", err)
+	}
+
+	lister := &fakeLister{rgs: map[string][]*armresources.ResourceGroup{}}
+	c := NewCollector(E2ECollectorConfig, cfg, testLogger(), nil, lister)
+	c.collectAll(context.Background())
+
+	metrics := collectMetrics(c)
+	if len(metrics) != 0 {
+		t.Errorf("expected 0 metrics for tenant without subs, got %d", len(metrics))
+	}
+}
+
+func TestDescribe(t *testing.T) {
+	subCfg := config.SubscriptionConfig{
+		Name:           "sub-a",
+		SubscriptionID: "sub-id",
+		Regions:        []string{"eastus"},
+	}
+	cfg := testConfig(subCfg)
+	c := NewCollector(E2ECollectorConfig, cfg, testLogger(), nil)
+
+	ch := make(chan *prometheus.Desc, 10)
+	c.Describe(ch)
+	close(ch)
+
+	var descs []*prometheus.Desc
+	for d := range ch {
+		descs = append(descs, d)
+	}
+
+	if len(descs) != 1 {
+		t.Fatalf("expected 1 descriptor, got %d", len(descs))
+	}
+}

--- a/tooling/tenant-quota/pkg/resourcegroups/lister.go
+++ b/tooling/tenant-quota/pkg/resourcegroups/lister.go
@@ -1,0 +1,74 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourcegroups
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+)
+
+// CollectorConfig parameterizes the resource group collector so different
+// tag-based resource group monitors can reuse the same collection logic.
+type CollectorConfig struct {
+	TagFilter    string // ARM filter string for the ListPager (e.g. "tagName eq 'foo' and tagValue eq 'bar'")
+	TTLTagKey    string // tag key holding the RFC3339 expiry timestamp
+	MetricPrefix string // prefix for Prometheus metric names (e.g. "e2e_resource_group")
+	Name         string // human-readable name for log messages (e.g. "e2e resource group")
+}
+
+// E2ECollectorConfig is the configuration for monitoring E2E-tagged
+// resource groups created by CI test jobs.
+var E2ECollectorConfig = CollectorConfig{
+	TagFilter:    "tagName eq 'e2e.aro-hcp-ci.redhat.com' and tagValue eq 'true'",
+	TTLTagKey:    "deleteAfter.aro-hcp-ci.redhat.com",
+	MetricPrefix: "e2e_resource_group",
+	Name:         "e2e resource group",
+}
+
+// ResourceGroupLister abstracts Azure RG listing for testability.
+type ResourceGroupLister interface {
+	ListResourceGroups(ctx context.Context, subscriptionID string) ([]*armresources.ResourceGroup, error)
+}
+
+// AzureResourceGroupLister is the production implementation using the ARM SDK.
+type AzureResourceGroupLister struct {
+	cred   *azidentity.ClientSecretCredential
+	filter string
+}
+
+func (a *AzureResourceGroupLister) ListResourceGroups(ctx context.Context, subscriptionID string) ([]*armresources.ResourceGroup, error) {
+	client, err := armresources.NewResourceGroupsClient(subscriptionID, a.cred, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create resource groups client: %w", err)
+	}
+
+	pager := client.NewListPager(&armresources.ResourceGroupsClientListOptions{
+		Filter: to.Ptr(a.filter),
+	})
+
+	var result []*armresources.ResourceGroup
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("list resource groups: %w", err)
+		}
+		result = append(result, page.Value...)
+	}
+	return result, nil
+}


### PR DESCRIPTION
[ARO-27250](https://issues.redhat.com/browse/ARO-27250)

### What

Adds a configurable resource group collector to the tenant-quota service that periodically scans Azure subscriptions for resource groups matching a tag filter and exposes a per-resource-group Prometheus gauge with the `deleteAfter` TTL timestamp. The first instance targets E2E CI resource groups. Includes tiered Azure Monitor alerts with PromQL-based aggregation and a staleness alert.

New metric:
- `e2e_resource_group_expiry_timestamp` - Unix timestamp of the `deleteAfter` TTL tag for each tagged RG (labels: `resource_group`, `region`, `subscription_id`, `subscription_name`)

Consumers derive everything via PromQL:
- Expired count: `count(e2e_resource_group_expiry_timestamp < time())`
- Active count: `count(e2e_resource_group_expiry_timestamp)`
- Max staleness: `max(time() - (e2e_resource_group_expiry_timestamp < time()))`

New alerts:
- `E2EExpiredResourceGroupsInfo` (sev 4, 2h) - >10 expired RGs per subscription
- `E2EExpiredResourceGroupsEscalation` (sev 4, 2h) - >25 expired RGs per subscription
- `E2EExpiredResourceGroupStale` (sev 4, 15m) - oldest expired RG past 7 days per subscription
- `E2EResourceGroupMetricsStale` (sev 2, 30m) - collector metrics absent

### Why

Prow e2e jobs can report success while leaving leaked resource groups behind. There was no observability signal to detect this - cleanup failures went unnoticed until subscription quotas were hit. This collector closes that gap by scanning for RGs past their `deleteAfter` TTL and driving alerts.

### Testing

Unit tests covering:
- Per-RG timestamp emission with correct Unix values and all label dimensions
- Multi-region tracking with individual time series per RG
- Missing/unparseable TTL tags (gracefully skipped, no metric emitted)
- API error handling (returns zero metrics, no crash)
- Tenants without subscriptions (skip path)
- Describe method (1 descriptor registered)

All tests pass with `-race`. Locally validated against dev Azure subscriptions — confirmed 332 tagged RGs detected (91 expired, oldest at ~87 days).

### Special notes for your reviewer

- The collector emits raw timestamps per RG following the Prometheus convention of "expose facts, derive meaning in queries." All aggregation (counts, max age) lives in the alert PromQL expressions.
- Alert thresholds are extracted to Bicep variables and intentionally relaxed for initial rollout given the current baseline. TODOs document the tightening plan.
- The collector is generic via `CollectorConfig` - E2E is the first instance but the same pattern can monitor other tag-based RG sets
- Hosted in `tenant-quota` to reuse existing credentials, Prometheus registry, and opstool deployment infrastructure. The service name is now slightly misleading since it monitors resource group TTLs in addition to quotas - renaming is out of scope for this PR
- The `resourcegroups` directory name is gitignored at repo root (line 30 of `.gitignore`); overridden via `tooling/tenant-quota/.gitignore`

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge