### PR TITLE
feat: add SDK pipeline policy to retry version-not-found on cluster create/update

### DIFF
--- a/test/e2e/control_plane_automated_z_stream_upgrade.go
+++ b/test/e2e/control_plane_automated_z_stream_upgrade.go
@@ -16,7 +16,6 @@ package e2e
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -25,9 +24,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	"k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/apimachinery/pkg/util/wait"
-
-	azcore "github.com/Azure/azure-sdk-for-go/sdk/azcore"
 
 	"github.com/Azure/ARO-HCP/internal/cincinnati"
 	"github.com/Azure/ARO-HCP/test/util/framework"
@@ -96,45 +92,14 @@ var _ = Describe("Service Provider", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create customer resources for z-stream cluster %q", clusterName)
 
 			By(fmt.Sprintf("creating the HCP cluster with version '%s' on candidate channel", installVersion))
-			// Cincinnati can advertise a z-stream build before Cluster Service has registered that version, so
-			// create fails with InvalidRequestContent until the worker in CS catches up—rare but flaky. We retry with backoff
-			// for up to 5m instead of failing the whole test. See https://github.com/Azure/ARO-HCP/pull/4621#discussion_r2986322194
-			// Drop this retry once cluster creation runs in the backend (https://github.com/Azure/ARO-HCP/pull/4477).
-			stopRetryingAfter := time.Now().Add(5 * time.Minute)
-			backoffErr := wait.ExponentialBackoffWithContext(ctx, wait.Backoff{
-				Duration: 5 * time.Second,
-				Factor:   2,
-				Jitter:   0.1,
-				Steps:    25,
-				Cap:      45 * time.Second,
-			}, func(_ context.Context) (done bool, err error) {
-				createErr := tc.CreateHCPClusterFromParam20240610(
-					ctx,
-					GinkgoLogr,
-					*resourceGroup.Name,
-					clusterParams,
-					framework.ClusterCreationTimeout,
-				)
-				if createErr == nil {
-					return true, nil
-				}
-				var azureErr *azcore.ResponseError
-				// Example ARM body: { "error": { "code": "InvalidRequestContent", "message": "Version 'openshift-v4.y.z-candidate' doesn't exist" } }
-				shouldRetryMissingVersionInCS := errors.As(createErr, &azureErr) &&
-					azureErr.ErrorCode == "InvalidRequestContent" &&
-					strings.Contains(azureErr.Error(), "Version") &&
-					strings.Contains(azureErr.Error(), "openshift-v") &&
-					strings.Contains(azureErr.Error(), "doesn't exist")
-				if shouldRetryMissingVersionInCS {
-					if time.Now().After(stopRetryingAfter) {
-						return false, fmt.Errorf("giving up after %v waiting for OpenShift version in Cluster Service: %w", 5*time.Minute, createErr)
-					}
-					GinkgoLogr.Info("OpenShift version not yet in Cluster Service; retrying cluster create", "error", createErr)
-					return false, nil
-				}
-				return false, createErr
-			})
-			Expect(backoffErr).NotTo(HaveOccurred(), "failed to create HCP cluster %q with version %s on candidate channel", clusterName, installVersion)
+			err = tc.CreateHCPClusterFromParam20240610(
+				ctx,
+				GinkgoLogr,
+				*resourceGroup.Name,
+				clusterParams,
+				framework.ClusterCreationTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster %q with version %s on candidate channel", clusterName, installVersion)
 
 			By("verifying the cluster is viable")
 			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(

--- a/test/util/framework/azure_client_policies.go
+++ b/test/util/framework/azure_client_policies.go
@@ -30,9 +30,11 @@ import (
 	"github.com/onsi/ginkgo/v2"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 
+	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 )
 
@@ -283,4 +285,112 @@ func (p *sanitizeAuthHeaderPolicy) Do(req *policy.Request) (*http.Response, erro
 		resp.Request.Header["Authorization"] = []string{"redacted"}
 	}
 	return resp, err
+}
+
+// retryVersionNotFoundPolicy is a pipeline policy that retries transient
+// InvalidRequestContent errors caused by an OpenShift version not yet being
+// registered in Cluster Service.
+//
+// Cincinnati can advertise a z-stream build before Cluster Service registers
+// that version, causing cluster create/update to fail with:
+//
+//	{"error":{"code":"InvalidRequestContent","message":"Version 'openshift-v4.y.z-candidate' doesn't exist"}}
+//
+// The policy only activates for PUT/PATCH requests targeting the cluster
+// resource type (Microsoft.RedHatOpenShift/hcpOpenShiftClusters), excluding
+// child resources like node pools or external auth.
+//
+// See https://github.com/Azure/ARO-HCP/pull/4621#discussion_r2986322194
+type retryVersionNotFoundPolicy struct {
+	MaxRetries     int
+	BaseBackoff    time.Duration
+	MaxBackoff     time.Duration
+	MaxRetryWindow time.Duration
+}
+
+func NewRetryVersionNotFoundPolicy() *retryVersionNotFoundPolicy {
+	return &retryVersionNotFoundPolicy{
+		MaxRetries:     25,
+		BaseBackoff:    5 * time.Second,
+		MaxBackoff:     45 * time.Second,
+		MaxRetryWindow: 5 * time.Minute,
+	}
+}
+
+func (p *retryVersionNotFoundPolicy) Do(req *policy.Request) (*http.Response, error) {
+	method := req.Raw().Method
+	if !strings.EqualFold(method, http.MethodPut) && !strings.EqualFold(method, http.MethodPatch) {
+		return req.Next()
+	}
+
+	resourceID, err := azcorearm.ParseResourceID(req.Raw().URL.Path)
+	if err != nil {
+		return req.Next()
+	}
+	if !strings.EqualFold(resourceID.ResourceType.String(), api.ClusterResourceType.String()) {
+		return req.Next()
+	}
+
+	start := time.Now()
+	attempt := 0
+
+	for {
+		resp, err, retry := func(req *policy.Request) (resp *http.Response, err error, retry bool) {
+			retryReq := req.Clone(req.Raw().Context())
+			if err := retryReq.RewindBody(); err != nil {
+				return nil, err, false
+			}
+
+			resp, err = retryReq.Next()
+			if err == nil {
+				return resp, nil, false
+			}
+			defer func(resp *http.Response) {
+				if resp != nil {
+					if err := resp.Body.Close(); err != nil {
+						ginkgo.GinkgoLogr.Error(err, "failed to close response body")
+					}
+				}
+			}(resp)
+
+			var respErr *azcore.ResponseError
+			if errors.As(err, &respErr) &&
+				respErr.ErrorCode == "InvalidRequestContent" &&
+				strings.Contains(respErr.Error(), "Version") &&
+				strings.Contains(respErr.Error(), "openshift-v") &&
+				strings.Contains(respErr.Error(), "doesn't exist") {
+				return nil, err, true
+			}
+			return nil, err, false
+		}(req)
+
+		if !retry {
+			return resp, err
+		}
+
+		if attempt >= p.MaxRetries || time.Since(start) >= p.MaxRetryWindow {
+			return resp, fmt.Errorf("max retries or max retry window reached waiting for OpenShift version in Cluster Service: %w", err)
+		}
+
+		sleep := p.backoff(attempt)
+
+		ginkgo.GinkgoLogr.Info("OpenShift version not yet in Cluster Service; retrying",
+			"attempt", attempt+1,
+			"sleep", sleep.String(),
+			"url", req.Raw().URL.String())
+
+		select {
+		case <-time.After(sleep):
+		case <-req.Raw().Context().Done():
+			return nil, req.Raw().Context().Err()
+		}
+
+		attempt++
+	}
+}
+
+func (p *retryVersionNotFoundPolicy) backoff(attempt int) time.Duration {
+	sleep := min(p.BaseBackoff<<attempt, p.MaxBackoff)
+	jitter := time.Duration(rand.Int63n(int64(max(p.BaseBackoff/2, time.Millisecond))))
+	return sleep + jitter
 }

--- a/test/util/framework/azure_client_policies_test.go
+++ b/test/util/framework/azure_client_policies_test.go
@@ -18,7 +18,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -29,6 +31,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
 
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 )
@@ -658,6 +661,267 @@ func TestLROPollerRetryDeploymentNotFoundPolicy(t *testing.T) {
 	t.Run("backoff respects bounds", func(t *testing.T) {
 		t.Parallel()
 		pol := &lroPollerRetryDeploymentNotFoundPolicy{
+			BaseBackoff: 2 * time.Second,
+			MaxBackoff:  10 * time.Second,
+		}
+
+		for attempt := 0; attempt < 10; attempt++ {
+			d := pol.backoff(attempt)
+			expectedSleep := min(pol.BaseBackoff<<uint(attempt), pol.MaxBackoff)
+			assert.GreaterOrEqual(t, d, expectedSleep,
+				"attempt %d: backoff should be at least the base sleep", attempt)
+			assert.Less(t, d, expectedSleep+pol.BaseBackoff/2,
+				"attempt %d: backoff should be less than base sleep + max jitter", attempt)
+		}
+	})
+}
+
+func versionNotFoundError() (*http.Response, error) {
+	body := `{"error":{"code":"InvalidRequestContent","message":"Version 'openshift-v4.17.1-candidate' doesn't exist"}}`
+	return nil, &azcore.ResponseError{
+		StatusCode: http.StatusBadRequest,
+		ErrorCode:  "InvalidRequestContent",
+		RawResponse: &http.Response{
+			StatusCode: http.StatusBadRequest,
+			Header:     http.Header{"Content-Type": {"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(body)),
+		},
+	}
+}
+
+func newRetryVersionPolicyForTest() *retryVersionNotFoundPolicy {
+	return &retryVersionNotFoundPolicy{
+		MaxRetries:     5,
+		BaseBackoff:    time.Millisecond,
+		MaxBackoff:     5 * time.Millisecond,
+		MaxRetryWindow: time.Second,
+	}
+}
+
+const clusterPath = "/subscriptions/sub-id/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/my-cluster"
+
+func TestRetryVersionNotFoundPolicy(t *testing.T) {
+	t.Parallel()
+
+	t.Run("passes through GET requests", func(t *testing.T) {
+		t.Parallel()
+		pol := newRetryVersionPolicyForTest()
+		transport := &fakeTransport{do: func(r *http.Request) (*http.Response, error) { return okResponse() }}
+		pipeline := newTestPipeline(pol, transport)
+		req, err := runtime.NewRequest(context.Background(), http.MethodGet, "https://management.azure.com"+clusterPath)
+		require.NoError(t, err)
+
+		resp, err := pipeline.Do(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("passes through DELETE requests", func(t *testing.T) {
+		t.Parallel()
+		pol := newRetryVersionPolicyForTest()
+		transport := &fakeTransport{do: func(r *http.Request) (*http.Response, error) { return okResponse() }}
+		pipeline := newTestPipeline(pol, transport)
+		req, err := runtime.NewRequest(context.Background(), http.MethodDelete, "https://management.azure.com"+clusterPath)
+		require.NoError(t, err)
+
+		resp, err := pipeline.Do(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("passes through node pool requests", func(t *testing.T) {
+		t.Parallel()
+		pol := newRetryVersionPolicyForTest()
+		transport := &fakeTransport{do: func(r *http.Request) (*http.Response, error) { return okResponse() }}
+		pipeline := newTestPipeline(pol, transport)
+		req, err := runtime.NewRequest(context.Background(), http.MethodPut, "https://management.azure.com"+clusterPath+"/nodePools/np-1")
+		require.NoError(t, err)
+
+		resp, err := pipeline.Do(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("passes through unparseable paths", func(t *testing.T) {
+		t.Parallel()
+		pol := newRetryVersionPolicyForTest()
+		transport := &fakeTransport{do: func(r *http.Request) (*http.Response, error) { return okResponse() }}
+		pipeline := newTestPipeline(pol, transport)
+		req, err := runtime.NewRequest(context.Background(), http.MethodPut, "https://management.azure.com/foo/bar")
+		require.NoError(t, err)
+
+		resp, err := pipeline.Do(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("returns success on first attempt", func(t *testing.T) {
+		t.Parallel()
+		pol := newRetryVersionPolicyForTest()
+		transport := &fakeTransport{do: func(r *http.Request) (*http.Response, error) { return okResponse() }}
+		pipeline := newTestPipeline(pol, transport)
+		req, err := runtime.NewRequest(context.Background(), http.MethodPut, "https://management.azure.com"+clusterPath)
+		require.NoError(t, err)
+		require.NoError(t, req.SetBody(streaming.NopCloser(strings.NewReader(`{}`)), "application/json"))
+
+		resp, err := pipeline.Do(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("retries version not found on PUT then succeeds", func(t *testing.T) {
+		t.Parallel()
+		callCount := 0
+		pol := newRetryVersionPolicyForTest()
+		transport := &fakeTransport{
+			do: func(r *http.Request) (*http.Response, error) {
+				callCount++
+				if callCount <= 2 {
+					return versionNotFoundError()
+				}
+				return okResponse()
+			},
+		}
+		pipeline := newTestPipeline(pol, transport)
+		req, err := runtime.NewRequest(context.Background(), http.MethodPut, "https://management.azure.com"+clusterPath)
+		require.NoError(t, err)
+		require.NoError(t, req.SetBody(streaming.NopCloser(strings.NewReader(`{}`)), "application/json"))
+
+		resp, err := pipeline.Do(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, 3, callCount)
+	})
+
+	t.Run("retries version not found on PATCH then succeeds", func(t *testing.T) {
+		t.Parallel()
+		callCount := 0
+		pol := newRetryVersionPolicyForTest()
+		transport := &fakeTransport{
+			do: func(r *http.Request) (*http.Response, error) {
+				callCount++
+				if callCount <= 1 {
+					return versionNotFoundError()
+				}
+				return okResponse()
+			},
+		}
+		pipeline := newTestPipeline(pol, transport)
+		req, err := runtime.NewRequest(context.Background(), http.MethodPatch, "https://management.azure.com"+clusterPath)
+		require.NoError(t, err)
+		require.NoError(t, req.SetBody(streaming.NopCloser(strings.NewReader(`{}`)), "application/json"))
+
+		resp, err := pipeline.Do(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, 2, callCount)
+	})
+
+	t.Run("exhausts retries on persistent version not found", func(t *testing.T) {
+		t.Parallel()
+		callCount := 0
+		pol := &retryVersionNotFoundPolicy{
+			MaxRetries:     3,
+			BaseBackoff:    time.Millisecond,
+			MaxBackoff:     5 * time.Millisecond,
+			MaxRetryWindow: time.Second,
+		}
+		transport := &fakeTransport{
+			do: func(r *http.Request) (*http.Response, error) {
+				callCount++
+				return versionNotFoundError()
+			},
+		}
+		pipeline := newTestPipeline(pol, transport)
+		req, err := runtime.NewRequest(context.Background(), http.MethodPut, "https://management.azure.com"+clusterPath)
+		require.NoError(t, err)
+		require.NoError(t, req.SetBody(streaming.NopCloser(strings.NewReader(`{}`)), "application/json"))
+
+		_, err = pipeline.Do(req)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "max retries or max retry window reached")
+		assert.Equal(t, 4, callCount)
+	})
+
+	t.Run("does not retry non-version-not-found errors", func(t *testing.T) {
+		t.Parallel()
+		callCount := 0
+		pol := newRetryVersionPolicyForTest()
+		transport := &fakeTransport{
+			do: func(r *http.Request) (*http.Response, error) {
+				callCount++
+				return nil, &azcore.ResponseError{
+					StatusCode: http.StatusBadRequest,
+					ErrorCode:  "InvalidRequestContent",
+					RawResponse: &http.Response{
+						StatusCode: http.StatusBadRequest,
+						Header:     http.Header{},
+						Body:       http.NoBody,
+					},
+				}
+			},
+		}
+		pipeline := newTestPipeline(pol, transport)
+		req, err := runtime.NewRequest(context.Background(), http.MethodPut, "https://management.azure.com"+clusterPath)
+		require.NoError(t, err)
+		require.NoError(t, req.SetBody(streaming.NopCloser(strings.NewReader(`{}`)), "application/json"))
+
+		_, err = pipeline.Do(req)
+		assert.Error(t, err)
+		assert.Equal(t, 1, callCount)
+	})
+
+	t.Run("does not retry other error codes", func(t *testing.T) {
+		t.Parallel()
+		callCount := 0
+		pol := newRetryVersionPolicyForTest()
+		transport := &fakeTransport{
+			do: func(r *http.Request) (*http.Response, error) {
+				callCount++
+				return nil, &azcore.ResponseError{
+					StatusCode: http.StatusInternalServerError,
+					ErrorCode:  "InternalServerError",
+				}
+			},
+		}
+		pipeline := newTestPipeline(pol, transport)
+		req, err := runtime.NewRequest(context.Background(), http.MethodPut, "https://management.azure.com"+clusterPath)
+		require.NoError(t, err)
+		require.NoError(t, req.SetBody(streaming.NopCloser(strings.NewReader(`{}`)), "application/json"))
+
+		_, err = pipeline.Do(req)
+		assert.Error(t, err)
+		assert.Equal(t, 1, callCount)
+	})
+
+	t.Run("respects context cancellation", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(context.Background())
+		pol := &retryVersionNotFoundPolicy{
+			MaxRetries:     10,
+			BaseBackoff:    time.Millisecond,
+			MaxBackoff:     5 * time.Millisecond,
+			MaxRetryWindow: 10 * time.Second,
+		}
+		transport := &fakeTransport{
+			do: func(r *http.Request) (*http.Response, error) {
+				cancel()
+				return versionNotFoundError()
+			},
+		}
+		pipeline := newTestPipeline(pol, transport)
+		req, err := runtime.NewRequest(ctx, http.MethodPut, "https://management.azure.com"+clusterPath)
+		require.NoError(t, err)
+		require.NoError(t, req.SetBody(streaming.NopCloser(strings.NewReader(`{}`)), "application/json"))
+
+		_, err = pipeline.Do(req)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("backoff respects bounds", func(t *testing.T) {
+		t.Parallel()
+		pol := &retryVersionNotFoundPolicy{
 			BaseBackoff: 2 * time.Second,
 			MaxBackoff:  10 * time.Second,
 		}

--- a/test/util/framework/per_invocation_framework.go
+++ b/test/util/framework/per_invocation_framework.go
@@ -193,6 +193,7 @@ func (tc *perBinaryInvocationTestContext) getHCPClientFactoryOptions() *azcorear
 			&requestIDPolicy{},
 			&armSystemDataPolicy{},
 			&armResourceGroupValidationPolicy{rgClient: &defaultResourceGroupClient{cred: tc.azureCredentials}},
+			NewRetryVersionNotFoundPolicy(),
 			&sanitizeAuthHeaderPolicy{},
 		}
 		return &azcorearm.ClientOptions{
@@ -202,6 +203,7 @@ func (tc *perBinaryInvocationTestContext) getHCPClientFactoryOptions() *azcorear
 	clientOpts := azsdk.NewClientOptions(azsdk.ComponentE2E)
 	clientOpts.Retry = azureRetryOptions
 	clientOpts.PerCallPolicies = []policy.Policy{
+		NewRetryVersionNotFoundPolicy(),
 		&sanitizeAuthHeaderPolicy{},
 	}
 	return &azcorearm.ClientOptions{


### PR DESCRIPTION
## Summary

- Adds a reusable `retryVersionNotFoundPolicy` Azure SDK pipeline policy that retries transient `InvalidRequestContent` errors when an OpenShift version is not yet registered in Cluster Service (Cincinnati advertises z-stream builds before CS registers them)
- Policy scopes to PUT/PATCH requests on `Microsoft.RedHatOpenShift/hcpOpenShiftClusters` only, excluding child resources (node pools, external auth)
- Removes the inline retry loop from the z-stream upgrade E2E test since the policy now handles it transparently

Slack thread: https://redhat-external.slack.com/archives/C075PHEFZKQ/p1781300876636439

## Test plan

- [x] Unit tests pass: 12 new tests covering pass-through for wrong methods/resource types, retry+succeed on PUT and PATCH, retry exhaustion, non-matching errors, context cancellation, and backoff bounds
- [x] All existing framework tests still pass
- [x] Lint clean (`make lint` — 0 issues)
- [ ] E2E z-stream upgrade test passes in CI with the policy handling retries instead of the inline loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)