### PR TITLE
fix: unify install version prediction

### DIFF
--- a/test/e2e/control_plane_minor_upgrade.go
+++ b/test/e2e/control_plane_minor_upgrade.go
@@ -37,6 +37,7 @@ import (
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/upgradecontrollers"
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/cincinnati"
+	"github.com/Azure/ARO-HCP/internal/ocm"
 	hcpsdk20240610preview "github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
 	"github.com/Azure/ARO-HCP/test/util/framework"
 	"github.com/Azure/ARO-HCP/test/util/labels"
@@ -78,7 +79,47 @@ var _ = Describe("Customer", func() {
 			}
 			Expect(err).NotTo(HaveOccurred(), "failed to get versions in previous minor %s on channel %s", previousMinor.String(), channelGroup)
 
+			// Fast-fail: predict the exact install version the backend will use
+			// for a bare-minor request (e.g. "4.21") by calling the same helper
+			// the backend uses. This avoids a class of mismatch where Cincinnati
+			// has an upgrade path from some 4.y.z but not from the specific
+			// z-stream the backend pins (currently hardcoded in NewOpenShiftVersionXYZ).
+			// If the predicted install has no GA upgrade path to the target minor,
+			// skip before spending ~15 min creating a cluster that can't upgrade.
+			csVersion := ocm.NewOpenShiftVersionXYZ(previousMinorLine, channelGroup)
+			resolvedStr := strings.TrimPrefix(csVersion, api.OpenShiftVersionPrefix)
+			if channelGroup != "" && channelGroup != "stable" {
+				resolvedStr = strings.TrimSuffix(resolvedStr, "-"+channelGroup)
+			}
+			resolvedInstallVersion, err := semver.ParseTolerant(resolvedStr)
+			Expect(err).NotTo(HaveOccurred(), "failed to parse backend-predicted install version %q (from %q)", resolvedStr, csVersion)
+
+			resolvedUpgradeTargets, err := upgradecontrollers.FindAllUpgradeTargetVersionsInMinor(
+				ctx, cincinnatiClient, channelGroup, targetVer, []semver.Version{resolvedInstallVersion})
+			if err != nil {
+				if cincinnati.IsCincinnatiVersionNotFoundError(err) {
+					Skip(fmt.Sprintf("Cincinnati version not found checking upgrade from backend-predicted install %s to %s: %v",
+						resolvedInstallVersion, targetMinorLine, err))
+				}
+				Expect(err).NotTo(HaveOccurred(), "failed to check upgrade path from %s to %s",
+					resolvedInstallVersion, targetMinorLine)
+			}
+			hasGAUpgradeTarget := false
+			for _, v := range resolvedUpgradeTargets {
+				if len(v.Pre) == 0 {
+					hasGAUpgradeTarget = true
+					break
+				}
+			}
+			if !hasGAUpgradeTarget {
+				Skip(fmt.Sprintf("backend would resolve %q to install version %s, which has no GA upgrade path to %s in Cincinnati",
+					previousMinorLine, resolvedInstallVersion, targetMinorLine))
+			}
+
 			for _, possibleInstallVersion := range possibleInstallVersions {
+				if len(possibleInstallVersion.Pre) != 0 {
+					continue
+				}
 				possibleUpgradeVersions, err := upgradecontrollers.FindAllUpgradeTargetVersionsInMinor(ctx, cincinnatiClient, channelGroup, targetVer, []semver.Version{possibleInstallVersion})
 				if cincinnati.IsCincinnatiVersionNotFoundError(err) {
 					Skip(fmt.Sprintf("Cincinnati returned version not found for target minor %s on channel %s: %v",
@@ -88,6 +129,9 @@ var _ = Describe("Customer", func() {
 				Expect(err).NotTo(HaveOccurred(), "failed to find upgrade targets in minor %s for install version %s", targetVer.String(), possibleInstallVersion.String())
 
 				for _, possibleUpgradeVersion := range possibleUpgradeVersions {
+					if len(possibleUpgradeVersion.Pre) != 0 {
+						continue
+					}
 					possibleNextUpgradeVersions, err := upgradecontrollers.FindAllUpgradeTargetVersionsInMinor(ctx, cincinnatiClient, channelGroup, targetPlusOneVer, []semver.Version{possibleUpgradeVersion})
 					if cincinnati.IsCincinnatiVersionNotFoundError(err) {
 						// in this case we allow it because without a 4.y+2, we allow any 4.y+1
@@ -95,8 +139,14 @@ var _ = Describe("Customer", func() {
 						break
 					}
 					Expect(err).NotTo(HaveOccurred(), "failed to find upgrade targets in minor %s for upgrade version %s", targetPlusOneVer.String(), possibleUpgradeVersion.String())
-					if len(possibleNextUpgradeVersions) > 0 {
-						// in this case we allow it because the possibleInstallVersion has a possibleUpgradeVersion that can upgrade to 4.y+2
+					hasGANext := false
+					for _, v := range possibleNextUpgradeVersions {
+						if len(v.Pre) == 0 {
+							hasGANext = true
+							break
+						}
+					}
+					if hasGANext {
 						installVersion = &possibleInstallVersion
 						break
 					}


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Replace the control_plane_minor_upgrade E2E pre-check with one that predicts the install version using the same helper the backend uses (ocm.NewOpenShiftVersionXYZ), and filter pre-release versions out of the existing upgrade-path loop.

### Why

The test sends OpenshiftVersionId: "4.21" and the backend resolves bare minors to a specific z-stream via a hardcoded map (currently pinning 4.21 → 4.21.15). The existing pre-check loop validated upgrade paths from whichever 4.21.x Cincinnati happened to have an unconditional edge for — not from the z-stream the backend actually installs. When those two diverged, the test created a cluster that was guaranteed to fail its upgrade (no upgrade path found from 4.21.15 to 4.22.0). It also accepted pre-release upgrade targets (EC/RC) that aren't valid GA upgrade endpoints.

By predicting through NewOpenShiftVersionXYZ and rejecting pre-releases, the test now skips deterministically when no GA upgrade path exists from the version the backend will actually install — eliminating the wasted ~15-minute cluster create + spurious failure. The fix is generic and works for any minor in the test table, present or future.

### Testing


   - Static checks: go vet ./test/e2e/... and go build ./test/e2e/... pass cleanly.
   - Live Cincinnati simulation: Drove the new prediction + GA-filter code directly against api.openshift.com for all three production channels (stable, fast, candidate) and all currently-mapped minors (4.19→4.20,
    4.20→4.21, 4.21→4.22). Confirmed NewOpenShiftVersionXYZ predicts the exact z-streams the backend pins (4.19.30, 4.20.22, 4.21.15) and that the upgrade-path check correctly produces PROCEED for 4.19→4.20 and 4.20→4.21 and SKIP for all three 4.21→4.22 channels in today's graph state.
   - Cross-check against real failure artifacts: Confirmed that the failing
    4.21→4.22 INT run at 2026-06-11 20:13 UTC installed 4.21.15 and failed with no upgrade path found from 4.21.15 to 4.22.0 — the exact version and failure the new pre-check now predicts and skips on.
   - Cincinnati edge audit: Verified that 4.21.15 currently has no unconditional GA path to any
    4.22.x in candidate-4.22 / stable-4.22 / fast-4.22, and that the conditional-only paths (e.g. to 4.22.0 and 4.22.0-rc.*) would correctly be filtered out by the new GA check.

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
