### PR TITLE
fix: narrow gather-observability metric window to test execution

### DIFF
--- a/test/cmd/aro-hcp-tests/gather-observability/options.go
+++ b/test/cmd/aro-hcp-tests/gather-observability/options.go
@@ -139,11 +139,6 @@ func (o *ValidatedOptions) Complete(ctx context.Context) (*Options, error) {
 		return nil, fmt.Errorf("failed to get monitoring.hcpWorkspaceName from config: %w", err)
 	}
 
-	steps, err := timing.LoadSteps(ctx, o.TimingInputDir)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load steps: %w", err)
-	}
-
 	testTimingInfo, err := timing.LoadTestTimingInfo(ctx, o.TimingInputDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load test timing info: %w", err)
@@ -158,7 +153,7 @@ func (o *ValidatedOptions) Complete(ctx context.Context) (*Options, error) {
 		startFallback = &t
 	}
 
-	tw, err := timing.ComputeTimeWindow(ctx, clock.RealClock{}, steps, testTimingInfo, startFallback)
+	tw, err := timing.ComputeTimeWindow(ctx, clock.RealClock{}, nil, testTimingInfo, startFallback)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compute time window: %w", err)
 	}


### PR DESCRIPTION
### What

Stop loading infrastructure deployment steps (steps.yaml) when computing the metric query time window. The observability data we care about most is from the period when E2E tests are actually running.

The time window now derives exclusively from test timing metadata. The CLI fallback (--start-time-fallback) remains as a safety net when test timing is unavailable.

### Why

<!-- Briefly explain why this change is needed -->

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
