### PR TITLE
Rotate slot-manager acquire starting pool

### DIFF
--- a/test/cmd/aro-hcp-tests/slot-manager/DESIGN.md
+++ b/test/cmd/aro-hcp-tests/slot-manager/DESIGN.md
@@ -112,7 +112,7 @@ flowchart TD
     IsFixed -->|fixed| FixedFilter["Fixed-mode filter:\n1. allowed subscriptions\n2. override location if set\n3. else allowed locations"]
     IsFixed -->|runtime-selected| RSFilter["Runtime-selected filter:\n1. allowed subscriptions\n2. ignore allowed locations\nfor pool identity"]
 
-    FixedFilter --> Candidates["Ordered candidate pool list"]
+    FixedFilter --> Candidates["Candidate pool list\nwith rotated starting point"]
     RSFilter --> Candidates
 
     Candidates --> PassStart["Start pass N over candidates"]
@@ -150,8 +150,8 @@ flowchart TD
   - release step wiring,
   - formalized non-secret runtime contract centered on `SELECTED_LOCATION`.
 - Multi-pool candidate selection and fallback are implemented:
-  - fixed-mode environments filter candidate pools by `ALLOWED_SUBSCRIPTIONS` and either `ALLOWED_LOCATIONS` or `MULTISTAGE_PARAM_OVERRIDE_LOCATION`, then try pools in catalog order,
-  - runtime-selected environments use `ALLOWED_SUBSCRIPTIONS` for pool identity, ignore `ALLOWED_LOCATIONS` for candidate selection, and use `MULTISTAGE_PARAM_OVERRIDE_LOCATION` only as the concrete runtime location,
+  - fixed-mode environments filter candidate pools by `ALLOWED_SUBSCRIPTIONS` and either `ALLOWED_LOCATIONS` or `MULTISTAGE_PARAM_OVERRIDE_LOCATION`, then rotate the starting pool once per acquire run while preserving the remaining catalog order for fallback,
+  - runtime-selected environments use `ALLOWED_SUBSCRIPTIONS` for pool identity, ignore `ALLOWED_LOCATIONS` for candidate selection, and use `MULTISTAGE_PARAM_OVERRIDE_LOCATION` only as the concrete runtime location; they use the same rotated-start probing model,
   - the dev catalog now uses one runtime-selected pool per customer subscription, with `westus3` as the default runtime region,
   - those shared dev pools provision their MSI container stacks in `westus3` via `identity_provisioning_region`,
   - that intentionally optimizes the current rollout for multi-subscription, single-region operation first; multi-region CI behavior will need a follow-up job strategy.

--- a/test/cmd/aro-hcp-tests/slot-manager/acquire.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/acquire.go
@@ -108,6 +108,7 @@ type RawAcquireOptions struct {
 	LeaseProxyTimeout    time.Duration
 	MaxWaitForLease      time.Duration
 	LeaseWaitInterval    time.Duration
+	Now                  func() time.Time
 }
 
 type validatedAcquireOptions struct {
@@ -219,7 +220,7 @@ func (o *ValidatedAcquireOptions) Complete(_ context.Context) (*AcquireOptions, 
 			RuntimeLocationOverride: o.SelectedLocation,
 			CandidatePools:          candidatePools,
 			PoolEnvironment:         environment,
-			Now:                     time.Now,
+			Now:                     o.Now,
 			Sleep:                   sleepContext,
 		},
 	}, nil
@@ -247,6 +248,7 @@ func (o *AcquireOptions) Run(ctx context.Context) error {
 	if now == nil {
 		now = time.Now
 	}
+	candidatePools := rotatedCandidatePools(o.CandidatePools, now())
 	sleep := o.Sleep
 	if sleep == nil {
 		sleep = sleepContext
@@ -258,9 +260,9 @@ func (o *AcquireOptions) Run(ctx context.Context) error {
 	}
 
 	for pass := 1; ; pass++ {
-		unavailablePools := make([]string, 0, len(o.CandidatePools))
+		unavailablePools := make([]string, 0, len(candidatePools))
 
-		for _, pool := range o.CandidatePools {
+		for _, pool := range candidatePools {
 			leasedName, err := slots.AcquireLease(ctx, o.LeaseProxyURL, pool.ResourceType, o.LeaseProxyTimeout)
 			if err != nil {
 				if errors.Is(err, slots.ErrLeasePoolUnavailableNow) {
@@ -311,7 +313,7 @@ func (o *AcquireOptions) Run(ctx context.Context) error {
 				waitMessage,
 				"pass", pass,
 				"environment", o.PoolEnvironment,
-				"candidatePoolCount", len(o.CandidatePools),
+				"candidatePoolCount", len(candidatePools),
 				"candidatePoolFailures", poolFailureSummary,
 				"sleepDuration", sleepDuration,
 				"leaseWaitInterval", o.LeaseWaitInterval,
@@ -328,7 +330,7 @@ func (o *AcquireOptions) Run(ctx context.Context) error {
 			waitMessage,
 			"pass", pass,
 			"environment", o.PoolEnvironment,
-			"candidatePoolCount", len(o.CandidatePools),
+			"candidatePoolCount", len(candidatePools),
 			"candidatePoolFailures", poolFailureSummary,
 			"sleepDuration", o.LeaseWaitInterval,
 			"leaseWaitInterval", o.LeaseWaitInterval,
@@ -338,6 +340,22 @@ func (o *AcquireOptions) Run(ctx context.Context) error {
 			return fmt.Errorf("waiting to retry candidate pool pass: %w", err)
 		}
 	}
+}
+
+func rotatedCandidatePools(pools []slots.Pool, now time.Time) []slots.Pool {
+	if len(pools) < 2 {
+		return pools
+	}
+
+	startIndex := int(now.UnixNano() % int64(len(pools)))
+	if startIndex == 0 {
+		return pools
+	}
+
+	rotated := make([]slots.Pool, 0, len(pools))
+	rotated = append(rotated, pools[startIndex:]...)
+	rotated = append(rotated, pools[:startIndex]...)
+	return rotated
 }
 
 func (o *AcquireOptions) runtimeRegionForPool(pool slots.Pool) string {

--- a/test/cmd/aro-hcp-tests/slot-manager/acquire_test.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/acquire_test.go
@@ -343,6 +343,7 @@ environments:
 		LeaseProxyTimeout:   50 * time.Millisecond,
 		MaxWaitForLease:     DefaultMaxWaitForLease,
 		LeaseWaitInterval:   DefaultLeaseWaitInterval,
+		Now:                 staticNow(time.Unix(0, 0)),
 	})
 	if err != nil {
 		t.Fatalf("expected acquire to succeed: %v", err)
@@ -425,6 +426,7 @@ environments:
 		LeaseProxyTimeout:   50 * time.Millisecond,
 		MaxWaitForLease:     DefaultMaxWaitForLease,
 		LeaseWaitInterval:   DefaultLeaseWaitInterval,
+		Now:                 staticNow(time.Unix(0, 0)),
 	})
 	if err != nil {
 		t.Fatalf("expected acquire to fall back after timeout: %v", err)
@@ -492,6 +494,7 @@ environments:
 		LeaseProxyTimeout:   50 * time.Millisecond,
 		MaxWaitForLease:     DefaultMaxWaitForLease,
 		LeaseWaitInterval:   DefaultLeaseWaitInterval,
+		Now:                 staticNow(time.Unix(0, 0)),
 	})
 	if err != nil {
 		t.Fatalf("expected acquire to succeed: %v", err)
@@ -562,6 +565,7 @@ environments:
 		LeaseProxyTimeout:   5 * time.Second,
 		MaxWaitForLease:     DefaultMaxWaitForLease,
 		LeaseWaitInterval:   DefaultLeaseWaitInterval,
+		Now:                 staticNow(time.Unix(0, 0)),
 	})
 	if err == nil {
 		t.Fatal("expected acquire to fail on hard lease-proxy error")
@@ -636,6 +640,73 @@ environments:
 	}
 	if got, want := clock.slept, []time.Duration{1 * time.Minute}; !equalDurations(got, want) {
 		t.Fatalf("unexpected sleep durations: got %v want %v", got, want)
+	}
+}
+
+func TestAcquireRunRotatesCandidatePoolStartingPoint(t *testing.T) {
+	t.Parallel()
+
+	clusterProfileDir := writeAcquireTestClusterProfiles(t, "dev-sub-a")
+	catalogPath := writeAcquireTestCatalogFromYAML(t, `version: 1
+environments:
+  dev:
+    deploy_envs: [ci01]
+    pools:
+      - subscription_name: dev-sub-a
+        region: centralus
+        region_mode: fixed
+        resource_type: aro-hcp-dev-centralus-a-slot
+        slot_count: 1
+        identity_container_prefix: aro-hcp-msi-container-dev-a
+        identity_container_count: 2
+      - subscription_name: dev-sub-b
+        region: centralus
+        region_mode: fixed
+        resource_type: aro-hcp-dev-centralus-b-slot
+        slot_count: 1
+        identity_container_prefix: aro-hcp-msi-container-dev-b
+        identity_container_count: 2
+`)
+
+	server, acquireCalls, _ := newTestLeaseProxyServer(t, map[string][]leaseProxyReply{
+		"aro-hcp-dev-centralus-b-slot": {
+			unavailableAcquireReply("aro-hcp-dev-centralus-b-slot"),
+		},
+		"aro-hcp-dev-centralus-a-slot": {
+			successAcquireReply("aro-hcp-dev-centralus-a-slot-00"),
+		},
+	})
+	defer server.Close()
+
+	completed := completeAcquireForTest(t, &RawAcquireOptions{
+		ClusterProfileDir:   clusterProfileDir,
+		DeployEnv:           "ci01",
+		AllowedLocations:    []string{"centralus"},
+		SharedDir:           t.TempDir(),
+		CatalogPath:         catalogPath,
+		LeaseProxyServerURL: server.URL,
+		LeaseProxyTimeout:   50 * time.Millisecond,
+		MaxWaitForLease:     DefaultMaxWaitForLease,
+		LeaseWaitInterval:   DefaultLeaseWaitInterval,
+	})
+	completed.Now = staticNow(time.Unix(0, 1))
+
+	if err := completed.Run(context.Background()); err != nil {
+		t.Fatalf("expected acquire run to succeed with rotated starting pool: %v", err)
+	}
+	if got, want := *acquireCalls, []string{
+		"aro-hcp-dev-centralus-b-slot",
+		"aro-hcp-dev-centralus-a-slot",
+	}; !equalStrings(got, want) {
+		t.Fatalf("unexpected acquire call order: got %v want %v", got, want)
+	}
+
+	state, err := slots.LoadAcquiredSlotState(completed.SharedDir)
+	if err != nil {
+		t.Fatalf("expected acquired slot state to load: %v", err)
+	}
+	if state.Slot.ResourceType != "aro-hcp-dev-centralus-a-slot" {
+		t.Fatalf("expected fallback to preserve rotated order, got %q", state.Slot.ResourceType)
 	}
 }
 
@@ -846,6 +917,7 @@ environments:
 		LeaseProxyTimeout:   5 * time.Second,
 		MaxWaitForLease:     DefaultMaxWaitForLease,
 		LeaseWaitInterval:   DefaultLeaseWaitInterval,
+		Now:                 staticNow(time.Unix(0, 0)),
 	})
 	if err == nil {
 		t.Fatal("expected acquire to fail when customer subscription cannot be resolved")
@@ -910,6 +982,7 @@ environments:
 		LeaseProxyTimeout:   5 * time.Second,
 		MaxWaitForLease:     DefaultMaxWaitForLease,
 		LeaseWaitInterval:   DefaultLeaseWaitInterval,
+		Now:                 staticNow(time.Unix(0, 0)),
 	})
 	if err == nil {
 		t.Fatal("expected acquire to fail when the env file cannot be written")
@@ -1114,6 +1187,12 @@ type fakeClock struct {
 
 func newFakeClock(start time.Time) *fakeClock {
 	return &fakeClock{current: start}
+}
+
+func staticNow(at time.Time) func() time.Time {
+	return func() time.Time {
+		return at
+	}
 }
 
 func (c *fakeClock) Now() time.Time {


### PR DESCRIPTION
Spread leases more evenly across eligible pools by rotating the initial candidate per acquire run while preserving the existing fallback order. Add deterministic test coverage and document the rotated-start behavior.

https://redhat.atlassian.net/issues?filter=-1&selectedIssue=[ARO-27709](https://redhat.atlassian.net/browse/ARO-27709)