### PR TITLE
chore: unpin ACM/MCE components in image-updater

### DIFF
--- a/tooling/image-updater/config.yaml
+++ b/tooling/image-updater/config.yaml
@@ -70,7 +70,7 @@ images:
     group: hypershift-stack
     source:
       image: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
-      tag: "v2.16.2-462" # PINNED: advanced from v2.16.2-450 (expired from quay); skip v2.16.2-452 (klusterlet registration regression)
+      tagPattern: "^v\\d+\\.\\d+\\.\\d+-\\d+$"
       repoVersionUpgrade:
         repoPrefix: "acm-operator-bundle-acm-"
     targets:
@@ -80,7 +80,7 @@ images:
     group: hypershift-stack
     source:
       image: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211
-      tag: "v2.11.3-517" # PINNED: advanced from v2.11.2-506 (expired from quay); skip v2.11.2-508 (klusterlet registration regression)
+      tagPattern: "^v\\d+\\.\\d+\\.\\d+-\\d+$"
       repoVersionUpgrade:
         repoPrefix: "mce-operator-bundle-mce-"
     targets:


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-1187

### What

Replace pinned `tag` with `tagPattern` for ACM and MCE bundle images in the image-updater config to resume automatic image updates.

### Why

The ACM/MCE bundles were pinned in #5582  due to a klusterlet registration regression. The pinned tags have since expired from quay.io, breaking the periodic image-updater job:

```
"err": "failed to fetch latest value for acm-operator: failed to fetch image descriptor for tag v2.16.2-450: GET https://quay.io/v2/redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216/manifests/v2.16.2-450: TAG_EXPIRED"
```

https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-Azure-ARO-HCP-main-image-updater-image-updater-tooling/2066762764281450496

### Changes

- Replaced hardcoded `tag` pins with `tagPattern: "^v\d+\.\d+\.\d+-\d+$"` for both `acm-operator` and `acm-mce` in `tooling/image-updater/config.yaml`

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Commit history is clean (rebased/squashed)