### PR TITLE
feat: add cluster and nodepool controllers that ensure serviceprovider cosmos resources exist

### DIFF
--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -575,6 +575,13 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		unionKubeApplierInformers,
 	)
 
+	createServiceProviderClusterController := controllers.NewCreateServiceProviderClusterController(
+		activeOperationLister, b.options.ResourcesDBClient, backendInformers,
+	)
+	createServiceProviderNodePoolController := controllers.NewCreateServiceProviderNodePoolController(
+		activeOperationLister, b.options.ResourcesDBClient, backendInformers,
+	)
+
 	createClusterScopedReadDesiresController := controllers.NewCreateClusterScopedReadDesiresController(
 		activeOperationLister, b.options.ResourcesDBClient, b.options.KubeApplierDBClients,
 		backendInformers, b.options.MaestroSourceEnvironmentIdentifier,
@@ -782,6 +789,8 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 				go azureClusterResourceGroupExistenceValidationController.Run(ctx, 20)
 				go azureClusterManagedIdentitiesExistenceValidationController.Run(ctx, 20)
 				go nodePoolVersionController.Run(ctx, 20)
+				go createServiceProviderClusterController.Run(ctx, 20)
+				go createServiceProviderNodePoolController.Run(ctx, 20)
 				go createClusterScopedReadDesiresController.Run(ctx, 20)
 				go createNodePoolScopedReadDesiresController.Run(ctx, 20)
 				go maestroDeleteOrphanedReadonlyBundlesController.Run(ctx, 20)

--- a/backend/pkg/controllers/create_cluster_scoped_read_desires_controller.go
+++ b/backend/pkg/controllers/create_cluster_scoped_read_desires_controller.go
@@ -108,9 +108,12 @@ func (c *createClusterScopedReadDesiresSyncer) SyncOnce(ctx context.Context, key
 	// ServiceProviderCluster.Status.ManagementClusterResourceID; until that
 	// lands we have nowhere to write the ReadDesire, so skip and wait for
 	// the next reconcile cycle.
-	spc, err := database.GetOrCreateServiceProviderCluster(ctx, c.resourcesDBClient, key.GetResourceID())
+	spc, err := database.GetServiceProviderCluster(ctx, c.resourcesDBClient, key.GetResourceID())
+	if database.IsNotFoundError(err) {
+		return nil
+	}
 	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to get or create ServiceProviderCluster: %w", err))
+		return utils.TrackError(fmt.Errorf("failed to get ServiceProviderCluster: %w", err))
 	}
 	mcResourceID := spc.Status.ManagementClusterResourceID
 	if mcResourceID == nil {

--- a/backend/pkg/controllers/create_nodepool_scoped_read_desires_controller.go
+++ b/backend/pkg/controllers/create_nodepool_scoped_read_desires_controller.go
@@ -97,9 +97,12 @@ func (c *createNodePoolScopedReadDesiresSyncer) SyncOnce(ctx context.Context, ke
 		ResourceGroupName: key.ResourceGroupName,
 		HCPClusterName:    key.HCPClusterName,
 	}
-	spc, err := database.GetOrCreateServiceProviderCluster(ctx, c.resourcesDBClient, clusterKey.GetResourceID())
+	spc, err := database.GetServiceProviderCluster(ctx, c.resourcesDBClient, clusterKey.GetResourceID())
+	if database.IsNotFoundError(err) {
+		return nil
+	}
 	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to get or create ServiceProviderCluster: %w", err))
+		return utils.TrackError(fmt.Errorf("failed to get ServiceProviderCluster: %w", err))
 	}
 	mcResourceID := spc.Status.ManagementClusterResourceID
 	if mcResourceID == nil {

--- a/backend/pkg/controllers/create_service_provider_cluster_controller.go
+++ b/backend/pkg/controllers/create_service_provider_cluster_controller.go
@@ -1,0 +1,99 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// createServiceProviderClusterSyncer ensures the singleton ServiceProviderCluster
+// Cosmos document exists for each HCP cluster. If the cluster has DeletionTimestamp
+// set, creation is skipped.
+type createServiceProviderClusterSyncer struct {
+	cooldownChecker              controllerutil.CooldownChecker
+	clusterLister                listers.ClusterLister
+	serviceProviderClusterLister listers.ServiceProviderClusterLister
+	resourcesDBClient            database.ResourcesDBClient
+}
+
+var _ controllerutils.ClusterSyncer = (*createServiceProviderClusterSyncer)(nil)
+
+func NewCreateServiceProviderClusterController(
+	activeOperationLister listers.ActiveOperationLister,
+	resourcesDBClient database.ResourcesDBClient,
+	informers informers.BackendInformers,
+) controllerutils.Controller {
+	_, clusterLister := informers.Clusters()
+	_, serviceProviderClusterLister := informers.ServiceProviderClusters()
+
+	syncer := &createServiceProviderClusterSyncer{
+		cooldownChecker:              controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		clusterLister:                clusterLister,
+		serviceProviderClusterLister: serviceProviderClusterLister,
+		resourcesDBClient:            resourcesDBClient,
+	}
+
+	return controllerutils.NewClusterWatchingController(
+		"CreateServiceProviderCluster",
+		resourcesDBClient,
+		informers,
+		nil,
+		1*time.Minute,
+		syncer,
+	)
+}
+
+func (c *createServiceProviderClusterSyncer) CooldownChecker() controllerutil.CooldownChecker {
+	return c.cooldownChecker
+}
+
+func (c *createServiceProviderClusterSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPClusterKey) error {
+	cachedCluster, err := c.clusterLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get cluster from cache: %w", err))
+	}
+	if cachedCluster.ServiceProviderProperties.DeletionTimestamp != nil {
+		return nil
+	}
+
+	_, err = c.serviceProviderClusterLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if err == nil {
+		return nil
+	}
+	if !database.IsNotFoundError(err) {
+		return utils.TrackError(fmt.Errorf("failed to get ServiceProviderCluster from cache: %w", err))
+	}
+
+	if err := database.CreateServiceProviderCluster(ctx, c.resourcesDBClient, key.GetResourceID()); err != nil {
+		if database.IsConflictError(err) {
+			return nil
+		}
+		return utils.TrackError(fmt.Errorf("failed to create ServiceProviderCluster: %w", err))
+	}
+
+	return nil
+}

--- a/backend/pkg/controllers/create_service_provider_cluster_controller_test.go
+++ b/backend/pkg/controllers/create_service_provider_cluster_controller_test.go
@@ -1,0 +1,190 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+const (
+	createSPCSubscriptionID    = "00000000-0000-0000-0000-000000000000"
+	createSPCResourceGroupName = "test-rg"
+	createSPCClusterName       = "test-cluster"
+)
+
+func newCreateSPCClusterKey() controllerutils.HCPClusterKey {
+	return controllerutils.HCPClusterKey{
+		SubscriptionID:    createSPCSubscriptionID,
+		ResourceGroupName: createSPCResourceGroupName,
+		HCPClusterName:    createSPCClusterName,
+	}
+}
+
+func newCreateSPCClusterResourceID(t *testing.T) *azcorearm.ResourceID {
+	t.Helper()
+	return api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + createSPCSubscriptionID +
+			"/resourceGroups/" + createSPCResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + createSPCClusterName))
+}
+
+func newCreateSPCCluster(t *testing.T, opts ...func(*api.HCPOpenShiftCluster)) *api.HCPOpenShiftCluster {
+	t.Helper()
+	clusterResourceID := newCreateSPCClusterResourceID(t)
+	cluster := &api.HCPOpenShiftCluster{
+		CosmosMetadata: arm.CosmosMetadata{ResourceID: clusterResourceID},
+		TrackedResource: arm.TrackedResource{
+			Resource: arm.Resource{
+				ID:   clusterResourceID,
+				Name: createSPCClusterName,
+				Type: api.ClusterResourceType.String(),
+			},
+			Location: "eastus",
+		},
+	}
+	for _, opt := range opts {
+		opt(cluster)
+	}
+	return cluster
+}
+
+func newCreateSPCServiceProviderCluster(t *testing.T) *api.ServiceProviderCluster {
+	t.Helper()
+	clusterResourceID := newCreateSPCClusterResourceID(t)
+	spcResourceID := api.Must(azcorearm.ParseResourceID(
+		clusterResourceID.String() + "/" + api.ServiceProviderClusterResourceTypeName + "/" + api.ServiceProviderClusterResourceName))
+	return &api.ServiceProviderCluster{
+		CosmosMetadata: arm.CosmosMetadata{ResourceID: spcResourceID},
+	}
+}
+
+type alwaysAllowCooldownChecker struct{}
+
+func (a *alwaysAllowCooldownChecker) CanSync(_ context.Context, _ any) bool { return true }
+
+var _ controllerutil.CooldownChecker = (*alwaysAllowCooldownChecker)(nil)
+
+func TestCreateServiceProviderClusterSyncer_SyncOnce(t *testing.T) {
+	testKey := newCreateSPCClusterKey()
+
+	tests := []struct {
+		name         string
+		clusters     []*api.HCPOpenShiftCluster
+		spcForLister []*api.ServiceProviderCluster
+		seedSPCInDB  bool
+		wantSPCInDB  bool
+		expectError  bool
+	}{
+		{
+			name:        "cluster missing from cache is a no-op",
+			clusters:    nil,
+			wantSPCInDB: false,
+			expectError: false,
+		},
+		{
+			name: "cluster with deletion timestamp is a no-op",
+			clusters: []*api.HCPOpenShiftCluster{
+				newCreateSPCCluster(t, func(c *api.HCPOpenShiftCluster) {
+					c.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+				}),
+			},
+			wantSPCInDB: false,
+		},
+		{
+			name: "service provider cluster already in cache is a no-op",
+			clusters: []*api.HCPOpenShiftCluster{
+				newCreateSPCCluster(t),
+			},
+			spcForLister: []*api.ServiceProviderCluster{
+				newCreateSPCServiceProviderCluster(t),
+			},
+			wantSPCInDB: false,
+		},
+		{
+			name: "creates service provider cluster when missing from cache and DB",
+			clusters: []*api.HCPOpenShiftCluster{
+				newCreateSPCCluster(t),
+			},
+			wantSPCInDB: true,
+		},
+		{
+			name: "create conflict when document already exists in DB is treated as success",
+			clusters: []*api.HCPOpenShiftCluster{
+				newCreateSPCCluster(t),
+			},
+			seedSPCInDB: true,
+			wantSPCInDB: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := utils.ContextWithLogger(context.Background(), logr.Discard())
+			mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
+			if tt.seedSPCInDB {
+				_, err := mockResourcesDBClient.ServiceProviderClusters(
+					createSPCSubscriptionID, createSPCResourceGroupName, createSPCClusterName,
+				).Create(ctx, newCreateSPCServiceProviderCluster(t), nil)
+				require.NoError(t, err)
+			}
+
+			syncer := &createServiceProviderClusterSyncer{
+				cooldownChecker: &alwaysAllowCooldownChecker{},
+				clusterLister: &listertesting.SliceClusterLister{
+					Clusters: tt.clusters,
+				},
+				serviceProviderClusterLister: &listertesting.SliceServiceProviderClusterLister{
+					ServiceProviderClusters: tt.spcForLister,
+				},
+				resourcesDBClient: mockResourcesDBClient,
+			}
+
+			err := syncer.SyncOnce(ctx, testKey)
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			_, getErr := mockResourcesDBClient.ServiceProviderClusters(
+				createSPCSubscriptionID, createSPCResourceGroupName, createSPCClusterName,
+			).Get(ctx, api.ServiceProviderClusterResourceName)
+			if tt.wantSPCInDB {
+				require.NoError(t, getErr)
+			} else {
+				assert.True(t, database.IsNotFoundError(getErr))
+			}
+		})
+	}
+}

--- a/backend/pkg/controllers/create_service_provider_nodepool_controller.go
+++ b/backend/pkg/controllers/create_service_provider_nodepool_controller.go
@@ -1,0 +1,98 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// createServiceProviderNodePoolSyncer ensures the singleton ServiceProviderNodePool
+// Cosmos document exists for each HCP node pool. If the node pool has
+// DeletionTimestamp set, creation is skipped.
+type createServiceProviderNodePoolSyncer struct {
+	cooldownChecker               controllerutil.CooldownChecker
+	nodePoolLister                listers.NodePoolLister
+	serviceProviderNodePoolLister listers.ServiceProviderNodePoolLister
+	resourcesDBClient             database.ResourcesDBClient
+}
+
+var _ controllerutils.NodePoolSyncer = (*createServiceProviderNodePoolSyncer)(nil)
+
+func NewCreateServiceProviderNodePoolController(
+	activeOperationLister listers.ActiveOperationLister,
+	resourcesDBClient database.ResourcesDBClient,
+	informers informers.BackendInformers,
+) controllerutils.Controller {
+	_, nodePoolLister := informers.NodePools()
+	_, serviceProviderNodePoolLister := informers.ServiceProviderNodePools()
+
+	syncer := &createServiceProviderNodePoolSyncer{
+		cooldownChecker:               controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		nodePoolLister:                nodePoolLister,
+		serviceProviderNodePoolLister: serviceProviderNodePoolLister,
+		resourcesDBClient:             resourcesDBClient,
+	}
+
+	return controllerutils.NewNodePoolWatchingController(
+		"CreateServiceProviderNodePool",
+		resourcesDBClient,
+		informers,
+		1*time.Minute,
+		syncer,
+	)
+}
+
+func (c *createServiceProviderNodePoolSyncer) CooldownChecker() controllerutil.CooldownChecker {
+	return c.cooldownChecker
+}
+
+func (c *createServiceProviderNodePoolSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPNodePoolKey) error {
+	cachedNodePool, err := c.nodePoolLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get node pool from cache: %w", err))
+	}
+	if cachedNodePool.ServiceProviderProperties.DeletionTimestamp != nil {
+		return nil
+	}
+
+	_, err = c.serviceProviderNodePoolLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
+	if err == nil {
+		return nil
+	}
+	if !database.IsNotFoundError(err) {
+		return utils.TrackError(fmt.Errorf("failed to get ServiceProviderNodePool from cache: %w", err))
+	}
+
+	if err := database.CreateServiceProviderNodePool(ctx, c.resourcesDBClient, key.GetResourceID()); err != nil {
+		if database.IsConflictError(err) {
+			return nil
+		}
+		return utils.TrackError(fmt.Errorf("failed to create ServiceProviderNodePool: %w", err))
+	}
+
+	return nil
+}

--- a/backend/pkg/controllers/create_service_provider_nodepool_controller_test.go
+++ b/backend/pkg/controllers/create_service_provider_nodepool_controller_test.go
@@ -1,0 +1,185 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+const (
+	createSPNPSubscriptionID    = "00000000-0000-0000-0000-000000000000"
+	createSPNPResourceGroupName = "test-rg"
+	createSPNPClusterName       = "test-cluster"
+	createSPNPNodePoolName      = "test-nodepool"
+)
+
+func newCreateSPNPNodePoolKey() controllerutils.HCPNodePoolKey {
+	return controllerutils.HCPNodePoolKey{
+		SubscriptionID:    createSPNPSubscriptionID,
+		ResourceGroupName: createSPNPResourceGroupName,
+		HCPClusterName:    createSPNPClusterName,
+		HCPNodePoolName:   createSPNPNodePoolName,
+	}
+}
+
+func newCreateSPNPNodePoolResourceID(t *testing.T) *azcorearm.ResourceID {
+	t.Helper()
+	return api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + createSPNPSubscriptionID +
+			"/resourceGroups/" + createSPNPResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + createSPNPClusterName +
+			"/nodePools/" + createSPNPNodePoolName))
+}
+
+func newCreateSPNPNodePool(t *testing.T, opts ...func(*api.HCPOpenShiftClusterNodePool)) *api.HCPOpenShiftClusterNodePool {
+	t.Helper()
+	nodePoolResourceID := newCreateSPNPNodePoolResourceID(t)
+	nodePool := &api.HCPOpenShiftClusterNodePool{
+		CosmosMetadata: arm.CosmosMetadata{ResourceID: nodePoolResourceID},
+		TrackedResource: arm.TrackedResource{
+			Resource: arm.Resource{
+				ID:   nodePoolResourceID,
+				Name: createSPNPNodePoolName,
+				Type: api.NodePoolResourceType.String(),
+			},
+			Location: "eastus",
+		},
+	}
+	for _, opt := range opts {
+		opt(nodePool)
+	}
+	return nodePool
+}
+
+func newCreateSPNPServiceProviderNodePool(t *testing.T) *api.ServiceProviderNodePool {
+	t.Helper()
+	nodePoolResourceID := newCreateSPNPNodePoolResourceID(t)
+	spnpResourceID := api.Must(azcorearm.ParseResourceID(
+		nodePoolResourceID.String() + "/" + api.ServiceProviderNodePoolResourceTypeName + "/" + api.ServiceProviderNodePoolResourceName))
+	return &api.ServiceProviderNodePool{
+		CosmosMetadata: arm.CosmosMetadata{ResourceID: spnpResourceID},
+	}
+}
+
+func TestCreateServiceProviderNodePoolSyncer_SyncOnce(t *testing.T) {
+	testKey := newCreateSPNPNodePoolKey()
+
+	tests := []struct {
+		name          string
+		nodePools     []*api.HCPOpenShiftClusterNodePool
+		spnpForLister []*api.ServiceProviderNodePool
+		seedSPNPInDB  bool
+		wantSPNPInDB  bool
+		expectError   bool
+	}{
+		{
+			name:         "node pool missing from cache is a no-op",
+			nodePools:    nil,
+			wantSPNPInDB: false,
+		},
+		{
+			name: "node pool with deletion timestamp is a no-op",
+			nodePools: []*api.HCPOpenShiftClusterNodePool{
+				newCreateSPNPNodePool(t, func(np *api.HCPOpenShiftClusterNodePool) {
+					np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+				}),
+			},
+			wantSPNPInDB: false,
+		},
+		{
+			name: "service provider node pool already in cache is a no-op",
+			nodePools: []*api.HCPOpenShiftClusterNodePool{
+				newCreateSPNPNodePool(t),
+			},
+			spnpForLister: []*api.ServiceProviderNodePool{
+				newCreateSPNPServiceProviderNodePool(t),
+			},
+			wantSPNPInDB: false,
+		},
+		{
+			name: "creates service provider node pool when missing from cache and DB",
+			nodePools: []*api.HCPOpenShiftClusterNodePool{
+				newCreateSPNPNodePool(t),
+			},
+			wantSPNPInDB: true,
+		},
+		{
+			name: "create conflict when document already exists in DB is treated as success",
+			nodePools: []*api.HCPOpenShiftClusterNodePool{
+				newCreateSPNPNodePool(t),
+			},
+			seedSPNPInDB: true,
+			wantSPNPInDB: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := utils.ContextWithLogger(context.Background(), logr.Discard())
+			mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
+			if tt.seedSPNPInDB {
+				_, err := mockResourcesDBClient.ServiceProviderNodePools(
+					createSPNPSubscriptionID, createSPNPResourceGroupName, createSPNPClusterName, createSPNPNodePoolName,
+				).Create(ctx, newCreateSPNPServiceProviderNodePool(t), nil)
+				require.NoError(t, err)
+			}
+
+			syncer := &createServiceProviderNodePoolSyncer{
+				cooldownChecker: &alwaysAllowCooldownChecker{},
+				nodePoolLister: &listertesting.SliceNodePoolLister{
+					NodePools: tt.nodePools,
+				},
+				serviceProviderNodePoolLister: &listertesting.SliceServiceProviderNodePoolLister{
+					ServiceProviderNodePools: tt.spnpForLister,
+				},
+				resourcesDBClient: mockResourcesDBClient,
+			}
+
+			err := syncer.SyncOnce(ctx, testKey)
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			_, getErr := mockResourcesDBClient.ServiceProviderNodePools(
+				createSPNPSubscriptionID, createSPNPResourceGroupName, createSPNPClusterName, createSPNPNodePoolName,
+			).Get(ctx, api.ServiceProviderNodePoolResourceName)
+			if tt.wantSPNPInDB {
+				require.NoError(t, getErr)
+			} else {
+				assert.True(t, database.IsNotFoundError(getErr))
+			}
+		})
+	}
+}

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_active_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_active_version_controller.go
@@ -104,9 +104,12 @@ func (c *controlPlaneActiveVersionSyncer) SyncOnce(ctx context.Context, key cont
 		return utils.TrackError(err)
 	}
 
-	existingServiceProviderCluster, err := database.GetOrCreateServiceProviderCluster(ctx, c.resourcesDBClient, key.GetResourceID())
+	existingServiceProviderCluster, err := database.GetServiceProviderCluster(ctx, c.resourcesDBClient, key.GetResourceID())
+	if database.IsNotFoundError(err) {
+		return nil
+	}
 	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to get or create ServiceProviderCluster: %w", err))
+		return utils.TrackError(fmt.Errorf("failed to get ServiceProviderCluster: %w", err))
 	}
 	// Use NeedsUpdate (semantic equality) instead of slices.Equal: HCPClusterActiveVersion holds
 	// *semver.Version, and Go's `==` (which slices.Equal relies on) compares those pointers, not

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_active_version_controller_test.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_active_version_controller_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/api/kubeapplier"
+	"github.com/Azure/ARO-HCP/internal/database"
 	internallistertesting "github.com/Azure/ARO-HCP/internal/database/listertesting"
 	"github.com/Azure/ARO-HCP/internal/databasetesting"
 	"github.com/Azure/ARO-HCP/internal/utils"
@@ -101,6 +102,7 @@ func TestControlPlaneActiveVersionSyncer_SyncOnce(t *testing.T) {
 			seedDB: func(t *testing.T, ctx context.Context, mockResourcesDBClient *databasetesting.MockResourcesDBClient) {
 				t.Helper()
 				createTestHCPCluster(t, ctx, mockResourcesDBClient)
+				createEmptyServiceProviderCluster(t, ctx, mockResourcesDBClient)
 			},
 			readDesires: func(t *testing.T) []*kubeapplier.ReadDesire {
 				return []*kubeapplier.ReadDesire{newHostedClusterReadDesireWithVersions(t, nil,
@@ -125,6 +127,7 @@ func TestControlPlaneActiveVersionSyncer_SyncOnce(t *testing.T) {
 			seedDB: func(t *testing.T, ctx context.Context, mockResourcesDBClient *databasetesting.MockResourcesDBClient) {
 				t.Helper()
 				createTestHCPCluster(t, ctx, mockResourcesDBClient)
+				createEmptyServiceProviderCluster(t, ctx, mockResourcesDBClient)
 			},
 			readDesires: func(t *testing.T) []*kubeapplier.ReadDesire {
 				return []*kubeapplier.ReadDesire{newHostedClusterReadDesireWithVersions(t, nil,
@@ -148,6 +151,7 @@ func TestControlPlaneActiveVersionSyncer_SyncOnce(t *testing.T) {
 			seedDB: func(t *testing.T, ctx context.Context, mockResourcesDBClient *databasetesting.MockResourcesDBClient) {
 				t.Helper()
 				createTestHCPCluster(t, ctx, mockResourcesDBClient)
+				createEmptyServiceProviderCluster(t, ctx, mockResourcesDBClient)
 			},
 			readDesires: func(t *testing.T) []*kubeapplier.ReadDesire {
 				return []*kubeapplier.ReadDesire{newHostedClusterReadDesireWithVersions(t, nil, hsv1beta1.ControlPlaneVersionStatus{})}
@@ -165,6 +169,7 @@ func TestControlPlaneActiveVersionSyncer_SyncOnce(t *testing.T) {
 			seedDB: func(t *testing.T, ctx context.Context, mockResourcesDBClient *databasetesting.MockResourcesDBClient) {
 				t.Helper()
 				createTestHCPCluster(t, ctx, mockResourcesDBClient)
+				createEmptyServiceProviderCluster(t, ctx, mockResourcesDBClient)
 			},
 			readDesires: func(t *testing.T) []*kubeapplier.ReadDesire {
 				return []*kubeapplier.ReadDesire{newHostedClusterReadDesireWithVersions(t, nil, hsv1beta1.ControlPlaneVersionStatus{})}
@@ -182,6 +187,7 @@ func TestControlPlaneActiveVersionSyncer_SyncOnce(t *testing.T) {
 			seedDB: func(t *testing.T, ctx context.Context, mockResourcesDBClient *databasetesting.MockResourcesDBClient) {
 				t.Helper()
 				createTestHCPCluster(t, ctx, mockResourcesDBClient)
+				createEmptyServiceProviderCluster(t, ctx, mockResourcesDBClient)
 			},
 			readDesires: func(t *testing.T) []*kubeapplier.ReadDesire {
 				return []*kubeapplier.ReadDesire{newHostedClusterReadDesireWithVersions(t, nil,
@@ -207,6 +213,7 @@ func TestControlPlaneActiveVersionSyncer_SyncOnce(t *testing.T) {
 			seedDB: func(t *testing.T, ctx context.Context, mockResourcesDBClient *databasetesting.MockResourcesDBClient) {
 				t.Helper()
 				createTestHCPCluster(t, ctx, mockResourcesDBClient)
+				createEmptyServiceProviderCluster(t, ctx, mockResourcesDBClient)
 			},
 			readDesires: func(t *testing.T) []*kubeapplier.ReadDesire {
 				return []*kubeapplier.ReadDesire{newHostedClusterReadDesireWithVersions(t,
@@ -233,6 +240,7 @@ func TestControlPlaneActiveVersionSyncer_SyncOnce(t *testing.T) {
 			seedDB: func(t *testing.T, ctx context.Context, mockResourcesDBClient *databasetesting.MockResourcesDBClient) {
 				t.Helper()
 				createTestHCPCluster(t, ctx, mockResourcesDBClient)
+				createEmptyServiceProviderCluster(t, ctx, mockResourcesDBClient)
 			},
 			readDesires: func(t *testing.T) []*kubeapplier.ReadDesire {
 				return []*kubeapplier.ReadDesire{newHostedClusterReadDesireWithVersions(t, nil,
@@ -256,6 +264,7 @@ func TestControlPlaneActiveVersionSyncer_SyncOnce(t *testing.T) {
 			seedDB: func(t *testing.T, ctx context.Context, mockResourcesDBClient *databasetesting.MockResourcesDBClient) {
 				t.Helper()
 				createTestHCPCluster(t, ctx, mockResourcesDBClient)
+				createEmptyServiceProviderCluster(t, ctx, mockResourcesDBClient)
 			},
 			readDesires: func(t *testing.T) []*kubeapplier.ReadDesire {
 				return []*kubeapplier.ReadDesire{newHostedClusterReadDesireWithVersions(t,
@@ -379,6 +388,17 @@ func createTestHCPCluster(t *testing.T, ctx context.Context, mockResourcesDBClie
 	}
 	_, err = mockResourcesDBClient.HCPClusters(testSubscriptionID, testResourceGroupName).Create(ctx, cluster, nil)
 	require.NoError(t, err)
+}
+
+// createEmptyServiceProviderCluster seeds the minimal ServiceProviderCluster document
+// that CreateServiceProviderCluster / GetOrCreateServiceProviderCluster would create.
+func createEmptyServiceProviderCluster(t *testing.T, ctx context.Context, mockResourcesDBClient *databasetesting.MockResourcesDBClient) {
+	t.Helper()
+
+	clusterResourceID := api.Must(azcorearm.ParseResourceID("/subscriptions/" + testSubscriptionID +
+		"/resourceGroups/" + testResourceGroupName +
+		"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName))
+	require.NoError(t, database.CreateServiceProviderCluster(ctx, mockResourcesDBClient, clusterResourceID))
 }
 
 // newHostedClusterReadDesireWithVersions builds a ReadDesire whose

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
@@ -127,9 +127,12 @@ func (c *controlPlaneDesiredVersionSyncer) SyncOnce(ctx context.Context, key con
 		return nil
 	}
 
-	existingServiceProviderCluster, err := database.GetOrCreateServiceProviderCluster(ctx, c.resourcesDBClient, key.GetResourceID())
+	existingServiceProviderCluster, err := database.GetServiceProviderCluster(ctx, c.resourcesDBClient, key.GetResourceID())
+	if database.IsNotFoundError(err) {
+		return nil
+	}
 	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to get or create ServiceProviderCluster: %w", err))
+		return utils.TrackError(fmt.Errorf("failed to get ServiceProviderCluster: %w", err))
 	}
 
 	// Resolve the cluster UUID from the cached HostedCluster so we can build the Cincinnati client.

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
@@ -293,9 +293,12 @@ func (c *controlPlaneDesiredVersionSyncer) desiredControlPlaneZVersion(ctx conte
 		if err := validation.OpenshiftVersionAtMostOneMinorSkew(actualLatestMinorVersion.String(), desiredMinorVersion.String()); err != nil {
 			return nil, utils.TrackError(err)
 		}
-		clusterNodePools, err := c.listClusterAdmissionNodePools(ctx, clusterResourceID)
+		clusterNodePools, ready, err := c.listClusterAdmissionNodePools(ctx, clusterResourceID)
 		if err != nil {
 			return nil, utils.TrackError(err)
+		}
+		if !ready {
+			return nil, nil
 		}
 		if err := admission.AdmitClusterNodePoolsMinorVersionSkew(ctx, clusterNodePools, desiredMinorVersion); err != nil {
 			return nil, utils.TrackError(err)
@@ -337,21 +340,32 @@ func (c *controlPlaneDesiredVersionSyncer) desiredControlPlaneZVersion(ctx conte
 	))
 }
 
-// listClusterAdmissionNodePools prefetches every node pool under clusterResourceID
-// paired with its service-provider record, in the same shape that
+// listClusterAdmissionNodePools prefetches live node pools under clusterResourceID
+// paired with their service-provider record, in the same shape that
 // frontend.newClusterAdmissionContext builds for cluster admission. The upgrade
 // controller passes the result to admission.AdmitClusterNodePoolsMinorVersionSkew
 // directly so that admission code stays free of any DB dependency.
-func (c *controlPlaneDesiredVersionSyncer) listClusterAdmissionNodePools(ctx context.Context, clusterResourceID *azcorearm.ResourceID) ([]admission.ClusterAdmissionNodePool, error) {
+//
+// Node pools with DeletionTimestamp set are omitted. When a live node pool has
+// no ServiceProviderNodePool document yet, ready is false so the caller retries
+// on a later reconcile once the ensure controller has created it.
+func (c *controlPlaneDesiredVersionSyncer) listClusterAdmissionNodePools(ctx context.Context, clusterResourceID *azcorearm.ResourceID) ([]admission.ClusterAdmissionNodePool, bool, error) {
 	nodePoolIterator, err := c.resourcesDBClient.HCPClusters(clusterResourceID.SubscriptionID, clusterResourceID.ResourceGroupName).NodePools(clusterResourceID.Name).List(ctx, nil)
 	if err != nil {
-		return nil, utils.TrackError(err)
+		return nil, false, utils.TrackError(err)
 	}
 	var clusterNodePools []admission.ClusterAdmissionNodePool
 	for _, nodePool := range nodePoolIterator.Items(ctx) {
-		spNodePool, err := database.GetOrCreateServiceProviderNodePool(ctx, c.resourcesDBClient, nodePool.ID)
+		if nodePool.ServiceProviderProperties.DeletionTimestamp != nil {
+			continue
+		}
+
+		spNodePool, err := database.GetServiceProviderNodePool(ctx, c.resourcesDBClient, nodePool.ID)
+		if database.IsNotFoundError(err) {
+			return nil, false, nil
+		}
 		if err != nil {
-			return nil, utils.TrackError(err)
+			return nil, false, utils.TrackError(err)
 		}
 		clusterNodePools = append(clusterNodePools, admission.ClusterAdmissionNodePool{
 			NodePool:                nodePool,
@@ -359,9 +373,9 @@ func (c *controlPlaneDesiredVersionSyncer) listClusterAdmissionNodePools(ctx con
 		})
 	}
 	if err := nodePoolIterator.GetError(); err != nil {
-		return nil, utils.TrackError(err)
+		return nil, false, utils.TrackError(err)
 	}
-	return clusterNodePools, nil
+	return clusterNodePools, true, nil
 }
 
 // FindAllUpgradeTargetVersionsInMinor queries Cincinnati and finds the latest version within the specified target minor.

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller_test.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller_test.go
@@ -17,6 +17,7 @@ package upgradecontrollers
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/blang/semver/v4"
 	"github.com/go-logr/logr"
@@ -377,6 +378,45 @@ func TestDesiredControlPlaneZVersion_NextYStreamUpgrade(t *testing.T) {
 			expectedError:   false,
 		},
 		{
+			name:                 "Y-stream upgrade - waits when live node pool SPNP missing",
+			activeVersions:       []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.19.22")), State: configv1.CompletedUpdate}},
+			customerDesiredMinor: "4.20",
+			channelGroup:         "stable",
+			mockSetup:            func(mc *cincinnati.MockClient) {},
+			cosmosResources:      testCosmosClusterWithWorkersNodePoolMissingSPNP("4.18.0"),
+			expectedVersion:      nil,
+			expectedError:        false,
+		},
+		{
+			name:                 "Y-stream upgrade - proceeds when workers node pool is deleting",
+			activeVersions:       []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.19.22")), State: configv1.CompletedUpdate}},
+			customerDesiredMinor: "4.20",
+			channelGroup:         "stable",
+			mockSetup: func(mc *cincinnati.MockClient) {
+				mc.EXPECT().GetUpdates(gomock.AssignableToTypeOf(context.Background()), api.Must(cincinnati.GetCincinnatiURI("stable")), "multi", "multi", "stable-4.20", semver.MustParse("4.19.22")).Return(
+					configv1.Release{Version: "4.19.22"},
+					[]configv1.Release{{Version: "4.20.15"}, {Version: "4.20.10"}, {Version: "4.19.25"}},
+					[]configv1.ConditionalUpdate{},
+					nil,
+				)
+				mc.EXPECT().GetUpdates(gomock.AssignableToTypeOf(context.Background()), api.Must(cincinnati.GetCincinnatiURI("stable")), "multi", "multi", "stable-4.21", semver.MustParse("4.20.15")).Return(
+					configv1.Release{Version: "4.20.15"},
+					[]configv1.Release{},
+					[]configv1.ConditionalUpdate{},
+					nil,
+				).Times(2)
+				mc.EXPECT().GetUpdates(gomock.AssignableToTypeOf(context.Background()), api.Must(cincinnati.GetCincinnatiURI("stable")), "multi", "multi", "stable-4.21", semver.MustParse("4.20.10")).Return(
+					configv1.Release{Version: "4.20.10"},
+					[]configv1.Release{{Version: "4.21.0"}},
+					[]configv1.ConditionalUpdate{},
+					nil,
+				)
+			},
+			cosmosResources: testCosmosClusterWithDeletingWorkersNodePool("4.18.0"),
+			expectedVersion: ptr.To(semver.MustParse("4.20.10")),
+			expectedError:   false,
+		},
+		{
 			name:                 "Y-stream upgrade - no direct path, falls back to Z-stream",
 			activeVersions:       []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.19.15")), State: configv1.CompletedUpdate}},
 			customerDesiredMinor: "4.20",
@@ -590,9 +630,52 @@ func TestDesiredControlPlaneZVersion_NextYStreamUpgrade(t *testing.T) {
 	}
 }
 
-// testCosmosClusterWithWorkersNodePoolAtVersion returns a cluster and workers node pool for the subscription, resource group,
-// and cluster name shared by desiredControlPlaneZVersion tests. nodePoolVersionId is properties.version.id on the pool.
+// testCosmosClusterWithWorkersNodePoolAtVersion returns a cluster, workers node pool, and matching
+// ServiceProviderNodePool for desiredControlPlaneZVersion tests. nodePoolVersionId is
+// properties.version.id on the pool.
 func testCosmosClusterWithWorkersNodePoolAtVersion(nodePoolVersionId string) []any {
+	clusterResourceId := api.Must(api.ToClusterResourceID("6b690bec-0c16-4ecb-8f67-781caf40bba7", "test-rg", "test-cluster"))
+	cluster := &api.HCPOpenShiftCluster{
+		CosmosMetadata: arm.CosmosMetadata{
+			ResourceID: clusterResourceId,
+		},
+		TrackedResource: arm.TrackedResource{
+			Resource: arm.Resource{
+				ID:   clusterResourceId,
+				Name: clusterResourceId.Name,
+				Type: clusterResourceId.ResourceType.String(),
+			},
+		},
+		ServiceProviderProperties: api.HCPOpenShiftClusterServiceProviderProperties{
+			ClusterServiceID: api.Ptr(api.Must(api.NewInternalID("/api/clusters_mgmt/v1/clusters/test-cluster"))),
+		},
+	}
+	nodePoolResourceId := api.Must(azcorearm.ParseResourceID(clusterResourceId.String() + "/nodePools/workers"))
+	spnpResourceID := api.Must(azcorearm.ParseResourceID(
+		nodePoolResourceId.String() + "/" + api.ServiceProviderNodePoolResourceTypeName + "/" + api.ServiceProviderNodePoolResourceName))
+	return []any{
+		cluster,
+		&api.HCPOpenShiftClusterNodePool{
+			CosmosMetadata: arm.CosmosMetadata{
+				ResourceID: nodePoolResourceId,
+			},
+			TrackedResource: arm.NewTrackedResource(nodePoolResourceId, "eastus"),
+			Properties: api.HCPOpenShiftClusterNodePoolProperties{
+				Version: api.NodePoolVersionProfile{ID: nodePoolVersionId},
+			},
+			ServiceProviderProperties: api.HCPOpenShiftClusterNodePoolServiceProviderProperties{
+				ClusterServiceID: api.Ptr(api.Must(api.NewInternalID("/api/clusters_mgmt/v1/clusters/test-cluster/node_pools/workers"))),
+			},
+		},
+		&api.ServiceProviderNodePool{
+			CosmosMetadata: arm.CosmosMetadata{ResourceID: spnpResourceID},
+		},
+	}
+}
+
+// testCosmosClusterWithWorkersNodePoolMissingSPNP returns a cluster and live workers node pool
+// with no ServiceProviderNodePool document (ensure controller has not created it yet).
+func testCosmosClusterWithWorkersNodePoolMissingSPNP(nodePoolVersionId string) []any {
 	clusterResourceId := api.Must(api.ToClusterResourceID("6b690bec-0c16-4ecb-8f67-781caf40bba7", "test-rg", "test-cluster"))
 	cluster := &api.HCPOpenShiftCluster{
 		CosmosMetadata: arm.CosmosMetadata{
@@ -622,6 +705,44 @@ func testCosmosClusterWithWorkersNodePoolAtVersion(nodePoolVersionId string) []a
 			},
 			ServiceProviderProperties: api.HCPOpenShiftClusterNodePoolServiceProviderProperties{
 				ClusterServiceID: api.Ptr(api.Must(api.NewInternalID("/api/clusters_mgmt/v1/clusters/test-cluster/node_pools/workers"))),
+			},
+		},
+	}
+}
+
+// testCosmosClusterWithDeletingWorkersNodePool returns a cluster and workers node pool marked
+// for deletion with no ServiceProviderNodePool document.
+func testCosmosClusterWithDeletingWorkersNodePool(nodePoolVersionId string) []any {
+	clusterResourceId := api.Must(api.ToClusterResourceID("6b690bec-0c16-4ecb-8f67-781caf40bba7", "test-rg", "test-cluster"))
+	cluster := &api.HCPOpenShiftCluster{
+		CosmosMetadata: arm.CosmosMetadata{
+			ResourceID: clusterResourceId,
+		},
+		TrackedResource: arm.TrackedResource{
+			Resource: arm.Resource{
+				ID:   clusterResourceId,
+				Name: clusterResourceId.Name,
+				Type: clusterResourceId.ResourceType.String(),
+			},
+		},
+		ServiceProviderProperties: api.HCPOpenShiftClusterServiceProviderProperties{
+			ClusterServiceID: api.Ptr(api.Must(api.NewInternalID("/api/clusters_mgmt/v1/clusters/test-cluster"))),
+		},
+	}
+	nodePoolResourceId := api.Must(azcorearm.ParseResourceID(clusterResourceId.String() + "/nodePools/workers"))
+	return []any{
+		cluster,
+		&api.HCPOpenShiftClusterNodePool{
+			CosmosMetadata: arm.CosmosMetadata{
+				ResourceID: nodePoolResourceId,
+			},
+			TrackedResource: arm.NewTrackedResource(nodePoolResourceId, "eastus"),
+			Properties: api.HCPOpenShiftClusterNodePoolProperties{
+				Version: api.NodePoolVersionProfile{ID: nodePoolVersionId},
+			},
+			ServiceProviderProperties: api.HCPOpenShiftClusterNodePoolServiceProviderProperties{
+				ClusterServiceID:  api.Ptr(api.Must(api.NewInternalID("/api/clusters_mgmt/v1/clusters/test-cluster/node_pools/workers"))),
+				DeletionTimestamp: &metav1.Time{Time: time.Now()},
 			},
 		},
 	}
@@ -1181,6 +1302,89 @@ func TestControlPlaneDesiredVersionSyncer_SyncOnce(t *testing.T) {
 					assert.Empty(t, intentFailedCondition.Message, "when wantIntentFailed.Status is false, intentFailedCondition.Message must be empty")
 				}
 			}
+		})
+	}
+}
+
+func TestListClusterAdmissionNodePools(t *testing.T) {
+	clusterResourceID := api.Must(api.ToClusterResourceID("6b690bec-0c16-4ecb-8f67-781caf40bba7", "test-rg", "test-cluster"))
+	workersNodePoolResourceID := api.Must(azcorearm.ParseResourceID(clusterResourceID.String() + "/nodePools/workers"))
+	workersSPNPResourceID := api.Must(azcorearm.ParseResourceID(
+		workersNodePoolResourceID.String() + "/" + api.ServiceProviderNodePoolResourceTypeName + "/" + api.ServiceProviderNodePoolResourceName))
+
+	newLiveWorkersNodePool := func() *api.HCPOpenShiftClusterNodePool {
+		return &api.HCPOpenShiftClusterNodePool{
+			CosmosMetadata:  arm.CosmosMetadata{ResourceID: workersNodePoolResourceID},
+			TrackedResource: arm.NewTrackedResource(workersNodePoolResourceID, "eastus"),
+			Properties: api.HCPOpenShiftClusterNodePoolProperties{
+				Version: api.NodePoolVersionProfile{ID: "4.19.15"},
+			},
+		}
+	}
+	newDeletingWorkersNodePool := func() *api.HCPOpenShiftClusterNodePool {
+		return &api.HCPOpenShiftClusterNodePool{
+			CosmosMetadata:  arm.CosmosMetadata{ResourceID: workersNodePoolResourceID},
+			TrackedResource: arm.NewTrackedResource(workersNodePoolResourceID, "eastus"),
+			ServiceProviderProperties: api.HCPOpenShiftClusterNodePoolServiceProviderProperties{
+				DeletionTimestamp: &metav1.Time{Time: time.Now()},
+			},
+		}
+	}
+	newWorkersSPNP := func() *api.ServiceProviderNodePool {
+		return &api.ServiceProviderNodePool{
+			CosmosMetadata: arm.CosmosMetadata{ResourceID: workersSPNPResourceID},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		resources func() []any
+		wantReady bool
+		wantLen   int
+		wantErr   bool
+	}{
+		{
+			name: "live node pool without SPNP is not ready",
+			resources: func() []any {
+				return []any{newLiveWorkersNodePool()}
+			},
+			wantReady: false,
+			wantLen:   0,
+		},
+		{
+			name: "deleting node pool without SPNP is skipped and ready",
+			resources: func() []any {
+				return []any{newDeletingWorkersNodePool()}
+			},
+			wantReady: true,
+			wantLen:   0,
+		},
+		{
+			name: "live node pool with SPNP is ready",
+			resources: func() []any {
+				return []any{newLiveWorkersNodePool(), newWorkersSPNP()}
+			},
+			wantReady: true,
+			wantLen:   1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, tt.resources())
+			require.NoError(t, err)
+
+			syncer := &controlPlaneDesiredVersionSyncer{resourcesDBClient: mockResourcesDBClient}
+			gotPools, ready, err := syncer.listClusterAdmissionNodePools(ctx, clusterResourceID)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantReady, ready)
+			assert.Len(t, gotPools, tt.wantLen)
 		})
 	}
 }

--- a/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller.go
@@ -135,16 +135,22 @@ func (c *nodePoolVersionSyncer) SyncOnce(ctx context.Context, key controllerutil
 		return nil
 	}
 
-	existingServiceProviderNodePool, err := database.GetOrCreateServiceProviderNodePool(ctx, c.resourcesDBClient, key.GetResourceID())
+	existingServiceProviderNodePool, err := database.GetServiceProviderNodePool(ctx, c.resourcesDBClient, key.GetResourceID())
+	if database.IsNotFoundError(err) {
+		return nil
+	}
 	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to get or create ServiceProviderNodePool: %w", err))
+		return utils.TrackError(fmt.Errorf("failed to get ServiceProviderNodePool: %w", err))
 	}
 
 	// Get the ServiceProviderCluster for control plane version validation
 	clusterResourceID := api.Must(api.ToClusterResourceID(key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName))
-	existingServiceProviderCluster, err := database.GetOrCreateServiceProviderCluster(ctx, c.resourcesDBClient, clusterResourceID)
+	existingServiceProviderCluster, err := database.GetServiceProviderCluster(ctx, c.resourcesDBClient, clusterResourceID)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
 	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to get or create ServiceProviderCluster: %w", err))
+		return utils.TrackError(fmt.Errorf("failed to get ServiceProviderCluster: %w", err))
 	}
 
 	// Get the cluster for Cincinnati client initialization

--- a/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller_test.go
+++ b/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller_test.go
@@ -252,6 +252,8 @@ func TestNodePoolVersionSyncer_SyncOnce(t *testing.T) {
 			seedDB: func(t *testing.T, ctx context.Context, mockResourcesDBClient *databasetesting.MockResourcesDBClient) {
 				t.Helper()
 				createTestNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.15")
+				createEmptyServiceProviderCluster(t, ctx, mockResourcesDBClient)
+				createEmptyServiceProviderNodePool(t, ctx, mockResourcesDBClient)
 			},
 			mockCS: func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec) {
 				t.Helper()
@@ -300,6 +302,8 @@ func TestNodePoolVersionSyncer_SyncOnce(t *testing.T) {
 			seedDB: func(t *testing.T, ctx context.Context, mockResourcesDBClient *databasetesting.MockResourcesDBClient) {
 				t.Helper()
 				createTestNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.15")
+				createEmptyServiceProviderCluster(t, ctx, mockResourcesDBClient)
+				createEmptyServiceProviderNodePool(t, ctx, mockResourcesDBClient)
 			},
 			mockCS: func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec) {
 				t.Helper()
@@ -1000,6 +1004,7 @@ func TestNodePoolVersionSyncer_SyncOnce_DesiredVersionUnchangedOnFailure_Changed
 	// Seed the database with a node pool
 	createTestNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.15")
 	createServiceProviderClusterWithVersion(t, ctx, mockResourcesDBClient, "4.19.99")
+	createEmptyServiceProviderNodePool(t, ctx, mockResourcesDBClient)
 
 	// Setup CS mock to return a node pool with version
 	csNodePool := newCSNodePool(t, "4.19.10")
@@ -1165,6 +1170,18 @@ func assertSyncResult(t *testing.T, err error, expectedError bool, expectedError
 	} else {
 		assert.NoError(t, err)
 	}
+}
+
+// createEmptyServiceProviderNodePool seeds the minimal ServiceProviderNodePool document
+// that CreateServiceProviderNodePool / GetOrCreateServiceProviderNodePool would create.
+func createEmptyServiceProviderNodePool(t *testing.T, ctx context.Context, mockResourcesDBClient *databasetesting.MockResourcesDBClient) {
+	t.Helper()
+
+	nodePoolResourceID := api.Must(azcorearm.ParseResourceID("/subscriptions/" + testSubscriptionID +
+		"/resourceGroups/" + testResourceGroupName +
+		"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+		"/nodePools/" + testNodePoolName))
+	require.NoError(t, database.CreateServiceProviderNodePool(ctx, mockResourcesDBClient, nodePoolResourceID))
 }
 
 // createServiceProviderClusterWithVersion creates a ServiceProviderCluster with the given control plane version.

--- a/backend/pkg/controllers/upgradecontrollers/trigger_control_plane_upgrade_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/trigger_control_plane_upgrade_controller.go
@@ -99,9 +99,12 @@ func (c *triggerControlPlaneUpgradeSyncer) SyncOnce(ctx context.Context, key con
 		return nil
 	}
 
-	existingServiceProviderCluster, err := database.GetOrCreateServiceProviderCluster(ctx, c.resourcesDBClient, key.GetResourceID())
+	existingServiceProviderCluster, err := database.GetServiceProviderCluster(ctx, c.resourcesDBClient, key.GetResourceID())
+	if database.IsNotFoundError(err) {
+		return nil
+	}
 	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to get or create ServiceProviderCluster: %w", err))
+		return utils.TrackError(fmt.Errorf("failed to get ServiceProviderCluster: %w", err))
 	}
 
 	desiredVersion := existingServiceProviderCluster.Spec.ControlPlaneVersion.DesiredVersion

--- a/backend/pkg/controllers/upgradecontrollers/trigger_node_pool_upgrade_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/trigger_node_pool_upgrade_controller.go
@@ -92,9 +92,12 @@ func (c *triggerNodePoolUpgradeSyncer) SyncOnce(ctx context.Context, key control
 		return nil
 	}
 
-	existingServiceProviderNodePool, err := database.GetOrCreateServiceProviderNodePool(ctx, c.resourcesDBClient, key.GetResourceID())
+	existingServiceProviderNodePool, err := database.GetServiceProviderNodePool(ctx, c.resourcesDBClient, key.GetResourceID())
+	if database.IsNotFoundError(err) {
+		return nil
+	}
 	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to get or create ServiceProviderNodePool: %w", err))
+		return utils.TrackError(fmt.Errorf("failed to get ServiceProviderNodePool: %w", err))
 	}
 
 	desiredVersion := existingServiceProviderNodePool.Spec.NodePoolVersion.DesiredVersion

--- a/backend/pkg/controllers/validationcontrollers/cluster_validation_controller.go
+++ b/backend/pkg/controllers/validationcontrollers/cluster_validation_controller.go
@@ -82,9 +82,12 @@ func (c *clusterValidationSyncer) SyncOnce(ctx context.Context, key controllerut
 		return utils.TrackError(fmt.Errorf("failed to get Cluster: %w", err))
 	}
 
-	existingServiceProviderCluster, err := database.GetOrCreateServiceProviderCluster(ctx, c.resourcesDBClient, key.GetResourceID())
+	existingServiceProviderCluster, err := database.GetServiceProviderCluster(ctx, c.resourcesDBClient, key.GetResourceID())
+	if database.IsNotFoundError(err) {
+		return nil
+	}
 	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to get or create ServiceProviderCluster: %w", err))
+		return utils.TrackError(fmt.Errorf("failed to get ServiceProviderCluster: %w", err))
 	}
 
 	shouldProcess := c.shouldProcess(existingServiceProviderCluster)

--- a/backend/pkg/controllers/validationcontrollers/nodepool_validation_controller.go
+++ b/backend/pkg/controllers/validationcontrollers/nodepool_validation_controller.go
@@ -87,9 +87,12 @@ func (c *nodePoolValidationSyncer) SyncOnce(ctx context.Context, key controlleru
 		return utils.TrackError(fmt.Errorf("failed to get NodePool: %w", err))
 	}
 
-	existingServiceProviderNodePool, err := database.GetOrCreateServiceProviderNodePool(ctx, c.resourcesDBClient, key.GetResourceID())
+	existingServiceProviderNodePool, err := database.GetServiceProviderNodePool(ctx, c.resourcesDBClient, key.GetResourceID())
+	if database.IsNotFoundError(err) {
+		return nil
+	}
 	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to get or create ServiceProviderNodePool: %w", err))
+		return utils.TrackError(fmt.Errorf("failed to get ServiceProviderNodePool: %w", err))
 	}
 
 	shouldProcess := c.shouldProcess(existingServiceProviderNodePool)

--- a/backend/pkg/controllers/validationcontrollers/nodepool_validation_controller_test.go
+++ b/backend/pkg/controllers/validationcontrollers/nodepool_validation_controller_test.go
@@ -124,6 +124,19 @@ func (m *mockNodePoolValidation) Validate(_ context.Context, _ *api.HCPOpenShift
 	return m.validateErr
 }
 
+func newTestServiceProviderNodePool(t *testing.T) *api.ServiceProviderNodePool {
+	t.Helper()
+	spnpResourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroup +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+			"/nodePools/" + testNodePoolName +
+			"/serviceProviderNodePools/default"))
+	return &api.ServiceProviderNodePool{
+		CosmosMetadata: arm.CosmosMetadata{ResourceID: spnpResourceID},
+	}
+}
+
 func TestNodePoolValidationSyncer_SyncOnce(t *testing.T) {
 
 	defaultSetupDB := func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
@@ -133,6 +146,9 @@ func TestNodePoolValidationSyncer_SyncOnce(t *testing.T) {
 		_, err = mockDB.HCPClusters(testSubscriptionID, testResourceGroup).NodePools(testClusterName).Create(ctx, newTestNodePool(t), nil)
 		require.NoError(t, err)
 		_, err = mockDB.Subscriptions().Create(ctx, newTestSubscription(), nil)
+		require.NoError(t, err)
+		_, err = mockDB.ServiceProviderNodePools(testSubscriptionID, testResourceGroup, testClusterName, testNodePoolName).
+			Create(ctx, newTestServiceProviderNodePool(t), nil)
 		require.NoError(t, err)
 	}
 
@@ -166,6 +182,19 @@ func TestNodePoolValidationSyncer_SyncOnce(t *testing.T) {
 			validation: &mockNodePoolValidation{name: testValidationName},
 		},
 		{
+			name: "service provider node pool not found -- no-op",
+			setupDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+				_, err := mockDB.HCPClusters(testSubscriptionID, testResourceGroup).Create(ctx, newTestCluster(t), nil)
+				require.NoError(t, err)
+				_, err = mockDB.HCPClusters(testSubscriptionID, testResourceGroup).NodePools(testClusterName).Create(ctx, newTestNodePool(t), nil)
+				require.NoError(t, err)
+				_, err = mockDB.Subscriptions().Create(ctx, newTestSubscription(), nil)
+				require.NoError(t, err)
+			},
+			validation: &mockNodePoolValidation{name: testValidationName},
+		},
+		{
 			name:    "validation succeeds -- condition set to True",
 			setupDB: defaultSetupDB,
 			validation: &mockNodePoolValidation{
@@ -187,26 +216,23 @@ func TestNodePoolValidationSyncer_SyncOnce(t *testing.T) {
 			name: "already-succeeded validation -- skipped",
 			setupDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
 				t.Helper()
-				defaultSetupDB(t, ctx, mockDB)
-				spnpResourceID := api.Must(azcorearm.ParseResourceID(
-					"/subscriptions/" + testSubscriptionID +
-						"/resourceGroups/" + testResourceGroup +
-						"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
-						"/nodePools/" + testNodePoolName +
-						"/serviceProviderNodePools/default"))
-				spnp := &api.ServiceProviderNodePool{
-					CosmosMetadata: arm.CosmosMetadata{ResourceID: spnpResourceID},
-					Status: api.ServiceProviderNodePoolStatus{
-						Validations: []metav1.Condition{
-							{
-								Type:   testValidationName,
-								Status: metav1.ConditionTrue,
-								Reason: "Succeeded",
-							},
+				_, err := mockDB.HCPClusters(testSubscriptionID, testResourceGroup).Create(ctx, newTestCluster(t), nil)
+				require.NoError(t, err)
+				_, err = mockDB.HCPClusters(testSubscriptionID, testResourceGroup).NodePools(testClusterName).Create(ctx, newTestNodePool(t), nil)
+				require.NoError(t, err)
+				_, err = mockDB.Subscriptions().Create(ctx, newTestSubscription(), nil)
+				require.NoError(t, err)
+				spnp := newTestServiceProviderNodePool(t)
+				spnp.Status = api.ServiceProviderNodePoolStatus{
+					Validations: []metav1.Condition{
+						{
+							Type:   testValidationName,
+							Status: metav1.ConditionTrue,
+							Reason: "Succeeded",
 						},
 					},
 				}
-				_, err := mockDB.ServiceProviderNodePools(testSubscriptionID, testResourceGroup, testClusterName, testNodePoolName).Create(ctx, spnp, nil)
+				_, err = mockDB.ServiceProviderNodePools(testSubscriptionID, testResourceGroup, testClusterName, testNodePoolName).Create(ctx, spnp, nil)
 				require.NoError(t, err)
 			},
 			validation: &mockNodePoolValidation{

--- a/internal/database/service_provider_cluster.go
+++ b/internal/database/service_provider_cluster.go
@@ -38,6 +38,22 @@ func newInitialServiceProviderCluster(clusterResourceID *azcorearm.ResourceID) *
 	}
 }
 
+// GetServiceProviderCluster gets the singleton ServiceProviderCluster instance
+// named `default` for the given cluster resource ID.
+func GetServiceProviderCluster(
+	ctx context.Context, dbClient ResourcesDBClient, clusterResourceID *azcorearm.ResourceID,
+) (*api.ServiceProviderCluster, error) {
+	if !armhelpers.ResourceTypeEqual(clusterResourceID.ResourceType, api.ClusterResourceType) {
+		return nil, utils.TrackError(fmt.Errorf("expected resource type %s, got %s", api.ClusterResourceType, clusterResourceID.ResourceType))
+	}
+
+	return dbClient.ServiceProviderClusters(
+		clusterResourceID.SubscriptionID,
+		clusterResourceID.ResourceGroupName,
+		clusterResourceID.Name,
+	).Get(ctx, api.ServiceProviderClusterResourceName)
+}
+
 // GetOrCreateServiceProviderCluster gets the singleton ServiceProviderCluster
 // instance named `default` for the given cluster resource ID.
 // If it doesn't exist, it creates a new one.
@@ -83,4 +99,28 @@ func GetOrCreateServiceProviderCluster(
 	}
 
 	return existingServiceProviderCluster, nil
+}
+
+// CreateServiceProviderCluster creates the singleton ServiceProviderCluster document
+// for the given cluster resource ID. A nil return means the document was created or
+// already exists (HTTP 409 Conflict).
+func CreateServiceProviderCluster(
+	ctx context.Context, dbClient ResourcesDBClient, clusterResourceID *azcorearm.ResourceID,
+) error {
+	if !armhelpers.ResourceTypeEqual(clusterResourceID.ResourceType, api.ClusterResourceType) {
+		return utils.TrackError(fmt.Errorf("expected resource type %s, got %s", api.ClusterResourceType, clusterResourceID.ResourceType))
+	}
+
+	serviceProviderClustersDBClient := dbClient.ServiceProviderClusters(
+		clusterResourceID.SubscriptionID,
+		clusterResourceID.ResourceGroupName,
+		clusterResourceID.Name,
+	)
+
+	_, err := serviceProviderClustersDBClient.Create(ctx, newInitialServiceProviderCluster(clusterResourceID), nil)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to create ServiceProviderCluster: %w", err))
+	}
+
+	return nil
 }

--- a/internal/database/service_provider_cluster.go
+++ b/internal/database/service_provider_cluster.go
@@ -102,8 +102,7 @@ func GetOrCreateServiceProviderCluster(
 }
 
 // CreateServiceProviderCluster creates the singleton ServiceProviderCluster document
-// for the given cluster resource ID. A nil return means the document was created or
-// already exists (HTTP 409 Conflict).
+// for the given cluster resource ID.
 func CreateServiceProviderCluster(
 	ctx context.Context, dbClient ResourcesDBClient, clusterResourceID *azcorearm.ResourceID,
 ) error {

--- a/internal/database/service_provider_nodepool.go
+++ b/internal/database/service_provider_nodepool.go
@@ -38,6 +38,23 @@ func newInitialServiceProviderNodePool(npResourceID *azcorearm.ResourceID) *api.
 	}
 }
 
+// GetServiceProviderNodePool gets the singleton ServiceProviderNodePool instance
+// named `default` for the given node pool resource ID.
+func GetServiceProviderNodePool(
+	ctx context.Context, dbClient ResourcesDBClient, nodePoolResourceID *azcorearm.ResourceID,
+) (*api.ServiceProviderNodePool, error) {
+	if !armhelpers.ResourceTypeEqual(nodePoolResourceID.ResourceType, api.NodePoolResourceType) {
+		return nil, utils.TrackError(fmt.Errorf("expected resource type %s, got %s", api.NodePoolResourceType, nodePoolResourceID.ResourceType))
+	}
+
+	return dbClient.ServiceProviderNodePools(
+		nodePoolResourceID.SubscriptionID,
+		nodePoolResourceID.ResourceGroupName,
+		nodePoolResourceID.Parent.Name,
+		nodePoolResourceID.Name,
+	).Get(ctx, api.ServiceProviderNodePoolResourceName)
+}
+
 // GetOrCreateServiceProviderNodePool gets the singleton ServiceProviderNodePool
 // instance named `default` for the given node pool resource ID.
 // If it doesn't exist, it creates a new one.
@@ -84,4 +101,29 @@ func GetOrCreateServiceProviderNodePool(
 	}
 
 	return existingServiceProviderNodePool, nil
+}
+
+// CreateServiceProviderNodePool creates the singleton ServiceProviderNodePool document
+// for the given node pool resource ID. A nil return means the document was created or
+// already exists (HTTP 409 Conflict).
+func CreateServiceProviderNodePool(
+	ctx context.Context, dbClient ResourcesDBClient, nodePoolResourceID *azcorearm.ResourceID,
+) error {
+	if !armhelpers.ResourceTypeEqual(nodePoolResourceID.ResourceType, api.NodePoolResourceType) {
+		return utils.TrackError(fmt.Errorf("expected resource type %s, got %s", api.NodePoolResourceType, nodePoolResourceID.ResourceType))
+	}
+
+	serviceProviderNodePoolsDBClient := dbClient.ServiceProviderNodePools(
+		nodePoolResourceID.SubscriptionID,
+		nodePoolResourceID.ResourceGroupName,
+		nodePoolResourceID.Parent.Name,
+		nodePoolResourceID.Name,
+	)
+
+	_, err := serviceProviderNodePoolsDBClient.Create(ctx, newInitialServiceProviderNodePool(nodePoolResourceID), nil)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to create ServiceProviderNodePool: %w", err))
+	}
+
+	return nil
 }

--- a/internal/database/service_provider_nodepool.go
+++ b/internal/database/service_provider_nodepool.go
@@ -104,8 +104,7 @@ func GetOrCreateServiceProviderNodePool(
 }
 
 // CreateServiceProviderNodePool creates the singleton ServiceProviderNodePool document
-// for the given node pool resource ID. A nil return means the document was created or
-// already exists (HTTP 409 Conflict).
+// for the given node pool resource ID.
 func CreateServiceProviderNodePool(
 	ctx context.Context, dbClient ResourcesDBClient, nodePoolResourceID *azcorearm.ResourceID,
 ) error {


### PR DESCRIPTION
Also update calls in backend that used GetOrCreateServiceProviderCluster and
GetOrCreateServiceProviderNodePool to just Get variants where if the
resource is not there we return early to retry later.