### PR TITLE
feat(observability): expose resource_id on KSM HostedCluster metrics

### DIFF
--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arohcp_monitor.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arohcp_monitor.yaml
@@ -67656,6 +67656,10 @@ data:
           namespace:
           - metadata
           - namespace
+          resource_id:
+          - metadata
+          - annotations
+          - azure.microsoft.com/hcp-cluster-azure-resource-id
           subscription_id:
           - spec
           - platform

--- a/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_mgmt_resources.yaml
+++ b/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_mgmt_resources.yaml
@@ -67656,6 +67656,10 @@ data:
           namespace:
           - metadata
           - namespace
+          resource_id:
+          - metadata
+          - annotations
+          - azure.microsoft.com/hcp-cluster-azure-resource-id
           subscription_id:
           - spec
           - platform

--- a/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_mgmt_resources_unset.yaml
+++ b/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_mgmt_resources_unset.yaml
@@ -67656,6 +67656,10 @@ data:
           namespace:
           - metadata
           - namespace
+          resource_id:
+          - metadata
+          - annotations
+          - azure.microsoft.com/hcp-cluster-azure-resource-id
           subscription_id:
           - spec
           - platform

--- a/observability/prometheus/values-mgmt.yaml
+++ b/observability/prometheus/values-mgmt.yaml
@@ -102,6 +102,7 @@ kube-prometheus-stack:
               api_url: [spec, services, "[service=APIServer]", servicePublishingStrategy, route, hostname]
               _id: [spec, clusterID]
               subscription_id: [spec, platform, azure, subscriptionID]
+              resource_id: [metadata, annotations, "azure.microsoft.com/hcp-cluster-azure-resource-id"]
             metrics:
             - name: "kubeapiserver_available"
               help: "KubeAPIServer availability condition"


### PR DESCRIPTION
### What

Add `resource_id` to the KSM custom-resource-state config for HostedCluster CRDs, mapping the Azure ARM resource ID from the `azure.microsoft.com/hcp-cluster-azure-resource-id` annotation as a label on the raw `hostedClusterAPI_*` KSM metrics.

This label is not included in the recording rules (which aggregate `by (name, namespace, _id, cluster)` for alerting). It is available on the raw metrics for `group_left` joins in dashboards and ad-hoc queries, e.g., joining KSM metrics with backend metrics or building Azure portal deep-links.

### Why

Enables joining KSM metrics with backend metrics (which already key on `resource_id`) and building dashboard deep-links to the Azure portal. Zero cardinality impact since each HostedCluster maps 1:1 to a resource ID.

### Testing

Helm test fixtures regenerated via `UPDATE=true go test ./tooling/helmtest/...`, all existing tests pass. The regenerated fixtures show the expected KSM config output with the new label.