### PR TITLE
fix: cleanup orphaned ameroot CA certificate from EventGrid namespaces

### DIFF
--- a/dev-infrastructure/scripts/regional-housekeeping.sh
+++ b/dev-infrastructure/scripts/regional-housekeeping.sh
@@ -86,16 +86,15 @@ if [ -z "$namespaces" ]; then
     echo "No EventGrid namespaces found in resource group $REGIONAL_RESOURCE_GROUP"
 else
     for ns in $namespaces; do
-        ameroot_id=$(az resource show \
+        if az eventgrid namespace ca-certificate show \
             --resource-group "$REGIONAL_RESOURCE_GROUP" \
-            --namespace Microsoft.EventGrid \
-            --resource-type namespaces/caCertificates \
-            --name "${ns}/ameroot" \
-            --query "id" -o tsv 2>/dev/null || true)
-
-        if [ -n "$ameroot_id" ]; then
+            --namespace-name "$ns" \
+            --name ameroot &>/dev/null; then
             echo "Found orphaned ameroot CA certificate on namespace '${ns}' - deleting"
-            execute az resource delete --ids "$ameroot_id"
+            execute az eventgrid namespace ca-certificate delete \
+                --resource-group "$REGIONAL_RESOURCE_GROUP" \
+                --namespace-name "$ns" \
+                --name ameroot --yes
         else
             echo "No ameroot CA certificate found on namespace '${ns}' - nothing to do"
         fi

--- a/dev-infrastructure/scripts/regional-housekeeping.sh
+++ b/dev-infrastructure/scripts/regional-housekeeping.sh
@@ -71,3 +71,33 @@ for workspace in $workspaces; do
         echo "Workspace '$workspace' has aroHCPPurpose tag: '$aro_purpose_tag' - preserving"
     fi
 done
+
+#
+#   E V E N T G R I D   C A   C E R T I F I C A T E S
+#
+
+echo "Checking for orphaned ameroot CA certificate on EventGrid namespaces in resource group $REGIONAL_RESOURCE_GROUP..."
+
+namespaces=$(az eventgrid namespace list \
+    --resource-group "$REGIONAL_RESOURCE_GROUP" \
+    --query "[].name" -o tsv)
+
+if [ -z "$namespaces" ]; then
+    echo "No EventGrid namespaces found in resource group $REGIONAL_RESOURCE_GROUP"
+else
+    for ns in $namespaces; do
+        ameroot_id=$(az resource show \
+            --resource-group "$REGIONAL_RESOURCE_GROUP" \
+            --namespace Microsoft.EventGrid \
+            --resource-type namespaces/caCertificates \
+            --name "${ns}/ameroot" \
+            --query "id" -o tsv 2>/dev/null || true)
+
+        if [ -n "$ameroot_id" ]; then
+            echo "Found orphaned ameroot CA certificate on namespace '${ns}' - deleting"
+            execute az resource delete --ids "$ameroot_id"
+        else
+            echo "No ameroot CA certificate found on namespace '${ns}' - nothing to do"
+        fi
+    done
+fi


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-938

### What

Add one time cleanup logic to the regional housekeeping script to delete the orphaned `ameroot` CA certificate from EventGrid namespaces.

### Why

PR [#5376 ](https://github.com/Azure/ARO-HCP/pull/5376) removed the expired `ameroot` CA certificate definition from `maestro-infra.bicep` to unblock deployments in INT. However, the region pipeline uses incremental ARM deployments (`action: ARM`), which do not delete resources that are removed from templates — they only stop creating/updating them. As a result, the expired `ameroot` CA certificate remains deployed on EventGrid namespaces in higher environments (int, stg, prod).

The `amerootv2` replacement certificate (expires Feb 2049) is already active and handling authentication, so the orphaned expired cert is harmless but should be cleaned up.

### How

Extends `dev-infrastructure/scripts/regional-housekeeping.sh` with a new section that:
1. Discovers EventGrid namespaces in the regional resource group
2. Checks each namespace for an `ameroot` CA certificate using `az eventgrid namespace ca-certificate show`
3. Deletes it if found using `az eventgrid namespace ca-certificate delete`
4. Is idempotent — once the cert is removed, subsequent runs are a no-op

No pipeline changes are needed — the existing `housekeeping` step in `region-pipeline.yaml` already runs this script after the `infra` step with the correct identity and `REGIONAL_RESOURCE_GROUP` variable.

### Testing

- Tested No-op against personal dev
- Validated all the expired evengrid certs in int, stg and prod
- Tested manually against INT environment in dry run mode (`uksouth-shared-resources` resource group)

```bash
DRY_RUN=true REGIONAL_RESOURCE_GROUP=uksouth-shared-resources ./dev-infrastructure/scripts/regional-housekeeping.sh

DRY_RUN mode enabled - will only show what would be deleted, not actually delete anything
Discovering Azure monitoring workspaces in resource group uksouth-shared-resources...
Found workspaces: services-uksouth
hcps-uksouth
Checking workspace: services-uksouth
Workspace 'services-uksouth' has aroHCPPurpose tag: 'services' - preserving
Checking workspace: hcps-uksouth
Workspace 'hcps-uksouth' has aroHCPPurpose tag: 'hcps' - preserving
Checking for orphaned ameroot CA certificate on EventGrid namespaces in resource group uksouth-shared-resources...
WARNING: This command is in preview and under development. Reference and support levels: https://aka.ms/CLI_refstatus
Found orphaned ameroot CA certificate on namespace 'arohcp-int-maestro-ln' - deleting
[DRY_RUN] Command: az eventgrid namespace ca-certificate delete --resource-group uksouth-shared-resources --namespace-name arohcp-int-maestro-ln --name ameroot --yes
```