### PR TITLE
feat(aks): disable AKS-managed automatic cluster upgrades

### DIFF
--- a/dev-infrastructure/modules/aks-cluster-base.bicep
+++ b/dev-infrastructure/modules/aks-cluster-base.bicep
@@ -344,8 +344,8 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2025-07-02-previ
       'max-node-provision-time': '15m'
     }
     autoUpgradeProfile: {
-      nodeOSUpgradeChannel: 'NodeImage'
-      upgradeChannel: 'patch'
+      nodeOSUpgradeChannel: 'None'
+      upgradeChannel: 'none'
     }
     azureMonitorProfile: {
       metrics: {
@@ -448,43 +448,6 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2025-07-02-previ
     aksClusterOutboundIPAddress
   ]
 }
-
-resource maintenanceWindows 'Microsoft.ContainerService/managedClusters/maintenanceConfigurations@2025-08-02-preview' = [
-  for maintenanceType in ['default', 'aksManagedAutoUpgradeSchedule', 'aksManagedNodeOSUpgradeSchedule']: {
-    parent: aksCluster
-    name: maintenanceType
-    properties: {
-      maintenanceWindow: {
-        durationHours: 10
-        startTime: '22:00'
-        notAllowedDates: [
-          {
-            start: '2025-11-16'
-            end: '2025-11-22'
-          }
-          {
-            start: '2025-11-24'
-            end: '2025-12-03'
-          }
-          {
-            start: '2025-12-22'
-            end: '2026-01-13'
-          }
-          {
-            start: '2026-02-16'
-            end: '2026-02-20'
-          }
-        ]
-        schedule: {
-          weekly: {
-            dayOfWeek: 'Saturday'
-            intervalWeeks: 1
-          }
-        }
-      }
-    }
-  }
-]
 
 module userAgentPools '../modules/aks/pool.bicep' = {
   name: 'user-agent-pools'


### PR DESCRIPTION
Jira: [AROSLSRE-1166](https://redhat.atlassian.net/browse/AROSLSRE-1166) (parent: [AROSLSRE-1164](https://redhat.atlassian.net/browse/AROSLSRE-1164))

## What this PR does

Disables AKS-managed automatic cluster upgrades in `dev-infrastructure/modules/aks-cluster-base.bicep`:

- `autoUpgradeProfile.upgradeChannel`: `patch` → `none`
- `autoUpgradeProfile.nodeOSUpgradeChannel`: `NodeImage` → `None`
- Removes the `maintenanceConfigurations` resource (the `default`, `aksManagedAutoUpgradeSchedule`, and `aksManagedNodeOSUpgradeSchedule` windows that ran **weekly on Saturday 22:00, 10h**).

## Why

Cluster updates are moving into the rollout pipeline (`upgrade-aks-cluster.sh`, see #5627 / [AROSLSRE-1165](https://redhat.atlassian.net/browse/AROSLSRE-1165)), which resolves and applies the latest available patch **and** refreshes node OS images.

Running disruptive operations unattended over the weekend risks broken clusters on Monday. Driving updates through rollouts is safer: rollouts are **monitored**, gated by **E2E tests** that validate the change, and progress through **Dev (always latest) → INT → Stage → Prod**. With pipeline-driven updates, AKS's own unattended auto-upgrade — and the weekend maintenance window that scheduled it — are no longer wanted.

The Saturday window was originally introduced in `14c315a5` to move the maintenance off Monday and avoid Monday e2e auth failures; removing the whole auto-upgrade supersedes that workaround.

## Testing

- `bicep build dev-infrastructure/modules/aks-cluster-base.bicep` succeeds (only the pre-existing `pool.bicep` BCP334 warning, unrelated to this change).
- Compiled ARM no longer contains any `maintenanceConfigurations`; `autoUpgradeProfile` is `None`/`none`.

## Special notes for your reviewer

- Once auto-upgrade is `none`, the maintenance schedules are no-ops, so they're removed together with it.
- **Node OS image patches**, previously auto-applied via `nodeOSUpgradeChannel: NodeImage`, are now applied by the pipeline: #5627 adds a `--node-image-only` upgrade pass to `upgrade-aks-cluster.sh`. No node-OS patch coverage is lost.
- `sdp-pipelines` needs no manual change — `hcp/ARO-HCP/` there is a vendored mirror of `Azure/ARO-HCP`, promoted automatically via the release-branch flow. The `classic/` maintenance windows are ARO Classic and are unaffected.

## PR Checklist

- [x] Tested changes (bicep build)
- [x] Linked Jira issue
- [ ] Reviewed by the team
