### PR TITLE
fix(observability): clean up and unify Grafana dashboard datasource configs

### DIFF
--- a/observability/grafana-dashboards/infra-dashboards/adhoc-explorer.json
+++ b/observability/grafana-dashboards/infra-dashboards/adhoc-explorer.json
@@ -23,7 +23,7 @@
         "multi": false,
         "options": [],
         "refresh": 1,
-        "regex": "",
+        "regex": "^Managed_Prometheus_.*$",
         "skipUrlSync": false
       },
       {

--- a/observability/grafana-dashboards/infra-dashboards/arobit-forwarder.json
+++ b/observability/grafana-dashboards/infra-dashboards/arobit-forwarder.json
@@ -664,16 +664,13 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "text": "Managed_Prometheus_services-usw3",
-          "value": "services-usw3"
-        },
+        "current": {},
         "includeAll": false,
         "name": "datasource",
         "options": [],
         "query": "prometheus",
         "refresh": 1,
-        "regex": "",
+        "regex": "^Managed_Prometheus_services-.*$",
         "type": "datasource"
       },
       {

--- a/observability/grafana-dashboards/infra-dashboards/cilium.json
+++ b/observability/grafana-dashboards/infra-dashboards/cilium.json
@@ -3678,11 +3678,7 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "selected": true,
-          "text": "Managed_Prometheus_arohcp-mwhtsch",
-          "value": "arohcp-mwhtsch"
-        },
+        "current": {},
         "hide": 0,
         "includeAll": false,
         "multi": false,

--- a/observability/grafana-dashboards/infra-dashboards/prometheus.json
+++ b/observability/grafana-dashboards/infra-dashboards/prometheus.json
@@ -4247,16 +4247,13 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "text": "Managed_Prometheus_services-usw3rgar",
-          "value": "services-usw3rgar"
-        },
+        "current": {},
         "label": "Data Source",
         "name": "datasource",
         "options": [],
         "query": "prometheus",
         "refresh": 1,
-        "regex": "",
+        "regex": "^Managed_Prometheus_services-.*$",
         "type": "datasource"
       },
       {

--- a/observability/grafana-dashboards/istio/control_plane_dashboard.json
+++ b/observability/grafana-dashboards/istio/control_plane_dashboard.json
@@ -933,7 +933,8 @@
         {
           "name": "datasource",
           "query": "prometheus",
-          "type": "datasource"
+          "type": "datasource",
+          "regex": "^Managed_Prometheus_services-.*$"
         }
       ]
     },

--- a/observability/grafana-dashboards/maestro/maestro-agent-slo.json
+++ b/observability/grafana-dashboards/maestro/maestro-agent-slo.json
@@ -339,7 +339,7 @@
         "query": "prometheus",
         "queryValue": "",
         "refresh": 1,
-        "regex": "",
+        "regex": "^Managed_Prometheus_services-.*$",
         "skipUrlSync": false,
         "type": "datasource"
       }

--- a/observability/grafana-dashboards/maestro/maestro-agent.json
+++ b/observability/grafana-dashboards/maestro/maestro-agent.json
@@ -650,10 +650,7 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "text": "Managed_Prometheus_services-usw3",
-          "value": "services-usw3"
-        },
+        "current": {},
         "name": "datasource",
         "options": [],
         "query": "prometheus",

--- a/observability/grafana-dashboards/maestro/maestro-server-slo.json
+++ b/observability/grafana-dashboards/maestro/maestro-server-slo.json
@@ -414,7 +414,7 @@
         "query": "prometheus",
         "queryValue": "",
         "refresh": 1,
-        "regex": "",
+        "regex": "^Managed_Prometheus_services-.*$",
         "skipUrlSync": false,
         "type": "datasource"
       }

--- a/observability/grafana-dashboards/maestro/maestro-server.json
+++ b/observability/grafana-dashboards/maestro/maestro-server.json
@@ -986,10 +986,7 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "text": "Managed_Prometheus_services-usw3",
-          "value": "services-usw3"
-        },
+        "current": {},
         "name": "datasource",
         "options": [],
         "query": "prometheus",

--- a/observability/grafana-dashboards/msi-credential-refresher/msi-credential-refresher.json
+++ b/observability/grafana-dashboards/msi-credential-refresher/msi-credential-refresher.json
@@ -260,7 +260,8 @@
         "label": "Datasource",
         "name": "datasource",
         "query": "prometheus",
-        "type": "datasource"
+        "type": "datasource",
+        "regex": "^Managed_Prometheus_services-.*$"
       }
     ]
   },

--- a/observability/grafana-dashboards/perfscale-dashboards/aks-performance.json
+++ b/observability/grafana-dashboards/perfscale-dashboards/aks-performance.json
@@ -5557,11 +5557,7 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "selected": true,
-          "text": "Managed_Prometheus_perf-scale-monitor-workspace-120",
-          "value": "perf-scale-monitor-workspace-120"
-        },
+        "current": {},
         "hide": 0,
         "includeAll": false,
         "label": "datasource",
@@ -5571,7 +5567,7 @@
         "query": "prometheus",
         "queryValue": "",
         "refresh": 1,
-        "regex": "",
+        "regex": "^Managed_Prometheus_.*$",
         "skipUrlSync": false,
         "type": "datasource"
       },

--- a/observability/grafana-dashboards/perfscale-dashboards/api-performance.json
+++ b/observability/grafana-dashboards/perfscale-dashboards/api-performance.json
@@ -2242,11 +2242,7 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "selected": false,
-          "text": "Managed_Prometheus_perf-scale-monitor-workspace-120",
-          "value": "perf-scale-monitor-workspace-120"
-        },
+        "current": {},
         "hide": 0,
         "includeAll": false,
         "label": "datasource",
@@ -2256,7 +2252,7 @@
         "query": "prometheus",
         "queryValue": "",
         "refresh": 1,
-        "regex": "",
+        "regex": "^Managed_Prometheus_.*$",
         "skipUrlSync": false,
         "type": "datasource"
       },

--- a/observability/grafana-dashboards/perfscale-dashboards/etcd-performance.json
+++ b/observability/grafana-dashboards/perfscale-dashboards/etcd-performance.json
@@ -2475,11 +2475,7 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "selected": true,
-          "text": "Managed_Prometheus_perf-scale-monitor-workspace-120",
-          "value": "perf-scale-monitor-workspace-120"
-        },
+        "current": {},
         "hide": 0,
         "includeAll": false,
         "label": "datasource",
@@ -2489,7 +2485,7 @@
         "query": "prometheus",
         "queryValue": "",
         "refresh": 1,
-        "regex": "",
+        "regex": "^Managed_Prometheus_hcps-.*$",
         "skipUrlSync": false,
         "type": "datasource"
       },

--- a/observability/grafana-dashboards/perfscale-dashboards/kubernetes-provisioning-diagnostics.json
+++ b/observability/grafana-dashboards/perfscale-dashboards/kubernetes-provisioning-diagnostics.json
@@ -1313,11 +1313,7 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "selected": false,
-          "text": "Prometheus",
-          "value": "Prometheus"
-        },
+        "current": {},
         "hide": 0,
         "includeAll": false,
         "label": "Datasource",
@@ -1326,7 +1322,7 @@
         "options": [],
         "query": "prometheus",
         "refresh": 1,
-        "regex": "",
+        "regex": "^Managed_Prometheus_.*$",
         "skipUrlSync": false,
         "type": "datasource"
       },


### PR DESCRIPTION
### What

Unify and clean up datasource configuration across all ARO-HCP Grafana dashboards:

- Add a datasource-variable regex to every dashboard that lacked one, in the common house format:
  - service-cluster dashboards (prometheus, arobit-forwarder, maestro-*-slo, msi-credential-refresher, istio): `^Managed_Prometheus_services-.*$`
  - universal perfscale dashboards (aks/api/provisioning) and Ad-hoc Explorer: `^Managed_Prometheus_.*$` (any prometheus datasource)
  - etcd-performance (hcps-specific): `^Managed_Prometheus_hcps-.*$`
- Clear stale `current` datasource pins (`services-usw3`, `arohcp-mwhtsch`, `perf-scale-monitor-workspace-120`, ...) that pointed at datasources no longer present, so dashboards open on a working datasource instead of a broken "datasource not found" selector.

### Why

Several dashboards either listed every datasource in their picker (including obsolete/dead ones) or opened pinned to a datasource that no longer exists. Datasource families and metric locations were verified against live prod (uksouth, eastus2). `grafanactl verify dashboards` passes clean.

Jira: https://redhat.atlassian.net/browse/AROSLSRE-1178

🤖 Generated with [Claude Code](https://claude.com/claude-code)