### PR TITLE
fix(recreate-broken-pools): ensure accelerated-networking on new node pools (AROSLSRE-1172)

### DIFF
--- a/dev-infrastructure/scripts/recreate-broken-pools/go.mod
+++ b/dev-infrastructure/scripts/recreate-broken-pools/go.mod
@@ -5,6 +5,7 @@ go 1.25.7
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6 v6.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v6 v6.6.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor v0.11.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0

--- a/dev-infrastructure/scripts/recreate-broken-pools/go.sum
+++ b/dev-infrastructure/scripts/recreate-broken-pools/go.sum
@@ -6,6 +6,8 @@ github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.4.0 h1:xFaZZ+IubdftrDH
 github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.4.0/go.mod h1:mCBhUhlMjLLJKr5aqw2TNS/VqJOie8MzWq3DAMJeKso=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 h1:fhqpLE3UEXi9lPaBRpQ6XuRW0nU7hgg4zlmZZa+a9q4=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0/go.mod h1:7dCRMLwisfRH3dBupKeNCioWYUZ4SS09Z14H+7i8ZoY=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6 v6.3.0 h1:Dc9miZr1Mhaqbb3cmJCRokkG16uk8JKkqOADf084zy4=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6 v6.3.0/go.mod h1:CHo9QYhWEvrKVeXsEMJSl2bpmYYNu6aG12JsSaFBXlY=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice v1.0.0 h1:figxyQZXzZQIcP3njhC68bYUiTw45J8/SsHaLW8Ax0M=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice v1.0.0/go.mod h1:TmlMW4W5OvXOmOyKNnor8nlMMiO1ctIyzmHme/VHsrA=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v5 v5.0.0 h1:5n7dPVqsWfVKw+ZiEKSd3Kzu7gwBkbEBkeXb8rgaE9Q=

--- a/dev-infrastructure/scripts/recreate-broken-pools/main.go
+++ b/dev-infrastructure/scripts/recreate-broken-pools/main.go
@@ -1284,7 +1284,7 @@ func (c *clients) detect(ctx context.Context) ([]nodePoolTarget, string, error) 
 	}
 
 	if len(wedged) == 0 && len(anBroken) == 0 {
-		return nil, fmt.Sprintf("no selected node pools with %s=%q are in wedge-compatible state or missing Swift accelerated-networking", nodePoolRoleLabel, c.cfg.nodePoolTag), nil
+		return nil, fmt.Sprintf("no selected node pools with %s=%q are in wedge-compatible state or have Swift accelerated-networking disabled", nodePoolRoleLabel, c.cfg.nodePoolTag), nil
 	}
 
 	var targets []nodePoolTarget

--- a/dev-infrastructure/scripts/recreate-broken-pools/main.go
+++ b/dev-infrastructure/scripts/recreate-broken-pools/main.go
@@ -1819,10 +1819,11 @@ func tempPoolReadyTimeout(wantReady int) time.Duration {
 // pool). To guard against this, every pool this binary creates (the temp pool
 // AND the recreated source pool) is first created with zero nodes so AKS
 // materializes the VMSS empty; we then verify — and if necessary patch —
-// accelerated-networking on the empty VMSS against a reference pool before
-// scaling up, so every node that boots inherits the corrected NIC config with
-// no reimage. If the corrected value cannot be confirmed we refuse to scale
-// up rather than create Swift-broken nodes.
+// accelerated-networking on the empty VMSS before scaling up, so every node that
+// boots inherits the corrected NIC config with no reimage. The check fails OPEN
+// (logs a WARN and proceeds) when the VMSS can't be located or its value is
+// indeterminate; it fails CLOSED (refuses to scale up) only when a known-wrong,
+// required value cannot be corrected, rather than create Swift-broken nodes.
 // ---------------------------------------------------------------------------
 
 // accelNetDecision is the outcome of comparing a pool's VMSS
@@ -1868,24 +1869,30 @@ func decideAccelNetworking(swiftRequired, refAN, refFound, tgtAN, tgtFound bool)
 
 // vmssAcceleratedNetworking reports the accelerated-networking value of a VMSS,
 // derived from its NIC configurations. found is false when the VMSS carries no
-// NIC config with an explicit value. When multiple NIC configs disagree the
-// result is the logical OR (enabled if any NIC has it enabled), which is the
-// conservative choice for a Swift-capable pool.
+// NIC config with an explicit value. enabled is the logical AND across all NIC
+// configs that carry an explicit value: a Swift pod can be scheduled onto any
+// node NIC, so a single NIC with accelerated-networking disabled makes the pool
+// Swift-broken. enabled is therefore true only when EVERY explicit NIC has it
+// enabled.
 func vmssAcceleratedNetworking(vmss *armcompute.VirtualMachineScaleSet) (enabled bool, found bool) {
 	if vmss == nil || vmss.Properties == nil || vmss.Properties.VirtualMachineProfile == nil ||
 		vmss.Properties.VirtualMachineProfile.NetworkProfile == nil {
 		return false, false
 	}
+	enabled = true
 	for _, nic := range vmss.Properties.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations {
 		if nic == nil || nic.Properties == nil || nic.Properties.EnableAcceleratedNetworking == nil {
 			continue
 		}
 		found = true
-		if *nic.Properties.EnableAcceleratedNetworking {
-			enabled = true
+		if !*nic.Properties.EnableAcceleratedNetworking {
+			enabled = false
 		}
 	}
-	return enabled, found
+	if !found {
+		return false, false
+	}
+	return enabled, true
 }
 
 // tagValue returns the value of an Azure resource tag, or "" if absent/nil.
@@ -1899,13 +1906,12 @@ func tagValue(tags map[string]*string, key string) string {
 	return ""
 }
 
-// matchPoolVMSS picks the backing VMSS of poolName from a pre-listed slice. It
-// matches first on the authoritative aks-managed-poolName tag and falls back to
-// the deterministic aks-<poolName>- name prefix. Returns ("", nil) when none.
+// matchPoolVMSS picks the backing VMSS of poolName from a pre-listed slice by
+// the authoritative aks-managed-poolName tag that AKS stamps on every VMSS it
+// manages (including freshly created 0-node pools). Returns ("", nil) when no
+// VMSS carries the tag — we deliberately do NOT guess by name convention, since
+// a wrong VMSS here would patch or recreate the wrong pool.
 func matchPoolVMSS(all []*armcompute.VirtualMachineScaleSet, poolName string) (string, *armcompute.VirtualMachineScaleSet) {
-	prefix := poolVMSSPrefix(poolName)
-	var fbName string
-	var fb *armcompute.VirtualMachineScaleSet
 	for _, v := range all {
 		if v == nil || v.Name == nil {
 			continue
@@ -1913,11 +1919,8 @@ func matchPoolVMSS(all []*armcompute.VirtualMachineScaleSet, poolName string) (s
 		if tagValue(v.Tags, aksManagedPoolNameTag) == poolName {
 			return *v.Name, v
 		}
-		if strings.HasPrefix(*v.Name, prefix) && fb == nil {
-			fbName, fb = *v.Name, v
-		}
 	}
-	return fbName, fb
+	return "", nil
 }
 
 // listNodeRGVMSS lists every VMSS in the node resource group once.
@@ -1938,8 +1941,7 @@ func (c *clients) listNodeRGVMSS(ctx context.Context) ([]*armcompute.VirtualMach
 }
 
 // findPoolVMSS locates the backing VMSS of an agent pool in the node resource
-// group. It matches first on the authoritative aks-managed-poolName tag and
-// falls back to the deterministic aks-<poolName>- name prefix.
+// group by the authoritative aks-managed-poolName tag.
 func (c *clients) findPoolVMSS(ctx context.Context, poolName string) (string, *armcompute.VirtualMachineScaleSet, error) {
 	all, err := c.listNodeRGVMSS(ctx)
 	if err != nil {
@@ -1949,7 +1951,7 @@ func (c *clients) findPoolVMSS(ctx context.Context, poolName string) (string, *a
 	if vmss != nil {
 		return name, vmss, nil
 	}
-	return "", nil, fmt.Errorf("no VMSS found for pool %s in %s (tag %s or name prefix %s)", poolName, c.cfg.nodeRG, aksManagedPoolNameTag, poolVMSSPrefix(poolName))
+	return "", nil, fmt.Errorf("no VMSS found for pool %s in %s (tag %s=%s)", poolName, c.cfg.nodeRG, aksManagedPoolNameTag, poolName)
 }
 
 // detectAccelNetBrokenPools inspects the live backing VMSS of each Swift pool
@@ -2014,8 +2016,11 @@ func (c *clients) waitForPoolVMSS(ctx context.Context, poolName string, timeout 
 // patchVMSSAccelNetworking sets accelerated-networking to want on every NIC
 // configuration of the VMSS via a read-modify-write full PUT. A full PUT
 // (rather than a partial Update) is used so the existing IP configurations and
-// subnet bindings are preserved verbatim. Patching an AKS-managed VMSS is
-// unsupported, so callers must re-verify the value afterwards.
+// subnet bindings are preserved verbatim. Directly patching an AKS-managed VMSS
+// is unsupported by AKS, but Microsoft explicitly asked us to do this in ICM
+// 815156644 as the mitigation for the RP bringing Swift VMSS up with
+// accelerated-networking disabled; callers must re-verify the value afterwards
+// because AKS may reconcile it back.
 func (c *clients) patchVMSSAccelNetworking(ctx context.Context, vmssName string, want bool) error {
 	resp, err := c.vmss.Get(ctx, c.cfg.nodeRG, vmssName, nil)
 	if err != nil {
@@ -2080,7 +2085,7 @@ func (c *clients) ensurePoolAccelNetworking(ctx context.Context, poolName, refPo
 	logf("pool %s accelerated-networking check: swiftRequired=%t reference(%s)=%t(found=%t) target=%t(found=%t): %s",
 		poolName, swiftRequired, refPool, refAN, refFound, tgtAN, tgtFound, d.reason)
 	if !d.patch {
-		return false, false, nil
+		return false, d.want, nil
 	}
 	if err := c.patchVMSSAccelNetworking(ctx, tgtName, d.want); err != nil {
 		return false, false, fmt.Errorf("pool %s: patch VMSS %s accelerated-networking=%t: %w", poolName, tgtName, d.want, err)
@@ -2109,7 +2114,11 @@ func (c *clients) verifyPoolAccelNetworking(ctx context.Context, poolName string
 		return nil
 	}
 	got, found := vmssAcceleratedNetworking(vmss)
-	if found && got != want {
+	if !found {
+		logf("WARN: pool %s: accelerated-networking indeterminate on VMSS after scale-up; skipping post-scale confirmation", poolName)
+		return nil
+	}
+	if got != want {
 		return fmt.Errorf("pool %s: accelerated-networking regressed to %t (want %t) after scale-up; AKS reconciled the VMSS back to the broken value — refusing to use Swift-broken nodes, manual intervention required", poolName, got, want)
 	}
 	logf("pool %s: accelerated-networking=%t confirmed after scale-up", poolName, want)

--- a/dev-infrastructure/scripts/recreate-broken-pools/main.go
+++ b/dev-infrastructure/scripts/recreate-broken-pools/main.go
@@ -165,6 +165,17 @@ const (
 	// aks-<poolName>-<hash>-vmss but the tag is exact).
 	aksManagedPoolNameTag = "aks-managed-poolName"
 
+	// swiftNodepoolTag is the tag the AKS provisioning bicep stamps on
+	// Swift V2 multi-tenancy node pools (enableSwiftV2Nodepools=true). A
+	// pool carrying this tag with value "true" hosts pods on delegated
+	// Swift NICs, which cannot attach unless the backing VMSS has
+	// accelerated-networking enabled. It is therefore both the marker that
+	// a pool REQUIRES accelerated-networking (AROSLSRE-1172) and the signal
+	// used to detect Swift pools whose VMSS came up with it disabled.
+	// Source: dev-infrastructure/modules/aks-cluster-base.bicep (swiftNodepoolTags).
+	swiftNodepoolTag      = "aks-nic-enable-multi-tenancy"
+	swiftNodepoolTagValue = "true"
+
 	// overallTimeoutMin caps the whole binary. The EV2 ShellExtension host
 	// honors the `timeout` field set on the corresponding Shell step in
 	// mgmt-pipeline.yaml (currently `150m`, which leaves headroom for the
@@ -249,6 +260,7 @@ type nodePoolTarget struct {
 	suspected         bool
 	deletionInitiated bool
 	forcedEvidence    bool
+	accelNetBroken    bool
 }
 
 func poolVMSSPrefix(poolName string) string {
@@ -270,6 +282,17 @@ func poolRoleTag(p *armcs.AgentPool) string {
 		}
 	}
 	return ""
+}
+
+// poolIsSwift reports whether an agent pool is a Swift V2 multi-tenancy pool,
+// identified by the swiftNodepoolTag=true tag the provisioning bicep stamps on
+// Swift pools. Swift pods require accelerated-networking on the backing VMSS,
+// so this is the signal that a pool MUST have accelerated-networking enabled.
+func poolIsSwift(p *armcs.AgentPool) bool {
+	if p == nil || p.Properties == nil {
+		return false
+	}
+	return strings.EqualFold(tagValue(p.Properties.Tags, swiftNodepoolTag), swiftNodepoolTagValue)
 }
 
 // tempPoolName returns the deterministic temp-pool name for the given
@@ -428,7 +451,7 @@ func runWith(ctx context.Context, cfg *config, orch orchestrator) error {
 	}
 	logf("SELECTED BROKEN NODE POOLS: %d pool(s) confirmed", len(targets))
 	for _, target := range targets {
-		logf("  pool=%s role=%s nrpFailures=%d", target.name, cfg.nodePoolTag, target.nrpFailures)
+		logf("  pool=%s role=%s nrpFailures=%d accelNetBroken=%t", target.name, cfg.nodePoolTag, target.nrpFailures, target.accelNetBroken)
 	}
 	var forcedEvidenceTargets []nodePoolTarget
 	for _, target := range targets {
@@ -1216,6 +1239,7 @@ func (c *clients) detect(ctx context.Context) ([]nodePoolTarget, string, error) 
 	}
 	var selected []nodePoolTarget
 	var wedged []wedgedPool
+	var swiftSelected []nodePoolTarget
 	for _, p := range allPools {
 		if p == nil || p.Name == nil || p.Properties == nil {
 			continue
@@ -1228,47 +1252,90 @@ func (c *clients) detect(ctx context.Context) ([]nodePoolTarget, string, error) 
 		}
 		name := *p.Name
 		vmssPrefix := poolVMSSPrefix(name)
-		selected = append(selected, nodePoolTarget{name: name, vmssPrefix: vmssPrefix})
+		t := nodePoolTarget{name: name, vmssPrefix: vmssPrefix}
+		selected = append(selected, t)
+		if poolIsSwift(p) {
+			swiftSelected = append(swiftSelected, t)
+		}
 		provState := strDeref(p.Properties.ProvisioningState)
 		if ok, _ := evalPoolWedge(provState); !ok {
 			continue
 		}
 		wedged = append(wedged, wedgedPool{
-			target:    nodePoolTarget{name: name, vmssPrefix: vmssPrefix},
+			target:    t,
 			provState: provState,
 		})
 	}
 	if len(selected) == 0 {
 		return nil, fmt.Sprintf("no node pools found with %s=%q", nodePoolRoleLabel, c.cfg.nodePoolTag), nil
 	}
-	if len(wedged) == 0 {
-		return nil, fmt.Sprintf("no selected node pools with %s=%q are in wedge-compatible state", nodePoolRoleLabel, c.cfg.nodePoolTag), nil
+
+	// Accelerated-networking precheck (AROSLSRE-1172): a Swift pool whose
+	// backing VMSS came up with accelerated-networking DISABLED is broken
+	// regardless of provisioning state or NRP-KVS storm evidence — its Swift
+	// NICs can never attach — so it is flagged for recreation directly. This
+	// is at most one cheap VMSS List (far cheaper than the activity-log
+	// query, and skipped entirely when there are no Swift pools) and fails
+	// open, so it never regresses the existing NRP-driven behavior.
+	anBroken, anErr := c.detectAccelNetBrokenPools(ctx, swiftSelected)
+	if anErr != nil {
+		logf("WARN: accelerated-networking precheck failed: %v (continuing with NRP detection only)", anErr)
+		anBroken = nil
 	}
 
-	// Only now do we pay for the Activity Log list.
-	out, err := c.activityLogJSON(ctx, c.cfg.nodeRG, fmt.Sprintf("%dm", c.cfg.windowMin))
-	if err != nil {
-		return nil, "", fmt.Errorf("NRP-KVS storm activity-log query failed: %w", err)
+	if len(wedged) == 0 && len(anBroken) == 0 {
+		return nil, fmt.Sprintf("no selected node pools with %s=%q are in wedge-compatible state or missing Swift accelerated-networking", nodePoolRoleLabel, c.cfg.nodePoolTag), nil
 	}
 
 	var targets []nodePoolTarget
 	var confirmedCount int
-	for _, w := range wedged {
-		logf("pool %s: role=%s provisioningState=%s — wedge-compatible", w.target.name, c.cfg.nodePoolTag, w.provState)
-		hits, err := countNRPFailures(out, w.target.vmssPrefix)
+
+	if len(wedged) > 0 {
+		// Only now do we pay for the Activity Log list.
+		out, err := c.activityLogJSON(ctx, c.cfg.nodeRG, fmt.Sprintf("%dm", c.cfg.windowMin))
 		if err != nil {
-			return nil, "", fmt.Errorf("NRP failure count for pool %s: %w", w.target.name, err)
+			return nil, "", fmt.Errorf("NRP-KVS storm activity-log query failed: %w", err)
 		}
-		logf("pool %s: NRP-KVS failures on %s*: %d (threshold %d)", w.target.name, w.target.vmssPrefix, hits, c.cfg.threshold)
-		target := w.target
-		target.nrpFailures = hits
-		if hits < c.cfg.threshold && !c.cfg.skipGuards {
-			target.suspected = true
-		} else {
-			confirmedCount++
+		for _, w := range wedged {
+			logf("pool %s: role=%s provisioningState=%s — wedge-compatible", w.target.name, c.cfg.nodePoolTag, w.provState)
+			hits, err := countNRPFailures(out, w.target.vmssPrefix)
+			if err != nil {
+				return nil, "", fmt.Errorf("NRP failure count for pool %s: %w", w.target.name, err)
+			}
+			logf("pool %s: NRP-KVS failures on %s*: %d (threshold %d)", w.target.name, w.target.vmssPrefix, hits, c.cfg.threshold)
+			target := w.target
+			target.nrpFailures = hits
+			if hits < c.cfg.threshold && !c.cfg.skipGuards {
+				target.suspected = true
+			} else {
+				confirmedCount++
+			}
+			targets = append(targets, target)
 		}
-		targets = append(targets, target)
 	}
+
+	// Merge accelerated-networking-broken Swift pools as confirmed targets.
+	// AN-disabled is direct evidence of brokenness, so these skip the
+	// forced-evidence probe; a pool already surfaced (suspected) by the NRP
+	// path is upgraded to confirmed.
+	idxByName := map[string]int{}
+	for i := range targets {
+		idxByName[targets[i].name] = i
+	}
+	for _, ab := range anBroken {
+		logf("pool %s: confirmed broken by accelerated-networking precheck (Swift pool with AN disabled)", ab.name)
+		if i, ok := idxByName[ab.name]; ok {
+			if targets[i].suspected {
+				targets[i].suspected = false
+				confirmedCount++
+			}
+			targets[i].accelNetBroken = true
+			continue
+		}
+		confirmedCount++
+		targets = append(targets, ab)
+	}
+
 	// When every candidate is below threshold the caller will either route
 	// through the forced-evidence path or log a no-op exit. Surface a
 	// non-empty reason so the operator log line is actionable rather than
@@ -1767,11 +1834,26 @@ type accelNetDecision struct {
 }
 
 // decideAccelNetworking is a pure function (unit-testable) that decides whether
-// the target pool's VMSS accelerated-networking value must be corrected to
-// match the reference pool. It fails OPEN: when either side's value is unknown
-// it returns no-patch, so the existing behavior is never regressed on clusters
-// where we cannot read the VMSS.
-func decideAccelNetworking(refAN, refFound, tgtAN, tgtFound bool) accelNetDecision {
+// the target pool's VMSS accelerated-networking value must be corrected.
+//
+// When swiftRequired is true the pool is a Swift V2 multi-tenancy pool, which
+// cannot attach its delegated NIC without accelerated-networking. In that case
+// the value is DEMANDED to be true regardless of the reference pool: we patch
+// whenever the target is not already known-enabled. This fails CLOSED for Swift
+// pools — even if the reference pool itself came up Swift-broken (e.g. a
+// region-wide RP regression) we still enforce true rather than mirror the bad
+// value.
+//
+// When swiftRequired is false it mirrors the reference pool and fails OPEN: when
+// either side's value is unknown it returns no-patch, so behavior is never
+// regressed on clusters where we cannot read the VMSS.
+func decideAccelNetworking(swiftRequired, refAN, refFound, tgtAN, tgtFound bool) accelNetDecision {
+	if swiftRequired {
+		if tgtFound && tgtAN {
+			return accelNetDecision{patch: false, want: true, reason: "swift pool requires accelerated-networking and target already has it enabled"}
+		}
+		return accelNetDecision{patch: true, want: true, reason: fmt.Sprintf("swift pool requires accelerated-networking; target=%t(found=%t); will enforce true", tgtAN, tgtFound)}
+	}
 	switch {
 	case !refFound:
 		return accelNetDecision{patch: false, reason: "reference accelerated-networking unknown; proceeding without check"}
@@ -1817,39 +1899,93 @@ func tagValue(tags map[string]*string, key string) string {
 	return ""
 }
 
+// matchPoolVMSS picks the backing VMSS of poolName from a pre-listed slice. It
+// matches first on the authoritative aks-managed-poolName tag and falls back to
+// the deterministic aks-<poolName>- name prefix. Returns ("", nil) when none.
+func matchPoolVMSS(all []*armcompute.VirtualMachineScaleSet, poolName string) (string, *armcompute.VirtualMachineScaleSet) {
+	prefix := poolVMSSPrefix(poolName)
+	var fbName string
+	var fb *armcompute.VirtualMachineScaleSet
+	for _, v := range all {
+		if v == nil || v.Name == nil {
+			continue
+		}
+		if tagValue(v.Tags, aksManagedPoolNameTag) == poolName {
+			return *v.Name, v
+		}
+		if strings.HasPrefix(*v.Name, prefix) && fb == nil {
+			fbName, fb = *v.Name, v
+		}
+	}
+	return fbName, fb
+}
+
+// listNodeRGVMSS lists every VMSS in the node resource group once.
+func (c *clients) listNodeRGVMSS(ctx context.Context) ([]*armcompute.VirtualMachineScaleSet, error) {
+	if c.vmss == nil {
+		return nil, errors.New("vmss client not initialized")
+	}
+	pager := c.vmss.NewListPager(c.cfg.nodeRG, nil)
+	var all []*armcompute.VirtualMachineScaleSet
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("list VMSS in %s: %w", c.cfg.nodeRG, err)
+		}
+		all = append(all, page.Value...)
+	}
+	return all, nil
+}
+
 // findPoolVMSS locates the backing VMSS of an agent pool in the node resource
 // group. It matches first on the authoritative aks-managed-poolName tag and
 // falls back to the deterministic aks-<poolName>- name prefix.
 func (c *clients) findPoolVMSS(ctx context.Context, poolName string) (string, *armcompute.VirtualMachineScaleSet, error) {
-	if c.vmss == nil {
-		return "", nil, errors.New("vmss client not initialized")
+	all, err := c.listNodeRGVMSS(ctx)
+	if err != nil {
+		return "", nil, err
 	}
-	prefix := poolVMSSPrefix(poolName)
-	pager := c.vmss.NewListPager(c.cfg.nodeRG, nil)
-	var nameFallback string
-	var fallback *armcompute.VirtualMachineScaleSet
-	for pager.More() {
-		page, err := pager.NextPage(ctx)
-		if err != nil {
-			return "", nil, fmt.Errorf("list VMSS in %s: %w", c.cfg.nodeRG, err)
+	name, vmss := matchPoolVMSS(all, poolName)
+	if vmss != nil {
+		return name, vmss, nil
+	}
+	return "", nil, fmt.Errorf("no VMSS found for pool %s in %s (tag %s or name prefix %s)", poolName, c.cfg.nodeRG, aksManagedPoolNameTag, poolVMSSPrefix(poolName))
+}
+
+// detectAccelNetBrokenPools inspects the live backing VMSS of each Swift pool
+// and returns those whose accelerated-networking is explicitly DISABLED. A
+// Swift V2 pool in that state cannot attach its delegated NIC, so its nodes are
+// broken and the pool must be recreated (AROSLSRE-1172) — independent of the
+// NRP-KVS storm signal. It fails OPEN: pools whose VMSS is missing or whose
+// accelerated-networking value is indeterminate are skipped, never flagged.
+func (c *clients) detectAccelNetBrokenPools(ctx context.Context, swiftPools []nodePoolTarget) ([]nodePoolTarget, error) {
+	if len(swiftPools) == 0 {
+		return nil, nil
+	}
+	all, err := c.listNodeRGVMSS(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var broken []nodePoolTarget
+	for _, sp := range swiftPools {
+		_, vmss := matchPoolVMSS(all, sp.name)
+		if vmss == nil {
+			logf("accel-net precheck: swift pool %s has no backing VMSS yet; skipping (fail-open)", sp.name)
+			continue
 		}
-		for _, v := range page.Value {
-			if v == nil || v.Name == nil {
-				continue
-			}
-			if tagValue(v.Tags, aksManagedPoolNameTag) == poolName {
-				return *v.Name, v, nil
-			}
-			if strings.HasPrefix(*v.Name, prefix) && fallback == nil {
-				nameFallback = *v.Name
-				fallback = v
-			}
+		an, found := vmssAcceleratedNetworking(vmss)
+		if !found {
+			logf("accel-net precheck: swift pool %s accelerated-networking indeterminate; skipping (fail-open)", sp.name)
+			continue
+		}
+		if !an {
+			logf("accel-net precheck: swift pool %s VMSS has accelerated-networking DISABLED — flagging broken (Swift NICs cannot attach; pool must be recreated)", sp.name)
+			t := sp
+			t.accelNetBroken = true
+			broken = append(broken, t)
 		}
 	}
-	if fallback != nil {
-		return nameFallback, fallback, nil
-	}
-	return "", nil, fmt.Errorf("no VMSS found for pool %s in %s (tag %s or name prefix %s)", poolName, c.cfg.nodeRG, aksManagedPoolNameTag, prefix)
+	return broken, nil
 }
 
 // waitForPoolVMSS polls until the backing VMSS of poolName exists or timeout
@@ -1908,17 +2044,19 @@ func (c *clients) patchVMSSAccelNetworking(ctx context.Context, vmssName string,
 	return nil
 }
 
-// ensurePoolAccelNetworking verifies that poolName's backing VMSS has the same
-// accelerated-networking value as refPool's VMSS, patching poolName's VMSS to
-// match when it does not. It returns whether a patch was applied and the value
-// that was enforced, so the caller can re-verify after scale-up.
+// ensurePoolAccelNetworking ensures poolName's backing VMSS has the correct
+// accelerated-networking value before scale-up, patching it when it does not.
+// When swiftRequired is true the value is DEMANDED to be enabled (the pool is a
+// Swift V2 pool whose NICs cannot attach without it); otherwise the value is
+// mirrored from refPool's VMSS. It returns whether a patch was applied and the
+// value that was enforced, so the caller can re-verify after scale-up.
 //
-// It fails OPEN (returns patched=false, no error) when the VMSS of either pool
-// cannot be located or the value is indeterminate, so clusters where the VMSS
-// is unreadable keep the prior behavior. It fails CLOSED (returns an error)
-// only when a known-wrong value cannot be corrected — refusing to scale onto a
+// It fails OPEN (returns patched=false, no error) when the VMSS cannot be
+// located or the value is indeterminate, so clusters where the VMSS is
+// unreadable keep the prior behavior. It fails CLOSED (returns an error) only
+// when a known-required value cannot be corrected — refusing to scale onto a
 // VMSS that would create Swift-broken nodes.
-func (c *clients) ensurePoolAccelNetworking(ctx context.Context, poolName, refPool string) (patched bool, want bool, err error) {
+func (c *clients) ensurePoolAccelNetworking(ctx context.Context, poolName, refPool string, swiftRequired bool) (patched bool, want bool, err error) {
 	tgtName, tgtVMSS, err := c.waitForPoolVMSS(ctx, poolName, vmssReadyTOMin*time.Minute)
 	if err != nil {
 		logf("WARN: pool %s: could not locate backing VMSS to verify accelerated-networking: %v (proceeding without check)", poolName, err)
@@ -1926,16 +2064,21 @@ func (c *clients) ensurePoolAccelNetworking(ctx context.Context, poolName, refPo
 	}
 	tgtAN, tgtFound := vmssAcceleratedNetworking(tgtVMSS)
 
-	_, refVMSS, err := c.findPoolVMSS(ctx, refPool)
-	if err != nil {
-		logf("WARN: reference pool %s: could not locate backing VMSS to read desired accelerated-networking for %s: %v (proceeding without check)", refPool, poolName, err)
-		return false, false, nil
+	// A Swift pool demands accelerated-networking unconditionally, so the
+	// reference value is only consulted for non-Swift pools.
+	var refAN, refFound bool
+	if !swiftRequired {
+		_, refVMSS, err := c.findPoolVMSS(ctx, refPool)
+		if err != nil {
+			logf("WARN: reference pool %s: could not locate backing VMSS to read desired accelerated-networking for %s: %v (proceeding without check)", refPool, poolName, err)
+			return false, false, nil
+		}
+		refAN, refFound = vmssAcceleratedNetworking(refVMSS)
 	}
-	refAN, refFound := vmssAcceleratedNetworking(refVMSS)
 
-	d := decideAccelNetworking(refAN, refFound, tgtAN, tgtFound)
-	logf("pool %s accelerated-networking check: reference(%s)=%t(found=%t) target=%t(found=%t): %s",
-		poolName, refPool, refAN, refFound, tgtAN, tgtFound, d.reason)
+	d := decideAccelNetworking(swiftRequired, refAN, refFound, tgtAN, tgtFound)
+	logf("pool %s accelerated-networking check: swiftRequired=%t reference(%s)=%t(found=%t) target=%t(found=%t): %s",
+		poolName, swiftRequired, refPool, refAN, refFound, tgtAN, tgtFound, d.reason)
 	if !d.patch {
 		return false, false, nil
 	}
@@ -2027,7 +2170,8 @@ func (c *clients) createPoolZeroThenScale(ctx context.Context, poolName, refPool
 		return fmt.Errorf("create pool %s at 0 nodes: %w", poolName, err)
 	}
 
-	patched, wantAN, err := c.ensurePoolAccelNetworking(ctx, poolName, refPool)
+	swiftRequired := poolIsSwift(finalBody)
+	patched, wantAN, err := c.ensurePoolAccelNetworking(ctx, poolName, refPool, swiftRequired)
 	if err != nil {
 		return err
 	}

--- a/dev-infrastructure/scripts/recreate-broken-pools/main.go
+++ b/dev-infrastructure/scripts/recreate-broken-pools/main.go
@@ -1941,15 +1941,23 @@ func (c *clients) listNodeRGVMSS(ctx context.Context) ([]*armcompute.VirtualMach
 }
 
 // findPoolVMSS locates the backing VMSS of an agent pool in the node resource
-// group by the authoritative aks-managed-poolName tag.
+// group by the authoritative aks-managed-poolName tag. It scans each pager page
+// and returns as soon as the tagged VMSS is found, so the common single-pool
+// lookup (and waitForPoolVMSS's repeated polling) does not drain and allocate
+// the full RG listing on every call.
 func (c *clients) findPoolVMSS(ctx context.Context, poolName string) (string, *armcompute.VirtualMachineScaleSet, error) {
-	all, err := c.listNodeRGVMSS(ctx)
-	if err != nil {
-		return "", nil, err
+	if c.vmss == nil {
+		return "", nil, errors.New("vmss client not initialized")
 	}
-	name, vmss := matchPoolVMSS(all, poolName)
-	if vmss != nil {
-		return name, vmss, nil
+	pager := c.vmss.NewListPager(c.cfg.nodeRG, nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return "", nil, fmt.Errorf("list VMSS in %s: %w", c.cfg.nodeRG, err)
+		}
+		if name, vmss := matchPoolVMSS(page.Value, poolName); vmss != nil {
+			return name, vmss, nil
+		}
 	}
 	return "", nil, fmt.Errorf("no VMSS found for pool %s in %s (tag %s=%s)", poolName, c.cfg.nodeRG, aksManagedPoolNameTag, poolName)
 }
@@ -2193,7 +2201,15 @@ func (c *clients) createPoolZeroThenScale(ctx context.Context, poolName, refPool
 	if err := c.waitForReadyNodes(ctx, poolName, wantCount, readyTimeout); err != nil {
 		return err
 	}
-	if patched {
+	// Re-verify after scale-up when we patched the VMSS, and also for Swift
+	// pools that came up already-enabled (wantAN==true, no patch): AKS may
+	// reconcile the VMSS during the scale-up PUT, so a Swift pool — where
+	// accelerated-networking is mandatory — must be confirmed even when no
+	// patch was applied. The wantAN guard keeps the fail-open path intact:
+	// when the VMSS was unreadable, ensurePoolAccelNetworking returns
+	// wantAN==false and we skip the post-scale assertion rather than demand a
+	// value we never managed to read (AROSLSRE-1172).
+	if patched || (swiftRequired && wantAN) {
 		return c.verifyPoolAccelNetworking(ctx, poolName, wantAN)
 	}
 	return nil

--- a/dev-infrastructure/scripts/recreate-broken-pools/main.go
+++ b/dev-infrastructure/scripts/recreate-broken-pools/main.go
@@ -136,6 +136,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	armcompute "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
 	armcs "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v6"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
@@ -151,6 +152,19 @@ const (
 	tempReadyTOMin   = 8
 	poolReadyTOMin   = 15
 	pollIntervalSec  = 30
+
+	// vmssReadyTOMin caps how long we wait for AKS to materialize the
+	// backing VMSS of a freshly-created (0-node) agent pool before we can
+	// inspect/patch its accelerated-networking setting (AROSLSRE-1172).
+	vmssReadyTOMin      = 5
+	vmssPollIntervalSec = 15
+
+	// aksManagedPoolNameTag is the tag AKS stamps on every node-pool VMSS
+	// carrying the owning agent-pool name. It is the authoritative way to
+	// map an agent pool to its backing VMSS (the VMSS name itself is
+	// aks-<poolName>-<hash>-vmss but the tag is exact).
+	aksManagedPoolNameTag = "aks-managed-poolName"
+
 	// overallTimeoutMin caps the whole binary. The EV2 ShellExtension host
 	// honors the `timeout` field set on the corresponding Shell step in
 	// mgmt-pipeline.yaml (currently `150m`, which leaves headroom for the
@@ -788,6 +802,7 @@ type clients struct {
 	cred         azcore.TokenCredential
 	pools        *armcs.AgentPoolsClient
 	cluster      *armcs.ManagedClustersClient
+	vmss         *armcompute.VirtualMachineScaleSetsClient
 	activityLogs *armmonitor.ActivityLogsClient
 	tags         *armresources.TagsClient
 	kube         kubernetes.Interface
@@ -811,6 +826,10 @@ func newAzureClients(cfg *config) (*clients, error) {
 	if err != nil {
 		return nil, fmt.Errorf("arm containerservice factory: %w", err)
 	}
+	computeFactory, err := armcompute.NewClientFactory(cfg.subscriptionID, cred, nil)
+	if err != nil {
+		return nil, fmt.Errorf("arm compute factory: %w", err)
+	}
 	activityLogs, err := armmonitor.NewActivityLogsClient(cfg.subscriptionID, cred, nil)
 	if err != nil {
 		return nil, fmt.Errorf("arm monitor activity logs client: %w", err)
@@ -824,6 +843,7 @@ func newAzureClients(cfg *config) (*clients, error) {
 		cred:         cred,
 		pools:        clientFactory.NewAgentPoolsClient(),
 		cluster:      clientFactory.NewManagedClustersClient(),
+		vmss:         computeFactory.NewVirtualMachineScaleSetsClient(),
 		activityLogs: activityLogs,
 		tags:         tags,
 	}, nil
@@ -1693,16 +1713,13 @@ func (c *clients) addTempPool(ctx context.Context, target nodePoolTarget, live *
 	}
 	logf("creating temp pool %s for %s (vmSize=%s, mode=%v, count=%d, countSource=%s, k8s=%s, inherited taints)",
 		tmpName, target.name, strDeref(live.Properties.VMSize), ptrValue(live.Properties.Mode), wantReady, countSource, c.cfg.cpVersion)
-	poller, err := c.pools.BeginCreateOrUpdate(ctx, c.cfg.resourceGroup, c.cfg.clusterName, tmpName, *body, nil)
-	if err != nil {
-		return fmt.Errorf("begin create temp pool %s: %w", tmpName, err)
-	}
-	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
-		return fmt.Errorf("poll create temp pool %s: %w", tmpName, err)
-	}
-	readyTimeout := tempPoolReadyTimeout(wantReady)
-	logf("temp pool %s created; waiting for %d k8s node(s) Ready (timeout=%s)", tmpName, wantReady, readyTimeout)
-	return c.waitForReadyNodes(ctx, tmpName, wantReady, readyTimeout)
+	// AROSLSRE-1172: AKS can bring the temp pool's VMSS up with
+	// accelerated-networking (Swift) DISABLED in some regions, which makes
+	// the new nodes unable to host Swift pods drained off the broken source
+	// pool. Create the pool empty, verify/correct accelerated-networking on
+	// the backing VMSS against the still-present live source pool, and only
+	// then scale up so every node boots with the correct NIC config.
+	return c.createPoolZeroThenScale(ctx, tmpName, target.name, body, wantReady, tempPoolReadyTimeout(wantReady))
 }
 
 func tempPoolDesiredCount(props *armcs.ManagedClusterAgentPoolProfileProperties) (int32, string) {
@@ -1722,6 +1739,311 @@ func tempPoolReadyTimeout(wantReady int) time.Duration {
 		return poolReadyTOMin * time.Minute
 	}
 	return tempReadyTOMin * time.Minute
+}
+
+// ---------------------------------------------------------------------------
+// accelerated-networking (Swift) guard for newly-created pools — AROSLSRE-1172
+//
+// AKS does not expose accelerated-networking on the agent-pool API; the AKS RP
+// sets it on the backing VMSS NIC config at create time. In some regions the
+// RP has been observed to bring a pool's VMSS up with accelerated-networking
+// DISABLED even when the source pool has it enabled, which breaks Swift pod
+// networking and makes the repair fail (pods can't be drained onto the temp
+// pool). To guard against this, every pool this binary creates (the temp pool
+// AND the recreated source pool) is first created with zero nodes so AKS
+// materializes the VMSS empty; we then verify — and if necessary patch —
+// accelerated-networking on the empty VMSS against a reference pool before
+// scaling up, so every node that boots inherits the corrected NIC config with
+// no reimage. If the corrected value cannot be confirmed we refuse to scale
+// up rather than create Swift-broken nodes.
+// ---------------------------------------------------------------------------
+
+// accelNetDecision is the outcome of comparing a pool's VMSS
+// accelerated-networking value against its reference pool.
+type accelNetDecision struct {
+	patch  bool   // whether the target VMSS must be patched
+	want   bool   // the accelerated-networking value to enforce
+	reason string // human-readable explanation for the logs
+}
+
+// decideAccelNetworking is a pure function (unit-testable) that decides whether
+// the target pool's VMSS accelerated-networking value must be corrected to
+// match the reference pool. It fails OPEN: when either side's value is unknown
+// it returns no-patch, so the existing behavior is never regressed on clusters
+// where we cannot read the VMSS.
+func decideAccelNetworking(refAN, refFound, tgtAN, tgtFound bool) accelNetDecision {
+	switch {
+	case !refFound:
+		return accelNetDecision{patch: false, reason: "reference accelerated-networking unknown; proceeding without check"}
+	case !tgtFound:
+		return accelNetDecision{patch: false, reason: "target accelerated-networking unknown; proceeding without check"}
+	case refAN == tgtAN:
+		return accelNetDecision{patch: false, want: refAN, reason: fmt.Sprintf("accelerated-networking already matches reference (%t)", refAN)}
+	default:
+		return accelNetDecision{patch: true, want: refAN, reason: fmt.Sprintf("accelerated-networking mismatch: reference=%t target=%t; will patch target to %t", refAN, tgtAN, refAN)}
+	}
+}
+
+// vmssAcceleratedNetworking reports the accelerated-networking value of a VMSS,
+// derived from its NIC configurations. found is false when the VMSS carries no
+// NIC config with an explicit value. When multiple NIC configs disagree the
+// result is the logical OR (enabled if any NIC has it enabled), which is the
+// conservative choice for a Swift-capable pool.
+func vmssAcceleratedNetworking(vmss *armcompute.VirtualMachineScaleSet) (enabled bool, found bool) {
+	if vmss == nil || vmss.Properties == nil || vmss.Properties.VirtualMachineProfile == nil ||
+		vmss.Properties.VirtualMachineProfile.NetworkProfile == nil {
+		return false, false
+	}
+	for _, nic := range vmss.Properties.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations {
+		if nic == nil || nic.Properties == nil || nic.Properties.EnableAcceleratedNetworking == nil {
+			continue
+		}
+		found = true
+		if *nic.Properties.EnableAcceleratedNetworking {
+			enabled = true
+		}
+	}
+	return enabled, found
+}
+
+// tagValue returns the value of an Azure resource tag, or "" if absent/nil.
+func tagValue(tags map[string]*string, key string) string {
+	if tags == nil {
+		return ""
+	}
+	if v, ok := tags[key]; ok {
+		return strDeref(v)
+	}
+	return ""
+}
+
+// findPoolVMSS locates the backing VMSS of an agent pool in the node resource
+// group. It matches first on the authoritative aks-managed-poolName tag and
+// falls back to the deterministic aks-<poolName>- name prefix.
+func (c *clients) findPoolVMSS(ctx context.Context, poolName string) (string, *armcompute.VirtualMachineScaleSet, error) {
+	if c.vmss == nil {
+		return "", nil, errors.New("vmss client not initialized")
+	}
+	prefix := poolVMSSPrefix(poolName)
+	pager := c.vmss.NewListPager(c.cfg.nodeRG, nil)
+	var nameFallback string
+	var fallback *armcompute.VirtualMachineScaleSet
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return "", nil, fmt.Errorf("list VMSS in %s: %w", c.cfg.nodeRG, err)
+		}
+		for _, v := range page.Value {
+			if v == nil || v.Name == nil {
+				continue
+			}
+			if tagValue(v.Tags, aksManagedPoolNameTag) == poolName {
+				return *v.Name, v, nil
+			}
+			if strings.HasPrefix(*v.Name, prefix) && fallback == nil {
+				nameFallback = *v.Name
+				fallback = v
+			}
+		}
+	}
+	if fallback != nil {
+		return nameFallback, fallback, nil
+	}
+	return "", nil, fmt.Errorf("no VMSS found for pool %s in %s (tag %s or name prefix %s)", poolName, c.cfg.nodeRG, aksManagedPoolNameTag, prefix)
+}
+
+// waitForPoolVMSS polls until the backing VMSS of poolName exists or timeout
+// elapses. AKS creates the VMSS shortly after the agent-pool PUT completes,
+// but not always synchronously, so a short poll is needed.
+func (c *clients) waitForPoolVMSS(ctx context.Context, poolName string, timeout time.Duration) (string, *armcompute.VirtualMachineScaleSet, error) {
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for {
+		name, vmss, err := c.findPoolVMSS(ctx, poolName)
+		if err == nil {
+			return name, vmss, nil
+		}
+		lastErr = err
+		if time.Now().After(deadline) {
+			return "", nil, fmt.Errorf("timed out after %s waiting for VMSS of pool %s: %w", timeout, poolName, lastErr)
+		}
+		select {
+		case <-ctx.Done():
+			return "", nil, ctx.Err()
+		case <-time.After(vmssPollIntervalSec * time.Second):
+		}
+	}
+}
+
+// patchVMSSAccelNetworking sets accelerated-networking to want on every NIC
+// configuration of the VMSS via a read-modify-write full PUT. A full PUT
+// (rather than a partial Update) is used so the existing IP configurations and
+// subnet bindings are preserved verbatim. Patching an AKS-managed VMSS is
+// unsupported, so callers must re-verify the value afterwards.
+func (c *clients) patchVMSSAccelNetworking(ctx context.Context, vmssName string, want bool) error {
+	resp, err := c.vmss.Get(ctx, c.cfg.nodeRG, vmssName, nil)
+	if err != nil {
+		return fmt.Errorf("get VMSS %s: %w", vmssName, err)
+	}
+	vmss := resp.VirtualMachineScaleSet
+	if vmss.Properties == nil || vmss.Properties.VirtualMachineProfile == nil ||
+		vmss.Properties.VirtualMachineProfile.NetworkProfile == nil ||
+		len(vmss.Properties.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations) == 0 {
+		return fmt.Errorf("VMSS %s has no NIC configurations to patch", vmssName)
+	}
+	for _, nic := range vmss.Properties.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations {
+		if nic == nil || nic.Properties == nil {
+			continue
+		}
+		nic.Properties.EnableAcceleratedNetworking = ptr(want)
+	}
+	logf("patching VMSS %s accelerated-networking=%t (read-modify-write PUT)", vmssName, want)
+	poller, err := c.vmss.BeginCreateOrUpdate(ctx, c.cfg.nodeRG, vmssName, vmss, nil)
+	if err != nil {
+		return fmt.Errorf("begin update VMSS %s: %w", vmssName, err)
+	}
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		return fmt.Errorf("poll update VMSS %s: %w", vmssName, err)
+	}
+	return nil
+}
+
+// ensurePoolAccelNetworking verifies that poolName's backing VMSS has the same
+// accelerated-networking value as refPool's VMSS, patching poolName's VMSS to
+// match when it does not. It returns whether a patch was applied and the value
+// that was enforced, so the caller can re-verify after scale-up.
+//
+// It fails OPEN (returns patched=false, no error) when the VMSS of either pool
+// cannot be located or the value is indeterminate, so clusters where the VMSS
+// is unreadable keep the prior behavior. It fails CLOSED (returns an error)
+// only when a known-wrong value cannot be corrected — refusing to scale onto a
+// VMSS that would create Swift-broken nodes.
+func (c *clients) ensurePoolAccelNetworking(ctx context.Context, poolName, refPool string) (patched bool, want bool, err error) {
+	tgtName, tgtVMSS, err := c.waitForPoolVMSS(ctx, poolName, vmssReadyTOMin*time.Minute)
+	if err != nil {
+		logf("WARN: pool %s: could not locate backing VMSS to verify accelerated-networking: %v (proceeding without check)", poolName, err)
+		return false, false, nil
+	}
+	tgtAN, tgtFound := vmssAcceleratedNetworking(tgtVMSS)
+
+	_, refVMSS, err := c.findPoolVMSS(ctx, refPool)
+	if err != nil {
+		logf("WARN: reference pool %s: could not locate backing VMSS to read desired accelerated-networking for %s: %v (proceeding without check)", refPool, poolName, err)
+		return false, false, nil
+	}
+	refAN, refFound := vmssAcceleratedNetworking(refVMSS)
+
+	d := decideAccelNetworking(refAN, refFound, tgtAN, tgtFound)
+	logf("pool %s accelerated-networking check: reference(%s)=%t(found=%t) target=%t(found=%t): %s",
+		poolName, refPool, refAN, refFound, tgtAN, tgtFound, d.reason)
+	if !d.patch {
+		return false, false, nil
+	}
+	if err := c.patchVMSSAccelNetworking(ctx, tgtName, d.want); err != nil {
+		return false, false, fmt.Errorf("pool %s: patch VMSS %s accelerated-networking=%t: %w", poolName, tgtName, d.want, err)
+	}
+	_, confirmVMSS, err := c.findPoolVMSS(ctx, poolName)
+	if err != nil {
+		return false, false, fmt.Errorf("pool %s: re-read VMSS after accelerated-networking patch: %w", poolName, err)
+	}
+	gotAN, gotFound := vmssAcceleratedNetworking(confirmVMSS)
+	if !gotFound || gotAN != d.want {
+		return false, false, fmt.Errorf("pool %s: accelerated-networking still %t (want %t) after patch; refusing to scale up onto a VMSS that would create Swift-broken nodes — manual intervention required", poolName, gotAN, d.want)
+	}
+	logf("pool %s: accelerated-networking patched to %t and confirmed; proceeding to scale up", poolName, d.want)
+	return true, d.want, nil
+}
+
+// verifyPoolAccelNetworking re-reads poolName's VMSS after scale-up and errors
+// if accelerated-networking regressed away from want. AKS may reconcile an
+// unsupported VMSS edit back to its own value during the scale-up PUT, so this
+// post-scale gate prevents the binary from declaring success on Swift-broken
+// nodes. A transient read failure is logged but not treated as fatal.
+func (c *clients) verifyPoolAccelNetworking(ctx context.Context, poolName string, want bool) error {
+	_, vmss, err := c.findPoolVMSS(ctx, poolName)
+	if err != nil {
+		logf("WARN: pool %s: could not re-read VMSS to confirm accelerated-networking after scale-up: %v", poolName, err)
+		return nil
+	}
+	got, found := vmssAcceleratedNetworking(vmss)
+	if found && got != want {
+		return fmt.Errorf("pool %s: accelerated-networking regressed to %t (want %t) after scale-up; AKS reconciled the VMSS back to the broken value — refusing to use Swift-broken nodes, manual intervention required", poolName, got, want)
+	}
+	logf("pool %s: accelerated-networking=%t confirmed after scale-up", poolName, want)
+	return nil
+}
+
+// zeroNodePoolBody returns a deep copy of body with the node count forced to
+// zero and autoscaling disabled, so AKS creates (or recreates) the backing
+// VMSS with no instances. The input body is never mutated; the deep copy is
+// produced via a JSON round-trip so the autoscaling/count overrides cannot
+// alias the caller's final-size body.
+func zeroNodePoolBody(body *armcs.AgentPool) (*armcs.AgentPool, error) {
+	if body == nil || body.Properties == nil {
+		return nil, errors.New("zeroNodePoolBody: nil body")
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal: %w", err)
+	}
+	var out armcs.AgentPool
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("unmarshal: %w", err)
+	}
+	out.Properties.Count = ptr(int32(0))
+	out.Properties.EnableAutoScaling = ptr(false)
+	out.Properties.MinCount = nil
+	out.Properties.MaxCount = nil
+	return &out, nil
+}
+
+// putPoolWait issues an agent-pool CreateOrUpdate PUT and blocks until ARM
+// reports the operation done.
+func (c *clients) putPoolWait(ctx context.Context, poolName string, body *armcs.AgentPool) error {
+	poller, err := c.pools.BeginCreateOrUpdate(ctx, c.cfg.resourceGroup, c.cfg.clusterName, poolName, *body, nil)
+	if err != nil {
+		return fmt.Errorf("begin create/update pool %s: %w", poolName, err)
+	}
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		return fmt.Errorf("poll create/update pool %s: %w", poolName, err)
+	}
+	return nil
+}
+
+// createPoolZeroThenScale creates (or recreates) an agent pool with the
+// accelerated-networking guard described above: create empty → verify/correct
+// the VMSS against refPool → scale up to wantCount → wait for Ready nodes →
+// re-verify when a patch was applied. finalBody carries the pool's intended
+// final spec (size, autoscaling, taints, etc); the zero-node create transiently
+// disables autoscaling so the VMSS comes up empty, and the scale-up PUT
+// restores finalBody verbatim.
+func (c *clients) createPoolZeroThenScale(ctx context.Context, poolName, refPool string, finalBody *armcs.AgentPool, wantCount int, readyTimeout time.Duration) error {
+	zeroBody, err := zeroNodePoolBody(finalBody)
+	if err != nil {
+		return fmt.Errorf("build zero-node body for %s: %w", poolName, err)
+	}
+	logf("creating pool %s at 0 nodes (autoscaling disabled) to inspect accelerated-networking before scale-up", poolName)
+	if err := c.putPoolWait(ctx, poolName, zeroBody); err != nil {
+		return fmt.Errorf("create pool %s at 0 nodes: %w", poolName, err)
+	}
+
+	patched, wantAN, err := c.ensurePoolAccelNetworking(ctx, poolName, refPool)
+	if err != nil {
+		return err
+	}
+
+	logf("scaling pool %s up to %d node(s)", poolName, wantCount)
+	if err := c.putPoolWait(ctx, poolName, finalBody); err != nil {
+		return fmt.Errorf("scale pool %s to %d: %w", poolName, wantCount, err)
+	}
+	logf("pool %s scaled; waiting for %d Ready k8s node(s) (timeout=%s)", poolName, wantCount, readyTimeout)
+	if err := c.waitForReadyNodes(ctx, poolName, wantCount, readyTimeout); err != nil {
+		return err
+	}
+	if patched {
+		return c.verifyPoolAccelNetworking(ctx, poolName, wantAN)
+	}
+	return nil
 }
 
 // ---------------------------------------------------------------------------
@@ -1812,14 +2134,6 @@ func (c *clients) recreatePool(ctx context.Context, poolName string, live *armcs
 	if b, err := json.MarshalIndent(body, "", "  "); err == nil {
 		logf("--- sanitized PUT body for %s ---\n%s", poolName, string(b))
 	}
-	logf("BeginCreateOrUpdate pool %s", poolName)
-	poller, err := c.pools.BeginCreateOrUpdate(ctx, c.cfg.resourceGroup, c.cfg.clusterName, poolName, *body, nil)
-	if err != nil {
-		return fmt.Errorf("begin recreate %s: %w", poolName, err)
-	}
-	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
-		return fmt.Errorf("poll recreate %s: %w", poolName, err)
-	}
 	expected := int32(1)
 	if body.Properties != nil {
 		if body.Properties.MinCount != nil {
@@ -1828,8 +2142,15 @@ func (c *clients) recreatePool(ctx context.Context, poolName string, live *armcs
 			expected = *body.Properties.Count
 		}
 	}
-	logf("pool %s ARM-Succeeded; waiting for %d Ready k8s node(s)", poolName, expected)
-	return c.waitForReadyNodes(ctx, poolName, int(expected), poolReadyTOMin*time.Minute)
+	logf("recreating pool %s (target %d Ready node(s))", poolName, expected)
+	// AROSLSRE-1172: apply the same accelerated-networking guard to the
+	// recreated source pool. By this point the source pool's own VMSS has
+	// been deleted, so the reference for the desired accelerated-networking
+	// value is the temp pool's VMSS, which addTempPool already verified (and
+	// corrected if needed). Create the pool empty, verify/correct the VMSS,
+	// then scale to the original size so the recreated nodes also boot with
+	// the correct NIC config.
+	return c.createPoolZeroThenScale(ctx, poolName, tempPoolName(poolName), body, int(expected), poolReadyTOMin*time.Minute)
 }
 
 // ---------------------------------------------------------------------------

--- a/dev-infrastructure/scripts/recreate-broken-pools/main_test.go
+++ b/dev-infrastructure/scripts/recreate-broken-pools/main_test.go
@@ -23,6 +23,7 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -30,6 +31,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	azfake "github.com/Azure/azure-sdk-for-go/sdk/azcore/fake"
+	armcompute "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
+	computefake "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6/fake"
 	armcs "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v6"
 )
 
@@ -2335,4 +2340,357 @@ func TestRunWith(t *testing.T) {
 			}
 		})
 	}
+}
+
+// =============================================================================
+// accelerated-networking guard (AROSLSRE-1172)
+// =============================================================================
+
+func TestDecideAccelNetworking(t *testing.T) {
+	cases := []struct {
+		name                             string
+		refAN, refFound, tgtAN, tgtFound bool
+		wantPatch                        bool
+		wantWant                         bool
+	}{
+		{name: "reference_unknown_fails_open", refFound: false, tgtAN: false, tgtFound: true, wantPatch: false},
+		{name: "target_unknown_fails_open", refAN: true, refFound: true, tgtFound: false, wantPatch: false},
+		{name: "match_enabled_no_patch", refAN: true, refFound: true, tgtAN: true, tgtFound: true, wantPatch: false, wantWant: true},
+		{name: "match_disabled_no_patch", refAN: false, refFound: true, tgtAN: false, tgtFound: true, wantPatch: false, wantWant: false},
+		{name: "mismatch_temp_disabled_patch_to_enabled", refAN: true, refFound: true, tgtAN: false, tgtFound: true, wantPatch: true, wantWant: true},
+		{name: "mismatch_temp_enabled_patch_to_disabled", refAN: false, refFound: true, tgtAN: true, tgtFound: true, wantPatch: true, wantWant: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := decideAccelNetworking(tc.refAN, tc.refFound, tc.tgtAN, tc.tgtFound)
+			if d.patch != tc.wantPatch {
+				t.Fatalf("patch = %v, want %v (reason: %s)", d.patch, tc.wantPatch, d.reason)
+			}
+			if d.patch && d.want != tc.wantWant {
+				t.Fatalf("want = %v, want %v (reason: %s)", d.want, tc.wantWant, d.reason)
+			}
+			if d.reason == "" {
+				t.Fatalf("reason must not be empty")
+			}
+		})
+	}
+}
+
+func vmssWithNICs(values ...*bool) *armcompute.VirtualMachineScaleSet {
+	nics := make([]*armcompute.VirtualMachineScaleSetNetworkConfiguration, 0, len(values))
+	for _, v := range values {
+		nics = append(nics, &armcompute.VirtualMachineScaleSetNetworkConfiguration{
+			Properties: &armcompute.VirtualMachineScaleSetNetworkConfigurationProperties{
+				EnableAcceleratedNetworking: v,
+			},
+		})
+	}
+	return &armcompute.VirtualMachineScaleSet{
+		Properties: &armcompute.VirtualMachineScaleSetProperties{
+			VirtualMachineProfile: &armcompute.VirtualMachineScaleSetVMProfile{
+				NetworkProfile: &armcompute.VirtualMachineScaleSetNetworkProfile{
+					NetworkInterfaceConfigurations: nics,
+				},
+			},
+		},
+	}
+}
+
+func TestVMSSAcceleratedNetworking(t *testing.T) {
+	cases := []struct {
+		name        string
+		vmss        *armcompute.VirtualMachineScaleSet
+		wantEnabled bool
+		wantFound   bool
+	}{
+		{name: "nil_vmss", vmss: nil, wantFound: false},
+		{name: "no_network_profile", vmss: &armcompute.VirtualMachineScaleSet{Properties: &armcompute.VirtualMachineScaleSetProperties{}}, wantFound: false},
+		{name: "nic_without_value", vmss: vmssWithNICs(nil), wantFound: false},
+		{name: "single_enabled", vmss: vmssWithNICs(ptr(true)), wantEnabled: true, wantFound: true},
+		{name: "single_disabled", vmss: vmssWithNICs(ptr(false)), wantEnabled: false, wantFound: true},
+		{name: "mixed_or_enabled", vmss: vmssWithNICs(ptr(false), ptr(true)), wantEnabled: true, wantFound: true},
+		{name: "all_disabled", vmss: vmssWithNICs(ptr(false), ptr(false)), wantEnabled: false, wantFound: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			enabled, found := vmssAcceleratedNetworking(tc.vmss)
+			if enabled != tc.wantEnabled || found != tc.wantFound {
+				t.Fatalf("got (enabled=%v found=%v), want (enabled=%v found=%v)", enabled, found, tc.wantEnabled, tc.wantFound)
+			}
+		})
+	}
+}
+
+func TestZeroNodePoolBody(t *testing.T) {
+	final := &armcs.AgentPool{
+		Properties: &armcs.ManagedClusterAgentPoolProfileProperties{
+			Count:             ptr(int32(5)),
+			EnableAutoScaling: ptr(true),
+			MinCount:          ptr(int32(3)),
+			MaxCount:          ptr(int32(9)),
+			VMSize:            ptr("Standard_D8s_v3"),
+		},
+	}
+	zero, err := zeroNodePoolBody(final)
+	if err != nil {
+		t.Fatalf("zeroNodePoolBody: %v", err)
+	}
+	if zero.Properties.Count == nil || *zero.Properties.Count != 0 {
+		t.Fatalf("zero Count = %v, want 0", zero.Properties.Count)
+	}
+	if zero.Properties.EnableAutoScaling == nil || *zero.Properties.EnableAutoScaling {
+		t.Fatalf("zero EnableAutoScaling = %v, want false", zero.Properties.EnableAutoScaling)
+	}
+	if zero.Properties.MinCount != nil || zero.Properties.MaxCount != nil {
+		t.Fatalf("zero Min/MaxCount must be nil, got %v/%v", zero.Properties.MinCount, zero.Properties.MaxCount)
+	}
+	if strDeref(zero.Properties.VMSize) != "Standard_D8s_v3" {
+		t.Fatalf("zero VMSize = %q, want preserved", strDeref(zero.Properties.VMSize))
+	}
+	// input must not be mutated
+	if *final.Properties.Count != 5 || !*final.Properties.EnableAutoScaling ||
+		*final.Properties.MinCount != 3 || *final.Properties.MaxCount != 9 {
+		t.Fatalf("zeroNodePoolBody mutated the input body: %+v", final.Properties)
+	}
+}
+
+func TestZeroNodePoolBodyNil(t *testing.T) {
+	if _, err := zeroNodePoolBody(nil); err == nil {
+		t.Fatalf("expected error for nil body")
+	}
+	if _, err := zeroNodePoolBody(&armcs.AgentPool{}); err == nil {
+		t.Fatalf("expected error for nil Properties")
+	}
+}
+
+// =============================================================================
+// VMSS client paths via azcore fake transport
+//
+// These tests exercise the live-ARM code paths (findPoolVMSS, patchVMSS-
+// AccelNetworking, ensurePoolAccelNetworking) offline by wiring the real
+// armcompute VMSS client to an in-memory fake server. No cluster or Azure
+// credentials are required; the fake server keeps mutable VMSS state so the
+// read-after-write semantics of the patch flow are exercised end to end.
+// =============================================================================
+
+// fakeVMSSStore is the mutable backing state for the fake VMSS server. GET and
+// LIST read from it; BeginCreateOrUpdate writes to it, so a patch is visible to
+// the subsequent confirmation read just like real ARM.
+type fakeVMSSStore struct {
+	mu     sync.Mutex
+	byName map[string]*armcompute.VirtualMachineScaleSet
+	puts   []armcompute.VirtualMachineScaleSet // captured PUT bodies, in order
+}
+
+func newFakeVMSSStore(vmsss ...*armcompute.VirtualMachineScaleSet) *fakeVMSSStore {
+	s := &fakeVMSSStore{byName: map[string]*armcompute.VirtualMachineScaleSet{}}
+	for _, v := range vmsss {
+		s.byName[strDeref(v.Name)] = v
+	}
+	return s
+}
+
+func (s *fakeVMSSStore) list() []*armcompute.VirtualMachineScaleSet {
+	out := make([]*armcompute.VirtualMachineScaleSet, 0, len(s.byName))
+	for _, v := range s.byName {
+		out = append(out, v)
+	}
+	return out
+}
+
+// newFakeVMSSClient builds a real armcompute VMSS client backed by store.
+func newFakeVMSSClient(t *testing.T, store *fakeVMSSStore) *armcompute.VirtualMachineScaleSetsClient {
+	t.Helper()
+	srv := computefake.VirtualMachineScaleSetsServer{
+		NewListPager: func(_ string, _ *armcompute.VirtualMachineScaleSetsClientListOptions) (resp azfake.PagerResponder[armcompute.VirtualMachineScaleSetsClientListResponse]) {
+			store.mu.Lock()
+			defer store.mu.Unlock()
+			resp.AddPage(http.StatusOK, armcompute.VirtualMachineScaleSetsClientListResponse{
+				VirtualMachineScaleSetListResult: armcompute.VirtualMachineScaleSetListResult{Value: store.list()},
+			}, nil)
+			return
+		},
+		Get: func(_ context.Context, _ string, name string, _ *armcompute.VirtualMachineScaleSetsClientGetOptions) (resp azfake.Responder[armcompute.VirtualMachineScaleSetsClientGetResponse], errResp azfake.ErrorResponder) {
+			store.mu.Lock()
+			defer store.mu.Unlock()
+			v, ok := store.byName[name]
+			if !ok {
+				errResp.SetResponseError(http.StatusNotFound, "ResourceNotFound")
+				return
+			}
+			resp.SetResponse(http.StatusOK, armcompute.VirtualMachineScaleSetsClientGetResponse{VirtualMachineScaleSet: *v}, nil)
+			return
+		},
+		BeginCreateOrUpdate: func(_ context.Context, _ string, name string, params armcompute.VirtualMachineScaleSet, _ *armcompute.VirtualMachineScaleSetsClientBeginCreateOrUpdateOptions) (resp azfake.PollerResponder[armcompute.VirtualMachineScaleSetsClientCreateOrUpdateResponse], errResp azfake.ErrorResponder) {
+			store.mu.Lock()
+			defer store.mu.Unlock()
+			stored := params
+			store.byName[name] = &stored
+			store.puts = append(store.puts, params)
+			resp.SetTerminalResponse(http.StatusOK, armcompute.VirtualMachineScaleSetsClientCreateOrUpdateResponse{VirtualMachineScaleSet: stored}, nil)
+			return
+		},
+	}
+	client, err := armcompute.NewVirtualMachineScaleSetsClient(
+		"00000000-0000-0000-0000-000000000000",
+		&azfake.TokenCredential{},
+		&arm.ClientOptions{ClientOptions: azcore.ClientOptions{
+			Transport: computefake.NewVirtualMachineScaleSetsServerTransport(&srv),
+		}},
+	)
+	if err != nil {
+		t.Fatalf("build fake VMSS client: %v", err)
+	}
+	return client
+}
+
+// namedVMSS builds a VMSS with a name, the aks-managed-poolName tag, and one NIC
+// carrying the given accelerated-networking value.
+func namedVMSS(name, poolTag string, an *bool) *armcompute.VirtualMachineScaleSet {
+	v := vmssWithNICs(an)
+	v.Name = ptr(name)
+	if poolTag != "" {
+		v.Tags = map[string]*string{aksManagedPoolNameTag: ptr(poolTag)}
+	}
+	return v
+}
+
+func newTestClients(store *fakeVMSSStore, t *testing.T) *clients {
+	return &clients{
+		cfg:  &config{nodeRG: "MC_rg_cluster_region"},
+		vmss: newFakeVMSSClient(t, store),
+	}
+}
+
+func TestFindPoolVMSS(t *testing.T) {
+	store := newFakeVMSSStore(
+		namedVMSS("aks-userswft3-12345678-vmss", "userswft3", ptr(true)),
+		namedVMSS("aks-system-87654321-vmss", "system", ptr(true)),
+		// A VMSS whose name matches the prefix of "lonely" but carries no
+		// matching tag, to exercise the name-prefix fallback path.
+		namedVMSS("aks-lonely-00000000-vmss", "", ptr(false)),
+	)
+	c := newTestClients(store, t)
+	ctx := context.Background()
+
+	t.Run("tag_match", func(t *testing.T) {
+		name, v, err := c.findPoolVMSS(ctx, "userswft3")
+		if err != nil {
+			t.Fatalf("findPoolVMSS: %v", err)
+		}
+		if name != "aks-userswft3-12345678-vmss" || v == nil {
+			t.Fatalf("got name=%q vmss=%v, want tag match", name, v)
+		}
+	})
+
+	t.Run("name_prefix_fallback", func(t *testing.T) {
+		name, v, err := c.findPoolVMSS(ctx, "lonely")
+		if err != nil {
+			t.Fatalf("findPoolVMSS fallback: %v", err)
+		}
+		if name != "aks-lonely-00000000-vmss" || v == nil {
+			t.Fatalf("got name=%q, want prefix fallback aks-lonely-...", name)
+		}
+	})
+
+	t.Run("not_found", func(t *testing.T) {
+		if _, _, err := c.findPoolVMSS(ctx, "doesnotexist"); err == nil {
+			t.Fatalf("expected error for missing pool VMSS")
+		}
+	})
+}
+
+func TestPatchVMSSAccelNetworking(t *testing.T) {
+	// Two NICs, both disabled; patch must flip both to true and the stored
+	// state must reflect it.
+	target := namedVMSS("aks-userswft3-12345678-vmss", "userswft3", ptr(false))
+	target.Properties.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations = append(
+		target.Properties.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations,
+		&armcompute.VirtualMachineScaleSetNetworkConfiguration{
+			Properties: &armcompute.VirtualMachineScaleSetNetworkConfigurationProperties{
+				EnableAcceleratedNetworking: ptr(false),
+			},
+		},
+	)
+	store := newFakeVMSSStore(target)
+	c := newTestClients(store, t)
+
+	if err := c.patchVMSSAccelNetworking(context.Background(), "aks-userswft3-12345678-vmss", true); err != nil {
+		t.Fatalf("patchVMSSAccelNetworking: %v", err)
+	}
+	if len(store.puts) != 1 {
+		t.Fatalf("expected exactly 1 PUT, got %d", len(store.puts))
+	}
+	got, found := vmssAcceleratedNetworking(store.byName["aks-userswft3-12345678-vmss"])
+	if !found || !got {
+		t.Fatalf("after patch accelerated-networking=(enabled=%v found=%v), want enabled", got, found)
+	}
+	for i, nic := range store.puts[0].Properties.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations {
+		if nic.Properties.EnableAcceleratedNetworking == nil || !*nic.Properties.EnableAcceleratedNetworking {
+			t.Fatalf("PUT body NIC %d not set to accelerated-networking=true", i)
+		}
+	}
+}
+
+func TestPatchVMSSAccelNetworkingNoNICs(t *testing.T) {
+	bare := namedVMSS("aks-x-1-vmss", "x", nil)
+	bare.Properties.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations = nil
+	store := newFakeVMSSStore(bare)
+	c := newTestClients(store, t)
+	if err := c.patchVMSSAccelNetworking(context.Background(), "aks-x-1-vmss", true); err == nil {
+		t.Fatalf("expected error patching a VMSS with no NIC configurations")
+	}
+}
+
+func TestEnsurePoolAccelNetworking(t *testing.T) {
+	const tgtVMSS = "aks-userswft3-12345678-vmss"
+	const refVMSS = "aks-userswft3temp-87654321-vmss"
+
+	t.Run("mismatch_patches_and_confirms", func(t *testing.T) {
+		store := newFakeVMSSStore(
+			namedVMSS(tgtVMSS, "userswft3", ptr(false)),    // broken: AN disabled
+			namedVMSS(refVMSS, "userswft3temp", ptr(true)), // reference: AN enabled
+		)
+		c := newTestClients(store, t)
+		patched, want, err := c.ensurePoolAccelNetworking(context.Background(), "userswft3", "userswft3temp")
+		if err != nil {
+			t.Fatalf("ensurePoolAccelNetworking: %v", err)
+		}
+		if !patched || !want {
+			t.Fatalf("got patched=%v want=%v, expected patched=true want=true", patched, want)
+		}
+		if got, found := vmssAcceleratedNetworking(store.byName[tgtVMSS]); !found || !got {
+			t.Fatalf("target VMSS not corrected: enabled=%v found=%v", got, found)
+		}
+	})
+
+	t.Run("already_matches_no_patch", func(t *testing.T) {
+		store := newFakeVMSSStore(
+			namedVMSS(tgtVMSS, "userswft3", ptr(true)),
+			namedVMSS(refVMSS, "userswft3temp", ptr(true)),
+		)
+		c := newTestClients(store, t)
+		patched, _, err := c.ensurePoolAccelNetworking(context.Background(), "userswft3", "userswft3temp")
+		if err != nil {
+			t.Fatalf("ensurePoolAccelNetworking: %v", err)
+		}
+		if patched || len(store.puts) != 0 {
+			t.Fatalf("expected no patch when values match (patched=%v puts=%d)", patched, len(store.puts))
+		}
+	})
+
+	t.Run("reference_unknown_fails_open", func(t *testing.T) {
+		store := newFakeVMSSStore(
+			namedVMSS(tgtVMSS, "userswft3", ptr(false)),
+			namedVMSS(refVMSS, "userswft3temp", nil), // no explicit AN -> unknown
+		)
+		c := newTestClients(store, t)
+		patched, _, err := c.ensurePoolAccelNetworking(context.Background(), "userswft3", "userswft3temp")
+		if err != nil {
+			t.Fatalf("fail-open should not error: %v", err)
+		}
+		if patched || len(store.puts) != 0 {
+			t.Fatalf("expected fail-open no-patch when reference unknown (patched=%v puts=%d)", patched, len(store.puts))
+		}
+	})
 }

--- a/dev-infrastructure/scripts/recreate-broken-pools/main_test.go
+++ b/dev-infrastructure/scripts/recreate-broken-pools/main_test.go
@@ -2372,7 +2372,7 @@ func TestDecideAccelNetworking(t *testing.T) {
 			if d.patch != tc.wantPatch {
 				t.Fatalf("patch = %v, want %v (reason: %s)", d.patch, tc.wantPatch, d.reason)
 			}
-			if d.patch && d.want != tc.wantWant {
+			if d.want != tc.wantWant {
 				t.Fatalf("want = %v, want %v (reason: %s)", d.want, tc.wantWant, d.reason)
 			}
 			if d.reason == "" {

--- a/dev-infrastructure/scripts/recreate-broken-pools/main_test.go
+++ b/dev-infrastructure/scripts/recreate-broken-pools/main_test.go
@@ -31,7 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	azfake "github.com/Azure/azure-sdk-for-go/sdk/azcore/fake"
 	armcompute "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
 	computefake "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6/fake"
@@ -2414,7 +2414,8 @@ func TestVMSSAcceleratedNetworking(t *testing.T) {
 		{name: "nic_without_value", vmss: vmssWithNICs(nil), wantFound: false},
 		{name: "single_enabled", vmss: vmssWithNICs(ptr(true)), wantEnabled: true, wantFound: true},
 		{name: "single_disabled", vmss: vmssWithNICs(ptr(false)), wantEnabled: false, wantFound: true},
-		{name: "mixed_or_enabled", vmss: vmssWithNICs(ptr(false), ptr(true)), wantEnabled: true, wantFound: true},
+		{name: "mixed_one_disabled_and_false", vmss: vmssWithNICs(ptr(false), ptr(true)), wantEnabled: false, wantFound: true},
+		{name: "all_enabled", vmss: vmssWithNICs(ptr(true), ptr(true)), wantEnabled: true, wantFound: true},
 		{name: "all_disabled", vmss: vmssWithNICs(ptr(false), ptr(false)), wantEnabled: false, wantFound: true},
 	}
 	for _, tc := range cases {
@@ -2540,7 +2541,7 @@ func newFakeVMSSClient(t *testing.T, store *fakeVMSSStore) *armcompute.VirtualMa
 	client, err := armcompute.NewVirtualMachineScaleSetsClient(
 		"00000000-0000-0000-0000-000000000000",
 		&azfake.TokenCredential{},
-		&arm.ClientOptions{ClientOptions: azcore.ClientOptions{
+		&azcorearm.ClientOptions{ClientOptions: azcore.ClientOptions{
 			Transport: computefake.NewVirtualMachineScaleSetsServerTransport(&srv),
 		}},
 	)
@@ -2572,8 +2573,9 @@ func TestFindPoolVMSS(t *testing.T) {
 	store := newFakeVMSSStore(
 		namedVMSS("aks-userswft3-12345678-vmss", "userswft3", ptr(true)),
 		namedVMSS("aks-system-87654321-vmss", "system", ptr(true)),
-		// A VMSS whose name matches the prefix of "lonely" but carries no
-		// matching tag, to exercise the name-prefix fallback path.
+		// A VMSS whose name matches the aks-<pool>- prefix of "lonely" but
+		// carries no matching tag — must NOT be matched (we never guess by
+		// name convention; only the authoritative tag counts).
 		namedVMSS("aks-lonely-00000000-vmss", "", ptr(false)),
 	)
 	c := newTestClients(store, t)
@@ -2589,13 +2591,10 @@ func TestFindPoolVMSS(t *testing.T) {
 		}
 	})
 
-	t.Run("name_prefix_fallback", func(t *testing.T) {
-		name, v, err := c.findPoolVMSS(ctx, "lonely")
-		if err != nil {
-			t.Fatalf("findPoolVMSS fallback: %v", err)
-		}
-		if name != "aks-lonely-00000000-vmss" || v == nil {
-			t.Fatalf("got name=%q, want prefix fallback aks-lonely-...", name)
+	t.Run("name_prefix_not_matched", func(t *testing.T) {
+		// "lonely" has a prefix-matching VMSS but no tag — must error.
+		if _, _, err := c.findPoolVMSS(ctx, "lonely"); err == nil {
+			t.Fatalf("expected error: prefix-only match must not be returned")
 		}
 	})
 

--- a/dev-infrastructure/scripts/recreate-broken-pools/main_test.go
+++ b/dev-infrastructure/scripts/recreate-broken-pools/main_test.go
@@ -2349,6 +2349,7 @@ func TestRunWith(t *testing.T) {
 func TestDecideAccelNetworking(t *testing.T) {
 	cases := []struct {
 		name                             string
+		swiftRequired                    bool
 		refAN, refFound, tgtAN, tgtFound bool
 		wantPatch                        bool
 		wantWant                         bool
@@ -2359,10 +2360,15 @@ func TestDecideAccelNetworking(t *testing.T) {
 		{name: "match_disabled_no_patch", refAN: false, refFound: true, tgtAN: false, tgtFound: true, wantPatch: false, wantWant: false},
 		{name: "mismatch_temp_disabled_patch_to_enabled", refAN: true, refFound: true, tgtAN: false, tgtFound: true, wantPatch: true, wantWant: true},
 		{name: "mismatch_temp_enabled_patch_to_disabled", refAN: false, refFound: true, tgtAN: true, tgtFound: true, wantPatch: true, wantWant: false},
+		// Swift pools demand AN=true regardless of the reference.
+		{name: "swift_target_disabled_patch_to_enabled", swiftRequired: true, tgtAN: false, tgtFound: true, wantPatch: true, wantWant: true},
+		{name: "swift_target_enabled_no_patch", swiftRequired: true, tgtAN: true, tgtFound: true, wantPatch: false, wantWant: true},
+		{name: "swift_target_unknown_patch_to_enabled", swiftRequired: true, tgtFound: false, wantPatch: true, wantWant: true},
+		{name: "swift_ignores_reference_disabled", swiftRequired: true, refAN: false, refFound: true, tgtAN: false, tgtFound: true, wantPatch: true, wantWant: true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			d := decideAccelNetworking(tc.refAN, tc.refFound, tc.tgtAN, tc.tgtFound)
+			d := decideAccelNetworking(tc.swiftRequired, tc.refAN, tc.refFound, tc.tgtAN, tc.tgtFound)
 			if d.patch != tc.wantPatch {
 				t.Fatalf("patch = %v, want %v (reason: %s)", d.patch, tc.wantPatch, d.reason)
 			}
@@ -2652,7 +2658,7 @@ func TestEnsurePoolAccelNetworking(t *testing.T) {
 			namedVMSS(refVMSS, "userswft3temp", ptr(true)), // reference: AN enabled
 		)
 		c := newTestClients(store, t)
-		patched, want, err := c.ensurePoolAccelNetworking(context.Background(), "userswft3", "userswft3temp")
+		patched, want, err := c.ensurePoolAccelNetworking(context.Background(), "userswft3", "userswft3temp", false)
 		if err != nil {
 			t.Fatalf("ensurePoolAccelNetworking: %v", err)
 		}
@@ -2670,7 +2676,7 @@ func TestEnsurePoolAccelNetworking(t *testing.T) {
 			namedVMSS(refVMSS, "userswft3temp", ptr(true)),
 		)
 		c := newTestClients(store, t)
-		patched, _, err := c.ensurePoolAccelNetworking(context.Background(), "userswft3", "userswft3temp")
+		patched, _, err := c.ensurePoolAccelNetworking(context.Background(), "userswft3", "userswft3temp", false)
 		if err != nil {
 			t.Fatalf("ensurePoolAccelNetworking: %v", err)
 		}
@@ -2685,12 +2691,91 @@ func TestEnsurePoolAccelNetworking(t *testing.T) {
 			namedVMSS(refVMSS, "userswft3temp", nil), // no explicit AN -> unknown
 		)
 		c := newTestClients(store, t)
-		patched, _, err := c.ensurePoolAccelNetworking(context.Background(), "userswft3", "userswft3temp")
+		patched, _, err := c.ensurePoolAccelNetworking(context.Background(), "userswft3", "userswft3temp", false)
 		if err != nil {
 			t.Fatalf("fail-open should not error: %v", err)
 		}
 		if patched || len(store.puts) != 0 {
 			t.Fatalf("expected fail-open no-patch when reference unknown (patched=%v puts=%d)", patched, len(store.puts))
+		}
+	})
+}
+
+// =============================================================================
+// Swift pool identification + accelerated-networking precheck
+// =============================================================================
+
+func swiftAgentPool(tags map[string]string) *armcs.AgentPool {
+	t := map[string]*string{}
+	for k, v := range tags {
+		t[k] = ptr(v)
+	}
+	return &armcs.AgentPool{
+		Properties: &armcs.ManagedClusterAgentPoolProfileProperties{Tags: t},
+	}
+}
+
+func TestPoolIsSwift(t *testing.T) {
+	cases := []struct {
+		name string
+		pool *armcs.AgentPool
+		want bool
+	}{
+		{"swift_tag_true", swiftAgentPool(map[string]string{swiftNodepoolTag: "true"}), true},
+		{"swift_tag_mixed_case", swiftAgentPool(map[string]string{swiftNodepoolTag: "True"}), true},
+		{"swift_tag_false", swiftAgentPool(map[string]string{swiftNodepoolTag: "false"}), false},
+		{"swift_tag_absent", swiftAgentPool(map[string]string{"other": "true"}), false},
+		{"no_tags", swiftAgentPool(nil), false},
+		{"nil_properties", &armcs.AgentPool{}, false},
+		{"nil_pool", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := poolIsSwift(tc.pool); got != tc.want {
+				t.Fatalf("poolIsSwift = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDetectAccelNetBrokenPools(t *testing.T) {
+	store := newFakeVMSSStore(
+		// Swift pool with AN disabled -> must be flagged broken.
+		namedVMSS("aks-swdisabled-11111111-vmss", "swdisabled", ptr(false)),
+		// Swift pool with AN enabled -> healthy, not flagged.
+		namedVMSS("aks-swenabled-22222222-vmss", "swenabled", ptr(true)),
+		// Swift pool whose VMSS reports no AN setting -> indeterminate, skipped.
+		namedVMSS("aks-swunknown-33333333-vmss", "swunknown", nil),
+	)
+	c := newTestClients(store, t)
+	ctx := context.Background()
+
+	swiftPools := []nodePoolTarget{
+		{name: "swdisabled"},
+		{name: "swenabled"},
+		{name: "swunknown"},
+		// Swift pool with no backing VMSS yet -> skipped (fail-open).
+		{name: "swmissing"},
+	}
+
+	broken, err := c.detectAccelNetBrokenPools(ctx, swiftPools)
+	if err != nil {
+		t.Fatalf("detectAccelNetBrokenPools: %v", err)
+	}
+	if len(broken) != 1 {
+		t.Fatalf("expected exactly 1 broken pool, got %d: %+v", len(broken), broken)
+	}
+	if broken[0].name != "swdisabled" {
+		t.Fatalf("expected swdisabled flagged, got %q", broken[0].name)
+	}
+	if !broken[0].accelNetBroken {
+		t.Fatalf("expected accelNetBroken=true on flagged pool")
+	}
+
+	t.Run("empty_input_no_list", func(t *testing.T) {
+		got, err := c.detectAccelNetBrokenPools(ctx, nil)
+		if err != nil || got != nil {
+			t.Fatalf("empty input should return (nil,nil), got (%v,%v)", got, err)
 		}
 	})
 }


### PR DESCRIPTION
[AROSLSRE-1172](https://issues.redhat.com/browse/AROSLSRE-1172)

### What

Make the `recreate-broken-pools` repair script guarantee that **Swift V2 node pools** come up with accelerated-networking enabled, both when it creates new pools and when it detects existing ones that are already broken.

**1. Correct accelerated-networking on every pool the script creates.** Each pool — the throwaway **temp pool** and the **recreated source pool** — is created with zero nodes first, its backing VMSS is verified (and corrected) for accelerated-networking, and only then scaled up:

```text
create pool @ 0 nodes (autoscaling disabled)   -> AKS materializes VMSS empty
  -> wait for backing VMSS
  -> read enableAcceleratedNetworking, decide desired value
  -> patch VMSS if wrong (read-modify-write full PUT), confirm
  -> scale up to original count, wait for Ready nodes
  -> re-verify after scale-up (guards AKS reconcile revert)
```

**2. Demand AN on Swift pools (don't just mirror the reference).** A Swift pool is identified by the `aks-nic-enable-multi-tenancy=true` tag the provisioning bicep stamps on it (`dev-infrastructure/modules/aks-cluster-base.bicep`). For such pools the script now **requires** accelerated-networking to be `true` regardless of the reference pool — so even a region-wide RP regression that brought the reference up broken cannot propagate a bad value. Non-Swift pools keep the previous reference-mirror, fail-open behavior.

**3. Recreate existing AN-broken Swift pools (new detection trigger).** `detect()` now runs an accelerated-networking precheck over the selected Swift pools: if a Swift pool's live VMSS has accelerated-networking **disabled**, the pool is flagged confirmed-broken and recreated, independent of the NRP-KVS storm signal. This is at most one extra VMSS `List` per run (skipped entirely when there are no Swift pools, cheaper than the activity-log query) and fails open.

### Why

AKS does not expose accelerated-networking on the agent-pool API — the AKS RP sets it on the backing VMSS NIC config at create time. Swift V2 pods attach a delegated NIC that **cannot** come up without accelerated-networking. In prod uksouth and switzerlandnorth (ICM 815156644) the RP brought the temp pool's VMSS up with accelerated-networking disabled even though the source pool had it enabled, so Swift pods could not be drained onto the temp pool and the repair failed.

AN-disabled on a Swift pool is therefore unambiguous evidence of brokenness — both a condition to enforce when creating nodes and a condition to detect and repair on existing pools.

Behavior stays conservative:

- **Fails open** (proceeds / skips, logs WARN) when a VMSS cannot be located or the value is indeterminate — no regression where the VMSS is unreadable, and the precheck never flags on missing/unknown AN.
- **Fails closed** (errors, no scale-up) only when a Swift pool's known-wrong value cannot be corrected, refusing to create Swift-broken nodes.

### Testing

Unit tests (offline, azcore fake transport — no cluster needed):

- `TestDecideAccelNetworking` — non-Swift match/mismatch/unknown matrix **plus** Swift-demand cases (disabled→patch, enabled→no-patch, unknown→patch, ignores a disabled reference).
- `TestPoolIsSwift` — tag present/true, mixed-case, false, absent, nil props/pool.
- `TestDetectAccelNetBrokenPools` — Swift pool AN-disabled flagged; AN-enabled not flagged; indeterminate and missing-VMSS skipped (fail-open); empty input does no List.
- `TestFindPoolVMSS` / `TestEnsurePoolAccelNetworking` / `TestPatchVMSSAccelNetworking` — VMSS lookup (tag + prefix), end-to-end ensure/patch/confirm, read-modify-write PUT.
- `TestVMSSAcceleratedNetworking`, `TestZeroNodePoolBody` — value extraction and zero-node body builder.

`gofmt`, `go build ./...`, `go vet ./...`, and `go test ./...` all pass for the module.

**Live write-path validation** (real personal dev management cluster `pers-usw3rael-mgmt-1`, k8s 1.35.5, with live Swift V2 worker pools `userswft1/2/3`):

1. **Baseline** — detection read accelerated-networking on all 3 Swift pools, reported `0 broken`, zero false positives.
2. **Detection** — broke AN on one NIC of `userswft2`'s VMSS (`enableAcceleratedNetworking=false` on NIC[0], NIC[1] left `true`); dry-run correctly flagged it (`accelNetBroken=true`, `nrpFailures=0`), confirming the AN-demand AND semantics and the NRP-independent detection trigger.
3. **Live remediation** (`DRY_RUN=false`) — full `createPoolZeroThenScale` flow ran cleanly: temp pool created @ 0 → AN verified → scaled; `userswft2` cordoned/drained/deleted; recreated @ 0 → AN verified → scaled to original count (`accelerated-networking=true confirmed after scale-up`); temp pool cleaned up; `DONE` with 0 residual NRP failures.
4. **Final state** — `userswft2` is a new VMSS (`aks-userswft2-30745802-vmss`, was `-10533704-`) with AN `[true, true]` on both NICs; nodepool `Succeeded`, original count, Swift tag intact. All other pools untouched — zero collateral.

### Special notes for your reviewer

The Swift identifier is the `aks-nic-enable-multi-tenancy=true` tag; `agentPoolForCreate` strips only `aks-managed-` tags, so the tag survives cloning into the temp and recreated pool bodies — `poolIsSwift(finalBody)` is true for both. The AN precheck always runs (no config flag) but is conservative and fail-open, so it cannot regress the existing NRP-driven path. Patching an AKS-managed VMSS is technically unsupported, so the post-scale re-verification remains the safety net.

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

