### PR TITLE
fix(maestro): harden maestro-server against Postgres blips (AROSLSRE-1170)

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -36,6 +36,7 @@ ignore:
 - '**/zz_fixture_TestHelmTemplate*.yaml'
 - 'velero/deploy/templates/install-job.yaml'
 - 'maestro/server/deploy/templates/maestro.deployment.yaml'
+- 'maestro/server/deploy/templates/maestro.pdb.yaml'
 - 'maestro/server/deploy/templates/allow-cluster-service.authorizationpolicy.yaml'
 - 'maestro/server/deploy/templates/allow-backend.authorizationpolicy.yaml'
 - 'maestro/server/deploy/templates/allow-fleet-controller.authorizationpolicy.yaml'

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -910,7 +910,7 @@ defaults:
       loglevel: 2
       managedIdentityName: maestro-server
       k8s:
-        replicas: 1
+        replicas: 2
         namespace: maestro
         serviceAccountName: maestro
         resources:
@@ -958,7 +958,7 @@ defaults:
     image:
       registry: quay.io
       repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
-      digest: sha256:1568fda504ca91a9cfee998067174ebd46f5ac2603a8663ebefbac94d6483a85 # e43800d7020340d3fb4c0cfa81a8099e06e303f8 (2026-06-16 17:37)
+      digest: sha256:784f3670c04a303b0c0fbd98048bc3e941c03b65122c53b0e0da58abcdec65b3 # ff220ea357a20c79d07659263b8bbbd555d60abd (2026-06-24 15:55)
   # ACM
   acm:
     operator:

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -545,7 +545,7 @@ maestro:
     name: arohcp-ci00-maestro-j7654321
     private: false
   image:
-    digest: sha256:1568fda504ca91a9cfee998067174ebd46f5ac2603a8663ebefbac94d6483a85
+    digest: sha256:784f3670c04a303b0c0fbd98048bc3e941c03b65122c53b0e0da58abcdec65b3
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:
@@ -569,7 +569,7 @@ maestro:
   server:
     k8s:
       namespace: maestro
-      replicas: 1
+      replicas: 2
       resources:
         limits:
           memory: unlimited

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -545,7 +545,7 @@ maestro:
     name: arohcp-ci01-maestro-j7654321
     private: false
   image:
-    digest: sha256:1568fda504ca91a9cfee998067174ebd46f5ac2603a8663ebefbac94d6483a85
+    digest: sha256:784f3670c04a303b0c0fbd98048bc3e941c03b65122c53b0e0da58abcdec65b3
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:
@@ -569,7 +569,7 @@ maestro:
   server:
     k8s:
       namespace: maestro
-      replicas: 1
+      replicas: 2
       resources:
         limits:
           memory: unlimited

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -545,7 +545,7 @@ maestro:
     name: arohcp-cspr-maestro-usw3
     private: false
   image:
-    digest: sha256:1568fda504ca91a9cfee998067174ebd46f5ac2603a8663ebefbac94d6483a85
+    digest: sha256:784f3670c04a303b0c0fbd98048bc3e941c03b65122c53b0e0da58abcdec65b3
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:
@@ -569,7 +569,7 @@ maestro:
   server:
     k8s:
       namespace: maestro
-      replicas: 1
+      replicas: 2
       resources:
         limits:
           memory: unlimited

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -545,7 +545,7 @@ maestro:
     name: arohcp-dev-maestro-usw3
     private: false
   image:
-    digest: sha256:1568fda504ca91a9cfee998067174ebd46f5ac2603a8663ebefbac94d6483a85
+    digest: sha256:784f3670c04a303b0c0fbd98048bc3e941c03b65122c53b0e0da58abcdec65b3
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:
@@ -569,7 +569,7 @@ maestro:
   server:
     k8s:
       namespace: maestro
-      replicas: 1
+      replicas: 2
       resources:
         limits:
           memory: unlimited

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -545,7 +545,7 @@ maestro:
     name: arohcp-perf-maestro-usw3ptest
     private: false
   image:
-    digest: sha256:1568fda504ca91a9cfee998067174ebd46f5ac2603a8663ebefbac94d6483a85
+    digest: sha256:784f3670c04a303b0c0fbd98048bc3e941c03b65122c53b0e0da58abcdec65b3
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:
@@ -569,7 +569,7 @@ maestro:
   server:
     k8s:
       namespace: maestro
-      replicas: 1
+      replicas: 2
       resources:
         limits:
           memory: unlimited

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -545,7 +545,7 @@ maestro:
     name: arohcp-pers-maestro-usw3test
     private: false
   image:
-    digest: sha256:1568fda504ca91a9cfee998067174ebd46f5ac2603a8663ebefbac94d6483a85
+    digest: sha256:784f3670c04a303b0c0fbd98048bc3e941c03b65122c53b0e0da58abcdec65b3
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:
@@ -569,7 +569,7 @@ maestro:
   server:
     k8s:
       namespace: maestro
-      replicas: 1
+      replicas: 2
       resources:
         limits:
           memory: unlimited

--- a/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
@@ -1000,6 +1000,60 @@ resource maestro 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
         for: 'PT10M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'MaestroServerNoReadyReplicas'
+        enabled: true
+        labels: {
+          severity: 'critical'
+        }
+        annotations: {
+          correlationId: 'MaestroServerNoReadyReplicas/{{ $labels.cluster }}'
+          description: 'No maestro-server replicas have been Ready for 5 minutes. Readiness is gated on Postgres connectivity, so maestro is likely unable to reach its database; Clusters Service will get 503 and HCP cluster provisioning will stall.'
+          info: 'No maestro-server replicas have been Ready for 5 minutes. Readiness is gated on Postgres connectivity, so maestro is likely unable to reach its database; Clusters Service will get 503 and HCP cluster provisioning will stall.'
+          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/maestro/index.html'
+          summary: 'No maestro-server replicas are Ready'
+          title: 'No maestro-server replicas are Ready'
+        }
+        expression: 'kube_deployment_status_replicas_available{namespace="maestro", deployment="maestro"} == 0 and kube_deployment_spec_replicas{namespace="maestro", deployment="maestro"} > 0'
+        for: 'PT5M'
+        severity: severityCeiling > 0 ? max(2, severityCeiling) : 2
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'MaestroServerReplicaNotReady'
+        enabled: true
+        labels: {
+          severity: 'warning'
+        }
+        annotations: {
+          correlationId: 'MaestroServerReplicaNotReady/{{ $labels.cluster }}'
+          description: 'At least one maestro-server replica has been NotReady for 15 minutes (available {{ $value }} below desired). Readiness is gated on Postgres connectivity, so a persistently NotReady replica usually indicates database connectivity problems.'
+          info: 'At least one maestro-server replica has been NotReady for 15 minutes (available {{ $value }} below desired). Readiness is gated on Postgres connectivity, so a persistently NotReady replica usually indicates database connectivity problems.'
+          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/maestro/index.html'
+          summary: 'A maestro-server replica is not Ready'
+          title: 'A maestro-server replica is not Ready'
+        }
+        expression: 'kube_deployment_status_replicas_available{namespace="maestro", deployment="maestro"} > 0 and kube_deployment_status_replicas_available{namespace="maestro", deployment="maestro"} < kube_deployment_spec_replicas{namespace="maestro", deployment="maestro"}'
+        for: 'PT15M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
     ]
     scopes: [
       azureMonitoring

--- a/maestro/alerts/maestro-prometheusRule.yaml
+++ b/maestro/alerts/maestro-prometheusRule.yaml
@@ -77,3 +77,42 @@ spec:
         description: 'Maestro spec controller reconcile error rate is above 10% for the last 10 minutes. Resources may not be reaching management clusters. Current value: {{ $value | humanizePercentage }}.'
         runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/maestro/index.html'
         summary: 'Maestro spec controller reconcile error rate is high'
+    - alert: MaestroServerNoReadyReplicas
+      # Fires when no maestro-server replicas are Ready. The readiness
+      # probe is gated on Postgres connectivity (/healthcheck runs an
+      # instance-row SELECT), while liveness uses the process-only
+      # /livez probe and no longer restarts the pod on DB errors. A
+      # sustained zero-Ready count therefore means maestro cannot reach
+      # its database: Clusters Service receives 503 and HCP provisioning
+      # stalls. This is the AROSLSRE-1170 outage condition.
+      expr: |
+        kube_deployment_status_replicas_available{namespace="maestro", deployment="maestro"} == 0
+        and
+        kube_deployment_spec_replicas{namespace="maestro", deployment="maestro"} > 0
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        description: 'No maestro-server replicas have been Ready for 5 minutes. Readiness is gated on Postgres connectivity, so maestro is likely unable to reach its database; Clusters Service will get 503 and HCP cluster provisioning will stall.'
+        runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/maestro/index.html'
+        summary: 'No maestro-server replicas are Ready'
+    - alert: MaestroServerReplicaNotReady
+      # Fires when at least one (but not all) maestro-server replicas
+      # are not Ready for a sustained period. Because liveness now uses
+      # the process-only /livez probe, a replica that cannot reach
+      # Postgres stays Running but NotReady (removed from Service
+      # endpoints by readiness) instead of crash-looping, so this is the
+      # primary early signal of degraded database connectivity. The
+      # window is long enough to ignore normal rollouts.
+      expr: |
+        kube_deployment_status_replicas_available{namespace="maestro", deployment="maestro"} > 0
+        and
+        kube_deployment_status_replicas_available{namespace="maestro", deployment="maestro"}
+          < kube_deployment_spec_replicas{namespace="maestro", deployment="maestro"}
+      for: 15m
+      labels:
+        severity: warning
+      annotations:
+        description: 'At least one maestro-server replica has been NotReady for 15 minutes (available {{ $value }} below desired). Readiness is gated on Postgres connectivity, so a persistently NotReady replica usually indicates database connectivity problems.'
+        runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/maestro/index.html'
+        summary: 'A maestro-server replica is not Ready'

--- a/maestro/alerts/maestro-prometheusRule_test.yaml
+++ b/maestro/alerts/maestro-prometheusRule_test.yaml
@@ -110,3 +110,74 @@ tests:
   - eval_time: 15m
     alertname: MaestroSpecControllerReconcileErrors
     exp_alerts: []
+# Test: MaestroServerNoReadyReplicas fires when 0 replicas available for 5m
+- interval: 1m
+  input_series:
+  - series: 'kube_deployment_status_replicas_available{namespace="maestro", deployment="maestro"}'
+    values: "0x10" # no Ready replicas
+  - series: 'kube_deployment_spec_replicas{namespace="maestro", deployment="maestro"}'
+    values: "2x10" # 2 desired
+  alert_rule_test:
+  - eval_time: 6m
+    alertname: MaestroServerNoReadyReplicas
+    exp_alerts:
+    - exp_labels:
+        severity: critical
+        namespace: maestro
+        deployment: maestro
+      exp_annotations:
+        description: 'No maestro-server replicas have been Ready for 5 minutes. Readiness is gated on Postgres connectivity, so maestro is likely unable to reach its database; Clusters Service will get 503 and HCP cluster provisioning will stall.'
+        runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/maestro/index.html'
+        summary: 'No maestro-server replicas are Ready'
+# Test: MaestroServerNoReadyReplicas does not fire when all replicas available
+- interval: 1m
+  input_series:
+  - series: 'kube_deployment_status_replicas_available{namespace="maestro", deployment="maestro"}'
+    values: "2x10"
+  - series: 'kube_deployment_spec_replicas{namespace="maestro", deployment="maestro"}'
+    values: "2x10"
+  alert_rule_test:
+  - eval_time: 6m
+    alertname: MaestroServerNoReadyReplicas
+    exp_alerts: []
+# Test: MaestroServerReplicaNotReady fires when available < desired (but > 0) for 15m
+- interval: 1m
+  input_series:
+  - series: 'kube_deployment_status_replicas_available{namespace="maestro", deployment="maestro"}'
+    values: "1x20" # 1 of 2 Ready
+  - series: 'kube_deployment_spec_replicas{namespace="maestro", deployment="maestro"}'
+    values: "2x20"
+  alert_rule_test:
+  - eval_time: 16m
+    alertname: MaestroServerReplicaNotReady
+    exp_alerts:
+    - exp_labels:
+        severity: warning
+        namespace: maestro
+        deployment: maestro
+      exp_annotations:
+        description: 'At least one maestro-server replica has been NotReady for 15 minutes (available 1 below desired). Readiness is gated on Postgres connectivity, so a persistently NotReady replica usually indicates database connectivity problems.'
+        runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/maestro/index.html'
+        summary: 'A maestro-server replica is not Ready'
+# Test: MaestroServerReplicaNotReady does not fire when all replicas available
+- interval: 1m
+  input_series:
+  - series: 'kube_deployment_status_replicas_available{namespace="maestro", deployment="maestro"}'
+    values: "2x20"
+  - series: 'kube_deployment_spec_replicas{namespace="maestro", deployment="maestro"}'
+    values: "2x20"
+  alert_rule_test:
+  - eval_time: 16m
+    alertname: MaestroServerReplicaNotReady
+    exp_alerts: []
+# Test: MaestroServerReplicaNotReady does not fire when 0 available (that is the critical alert)
+- interval: 1m
+  input_series:
+  - series: 'kube_deployment_status_replicas_available{namespace="maestro", deployment="maestro"}'
+    values: "0x20"
+  - series: 'kube_deployment_spec_replicas{namespace="maestro", deployment="maestro"}'
+    values: "2x20"
+  alert_rule_test:
+  - eval_time: 16m
+    alertname: MaestroServerReplicaNotReady
+    exp_alerts: []

--- a/maestro/server/deploy/templates/maestro.deployment.yaml
+++ b/maestro/server/deploy/templates/maestro.deployment.yaml
@@ -162,9 +162,15 @@ spec:
           limits:
             memory: '{{ .Values.deployment.resources.limits.memory }}'
 {{- end }}
+        # NOTE: liveness uses /livez, a process-only endpoint that does NOT touch
+        # Postgres (openshift-online/maestro#543), so a transient DB slowdown no
+        # longer fails this probe. Readiness keeps using /healthcheck (which does a
+        # Postgres instance-row read), so a pod that can't reach the DB is pulled
+        # from Service endpoints instead of being restarted into a connection-pool
+        # reset storm (AROSLSRE-1170).
         livenessProbe:
           httpGet:
-            path: /healthcheck
+            path: /livez
             port: {{ .Values.maestro.healthCheckBindPort }}
             scheme: HTTP
           initialDelaySeconds: 25

--- a/maestro/server/deploy/templates/maestro.pdb.yaml
+++ b/maestro/server/deploy/templates/maestro.pdb.yaml
@@ -1,0 +1,14 @@
+{{- if gt (int .Values.deployment.replicas) 1 }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: maestro
+  namespace: '{{ .Release.Namespace }}'
+  labels:
+    app: maestro
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: maestro
+{{- end }}

--- a/maestro/server/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_maestro_server.yaml
+++ b/maestro/server/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_maestro_server.yaml
@@ -1,4 +1,18 @@
 ---
+# Source: maestro-server/templates/maestro.pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: maestro
+  namespace: 'maestro'
+  labels:
+    app: maestro
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: maestro
+---
 # Source: maestro-server/templates/maestro.serviceaccount.yaml
 kind: ServiceAccount
 apiVersion: v1
@@ -120,7 +134,7 @@ spec:
   selector:
     matchLabels:
       app: maestro
-  replicas: 1
+  replicas: 2
   strategy:
     rollingUpdate:
       maxSurge: 0
@@ -242,9 +256,15 @@ spec:
           requests:
             cpu: '200m'
             memory: '512Mi'
+        # NOTE: liveness uses /livez, a process-only endpoint that does NOT touch
+        # Postgres (openshift-online/maestro#543), so a transient DB slowdown no
+        # longer fails this probe. Readiness keeps using /healthcheck (which does a
+        # Postgres instance-row read), so a pod that can't reach the DB is pulled
+        # from Service endpoints instead of being restarted into a connection-pool
+        # reset storm (AROSLSRE-1170).
         livenessProbe:
           httpGet:
-            path: /healthcheck
+            path: /livez
             port: 8083
             scheme: HTTP
           initialDelaySeconds: 25


### PR DESCRIPTION
<!-- [AROSLSRE-1170](https://redhat.atlassian.net/browse/AROSLSRE-1170) -->

Hardens `maestro-server` against transient Postgres slowdowns, the failure mode behind the canary (`eastus2euap`) outage ([AROSLSRE-1170](https://redhat.atlassian.net/browse/AROSLSRE-1170)).

### What

- **HA:** default `maestro.server.k8s.replicas` `1 → 2` (applies to all environments; no overlay overrides it).
- **PodDisruptionBudget:** new `maestro.pdb.yaml` with `minAvailable: 1`, guarded on `replicas > 1`, so node drains / rollouts keep at least one replica serving.
- **Alerting:** two new maestro PrometheusRules (`maestro/alerts/maestro-prometheusRule.yaml`) — `MaestroServerNoReadyReplicas` (critical: zero Ready replicas, the [AROSLSRE-1170](https://redhat.atlassian.net/browse/AROSLSRE-1170) outage condition) and `MaestroServerReplicaNotReady` (warning: a replica NotReady > 15m). With liveness on `/livez`, a DB-sick pod stays Running-but-NotReady instead of crash-looping, so readiness is now the primary signal; these alerts make that visible.
- **Liveness decoupled from Postgres:** the liveness probe now points at the process-only **`/livez`** endpoint (added in [openshift-online/maestro#543](https://github.com/openshift-online/maestro/pull/543); `/livez` does NOT touch the database). Readiness keeps using `/healthcheck` (instance-row `SELECT`), so a pod that can't reach Postgres is pulled from Service endpoints instead of being restarted.
- **Image bump:** maestro image `85df8220` (2026-06-10) → `ff220ea3` (2026-06-24, `sha256:784f3670…`) so the deployed binary serves `/livez`. The probe switch is gated on this build; an older image would `404 /livez` and crash-loop.

Regenerated helm fixtures and materialized config are included.

### Why

In the canary incident, `maestro-server` ran with **a single replica** and **both** liveness and readiness probes pointed at the Postgres-backed `/healthcheck` endpoint (DB error → HTTP 500). A transient Postgres slowdown therefore:

```text
/healthcheck SELECT slow/err
  -> liveness probe fails (5x10s = 50s)
  -> kubelet restarts the ONLY pod
  -> GORM pool closes ("sql: database is closed")
  -> reconnect storm makes Postgres worse
  -> Clusters Service gets 503 via the Istio sidecar
  -> hcp-namespace-provision stalls past the 20m create timeout
```

It is a self-reinforcing crash loop. Two replicas + a PDB remove the single point of failure, and a process-only liveness probe stops a recoverable DB blip from escalating into a restart/reconnect storm. Maestro already supports multiple instances (heartbeat + advisory locks + dispatcher), so an up-but-not-DB-ready pod is correctly handled by readiness.

### Testing

- `make -C config/ materialize` — regenerates rendered config + helm fixtures (committed).
- `make -C tooling/prometheus-rules run-sl-services` — regenerates the alerting bicep and runs the promtool unit tests for the two new alerts (**passes**).
- `make test-helm-fixtures` — **passes**; fixture shows `replicas: 2`, liveness `httpGet.path: /livez`, readiness still `/healthcheck`, and the new `PodDisruptionBudget` (`minAvailable: 1`).
- `make -C config/ detect-change` — idempotent (clean once committed).
- No application code change; behavior is deployment-manifest only.

### Special notes for your reviewer

- The maestro image bump (`ff220ea3`) is **required** by the `/livez` probe switch and is bundled here intentionally; the two are not safe to split.
- `replicas: 2` in prod has a small cost/capacity impact — flagging for explicit reviewer sign-off.

Follow-up (separate work, not in this PR):

- **Postgres capacity / RCA** — the flexible server is `Standard_D2s_v3` (2 vCPU) with `maxOpenConnections: 50` per pod; review Azure Monitor metrics (connections, CPU, IOPS, failovers) around the incident and right-size SKU / pool (consider PgBouncer).

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge


