### PR TITLE
fix(recreate-broken-pools): scope VMSS accel-networking patch to avoid linked image 403 (AROSLSRE-1172)

### DIFF
--- a/dev-infrastructure/scripts/recreate-broken-pools/main.go
+++ b/dev-infrastructure/scripts/recreate-broken-pools/main.go
@@ -2022,13 +2022,22 @@ func (c *clients) waitForPoolVMSS(ctx context.Context, poolName string, timeout 
 }
 
 // patchVMSSAccelNetworking sets accelerated-networking to want on every NIC
-// configuration of the VMSS via a read-modify-write full PUT. A full PUT
-// (rather than a partial Update) is used so the existing IP configurations and
-// subnet bindings are preserved verbatim. Directly patching an AKS-managed VMSS
-// is unsupported by AKS, but Microsoft explicitly asked us to do this in ICM
-// 815156644 as the mitigation for the RP bringing Swift VMSS up with
-// accelerated-networking disabled; callers must re-verify the value afterwards
-// because AKS may reconcile it back.
+// configuration of the VMSS via a scoped PATCH that carries only the network
+// profile. Directly patching an AKS-managed VMSS is unsupported by AKS, but
+// Microsoft explicitly asked us to do this in ICM 815156644 as the mitigation
+// for the RP bringing Swift VMSS up with accelerated-networking disabled;
+// callers must re-verify the value afterwards because AKS may reconcile it back.
+//
+// A scoped PATCH (Update) is used instead of a read-modify-write full PUT
+// (CreateOrUpdate) on purpose. A full PUT re-sends the VMSS
+// storageProfile.imageReference, which on AKS nodes points at a shared-image
+// gallery version in a first-party (RP-owned) subscription. ARM then runs a
+// linked-access check (Microsoft.Compute/galleries/images/versions/read) on
+// that subscription, which the deploying identity is not authorized for, so the
+// PUT fails with 403 LinkedAuthorizationFailed (observed in INT, AROSLSRE-1172).
+// Sending only the network profile omits storageProfile entirely, avoiding the
+// image link while preserving every NIC/IP configuration verbatim (the existing
+// configs are read back and re-emitted unchanged except for the AN flag).
 func (c *clients) patchVMSSAccelNetworking(ctx context.Context, vmssName string, want bool) error {
 	resp, err := c.vmss.Get(ctx, c.cfg.nodeRG, vmssName, nil)
 	if err != nil {
@@ -2046,8 +2055,21 @@ func (c *clients) patchVMSSAccelNetworking(ctx context.Context, vmssName string,
 		}
 		nic.Properties.EnableAcceleratedNetworking = ptr(want)
 	}
-	logf("patching VMSS %s accelerated-networking=%t (read-modify-write PUT)", vmssName, want)
-	poller, err := c.vmss.BeginCreateOrUpdate(ctx, c.cfg.nodeRG, vmssName, vmss, nil)
+	updNICs, err := toUpdateNetworkInterfaceConfigs(vmss.Properties.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations)
+	if err != nil {
+		return fmt.Errorf("convert VMSS %s network config for patch: %w", vmssName, err)
+	}
+	update := armcompute.VirtualMachineScaleSetUpdate{
+		Properties: &armcompute.VirtualMachineScaleSetUpdateProperties{
+			VirtualMachineProfile: &armcompute.VirtualMachineScaleSetUpdateVMProfile{
+				NetworkProfile: &armcompute.VirtualMachineScaleSetUpdateNetworkProfile{
+					NetworkInterfaceConfigurations: updNICs,
+				},
+			},
+		},
+	}
+	logf("patching VMSS %s accelerated-networking=%t (scoped network PATCH; storageProfile omitted to avoid linked image auth)", vmssName, want)
+	poller, err := c.vmss.BeginUpdate(ctx, c.cfg.nodeRG, vmssName, update, nil)
 	if err != nil {
 		return fmt.Errorf("begin update VMSS %s: %w", vmssName, err)
 	}
@@ -2055,6 +2077,35 @@ func (c *clients) patchVMSSAccelNetworking(ctx context.Context, vmssName string,
 		return fmt.Errorf("poll update VMSS %s: %w", vmssName, err)
 	}
 	return nil
+}
+
+// toUpdateNetworkInterfaceConfigs converts the full-model NIC configurations
+// read from a VMSS into their PATCH/Update equivalents, preserving every field
+// (IP configurations, subnets, load-balancer pools, ...) by round-tripping
+// through the shared ARM JSON representation. The create and update Go types
+// differ only in their wrapper struct; their JSON wire keys are identical, so a
+// marshal/unmarshal is a faithful, field-drift-proof translation that keeps the
+// existing network configuration intact and changes only what the caller set.
+func toUpdateNetworkInterfaceConfigs(nics []*armcompute.VirtualMachineScaleSetNetworkConfiguration) ([]*armcompute.VirtualMachineScaleSetUpdateNetworkConfiguration, error) {
+	out := make([]*armcompute.VirtualMachineScaleSetUpdateNetworkConfiguration, 0, len(nics))
+	for _, nic := range nics {
+		if nic == nil {
+			continue
+		}
+		b, err := json.Marshal(nic)
+		if err != nil {
+			return nil, fmt.Errorf("marshal NIC config: %w", err)
+		}
+		var upd armcompute.VirtualMachineScaleSetUpdateNetworkConfiguration
+		if err := json.Unmarshal(b, &upd); err != nil {
+			return nil, fmt.Errorf("unmarshal NIC config into update form: %w", err)
+		}
+		out = append(out, &upd)
+	}
+	if len(out) == 0 {
+		return nil, errors.New("no NIC configurations to convert")
+	}
+	return out, nil
 }
 
 // ensurePoolAccelNetworking ensures poolName's backing VMSS has the correct

--- a/dev-infrastructure/scripts/recreate-broken-pools/main.go
+++ b/dev-infrastructure/scripts/recreate-broken-pools/main.go
@@ -2050,8 +2050,11 @@ func (c *clients) patchVMSSAccelNetworking(ctx context.Context, vmssName string,
 		return fmt.Errorf("VMSS %s has no NIC configurations to patch", vmssName)
 	}
 	for _, nic := range vmss.Properties.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations {
-		if nic == nil || nic.Properties == nil {
+		if nic == nil {
 			continue
+		}
+		if nic.Properties == nil {
+			nic.Properties = &armcompute.VirtualMachineScaleSetNetworkConfigurationProperties{}
 		}
 		nic.Properties.EnableAcceleratedNetworking = ptr(want)
 	}

--- a/dev-infrastructure/scripts/recreate-broken-pools/main_test.go
+++ b/dev-infrastructure/scripts/recreate-broken-pools/main_test.go
@@ -2481,8 +2481,9 @@ func TestZeroNodePoolBodyNil(t *testing.T) {
 // =============================================================================
 
 // fakeVMSSStore is the mutable backing state for the fake VMSS server. GET and
-// LIST read from it; BeginCreateOrUpdate writes to it, so a patch is visible to
-// the subsequent confirmation read just like real ARM.
+// LIST read from it; BeginCreateOrUpdate (full PUT) and BeginUpdate (scoped
+// PATCH) both write to it, so a patch is visible to the subsequent confirmation
+// read just like real ARM.
 type fakeVMSSStore struct {
 	mu      sync.Mutex
 	byName  map[string]*armcompute.VirtualMachineScaleSet

--- a/dev-infrastructure/scripts/recreate-broken-pools/main_test.go
+++ b/dev-infrastructure/scripts/recreate-broken-pools/main_test.go
@@ -2484,9 +2484,10 @@ func TestZeroNodePoolBodyNil(t *testing.T) {
 // LIST read from it; BeginCreateOrUpdate writes to it, so a patch is visible to
 // the subsequent confirmation read just like real ARM.
 type fakeVMSSStore struct {
-	mu     sync.Mutex
-	byName map[string]*armcompute.VirtualMachineScaleSet
-	puts   []armcompute.VirtualMachineScaleSet // captured PUT bodies, in order
+	mu      sync.Mutex
+	byName  map[string]*armcompute.VirtualMachineScaleSet
+	puts    []armcompute.VirtualMachineScaleSet       // captured full-PUT bodies, in order
+	updates []armcompute.VirtualMachineScaleSetUpdate // captured scoped-PATCH bodies, in order
 }
 
 func newFakeVMSSStore(vmsss ...*armcompute.VirtualMachineScaleSet) *fakeVMSSStore {
@@ -2535,6 +2536,38 @@ func newFakeVMSSClient(t *testing.T, store *fakeVMSSStore) *armcompute.VirtualMa
 			store.byName[name] = &stored
 			store.puts = append(store.puts, params)
 			resp.SetTerminalResponse(http.StatusOK, armcompute.VirtualMachineScaleSetsClientCreateOrUpdateResponse{VirtualMachineScaleSet: stored}, nil)
+			return
+		},
+		BeginUpdate: func(_ context.Context, _ string, name string, params armcompute.VirtualMachineScaleSetUpdate, _ *armcompute.VirtualMachineScaleSetsClientBeginUpdateOptions) (resp azfake.PollerResponder[armcompute.VirtualMachineScaleSetsClientUpdateResponse], errResp azfake.ErrorResponder) {
+			store.mu.Lock()
+			defer store.mu.Unlock()
+			v, ok := store.byName[name]
+			if !ok {
+				errResp.SetResponseError(http.StatusNotFound, "ResourceNotFound")
+				return
+			}
+			store.updates = append(store.updates, params)
+			// Apply only the accelerated-networking flag from the scoped PATCH
+			// body onto the stored NIC configs (matched by position), mirroring
+			// ARM's merge of the network profile while leaving everything else
+			// untouched.
+			if params.Properties != nil && params.Properties.VirtualMachineProfile != nil &&
+				params.Properties.VirtualMachineProfile.NetworkProfile != nil &&
+				v.Properties != nil && v.Properties.VirtualMachineProfile != nil &&
+				v.Properties.VirtualMachineProfile.NetworkProfile != nil {
+				upd := params.Properties.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations
+				cur := v.Properties.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations
+				for i := range upd {
+					if i >= len(cur) || upd[i] == nil || upd[i].Properties == nil || cur[i] == nil {
+						continue
+					}
+					if cur[i].Properties == nil {
+						cur[i].Properties = &armcompute.VirtualMachineScaleSetNetworkConfigurationProperties{}
+					}
+					cur[i].Properties.EnableAcceleratedNetworking = upd[i].Properties.EnableAcceleratedNetworking
+				}
+			}
+			resp.SetTerminalResponse(http.StatusOK, armcompute.VirtualMachineScaleSetsClientUpdateResponse{VirtualMachineScaleSet: *v}, nil)
 			return
 		},
 	}
@@ -2623,16 +2656,34 @@ func TestPatchVMSSAccelNetworking(t *testing.T) {
 	if err := c.patchVMSSAccelNetworking(context.Background(), "aks-userswft3-12345678-vmss", true); err != nil {
 		t.Fatalf("patchVMSSAccelNetworking: %v", err)
 	}
-	if len(store.puts) != 1 {
-		t.Fatalf("expected exactly 1 PUT, got %d", len(store.puts))
+	// Regression guard: the fix must NOT issue a full read-modify-write PUT
+	// (which re-sends storageProfile.imageReference and triggers the linked
+	// image-gallery 403 LinkedAuthorizationFailed). It must use a scoped PATCH.
+	if len(store.puts) != 0 {
+		t.Fatalf("expected 0 full PUTs (scoped PATCH only), got %d", len(store.puts))
+	}
+	if len(store.updates) != 1 {
+		t.Fatalf("expected exactly 1 scoped PATCH, got %d", len(store.updates))
+	}
+	// The PATCH body must carry only the network profile; storageProfile must be
+	// omitted so ARM never runs the linked image-gallery auth check.
+	updProps := store.updates[0].Properties
+	if updProps == nil || updProps.VirtualMachineProfile == nil {
+		t.Fatalf("PATCH body missing virtualMachineProfile")
+	}
+	if updProps.VirtualMachineProfile.StorageProfile != nil {
+		t.Fatalf("PATCH body must omit storageProfile to avoid linked image auth")
+	}
+	if updProps.VirtualMachineProfile.NetworkProfile == nil {
+		t.Fatalf("PATCH body missing networkProfile")
 	}
 	got, found := vmssAcceleratedNetworking(store.byName["aks-userswft3-12345678-vmss"])
 	if !found || !got {
 		t.Fatalf("after patch accelerated-networking=(enabled=%v found=%v), want enabled", got, found)
 	}
-	for i, nic := range store.puts[0].Properties.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations {
-		if nic.Properties.EnableAcceleratedNetworking == nil || !*nic.Properties.EnableAcceleratedNetworking {
-			t.Fatalf("PUT body NIC %d not set to accelerated-networking=true", i)
+	for i, nic := range updProps.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations {
+		if nic.Properties == nil || nic.Properties.EnableAcceleratedNetworking == nil || !*nic.Properties.EnableAcceleratedNetworking {
+			t.Fatalf("PATCH body NIC %d not set to accelerated-networking=true", i)
 		}
 	}
 }


### PR DESCRIPTION
[AROSLSRE-1172](https://redhat.atlassian.net/browse/AROSLSRE-1172) · subtask [AROSLSRE-1180](https://redhat.atlassian.net/browse/AROSLSRE-1180)

### What

Change the `recreate-broken-pools` accelerated-networking remediation from a full read-modify-write PUT to a **scoped PATCH** (`BeginUpdate`) that carries only the VMSS network profile.

### Why

The deployed fix (PR #5649) correctly detects Swift node pools brought up without accelerated-networking and tries to patch the backing VMSS — but the patch itself fails in INT with **403 LinkedAuthorizationFailed**, so the pools are never remediated.

Root cause: a full PUT re-sends `storageProfile.imageReference`, which on AKS nodes points at a shared-image-gallery version in a first-party (RP-owned) subscription. ARM then runs a linked-access check (`Microsoft.Compute/galleries/images/versions/read`) on that subscription that the deploying identity is not authorized for.

```text
full PUT (CreateOrUpdate)
  -> re-sends storageProfile.imageReference (SIG version in RP sub)
  -> ARM linked-access check: galleries/images/versions/read
  -> identity not authorized -> 403 LinkedAuthorizationFailed -> exit 1
```

A PATCH that omits `storageProfile` never references the image, so the link check never runs:

```text
scoped PATCH (Update) with only networkProfile
  -> no storageProfile in body -> no image link check
  -> accelerated-networking flipped, NIC/IP configs preserved
```

Existing NIC/IP configurations are read back and re-emitted verbatim (only the `enableAcceleratedNetworking` flag changes) via a JSON round-trip between the create and update NIC models, whose ARM wire keys are identical. The change is safe because the temp pool is created at 0 nodes, so flipping accelerated-networking needs no instance reimage; the post-patch re-verify + fail-closed guard is unchanged.

### Testing

`go build ./...`, `go vet ./...`, and `go test ./...` pass in `dev-infrastructure/scripts/recreate-broken-pools`.

`TestPatchVMSSAccelNetworking` is now a regression guard: it asserts **0 full PUTs**, exactly **1 scoped PATCH**, that the PATCH body **omits `storageProfile`** and carries the network profile, and that accelerated-networking is flipped to `true` on every NIC.

### Special notes for your reviewer

Strictly read-only on live INT infra throughout this investigation — this code change is the remediation path. The 403 was observed live in INT on 2026-06-15 (see [AROSLSRE-1172](https://redhat.atlassian.net/browse/AROSLSRE-1172) / [AROSLSRE-1176](https://redhat.atlassian.net/browse/AROSLSRE-1176)).

### PR Checklist

- [x] Tests added/updated and passing
- [x] Conventional Commit title with Jira key

