### PR TITLE
feat: move and enable asynchronous CS delete interaction for clusters, nodepools and externalauths

### DIFF
--- a/backend/pkg/controllers/clusterdeletion/cluster_child_resources_cleanup_controller.go
+++ b/backend/pkg/controllers/clusterdeletion/cluster_child_resources_cleanup_controller.go
@@ -202,6 +202,8 @@ func (c *clusterChildResourcesCleanupController) SyncOnce(ctx context.Context, k
 		return utils.TrackError(err)
 	}
 
+	logger.Info("all included cluster cosmos child resources deleted")
+
 	return nil
 }
 
@@ -364,6 +366,8 @@ func (c *clusterChildResourcesCleanupController) ensureClusterScopedKubeApplierR
 	if err := desireIterator.GetError(); err != nil {
 		return utils.TrackError(fmt.Errorf("error iterating cluster-scoped kube-applier resources: %w", err))
 	}
+
+	logger.Info("all included cluster-scoped kube-applier child resources deleted")
 
 	return nil
 }

--- a/backend/pkg/controllers/controllerutils/cooldown.go
+++ b/backend/pkg/controllers/controllerutils/cooldown.go
@@ -55,6 +55,10 @@ func (c *ActiveOperationBasedChecker) CanSync(ctx context.Context, key any) bool
 	switch castKey := key.(type) {
 	case HCPClusterKey:
 		activeOperations, err = c.activeOperationLister.ListActiveOperationsForCluster(ctx, castKey.SubscriptionID, castKey.ResourceGroupName, castKey.HCPClusterName)
+	case HCPNodePoolKey:
+		activeOperations, err = c.activeOperationLister.ListActiveOperationsForNodePool(ctx, castKey.SubscriptionID, castKey.ResourceGroupName, castKey.HCPClusterName, castKey.HCPNodePoolName)
+	case HCPExternalAuthKey:
+		activeOperations, err = c.activeOperationLister.ListActiveOperationsForExternalAuth(ctx, castKey.SubscriptionID, castKey.ResourceGroupName, castKey.HCPClusterName, castKey.HCPExternalAuthName)
 	case OperationKey:
 		ret := c.activeOperationTimer.CanSync(ctx, key)
 		return ret

--- a/backend/pkg/controllers/create_cluster_scoped_read_desires_controller.go
+++ b/backend/pkg/controllers/create_cluster_scoped_read_desires_controller.go
@@ -97,6 +97,9 @@ func (c *createClusterScopedReadDesiresSyncer) SyncOnce(ctx context.Context, key
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to get Cluster: %w", err))
 	}
+	if existingCluster.ServiceProviderProperties.DeletionTimestamp != nil {
+		return nil
+	}
 	if existingCluster.ServiceProviderProperties.ClusterServiceID == nil {
 		// We don't have a CS reference yet; we'll retrigger once it's set.
 		return nil

--- a/backend/pkg/controllers/create_nodepool_scoped_read_desires_controller.go
+++ b/backend/pkg/controllers/create_nodepool_scoped_read_desires_controller.go
@@ -84,6 +84,9 @@ func (c *createNodePoolScopedReadDesiresSyncer) SyncOnce(ctx context.Context, ke
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to get NodePool: %w", err))
 	}
+	if existingNodePool.ServiceProviderProperties.DeletionTimestamp != nil {
+		return nil
+	}
 	if existingNodePool.ServiceProviderProperties.ClusterServiceID == nil ||
 		len(existingNodePool.ServiceProviderProperties.ClusterServiceID.String()) == 0 {
 		return nil

--- a/backend/pkg/controllers/externalauthdeletion/external_auth_child_resources_cleanup_controller.go
+++ b/backend/pkg/controllers/externalauthdeletion/external_auth_child_resources_cleanup_controller.go
@@ -152,5 +152,7 @@ func (c *externalAuthChildResourcesCleanupController) SyncOnce(ctx context.Conte
 		return utils.TrackError(err)
 	}
 
+	logger.Info("all included external auth cosmos child resources deleted")
+
 	return nil
 }

--- a/backend/pkg/controllers/nodepooldeletion/node_pool_child_resources_cleanup_controller.go
+++ b/backend/pkg/controllers/nodepooldeletion/node_pool_child_resources_cleanup_controller.go
@@ -164,6 +164,8 @@ func (c *nodePoolChildResourcesCleanupController) SyncOnce(ctx context.Context, 
 		return utils.TrackError(err)
 	}
 
+	logger.Info("all included nodepool child resources deleted")
+
 	return nil
 }
 
@@ -315,6 +317,8 @@ func (c *nodePoolChildResourcesCleanupController) ensureNodePoolScopedKubeApplie
 	if err := desireIterator.GetError(); err != nil {
 		return utils.TrackError(fmt.Errorf("error iterating nodepool-scoped kube-applier resources: %w", err))
 	}
+
+	logger.Info("all included nodepool-scoped kube-applier child resources deleted")
 
 	return nil
 }

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_active_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_active_version_controller.go
@@ -81,12 +81,15 @@ func (c *controlPlaneActiveVersionSyncer) CooldownChecker() controllerutil.Coold
 // from the per-cluster ReadDesire's observed HostedCluster. Each active version
 // includes Version and State (Completed or Partial) and is persisted on replace.
 func (c *controlPlaneActiveVersionSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPClusterKey) error {
-	_, err := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).Get(ctx, key.HCPClusterName)
+	existingCluster, err := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).Get(ctx, key.HCPClusterName)
 	if database.IsNotFoundError(err) {
 		return nil
 	}
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to get Cluster: %w", err))
+	}
+	if existingCluster.ServiceProviderProperties.DeletionTimestamp != nil {
+		return nil
 	}
 
 	hostedCluster, err := maestrohelpers.GetCachedHostedClusterForCluster(ctx, c.readDesireLister, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
@@ -121,6 +121,9 @@ func (c *controlPlaneDesiredVersionSyncer) SyncOnce(ctx context.Context, key con
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to get Cluster: %w", err))
 	}
+	if existingCluster.ServiceProviderProperties.DeletionTimestamp != nil {
+		return nil
+	}
 	if existingCluster.ServiceProviderProperties.ClusterServiceID == nil {
 		// Currently, this is correct.  We will likely refactor and change this to separate the read of active versions from the determination
 		// of the next desired version: we'll need to choose a desired version even if there are no active versions.

--- a/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller.go
@@ -130,6 +130,9 @@ func (c *nodePoolVersionSyncer) SyncOnce(ctx context.Context, key controllerutil
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to get node pool from cosmos: %w", err))
 	}
+	if nodePool.ServiceProviderProperties.DeletionTimestamp != nil {
+		return nil
+	}
 	if nodePool.ServiceProviderProperties.ClusterServiceID == nil || len(nodePool.ServiceProviderProperties.ClusterServiceID.String()) == 0 {
 		// if we have no clusterservice nodepool, we have nothing to sync.
 		return nil

--- a/backend/pkg/controllers/upgradecontrollers/trigger_control_plane_upgrade_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/trigger_control_plane_upgrade_controller.go
@@ -94,6 +94,9 @@ func (c *triggerControlPlaneUpgradeSyncer) SyncOnce(ctx context.Context, key con
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to get Cluster: %w", err))
 	}
+	if existingCluster.ServiceProviderProperties.DeletionTimestamp != nil {
+		return nil
+	}
 	if existingCluster.ServiceProviderProperties.ClusterServiceID == nil {
 		// if we have no clusterService cluster, we have nothing to trigger.
 		return nil

--- a/backend/pkg/controllers/upgradecontrollers/trigger_node_pool_upgrade_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/trigger_node_pool_upgrade_controller.go
@@ -87,6 +87,9 @@ func (c *triggerNodePoolUpgradeSyncer) SyncOnce(ctx context.Context, key control
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to get NodePool: %w", err))
 	}
+	if existingNodePool.ServiceProviderProperties.DeletionTimestamp != nil {
+		return nil
+	}
 	// if we have no clusterservice nodepool, we have nothing to trigger.
 	if existingNodePool.ServiceProviderProperties.ClusterServiceID == nil || len(existingNodePool.ServiceProviderProperties.ClusterServiceID.String()) == 0 {
 		return nil

--- a/backend/pkg/controllers/validationcontrollers/cluster_validation_controller.go
+++ b/backend/pkg/controllers/validationcontrollers/cluster_validation_controller.go
@@ -81,6 +81,9 @@ func (c *clusterValidationSyncer) SyncOnce(ctx context.Context, key controllerut
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to get Cluster: %w", err))
 	}
+	if existingCluster.ServiceProviderProperties.DeletionTimestamp != nil {
+		return nil
+	}
 
 	existingServiceProviderCluster, err := database.GetOrCreateServiceProviderCluster(ctx, c.resourcesDBClient, key.GetResourceID())
 	if err != nil {

--- a/backend/pkg/controllers/validationcontrollers/nodepool_validation_controller.go
+++ b/backend/pkg/controllers/validationcontrollers/nodepool_validation_controller.go
@@ -78,6 +78,9 @@ func (c *nodePoolValidationSyncer) SyncOnce(ctx context.Context, key controlleru
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to get Cluster: %w", err))
 	}
+	if existingCluster.ServiceProviderProperties.DeletionTimestamp != nil {
+		return nil
+	}
 
 	existingNodePool, err := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).NodePools(key.HCPClusterName).Get(ctx, key.HCPNodePoolName)
 	if database.IsNotFoundError(err) {
@@ -85,6 +88,9 @@ func (c *nodePoolValidationSyncer) SyncOnce(ctx context.Context, key controlleru
 	}
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to get NodePool: %w", err))
+	}
+	if existingNodePool.ServiceProviderProperties.DeletionTimestamp != nil {
+		return nil
 	}
 
 	existingServiceProviderNodePool, err := database.GetOrCreateServiceProviderNodePool(ctx, c.resourcesDBClient, key.GetResourceID())

--- a/backend/pkg/informers/informers.go
+++ b/backend/pkg/informers/informers.go
@@ -592,6 +592,8 @@ func NewActiveOperationInformerWithRelistDuration(lister database.GlobalLister[a
 			Indexers: cache.Indexers{
 				listers.ByResourceGroup: activeOperationResourceGroupIndexFunc,
 				listers.ByCluster:       activeOperationClusterIndexFunc,
+				listers.ByNodePool:      activeOperationNodePoolIndexFunc,
+				listers.ByExternalAuth:  activeOperationExternalAuthIndexFunc,
 			},
 		},
 	)
@@ -685,6 +687,32 @@ func activeOperationClusterIndexFunc(obj interface{}) ([]string, error) {
 	}
 
 	return clusterResourceIDFromResourceID(op.ExternalID)
+}
+
+// activeOperationNodePoolIndexFunc indexes operations by their associated node pool
+// resource ID, derived from ExternalID. If ExternalID is a node pool resource ID,
+// it is used directly. If it is a descendant of a node pool, the parent node pool
+// resource ID is used.
+func activeOperationNodePoolIndexFunc(obj interface{}) ([]string, error) {
+	op, ok := obj.(*api.Operation)
+	if !ok {
+		return nil, fmt.Errorf("expected *api.Operation, got %T", obj)
+	}
+
+	return nodePoolResourceIDFromResourceID(op.ExternalID)
+}
+
+// activeOperationExternalAuthIndexFunc indexes operations by their associated
+// external auth resource ID, derived from ExternalID. If ExternalID is an external
+// auth resource ID, it is used directly. If it is a descendant of an external auth,
+// the parent external auth resource ID is used.
+func activeOperationExternalAuthIndexFunc(obj interface{}) ([]string, error) {
+	op, ok := obj.(*api.Operation)
+	if !ok {
+		return nil, fmt.Errorf("expected *api.Operation, got %T", obj)
+	}
+
+	return externalAuthResourceIDFromResourceID(op.ExternalID)
 }
 
 // nodePoolResourceIDIndexFunc indexes objects by the node pool resource ID of their nearest

--- a/backend/pkg/listers/active_operation_lister.go
+++ b/backend/pkg/listers/active_operation_lister.go
@@ -26,7 +26,18 @@ import (
 type ActiveOperationLister interface {
 	List(ctx context.Context) ([]*api.Operation, error)
 	Get(ctx context.Context, subscriptionID, name string) (*api.Operation, error)
+	// ListActiveOperationsForCluster returns active operations by their associated cluster.
+	// This includes operations whose ExternalID is the cluster itself and operations
+	// on child resources (node pools, external auths) under that cluster.
 	ListActiveOperationsForCluster(ctx context.Context, subscriptionName, resourceGroupName, clusterName string) ([]*api.Operation, error)
+	// ListActiveOperationsForNodePool returns active operations by their associated node pool.
+	// This includes operations whose ExternalID is the node pool itself and operations
+	// on descendant resources under that node pool.
+	ListActiveOperationsForNodePool(ctx context.Context, subscriptionName, resourceGroupName, clusterName, nodePoolName string) ([]*api.Operation, error)
+	// ListActiveOperationsForExternalAuth returns active operations by their associated external auth.
+	// This includes operations whose ExternalID is the external auth itself and operations
+	// on descendant resources under that external auth.
+	ListActiveOperationsForExternalAuth(ctx context.Context, subscriptionName, resourceGroupName, clusterName, externalAuthName string) ([]*api.Operation, error)
 }
 
 // activeOperationLister implements ActiveOperationLister backed by a SharedIndexInformer.
@@ -57,4 +68,14 @@ func (l *activeOperationLister) Get(ctx context.Context, subscriptionID, name st
 func (l *activeOperationLister) ListActiveOperationsForCluster(ctx context.Context, subscriptionName, resourceGroupName, clusterName string) ([]*api.Operation, error) {
 	key := api.ToClusterResourceIDString(subscriptionName, resourceGroupName, clusterName)
 	return listFromIndex[api.Operation](l.indexer, ByCluster, key)
+}
+
+func (l *activeOperationLister) ListActiveOperationsForNodePool(ctx context.Context, subscriptionName, resourceGroupName, clusterName, nodePoolName string) ([]*api.Operation, error) {
+	key := api.ToNodePoolResourceIDString(subscriptionName, resourceGroupName, clusterName, nodePoolName)
+	return listFromIndex[api.Operation](l.indexer, ByNodePool, key)
+}
+
+func (l *activeOperationLister) ListActiveOperationsForExternalAuth(ctx context.Context, subscriptionName, resourceGroupName, clusterName, externalAuthName string) ([]*api.Operation, error) {
+	key := api.ToExternalAuthResourceIDString(subscriptionName, resourceGroupName, clusterName, externalAuthName)
+	return listFromIndex[api.Operation](l.indexer, ByExternalAuth, key)
 }

--- a/backend/pkg/listertesting/db_listers.go
+++ b/backend/pkg/listertesting/db_listers.go
@@ -114,15 +114,31 @@ func (l *DBActiveOperationLister) Get(ctx context.Context, subscriptionID, name 
 	return l.ResourcesDBClient.Operations(subscriptionID).Get(ctx, name)
 }
 
+// ListActiveOperationsForCluster returns active operations for the cluster and its
+// child resources (node pools, external auths), matching production lister semantics.
 func (l *DBActiveOperationLister) ListActiveOperationsForCluster(ctx context.Context, subscriptionID, resourceGroupName, clusterName string) ([]*api.Operation, error) {
 	clusterKey := api.ToClusterResourceIDString(subscriptionID, resourceGroupName, clusterName)
+	return l.listByPrefix(ctx, clusterKey)
+}
+
+func (l *DBActiveOperationLister) ListActiveOperationsForNodePool(ctx context.Context, subscriptionID, resourceGroupName, clusterName, nodePoolName string) ([]*api.Operation, error) {
+	nodePoolKey := api.ToNodePoolResourceIDString(subscriptionID, resourceGroupName, clusterName, nodePoolName)
+	return l.listByPrefix(ctx, nodePoolKey)
+}
+
+func (l *DBActiveOperationLister) ListActiveOperationsForExternalAuth(ctx context.Context, subscriptionID, resourceGroupName, clusterName, externalAuthName string) ([]*api.Operation, error) {
+	externalAuthKey := api.ToExternalAuthResourceIDString(subscriptionID, resourceGroupName, clusterName, externalAuthName)
+	return l.listByPrefix(ctx, externalAuthKey)
+}
+
+func (l *DBActiveOperationLister) listByPrefix(ctx context.Context, prefix string) ([]*api.Operation, error) {
 	all, err := l.List(ctx)
 	if err != nil {
 		return nil, err
 	}
 	var result []*api.Operation
 	for _, op := range all {
-		if op.ExternalID != nil && strings.HasPrefix(strings.ToLower(op.ExternalID.String()), strings.ToLower(clusterKey)) {
+		if op.ExternalID != nil && strings.HasPrefix(strings.ToLower(op.ExternalID.String()), strings.ToLower(prefix)) {
 			result = append(result, op)
 		}
 	}

--- a/backend/pkg/listertesting/db_listers_test.go
+++ b/backend/pkg/listertesting/db_listers_test.go
@@ -155,8 +155,12 @@ func TestDBActiveOperationLister(t *testing.T) {
 	op1.Status = arm.ProvisioningStateProvisioning
 	op2 := newTestOperation(testSubscriptionID, "op2", testSubscriptionID, testResourceGroupName, testClusterName)
 	op2.Status = arm.ProvisioningStateProvisioning
+	npOp1 := newTestNodePoolOperation(testSubscriptionID, "np-op1", testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName)
+	npOp1.Status = arm.ProvisioningStateProvisioning
+	eaOp1 := newTestExternalAuthOperation(testSubscriptionID, "ea-op1", testSubscriptionID, testResourceGroupName, testClusterName, testExternalAuthName)
+	eaOp1.Status = arm.ProvisioningStateProvisioning
 
-	mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, []any{cluster, op1, op2})
+	mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, []any{cluster, op1, op2, npOp1, eaOp1})
 	require.NoError(t, err)
 
 	lister := &DBActiveOperationLister{ResourcesDBClient: mockResourcesDBClient}
@@ -164,7 +168,7 @@ func TestDBActiveOperationLister(t *testing.T) {
 	t.Run("List returns all active operations", func(t *testing.T) {
 		result, err := lister.List(ctx)
 		require.NoError(t, err)
-		assert.Len(t, result, 2)
+		assert.Len(t, result, 4)
 	})
 
 	t.Run("Get returns matching operation", func(t *testing.T) {
@@ -179,10 +183,24 @@ func TestDBActiveOperationLister(t *testing.T) {
 		assert.True(t, database.IsNotFoundError(err))
 	})
 
-	t.Run("ListActiveOperationsForCluster returns operations for cluster", func(t *testing.T) {
+	t.Run("ListActiveOperationsForCluster returns operations for cluster including child resources", func(t *testing.T) {
 		result, err := lister.ListActiveOperationsForCluster(ctx, testSubscriptionID, testResourceGroupName, testClusterName)
 		require.NoError(t, err)
-		assert.Len(t, result, 2)
+		assert.Len(t, result, 4)
+	})
+
+	t.Run("ListActiveOperationsForNodePool returns operations for node pool", func(t *testing.T) {
+		result, err := lister.ListActiveOperationsForNodePool(ctx, testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName)
+		require.NoError(t, err)
+		assert.Len(t, result, 1)
+		assert.Equal(t, "np-op1", result[0].OperationID.Name)
+	})
+
+	t.Run("ListActiveOperationsForExternalAuth returns operations for external auth", func(t *testing.T) {
+		result, err := lister.ListActiveOperationsForExternalAuth(ctx, testSubscriptionID, testResourceGroupName, testClusterName, testExternalAuthName)
+		require.NoError(t, err)
+		assert.Len(t, result, 1)
+		assert.Equal(t, "ea-op1", result[0].OperationID.Name)
 	})
 }
 
@@ -791,6 +809,100 @@ func TestDBActiveOperationListerWithUpdates(t *testing.T) {
 	})
 }
 
+func TestDBActiveOperationListerWithUpdates_ListActiveOperationsForNodePool(t *testing.T) {
+	ctx := context.Background()
+	mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
+
+	cluster := newTestCluster(testSubscriptionID, testResourceGroupName, testClusterName)
+	clusterCRUD := mockResourcesDBClient.HCPClusters(testSubscriptionID, testResourceGroupName)
+	_, err := clusterCRUD.Create(ctx, cluster, nil)
+	require.NoError(t, err)
+
+	np := newTestNodePool(testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName)
+	nodePoolCRUD := clusterCRUD.NodePools(testClusterName)
+	_, err = nodePoolCRUD.Create(ctx, np, nil)
+	require.NoError(t, err)
+
+	op := newTestNodePoolOperation(testSubscriptionID, "np-op1", testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName)
+	op.Status = arm.ProvisioningStateProvisioning
+
+	opCRUD := mockResourcesDBClient.Operations(testSubscriptionID)
+	createdOp, err := opCRUD.Create(ctx, op, nil)
+	require.NoError(t, err)
+
+	lister := &DBActiveOperationLister{ResourcesDBClient: mockResourcesDBClient}
+
+	t.Run("ListActiveOperationsForNodePool returns operation with Provisioning status", func(t *testing.T) {
+		result, err := lister.ListActiveOperationsForNodePool(ctx, testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName)
+		require.NoError(t, err)
+		assert.Len(t, result, 1)
+		assert.Equal(t, arm.ProvisioningStateProvisioning, result[0].Status)
+	})
+
+	createdOp.Status = arm.ProvisioningStateSucceeded
+	_, err = opCRUD.Replace(ctx, createdOp, nil)
+	require.NoError(t, err)
+
+	t.Run("ListActiveOperationsForNodePool excludes operation after update to terminal state", func(t *testing.T) {
+		result, err := lister.ListActiveOperationsForNodePool(ctx, testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName)
+		require.NoError(t, err)
+		assert.Empty(t, result)
+	})
+
+	t.Run("Get still returns operation even in terminal state", func(t *testing.T) {
+		result, err := lister.Get(ctx, testSubscriptionID, "np-op1")
+		require.NoError(t, err)
+		assert.Equal(t, arm.ProvisioningStateSucceeded, result.Status)
+	})
+}
+
+func TestDBActiveOperationListerWithUpdates_ListActiveOperationsForExternalAuth(t *testing.T) {
+	ctx := context.Background()
+	mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
+
+	cluster := newTestCluster(testSubscriptionID, testResourceGroupName, testClusterName)
+	clusterCRUD := mockResourcesDBClient.HCPClusters(testSubscriptionID, testResourceGroupName)
+	_, err := clusterCRUD.Create(ctx, cluster, nil)
+	require.NoError(t, err)
+
+	ea := newTestExternalAuth(testSubscriptionID, testResourceGroupName, testClusterName, testExternalAuthName)
+	externalAuthCRUD := clusterCRUD.ExternalAuth(testClusterName)
+	_, err = externalAuthCRUD.Create(ctx, ea, nil)
+	require.NoError(t, err)
+
+	op := newTestExternalAuthOperation(testSubscriptionID, "ea-op1", testSubscriptionID, testResourceGroupName, testClusterName, testExternalAuthName)
+	op.Status = arm.ProvisioningStateProvisioning
+
+	opCRUD := mockResourcesDBClient.Operations(testSubscriptionID)
+	createdOp, err := opCRUD.Create(ctx, op, nil)
+	require.NoError(t, err)
+
+	lister := &DBActiveOperationLister{ResourcesDBClient: mockResourcesDBClient}
+
+	t.Run("ListActiveOperationsForExternalAuth returns operation with Provisioning status", func(t *testing.T) {
+		result, err := lister.ListActiveOperationsForExternalAuth(ctx, testSubscriptionID, testResourceGroupName, testClusterName, testExternalAuthName)
+		require.NoError(t, err)
+		assert.Len(t, result, 1)
+		assert.Equal(t, arm.ProvisioningStateProvisioning, result[0].Status)
+	})
+
+	createdOp.Status = arm.ProvisioningStateSucceeded
+	_, err = opCRUD.Replace(ctx, createdOp, nil)
+	require.NoError(t, err)
+
+	t.Run("ListActiveOperationsForExternalAuth excludes operation after update to terminal state", func(t *testing.T) {
+		result, err := lister.ListActiveOperationsForExternalAuth(ctx, testSubscriptionID, testResourceGroupName, testClusterName, testExternalAuthName)
+		require.NoError(t, err)
+		assert.Empty(t, result)
+	})
+
+	t.Run("Get still returns operation even in terminal state", func(t *testing.T) {
+		result, err := lister.Get(ctx, testSubscriptionID, "ea-op1")
+		require.NoError(t, err)
+		assert.Equal(t, arm.ProvisioningStateSucceeded, result.Status)
+	})
+}
+
 // Tests for NewmockResourcesDBClientWithResources initialization helper
 
 func TestNewMockResourcesDBClientWithResources_Clusters(t *testing.T) {
@@ -890,8 +1002,12 @@ func TestNewMockResourcesDBClientWithResources_Operations(t *testing.T) {
 	op1.Status = arm.ProvisioningStateProvisioning
 	op2 := newTestOperation(testSubscriptionID, "op2", testSubscriptionID, testResourceGroupName, testClusterName)
 	op2.Status = arm.ProvisioningStateProvisioning
+	npOp1 := newTestNodePoolOperation(testSubscriptionID, "np-op1", testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName)
+	npOp1.Status = arm.ProvisioningStateProvisioning
+	eaOp1 := newTestExternalAuthOperation(testSubscriptionID, "ea-op1", testSubscriptionID, testResourceGroupName, testClusterName, testExternalAuthName)
+	eaOp1.Status = arm.ProvisioningStateProvisioning
 
-	mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, []any{cluster, op1, op2})
+	mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, []any{cluster, op1, op2, npOp1, eaOp1})
 	require.NoError(t, err)
 
 	lister := &DBActiveOperationLister{ResourcesDBClient: mockResourcesDBClient}
@@ -899,7 +1015,7 @@ func TestNewMockResourcesDBClientWithResources_Operations(t *testing.T) {
 	t.Run("List returns all initialized operations", func(t *testing.T) {
 		result, err := lister.List(ctx)
 		require.NoError(t, err)
-		assert.Len(t, result, 2)
+		assert.Len(t, result, 4)
 	})
 
 	t.Run("Get returns initialized operation", func(t *testing.T) {
@@ -908,10 +1024,24 @@ func TestNewMockResourcesDBClientWithResources_Operations(t *testing.T) {
 		assert.Equal(t, "op1", result.OperationID.Name)
 	})
 
-	t.Run("ListActiveOperationsForCluster returns operations for cluster", func(t *testing.T) {
+	t.Run("ListActiveOperationsForCluster returns operations for cluster including child resources", func(t *testing.T) {
 		result, err := lister.ListActiveOperationsForCluster(ctx, testSubscriptionID, testResourceGroupName, testClusterName)
 		require.NoError(t, err)
-		assert.Len(t, result, 2)
+		assert.Len(t, result, 4)
+	})
+
+	t.Run("ListActiveOperationsForNodePool returns operations for node pool", func(t *testing.T) {
+		result, err := lister.ListActiveOperationsForNodePool(ctx, testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName)
+		require.NoError(t, err)
+		assert.Len(t, result, 1)
+		assert.Equal(t, "np-op1", result[0].OperationID.Name)
+	})
+
+	t.Run("ListActiveOperationsForExternalAuth returns operations for external auth", func(t *testing.T) {
+		result, err := lister.ListActiveOperationsForExternalAuth(ctx, testSubscriptionID, testResourceGroupName, testClusterName, testExternalAuthName)
+		require.NoError(t, err)
+		assert.Len(t, result, 1)
+		assert.Equal(t, "ea-op1", result[0].OperationID.Name)
 	})
 }
 

--- a/backend/pkg/listertesting/slice_listers.go
+++ b/backend/pkg/listertesting/slice_listers.go
@@ -142,18 +142,34 @@ func (l *SliceActiveOperationLister) Get(ctx context.Context, subscriptionID, na
 	return nil, database.NewNotFoundError()
 }
 
+// ListActiveOperationsForCluster returns active operations for the cluster and its
+// child resources (node pools, external auths), matching production lister semantics.
 func (l *SliceActiveOperationLister) ListActiveOperationsForCluster(ctx context.Context, subscriptionID, resourceGroupName, clusterName string) ([]*api.Operation, error) {
 	clusterKey := api.ToClusterResourceIDString(subscriptionID, resourceGroupName, clusterName)
+	return l.listByPrefix(clusterKey), nil
+}
+
+func (l *SliceActiveOperationLister) ListActiveOperationsForNodePool(ctx context.Context, subscriptionID, resourceGroupName, clusterName, nodePoolName string) ([]*api.Operation, error) {
+	nodePoolKey := api.ToNodePoolResourceIDString(subscriptionID, resourceGroupName, clusterName, nodePoolName)
+	return l.listByPrefix(nodePoolKey), nil
+}
+
+func (l *SliceActiveOperationLister) ListActiveOperationsForExternalAuth(ctx context.Context, subscriptionID, resourceGroupName, clusterName, externalAuthName string) ([]*api.Operation, error) {
+	externalAuthKey := api.ToExternalAuthResourceIDString(subscriptionID, resourceGroupName, clusterName, externalAuthName)
+	return l.listByPrefix(externalAuthKey), nil
+}
+
+func (l *SliceActiveOperationLister) listByPrefix(prefix string) []*api.Operation {
 	var result []*api.Operation
 	for _, op := range l.Operations {
 		if op.ExternalID == nil {
 			continue
 		}
-		if strings.HasPrefix(strings.ToLower(op.ExternalID.String()), strings.ToLower(clusterKey)) {
+		if strings.HasPrefix(strings.ToLower(op.ExternalID.String()), strings.ToLower(prefix)) {
 			result = append(result, op)
 		}
 	}
-	return result, nil
+	return result
 }
 
 // SliceExternalAuthLister implements listers.ExternalAuthLister backed by a slice.

--- a/backend/pkg/listertesting/slice_listers_test.go
+++ b/backend/pkg/listertesting/slice_listers_test.go
@@ -117,12 +117,17 @@ func TestSliceNodePoolLister(t *testing.T) {
 }
 
 func TestSliceActiveOperationLister(t *testing.T) {
-	op1 := newTestOperation(testSubscriptionID, "op1", testSubscriptionID, testResourceGroupName, testClusterName)
-	op2 := newTestOperation(testSubscriptionID, "op2", testSubscriptionID, testResourceGroupName, testClusterName)
-	op3 := newTestOperation(testSubscriptionID, "op3", testSubscriptionID, testResourceGroupName, testClusterName2)
+	clusterOp1 := newTestOperation(testSubscriptionID, "op1", testSubscriptionID, testResourceGroupName, testClusterName)
+	clusterOp2 := newTestOperation(testSubscriptionID, "op2", testSubscriptionID, testResourceGroupName, testClusterName)
+	clusterOp3 := newTestOperation(testSubscriptionID, "op3", testSubscriptionID, testResourceGroupName, testClusterName2)
+	npOp1 := newTestNodePoolOperation(testSubscriptionID, "np-op1", testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName)
+	npOp2 := newTestNodePoolOperation(testSubscriptionID, "np-op2", testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName)
+	npOp3 := newTestNodePoolOperation(testSubscriptionID, "np-op3", testSubscriptionID, testResourceGroupName, testClusterName, "nodepool-2")
+	eaOp1 := newTestExternalAuthOperation(testSubscriptionID, "ea-op1", testSubscriptionID, testResourceGroupName, testClusterName, testExternalAuthName)
+	eaOp2 := newTestExternalAuthOperation(testSubscriptionID, "ea-op2", testSubscriptionID, testResourceGroupName, testClusterName, "external-auth-2")
 
 	lister := &SliceActiveOperationLister{
-		Operations: []*api.Operation{op1, op2, op3},
+		Operations: []*api.Operation{clusterOp1, clusterOp2, clusterOp3, npOp1, npOp2, npOp3, eaOp1, eaOp2},
 	}
 
 	ctx := context.Background()
@@ -130,7 +135,7 @@ func TestSliceActiveOperationLister(t *testing.T) {
 	t.Run("List returns all operations", func(t *testing.T) {
 		result, err := lister.List(ctx)
 		require.NoError(t, err)
-		assert.Len(t, result, 3)
+		assert.Len(t, result, 8)
 	})
 
 	t.Run("Get returns matching operation", func(t *testing.T) {
@@ -145,10 +150,22 @@ func TestSliceActiveOperationLister(t *testing.T) {
 		assert.True(t, database.IsNotFoundError(err))
 	})
 
-	t.Run("ListActiveOperationsForCluster returns operations for cluster", func(t *testing.T) {
+	t.Run("ListActiveOperationsForCluster returns operations for cluster including child resources", func(t *testing.T) {
 		result, err := lister.ListActiveOperationsForCluster(ctx, testSubscriptionID, testResourceGroupName, testClusterName)
 		require.NoError(t, err)
+		assert.Len(t, result, 7)
+	})
+
+	t.Run("ListActiveOperationsForNodePool returns operations for node pool", func(t *testing.T) {
+		result, err := lister.ListActiveOperationsForNodePool(ctx, testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName)
+		require.NoError(t, err)
 		assert.Len(t, result, 2)
+	})
+
+	t.Run("ListActiveOperationsForExternalAuth returns operations for external auth", func(t *testing.T) {
+		result, err := lister.ListActiveOperationsForExternalAuth(ctx, testSubscriptionID, testResourceGroupName, testClusterName, testExternalAuthName)
+		require.NoError(t, err)
+		assert.Len(t, result, 1)
 	})
 }
 
@@ -367,6 +384,46 @@ func newTestOperation(subscriptionID, operationName, targetSubscription, targetR
 		"/subscriptions/" + targetSubscription +
 			"/resourceGroups/" + targetResourceGroup +
 			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + targetCluster,
+	))
+	return &api.Operation{
+		CosmosMetadata: arm.CosmosMetadata{
+			ResourceID: operationResourceID,
+		},
+		OperationID: operationResourceID,
+		ExternalID:  externalID,
+	}
+}
+
+func newTestNodePoolOperation(subscriptionID, operationName, targetSubscription, targetResourceGroup, targetCluster, nodePoolName string) *api.Operation {
+	operationResourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + subscriptionID +
+			"/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/" + operationName,
+	))
+	externalID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + targetSubscription +
+			"/resourceGroups/" + targetResourceGroup +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + targetCluster +
+			"/nodePools/" + nodePoolName,
+	))
+	return &api.Operation{
+		CosmosMetadata: arm.CosmosMetadata{
+			ResourceID: operationResourceID,
+		},
+		OperationID: operationResourceID,
+		ExternalID:  externalID,
+	}
+}
+
+func newTestExternalAuthOperation(subscriptionID, operationName, targetSubscription, targetResourceGroup, targetCluster, externalAuthName string) *api.Operation {
+	operationResourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + subscriptionID +
+			"/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/" + operationName,
+	))
+	externalID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + targetSubscription +
+			"/resourceGroups/" + targetResourceGroup +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + targetCluster +
+			"/externalAuths/" + externalAuthName,
 	))
 	return &api.Operation{
 		CosmosMetadata: arm.CosmosMetadata{

--- a/frontend/pkg/frontend/cluster.go
+++ b/frontend/pkg/frontend/cluster.go
@@ -17,7 +17,6 @@ package frontend
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"maps"
 	"net/http"
@@ -31,8 +30,6 @@ import (
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
-
-	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
 
 	"github.com/Azure/ARO-HCP/internal/admission"
 	"github.com/Azure/ARO-HCP/internal/api"
@@ -787,27 +784,9 @@ func (f *Frontend) DeleteCluster(writer http.ResponseWriter, request *http.Reque
 }
 
 func (f *Frontend) addDeleteClusterToTransaction(ctx context.Context, writer http.ResponseWriter, request *http.Request, transaction database.DBTransaction, cluster *api.HCPOpenShiftCluster) error {
-	logger := utils.LoggerFromContext(ctx)
-
 	correlationData, err := CorrelationDataFromContext(ctx)
 	if err != nil {
 		return utils.TrackError(err)
-	}
-
-	if cluster.ServiceProviderProperties.ClusterServiceID != nil {
-		err = f.clusterServiceClient.DeleteCluster(ctx, *cluster.ServiceProviderProperties.ClusterServiceID)
-		var ocmError *ocmerrors.Error
-		if errors.As(err, &ocmError) && ocmError.Status() == http.StatusNotFound {
-			// StatusNotFound means we have stale data in Cosmos DB.
-			// This can happen in test environments if a user bypasses
-			// the RP to delete a resource (e.g. "ocm delete"). It can
-			// also happen if an asynchronous deletion operation fails.
-			// we will fall through and cancel all operations and go through as normal a deletion flow as we can to avoid
-			// leaking data related to the resource, like controller status.
-			logger.Info("clusterService cluster missing, trying to clean up", "err", err)
-		} else if err != nil {
-			return utils.TrackError(err)
-		}
 	}
 
 	// Cluster Service will take care of canceling any ongoing operations
@@ -825,19 +804,18 @@ func (f *Frontend) addDeleteClusterToTransaction(ctx context.Context, writer htt
 		return utils.TrackError(err)
 	}
 
-	clusterServiceID := api.InternalID{}
-	if cluster.ServiceProviderProperties.ClusterServiceID != nil {
-		clusterServiceID = *cluster.ServiceProviderProperties.ClusterServiceID
-	}
 	operationDoc := database.NewOperation(
 		database.OperationRequestDelete,
 		cluster.ID,
-		clusterServiceID,
+		api.InternalID{},
 		f.azureLocation,
 		"",
 		"",
 		"",
 		correlationData)
+	// TODO remove this once migration of the new cluster deletion from frontend to backend approach is fully completed in all ARO-HCP
+	// permanent environments, for all regions.
+	operationDoc.UsesNewClusterDeletionApproach = true
 	if request != nil {
 		// these are optional because when this is triggered via the subscription deletion flow, there is no
 		// deletion request containing these headers so these operations cannot be directly tracked.
@@ -856,6 +834,9 @@ func (f *Frontend) addDeleteClusterToTransaction(ctx context.Context, writer htt
 	}
 	cluster.ServiceProviderProperties.ActiveOperationID = operationDoc.ResourceID.Name
 	cluster.ServiceProviderProperties.ProvisioningState = operationDoc.Status
+	// TODO remove this once migration of the new cluster deletion from frontend to backend approach is fully completed in all ARO-HCP
+	// permanent environments, for all regions.
+	cluster.ServiceProviderProperties.UsesNewClusterDeletionApproach = true
 	_, err = f.resourcesDBClient.HCPClusters(cluster.ID.SubscriptionID, cluster.ID.ResourceGroupName).
 		AddReplaceToTransaction(ctx, transaction, cluster, nil)
 	if err != nil {

--- a/frontend/pkg/frontend/external_auth.go
+++ b/frontend/pkg/frontend/external_auth.go
@@ -17,7 +17,6 @@ package frontend
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -28,8 +27,6 @@ import (
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
-
-	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
 
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
@@ -581,26 +578,6 @@ func (f *Frontend) DeleteExternalAuth(writer http.ResponseWriter, request *http.
 
 	logger.Info(fmt.Sprintf("deleting resource %s", externalAuth.ID))
 
-	// Temporary check until creation and deletion interaction with CS is moved to the backend: if a delete arrives and the external
-	// auth has not been created in CS or the ClusterServiceID reference has not been persisted in Cosmos, return an error.
-	if externalAuth.ServiceProviderProperties.ClusterServiceID == nil || len(externalAuth.ServiceProviderProperties.ClusterServiceID.String()) == 0 {
-		return utils.TrackError(fmt.Errorf("serviceProviderProperties.clusterServiceID is required to delete an external auth"))
-	}
-
-	err = f.clusterServiceClient.DeleteExternalAuth(ctx, *externalAuth.ServiceProviderProperties.ClusterServiceID)
-	var ocmError *ocmerrors.Error
-	if errors.As(err, &ocmError) && ocmError.Status() == http.StatusNotFound {
-		// StatusNotFound means we have stale data in Cosmos DB.
-		// This can happen in test environments if a user bypasses
-		// the RP to delete a resource (e.g. "ocm delete"). It can
-		// also happen if an asynchronous deletion operation fails.
-		// we will fall through and cancel all operations and go through as normal a deletion flow as we can to avoid
-		// leaking data related to the resource, like controller status.
-		logger.Info("clusterService externalauth missing, trying to clean up", "err", err)
-	} else if err != nil {
-		return utils.TrackError(err)
-	}
-
 	transaction := f.resourcesDBClient.NewTransaction(externalAuth.ID.SubscriptionID)
 	if err := f.addDeleteExternalAuthToTransaction(ctx, writer, request, transaction, externalAuth); err != nil {
 		return utils.TrackError(err)
@@ -631,21 +608,18 @@ func (f *Frontend) addDeleteExternalAuthToTransaction(ctx context.Context, write
 		return utils.TrackError(err)
 	}
 
-	// Temporary check until creation and deletion interaction with CS is moved to the backend: if a delete arrives and the external
-	// auth has not been created in CS or the ClusterServiceID reference has not been persisted in Cosmos, return an error.
-	if externalAuth.ServiceProviderProperties.ClusterServiceID == nil || len(externalAuth.ServiceProviderProperties.ClusterServiceID.String()) == 0 {
-		return utils.TrackError(fmt.Errorf("serviceProviderProperties.clusterServiceID is required to delete an external auth"))
-	}
-
 	operationDoc := database.NewOperation(
 		database.OperationRequestDelete,
 		externalAuth.ID,
-		*externalAuth.ServiceProviderProperties.ClusterServiceID,
+		api.InternalID{},
 		f.azureLocation,
 		"",
 		"",
 		"",
 		correlationData)
+	// TODO remove this once migration of the new external auth deletion from frontend to backend approach is fully completed in all ARO-HCP
+	// permanent environments, for all regions.
+	operationDoc.UsesNewExternalAuthDeletionApproach = true
 	if request != nil {
 		// these are optional because when this is triggered via the subscription deletion flow, there is no
 		// deletion request containing these headers so these operations cannot be directly tracked.
@@ -664,6 +638,9 @@ func (f *Frontend) addDeleteExternalAuthToTransaction(ctx context.Context, write
 	}
 	externalAuth.ServiceProviderProperties.ActiveOperationID = operationDoc.ResourceID.Name
 	externalAuth.Properties.ProvisioningState = operationDoc.Status
+	// TODO remove this once migration of the new external auth deletion from frontend to backend approach is fully completed in all ARO-HCP
+	// permanent environments, for all regions.
+	externalAuth.ServiceProviderProperties.UsesNewExternalAuthDeletionApproach = true
 	_, err = f.resourcesDBClient.HCPClusters(externalAuth.ID.SubscriptionID, externalAuth.ID.ResourceGroupName).ExternalAuth(externalAuth.ID.Parent.Name).
 		AddReplaceToTransaction(ctx, transaction, externalAuth, nil)
 	if err != nil {

--- a/frontend/pkg/frontend/node_pool.go
+++ b/frontend/pkg/frontend/node_pool.go
@@ -17,7 +17,6 @@ package frontend
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"maps"
 	"net/http"
@@ -30,8 +29,6 @@ import (
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
-
-	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
 
 	"github.com/Azure/ARO-HCP/internal/admission"
 	"github.com/Azure/ARO-HCP/internal/api"
@@ -734,26 +731,6 @@ func (f *Frontend) DeleteNodePool(writer http.ResponseWriter, request *http.Requ
 		return utils.TrackError(err)
 	}
 
-	// Temporary check until creation and deletion interaction with CS is moved to the backend: if a delete arrives and the node
-	// pool has not been created in CS or the ClusterServiceID reference has not been persisted in Cosmos, return an error.
-	if nodePool.ServiceProviderProperties.ClusterServiceID == nil || len(nodePool.ServiceProviderProperties.ClusterServiceID.String()) == 0 {
-		return utils.TrackError(fmt.Errorf("serviceProviderProperties.clusterServiceID is required to delete a node pool"))
-	}
-
-	err = f.clusterServiceClient.DeleteNodePool(ctx, *nodePool.ServiceProviderProperties.ClusterServiceID)
-	var ocmError *ocmerrors.Error
-	if errors.As(err, &ocmError) && ocmError.Status() == http.StatusNotFound {
-		// StatusNotFound means we have stale data in Cosmos DB.
-		// This can happen in test environments if a user bypasses
-		// the RP to delete a resource (e.g. "ocm delete"). It can
-		// also happen if an asynchronous deletion operation fails.
-		// we will fall through and cancel all operations and go through as normal a deletion flow as we can to avoid
-		// leaking data related to the resource, like controller status.
-		logger.Info("clusterService nodepool missing, trying to clean up", "err", err)
-	} else if err != nil {
-		return utils.TrackError(err)
-	}
-
 	transaction := f.resourcesDBClient.NewTransaction(nodePool.ID.SubscriptionID)
 	if err := f.addDeleteNodePoolToTransaction(ctx, writer, request, transaction, nodePool); err != nil {
 		return utils.TrackError(err)
@@ -784,21 +761,18 @@ func (f *Frontend) addDeleteNodePoolToTransaction(ctx context.Context, writer ht
 		return utils.TrackError(err)
 	}
 
-	// Temporary check until creation and deletion interaction with CS is moved to the backend: if a delete arrives and the node pool
-	// has not been created in CS or the ClusterServiceID reference has not been persisted in Cosmos, return an error.
-	if nodePool.ServiceProviderProperties.ClusterServiceID == nil || len(nodePool.ServiceProviderProperties.ClusterServiceID.String()) == 0 {
-		return utils.TrackError(fmt.Errorf("serviceProviderProperties.clusterServiceID is required to delete a node pool"))
-	}
-
 	operationDoc := database.NewOperation(
 		database.OperationRequestDelete,
 		nodePool.ID,
-		*nodePool.ServiceProviderProperties.ClusterServiceID,
+		api.InternalID{},
 		f.azureLocation,
 		"",
 		"",
 		"",
 		correlationData)
+	// TODO remove this once migration of the new node pool deletion from frontend to backend approach is fully completed in all ARO-HCP
+	// permanent environments, for all regions.
+	operationDoc.UsesNewNodePoolDeletionApproach = true
 	if request != nil {
 		// these are optional because when this is triggered via the subscription deletion flow, there is no
 		// deletion request containing these headers so these operations cannot be directly tracked.
@@ -817,6 +791,9 @@ func (f *Frontend) addDeleteNodePoolToTransaction(ctx context.Context, writer ht
 	}
 	nodePool.ServiceProviderProperties.ActiveOperationID = operationDoc.ResourceID.Name
 	nodePool.Properties.ProvisioningState = operationDoc.Status
+	// TODO remove this once migration of the new node pool deletion from frontend to backend approach is fully completed in all ARO-HCP
+	// permanent environments, for all regions.
+	nodePool.ServiceProviderProperties.UsesNewNodePoolDeletionApproach = true
 	_, err = f.resourcesDBClient.HCPClusters(nodePool.ID.SubscriptionID, nodePool.ID.ResourceGroupName).NodePools(nodePool.ID.Parent.Name).
 		AddReplaceToTransaction(ctx, transaction, nodePool, nil)
 	if err != nil {

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-cluster-operation/03-cosmosCompare-final-state/cluster-test-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-cluster-operation/03-cosmosCompare-final-state/cluster-test-cluster.json
@@ -69,7 +69,7 @@
 			"managedIdentitiesDataPlaneIdentityURL": "https://dummyhost.identity.azure.net/otherinformation?aqueryarg=somevalue",
 			"platform": {},
 			"provisioningState": "Deleting",
-			"usesNewClusterDeletionApproach": false
+			"usesNewClusterDeletionApproach": true
 		},
 		"status": {},
 		"systemData": {

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-cluster-operation/03-cosmosCompare-final-state/operation-cluster-delete.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-cluster-operation/03-cosmosCompare-final-state/operation-cluster-delete.json
@@ -5,7 +5,7 @@
 		"request": "Delete",
 		"status": "Deleting",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewClusterDeletionApproach": false,
+		"usesNewClusterDeletionApproach": true,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/cluster-test-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/cluster-test-cluster.json
@@ -69,7 +69,7 @@
 			"managedIdentitiesDataPlaneIdentityURL": "https://dummyhost.identity.azure.net/otherinformation?aqueryarg=somevalue",
 			"platform": {},
 			"provisioningState": "Deleting",
-			"usesNewClusterDeletionApproach": false
+			"usesNewClusterDeletionApproach": true
 		},
 		"status": {},
 		"systemData": {

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/nodepool-test-nodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/nodepool-test-nodepool.json
@@ -43,7 +43,7 @@
 			}
 		},
 		"serviceProviderProperties": {
-			"usesNewNodePoolDeletionApproach": false
+			"usesNewNodePoolDeletionApproach": true
 		},
 		"status": {},
 		"systemData": {

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/operation-cluster-delete.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/operation-cluster-delete.json
@@ -5,7 +5,7 @@
 		"request": "Delete",
 		"status": "Deleting",
 		"tenantId": "00000000-0000-0000-0000-000000000000",
-		"usesNewClusterDeletionApproach": false,
+		"usesNewClusterDeletionApproach": true,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false
 	},

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/operation-nodepool-delete.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/05-cosmosCompare-final-state/operation-nodepool-delete.json
@@ -6,7 +6,7 @@
 		"status": "Deleting",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
-		"usesNewNodePoolDeletionApproach": false
+		"usesNewNodePoolDeletionApproach": true
 	},
 	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",
 	"ttl": 604800

--- a/test/e2e/external_auth_list_and_verify.go
+++ b/test/e2e/external_auth_list_and_verify.go
@@ -17,13 +17,16 @@ package e2e
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"k8s.io/apimachinery/pkg/util/rand"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 
 	hcpsdk "github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
@@ -198,6 +201,40 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to get updated external auth config from cluster %s", clusterName)
 			Expect(*updatedResult.Properties.ProvisioningState).To(Equal(hcpsdk.ExternalAuthProvisioningStateSucceeded), "updated external auth provisioning state should be Succeeded")
 			Expect(*updatedResult.Properties.Claim.Mappings.Username.Prefix).To(Equal(*expectedExternalAuth.Properties.Claim.Mappings.Username.Prefix), "updated external auth Username.Prefix should match expected value")
+
+			By("deleting the external auth")
+			err = framework.DeleteExternalAuthAndWait20240610(
+				ctx,
+				externalAuthClient,
+				*resourceGroup.Name,
+				clusterName,
+				*expectedExternalAuth.Name,
+				framework.ExternalAuthDeletionTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to delete external auth config on cluster %s", clusterName)
+
+			By("confirming the external auth has been deleted")
+			_, getErr := framework.GetExternalAuth20240610(
+				ctx,
+				externalAuthClient,
+				*resourceGroup.Name,
+				clusterName,
+				*expectedExternalAuth.Name,
+			)
+			Expect(getErr).To(HaveOccurred(), "expected error when getting deleted external auth %s on cluster %s", *expectedExternalAuth.Name, clusterName)
+			var respErr *azcore.ResponseError
+			Expect(errors.As(getErr, &respErr)).To(BeTrue(), "expected azcore.ResponseError when getting deleted external auth %s", *expectedExternalAuth.Name)
+			Expect(respErr.StatusCode).To(Equal(http.StatusNotFound), "expected HTTP 404 when getting deleted external auth %s", *expectedExternalAuth.Name)
+
+			By("confirming list returns no external auth configs")
+			var extAuthCount int
+			pager = externalAuthClient.NewListByParentPager(*resourceGroup.Name, clusterName, nil)
+			for pager.More() {
+				page, err := pager.NextPage(ctx)
+				Expect(err).NotTo(HaveOccurred(), "failed to list external auth configs on cluster %s after delete", clusterName)
+				extAuthCount += len(page.Value)
+			}
+			Expect(extAuthCount).To(Equal(0), "expected no external auth configs on cluster %s after delete", clusterName)
 
 		})
 })

--- a/test/util/framework/constants.go
+++ b/test/util/framework/constants.go
@@ -28,7 +28,8 @@ const (
 
 // Deletion timeouts
 const (
-	HCPClusterDeletionTimeout = 45 * time.Minute
+	HCPClusterDeletionTimeout   = 45 * time.Minute
+	ExternalAuthDeletionTimeout = 25 * time.Minute
 )
 
 // Resource Update timeouts


### PR DESCRIPTION
This PR enables the deletion process of clusters, nodepools and externalauth to occur through backend controllers.

This includes removing CS delete interaction in frontend, occurring now in the backend.