### PR TITLE
fix: match CS validation for cluster and nodepool names

### DIFF
--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/hcpCluster-models.tsp
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/hcpCluster-models.tsp
@@ -23,7 +23,7 @@ namespace Microsoft.RedHatOpenShift;
 model HcpOpenShiftCluster is TrackedResource<HcpOpenShiftClusterProperties> {
   ...ResourceNameParameter<
     HcpOpenShiftCluster,
-    NamePattern = "^[a-zA-Z][-a-zA-Z0-9]{1,52}[a-zA-Z0-9]$"
+    NamePattern = "^[a-zA-Z]([-a-zA-Z0-9]{0,52}[a-zA-Z0-9])?$"
   >;
   ...ManagedServiceIdentityProperty;
 }
@@ -38,7 +38,7 @@ model HcpOpenShiftCluster is TrackedResource<HcpOpenShiftClusterProperties> {
 model NodePool is TrackedResource<NodePoolProperties> {
   ...ResourceNameParameter<
     NodePool,
-    NamePattern = "^[a-zA-Z][-a-zA-Z0-9]{1,13}[a-zA-Z0-9]$"
+    NamePattern = "^[a-zA-Z]([-a-zA-Z0-9]{0,13}[a-zA-Z0-9])?$"
   >;
   ...ManagedServiceIdentityProperty;
 }

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2024-06-10-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2024-06-10-preview/openapi.json
@@ -380,7 +380,7 @@
             "description": "The name of the HcpOpenShiftCluster",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,52}[a-zA-Z0-9]$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,52}[a-zA-Z0-9])?$"
           }
         ],
         "responses": {
@@ -425,7 +425,7 @@
             "description": "The name of the HcpOpenShiftCluster",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,52}[a-zA-Z0-9]$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,52}[a-zA-Z0-9])?$"
           },
           {
             "name": "resource",
@@ -500,7 +500,7 @@
             "description": "The name of the HcpOpenShiftCluster",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,52}[a-zA-Z0-9]$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,52}[a-zA-Z0-9])?$"
           },
           {
             "name": "properties",
@@ -572,7 +572,7 @@
             "description": "The name of the HcpOpenShiftCluster",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,52}[a-zA-Z0-9]$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,52}[a-zA-Z0-9])?$"
           }
         ],
         "responses": {
@@ -634,7 +634,7 @@
             "description": "The name of the HcpOpenShiftCluster",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,52}[a-zA-Z0-9]$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,52}[a-zA-Z0-9])?$"
           }
         ],
         "responses": {
@@ -684,7 +684,7 @@
             "description": "The name of the HcpOpenShiftCluster",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,52}[a-zA-Z0-9]$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,52}[a-zA-Z0-9])?$"
           },
           {
             "name": "externalAuthName",
@@ -737,7 +737,7 @@
             "description": "The name of the HcpOpenShiftCluster",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,52}[a-zA-Z0-9]$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,52}[a-zA-Z0-9])?$"
           },
           {
             "name": "externalAuthName",
@@ -820,7 +820,7 @@
             "description": "The name of the HcpOpenShiftCluster",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,52}[a-zA-Z0-9]$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,52}[a-zA-Z0-9])?$"
           },
           {
             "name": "externalAuthName",
@@ -900,7 +900,7 @@
             "description": "The name of the HcpOpenShiftCluster",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,52}[a-zA-Z0-9]$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,52}[a-zA-Z0-9])?$"
           },
           {
             "name": "externalAuthName",
@@ -970,7 +970,7 @@
             "description": "The name of the HcpOpenShiftCluster",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,52}[a-zA-Z0-9]$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,52}[a-zA-Z0-9])?$"
           }
         ],
         "responses": {
@@ -1020,7 +1020,7 @@
             "description": "The name of the HcpOpenShiftCluster",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,52}[a-zA-Z0-9]$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,52}[a-zA-Z0-9])?$"
           },
           {
             "name": "nodePoolName",
@@ -1028,7 +1028,7 @@
             "description": "The name of the NodePool",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,13}[a-zA-Z0-9]$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,13}[a-zA-Z0-9])?$"
           }
         ],
         "responses": {
@@ -1073,7 +1073,7 @@
             "description": "The name of the HcpOpenShiftCluster",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,52}[a-zA-Z0-9]$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,52}[a-zA-Z0-9])?$"
           },
           {
             "name": "nodePoolName",
@@ -1081,7 +1081,7 @@
             "description": "The name of the NodePool",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,13}[a-zA-Z0-9]$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,13}[a-zA-Z0-9])?$"
           },
           {
             "name": "resource",
@@ -1156,7 +1156,7 @@
             "description": "The name of the HcpOpenShiftCluster",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,52}[a-zA-Z0-9]$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,52}[a-zA-Z0-9])?$"
           },
           {
             "name": "nodePoolName",
@@ -1164,7 +1164,7 @@
             "description": "The name of the NodePool",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,13}[a-zA-Z0-9]$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,13}[a-zA-Z0-9])?$"
           },
           {
             "name": "properties",
@@ -1236,7 +1236,7 @@
             "description": "The name of the HcpOpenShiftCluster",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,52}[a-zA-Z0-9]$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,52}[a-zA-Z0-9])?$"
           },
           {
             "name": "nodePoolName",
@@ -1244,7 +1244,7 @@
             "description": "The name of the NodePool",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,13}[a-zA-Z0-9]$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,13}[a-zA-Z0-9])?$"
           }
         ],
         "responses": {
@@ -1306,7 +1306,7 @@
             "description": "The name of the HcpOpenShiftCluster",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,52}[a-zA-Z0-9]$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,52}[a-zA-Z0-9])?$"
           }
         ],
         "responses": {
@@ -1371,7 +1371,7 @@
             "description": "The name of the HcpOpenShiftCluster",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,52}[a-zA-Z0-9]$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,52}[a-zA-Z0-9])?$"
           }
         ],
         "responses": {

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2025-12-23-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2025-12-23-preview/openapi.json
@@ -380,7 +380,7 @@
             "description": "The name of the HcpOpenShiftCluster",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,52}[a-zA-Z0-9]$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,52}[a-zA-Z0-9])?$"
           }
         ],
         "responses": {
@@ -425,7 +425,7 @@
             "description": "The name of the HcpOpenShiftCluster",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,52}[a-zA-Z0-9]$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,52}[a-zA-Z0-9])?$"
           },
           {
             "name": "resource",
@@ -500,7 +500,7 @@
             "description": "The name of the HcpOpenShiftCluster",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,52}[a-zA-Z0-9]$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,52}[a-zA-Z0-9])?$"
           },
           {
             "name": "properties",
@@ -572,7 +572,7 @@
             "description": "The name of the HcpOpenShiftCluster",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,52}[a-zA-Z0-9]$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,52}[a-zA-Z0-9])?$"
           }
         ],
         "responses": {
@@ -634,7 +634,7 @@
             "description": "The name of the HcpOpenShiftCluster",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,52}[a-zA-Z0-9]$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,52}[a-zA-Z0-9])?$"
           }
         ],
         "responses": {
@@ -684,7 +684,7 @@
             "description": "The name of the HcpOpenShiftCluster",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,52}[a-zA-Z0-9]$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,52}[a-zA-Z0-9])?$"
           },
           {
             "name": "externalAuthName",
@@ -737,7 +737,7 @@
             "description": "The name of the HcpOpenShiftCluster",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,52}[a-zA-Z0-9]$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,52}[a-zA-Z0-9])?$"
           },
           {
             "name": "externalAuthName",
@@ -820,7 +820,7 @@
             "description": "The name of the HcpOpenShiftCluster",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,52}[a-zA-Z0-9]$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,52}[a-zA-Z0-9])?$"
           },
           {
             "name": "externalAuthName",
@@ -900,7 +900,7 @@
             "description": "The name of the HcpOpenShiftCluster",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,52}[a-zA-Z0-9]$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,52}[a-zA-Z0-9])?$"
           },
           {
             "name": "externalAuthName",
@@ -970,7 +970,7 @@
             "description": "The name of the HcpOpenShiftCluster",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,52}[a-zA-Z0-9]$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,52}[a-zA-Z0-9])?$"
           }
         ],
         "responses": {
@@ -1020,7 +1020,7 @@
             "description": "The name of the HcpOpenShiftCluster",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,52}[a-zA-Z0-9]$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,52}[a-zA-Z0-9])?$"
           },
           {
             "name": "nodePoolName",
@@ -1028,7 +1028,7 @@
             "description": "The name of the NodePool",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,13}[a-zA-Z0-9]$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,13}[a-zA-Z0-9])?$"
           }
         ],
         "responses": {
@@ -1073,7 +1073,7 @@
             "description": "The name of the HcpOpenShiftCluster",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,52}[a-zA-Z0-9]$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,52}[a-zA-Z0-9])?$"
           },
           {
             "name": "nodePoolName",
@@ -1081,7 +1081,7 @@
             "description": "The name of the NodePool",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,13}[a-zA-Z0-9]$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,13}[a-zA-Z0-9])?$"
           },
           {
             "name": "resource",
@@ -1156,7 +1156,7 @@
             "description": "The name of the HcpOpenShiftCluster",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,52}[a-zA-Z0-9]$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,52}[a-zA-Z0-9])?$"
           },
           {
             "name": "nodePoolName",
@@ -1164,7 +1164,7 @@
             "description": "The name of the NodePool",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,13}[a-zA-Z0-9]$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,13}[a-zA-Z0-9])?$"
           },
           {
             "name": "properties",
@@ -1236,7 +1236,7 @@
             "description": "The name of the HcpOpenShiftCluster",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,52}[a-zA-Z0-9]$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,52}[a-zA-Z0-9])?$"
           },
           {
             "name": "nodePoolName",
@@ -1244,7 +1244,7 @@
             "description": "The name of the NodePool",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,13}[a-zA-Z0-9]$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,13}[a-zA-Z0-9])?$"
           }
         ],
         "responses": {
@@ -1306,7 +1306,7 @@
             "description": "The name of the HcpOpenShiftCluster",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,52}[a-zA-Z0-9]$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,52}[a-zA-Z0-9])?$"
           }
         ],
         "responses": {
@@ -1371,7 +1371,7 @@
             "description": "The name of the HcpOpenShiftCluster",
             "required": true,
             "type": "string",
-            "pattern": "^[a-zA-Z][-a-zA-Z0-9]{1,52}[a-zA-Z0-9]$"
+            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]{0,52}[a-zA-Z0-9])?$"
           }
         ],
         "responses": {

--- a/internal/validation/validate_cluster_comprehensive_test.go
+++ b/internal/validation/validate_cluster_comprehensive_test.go
@@ -991,23 +991,24 @@ func TestValidateClusterCreate(t *testing.T) {
 			},
 		},
 		{
-			name: "invalid cluster resource name - too short",
+			name: "invalid cluster resource name - empty",
 			cluster: func() *api.HCPOpenShiftCluster {
 				c := createValidCluster()
-				c.ID.Name = "a"
-				c.Name = "a"
+				c.ID.Name = ""
+				c.Name = ""
 				return c
 			}(),
 			expectErrors: []utils.ExpectedError{
-				{Message: "must be a valid DNS RFC 1035 label", FieldPath: "id"},
+				{Message: "resource name is required", FieldPath: "trackedResource.resource.id"},
+				{Message: "resource name is required", FieldPath: "id"},
 			},
 		},
 		{
 			name: "valid cluster resource name - minimum length",
 			cluster: func() *api.HCPOpenShiftCluster {
 				c := createValidCluster()
-				c.ID.Name = "abc"
-				c.Name = "abc"
+				c.ID.Name = "a"
+				c.Name = "a"
 				return c
 			}(),
 			expectErrors: []utils.ExpectedError{},

--- a/internal/validation/validate_nodepools_comprehensive_test.go
+++ b/internal/validation/validate_nodepools_comprehensive_test.go
@@ -771,23 +771,24 @@ func TestValidateNodePoolCreate(t *testing.T) {
 			},
 		},
 		{
-			name: "invalid nodepool resource name - too short",
+			name: "invalid nodepool resource name - empty",
 			nodePool: func() *api.HCPOpenShiftClusterNodePool {
 				np := createValidNodePool()
-				np.ID.Name = "a"
+				np.ID.Name = ""
+				np.Name = ""
 				return np
 			}(),
 			expectErrors: []utils.ExpectedError{
-				{Message: "must be equal to", FieldPath: "trackedResource.resource.name"},
-				{Message: "must be a valid DNS RFC 1035 label", FieldPath: "id"},
+				{Message: "resource name is required", FieldPath: "trackedResource.resource.id"},
+				{Message: "resource name is required", FieldPath: "id"},
 			},
 		},
 		{
 			name: "valid nodepool resource name - minimum length",
 			nodePool: func() *api.HCPOpenShiftClusterNodePool {
 				np := createValidNodePool()
-				np.ID.Name = "abc"
-				np.Name = "abc"
+				np.ID.Name = "a"
+				np.Name = "a"
 				return np
 			}(),
 			expectErrors: []utils.ExpectedError{},

--- a/internal/validation/validators.go
+++ b/internal/validation/validators.go
@@ -319,11 +319,11 @@ var (
 	rfc1035LabelRegex          = regexp.MustCompile(dnsRegexStringRFC1035Label)
 	rfc1035ErrorString         = `(must be a valid DNS RFC 1035 label)`
 
-	clusterResourceName            = `^[a-zA-Z][-a-zA-Z0-9]{1,52}[a-zA-Z0-9]$`
+	clusterResourceName            = `^[a-zA-Z]([-a-zA-Z0-9]{0,52}[a-zA-Z0-9])?$`
 	clusterResourceNameRegex       = regexp.MustCompile(clusterResourceName)
 	clusterResourceNameErrorString = `(must be a valid DNS RFC 1035 label)`
 
-	nodePoolResourceName            = `^[a-zA-Z][-a-zA-Z0-9]{1,13}[a-zA-Z0-9]$`
+	nodePoolResourceName            = `^[a-zA-Z]([-a-zA-Z0-9]{0,13}[a-zA-Z0-9])?$`
 	nodePoolResourceNameRegex       = regexp.MustCompile(nodePoolResourceName)
 	nodePoolResourceNameErrorString = `(must be a valid DNS RFC 1035 label)`
 


### PR DESCRIPTION
Enforce what CS currently enforces, which is: instead of
minimum of 3 characters a minimum of 1 character.

This is a relaxation of the constraints around them