### PR TITLE
test: implement retry logic for VM console log fetching

### DIFF
--- a/test/util/framework/vm_helper.go
+++ b/test/util/framework/vm_helper.go
@@ -156,6 +156,15 @@ func GetVirtualMachinesInResourceGroup(
 	return vms, nil
 }
 
+// isRetryableBootDiagnosticsError checks if the error is a 409 OperationNotAllowed
+func isRetryableBootDiagnosticsError(err error) bool {
+	var azErr *azcore.ResponseError
+	if !errors.As(err, &azErr) {
+		return false
+	}
+	return azErr.StatusCode == http.StatusConflict && azErr.ErrorCode == "OperationNotAllowed"
+}
+
 // GetVirtualMachineConsoleLog retrieves the boot diagnostics serial console log from an Azure VM.
 // Returns an io.ReadCloser for streaming the console log data. The caller is responsible for closing the reader.
 // Returns an error if the retrieval fails or boot diagnostics is not enabled.
@@ -165,12 +174,31 @@ func GetVirtualMachineConsoleLog(
 	resourceGroupName string,
 	vmName string,
 ) (io.ReadCloser, error) {
+	logger := ginkgo.GinkgoLogr
 	vmClient := computeClientFactory.NewVirtualMachinesClient()
 
-	// Retrieve boot diagnostics data which includes the serial console log
-	result, err := vmClient.RetrieveBootDiagnosticsData(ctx, resourceGroupName, vmName, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve boot diagnostics data for VM %q: %w", vmName, err)
+	retryBackoff := []time.Duration{5 * time.Second, 10 * time.Second, 20 * time.Second, 20 * time.Second}
+	var result armcompute.VirtualMachinesClientRetrieveBootDiagnosticsDataResponse
+	var err error
+	for attempt := 0; ; attempt++ {
+		result, err = vmClient.RetrieveBootDiagnosticsData(ctx, resourceGroupName, vmName, nil)
+		if err == nil {
+			break
+		}
+		if !isRetryableBootDiagnosticsError(err) || attempt >= len(retryBackoff) {
+			return nil, fmt.Errorf("failed to retrieve boot diagnostics data for VM %q: %w", vmName, err)
+		}
+		wait := retryBackoff[attempt]
+		logger.Info("retrying boot diagnostics retrieval due to OperationNotAllowed",
+			"vmName", vmName,
+			"attempt", attempt+1,
+			"nextRetryIn", wait.String(),
+			"error", err.Error())
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("failed to retrieve boot diagnostics data for VM %q: %w", vmName, ctx.Err())
+		case <-time.After(wait):
+		}
 	}
 
 	// Check if serial console log URI is available

--- a/test/util/framework/vm_helper.go
+++ b/test/util/framework/vm_helper.go
@@ -27,6 +27,8 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 
+	"k8s.io/apimachinery/pkg/util/wait"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
@@ -177,28 +179,37 @@ func GetVirtualMachineConsoleLog(
 	logger := ginkgo.GinkgoLogr
 	vmClient := computeClientFactory.NewVirtualMachinesClient()
 
-	retryBackoff := []time.Duration{5 * time.Second, 10 * time.Second, 20 * time.Second, 20 * time.Second}
 	var result armcompute.VirtualMachinesClientRetrieveBootDiagnosticsDataResponse
-	var err error
-	for attempt := 0; ; attempt++ {
+	var attempt int
+	var lastRetryableErr error
+	retryErr := wait.ExponentialBackoffWithContext(ctx, wait.Backoff{
+		Duration: 5 * time.Second,
+		Factor:   2.0,
+		Steps:    5,
+		Cap:      20 * time.Second,
+	}, func(ctx context.Context) (bool, error) {
+		attempt++
+		var err error
 		result, err = vmClient.RetrieveBootDiagnosticsData(ctx, resourceGroupName, vmName, nil)
 		if err == nil {
-			break
+			return true, nil
 		}
-		if !isRetryableBootDiagnosticsError(err) || attempt >= len(retryBackoff) {
-			return nil, fmt.Errorf("failed to retrieve boot diagnostics data for VM %q: %w", vmName, err)
+		if isRetryableBootDiagnosticsError(err) {
+			lastRetryableErr = err
+			logger.Info("retrying boot diagnostics retrieval due to OperationNotAllowed",
+				"vmName", vmName,
+				"attempt", attempt,
+				"error", err.Error())
+			return false, nil
 		}
-		wait := retryBackoff[attempt]
-		logger.Info("retrying boot diagnostics retrieval due to OperationNotAllowed",
-			"vmName", vmName,
-			"attempt", attempt+1,
-			"nextRetryIn", wait.String(),
-			"error", err.Error())
-		select {
-		case <-ctx.Done():
-			return nil, fmt.Errorf("failed to retrieve boot diagnostics data for VM %q: %w", vmName, ctx.Err())
-		case <-time.After(wait):
+		return false, err
+	})
+
+	if retryErr != nil {
+		if wait.Interrupted(retryErr) && lastRetryableErr != nil {
+			return nil, fmt.Errorf("failed to retrieve boot diagnostics data for VM %q after %d attempts, last error: %w", vmName, attempt, lastRetryableErr)
 		}
+		return nil, fmt.Errorf("failed to retrieve boot diagnostics data for VM %q: %w", vmName, retryErr)
 	}
 
 	// Check if serial console log URI is available

--- a/test/util/framework/vm_helper_test.go
+++ b/test/util/framework/vm_helper_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
+func TestIsRetryableBootDiagnosticsError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "non-Azure error",
+			err:      fmt.Errorf("some random error"),
+			expected: false,
+		},
+		{
+			name: "409 OperationNotAllowed is retryable",
+			err: &azcore.ResponseError{
+				StatusCode: http.StatusConflict,
+				ErrorCode:  "OperationNotAllowed",
+			},
+			expected: true,
+		},
+		{
+			name: "409 with different error code is not retryable",
+			err: &azcore.ResponseError{
+				StatusCode: http.StatusConflict,
+				ErrorCode:  "ResourceGroupNotFound",
+			},
+			expected: false,
+		},
+		{
+			name: "404 is not retryable",
+			err: &azcore.ResponseError{
+				StatusCode: http.StatusNotFound,
+			},
+			expected: false,
+		},
+		{
+			name: "500 is not retryable",
+			err: &azcore.ResponseError{
+				StatusCode: http.StatusInternalServerError,
+			},
+			expected: false,
+		},
+		{
+			name: "wrapped 409 OperationNotAllowed is retryable",
+			err: fmt.Errorf("outer: %w", &azcore.ResponseError{
+				StatusCode: http.StatusConflict,
+				ErrorCode:  "OperationNotAllowed",
+			}),
+			expected: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := isRetryableBootDiagnosticsError(tc.err)
+			if result != tc.expected {
+				t.Errorf("isRetryableBootDiagnosticsError(%v) = %v, want %v", tc.err, result, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
[ARO-27306](https://redhat.atlassian.net/browse/ARO-27306)

### What

Implements retry logic in `vm_helper.go` around the `RetrieveBootDiagnosticsData` call, check for `StatusCode == 409` and `ErrorCode == "OperationNotAllowed"`.
Implementation uses 4 retries with capped exponential back-off (5, 10, 20, 20), total 55 seconds.

### Why

Make VM console log fetching more robust and resilient to transient issues. 

### Testing

Modifies test framework helper and includes unit tests for said modifications. 

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [x] All comment threads resolved before merge
