### PR TITLE
fix(aks): resolve latest patch and refresh node images on upgrade (AROSLSRE-1165)

### DIFF
--- a/dev-infrastructure/scripts/upgrade-aks-cluster.sh
+++ b/dev-infrastructure/scripts/upgrade-aks-cluster.sh
@@ -119,13 +119,16 @@ fi
 
 # Node OS image upgrade.
 #
-# This replaces the AKS-managed nodeOSUpgradeChannel/auto-upgrade that used to
-# pull the latest node image (security patches) on a maintenance schedule. We
-# now drive it from the pipeline: for each node pool, compare the running node
-# image against the latest available one and run a node-image-only upgrade when
-# a newer image exists. A Kubernetes version upgrade above already reimages
-# nodes to the latest image for the target version, so this is typically a
-# no-op right after one and only does work when the image alone is stale.
+# This is the pipeline-driven replacement for the AKS-managed
+# nodeOSUpgradeChannel/auto-upgrade, which is disabled in the AKS base module
+# (autoUpgradeProfile.nodeOSUpgradeChannel: 'None', see the companion change in
+# dev-infrastructure/modules/aks-cluster-base.bicep). It used to pull the latest
+# node image (security patches) on a maintenance schedule; we now drive it from
+# the pipeline: for each node pool, compare the running node image against the
+# latest available one and run a node-image-only upgrade when a newer image
+# exists. A Kubernetes version upgrade above already reimages nodes to the
+# latest image for the target version, so this is typically a no-op right after
+# one and only does work when the image alone is stale.
 echo "Checking node image versions..."
 NODE_IMAGE_UPGRADE_NEEDED=false
 

--- a/dev-infrastructure/scripts/upgrade-aks-cluster.sh
+++ b/dev-infrastructure/scripts/upgrade-aks-cluster.sh
@@ -4,10 +4,51 @@ set -euo pipefail
 # Inputs via environment variables:
 #   RESOURCE_GROUP - Resource group containing the cluster
 #   CLUSTER_NAME   - AKS cluster name
-#   KUBERNETES_VERSION - Kubernetes Version
+#   KUBERNETES_VERSION - Kubernetes Version. May be a minor version (e.g. "1.35")
+#                        or a pinned patch version (e.g. "1.35.5").
 
 version_greater_than() {
     [ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" != "$1" ]
+}
+
+# Resolve the requested Kubernetes version to a concrete upgrade target.
+#
+# When KUBERNETES_VERSION is a minor version (X.Y), AKS would otherwise pick an
+# arbitrary default patch on upgrade and never chase newer patches once the
+# cluster is at or above that minor. Instead, resolve it to the highest patch
+# (X.Y.Z) currently available for that minor in the cluster's region, taking
+# into account both the current version and the patches AKS offers as upgrades.
+#
+# When a full patch version (X.Y.Z) is pinned, honor it verbatim.
+resolve_target_version() {
+    local requested="$1"
+    local current="$2"
+
+    if [[ "${requested}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        echo "${requested}"
+        return
+    fi
+
+    local available
+    available=$(az aks get-upgrades \
+        --resource-group "${RESOURCE_GROUP}" \
+        --name "${CLUSTER_NAME}" \
+        --query "controlPlaneProfile.upgrades[].kubernetesVersion" \
+        --output tsv 2>/dev/null || true)
+
+    local resolved
+    resolved=$(printf '%s\n%s\n' "${current}" "${available}" \
+        | grep -E "^${requested//./\\.}\.[0-9]+$" \
+        | sort -V \
+        | tail -n1)
+
+    if [ -n "${resolved}" ]; then
+        echo "${resolved}"
+    else
+        # No patch for the requested minor is available yet (or get-upgrades
+        # failed); fall back to the requested minor and let AKS pick a patch.
+        echo "${requested}"
+    fi
 }
 
 echo "Checking if cluster '${CLUSTER_NAME}' in RG '${RESOURCE_GROUP}' needs upgrade to '${KUBERNETES_VERSION}'..."
@@ -19,16 +60,19 @@ CURRENT_CP_VERSION=$(az aks show \
     --query currentKubernetesVersion \
     --output tsv)
 
+TARGET_VERSION=$(resolve_target_version "${KUBERNETES_VERSION}" "${CURRENT_CP_VERSION}")
+
 echo "Current control plane version: ${CURRENT_CP_VERSION}"
-echo "Target version: ${KUBERNETES_VERSION}"
+echo "Requested version: ${KUBERNETES_VERSION}"
+echo "Resolved target version: ${TARGET_VERSION}"
 
 # Check if control plane needs upgrade
 NEEDS_UPGRADE=false
-if version_greater_than "${KUBERNETES_VERSION}" "${CURRENT_CP_VERSION}"; then
-    echo "Control plane needs upgrade from ${CURRENT_CP_VERSION} to ${KUBERNETES_VERSION}"
+if version_greater_than "${TARGET_VERSION}" "${CURRENT_CP_VERSION}"; then
+    echo "Control plane needs upgrade from ${CURRENT_CP_VERSION} to ${TARGET_VERSION}"
     NEEDS_UPGRADE=true
 else
-    echo "Control plane is at ${CURRENT_CP_VERSION}, target is ${KUBERNETES_VERSION} - no upgrade needed"
+    echo "Control plane is at ${CURRENT_CP_VERSION}, target is ${TARGET_VERSION} - no upgrade needed"
 fi
 
 # Get node pool versions and check if any need upgrade
@@ -43,26 +87,26 @@ if [ -n "${NODE_POOLS}" ]; then
     while IFS=$'\t' read -r POOL_NAME POOL_VERSION; do
         echo "  Node pool '${POOL_NAME}': ${POOL_VERSION}"
 
-        if version_greater_than "${KUBERNETES_VERSION}" "${POOL_VERSION}"; then
-            echo "  Node pool '${POOL_NAME}' needs upgrade from ${POOL_VERSION} to ${KUBERNETES_VERSION}"
+        if version_greater_than "${TARGET_VERSION}" "${POOL_VERSION}"; then
+            echo "  Node pool '${POOL_NAME}' needs upgrade from ${POOL_VERSION} to ${TARGET_VERSION}"
             NEEDS_UPGRADE=true
         else
-            echo "  Node pool '${POOL_NAME}' is at ${POOL_VERSION}, target is ${KUBERNETES_VERSION} - no upgrade needed"
+            echo "  Node pool '${POOL_NAME}' is at ${POOL_VERSION}, target is ${TARGET_VERSION} - no upgrade needed"
         fi
     done <<< "${NODE_POOLS}"
 fi
 
 if [ "${NEEDS_UPGRADE}" = "false" ]; then
-    echo "Cluster does not need upgrade - all components are at or above target version ${KUBERNETES_VERSION}."
+    echo "Cluster does not need upgrade - all components are at or above target version ${TARGET_VERSION}."
     exit 0
 fi
 
-echo "Upgrading cluster '${CLUSTER_NAME}' in RG '${RESOURCE_GROUP}' to '${KUBERNETES_VERSION}'..."
+echo "Upgrading cluster '${CLUSTER_NAME}' in RG '${RESOURCE_GROUP}' to '${TARGET_VERSION}'..."
 
 az aks upgrade \
     --resource-group "${RESOURCE_GROUP}" \
     --name "${CLUSTER_NAME}" \
-    --kubernetes-version "${KUBERNETES_VERSION}" \
+    --kubernetes-version "${TARGET_VERSION}" \
     --yes
 
 echo "Waiting for upgrade to complete..."
@@ -73,4 +117,3 @@ az aks wait \
     --timeout 3600
 
 echo "Upgrade completed successfully."
-

--- a/dev-infrastructure/scripts/upgrade-aks-cluster.sh
+++ b/dev-infrastructure/scripts/upgrade-aks-cluster.sh
@@ -40,7 +40,7 @@ resolve_target_version() {
     resolved=$(printf '%s\n%s\n' "${current}" "${available}" \
         | grep -E "^${requested//./\\.}\.[0-9]+$" \
         | sort -V \
-        | tail -n1)
+        | tail -n1 || true)
 
     if [ -n "${resolved}" ]; then
         echo "${resolved}"

--- a/dev-infrastructure/scripts/upgrade-aks-cluster.sh
+++ b/dev-infrastructure/scripts/upgrade-aks-cluster.sh
@@ -96,24 +96,89 @@ if [ -n "${NODE_POOLS}" ]; then
     done <<< "${NODE_POOLS}"
 fi
 
-if [ "${NEEDS_UPGRADE}" = "false" ]; then
-    echo "Cluster does not need upgrade - all components are at or above target version ${TARGET_VERSION}."
-    exit 0
+if [ "${NEEDS_UPGRADE}" = "true" ]; then
+    echo "Upgrading cluster '${CLUSTER_NAME}' in RG '${RESOURCE_GROUP}' to '${TARGET_VERSION}'..."
+
+    az aks upgrade \
+        --resource-group "${RESOURCE_GROUP}" \
+        --name "${CLUSTER_NAME}" \
+        --kubernetes-version "${TARGET_VERSION}" \
+        --yes
+
+    echo "Waiting for Kubernetes version upgrade to complete..."
+    az aks wait \
+        --resource-group "${RESOURCE_GROUP}" \
+        --name "${CLUSTER_NAME}" \
+        --updated \
+        --timeout 3600
+
+    echo "Kubernetes version upgrade completed successfully."
+else
+    echo "Control plane and node pools are at or above target version ${TARGET_VERSION} - no version upgrade needed."
 fi
 
-echo "Upgrading cluster '${CLUSTER_NAME}' in RG '${RESOURCE_GROUP}' to '${TARGET_VERSION}'..."
+# Node OS image upgrade.
+#
+# This replaces the AKS-managed nodeOSUpgradeChannel/auto-upgrade that used to
+# pull the latest node image (security patches) on a maintenance schedule. We
+# now drive it from the pipeline: for each node pool, compare the running node
+# image against the latest available one and run a node-image-only upgrade when
+# a newer image exists. A Kubernetes version upgrade above already reimages
+# nodes to the latest image for the target version, so this is typically a
+# no-op right after one and only does work when the image alone is stale.
+echo "Checking node image versions..."
+NODE_IMAGE_UPGRADE_NEEDED=false
 
-az aks upgrade \
+NODE_POOL_NAMES=$(az aks nodepool list \
     --resource-group "${RESOURCE_GROUP}" \
-    --name "${CLUSTER_NAME}" \
-    --kubernetes-version "${TARGET_VERSION}" \
-    --yes
+    --cluster-name "${CLUSTER_NAME}" \
+    --query '[].name' \
+    --output tsv)
 
-echo "Waiting for upgrade to complete..."
-az aks wait \
-    --resource-group "${RESOURCE_GROUP}" \
-    --name "${CLUSTER_NAME}" \
-    --updated \
-    --timeout 3600
+if [ -n "${NODE_POOL_NAMES}" ]; then
+    while IFS= read -r POOL_NAME; do
+        [ -z "${POOL_NAME}" ] && continue
 
-echo "Upgrade completed successfully."
+        CURRENT_IMAGE=$(az aks nodepool show \
+            --resource-group "${RESOURCE_GROUP}" \
+            --cluster-name "${CLUSTER_NAME}" \
+            --name "${POOL_NAME}" \
+            --query nodeImageVersion \
+            --output tsv)
+
+        LATEST_IMAGE=$(az aks nodepool get-upgrades \
+            --resource-group "${RESOURCE_GROUP}" \
+            --cluster-name "${CLUSTER_NAME}" \
+            --nodepool-name "${POOL_NAME}" \
+            --query latestNodeImageVersion \
+            --output tsv 2>/dev/null || true)
+
+        echo "  Node pool '${POOL_NAME}': image ${CURRENT_IMAGE} (latest available: ${LATEST_IMAGE:-unknown})"
+
+        if [ -n "${LATEST_IMAGE}" ] && [ "${CURRENT_IMAGE}" != "${LATEST_IMAGE}" ]; then
+            echo "  Node pool '${POOL_NAME}' has a newer node image available"
+            NODE_IMAGE_UPGRADE_NEEDED=true
+        fi
+    done <<< "${NODE_POOL_NAMES}"
+fi
+
+if [ "${NODE_IMAGE_UPGRADE_NEEDED}" = "true" ]; then
+    echo "Upgrading node images for cluster '${CLUSTER_NAME}' in RG '${RESOURCE_GROUP}'..."
+
+    az aks upgrade \
+        --resource-group "${RESOURCE_GROUP}" \
+        --name "${CLUSTER_NAME}" \
+        --node-image-only \
+        --yes
+
+    echo "Waiting for node image upgrade to complete..."
+    az aks wait \
+        --resource-group "${RESOURCE_GROUP}" \
+        --name "${CLUSTER_NAME}" \
+        --updated \
+        --timeout 3600
+
+    echo "Node image upgrade completed successfully."
+else
+    echo "Node images are up to date - no node image upgrade needed."
+fi


### PR DESCRIPTION
Jira: [AROSLSRE-1165](https://redhat.atlassian.net/browse/AROSLSRE-1165) (parent: [AROSLSRE-1164](https://redhat.atlassian.net/browse/AROSLSRE-1164))

### What

`dev-infrastructure/scripts/upgrade-aks-cluster.sh` now fully owns AKS updates from the rollout pipeline:

- **Kubernetes version** — resolves a configured **minor** version (e.g. `1.35`) to the **highest available patch** for that minor before deciding whether to upgrade, instead of treating the minor as a version floor. A pinned full patch `X.Y.Z` is honored verbatim. The control plane + node pools upgrade only when behind.
- **Node OS image** — after the (optional) version upgrade, each node pool's `nodeImageVersion` is compared against `latestNodeImageVersion`; if any pool is stale, a `az aks upgrade --node-image-only` pass refreshes node images. This replaces the AKS-managed `nodeOSUpgradeChannel` removed in #5628.
- No `X.Y.z` available yet, or `get-upgrades` fails → falls back to the previous behavior (pass the minor, let AKS choose) without erroring.
- Already-current clusters short-circuit with "no upgrade needed".

### Why

Cluster updates are moving from AKS's unattended weekend auto-upgrade into the rollout pipeline. Running disruptive operations unattended over the weekend risks broken clusters on Monday. Driving updates through rollouts is safer: rollouts are **monitored**, gated by **E2E tests** that validate the change, and progress through **Dev (always latest) → INT → Stage → Prod**.

Two concrete gaps this closes:

- `KUBERNETES_VERSION` comes from `svc.aks.kubernetesVersion` / `mgmt.aks.kubernetesVersion`, normally a minor like `1.35`. The old `sort -V` comparison treated it as a floor, so once a cluster reached any `1.35.x` it reported "no upgrade needed" and never picked up newer `1.35.z` patch fixes.
- With `nodeOSUpgradeChannel` removed (#5628), node OS image patches now need an explicit pipeline pass — added here.

### Testing

- `bash -n` syntax check passes.
- Unit-tested the upgrade flow with a mocked `az` under `set -euo pipefail` across cases: behind-minor, on-minor-with-newer-patch, already-latest (no-op), pinned full patch (verbatim), empty `get-upgrades` (fallback), and node-image-only (version current, stale node image).

```
req=1.35   cur=1.34.5 avail=[1.35.1,1.35.3]         -> 1.35.3
req=1.35   cur=1.35.2 avail=[1.35.3,1.35.5,1.36.0]  -> 1.35.5
req=1.35   cur=1.35.5 avail=[1.36.0,1.36.1]         -> 1.35.5
req=1.32.5 cur=1.32.1 avail=[1.99.9]                -> 1.32.5
req=1.35   cur=1.34.0 avail=[]                       -> 1.35
```

### Special notes for your reviewer

- `az aks get-upgrades` is cluster-scoped (no region argument needed) and only returns forward upgrade targets, so the current version is folded in before taking the max to correctly handle the already-latest case.
- A Kubernetes version upgrade already reimages nodes to the latest image for that version, so the node-image pass is a no-op immediately after one; it matters for clusters that are already on the target version but have a stale node image.

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
