### PR TITLE
fix: anchor control plane desired version on previous selected desired

### DIFF
--- a/backend/pkg/controllers/upgradecontrollers/control_plane_active_version_controller_test.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_active_version_controller_test.go
@@ -77,7 +77,7 @@ func TestControlPlaneActiveVersionSyncer_SyncOnce(t *testing.T) {
 			seedDB: func(t *testing.T, ctx context.Context, mockResourcesDBClient *databasetesting.MockResourcesDBClient) {
 				t.Helper()
 				createTestHCPCluster(t, ctx, mockResourcesDBClient)
-				createServiceProviderClusterWithVersion(t, ctx, mockResourcesDBClient, "4.19.15")
+				createServiceProviderClusterWithVersion(t, ctx, mockResourcesDBClient, "4.19.15", nil)
 			},
 			readDesires: func(t *testing.T) []*kubeapplier.ReadDesire {
 				return []*kubeapplier.ReadDesire{newHostedClusterReadDesireWithVersions(t, nil,
@@ -321,7 +321,7 @@ func TestControlPlaneActiveVersionSyncer_NoReplaceWhenVersionsUnchanged(t *testi
 	mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
 
 	createTestHCPCluster(t, runCtx, mockResourcesDBClient)
-	createServiceProviderClusterWithVersion(t, runCtx, mockResourcesDBClient, "4.19.15")
+	createServiceProviderClusterWithVersion(t, runCtx, mockResourcesDBClient, "4.19.15", nil)
 	desires := []*kubeapplier.ReadDesire{newHostedClusterReadDesireWithVersions(t, nil,
 		hsv1beta1.ControlPlaneVersionStatus{History: []hsv1beta1.ControlPlaneUpdateHistory{
 			{Version: "4.19.15", State: configv1.CompletedUpdate},

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
@@ -146,6 +146,19 @@ func (c *controlPlaneDesiredVersionSyncer) SyncOnce(ctx context.Context, key con
 	customerDesiredMinor := existingCluster.CustomerProperties.Version.ID
 	channelGroup := existingCluster.CustomerProperties.Version.ChannelGroup
 	activeVersions := existingServiceProviderCluster.Status.ControlPlaneVersion.ActiveVersions
+	previousDesiredVersion := existingServiceProviderCluster.Spec.ControlPlaneVersion.DesiredVersion
+	var fromVersions []semver.Version
+	for _, activeVersion := range activeVersions {
+		fromVersions = append(fromVersions, *activeVersion.Version)
+	}
+	// Include the previous desired version when it is not yet active so Cincinnati
+	// candidate intersection still requires a path from that target. This prevents
+	// graph changes from selecting a lower patch without an SRE-initiated rollback.
+	if previousDesiredVersion != nil && !slices.ContainsFunc(activeVersions, func(activeVersion api.HCPClusterActiveVersion) bool {
+		return activeVersion.Version.EQ(*previousDesiredVersion)
+	}) {
+		fromVersions = append([]semver.Version{*previousDesiredVersion}, fromVersions...)
+	}
 	subscription, err := c.subscriptionLister.Get(ctx, key.SubscriptionID)
 	if err != nil {
 		return utils.TrackError(err)
@@ -154,7 +167,7 @@ func (c *controlPlaneDesiredVersionSyncer) SyncOnce(ctx context.Context, key con
 		Type:    operation.Update,
 		Options: validation.AFECsToValidationOptions(subscription.GetRegisteredFeatures()),
 	}
-	desiredVersion, err := c.desiredControlPlaneZVersion(ctx, cincinnatiClient, key.GetResourceID(), customerDesiredMinor, channelGroup, activeVersions,
+	desiredVersion, err := c.desiredControlPlaneZVersion(ctx, cincinnatiClient, key.GetResourceID(), customerDesiredMinor, channelGroup, fromVersions,
 		operation.HasOption(api.FeatureExperimentalReleaseFeatures))
 
 	if err != nil {
@@ -181,7 +194,6 @@ func (c *controlPlaneDesiredVersionSyncer) SyncOnce(ctx context.Context, key con
 		return utils.TrackError(err)
 	}
 
-	previousDesiredVersion := existingServiceProviderCluster.Spec.ControlPlaneVersion.DesiredVersion
 	desiredVersionUpdated := false
 	if desiredVersion != nil && (previousDesiredVersion == nil || !desiredVersion.EQ(*previousDesiredVersion)) {
 		logger.Info("Selected desired version", "desiredVersion", desiredVersion, "previousDesiredVersion", previousDesiredVersion)
@@ -220,15 +232,18 @@ func (c *controlPlaneDesiredVersionSyncer) SyncOnce(ctx context.Context, key con
 // The desired version selection logic is executed on each controller sync.
 // NOTE: Rollback to a previous z-stream is not currently supported (future enhancement).
 //
+// fromVersions supplies the anchor versions for Cincinnati intersection: active control plane
+// versions plus, when not yet active, the previous desired version (prepended first).
+//
 // It dispatches to one of three resolution methods based on the current cluster state:
-// - Case 1: Initial version selection (no active versions yet)
+// - Case 1: Initial version selection (no from versions)
 // - Case 2: Z-stream managed upgrade (customer desired minor == actual minor)
 // - Case 3: Next Y-stream user-initiated upgrade (customer desired minor == actual minor + 1)
 //
 // customerDesiredMinor and channelGroup are required. If they are not specified, no version is returned.
 // Returns nil if no upgrade is needed.
 func (c *controlPlaneDesiredVersionSyncer) desiredControlPlaneZVersion(ctx context.Context, cincinnatiClient cincinnati.Client, clusterResourceID *azcorearm.ResourceID,
-	customerDesiredMinor string, channelGroup string, activeVersions []api.HCPClusterActiveVersion, allowExperimentalReleaseFeatures bool) (*semver.Version, error) {
+	customerDesiredMinor string, channelGroup string, fromVersions []semver.Version, allowExperimentalReleaseFeatures bool) (*semver.Version, error) {
 	logger := utils.LoggerFromContext(ctx)
 
 	if len(customerDesiredMinor) == 0 {
@@ -240,7 +255,7 @@ func (c *controlPlaneDesiredVersionSyncer) desiredControlPlaneZVersion(ctx conte
 		return nil, nil
 	}
 
-	if len(activeVersions) == 0 {
+	if len(fromVersions) == 0 {
 		logger.Info("Resolving initial desired version", "customerDesiredMinor", customerDesiredMinor, "channelGroup", channelGroup)
 
 		// ParseTolerant handles both "4.19" and "4.19.0" formats
@@ -265,10 +280,7 @@ func (c *controlPlaneDesiredVersionSyncer) desiredControlPlaneZVersion(ctx conte
 		return initialDesiredVersion, nil
 	}
 
-	// Extract active versions and determine actual minor (if any)
-	// Use the most recent version to determine the minor version
-	actualLatestVersion := activeVersions[0].Version
-
+	actualLatestVersion := fromVersions[0]
 	actualLatestMinorVersion := semver.MustParse(fmt.Sprintf("%d.%d.0", actualLatestVersion.Major, actualLatestVersion.Minor))
 
 	// ParseTolerant handles both "4.19", "4.19.0" and full versions like "4.20.15". Normalize to major.minor.0
@@ -299,19 +311,14 @@ func (c *controlPlaneDesiredVersionSyncer) desiredControlPlaneZVersion(ctx conte
 		}
 	}
 
-	activeVersionList := make([]semver.Version, 0, len(activeVersions))
-	for _, av := range activeVersions {
-		activeVersionList = append(activeVersionList, *av.Version)
-	}
-
 	if desiredMinorVersion.EQ(actualLatestMinorVersion) {
-		return FindBestVersionInMinor(ctx, cincinnatiClient, channelGroup, desiredMinorVersion, activeVersionList, false)
+		return FindBestVersionInMinor(ctx, cincinnatiClient, channelGroup, desiredMinorVersion, fromVersions, false)
 	}
 
-	logger.Info("Resolving user-initiated upgrade desired version", "actualMinor", actualLatestMinorVersion.String(), "activeVersions", activeVersions,
+	logger.Info("Resolving user-initiated upgrade desired version", "actualMinor", actualLatestMinorVersion.String(), "fromVersions", fromVersions,
 		"channelGroup", channelGroup, "targetMinor", desiredMinorVersion.String())
 
-	latestVersion, err := FindBestVersionInMinor(ctx, cincinnatiClient, channelGroup, desiredMinorVersion, activeVersionList, true)
+	latestVersion, err := FindBestVersionInMinor(ctx, cincinnatiClient, channelGroup, desiredMinorVersion, fromVersions, true)
 	if err != nil {
 		return nil, utils.TrackError(err)
 	}
@@ -320,7 +327,7 @@ func (c *controlPlaneDesiredVersionSyncer) desiredControlPlaneZVersion(ctx conte
 	}
 
 	// User-requested control plane minor has no path yet; advance to latest patch on the current minor toward a gateway for a later user-initiated upgrade.
-	fallbackVersion, err := FindBestVersionInMinor(ctx, cincinnatiClient, channelGroup, actualLatestMinorVersion, activeVersionList, false)
+	fallbackVersion, err := FindBestVersionInMinor(ctx, cincinnatiClient, channelGroup, actualLatestMinorVersion, fromVersions, false)
 	if err != nil {
 		return nil, utils.TrackError(err)
 	}
@@ -367,17 +374,17 @@ func (c *controlPlaneDesiredVersionSyncer) listClusterAdmissionNodePools(ctx con
 // It prioritizes versions that have an upgrade path to the next minor version (gateway versions).
 //
 // Version selection algorithm:
-//  1. Query Cincinnati for all available updates from EACH active version in the target minor channel
+//  1. Query Cincinnati for all available updates from EACH fromVersion in the target minor channel
 //  2. Filter candidates: only include versions within the target minor
-//  3. Intersect candidate sets: only keep versions reachable from ALL active versions
+//  3. Intersect candidate sets: only keep versions reachable from ALL fromVersions
 //  4. Sort candidates by version (descending - latest first)
 //
 // Examples:
 //   - Z-stream (4.19.15 → 4.19.z): Find latest 4.19.z with path to 4.20, or latest 4.19.z
 //   - Y-stream (4.19.x → 4.20.z): Find latest 4.20.z with path to 4.21, or latest 4.20.z
 //
-// When multiple active versions are provided, this method ensures that the selected version
-// is reachable from ALL active versions by intersecting the upgrade paths.
+// When multiple from versions are provided, this method ensures that the selected version
+// is reachable from ALL from versions by intersecting the upgrade paths.
 //
 // Returns nil if no suitable version is found.
 func FindAllUpgradeTargetVersionsInMinor(
@@ -385,7 +392,7 @@ func FindAllUpgradeTargetVersionsInMinor(
 	cincinnatiClient cincinnati.Client,
 	channelGroup string,
 	targetMinorVersion semver.Version,
-	activeVersions []semver.Version,
+	fromVersions []semver.Version,
 ) ([]semver.Version, error) {
 	cincinnatiURI, err := cincinnati.GetCincinnatiURI(channelGroup)
 	if err != nil {
@@ -395,14 +402,14 @@ func FindAllUpgradeTargetVersionsInMinor(
 	targetMinorString := fmt.Sprintf("%d.%d", targetMinorVersion.Major, targetMinorVersion.Minor)
 	cincinnatiChannel := fmt.Sprintf("%s-%s", channelGroup, targetMinorString)
 
-	// For active versions, intersect their upgrade candidates
+	// Intersect upgrade candidates across all fromVersions.
 	candidatesByVersion := map[string]struct {
 		version semver.Version
 		count   int
 	}{}
 
-	for _, activeVersion := range activeVersions {
-		_, candidateReleases, _, err := cincinnatiClient.GetUpdates(ctx, cincinnatiURI, "multi", "multi", cincinnatiChannel, activeVersion)
+	for _, fromVersion := range fromVersions {
+		_, candidateReleases, _, err := cincinnatiClient.GetUpdates(ctx, cincinnatiURI, "multi", "multi", cincinnatiChannel, fromVersion)
 		if err != nil {
 			return nil, utils.TrackError(err)
 		}
@@ -422,10 +429,10 @@ func FindAllUpgradeTargetVersionsInMinor(
 		}
 	}
 
-	// Extract only candidates that appeared for ALL active versions (intersection)
+	// Extract only candidates that appeared for ALL fromVersions (intersection).
 	commonCandidates := []semver.Version{}
 	for _, candidateEntry := range candidatesByVersion {
-		if candidateEntry.count == len(activeVersions) {
+		if candidateEntry.count == len(fromVersions) {
 			commonCandidates = append(commonCandidates, candidateEntry.version)
 		}
 	}
@@ -439,9 +446,9 @@ func FindAllUpgradeTargetVersionsInMinor(
 // It prioritizes versions that have an upgrade path to the next minor version (gateway versions).
 //
 // Version selection algorithm:
-//  1. Query Cincinnati for all available updates from EACH active version in the target minor channel
+//  1. Query Cincinnati for all available updates from EACH fromVersion in the target minor channel
 //  2. Filter candidates: only include versions within the target minor
-//  3. Intersect candidate sets: only keep versions reachable from ALL active versions
+//  3. Intersect candidate sets: only keep versions reachable from ALL fromVersions
 //  4. Sort candidates by version (descending - latest first)
 //  5. Check if next minor (4.(y+1)) channel exists in Cincinnati
 //  6. If next minor doesn't exist: return the latest candidate
@@ -456,8 +463,8 @@ func FindAllUpgradeTargetVersionsInMinor(
 //   - Z-stream (4.19.15 → 4.19.z): Find latest 4.19.z with path to 4.20, or nil if none
 //   - Y-stream (4.19.x → 4.20.z): Find latest 4.20.z with path to 4.21, or latest 4.20.z
 //
-// When multiple active versions are provided, this method ensures that the selected version
-// is reachable from ALL active versions by intersecting the upgrade paths.
+// When multiple from versions are provided, this method ensures that the selected version
+// is reachable from ALL from versions by intersecting the upgrade paths.
 //
 // Returns nil if no suitable version is found.
 func FindBestVersionInMinor(
@@ -465,10 +472,10 @@ func FindBestVersionInMinor(
 	cincinnatiClient cincinnati.Client,
 	channelGroup string,
 	targetMinorVersion semver.Version,
-	activeVersions []semver.Version,
+	fromVersions []semver.Version,
 	preferLatestOverGateway bool,
 ) (*semver.Version, error) {
-	commonCandidates, err := FindAllUpgradeTargetVersionsInMinor(ctx, cincinnatiClient, channelGroup, targetMinorVersion, activeVersions)
+	commonCandidates, err := FindAllUpgradeTargetVersionsInMinor(ctx, cincinnatiClient, channelGroup, targetMinorVersion, fromVersions)
 	if err != nil {
 		return nil, utils.TrackError(err)
 	}

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller_test.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller_test.go
@@ -46,7 +46,7 @@ import (
 func TestDesiredControlPlaneZVersion_ZStreamManagedUpgrade(t *testing.T) {
 	tests := []struct {
 		name                  string
-		activeVersions        []api.HCPClusterActiveVersion
+		fromVersions          []semver.Version
 		customerDesiredMinor  string
 		channelGroup          string
 		mockSetup             func(*cincinnati.MockClient)
@@ -56,7 +56,7 @@ func TestDesiredControlPlaneZVersion_ZStreamManagedUpgrade(t *testing.T) {
 	}{
 		{
 			name:                 "Z-stream upgrade - finds latest gateway",
-			activeVersions:       []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.19.15")), State: configv1.CompletedUpdate}},
+			fromVersions:         []semver.Version{semver.MustParse("4.19.15")},
 			customerDesiredMinor: "4.19",
 			channelGroup:         "stable",
 			mockSetup: func(mc *cincinnati.MockClient) {
@@ -81,7 +81,7 @@ func TestDesiredControlPlaneZVersion_ZStreamManagedUpgrade(t *testing.T) {
 		},
 		{
 			name:                 "Z-stream upgrade - already at latest",
-			activeVersions:       []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.19.22")), State: configv1.CompletedUpdate}},
+			fromVersions:         []semver.Version{semver.MustParse("4.19.22")},
 			customerDesiredMinor: "4.19",
 			channelGroup:         "stable",
 			mockSetup: func(mc *cincinnati.MockClient) {
@@ -97,7 +97,7 @@ func TestDesiredControlPlaneZVersion_ZStreamManagedUpgrade(t *testing.T) {
 		},
 		{
 			name:                 "Z-stream upgrade - actual has edge to next minor, no gateway in candidates",
-			activeVersions:       []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.19.15")), State: configv1.CompletedUpdate}},
+			fromVersions:         []semver.Version{semver.MustParse("4.19.15")},
 			customerDesiredMinor: "4.19",
 			channelGroup:         "stable",
 			mockSetup: func(mc *cincinnati.MockClient) {
@@ -124,9 +124,9 @@ func TestDesiredControlPlaneZVersion_ZStreamManagedUpgrade(t *testing.T) {
 			name:                 "Z-stream upgrade - multiple active versions, only common candidates considered",
 			customerDesiredMinor: "4.19",
 			channelGroup:         "stable",
-			activeVersions: []api.HCPClusterActiveVersion{
-				{Version: ptr.To(semver.MustParse("4.19.12")), State: configv1.CompletedUpdate}, // Most recent
-				{Version: ptr.To(semver.MustParse("4.19.10")), State: configv1.CompletedUpdate}, // Older active version
+			fromVersions: []semver.Version{
+				semver.MustParse("4.19.12"), // Most recent
+				semver.MustParse("4.19.10"), // Older active version
 			},
 			mockSetup: func(mc *cincinnati.MockClient) {
 				// Query for 4.19 versions from 4.19.12 (most recent active version)
@@ -158,7 +158,7 @@ func TestDesiredControlPlaneZVersion_ZStreamManagedUpgrade(t *testing.T) {
 		},
 		{
 			name:                 "Z-stream upgrade - actual has NO edge to next minor, no gateway in candidates",
-			activeVersions:       []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.19.10")), State: configv1.CompletedUpdate}},
+			fromVersions:         []semver.Version{semver.MustParse("4.19.10")},
 			customerDesiredMinor: "4.19",
 			channelGroup:         "stable",
 			mockSetup: func(mc *cincinnati.MockClient) {
@@ -185,7 +185,7 @@ func TestDesiredControlPlaneZVersion_ZStreamManagedUpgrade(t *testing.T) {
 		},
 		{
 			name:                 "Z-stream upgrade - Cincinnati query error",
-			activeVersions:       []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.19.15")), State: configv1.CompletedUpdate}},
+			fromVersions:         []semver.Version{semver.MustParse("4.19.15")},
 			customerDesiredMinor: "4.19",
 			channelGroup:         "stable",
 			mockSetup: func(mc *cincinnati.MockClient) {
@@ -203,7 +203,7 @@ func TestDesiredControlPlaneZVersion_ZStreamManagedUpgrade(t *testing.T) {
 		},
 		{
 			name:                 "Z-stream upgrade - no desired minor version specified",
-			activeVersions:       []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.19.15")), State: configv1.CompletedUpdate}},
+			fromVersions:         []semver.Version{semver.MustParse("4.19.15")},
 			customerDesiredMinor: "",
 			channelGroup:         "stable",
 			mockSetup:            func(mc *cincinnati.MockClient) {},
@@ -212,7 +212,7 @@ func TestDesiredControlPlaneZVersion_ZStreamManagedUpgrade(t *testing.T) {
 		},
 		{
 			name:                 "Z-stream upgrade - no channel group specified",
-			activeVersions:       []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.19.15")), State: configv1.CompletedUpdate}},
+			fromVersions:         []semver.Version{semver.MustParse("4.19.15")},
 			customerDesiredMinor: "4.19",
 			channelGroup:         "",
 			mockSetup:            func(mc *cincinnati.MockClient) {},
@@ -221,7 +221,7 @@ func TestDesiredControlPlaneZVersion_ZStreamManagedUpgrade(t *testing.T) {
 		},
 		{
 			name:                 "Z-stream upgrade - candidate channel, customer desired full version (4.20.15) normalized to same minor",
-			activeVersions:       []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.20.10")), State: configv1.CompletedUpdate}},
+			fromVersions:         []semver.Version{semver.MustParse("4.20.10")},
 			customerDesiredMinor: "4.20.15",
 			channelGroup:         "candidate",
 			mockSetup: func(mc *cincinnati.MockClient) {
@@ -251,7 +251,7 @@ func TestDesiredControlPlaneZVersion_ZStreamManagedUpgrade(t *testing.T) {
 		},
 		{
 			name:                 "Z-stream upgrade - nightly channel, customer desired full version (4.19.0-0.nightly-multi-...) normalized to same minor",
-			activeVersions:       []api.HCPClusterActiveVersion{{Version: ptr.To(api.Must(semver.ParseTolerant("4.19.0-0.nightly-multi-2026-01-10-204154"))), State: configv1.CompletedUpdate}},
+			fromVersions:         []semver.Version{api.Must(semver.ParseTolerant("4.19.0-0.nightly-multi-2026-01-10-204154"))},
 			customerDesiredMinor: "4.19.0-0.nightly-multi-2026-01-12-061259",
 			channelGroup:         "nightly",
 			mockSetup: func(mc *cincinnati.MockClient) {
@@ -286,7 +286,7 @@ func TestDesiredControlPlaneZVersion_ZStreamManagedUpgrade(t *testing.T) {
 			syncer := &controlPlaneDesiredVersionSyncer{resourcesDBClient: databasetesting.NewMockResourcesDBClient()}
 
 			ctx := context.Background()
-			result, err := syncer.desiredControlPlaneZVersion(ctx, mockCincinnatiClient, api.Must(api.ToClusterResourceID("6b690bec-0c16-4ecb-8f67-781caf40bba7", "test-rg", "test-cluster")), tt.customerDesiredMinor, tt.channelGroup, tt.activeVersions, false)
+			result, err := syncer.desiredControlPlaneZVersion(ctx, mockCincinnatiClient, api.Must(api.ToClusterResourceID("6b690bec-0c16-4ecb-8f67-781caf40bba7", "test-rg", "test-cluster")), tt.customerDesiredMinor, tt.channelGroup, tt.fromVersions, false)
 
 			assertVersionResult(t, result, err, tt.expectedVersion, tt.expectedError, tt.expectedErrorContains)
 		})
@@ -296,7 +296,7 @@ func TestDesiredControlPlaneZVersion_ZStreamManagedUpgrade(t *testing.T) {
 func TestDesiredControlPlaneZVersion_NextYStreamUpgrade(t *testing.T) {
 	tests := []struct {
 		name                  string
-		activeVersions        []api.HCPClusterActiveVersion
+		fromVersions          []semver.Version
 		customerDesiredMinor  string
 		channelGroup          string
 		mockSetup             func(*cincinnati.MockClient)
@@ -307,7 +307,7 @@ func TestDesiredControlPlaneZVersion_NextYStreamUpgrade(t *testing.T) {
 	}{
 		{
 			name:                 "Y-stream upgrade - direct path available returns latest version with gateway to next minor",
-			activeVersions:       []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.19.22")), State: configv1.CompletedUpdate}},
+			fromVersions:         []semver.Version{semver.MustParse("4.19.22")},
 			customerDesiredMinor: "4.20",
 			channelGroup:         "stable",
 			mockSetup: func(mc *cincinnati.MockClient) {
@@ -342,7 +342,7 @@ func TestDesiredControlPlaneZVersion_NextYStreamUpgrade(t *testing.T) {
 		},
 		{
 			name:                 "Y-stream upgrade - succeeds with node pool within skew versus desired minor",
-			activeVersions:       []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.19.22")), State: configv1.CompletedUpdate}},
+			fromVersions:         []semver.Version{semver.MustParse("4.19.22")},
 			customerDesiredMinor: "4.20",
 			channelGroup:         "stable",
 			mockSetup: func(mc *cincinnati.MockClient) {
@@ -378,7 +378,7 @@ func TestDesiredControlPlaneZVersion_NextYStreamUpgrade(t *testing.T) {
 		},
 		{
 			name:                 "Y-stream upgrade - no direct path, falls back to Z-stream",
-			activeVersions:       []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.19.15")), State: configv1.CompletedUpdate}},
+			fromVersions:         []semver.Version{semver.MustParse("4.19.15")},
 			customerDesiredMinor: "4.20",
 			channelGroup:         "stable",
 			mockSetup: func(mc *cincinnati.MockClient) {
@@ -413,9 +413,9 @@ func TestDesiredControlPlaneZVersion_NextYStreamUpgrade(t *testing.T) {
 			name:                 "Y-stream upgrade - multiple active versions, only common candidates considered",
 			customerDesiredMinor: "4.20",
 			channelGroup:         "stable",
-			activeVersions: []api.HCPClusterActiveVersion{
-				{Version: ptr.To(semver.MustParse("4.19.18")), State: configv1.CompletedUpdate}, // Most recent
-				{Version: ptr.To(semver.MustParse("4.19.15")), State: configv1.CompletedUpdate}, // Older active version
+			fromVersions: []semver.Version{
+				semver.MustParse("4.19.18"), // Most recent
+				semver.MustParse("4.19.15"), // Older active version
 			},
 			mockSetup: func(mc *cincinnati.MockClient) {
 				// Query for 4.20 versions from 4.19.18 (most recent active version)
@@ -448,7 +448,7 @@ func TestDesiredControlPlaneZVersion_NextYStreamUpgrade(t *testing.T) {
 		},
 		{
 			name:                 "Y-stream upgrade - no gateway found but returns latest anyway",
-			activeVersions:       []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.19.15")), State: configv1.CompletedUpdate}},
+			fromVersions:         []semver.Version{semver.MustParse("4.19.15")},
 			customerDesiredMinor: "4.20",
 			channelGroup:         "stable",
 			mockSetup: func(mc *cincinnati.MockClient) {
@@ -474,7 +474,7 @@ func TestDesiredControlPlaneZVersion_NextYStreamUpgrade(t *testing.T) {
 		},
 		{
 			name:                 "Y-stream upgrade - next minor exists but no gateway, returns latest for security",
-			activeVersions:       []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.19.60")), State: configv1.CompletedUpdate}},
+			fromVersions:         []semver.Version{semver.MustParse("4.19.60")},
 			customerDesiredMinor: "4.20",
 			channelGroup:         "candidate",
 			cosmosResources:      testCosmosClusterWithWorkersNodePoolAtVersion("4.19.60"),
@@ -500,7 +500,7 @@ func TestDesiredControlPlaneZVersion_NextYStreamUpgrade(t *testing.T) {
 		},
 		{
 			name:                 "Y-stream upgrade - Cincinnati query error",
-			activeVersions:       []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.19.22")), State: configv1.CompletedUpdate}},
+			fromVersions:         []semver.Version{semver.MustParse("4.19.22")},
 			customerDesiredMinor: "4.20",
 			channelGroup:         "stable",
 			mockSetup: func(mc *cincinnati.MockClient) {
@@ -518,7 +518,7 @@ func TestDesiredControlPlaneZVersion_NextYStreamUpgrade(t *testing.T) {
 		},
 		{
 			name:                 "Y-stream upgrade - no path in target minor and already at latest in current minor",
-			activeVersions:       []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.20.22")), State: configv1.CompletedUpdate}},
+			fromVersions:         []semver.Version{semver.MustParse("4.20.22")},
 			customerDesiredMinor: "4.21",
 			channelGroup:         "candidate",
 			cosmosResources:      testCosmosClusterWithWorkersNodePoolAtVersion("4.20.22"),
@@ -545,7 +545,7 @@ func TestDesiredControlPlaneZVersion_NextYStreamUpgrade(t *testing.T) {
 		},
 		{
 			name:                 "Y-stream upgrade - candidates exist but no gateway to next minor, returns latest for security",
-			activeVersions:       []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.20.22")), State: configv1.CompletedUpdate}},
+			fromVersions:         []semver.Version{semver.MustParse("4.20.22")},
 			customerDesiredMinor: "4.21",
 			channelGroup:         "candidate",
 			cosmosResources:      testCosmosClusterWithWorkersNodePoolAtVersion("4.20.22"),
@@ -583,7 +583,7 @@ func TestDesiredControlPlaneZVersion_NextYStreamUpgrade(t *testing.T) {
 			require.NoError(t, err)
 			syncer := &controlPlaneDesiredVersionSyncer{resourcesDBClient: mockResourcesDBClient}
 
-			result, err := syncer.desiredControlPlaneZVersion(ctx, mockCincinnatiClient, api.Must(api.ToClusterResourceID("6b690bec-0c16-4ecb-8f67-781caf40bba7", "test-rg", "test-cluster")), tt.customerDesiredMinor, tt.channelGroup, tt.activeVersions, false)
+			result, err := syncer.desiredControlPlaneZVersion(ctx, mockCincinnatiClient, api.Must(api.ToClusterResourceID("6b690bec-0c16-4ecb-8f67-781caf40bba7", "test-rg", "test-cluster")), tt.customerDesiredMinor, tt.channelGroup, tt.fromVersions, false)
 
 			assertVersionResult(t, result, err, tt.expectedVersion, tt.expectedError, tt.expectedErrorContains)
 		})
@@ -630,7 +630,7 @@ func testCosmosClusterWithWorkersNodePoolAtVersion(nodePoolVersionId string) []a
 func TestDesiredControlPlaneZVersion_Validations(t *testing.T) {
 	tests := []struct {
 		name                        string
-		activeVersions              []api.HCPClusterActiveVersion
+		fromVersions                []semver.Version
 		customerDesiredMinor        string
 		channelGroup                string
 		mockSetup                   func(*cincinnati.MockClient)
@@ -642,7 +642,7 @@ func TestDesiredControlPlaneZVersion_Validations(t *testing.T) {
 	}{
 		{
 			name:                  "Validation - downgrade not allowed (4.20 -> 4.19)",
-			activeVersions:        []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.20.15")), State: configv1.CompletedUpdate}},
+			fromVersions:          []semver.Version{semver.MustParse("4.20.15")},
 			customerDesiredMinor:  "4.19",
 			channelGroup:          "stable",
 			mockSetup:             func(mc *cincinnati.MockClient) {},
@@ -652,7 +652,7 @@ func TestDesiredControlPlaneZVersion_Validations(t *testing.T) {
 		},
 		{
 			name:                  "Validation - OpenShift 5.x requires AFEC (4.20 -> 5.0)",
-			activeVersions:        []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.20.15")), State: configv1.CompletedUpdate}},
+			fromVersions:          []semver.Version{semver.MustParse("4.20.15")},
 			customerDesiredMinor:  "5.0",
 			channelGroup:          "stable",
 			mockSetup:             func(mc *cincinnati.MockClient) {},
@@ -662,7 +662,7 @@ func TestDesiredControlPlaneZVersion_Validations(t *testing.T) {
 		},
 		{
 			name:                        "Validation - unsupported cross-major (4.20 -> 5.0, not a supported 4→5 landing) when AFEC registered",
-			activeVersions:              []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.20.15")), State: configv1.CompletedUpdate}},
+			fromVersions:                []semver.Version{semver.MustParse("4.20.15")},
 			customerDesiredMinor:        "5.0",
 			channelGroup:                "stable",
 			mockSetup:                   func(mc *cincinnati.MockClient) {},
@@ -673,7 +673,7 @@ func TestDesiredControlPlaneZVersion_Validations(t *testing.T) {
 		},
 		{
 			name:                  "Validation - skip minor version not allowed (4.19 -> 4.21)",
-			activeVersions:        []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.19.22")), State: configv1.CompletedUpdate}},
+			fromVersions:          []semver.Version{semver.MustParse("4.19.22")},
 			customerDesiredMinor:  "4.21",
 			channelGroup:          "stable",
 			mockSetup:             func(mc *cincinnati.MockClient) {},
@@ -683,7 +683,7 @@ func TestDesiredControlPlaneZVersion_Validations(t *testing.T) {
 		},
 		{
 			name:                  "Validation - major version downgrade not allowed (5.1 -> 4.20)",
-			activeVersions:        []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("5.1.5")), State: configv1.CompletedUpdate}},
+			fromVersions:          []semver.Version{semver.MustParse("5.1.5")},
 			customerDesiredMinor:  "4.20",
 			channelGroup:          "stable",
 			mockSetup:             func(mc *cincinnati.MockClient) {},
@@ -693,7 +693,7 @@ func TestDesiredControlPlaneZVersion_Validations(t *testing.T) {
 		},
 		{
 			name:                        "Validation - node pool minor skew blocks supported cross-major desired minor",
-			activeVersions:              []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.22.0")), State: configv1.CompletedUpdate}},
+			fromVersions:                []semver.Version{semver.MustParse("4.22.0")},
 			customerDesiredMinor:        "5.0",
 			channelGroup:                "stable",
 			mockSetup:                   func(mc *cincinnati.MockClient) {},
@@ -717,7 +717,7 @@ func TestDesiredControlPlaneZVersion_Validations(t *testing.T) {
 			require.NoError(t, err)
 			syncer := &controlPlaneDesiredVersionSyncer{resourcesDBClient: mockResourcesDBClient}
 
-			result, err := syncer.desiredControlPlaneZVersion(ctx, mockCincinnatiClient, api.Must(api.ToClusterResourceID("6b690bec-0c16-4ecb-8f67-781caf40bba7", "test-rg", "test-cluster")), tt.customerDesiredMinor, tt.channelGroup, tt.activeVersions, tt.experimentalReleaseFeatures)
+			result, err := syncer.desiredControlPlaneZVersion(ctx, mockCincinnatiClient, api.Must(api.ToClusterResourceID("6b690bec-0c16-4ecb-8f67-781caf40bba7", "test-rg", "test-cluster")), tt.customerDesiredMinor, tt.channelGroup, tt.fromVersions, tt.experimentalReleaseFeatures)
 
 			assertVersionResult(t, result, err, tt.expectedVersion, tt.expectedError, tt.expectedErrorContains)
 		})
@@ -727,7 +727,7 @@ func TestDesiredControlPlaneZVersion_Validations(t *testing.T) {
 func TestDesiredControlPlaneZVersion_CrossMajorUpgrade(t *testing.T) {
 	tests := []struct {
 		name                        string
-		activeVersions              []api.HCPClusterActiveVersion
+		fromVersions                []semver.Version
 		customerDesiredMinor        string
 		channelGroup                string
 		mockSetup                   func(*cincinnati.MockClient)
@@ -739,7 +739,7 @@ func TestDesiredControlPlaneZVersion_CrossMajorUpgrade(t *testing.T) {
 	}{
 		{
 			name:                        "Cross-major allowed — 4.22 to 5.0 with experimental release features and compatible node pools",
-			activeVersions:              []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.22.0")), State: configv1.CompletedUpdate}},
+			fromVersions:                []semver.Version{semver.MustParse("4.22.0")},
 			customerDesiredMinor:        "5.0",
 			channelGroup:                "stable",
 			cosmosResources:             testCosmosClusterWithWorkersNodePoolAtVersion("4.22.0"),
@@ -770,7 +770,7 @@ func TestDesiredControlPlaneZVersion_CrossMajorUpgrade(t *testing.T) {
 		},
 		{
 			name:                        "Cross-major not allowed — 4.22 to 5.0 without experimental release features",
-			activeVersions:              []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.22.0")), State: configv1.CompletedUpdate}},
+			fromVersions:                []semver.Version{semver.MustParse("4.22.0")},
 			customerDesiredMinor:        "5.0",
 			channelGroup:                "stable",
 			mockSetup:                   func(mc *cincinnati.MockClient) {},
@@ -781,7 +781,7 @@ func TestDesiredControlPlaneZVersion_CrossMajorUpgrade(t *testing.T) {
 		},
 		{
 			name:                        "Cross-major not allowed — 4.21 to 5.0 is not a supported landing even with experimental release features",
-			activeVersions:              []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.21.10")), State: configv1.CompletedUpdate}},
+			fromVersions:                []semver.Version{semver.MustParse("4.21.10")},
 			customerDesiredMinor:        "5.0",
 			channelGroup:                "stable",
 			cosmosResources:             testCosmosClusterWithWorkersNodePoolAtVersion("4.21.0"),
@@ -793,7 +793,7 @@ func TestDesiredControlPlaneZVersion_CrossMajorUpgrade(t *testing.T) {
 		},
 		{
 			name:                        "Cross-major not allowed — 4.22 to 5.1 skips the supported 4.22 to 5.0 path",
-			activeVersions:              []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.22.0")), State: configv1.CompletedUpdate}},
+			fromVersions:                []semver.Version{semver.MustParse("4.22.0")},
 			customerDesiredMinor:        "5.1",
 			channelGroup:                "stable",
 			cosmosResources:             testCosmosClusterWithWorkersNodePoolAtVersion("4.22.0"),
@@ -817,7 +817,7 @@ func TestDesiredControlPlaneZVersion_CrossMajorUpgrade(t *testing.T) {
 			require.NoError(t, err)
 			syncer := &controlPlaneDesiredVersionSyncer{resourcesDBClient: mockResourcesDBClient}
 
-			result, err := syncer.desiredControlPlaneZVersion(ctx, mockCincinnatiClient, api.Must(api.ToClusterResourceID("6b690bec-0c16-4ecb-8f67-781caf40bba7", "test-rg", "test-cluster")), tt.customerDesiredMinor, tt.channelGroup, tt.activeVersions, tt.experimentalReleaseFeatures)
+			result, err := syncer.desiredControlPlaneZVersion(ctx, mockCincinnatiClient, api.Must(api.ToClusterResourceID("6b690bec-0c16-4ecb-8f67-781caf40bba7", "test-rg", "test-cluster")), tt.customerDesiredMinor, tt.channelGroup, tt.fromVersions, tt.experimentalReleaseFeatures)
 
 			assertVersionResult(t, result, err, tt.expectedVersion, tt.expectedError, tt.expectedErrorContains)
 		})
@@ -957,11 +957,8 @@ func TestDesiredControlPlaneZVersion_InitialVersionSelection(t *testing.T) {
 
 			syncer := &controlPlaneDesiredVersionSyncer{resourcesDBClient: databasetesting.NewMockResourcesDBClient()}
 
-			// Empty active versions - simulating a new cluster
-			activeVersions := []api.HCPClusterActiveVersion{}
-
 			ctx := context.Background()
-			result, err := syncer.desiredControlPlaneZVersion(ctx, mockCincinnatiClient, api.Must(api.ToClusterResourceID("6b690bec-0c16-4ecb-8f67-781caf40bba7", "test-rg", "test-cluster")), tt.customerDesiredMinor, tt.channelGroup, activeVersions, false)
+			result, err := syncer.desiredControlPlaneZVersion(ctx, mockCincinnatiClient, api.Must(api.ToClusterResourceID("6b690bec-0c16-4ecb-8f67-781caf40bba7", "test-rg", "test-cluster")), tt.customerDesiredMinor, tt.channelGroup, nil, false)
 
 			assertVersionResult(t, result, err, tt.expectedVersion, tt.expectedError, tt.expectedErrorContains)
 		})
@@ -1039,19 +1036,21 @@ func TestControlPlaneDesiredVersionSyncer_SyncOnce(t *testing.T) {
 	const testChannelGroup = "stable"
 
 	tests := []struct {
-		name                string
-		customerVersion     string
-		controlPlaneVersion string
-		setupCincinnati     func(mc *cincinnati.MockClient)
-		wantSyncErr         bool
-		wantErrContains     string
-		wantDesiredVersion  *semver.Version
-		wantIntentFailed    *metav1.Condition
+		name               string
+		customerVersion    string
+		activeVersion      string
+		desiredVersion     *semver.Version
+		setupCincinnati    func(mc *cincinnati.MockClient)
+		wantSyncErr        bool
+		wantErrContains    string
+		wantDesiredVersion *semver.Version
+		wantIntentFailed   *metav1.Condition
 	}{
 		{
-			name:                "successful resolution persists desired version and sets IntentFailed False",
-			customerVersion:     "4.19",
-			controlPlaneVersion: "4.19.15",
+			name:            "successful resolution initialises desired version when unset and sets IntentFailed False",
+			customerVersion: "4.19",
+			activeVersion:   "4.19.15",
+			desiredVersion:  nil,
 			setupCincinnati: func(mc *cincinnati.MockClient) {
 				mc.EXPECT().GetUpdates(gomock.Any(), stableURI, "multi", "multi", "stable-4.19", semver.MustParse("4.19.15")).Return(
 					configv1.Release{},
@@ -1071,11 +1070,38 @@ func TestControlPlaneDesiredVersionSyncer_SyncOnce(t *testing.T) {
 			},
 		},
 		{
-			name:                "validation error persists IntentFailed and does not set desired version",
-			customerVersion:     "4.19",
-			controlPlaneVersion: "4.20.15",
-			setupCincinnati:     func(mc *cincinnati.MockClient) {},
-			wantDesiredVersion:  nil,
+			name:            "previous desired anchors resolution when Cincinnati graph offers lower patch",
+			customerVersion: "4.19",
+			activeVersion:   "4.19.15",
+			desiredVersion:  ptr.To(semver.MustParse("4.19.22")),
+			setupCincinnati: func(mc *cincinnati.MockClient) {
+				mc.EXPECT().GetUpdates(gomock.Any(), stableURI, "multi", "multi", "stable-4.19", semver.MustParse("4.19.22")).Return(
+					configv1.Release{Version: "4.19.22"},
+					[]configv1.Release{},
+					nil,
+					nil,
+				).Times(1)
+				mc.EXPECT().GetUpdates(gomock.Any(), stableURI, "multi", "multi", "stable-4.19", semver.MustParse("4.19.15")).Return(
+					configv1.Release{Version: "4.19.15"},
+					[]configv1.Release{{Version: "4.19.18"}},
+					nil,
+					nil,
+				).Times(1)
+			},
+			wantDesiredVersion: ptr.To(semver.MustParse("4.19.22")),
+			wantIntentFailed: &metav1.Condition{
+				Type:   api.ControllerConditionTypeIntentFailed,
+				Status: metav1.ConditionFalse,
+				Reason: api.ControllerConditionReasonAsExpected,
+			},
+		},
+		{
+			name:               "validation error persists IntentFailed and preserves existing desired version",
+			customerVersion:    "4.19",
+			activeVersion:      "4.20.15",
+			desiredVersion:     ptr.To(semver.MustParse("4.20.15")),
+			setupCincinnati:    func(mc *cincinnati.MockClient) {},
+			wantDesiredVersion: ptr.To(semver.MustParse("4.20.15")),
 			wantIntentFailed: &metav1.Condition{
 				Type:    api.ControllerConditionTypeIntentFailed,
 				Status:  metav1.ConditionTrue,
@@ -1084,9 +1110,10 @@ func TestControlPlaneDesiredVersionSyncer_SyncOnce(t *testing.T) {
 			},
 		},
 		{
-			name:                "Cincinnati upstream error does not persist IntentFailed or desired version",
-			customerVersion:     "4.19",
-			controlPlaneVersion: "4.19.15",
+			name:            "Cincinnati upstream error does not persist IntentFailed or desired version",
+			customerVersion: "4.19",
+			activeVersion:   "4.19.15",
+			desiredVersion:  ptr.To(semver.MustParse("4.19.15")),
 			setupCincinnati: func(mc *cincinnati.MockClient) {
 				mc.EXPECT().GetUpdates(gomock.Any(), stableURI, "multi", "multi", "stable-4.19", semver.MustParse("4.19.15")).Return(
 					configv1.Release{}, nil, nil, &cvocincinnati.Error{Reason: "ServiceUnavailable", Message: "503 Service Unavailable"},
@@ -1094,19 +1121,20 @@ func TestControlPlaneDesiredVersionSyncer_SyncOnce(t *testing.T) {
 			},
 			wantSyncErr:        true,
 			wantErrContains:    "503 Service Unavailable",
-			wantDesiredVersion: nil,
+			wantDesiredVersion: ptr.To(semver.MustParse("4.19.15")),
 			wantIntentFailed:   nil,
 		},
 		{
-			name:                "Cincinnati VersionNotFound persists IntentFailed and does not set desired version",
-			customerVersion:     "4.19",
-			controlPlaneVersion: "4.19.15",
+			name:            "Cincinnati VersionNotFound persists IntentFailed and preserves existing desired version",
+			customerVersion: "4.19",
+			activeVersion:   "4.19.15",
+			desiredVersion:  ptr.To(semver.MustParse("4.19.15")),
 			setupCincinnati: func(mc *cincinnati.MockClient) {
 				mc.EXPECT().GetUpdates(gomock.Any(), stableURI, "multi", "multi", "stable-4.19", semver.MustParse("4.19.15")).Return(
 					configv1.Release{}, nil, nil, &cvocincinnati.Error{Reason: "VersionNotFound"},
 				).Times(1)
 			},
-			wantDesiredVersion: nil,
+			wantDesiredVersion: ptr.To(semver.MustParse("4.19.15")),
 			wantIntentFailed: &metav1.Condition{
 				Type:    api.ControllerConditionTypeIntentFailed,
 				Status:  metav1.ConditionTrue,
@@ -1126,7 +1154,7 @@ func TestControlPlaneDesiredVersionSyncer_SyncOnce(t *testing.T) {
 			mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
 
 			createTestHCPClusterWithCustomerVersion(t, ctx, mockResourcesDBClient, tt.customerVersion, testChannelGroup)
-			createServiceProviderClusterWithVersion(t, ctx, mockResourcesDBClient, tt.controlPlaneVersion)
+			createServiceProviderClusterWithVersion(t, ctx, mockResourcesDBClient, tt.activeVersion, tt.desiredVersion)
 
 			mockCincinnati := cincinnati.NewMockClient(ctrl)
 			tt.setupCincinnati(mockCincinnati)

--- a/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller_test.go
+++ b/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller_test.go
@@ -541,7 +541,7 @@ func TestNodePoolVersionSyncer_SyncOnce_IntentFailed(t *testing.T) {
 
 			createTestNodePoolWithVersion(t, ctx, mockResourcesDBClient, tt.customerVersion)
 			createServiceProviderNodePoolWithVersion(t, ctx, mockResourcesDBClient, tt.nodePoolVersion)
-			createServiceProviderClusterWithVersion(t, ctx, mockResourcesDBClient, tt.controlPlaneVersion)
+			createServiceProviderClusterWithVersion(t, ctx, mockResourcesDBClient, tt.controlPlaneVersion, nil)
 
 			csNodePool := newCSNodePoolWithVersion(t, tt.nodePoolVersion)
 			mockCS.EXPECT().
@@ -999,7 +999,7 @@ func TestNodePoolVersionSyncer_SyncOnce_DesiredVersionUnchangedOnFailure_Changed
 
 	// Seed the database with a node pool
 	createTestNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.15")
-	createServiceProviderClusterWithVersion(t, ctx, mockResourcesDBClient, "4.19.99")
+	createServiceProviderClusterWithVersion(t, ctx, mockResourcesDBClient, "4.19.99", nil)
 
 	// Setup CS mock to return a node pool with version
 	csNodePool := newCSNodePool(t, "4.19.10")
@@ -1167,8 +1167,8 @@ func assertSyncResult(t *testing.T, err error, expectedError bool, expectedError
 	}
 }
 
-// createServiceProviderClusterWithVersion creates a ServiceProviderCluster with the given control plane version.
-func createServiceProviderClusterWithVersion(t *testing.T, ctx context.Context, mockResourcesDBClient *databasetesting.MockResourcesDBClient, controlPlaneVersion string) {
+// createServiceProviderClusterWithVersion creates a ServiceProviderCluster with the given active control plane version.
+func createServiceProviderClusterWithVersion(t *testing.T, ctx context.Context, mockResourcesDBClient *databasetesting.MockResourcesDBClient, activeVersion string, desiredVersion *semver.Version) {
 	t.Helper()
 
 	clusterResourceID := "/subscriptions/" + testSubscriptionID +
@@ -1177,7 +1177,7 @@ func createServiceProviderClusterWithVersion(t *testing.T, ctx context.Context, 
 	// ServiceProviderCluster resource ID format: {clusterResourceID}/{resourceTypeName}/{resourceName}
 	spClusterResourceID := clusterResourceID + "/" + api.ServiceProviderClusterResourceTypeName + "/" + api.ServiceProviderClusterResourceName
 
-	cpVersion := semver.MustParse(controlPlaneVersion)
+	cpVersion := semver.MustParse(activeVersion)
 	spCluster := &api.ServiceProviderCluster{
 		CosmosMetadata: api.CosmosMetadata{
 			ResourceID: api.Must(azcorearm.ParseResourceID(spClusterResourceID)),
@@ -1189,6 +1189,9 @@ func createServiceProviderClusterWithVersion(t *testing.T, ctx context.Context, 
 				},
 			},
 		},
+	}
+	if desiredVersion != nil {
+		spCluster.Spec.ControlPlaneVersion.DesiredVersion = desiredVersion
 	}
 	_, err := mockResourcesDBClient.ServiceProviderClusters(testSubscriptionID, testResourceGroupName, testClusterName).Create(ctx, spCluster, nil)
 	require.NoError(t, err)


### PR DESCRIPTION
### What

fix: anchor control plane desired version on previous selected desired

### Why

When Cincinnati graph edges change between sync cycles, the control plane desired version controller could re-resolve to a lower z-stream patch even though the cluster had already been steered toward a higher target. That produced visible desired-version flapping in ServiceLogs.

This has been observed from the kusto logs e.g

https://dataexplorer.azure.com/clusters/hcp-dev-us-2.eastus2/databases/ServiceLogs?query=H4sIAAAAAAAAA3VRPU%2FDMBDd%2BytOXdpKcWSbNipBnWBkQAIxsCDHPqUpiR2dnVRF%2FHhcCk0rES%2B%2Bj%2Fee7549BrAuUGe1CpWzd5NC6Q%2B05tGVfvIFLbkd6gChatAH1bQJ1K5MQNedD0gJWBUbrdL4foxiw9mgKov0k0eF%2FRYJBz4UGPaIdm5UwGN1LrnMGM%2BYEC%2FiNhcy56uUn87bAtIU%2FkNKkXOei%2FWAXJzf%2Bp0NNhuY6YoLtltlcrm%2Bkcz3enaGxT3%2BpvUwpZLplh18IFQN69qSlEG2ZFKyZVaUvZ6OEEdZn8222Y2xnrGOtqIBg76iePdIPvo%2Fhr%2BPEbn6qVYWH06U14HhyMR9i8OFzcrr0e9LzZXCqdYS9pXr%2FLX6N%2F0Ch4EgAgAA

| Timestamp (UTC)           | Desired version | Previous desired |
|---------------------------|-----------------|------------------|
| 11/06/2026, 20:09:07.241  | 4.21.19         | —                |
| 11/06/2026, 20:09:07.674  | 4.21.19         | —                |
| 11/06/2026, 20:15:33.127  | 4.21.18         | 4.21.19          |
| 11/06/2026, 20:16:03.736  | 4.21.19         | 4.21.18          |
| 11/06/2026, 20:16:58.177  | 4.21.18         | 4.21.19          |
| 11/06/2026, 20:17:13.361  | 4.21.17         | 4.21.18          |
| 11/06/2026, 20:17:13.838  | 4.21.19         | 4.21.17          |
| 11/06/2026, 20:18:21.650  | 4.21.18         | 4.21.19          |
| 11/06/2026, 20:18:29.042  | 4.21.19         | 4.21.18          |
| 11/06/2026, 20:19:34.639  | 4.21.18         | 4.21.19          |

Root cause: desired version resolution used only active control plane versions. When Cincinnati graph edges changed, candidate intersection could shift to a lower patch even though the previously selected desired was still the intended target.

Fix: build fromVersions from active versions and prepend the previous desired when it is not yet active, so resolution stays anchored to that target. Rollback is not implemented yet; when it is, that will be the only case where desired is permitted to move backward.


### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
