### PR TITLE
fix: count all non-primary NICs in mgmt-agent SWIFT NIC controller

### DIFF
--- a/mgmt-agent/pkg/controller/controller.go
+++ b/mgmt-agent/pkg/controller/controller.go
@@ -222,7 +222,7 @@ func (c *SwiftNICController) process(ctx context.Context, node *corev1.Node) (*a
 		), nil
 }
 
-// countSwiftNICs counts non-primary accelerated networking NICs on a VMSS VM.
+// countSwiftNICs counts non-primary NICs on a VMSS VM.
 func countSwiftNICs(vm armcompute.VirtualMachineScaleSetVMsClientGetResponse) int {
 	count := 0
 	if vm.Properties == nil || vm.Properties.NetworkProfileConfiguration == nil {
@@ -233,8 +233,7 @@ func countSwiftNICs(vm armcompute.VirtualMachineScaleSetVMsClientGetResponse) in
 			continue
 		}
 		isPrimary := nic.Properties.Primary != nil && *nic.Properties.Primary
-		isAccelerated := nic.Properties.EnableAcceleratedNetworking != nil && *nic.Properties.EnableAcceleratedNetworking
-		if !isPrimary && isAccelerated {
+		if !isPrimary {
 			count++
 		}
 	}

--- a/mgmt-agent/pkg/controller/controller_test.go
+++ b/mgmt-agent/pkg/controller/controller_test.go
@@ -87,33 +87,33 @@ func TestProcess(t *testing.T) {
 			},
 			getVM: func(ctx context.Context, sub, rg, vmss, id string) (armcompute.VirtualMachineScaleSetVMsClientGetResponse, error) {
 				return vmResponse(
-					nic(true, true),  // primary accelerated — excluded
-					nic(false, true), // non-primary accelerated — counted
-					nic(false, true), // non-primary accelerated — counted
-					nic(false, true), // non-primary accelerated — counted
-					nic(false, true), // non-primary accelerated — counted
-					nic(false, true), // non-primary accelerated — counted
-					nic(false, true), // non-primary accelerated — counted
-					nic(false, true), // non-primary accelerated — counted
+					nic(true, true),   // primary accelerated — excluded
+					nic(false, true),  // non-primary accelerated — counted
+					nic(false, true),  // non-primary accelerated — counted
+					nic(false, true),  // non-primary accelerated — counted
+					nic(false, false), // non-primary non-accelerated — counted
+					nic(false, true),  // non-primary accelerated — counted
+					nic(false, false), // non-primary non-accelerated — counted
+					nic(false, true),  // non-primary accelerated — counted
 				), nil
 			},
 			wantApply:    true,
 			wantNICCount: 7,
 		},
 		{
-			name: "VM with no accelerated NICs",
+			name: "VM with non-accelerated NICs",
 			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
 				Spec:       corev1.NodeSpec{ProviderID: validProviderID},
 			},
 			getVM: func(ctx context.Context, sub, rg, vmss, id string) (armcompute.VirtualMachineScaleSetVMsClientGetResponse, error) {
 				return vmResponse(
-					nic(true, false),  // primary, not accelerated
-					nic(false, false), // non-primary, not accelerated
+					nic(true, false),  // primary, not accelerated — excluded
+					nic(false, false), // non-primary, not accelerated — counted
 				), nil
 			},
 			wantApply:    true,
-			wantNICCount: 0,
+			wantNICCount: 1,
 		},
 		{
 			name: "VM with nil properties",


### PR DESCRIPTION
### What

Previously only accelerated NICs were counted, causing non-accelerated SWIFT NICs to be excluded from node capacity.
relates to unreliable accelerated network NIC provisioning described in https://portal.microsofticm.com/imp/v5/incidents/details/815156644/summary

### Why

<!-- Briefly explain why this change is needed -->

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
