### PR TITLE
chore(image-updater): remove aro-hcp-exporter from bumper config (AROSLSRE-1173)

### DIFF
--- a/tooling/image-updater/README.md
+++ b/tooling/image-updater/README.md
@@ -202,13 +202,13 @@ To pin an image to a specific digest and prevent automatic updates:
 2. **Update `config.yaml`** to use a specific `tag` instead of `tagPattern`:
 
 ```yaml
-aro-hcp-exporter:
+imageSync:
   source:
-    image: arohcpsvcdev.azurecr.io/arohcpmetrics
-    tag: "013ae7f72821c95873141388054ed7fdaa75dbf71d78e8701240fb39e5a39c51"  # Pin to specific digest
+    image: arohcpsvcdev.azurecr.io/image-sync/oc-mirror
+    tag: "8755133"  # Pin to a specific tag instead of tagPattern
     useAuth: true
   targets:
-  - jsonPath: defaults.customExporter.image.digest
+  - jsonPath: defaults.imageSync.ocMirror.image.digest
     filePath: ../../config/config.yaml
 ```
 
@@ -222,7 +222,7 @@ az login
 
 ```bash
 # Update specific component
-make update COMPONENTS=aro-hcp-exporter
+make update COMPONENTS=imageSync
 ```
 
 5. **Run materialize** to update rendered configs:
@@ -300,12 +300,12 @@ clusters-service:
 
 **Azure Container Registry (Private)**:
 ```yaml
-aro-hcp-exporter:
+imageSync:
   source:
-    image: arohcpsvcdev.azurecr.io/arohcpmetrics
+    image: arohcpsvcdev.azurecr.io/image-sync/oc-mirror
     useAuth: true  # Uses DefaultAzureCredential
   targets:
-  - jsonPath: defaults.customExporter.image.digest
+  - jsonPath: defaults.imageSync.ocMirror.image.digest
     filePath: ../../config/config.yaml
 ```
 

--- a/tooling/image-updater/config.yaml
+++ b/tooling/image-updater/config.yaml
@@ -56,15 +56,6 @@ images:
     targets:
     - jsonPath: defaults.clustersService.image.digest
       filePath: ../../config/config.yaml
-  # Custom Exporter image
-  aro-hcp-exporter:
-    group: aro-hcp-exporter
-    source:
-      image: arohcpsvcdev.azurecr.io/arohcpmetrics
-      useAuth: true
-    targets:
-    - jsonPath: defaults.customExporter.image.digest
-      filePath: ../../config/config.yaml
   # Kube Events image
   kubeEvents:
     group: obs-agents


### PR DESCRIPTION
[AROSLSRE-1173](https://redhat.atlassian.net/browse/AROSLSRE-1173)

### What

Remove the `aro-hcp-exporter` (arohcpmetrics) component, and its single-member `aro-hcp-exporter` group, from the image-updater bumper config (`tooling/image-updater/config.yaml`). Repoint the two README examples that used `aro-hcp-exporter` to the still-valid private-ACR `imageSync` component.

`config/config.yaml` is untouched — the `defaults.customExporter.image.digest` value stays as-is, it just won't be auto-updated by this tool anymore.

### Why

`aro-hcp-exporter` is a first-party ARO-HCP image (`tooling/aro-hcp-exporter/`, built and pushed to the dev ACR on every build) with the same profile as the `aro-rp` images (`frontend`, `backend`, `admin-api`, `sessiongate`) removed in #5400 / [AROSLSRE-778](https://redhat.atlassian.net/browse/AROSLSRE-778) — but it was missed by that cleanup.

Its INT/STG/PROD digests are already owned by the **sdp-pipelines bumper**:

```text
tooling/pkg/release/candidate/bump/options.go:494  bump list includes "arohcpmetrics"
tooling/pkg/release/candidate/bump/options.go:612  "arohcpmetrics" -> defaults.customExporter.image.digest
```

So keeping it in the image-updater is redundant and recreates exactly the conflict #5400 set out to eliminate: a `bump-all` run can overwrite a release-validated digest with whatever is latest in the dev ACR. #5625 is live proof — the periodic image-updater job re-bumped `aro-hcp-exporter` from the dev ACR.

### Testing

- `go build ./...` in `tooling/image-updater` compiles cleanly.
- Dry-run confirms the component is gone:

```text
$ ./image-updater update --config config.yaml --tags --components aro-hcp-exporter --dry-run
ERROR: component "aro-hcp-exporter" not found in configuration
```

- `grep` for `aro-hcp-exporter` / `arohcpmetrics` / `customExporter` under `tooling/image-updater/` returns nothing.

### Special notes for your reviewer

- Config-and-docs only; no digest changes, so no `make materialize` / rendered-config changes are needed (mirrors #5400, which also left `config/config.yaml` untouched).
- The `aro-hcp-exporter` group no longer exists after this change.

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
