### PR TITLE
feat(backend): surface silent kube-applier gate in logs (AROSLSRE-1188)

### DIFF
--- a/backend/pkg/controllers/create_cluster_scoped_read_desires_controller.go
+++ b/backend/pkg/controllers/create_cluster_scoped_read_desires_controller.go
@@ -90,6 +90,15 @@ func NewCreateClusterScopedReadDesiresController(
 }
 
 func (c *createClusterScopedReadDesiresSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPClusterKey) error {
+	logger := utils.LoggerFromContext(ctx).WithValues(utils.LogValues{}.
+		AddSubscriptionID(key.SubscriptionID).
+		AddResourceGroup(key.ResourceGroupName).
+		AddHCPClusterName(key.HCPClusterName)...)
+	// Inject the cluster-scoped logger so downstream helpers (e.g.
+	// kubeApplierDBClients.For) that read utils.LoggerFromContext(ctx)
+	// also emit the cluster-identifying fields.
+	ctx = utils.ContextWithLogger(ctx, logger)
+
 	existingCluster, err := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).Get(ctx, key.HCPClusterName)
 	if database.IsNotFoundError(err) {
 		return nil
@@ -137,7 +146,9 @@ func (c *createClusterScopedReadDesiresSyncer) SyncOnce(ctx context.Context, key
 	kaClient := c.kubeApplierDBClients.For(ctx, mcResourceID)
 	if kaClient == nil {
 		// Registry doesn't have an entry yet for this MC (e.g. the fleet
-		// lister hasn't caught up). Skip and rely on retrigger.
+		// lister hasn't caught up). Skip and rely on retrigger. When the MC
+		// document is registered but misconfigured (e.g. missing its
+		// kube-applier container name), For() surfaces that loudly.
 		return nil
 	}
 	crud, err := kaClient.ReadDesiresForCluster(key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)

--- a/internal/database/kube_applier_client.go
+++ b/internal/database/kube_applier_client.go
@@ -408,12 +408,22 @@ func (c *kubeApplierDBClients) For(ctx context.Context, managementClusterResourc
 		return existing
 	}
 
+	logger := utils.LoggerFromContext(ctx).WithValues(
+		"managementClusterResourceID", managementClusterResourceID.String())
+
 	mc := c.findManagementClusterLocked(ctx, managementClusterResourceID)
 	if mc == nil {
+		// Lister hasn't observed this management cluster yet (e.g. fleet
+		// informer lag). Transient; the caller retriggers.
+		logger.V(1).Info("no management cluster found for resourceID; cannot build kube-applier client")
 		return nil
 	}
 	containerName := mc.Status.KubeApplierCosmosContainerName
 	if len(containerName) == 0 {
+		// The MC document exists but is missing its container name. This is not
+		// expected in steady state and silently prevents every per-cluster
+		// ReadDesire from being written (see ARO-27510); surface it loudly.
+		logger.Info("management cluster found but Status.KubeApplierCosmosContainerName is empty; kube-applier client cannot be built and per-cluster ReadDesires will not be written")
 		return nil
 	}
 	container, err := c.database.NewContainer(containerName)
@@ -421,6 +431,7 @@ func (c *kubeApplierDBClients) For(ctx context.Context, managementClusterResourc
 		// NewContainer only errors on malformed inputs at construction time —
 		// treat as misconfiguration and surface as nil. The caller already
 		// has to handle nil for "not found" anyway.
+		logger.Error(err, "failed to construct kube-applier cosmos container; treating as unavailable", "containerName", containerName)
 		return nil
 	}
 	// Partition key per container is the lowercased MaestroConsumerName; *Desire


### PR DESCRIPTION
Jira: [AROSLSRE-1188](https://redhat.atlassian.net/browse/AROSLSRE-1188) — follow-up to [ARO-27510](https://redhat.atlassian.net/browse/ARO-27510)

### What

Add structured logging in `KubeApplierDBClients.For()` so its silent `return nil` gates become queryable:

- `mc == nil` at `V(1)` (fleet informer lag; transient).
- empty `Status.KubeApplierCosmosContainerName` at `Info` — not expected in steady state; this is the [ARO-27510](https://redhat.atlassian.net/browse/ARO-27510) signature.
- `NewContainer` construction failure at `Error`.

The caller `createClusterScopedReadDesiresSyncer.SyncOnce` builds a cluster-scoped logger and injects it into `ctx` (`utils.ContextWithLogger`) so `For()`'s logs carry the subscription / resource-group / cluster fields. No logging is added on the controller's transient early-return gates, per convention.

No behavioural change — observability-only.

### Why

In [ARO-27510](https://redhat.atlassian.net/browse/ARO-27510), the STG Fleet management-cluster document was missing `Status.KubeApplierCosmosContainerName`. `For()` returned nil, the per-cluster ReadDesire was never written, and cluster-create hung at `Provisioning("")` until the 20-minute e2e timeout — with **no signal anywhere in Kusto**. The empty-container-name gate now logs loudly so this class of regression surfaces immediately next time.

### Testing

- `go build ./backend/pkg/controllers/... ./internal/database/...`
- `go vet` clean on both packages.
- `go test ./backend/pkg/controllers/ ./internal/database/ -count=1` — pass.

### Special notes for your reviewer

Per review feedback, transient-state logging on the controller's early-exit gates was dropped; the only logging added is in the kube-applier client. The cluster-scoped logger is retained solely to propagate cluster-identifying fields into `For()`'s logs via `ctx`.

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
