### PR TITLE
fix: update cidr test to use dsv3

### DIFF
--- a/test/e2e-setup/bicep/modules/test-vm.bicep
+++ b/test/e2e-setup/bicep/modules/test-vm.bicep
@@ -14,7 +14,7 @@ param adminUsername string = 'azureuser'
 param sshPublicKey string
 
 @description('VM size')
-param vmSize string = 'Standard_D2s_v5'
+param vmSize string = 'Standard_D2s_v3'
 
 @description('Location for the VM')
 param location string = resourceGroup().location

--- a/test/e2e/cluster_authorized_cidrs_connectivity.go
+++ b/test/e2e/cluster_authorized_cidrs_connectivity.go
@@ -97,11 +97,11 @@ var _ = Describe("Authorized CIDRs", func() {
 				vmName := fmt.Sprintf("%s-test-vm", clusterName)
 				// The test VM is a throwaway kubectl client: it only needs a public IP
 				// (used as the single authorized CIDR) and to make one API call to the
-				// cluster. We use the common general-purpose Standard_D2s_v5 (same 2-vCPU
+				// cluster. We use the common general-purpose Standard_D2s_v3 (same 2-vCPU
 				// size as the old burstable Standard_B2s) because the burstable B-series
 				// is the SKU class most prone to regional SkuNotAvailable capacity
 				// restrictions, which is what flaked this test.
-				const vmSize = "Standard_D2s_v5"
+				const vmSize = "Standard_D2s_v3"
 				var vmDeployment *armresources.DeploymentExtended
 				var deployErr error
 				// Bounded retry to absorb transient ARM errors, but fail fast on


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-1185

### What

change cidr test vm to dsv3 class

### Why

No quota for dsv5 in stage or prod in any region, quota increases denied.  

### Testing

e2e

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
