### PR TITLE
fix(frontend): return 409 on DELETE against Failed resources to prevent retry storms

### DIFF
--- a/frontend/pkg/frontend/helpers.go
+++ b/frontend/pkg/frontend/helpers.go
@@ -64,7 +64,8 @@ func checkForProvisioningStateConflict(
 	case database.OperationRequestCreate:
 		// Resource must already exist for there to be a conflict.
 	case database.OperationRequestDelete:
-		if provisioningState == arm.ProvisioningStateDeleting {
+		if provisioningState == arm.ProvisioningStateDeleting ||
+			provisioningState == arm.ProvisioningStateFailed {
 			return arm.NewConflictError(
 				resourceID,
 				"Resource is already deleting")
@@ -141,9 +142,11 @@ func (f *Frontend) DeleteAllResourcesInSubscription(ctx context.Context, subscri
 		return utils.TrackError(err)
 	}
 	for _, cluster := range clusterIterator.Items(ctx) {
-		if cluster.ServiceProviderProperties.ProvisioningState == arm.ProvisioningStateDeleting {
-			// don't try to delete already deleting clusters.  If we call the delete on them, the call will fail
-			// on various problems from cluster-service. We trust the existing delete is doing good things.
+		if cluster.ServiceProviderProperties.ProvisioningState == arm.ProvisioningStateDeleting ||
+			cluster.ServiceProviderProperties.ProvisioningState == arm.ProvisioningStateFailed {
+			// Skip clusters already being deleted or stuck in a failed state.
+			// Deleting: trust the existing delete operation.
+			// Failed: avoid retry storms from re-issuing deletes that will fail again.
 			continue
 		}
 		if err := f.addDeleteClusterToTransaction(ctx, nil, nil, transaction, cluster); err != nil {

--- a/frontend/pkg/frontend/helpers_test.go
+++ b/frontend/pkg/frontend/helpers_test.go
@@ -56,7 +56,9 @@ func TestCheckForProvisioningStateConflict(t *testing.T) {
 			name:             "Delete cluster",
 			resourceID:       api.TestClusterResourceID,
 			operationRequest: database.OperationRequestDelete,
-			directConflict:   func(s arm.ProvisioningState) bool { return s == arm.ProvisioningStateDeleting },
+			directConflict: func(s arm.ProvisioningState) bool {
+				return s == arm.ProvisioningStateDeleting || s == arm.ProvisioningStateFailed
+			},
 		},
 		{
 			name:             "Update cluster",
@@ -87,8 +89,10 @@ func TestCheckForProvisioningStateConflict(t *testing.T) {
 			name:             "Delete node pool",
 			resourceID:       api.TestNodePoolResourceID,
 			operationRequest: database.OperationRequestDelete,
-			directConflict:   func(s arm.ProvisioningState) bool { return s == arm.ProvisioningStateDeleting },
-			parentConflict:   parentConflictFunc,
+			directConflict: func(s arm.ProvisioningState) bool {
+				return s == arm.ProvisioningStateDeleting || s == arm.ProvisioningStateFailed
+			},
+			parentConflict: parentConflictFunc,
 		},
 		{
 			name:             "Update node pool",


### PR DESCRIPTION
[ARO-27726](https://redhat.atlassian.net/browse/ARO-27726)

### What

Return 409 Conflict on DELETE against resources in Failed provisioning state, and skip Failed clusters in the subscription sweep.

### Why

Without this, ARM and CAPZ controllers retry DELETE against stuck-Failed clusters indefinitely, generating 14k+ wasted operations across 5 clusters in 14 days.

### Testing

Updated `TestCheckForProvisioningStateConflict` to expect 409 for Failed state on delete operations (cluster and node pool).