### PR TITLE
fix(hcpctl): resolve Kusto endpoint for EUAP canary regions in snapshot (AROSLSRE-1171)

### DIFF
--- a/tooling/hcpctl/pkg/snapshot/prow.go
+++ b/tooling/hcpctl/pkg/snapshot/prow.go
@@ -576,13 +576,24 @@ func parseConfig(data []byte) (*ProwJobConfig, error) {
 	}
 
 	return &ProwJobConfig{
-		Region:                src.Kusto.Location,
+		Region:                kustoRegion(src.Kusto.Location),
 		KustoName:             src.Kusto.KustoName,
 		HCPDatabase:           src.Kusto.HostedControlPlaneLogsDatabase,
 		ServiceDatabase:       src.Kusto.ServiceLogsDatabase,
 		ServiceClusterName:    src.Svc.AKS.Name,
 		ManagementClusterName: src.Mgmt.AKS.Name,
 	}, nil
+}
+
+// kustoRegion maps a deployment region to the physical Azure region that hosts
+// its Kusto cluster. EUAP ("canary") regions such as "eastus2euap" and
+// "centraluseuap" do not have their own Kusto cluster; their cluster is deployed
+// in the underlying physical region ("eastus2", "centralus"). Stripping the
+// "euap" suffix yields the region segment that resolves in DNS
+// (e.g. hcp-prod-usc.eastus2.kusto.windows.net). Non-EUAP regions are returned
+// unchanged.
+func kustoRegion(region string) string {
+	return strings.TrimSuffix(region, "euap")
 }
 
 // findArtifactDir lists subdirectories under artifacts/ and returns the one

--- a/tooling/hcpctl/pkg/snapshot/prow_test.go
+++ b/tooling/hcpctl/pkg/snapshot/prow_test.go
@@ -1,0 +1,40 @@
+package snapshot
+
+import "testing"
+
+func TestKustoRegion(t *testing.T) {
+	tests := []struct {
+		name   string
+		region string
+		want   string
+	}{
+		{name: "non-euap region unchanged", region: "eastus2", want: "eastus2"},
+		{name: "west europe unchanged", region: "westeurope", want: "westeurope"},
+		{name: "eastus2euap canary maps to eastus2", region: "eastus2euap", want: "eastus2"},
+		{name: "centraluseuap canary maps to centralus", region: "centraluseuap", want: "centralus"},
+		{name: "empty region unchanged", region: "", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := kustoRegion(tt.region); got != tt.want {
+				t.Errorf("kustoRegion(%q) = %q, want %q", tt.region, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseConfigNormalizesCanaryRegion(t *testing.T) {
+	data := []byte("kusto:\n  kustoName: hcp-prod-usc\n  location: eastus2euap\n  serviceLogsDatabase: ServiceLogs\n  hostedControlPlaneLogsDatabase: HostedControlPlaneLogs\n")
+
+	cfg, err := parseConfig(data)
+	if err != nil {
+		t.Fatalf("parseConfig returned error: %v", err)
+	}
+	if cfg.Region != "eastus2" {
+		t.Errorf("Region = %q, want %q", cfg.Region, "eastus2")
+	}
+	if cfg.KustoName != "hcp-prod-usc" {
+		t.Errorf("KustoName = %q, want %q", cfg.KustoName, "hcp-prod-usc")
+	}
+}

--- a/tooling/hcpctl/pkg/snapshot/prow_test.go
+++ b/tooling/hcpctl/pkg/snapshot/prow_test.go
@@ -1,3 +1,17 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package snapshot
 
 import "testing"


### PR DESCRIPTION
### What

`snapshot from-prow-job` builds the Kusto cluster FQDN from the deployment region read out of the job's `config.yaml` (`kusto.location`). For EUAP ("canary") regions such as `eastus2euap` and `centraluseuap`, that produced an **unresolvable** host:

```
hcp-prod-usc.eastus2euap.kusto.windows.net  →  NXDOMAIN
```

EUAP regions do not host their own Kusto cluster — it lives in the underlying physical region (`eastus2`, `centralus`). This change normalizes the region by stripping the trailing `euap` suffix when deriving the Kusto location, so the endpoint resolves:

```
hcp-prod-usc.eastus2.kusto.windows.net  →  OK
```

Non-EUAP regions are returned unchanged.

### Why

When triaging a canary prod E2E failure (build `167769343`), every one of the 46 tests failed its Kusto gather phase with NXDOMAIN — so the snapshot produced **no** Kusto log evidence (no `manifest.json`, no per-phase query results), forcing manual Kusto REST triage. Canary/EUAP rollouts are exactly where we most need this tooling to work. Tracked in [AROSLSRE-1171](https://redhat.atlassian.net/browse/AROSLSRE-1171).

### Testing

- Added `TestKustoRegion` (table: `eastus2`→`eastus2`, `westeurope`→`westeurope`, `eastus2euap`→`eastus2`, `centraluseuap`→`centralus`, `""`→`""`) and `TestParseConfigNormalizesCanaryRegion` (asserts `kusto.location: eastus2euap` parses to `Region: eastus2`).
- `gofmt`/`go vet`/`go test ./pkg/snapshot/`/`go build ./...` clean.
- Re-ran `snapshot from-prow-job` end-to-end against the canary run: `region: eastus2`, **0 DNS errors**, produced `manifest.json` and Kusto results for maestro / clusters-service / frontend / backend.

### Special notes for your reviewer

The normalization is a single `strings.TrimSuffix(region, "euap")` applied in `parseConfig`. It is intentionally minimal — `euap` is the canonical Azure canary suffix, and stripping it yields the physical region segment that the Kusto cluster FQDN is built from.

### PR Checklist

- [x] Tests added/updated
- [x] `gofmt`/`go vet` clean
- [ ] Docs (n/a — internal tooling behavior fix)

Jira: [AROSLSRE-1171](https://redhat.atlassian.net/browse/AROSLSRE-1171)
