### PR TITLE
WIP: fix(e2e): size dev shard2/shard3 pools + parallelism for full parallel suite (AROSLSRE-1169)

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1605,7 +1605,7 @@ clouds:
                 vmSize: Standard_D4ds_v6
               userAgentPool:
                 maxCount: 14
-                minCount: 3
+                minCount: 6
                 osDiskSizeGB: 100
                 vmSize: Standard_D16ds_v6
                 secondaryNicCount: 7
@@ -1704,7 +1704,7 @@ clouds:
                 vmSize: Standard_D4ds_v6
               userAgentPool:
                 maxCount: 14
-                minCount: 3
+                minCount: 6
                 osDiskSizeGB: 100
                 vmSize: Standard_D16ds_v6
                 secondaryNicCount: 7

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -614,7 +614,7 @@ mgmt:
       zones: ""
     userAgentPool:
       maxCount: 14
-      minCount: 3
+      minCount: 6
       name: userswft
       osDiskSizeGB: 100
       poolCount: 3

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -614,7 +614,7 @@ mgmt:
       zones: ""
     userAgentPool:
       maxCount: 14
-      minCount: 3
+      minCount: 6
       name: userswft
       osDiskSizeGB: 100
       poolCount: 3

--- a/test/cmd/aro-hcp-tests/main.go
+++ b/test/cmd/aro-hcp-tests/main.go
@@ -178,7 +178,7 @@ func setupCli() *cobra.Command {
 		// Spec parallelism is limited by the leased identity containers. We set suite parallelism slightly above the number of
 		// leased identity containers to avoid multi-HCP tests blocking single-HCP tests from obtaining a lease.
 		// LEASED_MSI_CONTAINERS=20
-		Parallelism: 24,
+		Parallelism: 55,
 		TestTimeout: &rpApiCompatTestTimeout,
 	})
 	ext.AddSuite(e.Suite{

--- a/test/e2e-config/e2e-slots.yaml
+++ b/test/e2e-config/e2e-slots.yaml
@@ -28,7 +28,7 @@ environments:
     # identity_container_count is higher than shard0/shard1 (55 vs 20) because this
     # single-tenant subscription is sized to run the full DEV E2E suite in parallel.
     # The parallel suite's peak simultaneous demand is 50 containers (47 specs: 45x1,
-    # 1x2, 1x3); 55 covers that with headroom and matches the suite Parallelism.
+    # 1x2, 1x3); 55 covers that with headroom.
     - subscription_name: "ARO HCP E2E Hosted Clusters - Dev - 02"
       region: westus3
       region_mode: runtime-selected
@@ -40,7 +40,7 @@ environments:
     # identity_container_count is higher than shard0/shard1 (55 vs 20) because this
     # single-tenant subscription is sized to run the full DEV E2E suite in parallel.
     # The parallel suite's peak simultaneous demand is 50 containers (47 specs: 45x1,
-    # 1x2, 1x3); 55 covers that with headroom and matches the suite Parallelism.
+    # 1x2, 1x3); 55 covers that with headroom.
     - subscription_name: "ARO HCP E2E Hosted Clusters - Dev - 03"
       region: westus3
       region_mode: runtime-selected

--- a/test/e2e-config/e2e-slots.yaml
+++ b/test/e2e-config/e2e-slots.yaml
@@ -25,25 +25,29 @@ environments:
       identity_container_prefix: aro-hcp-msi-container-dev-shard0
       identity_container_count: 20
     # shard2: dedicated dev capacity on the third customer subscription.
-    # identity_container_count is higher than shard0/shard1 (40 vs 20) because this
+    # identity_container_count is higher than shard0/shard1 (55 vs 20) because this
     # single-tenant subscription is sized to run the full DEV E2E suite in parallel.
+    # The parallel suite's peak simultaneous demand is 50 containers (47 specs: 45x1,
+    # 1x2, 1x3); 55 covers that with headroom and matches the suite Parallelism.
     - subscription_name: "ARO HCP E2E Hosted Clusters - Dev - 02"
       region: westus3
       region_mode: runtime-selected
       resource_type: aro-hcp-dev-shard2-slot
       slot_count: 1
       identity_container_prefix: aro-hcp-msi-container-dev-shard2
-      identity_container_count: 40
+      identity_container_count: 55
     # shard3: dedicated dev capacity on the fourth customer subscription.
-    # identity_container_count is higher than shard0/shard1 (40 vs 20) because this
+    # identity_container_count is higher than shard0/shard1 (55 vs 20) because this
     # single-tenant subscription is sized to run the full DEV E2E suite in parallel.
+    # The parallel suite's peak simultaneous demand is 50 containers (47 specs: 45x1,
+    # 1x2, 1x3); 55 covers that with headroom and matches the suite Parallelism.
     - subscription_name: "ARO HCP E2E Hosted Clusters - Dev - 03"
       region: westus3
       region_mode: runtime-selected
       resource_type: aro-hcp-dev-shard3-slot
       slot_count: 1
       identity_container_prefix: aro-hcp-msi-container-dev-shard3
-      identity_container_count: 40
+      identity_container_count: 55
   int:
     deploy_envs:
     - int


### PR DESCRIPTION
[AROSLSRE-1169](https://redhat.atlassian.net/browse/AROSLSRE-1169)

> **Status:** WIP / `/hold` — held until the next `e2e-parallel-1-wave` run confirms no identity-container backpressure. Remove the hold with `/unhold` once green.

### What

Three complementary changes so the full `rp-api-compat-all/parallel` E2E suite runs in parallel without backpressure:

- Raise `identity_container_count` from `40` to `55` for the dedicated dev `shard2` (Dev-02) and `shard3` (Dev-03) pools in `test/e2e-config/e2e-slots.yaml`.
- Raise suite `Parallelism` to 55 (`test/cmd/aro-hcp-tests/main.go`).
- Raise `ci01` swift nodepool `minCount` 3 → 6 to cope with the increased HCP load (`config/config.yaml` + rendered configs).

The parallelism and ci01 minCount commits originate from #5599; the pool sizing fix is the new remedy for the actual bottleneck.

### Why

The `e2e-parallel-1-wave` job runs against the single-tenant Dev-02/Dev-03 pools, but the suite's peak simultaneous demand exceeds the current pool of 40, so specs queue on the leasing backpressure path. Measured from the passing run `pull-ci-Azure-ARO-HCP-main-e2e-parallel-1-wave/2065396091074908160` (47 specs, all request containers):

```text
45 specs x 1 container = 45
 1 spec  x 2 containers =  2   (subnet/NSG reuse)
 1 spec  x 3 containers =  3   (several HCP clusters / same managed RG)
-----------------------------
peak simultaneous demand = 50
```

With only 40 containers, ~10 specs wait; one spec waited ~25 minutes:

```text
"msg"="Not enough free identity containers, waiting to retry" "error"="...only 0 are assigned"
...
"msg"="Successfully assigned identity containers" "count"=1 "attempt"=26 "elapsed"="25m2s"
```

Raising parallelism alone can't fix this — the leased pool is the bottleneck. `55` covers the 50 peak with headroom and matches `Parallelism`. It stays well under the per-subscription ceiling (~140 = 4000 role assignments / ~28 worst-case per cluster) on these dedicated subs. The ci01 `minCount` bump gives the management cluster capacity for the extra concurrent HCPs.

### Testing

Validated by the next `e2e-parallel-1-wave` run against Dev-02/Dev-03 — expect no "Not enough free identity containers" retries. YAML parses and `shard2`/`shard3` resolve to `identity_container_count: 55`.

### Special notes for your reviewer

Currently on `/hold` pending an E2E run. Only the two dedicated single-tenant pools change for container counts; shared `shard0`/`shard1` (constrained by the 4000 role-assignments-per-subscription limit) are untouched. Parallelism + ci01 minCount commits are carried over from #5599.

### PR Checklist

- [x] Update e2e-slots configuration
- [x] Raise suite parallelism to 55
- [x] Raise ci01 swift nodepool minCount
- [ ] CI green / remove hold
