### PR TITLE
fix: pass --cloud/--environment to prow-job-executor

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -43,15 +43,18 @@ build: $(PROW_JOB_EXECUTOR) $(ARO_HCP_TESTS)
 int-e2e:
 	PROW_JOB_NAME="$$(yq .clouds.public.environments.int.defaults.e2e.regionTest.prowJobName < ../config/config.msft.clouds-overlay.yaml)" \
 	REGION="uksouth" \
+	ENVIRONMENT="int" \
 	$(MAKE) e2e
 
 stage-e2e:
 	PROW_JOB_NAME="$$(yq .clouds.public.environments.stg.defaults.e2e.regionTest.prowJobName < ../config/config.msft.clouds-overlay.yaml)" \
 	REGION="uksouth" \
+	ENVIRONMENT="stg" \
 	$(MAKE) e2e
 
 prod-e2e:
 	PROW_JOB_NAME="$$(yq .clouds.public.environments.prod.defaults.e2e.regionTest.prowJobName < ../config/config.msft.clouds-overlay.yaml)" \
+	ENVIRONMENT="prod" \
 	$(MAKE) e2e
 
 e2e: $(PROW_JOB_EXECUTOR)
@@ -63,6 +66,8 @@ e2e: $(PROW_JOB_EXECUTOR)
 	PROW_TOKEN_KEYVAULT="$$(yq .global.keyVault.name < ../config/rendered/dev/dev/westus3.yaml)" \
 	PROW_TOKEN_SECRET="$$(yq .e2e.prow.globalKeyVaultTokenSecret < ../config/rendered/dev/dev/westus3.yaml)" \
 	KEY_VAULT_DNSSUFFIX="vault.azure.net" \
+	CLOUD="$${CLOUD:-public}" \
+	ENVIRONMENT="$${ENVIRONMENT:?ENVIRONMENT must be set (e.g. int, stg, prod)}" \
 	BASE_SHA="$${BASE_SHA:-$$(git rev-parse HEAD)}" \
 	DRY_RUN="false" \
 	GATE_PROMOTION="true" \

--- a/test/execute-prow-job.sh
+++ b/test/execute-prow-job.sh
@@ -35,4 +35,4 @@ if [ -n "${zz_injected_EV2RolloutVersion:-}" ]; then
   fi
 fi
 
-"${PROW_JOB_EXECUTOR}" execute --prow-token-keyvault-uri "https://${PROW_TOKEN_KEYVAULT}.${KEY_VAULT_DNSSUFFIX}" --prow-token-keyvault-secret "$PROW_TOKEN_SECRET" --job-name "$PROW_JOB_NAME" --region "$REGION" --ev2-rollout-version "${zz_injected_EV2RolloutVersion:-}" --dry-run="${DRY_RUN:-false}" --gate-promotion="${GATE_PROMOTION:-false}" ${BASE_SHA_ARGS[@]+"${BASE_SHA_ARGS[@]}"}
+"${PROW_JOB_EXECUTOR}" execute --prow-token-keyvault-uri "https://${PROW_TOKEN_KEYVAULT}.${KEY_VAULT_DNSSUFFIX}" --prow-token-keyvault-secret "$PROW_TOKEN_SECRET" --job-name "$PROW_JOB_NAME" --cloud "$CLOUD" --environment "$ENVIRONMENT" --region "$REGION" --ev2-rollout-version "${zz_injected_EV2RolloutVersion:-}" --dry-run="${DRY_RUN:-false}" --gate-promotion="${GATE_PROMOTION:-false}" ${BASE_SHA_ARGS[@]+"${BASE_SHA_ARGS[@]}"}

--- a/tooling/templatize/pkg/pipeline/prow.go
+++ b/tooling/templatize/pkg/pipeline/prow.go
@@ -52,6 +52,8 @@ func runProwJobStep(step *types.ProwJobStep, ctx context.Context, options *StepR
 	}
 
 	opts := prowjobexecutor.DefaultExecuteOptions()
+	opts.Cloud = options.Cloud
+	opts.Environment = options.Environment
 	opts.Secret = step.TokenSecret
 	opts.KeyVaultURI = keyVaultURI
 	opts.ProwJobName = step.JobName


### PR DESCRIPTION
[AROSLSRE-1159](https://redhat.atlassian.net/browse/AROSLSRE-1159)

### What

https://github.com/Azure/ARO-Tools/pull/248 introduced new flags but not added in ARO-HCP

Pass the new `--cloud` and `--environment` flags through to `prow-job-executor`:
- `tooling/templatize/pkg/pipeline/prow.go` — sets `opts.Cloud`/`opts.Environment` from the existing `StepRunOptions` (already populated from the `--cloud` and `--deploy-env` CLI flags via `BaseRunOptions`).
- `test/execute-prow-job.sh` + `test/Makefile` — adds `--cloud`/`--environment` to the local developer e2e invocation; `int-e2e`/`stage-e2e`/`prod-e2e` targets set `ENVIRONMENT` accordingly, and `CLOUD` defaults to `public`.

### Why

Commit c26eb0de6 (`*: bump ARO-Tools`) pulled in a `prow-job-executor` that marks `--cloud` and `--environment` as required flags. Existing call-sites in this repo do not pass them, so any prow-job step now fails immediately with:

Failure - https://ra.ev2portal.azure.net/#/rollouts/Test/b8e9ef87-cd63-4085-ab14-1c637806568c/Microsoft.Azure.ARO.HCP.GlobalBuildout/313c4848-b115-429e-aa38-00fcab9245eb/list/Medium.uksouth/E2E.service.regionalGating-uksouth-1/shell%2FregionalGating/0/1

```
ERROR: command failed
{ "err": "required flag(s) \"cloud\", \"environment\" not set" }
```

This blocks EV2-driven e2e jobs (the failing CI log shape) and any local developer run of `make int-e2e`/`stage-e2e`/`prod-e2e`. The two new flags become pod annotations (`ev2.rollout/cloud`, `ev2.rollout/environment`) on the spawned Prow job.

### Testing

- `go build ./pkg/pipeline/...` in `tooling/templatize` — passes.
- `go build ./cmd/prow-job-executor/` in `test` — passes.
- `bash -n test/execute-prow-job.sh` — syntax OK.
- Manual smoke: `StepRunOptions.Cloud` and `StepRunOptions.Environment` are already populated by `cmd/entrypoint/run/options.go:155-169` and `cmd/pipeline/run/options.go:115-126`, so existing templatize invocations need no extra flags.

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes) — N/A
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide) — pending after push
- [ ] Draft PR used for WIP (if applicable) — N/A, opened ready
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented — N/A, mechanical wiring
- [ ] Specific reviewers tagged — will tag after open
- [ ] All comment threads resolved before merge