### PR TITLE
Support kmsKey.version rotation

### DIFF
--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/hcpCluster-models.tsp
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/hcpCluster-models.tsp
@@ -94,6 +94,13 @@ model HcpOpenShiftClusterProperties {
 
   /** Configure ETCD. */
   @visibility(Lifecycle.Read, Lifecycle.Create)
+  @removed(Versions.v2026_06_30_preview)
+  @renamedFrom(Versions.v2026_06_30_preview, "etcd")
+  etcdNoUpdate?: EtcdProfile;
+
+  /** Configure ETCD. */
+  @added(Versions.v2026_06_30_preview)
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
   etcd?: EtcdProfile;
 
   /** imageDigestMirrors is a set of rules to allow pulling images from a
@@ -551,11 +558,21 @@ model KmsKey {
   /** name is the name of the keyvault key used for encryption/decryption. */
   @maxLength(255)
   @minLength(1)
+  @removed(Versions.v2026_06_30_preview)
+  @renamedFrom(Versions.v2026_06_30_preview, "name")
+  nameImplicitVisibility: string;
+
+  /** name is the name of the keyvault key used for encryption/decryption. */
+  @added(Versions.v2026_06_30_preview)
+  @visibility(Lifecycle.Read, Lifecycle.Create)
+  @maxLength(255)
+  @minLength(1)
   name: string;
 
   /** version contains the version of the key to use. */
   @maxLength(255)
   @minLength(1)
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
   version: string;
 }
 
@@ -576,6 +593,15 @@ model EtcdProfile {
    * If not specified platform managed keys are used.
    */
   @visibility(Lifecycle.Read, Lifecycle.Create)
+  @removed(Versions.v2026_06_30_preview)
+  @renamedFrom(Versions.v2026_06_30_preview, "dataEncryption")
+  dataEncryptionNoUpdate?: EtcdDataEncryptionProfile;
+
+  /** ETCD Data Encryption settings.
+   * If not specified platform managed keys are used.
+   */
+  @added(Versions.v2026_06_30_preview)
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
   dataEncryption?: EtcdDataEncryptionProfile;
 }
 
@@ -591,6 +617,15 @@ model EtcdDataEncryptionProfile {
    * Required when keyManagementMode is "CustomerManaged".
    */
   @visibility(Lifecycle.Read, Lifecycle.Create)
+  @removed(Versions.v2026_06_30_preview)
+  @renamedFrom(Versions.v2026_06_30_preview, "customerManaged")
+  customerManagedNoUpdate?: CustomerManagedEncryptionProfile;
+
+  /** Specify customer managed encryption key details.
+   * Required when keyManagementMode is "CustomerManaged".
+   */
+  @added(Versions.v2026_06_30_preview)
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
   customerManaged?: CustomerManagedEncryptionProfile;
 }
 
@@ -607,6 +642,16 @@ model CustomerManagedEncryptionProfile {
    * Required when encryptionType is "KMS".
    */
   @visibility(Lifecycle.Read, Lifecycle.Create)
+  @removed(Versions.v2026_06_30_preview)
+  @renamedFrom(Versions.v2026_06_30_preview, "kms")
+  kmsNoUpdate?: KmsEncryptionProfile;
+
+  /** The Key Management Service (KMS) encryption key details.
+   *
+   * Required when encryptionType is "KMS".
+   */
+  @added(Versions.v2026_06_30_preview)
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
   kms?: KmsEncryptionProfile;
 }
 
@@ -629,6 +674,13 @@ model KmsEncryptionProfile {
 
   /** The details of the active key. */
   @visibility(Lifecycle.Read, Lifecycle.Create)
+  @removed(Versions.v2026_06_30_preview)
+  @renamedFrom(Versions.v2026_06_30_preview, "activeKey")
+  activeKeyNoUpdate: KmsKey;
+
+  /** The details of the active key. */
+  @added(Versions.v2026_06_30_preview)
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
   activeKey: KmsKey;
 }
 

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2024-06-10-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2024-06-10-preview/openapi.json
@@ -2534,7 +2534,12 @@
           "type": "string",
           "description": "version contains the version of the key to use.",
           "minLength": 1,
-          "maxLength": 255
+          "maxLength": 255,
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
         }
       },
       "required": [

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2025-12-23-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2025-12-23-preview/openapi.json
@@ -2633,7 +2633,12 @@
           "type": "string",
           "description": "version contains the version of the key to use.",
           "minLength": 1,
-          "maxLength": 255
+          "maxLength": 255,
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
         }
       },
       "required": [

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2026-06-30-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2026-06-30-preview/openapi.json
@@ -1690,6 +1690,22 @@
           "description": "The Key Management Service (KMS) encryption key details.\n\nRequired when encryptionType is \"KMS\".",
           "x-ms-mutability": [
             "read",
+            "update",
+            "create"
+          ]
+        }
+      }
+    },
+    "CustomerManagedEncryptionProfileUpdate": {
+      "type": "object",
+      "description": "Customer managed encryption key profile.",
+      "properties": {
+        "kms": {
+          "$ref": "#/definitions/KmsEncryptionProfileUpdate",
+          "description": "The Key Management Service (KMS) encryption key details.\n\nRequired when encryptionType is \"KMS\".",
+          "x-ms-mutability": [
+            "read",
+            "update",
             "create"
           ]
         }
@@ -1796,6 +1812,22 @@
           "description": "Specify customer managed encryption key details.\nRequired when keyManagementMode is \"CustomerManaged\".",
           "x-ms-mutability": [
             "read",
+            "update",
+            "create"
+          ]
+        }
+      }
+    },
+    "EtcdDataEncryptionProfileUpdate": {
+      "type": "object",
+      "description": "The ETCD data encryption settings.",
+      "properties": {
+        "customerManaged": {
+          "$ref": "#/definitions/CustomerManagedEncryptionProfileUpdate",
+          "description": "Specify customer managed encryption key details.\nRequired when keyManagementMode is \"CustomerManaged\".",
+          "x-ms-mutability": [
+            "read",
+            "update",
             "create"
           ]
         }
@@ -1810,6 +1842,22 @@
           "description": "ETCD Data Encryption settings.\nIf not specified platform managed keys are used.",
           "x-ms-mutability": [
             "read",
+            "update",
+            "create"
+          ]
+        }
+      }
+    },
+    "EtcdProfileUpdate": {
+      "type": "object",
+      "description": "The ETCD settings and configuration options.",
+      "properties": {
+        "dataEncryption": {
+          "$ref": "#/definitions/EtcdDataEncryptionProfileUpdate",
+          "description": "ETCD Data Encryption settings.\nIf not specified platform managed keys are used.",
+          "x-ms-mutability": [
+            "read",
+            "update",
             "create"
           ]
         }
@@ -2293,6 +2341,7 @@
           "description": "Configure ETCD.",
           "x-ms-mutability": [
             "read",
+            "update",
             "create"
           ]
         },
@@ -2368,6 +2417,15 @@
         "autoscaling": {
           "$ref": "#/definitions/ClusterAutoscalingProfile",
           "description": "Configure ClusterAutoscaling .",
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        },
+        "etcd": {
+          "$ref": "#/definitions/EtcdProfileUpdate",
+          "description": "Configure ETCD.",
           "x-ms-mutability": [
             "read",
             "update",
@@ -2669,6 +2727,7 @@
           "description": "The details of the active key.",
           "x-ms-mutability": [
             "read",
+            "update",
             "create"
           ]
         }
@@ -2679,6 +2738,21 @@
         "activeKey"
       ]
     },
+    "KmsEncryptionProfileUpdate": {
+      "type": "object",
+      "description": "Configure etcd encryption Key Management Service (KMS) key.\nYour Microsoft Entra application used to create the cluster must be authorized to access this keyvault,\ne.g using the AzureCLI: `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn (YOUR APPLICATION CLIENT ID)`",
+      "properties": {
+        "activeKey": {
+          "$ref": "#/definitions/KmsKeyUpdate",
+          "description": "The details of the active key.",
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        }
+      }
+    },
     "KmsKey": {
       "type": "object",
       "description": "A representation of a KeyVault Secret.",
@@ -2687,19 +2761,45 @@
           "type": "string",
           "description": "name is the name of the keyvault key used for encryption/decryption.",
           "minLength": 1,
-          "maxLength": 255
+          "maxLength": 255,
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
         },
         "version": {
           "type": "string",
           "description": "version contains the version of the key to use.",
           "minLength": 1,
-          "maxLength": 255
+          "maxLength": 255,
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
         }
       },
       "required": [
         "name",
         "version"
       ]
+    },
+    "KmsKeyUpdate": {
+      "type": "object",
+      "description": "A representation of a KeyVault Secret.",
+      "properties": {
+        "version": {
+          "type": "string",
+          "description": "version contains the version of the key to use.",
+          "minLength": 1,
+          "maxLength": 255,
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        }
+      }
     },
     "Label": {
       "type": "object",

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_update_state_calculation.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_update_state_calculation.go
@@ -80,6 +80,9 @@ func (c *operationClusterUpdate) hypershiftHostedClusterSpecMatchesDesired(clust
 	if matches, message := c.hypershiftHostedClusterImageContentSourcesSpecMatchesDesired(cluster.CustomerProperties.ImageDigestMirrors, hostedCluster.Spec.ImageContentSources); !matches {
 		return false, message
 	}
+	if matches, message := c.hypershiftHostedClusterEtcdSecretEncryptionSpecMatchesDesired(cluster.CustomerProperties.Etcd.DataEncryption, hostedCluster.Spec.SecretEncryption); !matches {
+		return false, message
+	}
 	return true, ""
 }
 
@@ -331,6 +334,46 @@ func (c *operationClusterUpdate) hypershiftHostedClusterImageContentSourcesSpecM
 		return false, fmt.Sprintf("hypershift HostedCluster has unexpected imageContentSource %q", source)
 	}
 
+	return true, ""
+}
+
+func (c *operationClusterUpdate) hypershiftHostedClusterEtcdSecretEncryptionSpecMatchesDesired(desired api.EtcdDataEncryptionProfile, observed *v1beta1.SecretEncryptionSpec) (bool, string) {
+
+	if observed == nil {
+		return false, "unexpected hypershift HostedCluster secret encryption is not set"
+	}
+
+	if matches, message := c.hypershiftHostedClusterCustomerManagedSecretEncryptionSpecMatchesDesired(desired, observed); !matches {
+		return matches, message
+	}
+
+	return true, ""
+}
+
+func (c *operationClusterUpdate) hypershiftHostedClusterCustomerManagedSecretEncryptionSpecMatchesDesired(desired api.EtcdDataEncryptionProfile, observed *v1beta1.SecretEncryptionSpec) (bool, string) {
+	if desired.KeyManagementMode != api.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged {
+		return false, fmt.Sprintf("support for desired key management mode %q for updates is not implemented", desired.KeyManagementMode)
+	}
+
+	if desired.CustomerManaged.EncryptionType != api.CustomerManagedEncryptionTypeKMS {
+		return false, fmt.Sprintf("support for desired customer managed key encryption type %s for updates is not implemented", desired.CustomerManaged.EncryptionType)
+	}
+
+	if observed.Type != v1beta1.KMS {
+		return false, fmt.Sprintf("hypershift HostedCluster secret encryption is: %q, want :%q", observed.Type, desired.CustomerManaged.EncryptionType)
+	}
+
+	if observed.KMS == nil {
+		return false, "unexpected hypershift HostedCluster kms secret encryption configuration unset"
+	}
+
+	if observed.KMS.Azure == nil {
+		return false, "unexpected hypershift HostedCluster kms secret encryption azure configuration unset"
+	}
+
+	if observed.KMS.Azure.ActiveKey.KeyVersion != desired.CustomerManaged.Kms.ActiveKey.Version {
+		return false, fmt.Sprintf("hypershift HostedCluster kms secret encryption active key version is: %q, want: %q", observed.KMS.Azure.ActiveKey.KeyVersion, desired.CustomerManaged.Kms.ActiveKey.Version)
+	}
 	return true, ""
 }
 

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_update_state_calculation_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_update_state_calculation_test.go
@@ -617,6 +617,161 @@ func TestHypershiftHostedClusterOperationState(t *testing.T) {
 			wantState:         arm.ProvisioningStateUpdating,
 			wantMessageSubstr: `is "quay.io/openshift/cpo:test", want unset`,
 		},
+		{
+			name: "kms cluster key version mismatch returns Updating",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := fixture.newCluster(nil)
+				c.CustomerProperties.Etcd = api.EtcdProfile{
+					DataEncryption: api.EtcdDataEncryptionProfile{
+						KeyManagementMode: api.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged,
+						CustomerManaged: &api.CustomerManagedEncryptionProfile{
+							EncryptionType: api.CustomerManagedEncryptionTypeKMS,
+							Kms: &api.KmsEncryptionProfile{
+								Visibility: api.KeyVaultVisibilityPublic,
+								ActiveKey: api.KmsKey{
+									Name:      "test-key",
+									VaultName: "test-vault",
+									Version:   "v2",
+								},
+							},
+						},
+					},
+				}
+				return c
+			}(),
+			serviceProviderCluster: emptySPC,
+			readDesires: []*kubeapplier.ReadDesire{
+				newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+					Spec: func() v1beta1.HostedClusterSpec {
+						spec := testClusterUpdateMatchingHostedClusterSpec()
+						spec.SecretEncryption = &v1beta1.SecretEncryptionSpec{
+							Type: v1beta1.KMS,
+							KMS: &v1beta1.KMSSpec{
+								Azure: &v1beta1.AzureKMSSpec{
+									ActiveKey: v1beta1.AzureKMSKey{
+										KeyVersion: "v1",
+									},
+								},
+							},
+						}
+						return spec
+					}(),
+				}),
+			},
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: `active key version is: "v1", want: "v2"`,
+		},
+		{
+			name: "kms cluster with nil SecretEncryption returns Updating",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := fixture.newCluster(nil)
+				c.CustomerProperties.Etcd = api.EtcdProfile{
+					DataEncryption: api.EtcdDataEncryptionProfile{
+						KeyManagementMode: api.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged,
+						CustomerManaged: &api.CustomerManagedEncryptionProfile{
+							EncryptionType: api.CustomerManagedEncryptionTypeKMS,
+							Kms: &api.KmsEncryptionProfile{
+								Visibility: api.KeyVaultVisibilityPublic,
+								ActiveKey: api.KmsKey{
+									Name:      "test-key",
+									VaultName: "test-vault",
+									Version:   "v1",
+								},
+							},
+						},
+					},
+				}
+				return c
+			}(),
+			serviceProviderCluster: emptySPC,
+			readDesires: []*kubeapplier.ReadDesire{
+				newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+					Spec: func() v1beta1.HostedClusterSpec {
+						spec := testClusterUpdateMatchingHostedClusterSpec()
+						spec.SecretEncryption = nil
+						return spec
+					}(),
+				}),
+			},
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: "secret encryption is not set",
+		},
+		{
+			name: "kms cluster key version matching returns Succeeded",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := fixture.newCluster(nil)
+				c.CustomerProperties.Etcd = api.EtcdProfile{
+					DataEncryption: api.EtcdDataEncryptionProfile{
+						KeyManagementMode: api.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged,
+						CustomerManaged: &api.CustomerManagedEncryptionProfile{
+							EncryptionType: api.CustomerManagedEncryptionTypeKMS,
+							Kms: &api.KmsEncryptionProfile{
+								Visibility: api.KeyVaultVisibilityPublic,
+								ActiveKey: api.KmsKey{
+									Name:      "test-key",
+									VaultName: "test-vault",
+									Version:   "v1",
+								},
+							},
+						},
+					},
+				}
+				return c
+			}(),
+			serviceProviderCluster: emptySPC,
+			readDesires: []*kubeapplier.ReadDesire{
+				newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+					Spec: func() v1beta1.HostedClusterSpec {
+						spec := testClusterUpdateMatchingHostedClusterSpec()
+						spec.SecretEncryption = &v1beta1.SecretEncryptionSpec{
+							Type: v1beta1.KMS,
+							KMS: &v1beta1.KMSSpec{
+								Azure: &v1beta1.AzureKMSSpec{
+									ActiveKey: v1beta1.AzureKMSKey{
+										KeyVersion: "v1",
+									},
+								},
+							},
+						}
+						return spec
+					}(),
+				}),
+			},
+			wantState: arm.ProvisioningStateSucceeded,
+		},
+		{
+			name: "Platform Managed data encryption returns Updating",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := fixture.newCluster(nil)
+				c.CustomerProperties.Etcd = api.EtcdProfile{
+					DataEncryption: api.EtcdDataEncryptionProfile{
+						KeyManagementMode: api.EtcdDataEncryptionKeyManagementModeTypePlatformManaged,
+					},
+				}
+				return c
+			}(),
+			serviceProviderCluster: emptySPC,
+			readDesires: []*kubeapplier.ReadDesire{
+				newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+					Spec: func() v1beta1.HostedClusterSpec {
+						spec := testClusterUpdateMatchingHostedClusterSpec()
+						spec.SecretEncryption = &v1beta1.SecretEncryptionSpec{
+							Type: v1beta1.KMS,
+							KMS: &v1beta1.KMSSpec{
+								Azure: &v1beta1.AzureKMSSpec{
+									ActiveKey: v1beta1.AzureKMSKey{
+										KeyVersion: "v1",
+									},
+								},
+							},
+						}
+						return spec
+					}(),
+				}),
+			},
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: "support for desired key management mode",
+		},
 	}
 
 	for _, tt := range tests {
@@ -1251,6 +1406,131 @@ func TestHypershiftHostedClusterImageContentSourcesSpecMatchesDesired(t *testing
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			matches, msg := controller.hypershiftHostedClusterImageContentSourcesSpecMatchesDesired(tt.desired, tt.observed)
+			assert.Equal(t, tt.wantMatch, matches)
+			if tt.wantSubstr != "" {
+				assert.Contains(t, msg, tt.wantSubstr)
+			}
+		})
+	}
+}
+
+func TestHypershiftHostedClusterEtcdSecretEncryptionSpecMatchesDesired(t *testing.T) {
+	t.Parallel()
+
+	controller := &operationClusterUpdate{}
+
+	etcdDesired := api.EtcdDataEncryptionProfile{
+		KeyManagementMode: api.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged,
+		CustomerManaged: &api.CustomerManagedEncryptionProfile{
+			EncryptionType: api.CustomerManagedEncryptionTypeKMS,
+			Kms: &api.KmsEncryptionProfile{
+				Visibility: api.KeyVaultVisibilityPublic,
+				ActiveKey: api.KmsKey{
+					Name:      "test-key",
+					VaultName: "test-vault",
+					Version:   "v1",
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name       string
+		desired    api.EtcdDataEncryptionProfile
+		observed   *v1beta1.SecretEncryptionSpec
+		wantMatch  bool
+		wantSubstr string
+	}{
+		{
+			name:       "customer managed KMS with nil observed returns mismatch",
+			desired:    etcdDesired,
+			observed:   nil,
+			wantMatch:  false,
+			wantSubstr: "secret encryption is not set",
+		},
+		{
+			name:    "customer managed KMS with observed type not KMS returns mismatch",
+			desired: etcdDesired,
+			observed: &v1beta1.SecretEncryptionSpec{
+				Type: v1beta1.AESCBC,
+			},
+			wantMatch:  false,
+			wantSubstr: `secret encryption is: "aescbc"`,
+		},
+		{
+			name:    "customer managed KMS with nil KMS field returns mismatch",
+			desired: etcdDesired,
+			observed: &v1beta1.SecretEncryptionSpec{
+				Type: v1beta1.KMS,
+			},
+			wantMatch:  false,
+			wantSubstr: "kms secret encryption configuration unset",
+		},
+		{
+			name:    "customer managed KMS with nil Azure field returns mismatch",
+			desired: etcdDesired,
+			observed: &v1beta1.SecretEncryptionSpec{
+				Type: v1beta1.KMS,
+				KMS:  &v1beta1.KMSSpec{},
+			},
+			wantMatch:  false,
+			wantSubstr: "azure configuration unset",
+		},
+		{
+			name:    "customer managed KMS key version mismatch",
+			desired: etcdDesired,
+			observed: &v1beta1.SecretEncryptionSpec{
+				Type: v1beta1.KMS,
+				KMS: &v1beta1.KMSSpec{
+					Azure: &v1beta1.AzureKMSSpec{
+						ActiveKey: v1beta1.AzureKMSKey{
+							KeyVersion: "v2",
+						},
+					},
+				},
+			},
+			wantMatch:  false,
+			wantSubstr: `active key version is: "v2", want: "v1"`,
+		},
+		{
+			name:    "customer managed KMS key version match",
+			desired: etcdDesired,
+			observed: &v1beta1.SecretEncryptionSpec{
+				Type: v1beta1.KMS,
+				KMS: &v1beta1.KMSSpec{
+					Azure: &v1beta1.AzureKMSSpec{
+						ActiveKey: v1beta1.AzureKMSKey{
+							KeyVersion: "v1",
+						},
+					},
+				},
+			},
+			wantMatch: true,
+		},
+		{
+			name: "platform managed",
+			desired: api.EtcdDataEncryptionProfile{
+				KeyManagementMode: api.EtcdDataEncryptionKeyManagementModeTypePlatformManaged,
+			},
+			observed: &v1beta1.SecretEncryptionSpec{
+				Type: v1beta1.KMS,
+				KMS: &v1beta1.KMSSpec{
+					Azure: &v1beta1.AzureKMSSpec{
+						ActiveKey: v1beta1.AzureKMSKey{
+							KeyVersion: "v1",
+						},
+					},
+				},
+			},
+			wantMatch:  false,
+			wantSubstr: `support for desired key management mode "PlatformManaged" for updates is not implemented`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			matches, msg := controller.hypershiftHostedClusterEtcdSecretEncryptionSpecMatchesDesired(tt.desired, tt.observed)
 			assert.Equal(t, tt.wantMatch, matches)
 			if tt.wantSubstr != "" {
 				assert.Contains(t, msg, tt.wantSubstr)

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_update_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_update_test.go
@@ -415,6 +415,110 @@ func TestOperationClusterUpdate_SynchronizeOperation(t *testing.T) {
 			},
 		},
 		{
+			name: "cs cluster ready with customerManaged KMS etcd key version match transitions operation to succeeded",
+			existingCluster: newClusterWithCustomerVersion("4.19", func(cluster *api.HCPOpenShiftCluster) {
+				cluster.CustomerProperties.Etcd = api.EtcdProfile{
+					DataEncryption: api.EtcdDataEncryptionProfile{
+						KeyManagementMode: api.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged,
+						CustomerManaged: &api.CustomerManagedEncryptionProfile{
+							EncryptionType: api.CustomerManagedEncryptionTypeKMS,
+							Kms: &api.KmsEncryptionProfile{
+								Visibility: api.KeyVaultVisibilityPublic,
+								ActiveKey: api.KmsKey{
+									Name:      "test-key",
+									VaultName: "test-vault",
+									Version:   "v1",
+								},
+							},
+						},
+					},
+				}
+			}),
+			existingOperation:              newOperationAccepted(),
+			existingServiceProviderCluster: newServiceProviderClusterWithSpecControlPlaneVersion("4.19"),
+			cachedHostedClusterReadDesire: newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+				Spec: func() v1beta1.HostedClusterSpec {
+					spec := testClusterUpdateMatchingHostedClusterSpec()
+					spec.SecretEncryption = &v1beta1.SecretEncryptionSpec{
+						Type: v1beta1.KMS,
+						KMS: &v1beta1.KMSSpec{
+							Azure: &v1beta1.AzureKMSSpec{
+								ActiveKey: v1beta1.AzureKMSKey{
+									KeyVersion: "v1",
+								},
+							},
+						},
+					}
+					return spec
+				}(),
+			}),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetCluster(gomock.Any(), fixture.clusterInternalID).
+					Return(newCSClusterWithState(arohcpv1alpha1.ClusterStateReady), nil)
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateSucceeded, op.Status)
+			},
+		},
+		{
+			name: "cs cluster ready with CMK KMS etcd key version mismatch keeps operation updating",
+			existingCluster: newClusterWithCustomerVersion("4.19", func(cluster *api.HCPOpenShiftCluster) {
+				cluster.CustomerProperties.Etcd = api.EtcdProfile{
+					DataEncryption: api.EtcdDataEncryptionProfile{
+						KeyManagementMode: api.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged,
+						CustomerManaged: &api.CustomerManagedEncryptionProfile{
+							EncryptionType: api.CustomerManagedEncryptionTypeKMS,
+							Kms: &api.KmsEncryptionProfile{
+								Visibility: api.KeyVaultVisibilityPublic,
+								ActiveKey: api.KmsKey{
+									Name:      "test-key",
+									VaultName: "test-vault",
+									Version:   "v2",
+								},
+							},
+						},
+					},
+				}
+			}),
+			existingOperation:              newOperationAccepted(),
+			existingServiceProviderCluster: newServiceProviderClusterWithSpecControlPlaneVersion("4.19"),
+			cachedHostedClusterReadDesire: newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+				Spec: func() v1beta1.HostedClusterSpec {
+					spec := testClusterUpdateMatchingHostedClusterSpec()
+					spec.SecretEncryption = &v1beta1.SecretEncryptionSpec{
+						Type: v1beta1.KMS,
+						KMS: &v1beta1.KMSSpec{
+							Azure: &v1beta1.AzureKMSSpec{
+								ActiveKey: v1beta1.AzureKMSKey{
+									KeyVersion: "v1",
+								},
+							},
+						},
+					}
+					return spec
+				}(),
+			}),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetCluster(gomock.Any(), fixture.clusterInternalID).
+					Return(newCSClusterWithState(arohcpv1alpha1.ClusterStateReady), nil)
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateUpdating, op.Status)
+				assert.Nil(t, op.Error)
+
+				cluster, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateUpdating, cluster.ServiceProviderProperties.ProvisioningState)
+				assert.Equal(t, testOperationName, cluster.ServiceProviderProperties.ActiveOperationID)
+			},
+		},
+		{
 			name: "cs cluster ready with hypershift autoscaling spec mismatch keeps operation updating",
 			existingCluster: newClusterWithCustomerVersion("4.19", func(cluster *api.HCPOpenShiftCluster) {
 				cluster.CustomerProperties.Autoscaling.MaxNodesTotal = 10

--- a/backend/pkg/controllers/operationcontrollers/test_helpers_test.go
+++ b/backend/pkg/controllers/operationcontrollers/test_helpers_test.go
@@ -104,6 +104,24 @@ func (f *clusterTestFixture) newCluster(createdAt *time.Time) *api.HCPOpenShiftC
 				},
 			},
 		},
+		CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
+			Etcd: api.EtcdProfile{
+				DataEncryption: api.EtcdDataEncryptionProfile{
+					KeyManagementMode: api.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged,
+					CustomerManaged: &api.CustomerManagedEncryptionProfile{
+						EncryptionType: api.CustomerManagedEncryptionTypeKMS,
+						Kms: &api.KmsEncryptionProfile{
+							Visibility: api.KeyVaultVisibilityPublic,
+							ActiveKey: api.KmsKey{
+								Name:      "test-key",
+								VaultName: "test-vault",
+								Version:   "v1",
+							},
+						},
+					},
+				},
+			},
+		},
 		ServiceProviderProperties: api.HCPOpenShiftClusterServiceProviderProperties{
 			ClusterServiceID:  &f.clusterInternalID,
 			ActiveOperationID: testOperationName,
@@ -377,6 +395,16 @@ func testClusterUpdateMatchingHostedClusterSpec() v1beta1.HostedClusterSpec {
 		},
 		ControllerAvailabilityPolicy:     v1beta1.HighlyAvailable,
 		InfrastructureAvailabilityPolicy: v1beta1.HighlyAvailable,
+		SecretEncryption: &v1beta1.SecretEncryptionSpec{
+			Type: v1beta1.KMS,
+			KMS: &v1beta1.KMSSpec{
+				Azure: &v1beta1.AzureKMSSpec{
+					ActiveKey: v1beta1.AzureKMSKey{
+						KeyVersion: "v1",
+					},
+				},
+			},
+		},
 	}
 }
 

--- a/internal/admission/admit_cluster.go
+++ b/internal/admission/admit_cluster.go
@@ -277,6 +277,7 @@ func admitClusterCustomerProperties(ctx context.Context, admissionContext *Clust
 	errs := field.ErrorList{}
 
 	errs = append(errs, admitClusterVersionProfile(ctx, admissionContext, op, fldPath.Child("version"), &newObj.Version, safe.Field(oldObj, validation.ToClusterCustomerPropertiesVersion))...)
+	errs = append(errs, admitClusterEtcdKmsKeyVersionChange(ctx, admissionContext, op, fldPath.Child("etcd", "dataEncryption", "customerManaged", "kms", "activeKey", "version"), newObj, oldObj)...)
 	errs = append(errs, admitClusterPlatform(ctx, admissionContext, op, fldPath.Child("platform"), &newObj.Platform)...)
 
 	return errs
@@ -462,4 +463,43 @@ func admitClusterVersionProfile(ctx context.Context, admissionContext *ClusterAd
 	}
 
 	return errs
+}
+
+// minKmsKeyVersionRotationVersion is the minimum OCP version whose CPO
+// supports etcd KMS key version rotation.
+var minKmsKeyVersionRotationVersion = semver.Version{Major: 4, Minor: 22}
+
+// admitClusterEtcdKmsKeyVersionChange rejects KMS key version changes when the
+// cluster's active control plane version predates the CPO support (< 4.22).
+// Only runs for API versions >= v20260630Preview where version is mutable;
+// older API versions block version changes via the immutability check in validation.
+func admitClusterEtcdKmsKeyVersionChange(_ context.Context, admissionContext *ClusterAdmissionContext, op operation.Operation, fldPath *field.Path, newObj, oldObj *api.HCPOpenShiftClusterCustomerProperties) field.ErrorList {
+	if op.Type != operation.Update || oldObj == nil {
+		return nil
+	}
+
+	if newObj.Etcd.DataEncryption.KeyManagementMode != api.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged && newObj.Etcd.DataEncryption.KeyManagementMode != oldObj.Etcd.DataEncryption.KeyManagementMode {
+		return field.ErrorList{field.Forbidden(fldPath, "KMS key version rotation is only supported for customer-managed encryption")}
+	}
+
+	if newObj.Etcd.DataEncryption.CustomerManaged.Kms.ActiveKey.Version == oldObj.Etcd.DataEncryption.CustomerManaged.Kms.ActiveKey.Version {
+		return nil
+	}
+
+	apiVersion := api.APIVersionFromOptions(op.Options)
+	if apiVersion.LT(api.APIVersionV20260630Preview) {
+		return field.ErrorList{field.Forbidden(fldPath, "KMS key version is immutable for this API version")}
+	}
+
+	if admissionContext.ServiceProviderCluster == nil {
+		return field.ErrorList{field.InternalError(fldPath, errors.New("cannot validate KMS key version rotation"))}
+	}
+
+	lowest, _ := apihelpers.FindLowestAndHighestClusterVersion(admissionContext.ServiceProviderCluster.Status.ControlPlaneVersion.ActiveVersions)
+	clusterVersion := semver.Version{Major: lowest.Major, Minor: lowest.Minor}
+	if clusterVersion.LT(minKmsKeyVersionRotationVersion) {
+		return field.ErrorList{field.Invalid(fldPath, newObj.Etcd.DataEncryption.CustomerManaged.Kms.ActiveKey.Version, fmt.Sprintf("KMS key version rotation requires cluster version %s or above", minKmsKeyVersionRotationVersion))}
+	}
+
+	return nil
 }

--- a/internal/admission/admit_cluster_test.go
+++ b/internal/admission/admit_cluster_test.go
@@ -591,27 +591,48 @@ func TestAdmitCluster_Update(t *testing.T) {
 		}
 	}
 
+	kmsEtcdProfile := func(keyVersion string) api.EtcdProfile {
+		return api.EtcdProfile{
+			DataEncryption: api.EtcdDataEncryptionProfile{
+				KeyManagementMode: api.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged,
+				CustomerManaged: &api.CustomerManagedEncryptionProfile{
+					Kms: &api.KmsEncryptionProfile{
+						ActiveKey: api.KmsKey{
+							Name:      "test-key",
+							VaultName: "test-vault",
+							Version:   keyVersion,
+						},
+					},
+				},
+			},
+		}
+	}
+
 	tests := []struct {
 		name                         string
 		oldClusterVersionID          string
-		clusterVersionID             string
+		channelGroup                 string
+		etcd                         api.EtcdProfile
+		options                      []string
 		serviceProviderClusterStatus api.ServiceProviderClusterStatus
 		nodePools                    []*api.HCPOpenShiftClusterNodePool
 		serviceProviderNodePools     []*api.ServiceProviderNodePool
+		newClusterFromOld            func(*api.HCPOpenShiftCluster) //This method uses a copy of the oldCluster, changes are applied to that copy.
 		expectErrors                 []utils.ExpectedError
 	}{
 		{
 			name:                         "empty desired version skips admission",
 			oldClusterVersionID:          "4.10",
-			clusterVersionID:             "",
 			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.22"),
 			nodePools:                    []*api.HCPOpenShiftClusterNodePool{makeTestNodePool("np1", "4.10.0")},
-			expectErrors:                 []utils.ExpectedError{},
+			newClusterFromOld: func(oldCopy *api.HCPOpenShiftCluster) {
+				oldCopy.CustomerProperties.Version.ID = ""
+			},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name:                         "unchanged version skips admission",
 			oldClusterVersionID:          "5.0",
-			clusterVersionID:             "5.0",
 			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.22"),
 			nodePools:                    []*api.HCPOpenShiftClusterNodePool{makeTestNodePool("workers", "4.20.0")},
 			expectErrors:                 []utils.ExpectedError{},
@@ -619,9 +640,10 @@ func TestAdmitCluster_Update(t *testing.T) {
 		{
 			name:                         "unparsable old version id",
 			oldClusterVersionID:          "4.x",
-			clusterVersionID:             "4.22",
 			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.22"),
-			nodePools:                    nil,
+			newClusterFromOld: func(c *api.HCPOpenShiftCluster) {
+				c.CustomerProperties.Version.ID = "4.22"
+			},
 			expectErrors: []utils.ExpectedError{
 				{FieldPath: "properties.version.id", Message: "Invalid character(s) found in minor number"},
 			},
@@ -629,25 +651,28 @@ func TestAdmitCluster_Update(t *testing.T) {
 		{
 			name:                         "skips skew vs lowest when old minor matches lowest active cluster version",
 			oldClusterVersionID:          "4.21",
-			clusterVersionID:             "4.23",
 			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.21"),
-			nodePools:                    nil,
-			expectErrors:                 []utils.ExpectedError{},
+			newClusterFromOld: func(c *api.HCPOpenShiftCluster) {
+				c.CustomerProperties.Version.ID = "4.23"
+			},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name:                         "allows 4.22 to 5.0 with active cluster version 4.22",
 			oldClusterVersionID:          "4.22",
-			clusterVersionID:             "5.0",
 			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.22"),
-			nodePools:                    nil,
-			expectErrors:                 []utils.ExpectedError{},
+			newClusterFromOld: func(c *api.HCPOpenShiftCluster) {
+				c.CustomerProperties.Version.ID = "5.0"
+			},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name:                         "rejects 5.1 when old minor below lowest active cluster version",
 			oldClusterVersionID:          "4.21",
-			clusterVersionID:             "5.1",
 			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.22"),
-			nodePools:                    nil,
+			newClusterFromOld: func(c *api.HCPOpenShiftCluster) {
+				c.CustomerProperties.Version.ID = "5.1"
+			},
 			expectErrors: []utils.ExpectedError{
 				{FieldPath: "properties.version.id", Message: "invalid upgrade path"},
 			},
@@ -655,9 +680,10 @@ func TestAdmitCluster_Update(t *testing.T) {
 		{
 			name:                         "rejects 4.24 when old minor below lowest active cluster version",
 			oldClusterVersionID:          "4.21",
-			clusterVersionID:             "4.24",
 			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.22"),
-			nodePools:                    nil,
+			newClusterFromOld: func(c *api.HCPOpenShiftCluster) {
+				c.CustomerProperties.Version.ID = "4.24"
+			},
 			expectErrors: []utils.ExpectedError{
 				{FieldPath: "properties.version.id", Message: "only upgrade to the next minor is allowed"},
 			},
@@ -665,9 +691,10 @@ func TestAdmitCluster_Update(t *testing.T) {
 		{
 			name:                         "rejects version below highest active cluster version",
 			oldClusterVersionID:          "4.22",
-			clusterVersionID:             "4.21",
 			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.22"),
-			nodePools:                    nil,
+			newClusterFromOld: func(c *api.HCPOpenShiftCluster) {
+				c.CustomerProperties.Version.ID = "4.21"
+			},
 			expectErrors: []utils.ExpectedError{
 				{FieldPath: "properties.version.id", Message: "must be at least"},
 			},
@@ -675,17 +702,19 @@ func TestAdmitCluster_Update(t *testing.T) {
 		{
 			name:                         "allows upgrade across adjacent active cluster minors",
 			oldClusterVersionID:          "4.21",
-			clusterVersionID:             "4.22",
 			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersions("4.22", "4.21"),
-			nodePools:                    nil,
-			expectErrors:                 []utils.ExpectedError{},
+			newClusterFromOld: func(c *api.HCPOpenShiftCluster) {
+				c.CustomerProperties.Version.ID = "4.22"
+			},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name:                         "rejects skip minor vs lowest when fleet spans minors",
 			oldClusterVersionID:          "4.21",
-			clusterVersionID:             "4.22",
 			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersions("4.20", "4.22"),
-			nodePools:                    nil,
+			newClusterFromOld: func(c *api.HCPOpenShiftCluster) {
+				c.CustomerProperties.Version.ID = "4.22"
+			},
 			expectErrors: []utils.ExpectedError{
 				{FieldPath: "properties.version.id", Message: "only upgrade to the next minor is allowed"},
 			},
@@ -693,9 +722,11 @@ func TestAdmitCluster_Update(t *testing.T) {
 		{
 			name:                         "rejects when node pool over two minors behind",
 			oldClusterVersionID:          "4.20",
-			clusterVersionID:             "4.21",
 			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.20"),
 			nodePools:                    []*api.HCPOpenShiftClusterNodePool{makeTestNodePool("workers", "4.17.0")},
+			newClusterFromOld: func(c *api.HCPOpenShiftCluster) {
+				c.CustomerProperties.Version.ID = "4.21"
+			},
 			expectErrors: []utils.ExpectedError{
 				{FieldPath: "properties.version.id", Message: "must not be more than two minor versions ahead"},
 			},
@@ -703,7 +734,6 @@ func TestAdmitCluster_Update(t *testing.T) {
 		{
 			name:                         "allows no-op version with node pools in skew",
 			oldClusterVersionID:          "4.20",
-			clusterVersionID:             "4.20",
 			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.20"),
 			nodePools: []*api.HCPOpenShiftClusterNodePool{
 				makeTestNodePool("workers", "4.18.0"),
@@ -715,49 +745,61 @@ func TestAdmitCluster_Update(t *testing.T) {
 		{
 			name:                         "allows 4.22 to 5.0 node pool 4.22",
 			oldClusterVersionID:          "4.22",
-			clusterVersionID:             "5.0",
 			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.22"),
 			nodePools:                    []*api.HCPOpenShiftClusterNodePool{makeTestNodePool("workers", "4.22.0")},
-			expectErrors:                 []utils.ExpectedError{},
+			newClusterFromOld: func(c *api.HCPOpenShiftCluster) {
+				c.CustomerProperties.Version.ID = "5.0"
+			},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name:                         "allows 4.22 to 5.0 node pool 4.21",
 			oldClusterVersionID:          "4.22",
-			clusterVersionID:             "5.0",
 			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.22"),
 			nodePools:                    []*api.HCPOpenShiftClusterNodePool{makeTestNodePool("workers", "4.21.0")},
-			expectErrors:                 []utils.ExpectedError{},
+			newClusterFromOld: func(c *api.HCPOpenShiftCluster) {
+				c.CustomerProperties.Version.ID = "5.0"
+			},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name:                         "allows 4.23 to 5.1 node pool 4.22",
 			oldClusterVersionID:          "4.23",
-			clusterVersionID:             "5.1",
 			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.23"),
 			nodePools:                    []*api.HCPOpenShiftClusterNodePool{makeTestNodePool("workers", "4.22.0")},
-			expectErrors:                 []utils.ExpectedError{},
+			newClusterFromOld: func(c *api.HCPOpenShiftCluster) {
+				c.CustomerProperties.Version.ID = "5.1"
+			},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name:                         "allows 4.23 to 5.1 node pool 4.23",
 			oldClusterVersionID:          "4.23",
-			clusterVersionID:             "5.1",
 			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.23"),
 			nodePools:                    []*api.HCPOpenShiftClusterNodePool{makeTestNodePool("workers", "4.23.0")},
-			expectErrors:                 []utils.ExpectedError{},
+			newClusterFromOld: func(c *api.HCPOpenShiftCluster) {
+				c.CustomerProperties.Version.ID = "5.1"
+			},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name:                         "allows 5.1 to 5.2 node pool 4.23",
 			oldClusterVersionID:          "5.1",
-			clusterVersionID:             "5.2",
 			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("5.1"),
 			nodePools:                    []*api.HCPOpenShiftClusterNodePool{makeTestNodePool("workers", "4.23.0")},
-			expectErrors:                 []utils.ExpectedError{},
+			newClusterFromOld: func(c *api.HCPOpenShiftCluster) {
+				c.CustomerProperties.Version.ID = "5.2"
+			},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name:                         "rejects 4.22 to 5.0 node pool 4.20",
 			oldClusterVersionID:          "4.22",
-			clusterVersionID:             "5.0",
 			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.22"),
 			nodePools:                    []*api.HCPOpenShiftClusterNodePool{makeTestNodePool("workers", "4.20.0")},
+			newClusterFromOld: func(c *api.HCPOpenShiftCluster) {
+				c.CustomerProperties.Version.ID = "5.0"
+			},
 			expectErrors: []utils.ExpectedError{
 				{FieldPath: "properties.version.id", Message: "incompatible with node pool"},
 			},
@@ -765,9 +807,11 @@ func TestAdmitCluster_Update(t *testing.T) {
 		{
 			name:                         "rejects 4.23 to 5.1 node pool 4.21",
 			oldClusterVersionID:          "4.23",
-			clusterVersionID:             "5.1",
 			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.23"),
 			nodePools:                    []*api.HCPOpenShiftClusterNodePool{makeTestNodePool("workers", "4.21.0")},
+			newClusterFromOld: func(c *api.HCPOpenShiftCluster) {
+				c.CustomerProperties.Version.ID = "5.1"
+			},
 			expectErrors: []utils.ExpectedError{
 				{FieldPath: "properties.version.id", Message: "incompatible with node pool"},
 			},
@@ -775,9 +819,11 @@ func TestAdmitCluster_Update(t *testing.T) {
 		{
 			name:                         "rejects 4.22 to 5.0 node pool 4.23",
 			oldClusterVersionID:          "4.22",
-			clusterVersionID:             "5.0",
 			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.22"),
 			nodePools:                    []*api.HCPOpenShiftClusterNodePool{makeTestNodePool("workers", "4.23.0")},
+			newClusterFromOld: func(c *api.HCPOpenShiftCluster) {
+				c.CustomerProperties.Version.ID = "5.0"
+			},
 			expectErrors: []utils.ExpectedError{
 				{FieldPath: "properties.version.id", Message: "incompatible with node pool"},
 			},
@@ -785,11 +831,13 @@ func TestAdmitCluster_Update(t *testing.T) {
 		{
 			name:                         "rejects 4.22 to 5.0 mixed node pool minors",
 			oldClusterVersionID:          "4.22",
-			clusterVersionID:             "5.0",
 			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.22"),
 			nodePools: []*api.HCPOpenShiftClusterNodePool{
 				makeTestNodePool("workers", "4.22.0"),
 				makeTestNodePool("legacy", "4.20.0"),
+			},
+			newClusterFromOld: func(c *api.HCPOpenShiftCluster) {
+				c.CustomerProperties.Version.ID = "5.0"
 			},
 			expectErrors: []utils.ExpectedError{
 				{FieldPath: "properties.version.id", Message: "incompatible with node pool"},
@@ -798,10 +846,12 @@ func TestAdmitCluster_Update(t *testing.T) {
 		{
 			name:                         "rejects 4.22 to 5.0 sp node pool behind customer minor",
 			oldClusterVersionID:          "4.22",
-			clusterVersionID:             "5.0",
 			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.22"),
 			nodePools:                    []*api.HCPOpenShiftClusterNodePool{makeTestNodePool("workers", "4.22.0")},
 			serviceProviderNodePools:     []*api.ServiceProviderNodePool{makeServiceProviderNodePool("workers", "4.17.0")},
+			newClusterFromOld: func(c *api.HCPOpenShiftCluster) {
+				c.CustomerProperties.Version.ID = "5.0"
+			},
 			expectErrors: []utils.ExpectedError{
 				{FieldPath: "properties.version.id", Message: "incompatible with node pool"},
 			},
@@ -809,10 +859,12 @@ func TestAdmitCluster_Update(t *testing.T) {
 		{
 			name:                         "rejects minor upgrade sp node pool two minors behind",
 			oldClusterVersionID:          "4.20",
-			clusterVersionID:             "4.21",
 			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.20"),
 			nodePools:                    []*api.HCPOpenShiftClusterNodePool{makeTestNodePool("workers", "4.20.0")},
 			serviceProviderNodePools:     []*api.ServiceProviderNodePool{makeServiceProviderNodePool("workers", "4.17.0")},
+			newClusterFromOld: func(c *api.HCPOpenShiftCluster) {
+				c.CustomerProperties.Version.ID = "4.21"
+			},
 			expectErrors: []utils.ExpectedError{
 				{FieldPath: "properties.version.id", Message: "must not be more than two minor versions ahead"},
 			},
@@ -820,10 +872,12 @@ func TestAdmitCluster_Update(t *testing.T) {
 		{
 			name:                         "rejects 4.22 to 5.0 incompatible lowest active cluster version",
 			oldClusterVersionID:          "4.22",
-			clusterVersionID:             "5.0",
 			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.22"),
 			nodePools:                    []*api.HCPOpenShiftClusterNodePool{makeTestNodePool("workers", "4.22.0")},
 			serviceProviderNodePools:     []*api.ServiceProviderNodePool{makeServiceProviderNodePool("workers", "4.22.0", "4.17.0")},
+			newClusterFromOld: func(c *api.HCPOpenShiftCluster) {
+				c.CustomerProperties.Version.ID = "5.0"
+			},
 			expectErrors: []utils.ExpectedError{
 				{FieldPath: "properties.version.id", Message: "incompatible with node pool"},
 			},
@@ -831,10 +885,91 @@ func TestAdmitCluster_Update(t *testing.T) {
 		{
 			name:                         "allows 4.22 to 5.0 compatible active cluster versions",
 			oldClusterVersionID:          "4.22",
-			clusterVersionID:             "5.0",
 			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.22"),
 			nodePools:                    []*api.HCPOpenShiftClusterNodePool{makeTestNodePool("workers", "4.22.0")},
 			serviceProviderNodePools:     []*api.ServiceProviderNodePool{makeServiceProviderNodePool("workers", "4.22.1", "4.22.0")},
+			newClusterFromOld: func(c *api.HCPOpenShiftCluster) {
+				c.CustomerProperties.Version.ID = "5.0"
+			},
+			expectErrors: []utils.ExpectedError{},
+		},
+		{
+			name:                         "kms key version change allowed at 4.22 nightly",
+			oldClusterVersionID:          "4.22",
+			channelGroup:                 "nightly",
+			etcd:                         kmsEtcdProfile("old-version"),
+			options:                      []string{api.APIVersionOption(api.APIVersionV20260630Preview)},
+			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.22.0-0.nightly-multi-2026-06-29-132714"),
+			newClusterFromOld: func(c *api.HCPOpenShiftCluster) {
+				c.CustomerProperties.Etcd.DataEncryption.CustomerManaged.Kms.ActiveKey.Version = "new-version"
+			},
+			expectErrors: []utils.ExpectedError{},
+		},
+		{
+			name:                         "kms key version change allowed at 4.22",
+			oldClusterVersionID:          "4.22",
+			etcd:                         kmsEtcdProfile("old-version"),
+			options:                      []string{api.APIVersionOption(api.APIVersionV20260630Preview)},
+			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.22.4"),
+			newClusterFromOld: func(c *api.HCPOpenShiftCluster) {
+				c.CustomerProperties.Etcd.DataEncryption.CustomerManaged.Kms.ActiveKey.Version = "new-version"
+			},
+			expectErrors: []utils.ExpectedError{},
+		},
+		{
+			name:                         "kms key version change allowed at 5.0",
+			oldClusterVersionID:          "4.22",
+			etcd:                         kmsEtcdProfile("old-version"),
+			options:                      []string{api.APIVersionOption(api.APIVersionV20260630Preview)},
+			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("5.0.1"),
+			newClusterFromOld: func(c *api.HCPOpenShiftCluster) {
+				c.CustomerProperties.Etcd.DataEncryption.CustomerManaged.Kms.ActiveKey.Version = "new-version"
+			},
+			expectErrors: []utils.ExpectedError{},
+		},
+		{
+			name:                         "kms key version change blocked at 4.21",
+			oldClusterVersionID:          "4.21",
+			etcd:                         kmsEtcdProfile("old-version"),
+			options:                      []string{api.APIVersionOption(api.APIVersionV20260630Preview)},
+			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.21.5"),
+			newClusterFromOld: func(c *api.HCPOpenShiftCluster) {
+				c.CustomerProperties.Etcd.DataEncryption.CustomerManaged.Kms.ActiveKey.Version = "new-version"
+			},
+			expectErrors: []utils.ExpectedError{
+				{FieldPath: "properties.etcd.dataEncryption.customerManaged.kms.activeKey.version", Message: "KMS key version rotation requires cluster version 4.22.0 or above"},
+			},
+		},
+		{
+			name:                         "kms key version change allowed during upgrade with lowest >= 4.22.4",
+			oldClusterVersionID:          "4.22",
+			etcd:                         kmsEtcdProfile("old-version"),
+			options:                      []string{api.APIVersionOption(api.APIVersionV20260630Preview)},
+			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersions("4.23.0", "4.22.4"),
+			newClusterFromOld: func(c *api.HCPOpenShiftCluster) {
+				c.CustomerProperties.Etcd.DataEncryption.CustomerManaged.Kms.ActiveKey.Version = "new-version"
+			},
+			expectErrors: []utils.ExpectedError{},
+		},
+		{
+			name:                         "kms key version change blocked during upgrade with lowest < 4.22.0",
+			oldClusterVersionID:          "4.22",
+			etcd:                         kmsEtcdProfile("old-version"),
+			options:                      []string{api.APIVersionOption(api.APIVersionV20260630Preview)},
+			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersions("4.22.0", "4.21.15"),
+			newClusterFromOld: func(c *api.HCPOpenShiftCluster) {
+				c.CustomerProperties.Etcd.DataEncryption.CustomerManaged.Kms.ActiveKey.Version = "new-version"
+			},
+			expectErrors: []utils.ExpectedError{
+				{FieldPath: "properties.etcd.dataEncryption.customerManaged.kms.activeKey.version", Message: "KMS key version rotation requires cluster version 4.22.0 or above"},
+			},
+		},
+		{
+			name:                         "no error when kms key version unchanged on old cluster",
+			oldClusterVersionID:          "4.21",
+			etcd:                         kmsEtcdProfile("same-version"),
+			options:                      []string{api.APIVersionOption(api.APIVersionV20260630Preview)},
+			serviceProviderClusterStatus: serviceProviderClusterStatusWithActiveControlPlaneVersion("4.21.0"),
 			expectErrors:                 []utils.ExpectedError{},
 		},
 	}
@@ -848,9 +983,6 @@ func TestAdmitCluster_Update(t *testing.T) {
 				Status:         tt.serviceProviderClusterStatus,
 			}
 
-			// Pair each node pool with its matching service provider node pool
-			// by name. The frontend's newClusterAdmissionContext prefetches both
-			// from Cosmos and zips them together; we replicate that wiring here.
 			spByName := map[string]*api.ServiceProviderNodePool{}
 			for _, sp := range tt.serviceProviderNodePools {
 				spByName[sp.ResourceID.Parent.Name] = sp
@@ -868,20 +1000,23 @@ func TestAdmitCluster_Update(t *testing.T) {
 				ClusterNodePools:       admissionNodePools,
 			}
 
+			etcd := tt.etcd
+			if etcd == (api.EtcdProfile{}) {
+				etcd = kmsEtcdProfile("v1")
+			}
 			oldCluster := &api.HCPOpenShiftCluster{
 				TrackedResource: arm.NewTrackedResource(clusterResourceID, "eastus"),
 				CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
-					Version: api.VersionProfile{ID: tt.oldClusterVersionID},
+					Version: api.VersionProfile{ID: tt.oldClusterVersionID, ChannelGroup: tt.channelGroup},
+					Etcd:    etcd,
 				},
 			}
-			newCluster := &api.HCPOpenShiftCluster{
-				TrackedResource: oldCluster.TrackedResource,
-				CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
-					Version: api.VersionProfile{ID: tt.clusterVersionID},
-				},
+			newCluster := oldCluster.DeepCopy()
+			if tt.newClusterFromOld != nil {
+				tt.newClusterFromOld(newCluster)
 			}
 
-			errs := AdmitCluster(ctx, admissionContext, operation.Operation{Type: operation.Update}, newCluster, oldCluster)
+			errs := AdmitCluster(ctx, admissionContext, operation.Operation{Type: operation.Update, Options: tt.options}, newCluster, oldCluster)
 
 			utils.VerifyErrorsMatch(t, tt.expectErrors, errs)
 		})

--- a/internal/api/v20260630preview/generated/models.go
+++ b/internal/api/v20260630preview/generated/models.go
@@ -103,6 +103,13 @@ type CustomerManagedEncryptionProfile struct {
 	Kms *KmsEncryptionProfile
 }
 
+// CustomerManagedEncryptionProfileUpdate - Customer managed encryption key profile.
+type CustomerManagedEncryptionProfileUpdate struct {
+	// The Key Management Service (KMS) encryption key details.
+	// Required when encryptionType is "KMS".
+	Kms *KmsEncryptionProfileUpdate
+}
+
 // DNSProfile - DNS contains the DNS settings of the cluster
 type DNSProfile struct {
 	// BaseDomainPrefix is the unique name of the cluster representing the OpenShift's cluster name. BaseDomainPrefix is the name
@@ -123,10 +130,22 @@ type EtcdDataEncryptionProfile struct {
 	KeyManagementMode *EtcdDataEncryptionKeyManagementModeType
 }
 
+// EtcdDataEncryptionProfileUpdate - The ETCD data encryption settings.
+type EtcdDataEncryptionProfileUpdate struct {
+	// Specify customer managed encryption key details. Required when keyManagementMode is "CustomerManaged".
+	CustomerManaged *CustomerManagedEncryptionProfileUpdate
+}
+
 // EtcdProfile - The ETCD settings and configuration options.
 type EtcdProfile struct {
 	// ETCD Data Encryption settings. If not specified platform managed keys are used.
 	DataEncryption *EtcdDataEncryptionProfile
+}
+
+// EtcdProfileUpdate - The ETCD settings and configuration options.
+type EtcdProfileUpdate struct {
+	// ETCD Data Encryption settings. If not specified platform managed keys are used.
+	DataEncryption *EtcdDataEncryptionProfileUpdate
 }
 
 // ExternalAuth resource
@@ -380,6 +399,9 @@ type HcpOpenShiftClusterPropertiesUpdate struct {
 	// Configure ClusterAutoscaling .
 	Autoscaling *ClusterAutoscalingProfile
 
+	// Configure ETCD.
+	Etcd *EtcdProfileUpdate
+
 	// imageDigestMirrors is a set of rules to allow pulling images from a mirrored registry by using digest specifications.
 	// WARNING: Updating this array will redeploy all node pools in the cluster.
 	ImageDigestMirrors []*ImageDigestMirror
@@ -554,12 +576,26 @@ type KmsEncryptionProfile struct {
 	Visibility *KeyVaultVisibility
 }
 
+// KmsEncryptionProfileUpdate - Configure etcd encryption Key Management Service (KMS) key. Your Microsoft Entra application
+// used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI: az keyvault
+// set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn (YOUR APPLICATION CLIENT ID)
+type KmsEncryptionProfileUpdate struct {
+	// The details of the active key.
+	ActiveKey *KmsKeyUpdate
+}
+
 // KmsKey - A representation of a KeyVault Secret.
 type KmsKey struct {
 	// REQUIRED; name is the name of the keyvault key used for encryption/decryption.
 	Name *string
 
 	// REQUIRED; version contains the version of the key to use.
+	Version *string
+}
+
+// KmsKeyUpdate - A representation of a KeyVault Secret.
+type KmsKeyUpdate struct {
+	// version contains the version of the key to use.
 	Version *string
 }
 

--- a/internal/api/v20260630preview/generated/models_serde.go
+++ b/internal/api/v20260630preview/generated/models_serde.go
@@ -259,6 +259,35 @@ func (c *CustomerManagedEncryptionProfile) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// MarshalJSON implements the json.Marshaller interface for type CustomerManagedEncryptionProfileUpdate.
+func (c CustomerManagedEncryptionProfileUpdate) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "kms", c.Kms)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type CustomerManagedEncryptionProfileUpdate.
+func (c *CustomerManagedEncryptionProfileUpdate) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", c, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "kms":
+			err = unpopulate(val, "Kms", &c.Kms)
+			delete(rawMsg, key)
+		default:
+			err = fmt.Errorf("unmarshalling type %T, unknown field %q", c, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", c, err)
+		}
+	}
+	return nil
+}
+
 // MarshalJSON implements the json.Marshaller interface for type DNSProfile.
 func (d DNSProfile) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
@@ -325,6 +354,35 @@ func (e *EtcdDataEncryptionProfile) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// MarshalJSON implements the json.Marshaller interface for type EtcdDataEncryptionProfileUpdate.
+func (e EtcdDataEncryptionProfileUpdate) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "customerManaged", e.CustomerManaged)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type EtcdDataEncryptionProfileUpdate.
+func (e *EtcdDataEncryptionProfileUpdate) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", e, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "customerManaged":
+			err = unpopulate(val, "CustomerManaged", &e.CustomerManaged)
+			delete(rawMsg, key)
+		default:
+			err = fmt.Errorf("unmarshalling type %T, unknown field %q", e, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", e, err)
+		}
+	}
+	return nil
+}
+
 // MarshalJSON implements the json.Marshaller interface for type EtcdProfile.
 func (e EtcdProfile) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
@@ -334,6 +392,35 @@ func (e EtcdProfile) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type EtcdProfile.
 func (e *EtcdProfile) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", e, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "dataEncryption":
+			err = unpopulate(val, "DataEncryption", &e.DataEncryption)
+			delete(rawMsg, key)
+		default:
+			err = fmt.Errorf("unmarshalling type %T, unknown field %q", e, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", e, err)
+		}
+	}
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaller interface for type EtcdProfileUpdate.
+func (e EtcdProfileUpdate) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "dataEncryption", e.DataEncryption)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type EtcdProfileUpdate.
+func (e *EtcdProfileUpdate) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return fmt.Errorf("unmarshalling type %T: %v", e, err)
@@ -973,6 +1060,7 @@ func (h *HcpOpenShiftClusterProperties) UnmarshalJSON(data []byte) error {
 func (h HcpOpenShiftClusterPropertiesUpdate) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "autoscaling", h.Autoscaling)
+	populate(objectMap, "etcd", h.Etcd)
 	populate(objectMap, "imageDigestMirrors", h.ImageDigestMirrors)
 	populate(objectMap, "nodeDrainTimeoutMinutes", h.NodeDrainTimeoutMinutes)
 	populate(objectMap, "platform", h.Platform)
@@ -991,6 +1079,9 @@ func (h *HcpOpenShiftClusterPropertiesUpdate) UnmarshalJSON(data []byte) error {
 		switch key {
 		case "autoscaling":
 			err = unpopulate(val, "Autoscaling", &h.Autoscaling)
+			delete(rawMsg, key)
+		case "etcd":
+			err = unpopulate(val, "Etcd", &h.Etcd)
 			delete(rawMsg, key)
 		case "imageDigestMirrors":
 			err = unpopulate(val, "ImageDigestMirrors", &h.ImageDigestMirrors)
@@ -1392,6 +1483,35 @@ func (k *KmsEncryptionProfile) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// MarshalJSON implements the json.Marshaller interface for type KmsEncryptionProfileUpdate.
+func (k KmsEncryptionProfileUpdate) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "activeKey", k.ActiveKey)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type KmsEncryptionProfileUpdate.
+func (k *KmsEncryptionProfileUpdate) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", k, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "activeKey":
+			err = unpopulate(val, "ActiveKey", &k.ActiveKey)
+			delete(rawMsg, key)
+		default:
+			err = fmt.Errorf("unmarshalling type %T, unknown field %q", k, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", k, err)
+		}
+	}
+	return nil
+}
+
 // MarshalJSON implements the json.Marshaller interface for type KmsKey.
 func (k KmsKey) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
@@ -1412,6 +1532,35 @@ func (k *KmsKey) UnmarshalJSON(data []byte) error {
 		case "name":
 			err = unpopulate(val, "Name", &k.Name)
 			delete(rawMsg, key)
+		case "version":
+			err = unpopulate(val, "Version", &k.Version)
+			delete(rawMsg, key)
+		default:
+			err = fmt.Errorf("unmarshalling type %T, unknown field %q", k, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", k, err)
+		}
+	}
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaller interface for type KmsKeyUpdate.
+func (k KmsKeyUpdate) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "version", k.Version)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type KmsKeyUpdate.
+func (k *KmsKeyUpdate) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", k, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
 		case "version":
 			err = unpopulate(val, "Version", &k.Version)
 			delete(rawMsg, key)

--- a/internal/ocm/cluster_update_dispatch_config.go
+++ b/internal/ocm/cluster_update_dispatch_config.go
@@ -116,6 +116,7 @@ type clusterUpdateDispatchConfig struct {
 	Autoscaling                    clusterUpdateDispatchConfigAutoscaling                    `json:"autoscaling,omitempty"`
 	ExperimentalFeatures           clusterUpdateDispatchConfigExperimentalFeatures           `json:"experimentalFeatures,omitempty"`
 	ServiceProviderClusterDispatch clusterUpdateDispatchConfigServiceProviderClusterDispatch `json:"serviceProviderClusterDispatch,omitempty"`
+	Etcd                           clusterUpdateDispatchConfigEtcd                           `json:"etcd,omitempty"`
 }
 
 // clusterUpdateDispatchConfigImageDigestMirror is the curated image mirror subset used for
@@ -146,6 +147,26 @@ type clusterUpdateDispatchConfigExperimentalFeatures struct {
 // subset of api.ServiceProviderCluster fields included in cluster update dispatch.
 type clusterUpdateDispatchConfigServiceProviderClusterDispatch struct {
 	DesiredHostedClusterControlPlaneSize *string `json:"desiredHostedClusterControlPlaneSize,omitempty"`
+}
+
+type clusterUpdateDispatchConfigEtcd struct {
+	DataEncryption clusterUpdateDispatchConfigEtcdDataEncryption `json:"dataEncryption,omitempty"`
+}
+
+type clusterUpdateDispatchConfigEtcdDataEncryption struct {
+	CustomerManaged *clusterUpdateDispatchConfigEtcdDataEncryptionCustomerManaged `json:"customerManaged,omitempty"`
+}
+
+type clusterUpdateDispatchConfigEtcdDataEncryptionCustomerManaged struct {
+	Kms *clusterUpdateDispatchConfigEtcdDataEncryptionCustomerManagedKms `json:"kms,omitempty"`
+}
+
+type clusterUpdateDispatchConfigEtcdDataEncryptionCustomerManagedKms struct {
+	ActiveKey clusterUpdateDispatchConfigEtcdDataEncryptionCustomerManagedKmsActiveKey `json:"activeKey,omitempty"`
+}
+
+type clusterUpdateDispatchConfigEtcdDataEncryptionCustomerManagedKmsActiveKey struct {
+	Version string `json:"version,omitempty"`
 }
 
 // ClusterUpdateDispatchConfigJSONFromRP returns the canonical JSON of the dispatch config
@@ -185,10 +206,32 @@ func clusterUpdateDispatchConfigFromRP(cluster *api.HCPOpenShiftCluster, service
 			ControlPlaneOperatorImage: cluster.ServiceProviderProperties.ExperimentalFeatures.ControlPlaneOperatorImage,
 		},
 		ServiceProviderClusterDispatch: clusterUpdateDispatchConfigServiceProviderClusterDispatch{},
+		Etcd:                           clusterUpdateDispatchEtcdFromRP(cluster.CustomerProperties.Etcd),
 	}
 
 	if serviceProviderCluster != nil {
 		res.ServiceProviderClusterDispatch.DesiredHostedClusterControlPlaneSize = serviceProviderCluster.Spec.DesiredHostedClusterControlPlaneSize
+	}
+
+	return res
+}
+
+// clusterUpdateDispatchEtcdFromRP copies kms active key version from RP etcd configuration into the
+// dispatch canonical form. Returns zero value when the cluster does not use customer-managed KMS.
+func clusterUpdateDispatchEtcdFromRP(etcd api.EtcdProfile) clusterUpdateDispatchConfigEtcd {
+	if etcd.DataEncryption.KeyManagementMode != api.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged {
+		return clusterUpdateDispatchConfigEtcd{}
+	}
+
+	res := clusterUpdateDispatchConfigEtcd{}
+	if etcd.DataEncryption.CustomerManaged.EncryptionType == api.CustomerManagedEncryptionTypeKMS {
+		res.DataEncryption.CustomerManaged = &clusterUpdateDispatchConfigEtcdDataEncryptionCustomerManaged{
+			Kms: &clusterUpdateDispatchConfigEtcdDataEncryptionCustomerManagedKms{
+				ActiveKey: clusterUpdateDispatchConfigEtcdDataEncryptionCustomerManagedKmsActiveKey{
+					Version: etcd.DataEncryption.CustomerManaged.Kms.ActiveKey.Version,
+				},
+			},
+		}
 	}
 
 	return res
@@ -230,6 +273,7 @@ func clusterUpdateDispatchConfigFromCS(csCluster *arohcpv1alpha1.Cluster) (*clus
 	config.NodeDrainTimeoutMinutes = ClusterUpdateDispatchConfigNodeDrainTimeoutFromCS(csCluster)
 	config.K8sAPIServerAuthorizedCIDRs = ClusterUpdateDispatchConfigAuthorizedCIDRsFromCS(csCluster.API())
 	config.ImageDigestMirrors = clusterUpdateDispatchConfigImageDigestMirrorsFromCS(csCluster.RegistryConfig())
+	config.Etcd = clusterUpdateDispatchConfigEtcdFromCS(csCluster.Azure())
 	config.ExperimentalFeatures = clusterUpdateDispatchConfigExperimentalFeaturesFromCS(csCluster)
 	config.ServiceProviderClusterDispatch.DesiredHostedClusterControlPlaneSize = clusterUpdateDispatchConfigServiceProviderClusterDispatchDesiredHostedClusterControlPlaneSizeFromCS(csCluster)
 	autoscaling, err := clusterUpdateDispatchConfigAutoscalingFromCS(csCluster.Autoscaler())
@@ -393,6 +437,54 @@ func clusterUpdateDispatchConfigAutoscalingFromCS(in *arohcpv1alpha1.ClusterAuto
 	}, nil
 }
 
+// clusterUpdateDispatchConfigActiveKeyVersionFromCS extracts the dispatch-managed KMS active key version
+// from a Cluster Service cluster. Returns zero value when the cluster does not use customer-managed KMS.
+func clusterUpdateDispatchConfigEtcdFromCS(in *arohcpv1alpha1.Azure) clusterUpdateDispatchConfigEtcd {
+
+	etcdEncryption, ok := in.GetEtcdEncryption()
+	if !ok || etcdEncryption == nil {
+		// platform managed
+		return clusterUpdateDispatchConfigEtcd{}
+	}
+	dataEncryption, ok := etcdEncryption.GetDataEncryption()
+	if !ok || dataEncryption == nil {
+		// platform managed
+		return clusterUpdateDispatchConfigEtcd{}
+	}
+
+	keyManagementMode, ok := dataEncryption.GetKeyManagementMode()
+	if !ok || keyManagementMode == csKeyManagementModePlatformManaged {
+		// platform managed
+		return clusterUpdateDispatchConfigEtcd{}
+	}
+
+	customerManaged := dataEncryption.CustomerManaged()
+
+	encryptionType := customerManaged.EncryptionType()
+	if encryptionType == "" && encryptionType != csCustomerManagedEncryptionTypeKms {
+		// No KMS encryption type
+		return clusterUpdateDispatchConfigEtcd{}
+	}
+
+	kms := customerManaged.Kms()
+
+	activeKey := kms.ActiveKey()
+
+	activeKeyKeyVersion := activeKey.KeyVersion()
+
+	return clusterUpdateDispatchConfigEtcd{
+		DataEncryption: clusterUpdateDispatchConfigEtcdDataEncryption{
+			CustomerManaged: &clusterUpdateDispatchConfigEtcdDataEncryptionCustomerManaged{
+				Kms: &clusterUpdateDispatchConfigEtcdDataEncryptionCustomerManagedKms{
+					ActiveKey: clusterUpdateDispatchConfigEtcdDataEncryptionCustomerManagedKmsActiveKey{
+						Version: activeKeyKeyVersion,
+					},
+				},
+			},
+		},
+	}
+}
+
 // clusterUpdateDispatchConfigHash returns a SHA-256 hex digest of the dispatch config
 // projected from RP desired state. The digest is computed from canonical JSON (sorted object
 // keys at every level), not from a raw json.Marshal of the struct.
@@ -417,7 +509,7 @@ func (c *clusterUpdateDispatchConfig) canonicalJSON() ([]byte, error) {
 // baseProperties depending on how they evaluate. If they evaluate to enabled then the corresponding
 // key is set to the value of the Experimental feature. If they evaluate to disabled then the corresponding key
 // is deleted from the baseProperties map.
-func (c *clusterUpdateDispatchConfig) applyToCSBuilders(clusterBuilder *arohcpv1alpha1.ClusterBuilder, clusterAPIBuilder *arohcpv1alpha1.ClusterAPIBuilder, baseProperties map[string]string) error {
+func (c *clusterUpdateDispatchConfig) applyToCSBuilders(clusterBuilder *arohcpv1alpha1.ClusterBuilder, clusterAPIBuilder *arohcpv1alpha1.ClusterAPIBuilder, azureBuilder *arohcpv1alpha1.AzureBuilder, etcdDataEncryptionCustomerManagedActiveKeyBuilder *arohcpv1alpha1.AzureKmsKeyBuilder, baseProperties map[string]string) error {
 	if baseProperties == nil {
 		baseProperties = map[string]string{}
 	}
@@ -436,6 +528,16 @@ func (c *clusterUpdateDispatchConfig) applyToCSBuilders(clusterBuilder *arohcpv1
 
 	clusterBuilder.RegistryConfig(arohcpv1alpha1.NewClusterRegistryConfig().
 		ImageDigestMirrors(convertImageDigestMirrorsToCSBuilder(clusterUpdateDispatchConfigImageDigestMirrorsToRP(c.ImageDigestMirrors))...))
+
+	var requiresAzureBuild = false
+	// We support updating the Active KMS key for etcd data encryption in customer managed key encryption mode
+	// only when we are in that mode
+	if c.Etcd.DataEncryption.CustomerManaged != nil && c.Etcd.DataEncryption.CustomerManaged.Kms != nil {
+		if etcdDataEncryptionCustomerManagedActiveKeyBuilder != nil {
+			requiresAzureBuild = true
+			etcdDataEncryptionCustomerManagedActiveKeyBuilder.KeyVersion(c.Etcd.DataEncryption.CustomerManaged.Kms.ActiveKey.Version)
+		}
+	}
 
 	experimentalFeatures := c.ExperimentalFeatures
 	if experimentalFeatures.ControlPlaneAvailability == api.SingleReplicaControlPlane {
@@ -460,6 +562,20 @@ func (c *clusterUpdateDispatchConfig) applyToCSBuilders(clusterBuilder *arohcpv1
 		delete(baseProperties, CSPropertyCPOImageOverride)
 	}
 	clusterBuilder.Properties(baseProperties)
+
+	// If you are changing a builder that is a child of Azure builder you need to add it here in case
+	// the azureBuilder is nil
+	if azureBuilder == nil && requiresAzureBuild {
+		azureBuilder = arohcpv1alpha1.NewAzure()
+		azureBuilder.EtcdEncryption(arohcpv1alpha1.NewAzureEtcdEncryption().
+			DataEncryption(arohcpv1alpha1.NewAzureEtcdDataEncryption().
+				CustomerManaged(arohcpv1alpha1.NewAzureEtcdDataEncryptionCustomerManaged().
+					Kms(arohcpv1alpha1.NewAzureKmsEncryption().
+						ActiveKey(etcdDataEncryptionCustomerManagedActiveKeyBuilder)))))
+	}
+	if azureBuilder != nil {
+		clusterBuilder.Azure(azureBuilder)
+	}
 
 	return nil
 }

--- a/internal/ocm/cluster_update_dispatch_config_test.go
+++ b/internal/ocm/cluster_update_dispatch_config_test.go
@@ -151,6 +151,29 @@ func TestClusterUpdateDispatchConfigHash(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "different KMS key version",
+			cluster: &api.HCPOpenShiftCluster{
+				CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
+					NodeDrainTimeoutMinutes: baseCustomerProperties.NodeDrainTimeoutMinutes,
+					API:                     baseCustomerProperties.API,
+					Autoscaling:             baseCustomerProperties.Autoscaling,
+					Etcd: api.EtcdProfile{
+						DataEncryption: api.EtcdDataEncryptionProfile{
+							KeyManagementMode: api.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged,
+							CustomerManaged: &api.CustomerManagedEncryptionProfile{
+								EncryptionType: api.CustomerManagedEncryptionTypeKMS,
+								Kms: &api.KmsEncryptionProfile{
+									ActiveKey: api.KmsKey{
+										Version: "v1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	// Each row changes one dispatch-managed field from the baseline above. Comparing against
@@ -191,6 +214,56 @@ func TestClusterUpdateDispatchConfigHashExcludesNonUpdatableFields(t *testing.T)
 	hash2, err := clusterUpdateDispatchConfigHash(cluster2, &api.ServiceProviderCluster{})
 	require.NoError(t, err)
 	assert.Equal(t, hash1, hash2)
+
+	// Immutable etcd fields (keyName, vaultName, visibility) should not affect the hash.
+	// Only the key version is mutable and dispatch-managed.
+	cluster3 := &api.HCPOpenShiftCluster{
+		CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
+			NodeDrainTimeoutMinutes: 30,
+			Etcd: api.EtcdProfile{
+				DataEncryption: api.EtcdDataEncryptionProfile{
+					KeyManagementMode: api.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged,
+					CustomerManaged: &api.CustomerManagedEncryptionProfile{
+						EncryptionType: api.CustomerManagedEncryptionTypeKMS,
+						Kms: &api.KmsEncryptionProfile{
+							Visibility: api.KeyVaultVisibilityPublic,
+							ActiveKey: api.KmsKey{
+								Name:      "key-A",
+								VaultName: "vault-A",
+								Version:   "v1",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	cluster4 := &api.HCPOpenShiftCluster{
+		CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
+			NodeDrainTimeoutMinutes: 30,
+			Etcd: api.EtcdProfile{
+				DataEncryption: api.EtcdDataEncryptionProfile{
+					KeyManagementMode: api.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged,
+					CustomerManaged: &api.CustomerManagedEncryptionProfile{
+						EncryptionType: api.CustomerManagedEncryptionTypeKMS,
+						Kms: &api.KmsEncryptionProfile{
+							Visibility: api.KeyVaultVisibilityPrivate,
+							ActiveKey: api.KmsKey{
+								Name:      "key-B",
+								VaultName: "vault-B",
+								Version:   "v1",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	hash3, err := clusterUpdateDispatchConfigHash(cluster3, &api.ServiceProviderCluster{})
+	require.NoError(t, err)
+	hash4, err := clusterUpdateDispatchConfigHash(cluster4, &api.ServiceProviderCluster{})
+	require.NoError(t, err)
+	assert.Equal(t, hash3, hash4, "changing immutable etcd fields (keyName, vaultName, visibility) should not change the dispatch config hash")
 }
 
 func TestClusterUpdateDispatchConfigHashExcludesTagsWithoutExperimentalFeatures(t *testing.T) {
@@ -541,6 +614,8 @@ func TestClusterUpdateDispatchConfigJSONFromRPAndCS(t *testing.T) {
 func TestClusterUpdateDispatchConfigApplyToCSBuilders(t *testing.T) {
 	clusterBuilder := arohcpv1alpha1.NewCluster()
 	clusterAPIBuilder := arohcpv1alpha1.NewClusterAPI()
+	azureKmsKeyBuilder := arohcpv1alpha1.NewAzureKmsKey()
+	azureBuilder := arohcpv1alpha1.NewAzure()
 
 	tests := []struct {
 		name           string
@@ -656,7 +731,7 @@ func TestClusterUpdateDispatchConfigApplyToCSBuilders(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.config.applyToCSBuilders(clusterBuilder, clusterAPIBuilder, tt.properties)
+			err := tt.config.applyToCSBuilders(clusterBuilder, clusterAPIBuilder, azureBuilder, azureKmsKeyBuilder, tt.properties)
 			require.NoError(t, err)
 			if tt.wantProperties != nil {
 				assert.Equal(t, tt.wantProperties, tt.properties)
@@ -1006,4 +1081,409 @@ func TestClusterUpdateDispatchConfigAutoscalerBuilder(t *testing.T) {
 	got, err := clusterUpdateDispatchConfigAutoscalingFromCS(autoscaler)
 	require.NoError(t, err)
 	assert.Equal(t, config.Autoscaling, got)
+}
+
+func TestClusterUpdateDispatchEtcdFromRP(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		etcd api.EtcdProfile
+		want clusterUpdateDispatchConfigEtcd
+	}{
+		{
+			name: "empty mode returns zero value",
+			etcd: api.EtcdProfile{},
+			want: clusterUpdateDispatchConfigEtcd{},
+		},
+		{
+			name: "platform-managed returns zero value",
+			etcd: api.EtcdProfile{
+				DataEncryption: api.EtcdDataEncryptionProfile{
+					KeyManagementMode: api.EtcdDataEncryptionKeyManagementModeTypePlatformManaged,
+				},
+			},
+			want: clusterUpdateDispatchConfigEtcd{},
+		},
+		{
+			name: "customer managed KMS returns version",
+			etcd: api.EtcdProfile{
+				DataEncryption: api.EtcdDataEncryptionProfile{
+					KeyManagementMode: api.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged,
+					CustomerManaged: &api.CustomerManagedEncryptionProfile{
+						EncryptionType: api.CustomerManagedEncryptionTypeKMS,
+						Kms: &api.KmsEncryptionProfile{
+							Visibility: api.KeyVaultVisibilityPublic,
+							ActiveKey: api.KmsKey{
+								Name:      "test-key",
+								VaultName: "test-vault",
+								Version:   "v1",
+							},
+						},
+					},
+				},
+			},
+			want: clusterUpdateDispatchConfigEtcd{
+				DataEncryption: clusterUpdateDispatchConfigEtcdDataEncryption{
+					CustomerManaged: &clusterUpdateDispatchConfigEtcdDataEncryptionCustomerManaged{
+						Kms: &clusterUpdateDispatchConfigEtcdDataEncryptionCustomerManagedKms{
+							ActiveKey: clusterUpdateDispatchConfigEtcdDataEncryptionCustomerManagedKmsActiveKey{
+								Version: "v1",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "customer managed KMS with different version",
+			etcd: api.EtcdProfile{
+				DataEncryption: api.EtcdDataEncryptionProfile{
+					KeyManagementMode: api.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged,
+					CustomerManaged: &api.CustomerManagedEncryptionProfile{
+						EncryptionType: api.CustomerManagedEncryptionTypeKMS,
+						Kms: &api.KmsEncryptionProfile{
+							ActiveKey: api.KmsKey{
+								Version: "v2",
+							},
+						},
+					},
+				},
+			},
+			want: clusterUpdateDispatchConfigEtcd{
+				DataEncryption: clusterUpdateDispatchConfigEtcdDataEncryption{
+					CustomerManaged: &clusterUpdateDispatchConfigEtcdDataEncryptionCustomerManaged{
+						Kms: &clusterUpdateDispatchConfigEtcdDataEncryptionCustomerManagedKms{
+							ActiveKey: clusterUpdateDispatchConfigEtcdDataEncryptionCustomerManagedKmsActiveKey{
+								Version: "v2",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, clusterUpdateDispatchEtcdFromRP(tt.etcd))
+		})
+	}
+}
+
+func TestClusterUpdateDispatchConfigEtcdFromCS(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		azure func(t *testing.T) *arohcpv1alpha1.Azure
+		want  clusterUpdateDispatchConfigEtcd
+	}{
+		{
+			name: "no etcd encryption returns zero value",
+			azure: func(t *testing.T) *arohcpv1alpha1.Azure {
+				t.Helper()
+				cluster, err := arohcpv1alpha1.NewCluster().Azure(arohcpv1alpha1.NewAzure()).Build()
+				require.NoError(t, err)
+				return cluster.Azure()
+			},
+			want: clusterUpdateDispatchConfigEtcd{},
+		},
+		{
+			name: "platform-managed mode returns zero value",
+			azure: func(t *testing.T) *arohcpv1alpha1.Azure {
+				t.Helper()
+				cluster, err := arohcpv1alpha1.NewCluster().Azure(arohcpv1alpha1.NewAzure().
+					EtcdEncryption(arohcpv1alpha1.NewAzureEtcdEncryption().
+						DataEncryption(arohcpv1alpha1.NewAzureEtcdDataEncryption().
+							KeyManagementMode(csKeyManagementModePlatformManaged)))).Build()
+				require.NoError(t, err)
+				return cluster.Azure()
+			},
+			want: clusterUpdateDispatchConfigEtcd{},
+		},
+		{
+			name: "customer managed KMS returns version",
+			azure: func(t *testing.T) *arohcpv1alpha1.Azure {
+				t.Helper()
+				cluster, err := arohcpv1alpha1.NewCluster().Azure(arohcpv1alpha1.NewAzure().
+					EtcdEncryption(arohcpv1alpha1.NewAzureEtcdEncryption().
+						DataEncryption(arohcpv1alpha1.NewAzureEtcdDataEncryption().
+							KeyManagementMode(csKeyManagementModeCustomerManaged).
+							CustomerManaged(arohcpv1alpha1.NewAzureEtcdDataEncryptionCustomerManaged().
+								EncryptionType(csCustomerManagedEncryptionTypeKms).
+								Kms(arohcpv1alpha1.NewAzureKmsEncryption().
+									ActiveKey(arohcpv1alpha1.NewAzureKmsKey().
+										KeyVersion("v1"))))))).Build()
+				require.NoError(t, err)
+				return cluster.Azure()
+			},
+			want: clusterUpdateDispatchConfigEtcd{
+				DataEncryption: clusterUpdateDispatchConfigEtcdDataEncryption{
+					CustomerManaged: &clusterUpdateDispatchConfigEtcdDataEncryptionCustomerManaged{
+						Kms: &clusterUpdateDispatchConfigEtcdDataEncryptionCustomerManagedKms{
+							ActiveKey: clusterUpdateDispatchConfigEtcdDataEncryptionCustomerManagedKmsActiveKey{
+								Version: "v1",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, clusterUpdateDispatchConfigEtcdFromCS(tt.azure(t)))
+		})
+	}
+}
+
+func TestClusterUpdateDispatchConfigFromCSRoundTripWithKMS(t *testing.T) {
+	// oldClusterServiceCluster represents a KMS cluster that already exists in CS
+	// with all immutable fields set at creation time.
+	oldClusterServiceCluster, err := arohcpv1alpha1.NewCluster().
+		Azure(arohcpv1alpha1.NewAzure().
+			EtcdEncryption(arohcpv1alpha1.NewAzureEtcdEncryption().
+				DataEncryption(arohcpv1alpha1.NewAzureEtcdDataEncryption().
+					KeyManagementMode(csKeyManagementModeCustomerManaged).
+					CustomerManaged(arohcpv1alpha1.NewAzureEtcdDataEncryptionCustomerManaged().
+						EncryptionType(csCustomerManagedEncryptionTypeKms).
+						Kms(arohcpv1alpha1.NewAzureKmsEncryption().
+							ActiveKey(arohcpv1alpha1.NewAzureKmsKey().
+								KeyVersion("v0").KeyName("test-key").KeyVaultName("test-vault"))))))).Build()
+	require.NoError(t, err)
+
+	hcpCluster := &api.HCPOpenShiftCluster{
+		CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
+			Etcd: api.EtcdProfile{
+				DataEncryption: api.EtcdDataEncryptionProfile{
+					KeyManagementMode: api.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged,
+					CustomerManaged: &api.CustomerManagedEncryptionProfile{
+						EncryptionType: api.CustomerManagedEncryptionTypeKMS,
+						Kms: &api.KmsEncryptionProfile{
+							Visibility: api.KeyVaultVisibilityPublic,
+							ActiveKey: api.KmsKey{
+								Name:      "test-key",
+								VaultName: "test-vault",
+								Version:   "v1",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	spc := &api.ServiceProviderCluster{}
+
+	// BuildCSCluster in the update case (oldClusterServiceCluster != nil) produces
+	// a PATCH payload — it only contains mutable fields. Simulate what CS returns
+	// after applying the PATCH by building a full cluster with immutable fields
+	// from the old cluster plus the updated key version.
+	_, _, err = BuildCSCluster(nil, "11111111-1111-1111-1111-111111111111", hcpCluster, nil, oldClusterServiceCluster, spc)
+	require.NoError(t, err)
+
+	fullCSCluster, err := arohcpv1alpha1.NewCluster().
+		Azure(arohcpv1alpha1.NewAzure().
+			EtcdEncryption(arohcpv1alpha1.NewAzureEtcdEncryption().
+				DataEncryption(arohcpv1alpha1.NewAzureEtcdDataEncryption().
+					KeyManagementMode(csKeyManagementModeCustomerManaged).
+					CustomerManaged(arohcpv1alpha1.NewAzureEtcdDataEncryptionCustomerManaged().
+						EncryptionType(csCustomerManagedEncryptionTypeKms).
+						Kms(arohcpv1alpha1.NewAzureKmsEncryption().
+							ActiveKey(arohcpv1alpha1.NewAzureKmsKey().
+								KeyVersion("v1").KeyName("test-key").KeyVaultName("test-vault"))))))).Build()
+	require.NoError(t, err)
+
+	actualConfig, err := clusterUpdateDispatchConfigFromCS(fullCSCluster)
+	require.NoError(t, err)
+
+	require.NotNil(t, actualConfig.Etcd.DataEncryption.CustomerManaged)
+	require.NotNil(t, actualConfig.Etcd.DataEncryption.CustomerManaged.Kms)
+	assert.Equal(t, "v1", actualConfig.Etcd.DataEncryption.CustomerManaged.Kms.ActiveKey.Version)
+
+	desiredHash, err := clusterUpdateDispatchConfigFromRP(hcpCluster, spc).hash()
+	require.NoError(t, err)
+	actualHash, err := actualConfig.hash()
+	require.NoError(t, err)
+	assert.Equal(t, desiredHash, actualHash)
+}
+
+func TestClusterUpdateDispatchConfigJSONFromRPAndCSWithKMS(t *testing.T) {
+	hcpCluster := &api.HCPOpenShiftCluster{
+		CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
+			Etcd: api.EtcdProfile{
+				DataEncryption: api.EtcdDataEncryptionProfile{
+					KeyManagementMode: api.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged,
+					CustomerManaged: &api.CustomerManagedEncryptionProfile{
+						EncryptionType: api.CustomerManagedEncryptionTypeKMS,
+						Kms: &api.KmsEncryptionProfile{
+							ActiveKey: api.KmsKey{
+								Version: "v1",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	spc := &api.ServiceProviderCluster{}
+
+	// Simulate the full CS cluster that a GET would return after the key
+	// version update has been applied — immutable fields are already present.
+	fullCSCluster, err := arohcpv1alpha1.NewCluster().
+		Azure(arohcpv1alpha1.NewAzure().
+			EtcdEncryption(arohcpv1alpha1.NewAzureEtcdEncryption().
+				DataEncryption(arohcpv1alpha1.NewAzureEtcdDataEncryption().
+					KeyManagementMode(csKeyManagementModeCustomerManaged).
+					CustomerManaged(arohcpv1alpha1.NewAzureEtcdDataEncryptionCustomerManaged().
+						EncryptionType(csCustomerManagedEncryptionTypeKms).
+						Kms(arohcpv1alpha1.NewAzureKmsEncryption().
+							ActiveKey(arohcpv1alpha1.NewAzureKmsKey().
+								KeyVersion("v1"))))))).Build()
+	require.NoError(t, err)
+
+	desiredJSON, err := ClusterUpdateDispatchConfigJSONFromRP(hcpCluster, spc)
+	require.NoError(t, err)
+	actualJSON, err := ClusterUpdateDispatchConfigJSONFromCS(fullCSCluster)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, desiredJSON, actualJSON)
+	assert.Equal(t, desiredJSON, actualJSON)
+	assert.Contains(t, desiredJSON, `"version": "v1"`)
+}
+
+func TestClusterUpdateDispatchConfigApplyToCSBuildersEtcd(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		config            clusterUpdateDispatchConfig
+		kmsKeyBuilder     *arohcpv1alpha1.AzureKmsKeyBuilder
+		wantKeyVersion    string
+		wantKeyVersionSet bool
+	}{
+		{
+			name: "customer managed KMS sets key version on builder",
+			config: clusterUpdateDispatchConfig{
+				Etcd: clusterUpdateDispatchConfigEtcd{
+					DataEncryption: clusterUpdateDispatchConfigEtcdDataEncryption{
+						CustomerManaged: &clusterUpdateDispatchConfigEtcdDataEncryptionCustomerManaged{
+							Kms: &clusterUpdateDispatchConfigEtcdDataEncryptionCustomerManagedKms{
+								ActiveKey: clusterUpdateDispatchConfigEtcdDataEncryptionCustomerManagedKmsActiveKey{
+									Version: "v2",
+								},
+							},
+						},
+					},
+				},
+			},
+			kmsKeyBuilder:     arohcpv1alpha1.NewAzureKmsKey(),
+			wantKeyVersion:    "v2",
+			wantKeyVersionSet: true,
+		},
+		{
+			name:              "empty etcd does not set key version",
+			config:            clusterUpdateDispatchConfig{},
+			kmsKeyBuilder:     arohcpv1alpha1.NewAzureKmsKey(),
+			wantKeyVersionSet: false,
+		},
+		{
+			name: "nil builder is safely skipped",
+			config: clusterUpdateDispatchConfig{
+				Etcd: clusterUpdateDispatchConfigEtcd{
+					DataEncryption: clusterUpdateDispatchConfigEtcdDataEncryption{
+						CustomerManaged: &clusterUpdateDispatchConfigEtcdDataEncryptionCustomerManaged{
+							Kms: &clusterUpdateDispatchConfigEtcdDataEncryptionCustomerManagedKms{
+								ActiveKey: clusterUpdateDispatchConfigEtcdDataEncryptionCustomerManagedKmsActiveKey{
+									Version: "v2",
+								},
+							},
+						},
+					},
+				},
+			},
+			kmsKeyBuilder:     nil,
+			wantKeyVersionSet: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			clusterBuilder := arohcpv1alpha1.NewCluster()
+			clusterAPIBuilder := arohcpv1alpha1.NewClusterAPI()
+			properties := map[string]string{}
+
+			err := tt.config.applyToCSBuilders(clusterBuilder, clusterAPIBuilder, nil, tt.kmsKeyBuilder, properties)
+			require.NoError(t, err)
+
+			if tt.wantKeyVersionSet && tt.kmsKeyBuilder != nil {
+				key, err := tt.kmsKeyBuilder.Build()
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantKeyVersion, key.KeyVersion())
+			}
+		})
+	}
+}
+
+func TestClusterUpdateDispatchConfigFromCSEtcdExtraction(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		csCluster func(t *testing.T) *arohcpv1alpha1.Cluster
+		wantEtcd  clusterUpdateDispatchConfigEtcd
+	}{
+		{
+			name: "no etcd encryption returns zero value",
+			csCluster: func(t *testing.T) *arohcpv1alpha1.Cluster {
+				t.Helper()
+				cluster, err := arohcpv1alpha1.NewCluster().Build()
+				require.NoError(t, err)
+				return cluster
+			},
+			wantEtcd: clusterUpdateDispatchConfigEtcd{},
+		},
+		{
+			name: "customer managed KMS extracts version",
+			csCluster: func(t *testing.T) *arohcpv1alpha1.Cluster {
+				t.Helper()
+				cluster, err := arohcpv1alpha1.NewCluster().
+					Azure(arohcpv1alpha1.NewAzure().
+						EtcdEncryption(arohcpv1alpha1.NewAzureEtcdEncryption().
+							DataEncryption(arohcpv1alpha1.NewAzureEtcdDataEncryption().
+								KeyManagementMode(csKeyManagementModeCustomerManaged).
+								CustomerManaged(arohcpv1alpha1.NewAzureEtcdDataEncryptionCustomerManaged().
+									EncryptionType(csCustomerManagedEncryptionTypeKms).
+									Kms(arohcpv1alpha1.NewAzureKmsEncryption().
+										ActiveKey(arohcpv1alpha1.NewAzureKmsKey().
+											KeyVersion("v3"))))))).Build()
+				require.NoError(t, err)
+				return cluster
+			},
+			wantEtcd: clusterUpdateDispatchConfigEtcd{
+				DataEncryption: clusterUpdateDispatchConfigEtcdDataEncryption{
+					CustomerManaged: &clusterUpdateDispatchConfigEtcdDataEncryptionCustomerManaged{
+						Kms: &clusterUpdateDispatchConfigEtcdDataEncryptionCustomerManagedKms{
+							ActiveKey: clusterUpdateDispatchConfigEtcdDataEncryptionCustomerManagedKmsActiveKey{
+								Version: "v3",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := clusterUpdateDispatchConfigFromCS(tt.csCluster(t))
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantEtcd, got.Etcd)
+		})
+	}
 }

--- a/internal/ocm/convert.go
+++ b/internal/ocm/convert.go
@@ -268,7 +268,7 @@ func convertTokenClaimValidationRuleRPToCS(rule externalAuthUpdateDispatchConfig
 	}
 }
 
-func convertEtcdRPToCS(in api.EtcdProfile) (*arohcpv1alpha1.AzureEtcdEncryptionBuilder, error) {
+func convertEtcdRPToCS(in api.EtcdProfile, activeKeyBuilder *arohcpv1alpha1.AzureKmsKeyBuilder) (*arohcpv1alpha1.AzureEtcdEncryptionBuilder, error) {
 	keyManagementMode, err := convertKeyManagementModeTypeRPToCS(in.DataEncryption.KeyManagementMode)
 	if err != nil {
 		return nil, err
@@ -285,13 +285,11 @@ func convertEtcdRPToCS(in api.EtcdProfile) (*arohcpv1alpha1.AzureEtcdEncryptionB
 			EncryptionType(encryptionType)
 
 		if in.DataEncryption.CustomerManaged.Kms != nil {
-			azureKmsKeyBuilder := arohcpv1alpha1.NewAzureKmsKey().
+			activeKeyBuilder.
 				KeyName(in.DataEncryption.CustomerManaged.Kms.ActiveKey.Name).
-				KeyVaultName(in.DataEncryption.CustomerManaged.Kms.ActiveKey.VaultName).
-				KeyVersion(in.DataEncryption.CustomerManaged.Kms.ActiveKey.Version)
-			azureKmsEncryptionBuilder := arohcpv1alpha1.NewAzureKmsEncryption().ActiveKey(azureKmsKeyBuilder)
+				KeyVaultName(in.DataEncryption.CustomerManaged.Kms.ActiveKey.VaultName)
+			azureKmsEncryptionBuilder := arohcpv1alpha1.NewAzureKmsEncryption().ActiveKey(activeKeyBuilder)
 
-			// Add KeyVault visibility if specified
 			if len(in.DataEncryption.CustomerManaged.Kms.Visibility) != 0 {
 				visibility, err := convertKeyVaultVisibilityRPToCS(in.DataEncryption.CustomerManaged.Kms.Visibility)
 				if err != nil {
@@ -404,6 +402,9 @@ func BuildCSCluster(resourceID *azcorearm.ResourceID, tenantID string, hcpCluste
 
 	clusterBuilder := arohcpv1alpha1.NewCluster()
 	clusterAPIBuilder := arohcpv1alpha1.NewClusterAPI()
+	clusterKMSActiveKeyBuilder := arohcpv1alpha1.NewAzureKmsKey()
+
+	var azureBuilder *arohcpv1alpha1.AzureBuilder
 
 	// These attributes cannot be updated after cluster creation.
 	if oldClusterServiceCluster == nil {
@@ -411,8 +412,7 @@ func BuildCSCluster(resourceID *azcorearm.ResourceID, tenantID string, hcpCluste
 		if err != nil {
 			return nil, nil, err
 		}
-		// Add attributes that cannot be updated after cluster creation.
-		clusterBuilder, err = withImmutableAttributes(clusterBuilder, hcpCluster,
+		clusterBuilder, azureBuilder, err = withImmutableAttributes(clusterBuilder, hcpCluster,
 			resourceID.SubscriptionID,
 			resourceID.ResourceGroupName,
 			tenantID,
@@ -435,6 +435,14 @@ func BuildCSCluster(resourceID *azcorearm.ResourceID, tenantID string, hcpCluste
 		clusterBuilder.Ingresses(arohcpv1alpha1.NewIngressList().Items(
 			arohcpv1alpha1.NewIngress().Default(true).Listening(ingressListening),
 		))
+
+		etcdEncryption, err := convertEtcdRPToCS(hcpCluster.CustomerProperties.Etcd, clusterKMSActiveKeyBuilder)
+		if err != nil {
+			return nil, nil, err
+		}
+		azureBuilder.EtcdEncryption(etcdEncryption)
+		clusterBuilder.Azure(azureBuilder)
+
 	}
 
 	// Property layering for CS Properties(): preserve existing values (on update),
@@ -451,7 +459,7 @@ func BuildCSCluster(resourceID *azcorearm.ResourceID, tenantID string, hcpCluste
 	}
 
 	clusterUpdateDispatchConfig := clusterUpdateDispatchConfigFromRP(hcpCluster, serviceProviderCluster)
-	err = clusterUpdateDispatchConfig.applyToCSBuilders(clusterBuilder, clusterAPIBuilder, properties)
+	err = clusterUpdateDispatchConfig.applyToCSBuilders(clusterBuilder, clusterAPIBuilder, azureBuilder, clusterKMSActiveKeyBuilder, properties)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -501,14 +509,14 @@ func ConvertHostedClusterSizeOverrideToCS(desiredClusterControlPlanePodSizing ap
 	return "", false
 }
 
-func withImmutableAttributes(clusterBuilder *arohcpv1alpha1.ClusterBuilder, hcpCluster *api.HCPOpenShiftCluster, subscriptionID, resourceGroupName, tenantID, identityURL, csVersionID string) (*arohcpv1alpha1.ClusterBuilder, error) {
+func withImmutableAttributes(clusterBuilder *arohcpv1alpha1.ClusterBuilder, hcpCluster *api.HCPOpenShiftCluster, subscriptionID, resourceGroupName, tenantID, identityURL, csVersionID string) (*arohcpv1alpha1.ClusterBuilder, *arohcpv1alpha1.AzureBuilder, error) {
 	clusterImageRegistryState, err := convertClusterImageRegistryStateRPToCS(hcpCluster.CustomerProperties.ClusterImageRegistry)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	outboundType, err := convertOutboundTypeRPToCS(hcpCluster.CustomerProperties.Platform.OutboundType)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	clusterBuilder.
@@ -544,15 +552,6 @@ func withImmutableAttributes(clusterBuilder *arohcpv1alpha1.ClusterBuilder, hcpC
 		NodesOutboundConnectivity(arohcpv1alpha1.NewAzureNodesOutboundConnectivity().
 			OutboundType(outboundType))
 
-	// Only add etcd encryption if it's actually configured
-	if hcpCluster.CustomerProperties.Etcd.DataEncryption.KeyManagementMode != "" || hcpCluster.CustomerProperties.Etcd.DataEncryption.CustomerManaged != nil {
-		etcdEncryption, err := convertEtcdRPToCS(hcpCluster.CustomerProperties.Etcd)
-		if err != nil {
-			return nil, err
-		}
-		azureBuilder.EtcdEncryption(etcdEncryption)
-	}
-
 	// Cluster Service rejects an empty NetworkSecurityGroupResourceID string.
 	if hcpCluster.CustomerProperties.Platform.NetworkSecurityGroupID != nil {
 		azureBuilder.NetworkSecurityGroupResourceID(hcpCluster.CustomerProperties.Platform.NetworkSecurityGroupID.String())
@@ -585,14 +584,12 @@ func withImmutableAttributes(clusterBuilder *arohcpv1alpha1.ClusterBuilder, hcpC
 
 	azureBuilder.OperatorsAuthentication(arohcpv1alpha1.NewAzureOperatorsAuthentication().ManagedIdentities(managedIdentitiesBuilder))
 
-	clusterBuilder.Azure(azureBuilder)
-
 	// Cluster Service rejects an empty DomainPrefix string.
 	if hcpCluster.CustomerProperties.DNS.BaseDomainPrefix != "" {
 		clusterBuilder.DomainPrefix(hcpCluster.CustomerProperties.DNS.BaseDomainPrefix)
 	}
 
-	return clusterBuilder, nil
+	return clusterBuilder, azureBuilder, nil
 }
 
 // BuildCSNodePool creates a CS NodePoolBuilder object from an HCPOpenShiftClusterNodePool object.

--- a/internal/ocm/convert_test.go
+++ b/internal/ocm/convert_test.go
@@ -202,7 +202,7 @@ func TestWithImmutableAttributes(t *testing.T) {
 			hcpCluster := api.ClusterTestCase(t, tc.hcpCluster)
 			csVersionID, err := clusterCSVersionID(spcWithDesiredVersionFromHCPCluster(hcpCluster), hcpCluster)
 			require.NoError(t, err)
-			builder, err := withImmutableAttributes(
+			builder, azureBuilder, err := withImmutableAttributes(
 				ocmClusterDefaults(api.TestLocation),
 				hcpCluster,
 				api.TestSubscriptionID,
@@ -212,7 +212,7 @@ func TestWithImmutableAttributes(t *testing.T) {
 				csVersionID,
 			)
 			require.NoError(t, err)
-			result, err := builder.Build()
+			result, err := builder.Azure(azureBuilder).Build()
 			require.NoError(t, err)
 			buf.Reset()
 			require.NoError(t, arohcpv1alpha1.MarshalCluster(result, &buf))
@@ -257,20 +257,6 @@ func ocmClusterDefaults(azureLocation string) *arohcpv1alpha1.ClusterBuilder {
 		API(arohcpv1alpha1.NewClusterAPI().
 			Listening(arohcpv1alpha1.ListeningMethodExternal)).
 		Azure(arohcpv1alpha1.NewAzure().
-			EtcdEncryption(arohcpv1alpha1.NewAzureEtcdEncryption().
-				DataEncryption(arohcpv1alpha1.NewAzureEtcdDataEncryption().
-					KeyManagementMode(csKeyManagementModeCustomerManaged).
-					CustomerManaged(arohcpv1alpha1.NewAzureEtcdDataEncryptionCustomerManaged().
-						EncryptionType("kms").
-						Kms(arohcpv1alpha1.NewAzureKmsEncryption().
-							Visibility(arohcpv1alpha1.AzureKmsEncryptionVisibilityPublic).
-							ActiveKey(arohcpv1alpha1.NewAzureKmsKey().
-								KeyName("test-key").
-								KeyVaultName("test-vault").
-								KeyVersion("test-version"),
-							),
-						),
-					))).
 			ManagedResourceGroupName(api.TestManagedResourceGroupName).
 			NetworkSecurityGroupResourceID(api.TestNetworkSecurityGroupResourceID).
 			NodesOutboundConnectivity(arohcpv1alpha1.NewAzureNodesOutboundConnectivity().
@@ -669,22 +655,66 @@ func TestBuildCSExternalAuth(t *testing.T) {
 	}
 }
 
+// defaultTestKMSUpdateAzureBuilder returns the Azure builder that applyToCSBuilders
+// produces for an UPDATE when the test cluster has default KMS etcd encryption
+// (from MinimumValidClusterTestCase). Only the key version is dispatch-managed on update.
+func defaultTestKMSUpdateAzureBuilder() *arohcpv1alpha1.AzureBuilder {
+	return arohcpv1alpha1.NewAzure().
+		EtcdEncryption(arohcpv1alpha1.NewAzureEtcdEncryption().
+			DataEncryption(arohcpv1alpha1.NewAzureEtcdDataEncryption().
+				CustomerManaged(arohcpv1alpha1.NewAzureEtcdDataEncryptionCustomerManaged().
+					Kms(arohcpv1alpha1.NewAzureKmsEncryption().
+						ActiveKey(arohcpv1alpha1.NewAzureKmsKey().
+							KeyVersion("test-version"))))))
+}
+
 func getBaseCSClusterBuilder(updating bool) *arohcpv1alpha1.ClusterBuilder {
 	var builder *arohcpv1alpha1.ClusterBuilder
 	clusterAPIBuilder := arohcpv1alpha1.NewClusterAPI()
 
 	if updating {
-		builder = arohcpv1alpha1.NewCluster()
+		builder = arohcpv1alpha1.NewCluster().
+			Azure(defaultTestKMSUpdateAzureBuilder())
 	} else {
 		builder = ocmClusterDefaults(api.TestLocation)
 		clusterAPIBuilder = clusterAPIBuilder.Listening(arohcpv1alpha1.ListeningMethodExternal)
 		builder.Ingresses(arohcpv1alpha1.NewIngressList().Items(
 			arohcpv1alpha1.NewIngress().Default(true).Listening(arohcpv1alpha1.ListeningMethodExternal),
 		))
+		builder.Azure(arohcpv1alpha1.NewAzure().
+			EtcdEncryption(arohcpv1alpha1.NewAzureEtcdEncryption().
+				DataEncryption(arohcpv1alpha1.NewAzureEtcdDataEncryption().
+					KeyManagementMode(csKeyManagementModeCustomerManaged).
+					CustomerManaged(arohcpv1alpha1.NewAzureEtcdDataEncryptionCustomerManaged().
+						EncryptionType("kms").
+						Kms(arohcpv1alpha1.NewAzureKmsEncryption().
+							Visibility(arohcpv1alpha1.AzureKmsEncryptionVisibilityPublic).
+							ActiveKey(arohcpv1alpha1.NewAzureKmsKey().
+								KeyName("test-key").
+								KeyVaultName("test-vault").
+								KeyVersion("test-version"),
+							),
+						),
+					))).
+			ManagedResourceGroupName(api.TestManagedResourceGroupName).
+			NetworkSecurityGroupResourceID(api.TestNetworkSecurityGroupResourceID).
+			NodesOutboundConnectivity(arohcpv1alpha1.NewAzureNodesOutboundConnectivity().
+				OutboundType(csOutboundType)).
+			OperatorsAuthentication(arohcpv1alpha1.NewAzureOperatorsAuthentication().
+				ManagedIdentities(arohcpv1alpha1.NewAzureOperatorsAuthenticationManagedIdentities().
+					ControlPlaneOperatorsManagedIdentities(make(map[string]*arohcpv1alpha1.AzureControlPlaneManagedIdentityBuilder)).
+					DataPlaneOperatorsManagedIdentities(make(map[string]*arohcpv1alpha1.AzureDataPlaneManagedIdentityBuilder)).
+					ManagedIdentitiesDataPlaneIdentityUrl(api.TestManagedIdentitiesDataPlaneIdentityURL))).
+			ResourceGroupName(strings.ToLower(api.TestResourceGroupName)).
+			ResourceName(strings.ToLower(api.TestClusterName)).
+			SubnetResourceID(api.TestSubnetResourceID).
+			VnetIntegrationSubnetResourceID(api.TestVnetIntegrationSubnetResourceID).
+			SubscriptionID(strings.ToLower(api.TestSubscriptionID)).
+			TenantID(api.TestTenantID))
 	}
 
 	// Add common mutable fields that BuildCSCluster always sets
-	return builder.
+	builder = builder.
 		NodeDrainGracePeriod(arohcpv1alpha1.NewValue().
 			Unit(csNodeDrainGracePeriodUnit).
 			Value(float64(0))).
@@ -699,6 +729,8 @@ func getBaseCSClusterBuilder(updating bool) *arohcpv1alpha1.ClusterBuilder {
 			Allow(arohcpv1alpha1.NewCIDRBlockAllowAccess().
 				Mode(CSCIDRBlockAllowAccessModeAllowAll)))).
 		RegistryConfig(arohcpv1alpha1.NewClusterRegistryConfig().ImageDigestMirrors())
+
+	return builder
 }
 
 func TestBuildCSCluster(t *testing.T) {
@@ -1194,6 +1226,48 @@ func TestBuildCSCluster(t *testing.T) {
 					SubscriptionID(strings.ToLower(api.TestSubscriptionID)).
 					TenantID(api.TestTenantID),
 				),
+		},
+		{
+			name: "UPDATE - sets new KMS key version",
+			oldClusterServiceCluster: func() *arohcpv1alpha1.Cluster {
+				c, err := arohcpv1alpha1.NewCluster().Build()
+				if err != nil {
+					panic(err)
+				}
+				return c
+			}(),
+			hcpCluster: &api.HCPOpenShiftCluster{
+				CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
+					Etcd: api.EtcdProfile{
+						DataEncryption: api.EtcdDataEncryptionProfile{
+							KeyManagementMode: api.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged,
+							CustomerManaged: &api.CustomerManagedEncryptionProfile{
+								EncryptionType: api.CustomerManagedEncryptionTypeKMS,
+								Kms: &api.KmsEncryptionProfile{
+									Visibility: api.KeyVaultVisibilityPublic,
+									ActiveKey: api.KmsKey{
+										Name:      "test-key",
+										VaultName: "test-vault",
+										Version:   "v2",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedCSCluster: getBaseCSClusterBuilder(true).
+				Azure(arohcpv1alpha1.NewAzure().
+					EtcdEncryption(arohcpv1alpha1.NewAzureEtcdEncryption().
+						DataEncryption(arohcpv1alpha1.NewAzureEtcdDataEncryption().
+							CustomerManaged(arohcpv1alpha1.NewAzureEtcdDataEncryptionCustomerManaged().
+								Kms(arohcpv1alpha1.NewAzureKmsEncryption().
+									ActiveKey(arohcpv1alpha1.NewAzureKmsKey().
+										KeyVersion("v2"),
+									),
+								),
+							),
+						))),
 		},
 	}
 

--- a/internal/validation/validate_cluster.go
+++ b/internal/validation/validate_cluster.go
@@ -260,7 +260,6 @@ func validateClusterCustomerProperties(ctx context.Context, op operation.Operati
 	errs = append(errs, Maximum(ctx, op, fldPath.Child("nodeDrainTimeoutMinutes"), &newObj.NodeDrainTimeoutMinutes, safe.Field(oldObj, toNodeDrainTimeoutMinutes), 10080)...)
 
 	//Etcd                    EtcdProfile                 `json:"etcd,omitempty"`
-	errs = append(errs, immutableByReflect(ctx, op, fldPath.Child("etcd"), &newObj.Etcd, safe.Field(oldObj, toEtcd))...)
 	errs = append(errs, validateEtcdProfile(ctx, op, fldPath.Child("etcd"), &newObj.Etcd, safe.Field(oldObj, toEtcd))...)
 
 	//ClusterImageRegistry    ClusterImageRegistryProfile `json:"clusterImageRegistry,omitempty"`
@@ -821,7 +820,6 @@ func validateEtcdProfile(ctx context.Context, op operation.Operation, fldPath *f
 	errs := field.ErrorList{}
 
 	//DataEncryption EtcdDataEncryptionProfile `json:"dataEncryption,omitempty"`
-	errs = append(errs, immutableByReflect(ctx, op, fldPath.Child("dataEncryption"), &newObj.DataEncryption, safe.Field(oldObj, toEtcdProfileDataEncryption))...)
 	errs = append(errs, validateEtcdDataEncryptionProfile(ctx, op, fldPath.Child("dataEncryption"), &newObj.DataEncryption, safe.Field(oldObj, toEtcdProfileDataEncryption))...)
 
 	return errs
@@ -845,7 +843,6 @@ func validateEtcdDataEncryptionProfile(ctx context.Context, op operation.Operati
 	errs = append(errs, validate.Enum(ctx, op, fldPath.Child("keyManagementMode"), &newObj.KeyManagementMode, safe.Field(oldObj, toEtcdDataEncryptionProfileKeyManagementMode), api.ValidEtcdDataEncryptionKeyManagementModeType, nil)...)
 
 	//CustomerManaged   *CustomerManagedEncryptionProfile       `json:"customerManaged,omitempty"`
-	errs = append(errs, immutableByReflect(ctx, op, fldPath.Child("customerManaged"), newObj.CustomerManaged, safe.Field(oldObj, toEtcdDataEncryptionProfileCustomerManaged))...)
 	union := validate.NewDiscriminatedUnionMembership("keyManagementMode", validate.NewDiscriminatedUnionMember("customerManaged", "CustomerManaged"))
 	discriminatorExtractor := func(obj *api.EtcdDataEncryptionProfile) api.EtcdDataEncryptionKeyManagementModeType {
 		return obj.KeyManagementMode
@@ -880,7 +877,6 @@ func validateCustomerManagedEncryptionProfile(ctx context.Context, op operation.
 	errs = append(errs, validate.Enum(ctx, op, fldPath.Child("encryptionType"), &newObj.EncryptionType, safe.Field(oldObj, toCustomerManagedEncryptionProfileEncryptionType), api.ValidCustomerManagedEncryptionType, nil)...)
 
 	//Kms            *KmsEncryptionProfile         `json:"kms,omitempty"`
-	errs = append(errs, immutableByReflect(ctx, op, fldPath.Child("kms"), newObj.Kms, safe.Field(oldObj, toEtcdDataEncryptionProfileKms))...)
 	union := validate.NewDiscriminatedUnionMembership("encryptionType", validate.NewDiscriminatedUnionMember("kms", "KMS"))
 	discriminatorExtractor := func(obj *api.CustomerManagedEncryptionProfile) api.CustomerManagedEncryptionType {
 		return obj.EncryptionType
@@ -914,7 +910,6 @@ func validateKmsEncryptionProfile(ctx context.Context, op operation.Operation, f
 	errs = append(errs, validate.Enum(ctx, op, fldPath.Child("visibility"), &newObj.Visibility, safe.Field(oldObj, toKmsEncryptionProfileVisibility), api.ValidKeyVaultVisibility, nil)...)
 
 	//ActiveKey KmsKey `json:"activeKey,omitempty"`
-	errs = append(errs, immutableByReflect(ctx, op, fldPath.Child("activeKey"), &newObj.ActiveKey, safe.Field(oldObj, toKmsEncryptionProfileActiveKey))...)
 	errs = append(errs, validateKmsKey(ctx, op, fldPath.Child("activeKey"), &newObj.ActiveKey, safe.Field(oldObj, toKmsEncryptionProfileActiveKey))...)
 
 	return errs
@@ -940,7 +935,11 @@ func validateKmsKey(ctx context.Context, op operation.Operation, fldPath *field.
 	errs = append(errs, MaxLen(ctx, op, fldPath.Child("vaultName"), &newObj.VaultName, nil, 255)...)
 
 	//Version   string `json:"version"`
-	errs = append(errs, immutableByCompare(ctx, op, fldPath.Child("version"), &newObj.Version, safe.Field(oldObj, toKmsKeyVersion))...)
+	// The version field was made mutable in version 2026-06-30-preview.
+	apiVersion := api.APIVersionFromOptions(op.Options)
+	if len(apiVersion) > 0 && apiVersion.LT(api.APIVersionV20260630Preview) {
+		errs = append(errs, immutableByCompare(ctx, op, fldPath.Child("version"), &newObj.Version, safe.Field(oldObj, toKmsKeyVersion))...)
+	}
 	errs = append(errs, validate.RequiredValue(ctx, op, fldPath.Child("version"), &newObj.Version, nil)...)
 	errs = append(errs, MaxLen(ctx, op, fldPath.Child("version"), &newObj.Version, nil, 255)...)
 

--- a/internal/validation/validate_cluster_comprehensive_test.go
+++ b/internal/validation/validate_cluster_comprehensive_test.go
@@ -1762,9 +1762,6 @@ func TestValidateClusterUpdate(t *testing.T) {
 				return c
 			}(),
 			expectErrors: []utils.ExpectedError{
-				{Message: "field is immutable", FieldPath: "customerProperties.etcd"},
-				{Message: "field is immutable", FieldPath: "customerProperties.etcd.dataEncryption"},
-				{Message: "field is immutable", FieldPath: "customerProperties.etcd.dataEncryption.customerManaged"},
 				{Message: "must be specified when `keyManagementMode` is \"CustomerManaged\"", FieldPath: "customerProperties.etcd.dataEncryption.customerManaged"},
 			},
 		},
@@ -1803,11 +1800,83 @@ func TestValidateClusterUpdate(t *testing.T) {
 				return c
 			}(),
 			expectErrors: []utils.ExpectedError{
-				{Message: "field is immutable", FieldPath: "customerProperties.etcd"},
-				{Message: "field is immutable", FieldPath: "customerProperties.etcd.dataEncryption"},
-				{Message: "field is immutable", FieldPath: "customerProperties.etcd.dataEncryption.customerManaged"},
-				{Message: "field is immutable", FieldPath: "customerProperties.etcd.dataEncryption.customerManaged.kms"},
 				{Message: "field is immutable", FieldPath: "customerProperties.etcd.dataEncryption.customerManaged.kms.visibility"},
+			},
+		},
+		{
+			name: "mutable kms key version with v20260630preview - update",
+			newCluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Etcd.DataEncryption.KeyManagementMode = api.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged
+				c.CustomerProperties.Etcd.DataEncryption.CustomerManaged = &api.CustomerManagedEncryptionProfile{
+					EncryptionType: api.CustomerManagedEncryptionTypeKMS,
+					Kms: &api.KmsEncryptionProfile{
+						Visibility: api.KeyVaultVisibilityPublic,
+						ActiveKey: api.KmsKey{
+							Name:      "test-key",
+							VaultName: "test-vault",
+							Version:   "new-version",
+						},
+					},
+				}
+				return c
+			}(),
+			oldCluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Etcd.DataEncryption.KeyManagementMode = api.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged
+				c.CustomerProperties.Etcd.DataEncryption.CustomerManaged = &api.CustomerManagedEncryptionProfile{
+					EncryptionType: api.CustomerManagedEncryptionTypeKMS,
+					Kms: &api.KmsEncryptionProfile{
+						Visibility: api.KeyVaultVisibilityPublic,
+						ActiveKey: api.KmsKey{
+							Name:      "test-key",
+							VaultName: "test-vault",
+							Version:   "old-version",
+						},
+					},
+				}
+				return c
+			}(),
+			opOptions:    []string{api.APIVersionOption(api.APIVersionV20260630Preview)},
+			expectErrors: []utils.ExpectedError{},
+		},
+		{
+			name: "immutable kms key version without v20260630preview - update",
+			newCluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Etcd.DataEncryption.KeyManagementMode = api.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged
+				c.CustomerProperties.Etcd.DataEncryption.CustomerManaged = &api.CustomerManagedEncryptionProfile{
+					EncryptionType: api.CustomerManagedEncryptionTypeKMS,
+					Kms: &api.KmsEncryptionProfile{
+						Visibility: api.KeyVaultVisibilityPublic,
+						ActiveKey: api.KmsKey{
+							Name:      "test-key",
+							VaultName: "test-vault",
+							Version:   "new-version",
+						},
+					},
+				}
+				return c
+			}(),
+			oldCluster: func() *api.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Etcd.DataEncryption.KeyManagementMode = api.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged
+				c.CustomerProperties.Etcd.DataEncryption.CustomerManaged = &api.CustomerManagedEncryptionProfile{
+					EncryptionType: api.CustomerManagedEncryptionTypeKMS,
+					Kms: &api.KmsEncryptionProfile{
+						Visibility: api.KeyVaultVisibilityPublic,
+						ActiveKey: api.KmsKey{
+							Name:      "test-key",
+							VaultName: "test-vault",
+							Version:   "old-version",
+						},
+					},
+				}
+				return c
+			}(),
+			opOptions: []string{api.APIVersionOption(api.APIVersionV20251223Preview)},
+			expectErrors: []utils.ExpectedError{
+				{Message: "field is immutable", FieldPath: "customerProperties.etcd.dataEncryption.customerManaged.kms.activeKey.version"},
 			},
 		},
 		{

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/some-immutable-field-checks/05-httpReplace-cluster/expected-error.txt
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/some-immutable-field-checks/05-httpReplace-cluster/expected-error.txt
@@ -56,40 +56,10 @@
       {
         "code": "InvalidRequestContent",
         "message": "Forbidden: field is immutable",
-        "target": "properties.etcd"
-      }
-      {
-        "code": "InvalidRequestContent",
-        "message": "Forbidden: field is immutable",
-        "target": "properties.etcd.dataEncryption"
-      }
-      {
-        "code": "InvalidRequestContent",
-        "message": "Forbidden: field is immutable",
-        "target": "properties.etcd.dataEncryption.customerManaged"
-      }
-      {
-        "code": "InvalidRequestContent",
-        "message": "Forbidden: field is immutable",
-        "target": "properties.etcd.dataEncryption.customerManaged.kms"
-      }
-      {
-        "code": "InvalidRequestContent",
-        "message": "Forbidden: field is immutable",
-        "target": "properties.etcd.dataEncryption.customerManaged.kms.activeKey"
-      }
-      {
-        "code": "InvalidRequestContent",
-        "message": "Forbidden: field is immutable",
         "target": "properties.etcd.dataEncryption.customerManaged.kms.activeKey.name"
       }
       {
         "code": "InvalidRequestContent",
         "message": "Forbidden: field is immutable",
         "target": "properties.etcd.dataEncryption.customerManaged.kms.activeKey.vaultName"
-      }
-      {
-        "code": "InvalidRequestContent",
-        "message": "Forbidden: field is immutable",
-        "target": "properties.etcd.dataEncryption.customerManaged.kms.activeKey.version"
       }

--- a/test-integration/frontend/cross_version_roundtrip_test.go
+++ b/test-integration/frontend/cross_version_roundtrip_test.go
@@ -196,7 +196,7 @@ func clusterCreatePayload(clusterName, apiVersion string) []byte {
     "clusterImageRegistry": {
       "state": "Disabled"
     },
-    "etcd": {
+   "etcd": {
       "dataEncryption": {
         "customerManaged": {
           "encryptionType": "KMS",

--- a/test/e2e-setup/bicep/modules/customer-infra.bicep
+++ b/test/e2e-setup/bicep/modules/customer-infra.bicep
@@ -19,6 +19,9 @@ param clusterName string = ''
 @description('If set to true, creates a private KeyVault with publicNetworkAccess disabled')
 param privateKeyVault bool = false
 
+@description('Assign Key Vault Crypto Officer role to the deployer on the customer KeyVault that contains etcd encryption key')
+param assignKeyVaultCryptoOfficer bool = false
+
 //
 // Variables
 //
@@ -112,6 +115,24 @@ resource etcdEncryptionKey 'Microsoft.KeyVault/vaults/keys@2024-12-01-preview' =
   properties: {
     kty: 'RSA'
     keySize: 2048
+  }
+}
+
+// Key Vault Crypto Officer: allows key management operations (create, rotate, disable).
+// Assigned to the test runner principal so E2E tests can rotate etcd encryption keys.
+// https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/security#key-vault-crypto-officer
+var keyVaultCryptoOfficerRoleId = subscriptionResourceId(
+  'Microsoft.Authorization/roleDefinitions',
+  '14b46e9e-c2b7-41b4-b07b-48a6ebf60603'
+)
+
+resource customerKeyVaultCryptoOfficerRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (assignKeyVaultCryptoOfficer) {
+  name: guid(resourceGroup().id, deployer().objectId, keyVaultCryptoOfficerRoleId, customerKeyVault.id)
+  scope: customerKeyVault
+  properties: {
+    principalId: deployer().objectId
+    principalType: contains(deployer(), 'userPrincipalName') && !empty(deployer().userPrincipalName) ? 'User' : 'ServicePrincipal'
+    roleDefinitionId: keyVaultCryptoOfficerRoleId
   }
 }
 

--- a/test/e2e/kms_key_rotation.go
+++ b/test/e2e/kms_key_rotation.go
@@ -1,0 +1,323 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys"
+
+	hcpsdk20260630preview "github.com/Azure/ARO-HCP/test/sdk/v20260630preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
+	"github.com/Azure/ARO-HCP/test/util/framework"
+	"github.com/Azure/ARO-HCP/test/util/labels"
+	"github.com/Azure/ARO-HCP/test/util/verifiers"
+)
+
+const HCPClusterReencryptionUpgradeTimeout = 18 * time.Minute
+
+var _ = Describe("Customer", func() {
+	// Deadline for v20260630preview API deployment in non-dev environments
+	timeBombDeadline := framework.Must(time.Parse(time.RFC3339, "2026-07-31T00:00:00Z"))
+
+	It("should be able to rotate KMS key for a cluster with version >= 4.22",
+		labels.RequireNothing, labels.High, labels.Positive, labels.AroRpApiCompatible, labels.Slow,
+		func(ctx context.Context) {
+			const clusterName = "kms-key-rotate-422"
+
+			tc := framework.NewTestContext()
+
+			if tc.UsePooledIdentities() {
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
+				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
+			}
+
+			By("creating a resource group")
+			resourceGroup, err := tc.NewResourceGroup(ctx, "kms-key-rotate", tc.Location())
+			Expect(err).NotTo(HaveOccurred(), "failed to create resource group for KMS key rotation test")
+
+			By("creating cluster parameters with version 4.22")
+			clusterParams := framework.NewDefaultClusterParams20260630()
+			clusterParams.ClusterName = clusterName
+			clusterParams.OpenshiftVersionId = "4.22"
+
+			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
+			clusterParams.ManagedResourceGroupName = managedResourceGroupName
+
+			By("creating customer resources")
+			clusterParams, err = tc.CreateClusterCustomerResources20260630(ctx,
+				resourceGroup,
+				clusterParams,
+				map[string]interface{}{
+					"assignKeyVaultCryptoOfficer": true,
+				},
+				TestArtifactsFS,
+				framework.RBACScopeResourceGroup,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to create customer resources for KMS key rotation cluster")
+
+			By("creating the HCP cluster with version 4.22")
+			err = tc.CreateHCPClusterFromParam20260630(
+				ctx,
+				GinkgoLogr,
+				*resourceGroup.Name,
+				clusterParams,
+				nil, // imageDigestMirrors
+				framework.ClusterCreationTimeout,
+			)
+			if isAPINotDeployedError(err) {
+				if time.Now().Before(timeBombDeadline) {
+					Skip(fmt.Sprintf("v20260630preview API not yet deployed; skipping until %s", timeBombDeadline.Format(time.RFC3339)))
+				}
+				Fail(fmt.Sprintf("v20260630preview API still not deployed as of %s deadline", timeBombDeadline.Format(time.RFC3339)))
+			}
+			Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster for KMS key rotation test")
+
+			By("getting admin REST config")
+			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
+				ctx,
+				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
+				*resourceGroup.Name,
+				clusterName,
+				framework.GetAdminRESTConfigTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to get admin REST config for cluster")
+
+			By("ensuring the cluster is viable")
+			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig)
+			Expect(err).NotTo(HaveOccurred(), "failed to verify HCP cluster viability for update")
+
+			By("rotating the KMS key")
+			keyVaultURL := fmt.Sprintf("https://%s.vault.azure.net/", clusterParams.KeyVaultName)
+			cred, err := tc.AzureCredential()
+			Expect(err).NotTo(HaveOccurred(), "failed to get Azure credential")
+
+			keyClient, err := azkeys.NewClient(keyVaultURL, cred, nil)
+			Expect(err).NotTo(HaveOccurred(), "failed to create Key Vault client")
+
+			originalKeyVersion := clusterParams.EtcdEncryptionKeyVersion
+
+			GinkgoLogr.Info("Creating new key version (rotation)",
+				"keyVaultName", clusterParams.KeyVaultName,
+				"keyName", clusterParams.EtcdEncryptionKeyName,
+				"originalVersion", originalKeyVersion)
+
+			createKeyResp, err := keyClient.CreateKey(ctx, clusterParams.EtcdEncryptionKeyName, azkeys.CreateKeyParameters{
+				Kty:     to.Ptr(azkeys.KeyTypeRSA),
+				KeySize: to.Ptr(int32(2048)),
+			}, nil)
+			Expect(err).NotTo(HaveOccurred(), "failed to create new key version (rotation)")
+			Expect(createKeyResp.Key).NotTo(BeNil(), "created key response was nil")
+			Expect(createKeyResp.Key.KID).NotTo(BeNil(), "created key ID was nil")
+
+			firstKeyVersion := createKeyResp.Key.KID.Version()
+			Expect(firstKeyVersion).NotTo(BeEmpty(), "created key ID version was empty")
+
+			GinkgoLogr.Info("Successfully created new key version",
+				"keyVaultName", clusterParams.KeyVaultName,
+				"keyName", clusterParams.EtcdEncryptionKeyName,
+				"newVersion", firstKeyVersion)
+
+			By("updating the cluster with the new KMS key")
+			hcpClient := tc.Get20260630ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient()
+			updateResult, err := framework.UpdateHCPCluster20260630(
+				ctx,
+				hcpClient,
+				*resourceGroup.Name,
+				clusterName,
+				hcpsdk20260630preview.HcpOpenShiftClusterUpdate{
+					Properties: &hcpsdk20260630preview.HcpOpenShiftClusterPropertiesUpdate{
+						Etcd: &hcpsdk20260630preview.EtcdProfileUpdate{
+							DataEncryption: &hcpsdk20260630preview.EtcdDataEncryptionProfileUpdate{
+								CustomerManaged: &hcpsdk20260630preview.CustomerManagedEncryptionProfileUpdate{
+									Kms: &hcpsdk20260630preview.KmsEncryptionProfileUpdate{
+										ActiveKey: &hcpsdk20260630preview.KmsKeyUpdate{
+											Version: to.Ptr(firstKeyVersion),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				HCPClusterReencryptionUpgradeTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to update cluster with new KMS key")
+
+			Expect(updateResult.Properties).NotTo(BeNil(), "update result Properties was nil")
+			Expect(updateResult.Properties.ProvisioningState).NotTo(BeNil(), "update result ProvisioningState was nil")
+
+			GinkgoLogr.Info("Cluster update completed successfully",
+				"clusterName", clusterName,
+				"provisioningState", *updateResult.Properties.ProvisioningState,
+				"newKeyVersion", firstKeyVersion)
+
+			By("verifying the cluster references the new KMS key version")
+			Expect(updateResult.Properties.Etcd).NotTo(BeNil(), "update result Etcd was nil")
+			Expect(updateResult.Properties.Etcd.DataEncryption).NotTo(BeNil(), "update result DataEncryption was nil")
+			Expect(updateResult.Properties.Etcd.DataEncryption.CustomerManaged).NotTo(BeNil(), "update result CustomerManaged was nil")
+			Expect(updateResult.Properties.Etcd.DataEncryption.CustomerManaged.Kms).NotTo(BeNil(), "update result Kms was nil")
+			Expect(updateResult.Properties.Etcd.DataEncryption.CustomerManaged.Kms.ActiveKey).NotTo(BeNil(), "update result ActiveKey was nil")
+			Expect(updateResult.Properties.Etcd.DataEncryption.CustomerManaged.Kms.ActiveKey.Version).NotTo(BeNil(), "update result key Version was nil")
+			Expect(*updateResult.Properties.Etcd.DataEncryption.CustomerManaged.Kms.ActiveKey.Version).To(Equal(firstKeyVersion),
+				"cluster should reference the new KMS key version after update")
+
+			By("confirming key version persists via GET (round-trip verification)")
+			fetchedCluster, err := hcpClient.Get(ctx, *resourceGroup.Name, clusterName, nil)
+			Expect(err).NotTo(HaveOccurred(), "failed to GET cluster for round-trip verification")
+			Expect(fetchedCluster.Properties).NotTo(BeNil(), "fetched cluster Properties was nil")
+			Expect(fetchedCluster.Properties.Etcd).NotTo(BeNil(), "fetched cluster Etcd was nil")
+			Expect(fetchedCluster.Properties.Etcd.DataEncryption).NotTo(BeNil(), "fetched cluster DataEncryption was nil")
+			Expect(fetchedCluster.Properties.Etcd.DataEncryption.CustomerManaged).NotTo(BeNil(), "fetched cluster CustomerManaged was nil")
+			Expect(fetchedCluster.Properties.Etcd.DataEncryption.CustomerManaged.Kms).NotTo(BeNil(), "fetched cluster Kms was nil")
+			Expect(fetchedCluster.Properties.Etcd.DataEncryption.CustomerManaged.Kms.ActiveKey).NotTo(BeNil(), "fetched cluster ActiveKey was nil")
+			Expect(fetchedCluster.Properties.Etcd.DataEncryption.CustomerManaged.Kms.ActiveKey.Version).NotTo(BeNil(), "fetched cluster key Version was nil")
+			Expect(*fetchedCluster.Properties.Etcd.DataEncryption.CustomerManaged.Kms.ActiveKey.Version).To(Equal(firstKeyVersion),
+				"cluster should reference the new KMS key version after round-trip GET")
+
+			By("verifying StorageVersionMigration succeeded for re-encryption")
+			err = verifiers.VerifyStorageVersionMigrationSucceeded().Verify(ctx, adminRESTConfig)
+			Expect(err).NotTo(HaveOccurred(), "all StorageVersionMigration resources should reach Succeeded state after KMS key rotation")
+
+			By("disabling first key version")
+			keyParams := azkeys.UpdateKeyParameters{
+				KeyAttributes: &azkeys.KeyAttributes{
+					Enabled: to.Ptr(false),
+				},
+			}
+			updateKeyResp, err := keyClient.UpdateKey(ctx, clusterParams.EtcdEncryptionKeyName, originalKeyVersion, keyParams, nil)
+			Expect(err).NotTo(HaveOccurred(), "failed to disable old KMS key version: %v", originalKeyVersion)
+			Expect(updateKeyResp.Attributes.Enabled).ToNot(BeNil(), "update key response did not include enabled attribute")
+			Expect(*updateKeyResp.Attributes.Enabled).To(BeFalse(), "old key version should be disabled")
+
+			GinkgoLogr.Info("Old key version was disabled successfully",
+				"keyVersion", originalKeyVersion,
+				"enabled", updateKeyResp.Attributes.Enabled,
+			)
+
+			By("verify the Cluster is still fully functional")
+			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig, verifiers.VerifyStorageVersionMigrationSucceeded())
+			Expect(err).NotTo(HaveOccurred(), "all StorageVersionMigration resources should reach Succeeded state after KMS key rotation")
+
+			By("rotating the KMS key a second time")
+
+			GinkgoLogr.Info("Creating new key version (second rotation)",
+				"keyVaultName", clusterParams.KeyVaultName,
+				"keyName", clusterParams.EtcdEncryptionKeyName,
+				"currentKeyVersion", firstKeyVersion)
+
+			createKeyResp, err = keyClient.CreateKey(ctx, clusterParams.EtcdEncryptionKeyName, azkeys.CreateKeyParameters{
+				Kty:     to.Ptr(azkeys.KeyTypeRSA),
+				KeySize: to.Ptr(int32(2048)),
+			}, nil)
+			Expect(err).NotTo(HaveOccurred(), "failed to create new key version (second rotation)")
+			Expect(createKeyResp.Key).NotTo(BeNil(), "created key response was nil")
+			Expect(createKeyResp.Key.KID).NotTo(BeNil(), "created key ID was nil")
+
+			secondKeyVersion := createKeyResp.Key.KID.Version()
+			Expect(secondKeyVersion).NotTo(BeEmpty(), "created key ID version was empty")
+
+			GinkgoLogr.Info("Successfully created new key version (second rotation)",
+				"keyVaultName", clusterParams.KeyVaultName,
+				"keyName", clusterParams.EtcdEncryptionKeyName,
+				"newKeyVersion", secondKeyVersion)
+
+			By("updating the cluster with the new KMS key (second rotation)")
+			updateResult, err = framework.UpdateHCPCluster20260630(
+				ctx,
+				hcpClient,
+				*resourceGroup.Name,
+				clusterName,
+				hcpsdk20260630preview.HcpOpenShiftClusterUpdate{
+					Properties: &hcpsdk20260630preview.HcpOpenShiftClusterPropertiesUpdate{
+						Etcd: &hcpsdk20260630preview.EtcdProfileUpdate{
+							DataEncryption: &hcpsdk20260630preview.EtcdDataEncryptionProfileUpdate{
+								CustomerManaged: &hcpsdk20260630preview.CustomerManagedEncryptionProfileUpdate{
+									Kms: &hcpsdk20260630preview.KmsEncryptionProfileUpdate{
+										ActiveKey: &hcpsdk20260630preview.KmsKeyUpdate{
+											Version: to.Ptr(secondKeyVersion),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				HCPClusterReencryptionUpgradeTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to update cluster with new KMS key with the second rotation")
+
+			Expect(updateResult.Properties).NotTo(BeNil(), "update result Properties was nil")
+			Expect(updateResult.Properties.ProvisioningState).NotTo(BeNil(), "update result ProvisioningState was nil")
+
+			GinkgoLogr.Info("Cluster update completed successfully (second rotation)",
+				"clusterName", clusterName,
+				"provisioningState", *updateResult.Properties.ProvisioningState,
+				"newKeyVersion", secondKeyVersion)
+
+			By("verifying the cluster references the new KMS key version (second rotation)")
+			Expect(updateResult.Properties.Etcd).NotTo(BeNil(), "update result Etcd was nil")
+			Expect(updateResult.Properties.Etcd.DataEncryption).NotTo(BeNil(), "update result DataEncryption was nil")
+			Expect(updateResult.Properties.Etcd.DataEncryption.CustomerManaged).NotTo(BeNil(), "update result CustomerManaged was nil")
+			Expect(updateResult.Properties.Etcd.DataEncryption.CustomerManaged.Kms).NotTo(BeNil(), "update result Kms was nil")
+			Expect(updateResult.Properties.Etcd.DataEncryption.CustomerManaged.Kms.ActiveKey).NotTo(BeNil(), "update result ActiveKey was nil")
+			Expect(updateResult.Properties.Etcd.DataEncryption.CustomerManaged.Kms.ActiveKey.Version).NotTo(BeNil(), "update result key Version was nil")
+			Expect(*updateResult.Properties.Etcd.DataEncryption.CustomerManaged.Kms.ActiveKey.Version).To(Equal(secondKeyVersion),
+				"cluster should reference the new KMS key version after update")
+
+			By("confirming key version persists via GET for second rotation (round-trip verification)")
+			fetchedCluster, err = hcpClient.Get(ctx, *resourceGroup.Name, clusterName, nil)
+			Expect(err).NotTo(HaveOccurred(), "failed to GET cluster for round-trip verification")
+			Expect(fetchedCluster.Properties).NotTo(BeNil(), "fetched cluster Properties was nil")
+			Expect(fetchedCluster.Properties.Etcd).NotTo(BeNil(), "fetched cluster Etcd was nil")
+			Expect(fetchedCluster.Properties.Etcd.DataEncryption).NotTo(BeNil(), "fetched cluster DataEncryption was nil")
+			Expect(fetchedCluster.Properties.Etcd.DataEncryption.CustomerManaged).NotTo(BeNil(), "fetched cluster CustomerManaged was nil")
+			Expect(fetchedCluster.Properties.Etcd.DataEncryption.CustomerManaged.Kms).NotTo(BeNil(), "fetched cluster Kms was nil")
+			Expect(fetchedCluster.Properties.Etcd.DataEncryption.CustomerManaged.Kms.ActiveKey).NotTo(BeNil(), "fetched cluster ActiveKey was nil")
+			Expect(fetchedCluster.Properties.Etcd.DataEncryption.CustomerManaged.Kms.ActiveKey.Version).NotTo(BeNil(), "fetched cluster key Version was nil")
+			Expect(*fetchedCluster.Properties.Etcd.DataEncryption.CustomerManaged.Kms.ActiveKey.Version).To(Equal(secondKeyVersion),
+				"cluster should reference the new KMS key version after round-trip GET")
+
+			By("verifying StorageVersionMigration succeeded for re-encryption (second rotation)")
+			err = verifiers.VerifyStorageVersionMigrationSucceeded().Verify(ctx, adminRESTConfig)
+			Expect(err).NotTo(HaveOccurred(), "all StorageVersionMigration resources should reach Succeeded state after KMS key rotation")
+
+			By("disabling the old key version (second rotation)")
+			keyParams = azkeys.UpdateKeyParameters{
+				KeyAttributes: &azkeys.KeyAttributes{
+					Enabled: to.Ptr(false),
+				},
+			}
+			updateKeyResp, err = keyClient.UpdateKey(ctx, clusterParams.EtcdEncryptionKeyName, firstKeyVersion, keyParams, nil)
+			Expect(err).NotTo(HaveOccurred(), "failed to disable old KMS key version: %v", firstKeyVersion)
+			Expect(updateKeyResp.Attributes.Enabled).ToNot(BeNil(), "update key response did not include enabled attribute")
+			Expect(*updateKeyResp.Attributes.Enabled).To(BeFalse(), "old key version should be disabled")
+
+			GinkgoLogr.Info("First key version was disabled successfully",
+				"keyVersion", firstKeyVersion,
+				"enabled", updateKeyResp.Attributes.Enabled,
+			)
+
+			By("verify the Cluster is still fully functional after second rotation")
+			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig, verifiers.VerifyStorageVersionMigrationSucceeded())
+			Expect(err).NotTo(HaveOccurred(), "all StorageVersionMigration resources should reach Succeeded state after KMS key rotation")
+		},
+	)
+})

--- a/test/go.mod
+++ b/test/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1
+	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.4.0
 	github.com/blang/semver/v4 v4.0.0
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/dusted-go/logging v1.3.0
@@ -84,7 +85,6 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armfeatures v1.2.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v3 v3.0.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azcertificates v1.5.0 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.4.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.4.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 // indirect
 	github.com/Azure/go-amqp v1.5.0 // indirect

--- a/test/sdk/v20260630preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/models.go
+++ b/test/sdk/v20260630preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/models.go
@@ -103,6 +103,13 @@ type CustomerManagedEncryptionProfile struct {
 	Kms *KmsEncryptionProfile
 }
 
+// CustomerManagedEncryptionProfileUpdate - Customer managed encryption key profile.
+type CustomerManagedEncryptionProfileUpdate struct {
+	// The Key Management Service (KMS) encryption key details.
+	// Required when encryptionType is "KMS".
+	Kms *KmsEncryptionProfileUpdate
+}
+
 // DNSProfile - DNS contains the DNS settings of the cluster
 type DNSProfile struct {
 	// BaseDomainPrefix is the unique name of the cluster representing the OpenShift's cluster name. BaseDomainPrefix is the name
@@ -157,10 +164,22 @@ type EtcdDataEncryptionProfile struct {
 	KeyManagementMode *EtcdDataEncryptionKeyManagementModeType
 }
 
+// EtcdDataEncryptionProfileUpdate - The ETCD data encryption settings.
+type EtcdDataEncryptionProfileUpdate struct {
+	// Specify customer managed encryption key details. Required when keyManagementMode is "CustomerManaged".
+	CustomerManaged *CustomerManagedEncryptionProfileUpdate
+}
+
 // EtcdProfile - The ETCD settings and configuration options.
 type EtcdProfile struct {
 	// ETCD Data Encryption settings. If not specified platform managed keys are used.
 	DataEncryption *EtcdDataEncryptionProfile
+}
+
+// EtcdProfileUpdate - The ETCD settings and configuration options.
+type EtcdProfileUpdate struct {
+	// ETCD Data Encryption settings. If not specified platform managed keys are used.
+	DataEncryption *EtcdDataEncryptionProfileUpdate
 }
 
 // ExternalAuth resource
@@ -408,6 +427,9 @@ type HcpOpenShiftClusterPropertiesUpdate struct {
 	// Configure ClusterAutoscaling .
 	Autoscaling *ClusterAutoscalingProfile
 
+	// Configure ETCD.
+	Etcd *EtcdProfileUpdate
+
 	// imageDigestMirrors is a set of rules to allow pulling images from a mirrored registry by using digest specifications.
 	// WARNING: Updating this array will redeploy all node pools in the cluster.
 	ImageDigestMirrors []*ImageDigestMirror
@@ -582,12 +604,26 @@ type KmsEncryptionProfile struct {
 	Visibility *KeyVaultVisibility
 }
 
+// KmsEncryptionProfileUpdate - Configure etcd encryption Key Management Service (KMS) key. Your Microsoft Entra application
+// used to create the cluster must be authorized to access this keyvault, e.g using the AzureCLI: az keyvault
+// set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn (YOUR APPLICATION CLIENT ID)
+type KmsEncryptionProfileUpdate struct {
+	// The details of the active key.
+	ActiveKey *KmsKeyUpdate
+}
+
 // KmsKey - A representation of a KeyVault Secret.
 type KmsKey struct {
 	// REQUIRED; name is the name of the keyvault key used for encryption/decryption.
 	Name *string
 
 	// REQUIRED; version contains the version of the key to use.
+	Version *string
+}
+
+// KmsKeyUpdate - A representation of a KeyVault Secret.
+type KmsKeyUpdate struct {
+	// version contains the version of the key to use.
 	Version *string
 }
 

--- a/test/sdk/v20260630preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/models_serde.go
+++ b/test/sdk/v20260630preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/models_serde.go
@@ -245,6 +245,33 @@ func (c *CustomerManagedEncryptionProfile) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// MarshalJSON implements the json.Marshaller interface for type CustomerManagedEncryptionProfileUpdate.
+func (c CustomerManagedEncryptionProfileUpdate) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "kms", c.Kms)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type CustomerManagedEncryptionProfileUpdate.
+func (c *CustomerManagedEncryptionProfileUpdate) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", c, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "kms":
+			err = unpopulate(val, "Kms", &c.Kms)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", c, err)
+		}
+	}
+	return nil
+}
+
 // MarshalJSON implements the json.Marshaller interface for type DNSProfile.
 func (d DNSProfile) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
@@ -408,6 +435,33 @@ func (e *EtcdDataEncryptionProfile) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// MarshalJSON implements the json.Marshaller interface for type EtcdDataEncryptionProfileUpdate.
+func (e EtcdDataEncryptionProfileUpdate) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "customerManaged", e.CustomerManaged)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type EtcdDataEncryptionProfileUpdate.
+func (e *EtcdDataEncryptionProfileUpdate) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", e, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "customerManaged":
+			err = unpopulate(val, "CustomerManaged", &e.CustomerManaged)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", e, err)
+		}
+	}
+	return nil
+}
+
 // MarshalJSON implements the json.Marshaller interface for type EtcdProfile.
 func (e EtcdProfile) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
@@ -417,6 +471,33 @@ func (e EtcdProfile) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements the json.Unmarshaller interface for type EtcdProfile.
 func (e *EtcdProfile) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", e, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "dataEncryption":
+			err = unpopulate(val, "DataEncryption", &e.DataEncryption)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", e, err)
+		}
+	}
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaller interface for type EtcdProfileUpdate.
+func (e EtcdProfileUpdate) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "dataEncryption", e.DataEncryption)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type EtcdProfileUpdate.
+func (e *EtcdProfileUpdate) UnmarshalJSON(data []byte) error {
 	var rawMsg map[string]json.RawMessage
 	if err := json.Unmarshal(data, &rawMsg); err != nil {
 		return fmt.Errorf("unmarshalling type %T: %v", e, err)
@@ -1016,6 +1097,7 @@ func (h *HcpOpenShiftClusterProperties) UnmarshalJSON(data []byte) error {
 func (h HcpOpenShiftClusterPropertiesUpdate) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "autoscaling", h.Autoscaling)
+	populate(objectMap, "etcd", h.Etcd)
 	populate(objectMap, "imageDigestMirrors", h.ImageDigestMirrors)
 	populate(objectMap, "nodeDrainTimeoutMinutes", h.NodeDrainTimeoutMinutes)
 	populate(objectMap, "platform", h.Platform)
@@ -1034,6 +1116,9 @@ func (h *HcpOpenShiftClusterPropertiesUpdate) UnmarshalJSON(data []byte) error {
 		switch key {
 		case "autoscaling":
 			err = unpopulate(val, "Autoscaling", &h.Autoscaling)
+			delete(rawMsg, key)
+		case "etcd":
+			err = unpopulate(val, "Etcd", &h.Etcd)
 			delete(rawMsg, key)
 		case "imageDigestMirrors":
 			err = unpopulate(val, "ImageDigestMirrors", &h.ImageDigestMirrors)
@@ -1413,6 +1498,33 @@ func (k *KmsEncryptionProfile) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// MarshalJSON implements the json.Marshaller interface for type KmsEncryptionProfileUpdate.
+func (k KmsEncryptionProfileUpdate) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "activeKey", k.ActiveKey)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type KmsEncryptionProfileUpdate.
+func (k *KmsEncryptionProfileUpdate) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", k, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "activeKey":
+			err = unpopulate(val, "ActiveKey", &k.ActiveKey)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", k, err)
+		}
+	}
+	return nil
+}
+
 // MarshalJSON implements the json.Marshaller interface for type KmsKey.
 func (k KmsKey) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
@@ -1433,6 +1545,33 @@ func (k *KmsKey) UnmarshalJSON(data []byte) error {
 		case "name":
 			err = unpopulate(val, "Name", &k.Name)
 			delete(rawMsg, key)
+		case "version":
+			err = unpopulate(val, "Version", &k.Version)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", k, err)
+		}
+	}
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaller interface for type KmsKeyUpdate.
+func (k KmsKeyUpdate) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "version", k.Version)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type KmsKeyUpdate.
+func (k *KmsKeyUpdate) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", k, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
 		case "version":
 			err = unpopulate(val, "Version", &k.Version)
 			delete(rawMsg, key)

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_dev_cd_check_paralleldev_cd_check_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_dev_cd_check_paralleldev_cd_check_parallel.txt
@@ -59,6 +59,7 @@ Customer should be able to lifecycle and confirm external auth on a cluster
 Fleet should have registered stamps with ready management clusters
 Customer should be able to create an HCP cluster and manage ImageDigestMirrors
 Customer should be able to create an HCP cluster with Image Registry not present
+Customer should be able to rotate KMS key for a cluster with version >= 4.22
 Engineering should be able to retrieve kusto logs for a cluster and services
 Customer should be able to create a cluster with default autoscaling and a nodepool with autoscaling enabled up to replica limits
 Nodepool Ephemeral OS Disk should create a nodepool with ephemeral OS disk when autoRepair is enabled

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
@@ -64,6 +64,7 @@ Customer should be able to create an HCP cluster and manage ImageDigestMirrors
 Customer should be able to create an HCP cluster with Image Registry not present
 Image Registry Policy should deny pods with images from disallowed registries
 Image Registry Policy should allow pods with images from allowed registries and have a valid allowlist
+Customer should be able to rotate KMS key for a cluster with version >= 4.22
 Engineering should be able to retrieve kusto logs for a cluster and services
 Customer should be able to create a cluster with default autoscaling and a nodepool with autoscaling enabled up to replica limits
 Customer should respect cluster-wide node limits with nodepool autoscaling

--- a/test/util/framework/admin_api_helpers.go
+++ b/test/util/framework/admin_api_helpers.go
@@ -69,6 +69,7 @@ const (
 type AzureIdentityDetails struct {
 	PrincipalName string
 	PrincipalType PrincipalType
+	ObjectID      string
 }
 
 // GetCurrentAzureIdentityDetails extracts the current Azure identity from the
@@ -101,6 +102,11 @@ func (tc *perBinaryInvocationTestContext) GetCurrentAzureIdentityDetails(ctx con
 		return nil, fmt.Errorf("unexpected JWT claims type %T", parsed.Claims)
 	}
 
+	oid, ok := claims["oid"].(string)
+	if !ok {
+		return nil, fmt.Errorf("oid claim missing or not a string in token")
+	}
+
 	idType, ok := claims["idtyp"].(string)
 	if !ok {
 		return nil, fmt.Errorf("idtyp claim missing or not a string in token")
@@ -113,16 +119,14 @@ func (tc *perBinaryInvocationTestContext) GetCurrentAzureIdentityDetails(ctx con
 		return &AzureIdentityDetails{
 			PrincipalName: upn,
 			PrincipalType: PrincipalTypeDSTSUser,
+			ObjectID:      oid,
 		}, nil
 	}
 	if idType == "app" {
-		oid, ok := claims["oid"].(string)
-		if !ok {
-			return nil, fmt.Errorf("oid claim missing or not a string for app identity")
-		}
 		return &AzureIdentityDetails{
 			PrincipalName: oid,
 			PrincipalType: PrincipalTypeAADServicePrincipal,
+			ObjectID:      oid,
 		}, nil
 	}
 	return nil, fmt.Errorf("unknown identity type %q in token claims", idType)

--- a/test/util/verifiers/storageversionmigration.go
+++ b/test/util/verifiers/storageversionmigration.go
@@ -1,0 +1,156 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package verifiers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+)
+
+// HyperShift uses the out-of-tree migration.k8s.io CRD (not the in-tree storagemigration.k8s.io),
+// which has no typed client in client-go, so we use the dynamic client.
+var svmGVR = schema.GroupVersionResource{
+	Group:    "migration.k8s.io",
+	Version:  "v1alpha1",
+	Resource: "storageversionmigrations",
+}
+
+// VerifyStorageVersionMigrationSucceeded returns a verifier that checks all
+// encryption-migration-* StorageVersionMigration resources are in Succeeded state.
+// HCCO re-encryption controller creates StorageVersionMigration resources with this prefix
+// https://github.com/muraee/enhancements/blob/hypershift-etcd-reencryption/enhancements/hypershift/etcd-data-reencryption-on-key-rotation.md#component-2-re-encryption-orchestration-hcco
+func VerifyStorageVersionMigrationSucceeded() HostedClusterVerifier {
+	return verifyStorageVersionMigrationSucceeded{}
+}
+
+type verifyStorageVersionMigrationSucceeded struct{}
+
+func (v verifyStorageVersionMigrationSucceeded) Name() string {
+	return "VerifyStorageVersionMigrationSucceeded"
+}
+
+func (v verifyStorageVersionMigrationSucceeded) Verify(ctx context.Context, restConfig *rest.Config) error {
+	dynClient, err := dynamic.NewForConfig(restConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create dynamic client: %w", err)
+	}
+
+	svmList, err := dynClient.Resource(svmGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list StorageVersionMigration resources: %w", err)
+	}
+
+	var encryptionMigrations []unstructured.Unstructured
+	for i := range svmList.Items {
+		if strings.HasPrefix(svmList.Items[i].GetName(), "encryption-migration-") {
+			encryptionMigrations = append(encryptionMigrations, svmList.Items[i])
+		}
+	}
+
+	if len(encryptionMigrations) == 0 {
+		return fmt.Errorf("no encryption-migration-* StorageVersionMigration resources found")
+	}
+
+	var notSucceeded []string
+	for i := range encryptionMigrations {
+		if !storageVersionMigrationSucceeded(&encryptionMigrations[i]) {
+			notSucceeded = append(notSucceeded, encryptionMigrations[i].GetName())
+		}
+	}
+
+	if len(notSucceeded) > 0 {
+		sort.Strings(notSucceeded)
+		summaries := summarizeMigrations(encryptionMigrations)
+		summariesJSON, err := json.Marshal(summaries)
+		if err != nil {
+			return fmt.Errorf("%d encryption StorageVersionMigration resources not Succeeded: %s", len(notSucceeded), strings.Join(notSucceeded, ", "))
+		}
+		return fmt.Errorf("%d encryption StorageVersionMigration resources not Succeeded: %s; migrations=%s",
+			len(notSucceeded), strings.Join(notSucceeded, ", "), string(summariesJSON))
+	}
+
+	return nil
+}
+
+type migrationSummary struct {
+	Name       string             `json:"name"`
+	Resource   string             `json:"resource,omitempty"`
+	Conditions []conditionSummary `json:"conditions,omitempty"`
+}
+
+type conditionSummary struct {
+	Type   string `json:"type"`
+	Status string `json:"status"`
+}
+
+func summarizeMigrations(migrations []unstructured.Unstructured) []migrationSummary {
+	summaries := make([]migrationSummary, len(migrations))
+	for i := range migrations {
+		obj := &migrations[i]
+		s := migrationSummary{Name: obj.GetName()}
+
+		resource, _, _ := unstructured.NestedString(obj.Object, "spec", "resource", "resource")
+		if resource != "" {
+			group, _, _ := unstructured.NestedString(obj.Object, "spec", "resource", "group")
+			if group != "" {
+				s.Resource = group + "/" + resource
+			} else {
+				s.Resource = resource
+			}
+		}
+
+		conditions, found, err := unstructured.NestedSlice(obj.Object, "status", "conditions")
+		if err == nil && found {
+			for _, c := range conditions {
+				cond, ok := c.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				t, _ := cond["type"].(string)
+				status, _ := cond["status"].(string)
+				s.Conditions = append(s.Conditions, conditionSummary{Type: t, Status: status})
+			}
+		}
+
+		summaries[i] = s
+	}
+	return summaries
+}
+
+func storageVersionMigrationSucceeded(obj *unstructured.Unstructured) bool {
+	conditions, found, err := unstructured.NestedSlice(obj.Object, "status", "conditions")
+	if err != nil || !found {
+		return false
+	}
+	for _, c := range conditions {
+		cond, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if cond["type"] == "Succeeded" && cond["status"] == "True" {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-27470
https://redhat.atlassian.net/browse/ARO-27471

### What

Makes `KmsKey.Version` updatable via PATCH in the `v20260630preview` API so that customers can rotate their etcd encryption key version without recreating the cluster.

### Why

Customers using customer-managed encryption for etcd need to rotate their KMS key version periodically (security policy, key expiry, compliance). Today, all KMS fields — including `version` — are immutable after cluster creation. This forces a destructive cluster recreate just to update a key version, which is operationally unacceptable.

This PR is the **RP-side half** of the feature. Cluster Service is being updated separately to accept KMS key version changes on its PATCH endpoint. Both sides must be in place for end-to-end rotation to work, but neither breaks independently — the RP will send the version, and CS will either accept it (if updated) or ignore it (if not yet updated).

This PR has the changes for the ARM API spec and the frontend changes and adds E2E tests.

### Testing

**Unit tests**:
- Validation: "mutable kms key version" test verifies version-only change passes; "immutable kms visibility" expected errors updated to reflect removed parent-level guards
- Admission: 4 new test cases covering version-gated rotation at 4.21, 4.22, during upgrade, and no-change
- OCM conversion: "UPDATE - sends KMS key version" test verifies etcd encryption appears in the CS builder on update; `getBaseCSClusterBuilder(true)` updated to include default PlatformManaged etcd for update expectations

**Manual verification**: PATCH with key version change tested against dev environment confirming CS accepts the update and other fields remain unchanged.

**E2E tests**:
Added a simple E2E test that rotates the key version once and then disables the old key.
The test has a timebomb on the APIVersion being used. So it should be OK to merge, environments that doesn't have this API version will not use this test.
Example can be found in latest prod jobs https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-Azure-ARO-HCP-main-periodic-prod-e2e-parallel/2075037316002353152
Where the test `Customer should create a cluster using the 2026-06-30-preview API version` is skipped.

### Special notes for your reviewer

- The `@renamedFrom` suffix (`NoUpdate`) is a TypeSpec convention for this pattern — it doesn't appear in the generated API surface. The generated OpenAPI spec and SDK models are unchanged for older API versions. Verify this by checking that `internal/api/v20240610preview/generated/` and `internal/api/v20251223preview/generated/` are unmodified.

KMS key version rotation requires HyperShift changes that only land in OpenShift >= 4.22. The admission controller rejects key version changes when the cluster's **lowest active control plane version** is below 4.22. Why lowest and not requested? During a rolling upgrade, a cluster can have multiple active control plane versions (e.g. 4.22 + 4.23). Using the lowest ensures the rotation is only allowed when all active components support it.

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [ ] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

### Requirements to merge this change
- [x] CS rolled out to production
- [x] CPO override with the fix https://github.com/openshift/hypershift/pull/9010 merged
- [x] New HO image is deployed in ARO-HCP https://github.com/Azure/ARO-HCP/pull/6161
