### PR TITLE
test: make E2E VM SKU selection restriction-aware

### DIFF
--- a/nonlocal-e2e-specs.txt
+++ b/nonlocal-e2e-specs.txt
@@ -7,7 +7,7 @@
   "Get each nodepool from HCPOpenShiftCluster",
   "Successfully lists clusters filtered by resource group name",
   "creates a cluster and fails to update its name with a PATCH request",
-  "creates and deletes vm type NC4asT4v3 in a single cluster",
+  "creates and deletes a GPU nodepool in a single cluster",
   "should allow pods with images from allowed registries and have a valid allowlist",
   "should be able to create an HCP cluster then delete it by deleting the customer resource group",
   "should be able to forward control plane logs to a storage account and Event Hub via shoebox diagnostic settings",

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -199,6 +199,35 @@ For instructions and best practices on creating ARO HCP E2E test cases, refer to
 
 Be sure to review these guidelines before creating or updating ARO HCP E2E test cases.
 
+## Selecting VM sizes (SKUs)
+
+E2E tests must **not** hardcode VM SKUs. Across the many subscriptions and
+regions the suite runs in, a fixed SKU may be quota-restricted (for example
+`NotAvailableForSubscription`), which breaks node pool creation in that environment.
+
+Instead, resolve VM sizes at runtime through the restriction-aware selector in
+[`test/util/framework/vm_sku_selection.go`](../util/framework/vm_sku_selection.go):
+
+- `tc.SelectVMSize(ctx, selector)` queries the Azure **Resource SKUs** API for the
+  test location, filters out SKUs that are restricted in the current
+  subscription/location, applies the selector's capability filters, and returns
+  a usable SKU. When the selector requires zones, only SKUs with at least one
+  non-restricted zone are considered usable. It prefers the selector's ordered
+  `Preferred` list first (so behaviour is unchanged whenever the historical SKU
+  is available), then falls back to a deterministic, sorted pick.
+- Use the named selectors for common shapes: `DefaultWorkerVMSizeSelector()`,
+  `SmallWorkerVMSizeSelector()`, `JumpboxVMSizeSelector()`,
+  `ARM64NodePoolVMSizeSelector()`, `GPUNodePoolVMSizeSelector()`.
+- The default node pool params (`NewDefaultNodePoolParams20240610` /
+  `...20251223` / `...20260630`) leave `VMSize` empty; `CreateNodePoolFromParam*`
+  resolves it via `DefaultWorkerVMSizeSelector()` automatically. The OS disk
+  storage account type comes from the shared `DefaultDiskStorageAccountType`
+  constant. Set `VMSize` explicitly only to pin a specific size (for example
+  negative tests that assert on a specific SKU).
+
+Only reported **restrictions** are honoured; quota *headroom* (vCPU Usages API)
+is out of scope.
+
 ## Updating E2E Timeouts
 
 Shared timeout constants live in [`test/util/framework/constants.go`](../util/framework/constants.go).

--- a/test/e2e/arm64_nodepool.go
+++ b/test/e2e/arm64_nodepool.go
@@ -17,7 +17,6 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"regexp"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -45,7 +44,6 @@ var _ = Describe("Customer", func() {
 				customerNodePoolName             = "arm64-vm-np-1"
 			)
 			// This pattern matches a subset of the smallest (2GiB) ARM64-capable VM sizes listed in https://issues.redhat.com/browse/ARO-22443
-			vmSizePattern := regexp.MustCompile(`^Standard_D(?:2|4)pl(?:d)?s_v6$`)
 
 			tc := framework.NewTestContext()
 
@@ -89,8 +87,8 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster %q", customerClusterName)
 
 			By("discovering an ARM64-capable VM size")
-			nodePoolVMSize, err := tc.FindVirtualMachineSizeMatching(ctx, vmSizePattern)
-			Expect(err).NotTo(HaveOccurred(), "failed to find an ARM64-capable VM size")
+			nodePoolVMSize, err := tc.SelectVMSize(ctx, framework.ARM64NodePoolVMSizeSelector())
+			Expect(err).NotTo(HaveOccurred(), "failed to find an ARM64-capable VM size; check VM SKU restrictions/quota for the test subscription in %s", tc.Location())
 
 			By(fmt.Sprintf("creating the ARM64-based node pool %q with VM size %q", customerNodePoolName, nodePoolVMSize))
 			nodePoolParams := framework.NewDefaultNodePoolParams20240610()

--- a/test/e2e/cluster_authorized_cidrs_connectivity.go
+++ b/test/e2e/cluster_authorized_cidrs_connectivity.go
@@ -97,11 +97,12 @@ var _ = Describe("Authorized CIDRs", func() {
 				vmName := fmt.Sprintf("%s-test-vm", clusterName)
 				// The test VM is a throwaway kubectl client: it only needs a public IP
 				// (used as the single authorized CIDR) and to make one API call to the
-				// cluster. We use the common general-purpose Standard_D2s_v3 (same 2-vCPU
-				// size as the old burstable Standard_B2s) because the burstable B-series
-				// is the SKU class most prone to regional SkuNotAvailable capacity
+				// cluster. We use a small general-purpose D-series SKU (resolved
+				// restriction-aware) rather than the burstable B-series, which is the
+				// SKU class most prone to regional SkuNotAvailable capacity
 				// restrictions, which is what flaked this test.
-				const vmSize = "Standard_D2s_v3"
+				vmSize, err := tc.SelectVMSize(ctx, framework.JumpboxVMSizeSelector())
+				Expect(err).NotTo(HaveOccurred(), "failed to resolve a jumpbox VM size; check VM SKU restrictions/quota for the test subscription in %s", tc.Location())
 				var vmDeployment *armresources.DeploymentExtended
 				var deployErr error
 				// Bounded retry to absorb transient ARM errors, but fail fast on

--- a/test/e2e/cluster_version_backlevel.go
+++ b/test/e2e/cluster_version_backlevel.go
@@ -173,10 +173,13 @@ var _ = Describe("Customer", func() {
 					nodePoolName := customerNodePoolName + nodePoolSuffix
 
 					By("creating node pool version " + matchingNodePoolVersion + " and verifying a simple web app can run")
+					nodePoolDefaults := defaultNodePoolDefaults
+					nodePoolDefaults.vmSize, err = tc.SelectVMSize(ctx, framework.DefaultWorkerVMSizeSelector())
+					Expect(err).NotTo(HaveOccurred(), "failed to resolve the default worker VM size for the back-level node pool; check VM SKU restrictions/quota for the test subscription in %s", tc.Location())
 					nodePool, err := buildNodePoolRequest(
 						tc.Location(),
 						matchingNodePoolVersion,
-						defaultNodePoolDefaults,
+						nodePoolDefaults,
 					)
 					Expect(err).NotTo(HaveOccurred(), "failed to build node pool request for version %s", matchingNodePoolVersion)
 					nodePoolClient := tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient()
@@ -213,10 +216,13 @@ type nodePoolDefaults struct {
 }
 
 var defaultNodePoolDefaults = nodePoolDefaults{
-	replicas:               int32(2),
-	vmSize:                 "Standard_D8s_v3",
+	replicas: int32(2),
+	// vmSize is intentionally left empty: it is resolved at create time via the
+	// restriction-aware framework.DefaultWorkerVMSizeSelector so the suite is
+	// resilient to per-subscription SKU restrictions.
+	vmSize:                 "",
 	osDiskSizeGiB:          int32(64),
-	diskStorageAccountType: "StandardSSD_LRS",
+	diskStorageAccountType: framework.DefaultDiskStorageAccountType,
 	channelGroup:           "stable",
 }
 

--- a/test/e2e/gpu_nodepools_create_delete.go
+++ b/test/e2e/gpu_nodepools_create_delete.go
@@ -29,159 +29,140 @@ import (
 )
 
 var _ = Describe("HCP Nodepools GPU instances", func() {
-	// Mapping of human-friendly SKU identifiers to Azure VM size names
-	type gpuSKU struct {
-		display string
-		vmSize  string
-	}
-	gpuSkus := []gpuSKU{
-		{display: "NC4asT4v3", vmSize: "Standard_NC4as_T4_v3"},
-		/*{display: "NC8asT4v3", vmSize: "Standard_NC8as_T4_v3"},
-		{display: "NC12sv3", vmSize: "Standard_NC12s_v3"},
-		{display: "NC16asT4v3", vmSize: "Standard_NC16as_T4_v3"},
-		{display: "NC24sv3", vmSize: "Standard_NC24s_v3"},
-		{display: "NC24rsv3", vmSize: "Standard_NC24rs_v3"},
-		{display: "NC64asT4v3", vmSize: "Standard_NC64as_T4_v3"},
-		{display: "ND96asrv4", vmSize: "Standard_ND96asr_v4"},
-		{display: "NC24adsA100v4", vmSize: "Standard_NC24ads_A100_v4"},
-		{display: "NC48adsA100v4", vmSize: "Standard_NC48ads_A100_v4"},
-		{display: "NC96adsA100v4", vmSize: "Standard_NC96ads_A100_v4"},
-		{display: "ND96amsrA100v4", vmSize: "Standard_ND96amsr_A100_v4"},*/
-	}
+	It("creates and deletes a GPU nodepool in a single cluster",
+		labels.RequireNothing,
+		labels.Critical,
+		labels.Positive,
+		labels.IntegrationOnly,
+		func(ctx context.Context) {
+			const (
+				customerClusterName = "cluster-gpu-np"
+				defaultNodePoolName = "np-1"
+				gpuNodePoolName     = "gpu-np-1"
+			)
 
-	for _, sku := range gpuSkus {
-		sku := sku
-		It("creates and deletes vm type "+sku.display+" in a single cluster",
-			labels.RequireNothing,
-			labels.Critical,
-			labels.Positive,
-			labels.IntegrationOnly,
-			func(ctx context.Context) {
-				const (
-					customerClusterName = "cluster-gpu-np"
-					defaultNodePoolName = "np-1"
-					gpuNodePoolName     = "gpu-np-1"
-				)
+			tc := framework.NewTestContext()
 
-				tc := framework.NewTestContext()
+			By("discovering an available GPU VM size")
+			gpuVMSize, err := tc.SelectVMSize(ctx, framework.GPUNodePoolVMSizeSelector())
+			Expect(err).NotTo(HaveOccurred(), "failed to discover a GPU VM size")
 
-				if tc.UsePooledIdentities() {
-					err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
-					Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
-				}
+			if tc.UsePooledIdentities() {
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
+				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
+			}
 
-				By("creating a resource group")
-				resourceGroup, err := tc.NewResourceGroup(ctx, "rg-gpu-nodepool-"+sku.display, tc.Location())
-				Expect(err).NotTo(HaveOccurred(), "failed to create resource group for GPU nodepool test")
+			By("creating a resource group")
+			resourceGroup, err := tc.NewResourceGroup(ctx, "rg-gpu-nodepool", tc.Location())
+			Expect(err).NotTo(HaveOccurred(), "failed to create resource group for GPU nodepool test")
 
-				clusterParams := framework.NewDefaultClusterParams20240610()
-				clusterParams.ClusterName = customerClusterName
-				managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
-				clusterParams.ManagedResourceGroupName = managedResourceGroupName
+			clusterParams := framework.NewDefaultClusterParams20240610()
+			clusterParams.ClusterName = customerClusterName
+			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
+			clusterParams.ManagedResourceGroupName = managedResourceGroupName
 
-				By("creating customer resources (infrastructure and managed identities) for cluster")
-				clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,
-					resourceGroup,
-					clusterParams,
-					map[string]interface{}{},
-					TestArtifactsFS,
-					framework.RBACScopeResourceGroup,
-				)
-				Expect(err).NotTo(HaveOccurred(), "failed to create customer resources for GPU nodepool cluster")
+			By("creating customer resources (infrastructure and managed identities) for cluster")
+			clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,
+				resourceGroup,
+				clusterParams,
+				map[string]interface{}{},
+				TestArtifactsFS,
+				framework.RBACScopeResourceGroup,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to create customer resources for GPU nodepool cluster")
 
-				By("creating the HCP cluster")
-				err = tc.CreateHCPClusterFromParam20240610(ctx,
-					GinkgoLogr,
-					*resourceGroup.Name,
-					clusterParams,
-					framework.ClusterCreationTimeout,
-				)
-				Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster for GPU nodepool test")
+			By("creating the HCP cluster")
+			err = tc.CreateHCPClusterFromParam20240610(ctx,
+				GinkgoLogr,
+				*resourceGroup.Name,
+				clusterParams,
+				framework.ClusterCreationTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster for GPU nodepool test")
 
-				By("getting credentials and verifying cluster is viable")
-				adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
-					ctx,
-					tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
-					*resourceGroup.Name,
-					customerClusterName,
-					framework.GetAdminRESTConfigTimeout,
-				)
-				Expect(err).NotTo(HaveOccurred(), "failed to get admin REST config for cluster %s", customerClusterName)
-				Expect(verifiers.VerifyHCPCluster(ctx, adminRESTConfig)).To(Succeed(), "failed to verify basic cluster health for %s", customerClusterName)
+			By("getting credentials and verifying cluster is viable")
+			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
+				ctx,
+				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
+				*resourceGroup.Name,
+				customerClusterName,
+				framework.GetAdminRESTConfigTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to get admin REST config for cluster %s", customerClusterName)
+			Expect(verifiers.VerifyHCPCluster(ctx, adminRESTConfig)).To(Succeed(), "failed to verify basic cluster health for %s", customerClusterName)
 
-				// this test deletes gpu node pool later. if we only create gpu node pool and then delete it,
-				// we will get an error: "The last node pool can not be deleted from a cluster."
-				// that's why firstly we create a default node pool (which by the way is cheaper than gpu node pool)
-				// so that gpu node pool can be deleted later without any error.
-				// we create a default node pool with two replicas instead of one,
-				// because in the latter case we will get this error: "A hosted cluster requires at least 2 replicas"
-				By("creating default nodepool")
-				defaultNodePoolParams := framework.NewDefaultNodePoolParams20240610()
-				defaultNodePoolParams.ClusterName = customerClusterName
-				defaultNodePoolParams.NodePoolName = defaultNodePoolName
-				defaultNodePoolParams.Replicas = int32(2)
+			// this test deletes gpu node pool later. if we only create gpu node pool and then delete it,
+			// we will get an error: "The last node pool can not be deleted from a cluster."
+			// that's why firstly we create a default node pool (which by the way is cheaper than gpu node pool)
+			// so that gpu node pool can be deleted later without any error.
+			// we create a default node pool with two replicas instead of one,
+			// because in the latter case we will get this error: "A hosted cluster requires at least 2 replicas"
+			By("creating default nodepool")
+			defaultNodePoolParams := framework.NewDefaultNodePoolParams20240610()
+			defaultNodePoolParams.ClusterName = customerClusterName
+			defaultNodePoolParams.NodePoolName = defaultNodePoolName
+			defaultNodePoolParams.Replicas = int32(2)
 
-				err = tc.CreateNodePoolFromParam20240610(ctx,
-					GinkgoLogr,
-					*resourceGroup.Name,
-					managedResourceGroupName,
-					customerClusterName,
-					defaultNodePoolParams,
-					framework.NodePoolCreationTimeout,
-				)
-				Expect(err).NotTo(HaveOccurred(), "failed to create default nodepool %s", defaultNodePoolName)
+			err = tc.CreateNodePoolFromParam20240610(ctx,
+				GinkgoLogr,
+				*resourceGroup.Name,
+				managedResourceGroupName,
+				customerClusterName,
+				defaultNodePoolParams,
+				framework.NodePoolCreationTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to create default nodepool %s", defaultNodePoolName)
 
-				By(fmt.Sprintf("creating GPU nodepool with VM size %q", sku.vmSize))
-				gpuNodePoolParams := framework.NewDefaultNodePoolParams20240610()
-				gpuNodePoolParams.ClusterName = customerClusterName
-				gpuNodePoolParams.NodePoolName = gpuNodePoolName
-				gpuNodePoolParams.Replicas = int32(1)
-				gpuNodePoolParams.VMSize = sku.vmSize
+			By(fmt.Sprintf("creating GPU nodepool with VM size %q", gpuVMSize))
+			gpuNodePoolParams := framework.NewDefaultNodePoolParams20240610()
+			gpuNodePoolParams.ClusterName = customerClusterName
+			gpuNodePoolParams.NodePoolName = gpuNodePoolName
+			gpuNodePoolParams.Replicas = int32(1)
+			gpuNodePoolParams.VMSize = gpuVMSize
 
-				err = tc.CreateNodePoolFromParam20240610(ctx,
-					GinkgoLogr,
-					*resourceGroup.Name,
-					managedResourceGroupName,
-					customerClusterName,
-					gpuNodePoolParams,
-					framework.NodePoolCreationTimeout,
-				)
-				Expect(err).NotTo(HaveOccurred(), "failed to create GPU nodepool %s with VM size %s", gpuNodePoolName, sku.vmSize)
+			err = tc.CreateNodePoolFromParam20240610(ctx,
+				GinkgoLogr,
+				*resourceGroup.Name,
+				managedResourceGroupName,
+				customerClusterName,
+				gpuNodePoolParams,
+				framework.NodePoolCreationTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to create GPU nodepool %s with VM size %s", gpuNodePoolName, gpuVMSize)
 
-				By("verifying GPU nodepool provisioning succeeded with correct VM size")
-				created, err := framework.GetNodePool20240610(ctx,
-					tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient(),
-					*resourceGroup.Name,
-					customerClusterName,
-					gpuNodePoolName,
-				)
-				Expect(err).NotTo(HaveOccurred(), "failed to get GPU nodepool %s", gpuNodePoolName)
-				Expect(created.Properties).ToNot(BeNil(), "GPU nodepool Properties was nil")
-				Expect(created.Properties.ProvisioningState).ToNot(BeNil(), "GPU nodepool Properties.ProvisioningState was nil")
-				Expect(*created.Properties.ProvisioningState).To(Equal(hcpsdk20240610preview.ProvisioningStateSucceeded), "GPU nodepool %s provisioning state should be Succeeded", gpuNodePoolName)
-				Expect(created.Properties.Platform).ToNot(BeNil(), "GPU nodepool Properties.Platform was nil")
-				Expect(created.Properties.Platform.VMSize).ToNot(BeNil(), "GPU nodepool Properties.Platform.VMSize was nil")
-				Expect(*created.Properties.Platform.VMSize).To(Equal(sku.vmSize), "GPU nodepool %s VM size should be %s", gpuNodePoolName, sku.vmSize)
+			By("verifying GPU nodepool provisioning succeeded with correct VM size")
+			created, err := framework.GetNodePool20240610(ctx,
+				tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient(),
+				*resourceGroup.Name,
+				customerClusterName,
+				gpuNodePoolName,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to get GPU nodepool %s", gpuNodePoolName)
+			Expect(created.Properties).ToNot(BeNil(), "GPU nodepool Properties was nil")
+			Expect(created.Properties.ProvisioningState).ToNot(BeNil(), "GPU nodepool Properties.ProvisioningState was nil")
+			Expect(*created.Properties.ProvisioningState).To(Equal(hcpsdk20240610preview.ProvisioningStateSucceeded), "GPU nodepool %s provisioning state should be Succeeded", gpuNodePoolName)
+			Expect(created.Properties.Platform).ToNot(BeNil(), "GPU nodepool Properties.Platform was nil")
+			Expect(created.Properties.Platform.VMSize).ToNot(BeNil(), "GPU nodepool Properties.Platform.VMSize was nil")
+			Expect(*created.Properties.Platform.VMSize).To(Equal(gpuVMSize), "GPU nodepool %s VM size should be %s", gpuNodePoolName, gpuVMSize)
 
-				By("deleting GPU nodepool")
-				Expect(framework.DeleteNodePool20240610(
-					ctx,
-					tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient(),
-					*resourceGroup.Name,
-					customerClusterName,
-					gpuNodePoolName,
-					25*time.Minute,
-				)).To(Succeed(), "failed to delete GPU nodepool %s", gpuNodePoolName)
+			By("deleting GPU nodepool")
+			Expect(framework.DeleteNodePool20240610(
+				ctx,
+				tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient(),
+				*resourceGroup.Name,
+				customerClusterName,
+				gpuNodePoolName,
+				25*time.Minute,
+			)).To(Succeed(), "failed to delete GPU nodepool %s", gpuNodePoolName)
 
-				By("confirming GPU nodepool has been deleted")
-				_, getErr := framework.GetNodePool20240610(ctx,
-					tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient(),
-					*resourceGroup.Name,
-					customerClusterName,
-					gpuNodePoolName,
-				)
-				Expect(getErr).To(HaveOccurred(), "expected GPU nodepool %s to be deleted but it still exists", gpuNodePoolName)
-			},
-		)
-	}
+			By("confirming GPU nodepool has been deleted")
+			_, getErr := framework.GetNodePool20240610(ctx,
+				tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient(),
+				*resourceGroup.Name,
+				customerClusterName,
+				gpuNodePoolName,
+			)
+			Expect(getErr).To(HaveOccurred(), "expected GPU nodepool %s to be deleted but it still exists", gpuNodePoolName)
+		},
+	)
 })

--- a/test/e2e/nodepool_autoscaling.go
+++ b/test/e2e/nodepool_autoscaling.go
@@ -61,8 +61,10 @@ var _ = Describe("Customer", func() {
 				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
 			}
 
-			By("checking if the region supports availability zones")
-			hasAZ, err := tc.LocationHasAvailabilityZones(ctx, "Standard_D8s_v3")
+			By("resolving the default worker VM size and checking if the region supports availability zones")
+			workerVMSize, err := tc.SelectVMSize(ctx, framework.DefaultWorkerVMSizeSelector())
+			Expect(err).NotTo(HaveOccurred(), "failed to resolve the default worker VM size")
+			hasAZ, err := tc.LocationHasAvailabilityZones(ctx, workerVMSize)
 			Expect(err).NotTo(HaveOccurred(), "failed to check availability zone support")
 
 			By("creating a resource group")

--- a/test/e2e/nodepool_ephemeral_osdisk.go
+++ b/test/e2e/nodepool_ephemeral_osdisk.go
@@ -110,10 +110,16 @@ var _ = Describe("Nodepool Ephemeral OS Disk", func() {
 			)
 			Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster %s", customerClusterName)
 
+			By("selecting a VM size that supports ephemeral OS disks")
+			vmSize, err := tc.SelectVMSize(ctx, framework.EphemeralOSDiskWorkerVMSizeSelector())
+			Expect(err).NotTo(HaveOccurred(), "failed to select a VM size with ephemeral OS disk support; "+
+				"this typically indicates a SKU restriction or quota issue in the test subscription/region")
+
 			By("creating nodepool with ephemeral OS disk and autoRepair enabled")
 			nodePoolParams := framework.NewDefaultNodePoolParams20251223()
 			nodePoolParams.ClusterName = customerClusterName
 			nodePoolParams.NodePoolName = customerNodePoolName
+			nodePoolParams.VMSize = vmSize
 			nodePoolParams.DiskType = hcpsdk20251223preview.OsDiskTypeEphemeral
 			nodePoolParams.AutoRepair = true
 			err = tc.CreateNodePoolFromParam20251223(

--- a/test/e2e/nodepool_labels_taints.go
+++ b/test/e2e/nodepool_labels_taints.go
@@ -108,7 +108,9 @@ var _ = Describe("Customer", func() {
 			initialReplicas := nodePoolParams.Replicas
 
 			// using a smaller VM size for faster provisioning
-			nodePoolParams.VMSize = "Standard_D4s_v3"
+			smallVMSize, err := tc.SelectVMSize(ctx, framework.SmallWorkerVMSizeSelector())
+			Expect(err).NotTo(HaveOccurred(), "failed to resolve a small worker VM size; check VM SKU restrictions/quota for the test subscription in %s", tc.Location())
+			nodePoolParams.VMSize = smallVMSize
 
 			nodePool := framework.BuildNodePoolFromParams20240610(nodePoolParams, tc.Location())
 

--- a/test/e2e/simple_negative_cases.go
+++ b/test/e2e/simple_negative_cases.go
@@ -189,6 +189,10 @@ var _ = Describe("Customer", func() {
 			} else if nodePool.Properties.Platform == nil {
 				errs = append(errs, fmt.Errorf("nodepool platform properties are nil"))
 			} else {
+				originalVMSize := ""
+				if nodePool.Properties.Platform.VMSize != nil {
+					originalVMSize = *nodePool.Properties.Platform.VMSize
+				}
 				nodePool.Properties.Platform.VMSize = to.Ptr("Standard_D16s_v3")
 				nodePool.Properties.Platform.AvailabilityZone = to.Ptr("2")
 				if nodePool.Properties.Platform.OSDisk != nil {
@@ -207,7 +211,7 @@ var _ = Describe("Customer", func() {
 					} else {
 						platform := updatedNodePool.Properties.Platform
 
-						if platform.VMSize != nil && *platform.VMSize != "Standard_D8s_v3" {
+						if platform.VMSize != nil && *platform.VMSize != originalVMSize {
 							errs = append(errs, fmt.Errorf("vmSize was modified despite immutable error"))
 						}
 

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
@@ -57,7 +57,7 @@ Customer should be able to successfully upgrade control plane minor version from
 Customer should be able to successfully upgrade control plane minor version from 5.11 minor to 5.12 minor
 Customer should be able to create a cluster with an external auth config and get the external auth config
 Customer should be able to lifecycle and confirm external auth on a cluster
-HCP Nodepools GPU instances creates and deletes vm type NC4asT4v3 in a single cluster
+HCP Nodepools GPU instances creates and deletes a GPU nodepool in a single cluster
 Customer should be able to create an HCP cluster and manage ImageDigestMirrors
 Customer should be able to create an HCP cluster with Image Registry not present
 Customer should be able to create a cluster with default autoscaling and a nodepool with autoscaling enabled up to replica limits

--- a/test/util/framework/deployment_helper.go
+++ b/test/util/framework/deployment_helper.go
@@ -434,6 +434,14 @@ func (tc *perItOrDescribeTestContext) CreateNodePoolFromParam20240610(
 		return fmt.Errorf("nodePoolName parameter not found or empty")
 	}
 
+	if parameters.VMSize == "" {
+		vmSize, err := tc.SelectVMSize(nodePoolCtx, DefaultWorkerVMSizeSelector())
+		if err != nil {
+			return fmt.Errorf("failed to resolve default VM size for node pool %s (check VM SKU restrictions/quota for the test subscription in %s): %w", nodePoolName, tc.Location(), err)
+		}
+		parameters.VMSize = vmSize
+	}
+
 	nodePool := BuildNodePoolFromParams20240610(parameters, tc.Location())
 
 	if _, err := CreateNodePoolAndWait20240610(
@@ -498,6 +506,14 @@ func (tc *perItOrDescribeTestContext) CreateNodePoolFromParam20251223(
 	nodePoolName := parameters.NodePoolName
 	if nodePoolName == "" {
 		return fmt.Errorf("nodePoolName parameter not found or empty")
+	}
+
+	if parameters.VMSize == "" {
+		vmSize, err := tc.SelectVMSize(nodePoolCtx, DefaultWorkerVMSizeSelector())
+		if err != nil {
+			return fmt.Errorf("failed to resolve default VM size for node pool %s (check VM SKU restrictions/quota for the test subscription in %s): %w", nodePoolName, tc.Location(), err)
+		}
+		parameters.VMSize = vmSize
 	}
 
 	nodePool := BuildNodePoolFromParams20251223(parameters, tc.Location())
@@ -607,6 +623,14 @@ func (tc *perItOrDescribeTestContext) CreateNodePoolFromParam20260630(
 	nodePoolName := parameters.NodePoolName
 	if nodePoolName == "" {
 		return fmt.Errorf("nodePoolName parameter not found or empty")
+	}
+
+	if parameters.VMSize == "" {
+		vmSize, err := tc.SelectVMSize(nodePoolCtx, DefaultWorkerVMSizeSelector())
+		if err != nil {
+			return fmt.Errorf("failed to resolve default VM size for node pool %s (check VM SKU restrictions/quota for the test subscription in %s): %w", nodePoolName, tc.Location(), err)
+		}
+		parameters.VMSize = vmSize
 	}
 
 	nodePool := BuildNodePoolFromParams20260630(parameters, tc.Location())

--- a/test/util/framework/deployment_params.go
+++ b/test/util/framework/deployment_params.go
@@ -382,33 +382,43 @@ type NodePoolAutoScalingParams struct {
 
 func NewDefaultNodePoolParams20240610() NodePoolParams20240610 {
 	return NodePoolParams20240610{
-		OpenshiftVersionId:     DefaultOpenshiftNodePoolVersionId(),
-		Replicas:               int32(2),
-		VMSize:                 "Standard_D8s_v3",
+		OpenshiftVersionId: DefaultOpenshiftNodePoolVersionId(),
+		Replicas:           int32(2),
+		// VMSize is intentionally left empty: CreateNodePoolFromParam20240610
+		// resolves it via the restriction-aware DefaultWorkerVMSizeSelector at
+		// create time so the suite is resilient to per-subscription SKU
+		// restrictions. Set it explicitly to pin a specific size.
+		VMSize:                 "",
 		OSDiskSizeGiB:          int32(64),
-		DiskStorageAccountType: "StandardSSD_LRS",
+		DiskStorageAccountType: DefaultDiskStorageAccountType,
 		ChannelGroup:           DefaultOpenshiftNodePoolChannelGroup(),
 	}
 }
 
 func NewDefaultNodePoolParams20251223() NodePoolParams20251223 {
 	return NodePoolParams20251223{
-		OpenshiftVersionId:     DefaultOpenshiftNodePoolVersionId(),
-		Replicas:               int32(2),
-		VMSize:                 "Standard_D8s_v3",
+		OpenshiftVersionId: DefaultOpenshiftNodePoolVersionId(),
+		Replicas:           int32(2),
+		// VMSize is intentionally left empty: CreateNodePoolFromParam20251223
+		// resolves it via the restriction-aware DefaultWorkerVMSizeSelector at
+		// create time. Set it explicitly to pin a specific size.
+		VMSize:                 "",
 		OSDiskSizeGiB:          int32(64),
-		DiskStorageAccountType: "StandardSSD_LRS",
+		DiskStorageAccountType: DefaultDiskStorageAccountType,
 		ChannelGroup:           DefaultOpenshiftNodePoolChannelGroup(),
 	}
 }
 
 func NewDefaultNodePoolParams20260630() NodePoolParams20260630 {
 	return NodePoolParams20260630{
-		OpenshiftVersionId:     DefaultOpenshiftNodePoolVersionId(),
-		Replicas:               int32(2),
-		VMSize:                 "Standard_D8s_v3",
+		OpenshiftVersionId: DefaultOpenshiftNodePoolVersionId(),
+		Replicas:           int32(2),
+		// VMSize is intentionally left empty: CreateNodePoolFromParam20260630
+		// resolves it via the restriction-aware DefaultWorkerVMSizeSelector at
+		// create time. Set it explicitly to pin a specific size.
+		VMSize:                 "",
 		OSDiskSizeGiB:          int32(64),
-		DiskStorageAccountType: "StandardSSD_LRS",
+		DiskStorageAccountType: DefaultDiskStorageAccountType,
 		ChannelGroup:           DefaultOpenshiftNodePoolChannelGroup(),
 	}
 }

--- a/test/util/framework/per_invocation_framework.go
+++ b/test/util/framework/per_invocation_framework.go
@@ -37,6 +37,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
 
 	"github.com/Azure/ARO-HCP/internal/azsdk"
@@ -63,6 +64,11 @@ type perBinaryInvocationTestContext struct {
 	azureCredentials  azcore.TokenCredential
 	identityPoolState *leasedIdentityPoolState
 	defaultTransport  *http.Transport
+	// virtualMachineResourceSKUsByLocation memoizes the slow Resource SKUs API
+	// for the duration of the whole e2e suite run. All specs in one invocation
+	// target the same location, so a suite-wide cache avoids repeatedly burning
+	// per-test timeout budget on the same ARM call.
+	virtualMachineResourceSKUsByLocation map[string][]*armcompute.ResourceSKU
 }
 
 type CleanupFunc func(ctx context.Context) error
@@ -93,21 +99,22 @@ var azureRetryOptions = policy.RetryOptions{
 func invocationContext() *perBinaryInvocationTestContext {
 	initializeOnce.Do(func() {
 		invocationContextInstance = &perBinaryInvocationTestContext{
-			artifactDir:              artifactDir(),
-			sharedDir:                SharedDir(),
-			subscriptionName:         subscriptionName(),
-			tenantID:                 tenantID(),
-			testUserClientID:         testUserClientID(),
-			location:                 location(),
-			pullSecretPath:           pullSecretPath(),
-			frontendAddress:          frontendAddress(),
-			adminAPIAddress:          adminAPIAddress(),
-			skipCertVerification:     skipCertVerification(),
-			isDevelopmentEnvironment: IsDevelopmentEnvironment(),
-			skipCleanup:              skipCleanup(),
-			pooledIdentities:         pooledIdentities(),
-			compressTimingMetadata:   compressTimingMetadata(),
-			defaultTransport:         defaultHTTPTransport(),
+			artifactDir:                          artifactDir(),
+			sharedDir:                            SharedDir(),
+			subscriptionName:                     subscriptionName(),
+			tenantID:                             tenantID(),
+			testUserClientID:                     testUserClientID(),
+			location:                             location(),
+			pullSecretPath:                       pullSecretPath(),
+			frontendAddress:                      frontendAddress(),
+			adminAPIAddress:                      adminAPIAddress(),
+			skipCertVerification:                 skipCertVerification(),
+			isDevelopmentEnvironment:             IsDevelopmentEnvironment(),
+			skipCleanup:                          skipCleanup(),
+			pooledIdentities:                     pooledIdentities(),
+			compressTimingMetadata:               compressTimingMetadata(),
+			defaultTransport:                     defaultHTTPTransport(),
+			virtualMachineResourceSKUsByLocation: make(map[string][]*armcompute.ResourceSKU),
 		}
 	})
 	return invocationContextInstance

--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -27,7 +27,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -1141,86 +1140,21 @@ func (tc *perItOrDescribeTestContext) PullSecretPath() string {
 	return tc.perBinaryInvocationTestContext.pullSecretPath
 }
 
-// FindVirtualMachineSizeMatching queries Azure for available VM sizes in the test location
-// and returns a randomly selected size name that matches the provided regex pattern.
-// This is useful for finding VM sizes that meet specific criteria (e.g., matching a family like "Standard_D.*")
-// while avoiding bias towards any particular size.
-func (tc *perItOrDescribeTestContext) FindVirtualMachineSizeMatching(ctx context.Context, pattern *regexp.Regexp) (string, error) {
-	if pattern == nil {
-		return "", fmt.Errorf("pattern cannot be nil")
-	}
-
-	clientFactory, err := tc.GetARMComputeClientFactory(ctx)
-	if err != nil {
-		return "", fmt.Errorf("failed to get ARM compute client factory: %w", err)
-	}
-
+// LocationHasAvailabilityZones checks if the given VM SKU has at least one
+// non-restricted availability zone in the current test location by querying the
+// Azure Resource SKUs API.
+func (tc *perItOrDescribeTestContext) LocationHasAvailabilityZones(ctx context.Context, vmSize string) (bool, error) {
 	location := tc.Location()
-	matches := make([]string, 0)
-
-	vmSizesClient := clientFactory.NewVirtualMachineSizesClient()
-	pager := vmSizesClient.NewListPager(location, nil)
-	for pager.More() {
-		page, err := pager.NextPage(ctx)
-		if err != nil {
-			return "", fmt.Errorf("failed to list VM sizes in %s: %w", location, err)
-		}
-		if page.Value == nil {
+	skus, err := tc.listVirtualMachineResourceSKUs(ctx, location)
+	if err != nil {
+		return false, err
+	}
+	for _, sku := range skus {
+		if sku.Name == nil || *sku.Name != vmSize {
 			continue
 		}
-		for _, size := range page.Value {
-			if size.Name == nil {
-				continue
-			}
-			if pattern.MatchString(*size.Name) {
-				matches = append(matches, *size.Name)
-			}
-		}
-	}
-
-	if len(matches) == 0 {
-		return "", fmt.Errorf("no VM size matching %q found in %s", pattern.String(), location)
-	}
-
-	// Randomly select a VM size from the matches to avoid bias towards the first or last size in the list.
-	selected := matches[rand.Intn(len(matches))]
-	return selected, nil
-}
-
-// LocationHasAvailabilityZones checks if the given VM SKU has availability zones
-// in the current test location by querying the Azure Resource SKUs API.
-func (tc *perItOrDescribeTestContext) LocationHasAvailabilityZones(ctx context.Context, vmSize string) (bool, error) {
-	clientFactory, err := tc.GetARMComputeClientFactory(ctx)
-	if err != nil {
-		return false, fmt.Errorf("failed to get ARM compute client factory: %w", err)
-	}
-
-	location := tc.Location()
-	skuClient := clientFactory.NewResourceSKUsClient()
-	filter := fmt.Sprintf("location eq '%s'", location)
-	pager := skuClient.NewListPager(&armcompute.ResourceSKUsClientListOptions{
-		Filter: &filter,
-	})
-	for pager.More() {
-		page, err := pager.NextPage(ctx)
-		if err != nil {
-			return false, fmt.Errorf("failed to list resource SKUs in %s: %w", location, err)
-		}
-		for _, sku := range page.Value {
-			if sku.Name == nil || *sku.Name != vmSize {
-				continue
-			}
-			if sku.ResourceType == nil || *sku.ResourceType != "virtualMachines" {
-				continue
-			}
-			for _, locationInfo := range sku.LocationInfo {
-				if locationInfo.Location == nil || !strings.EqualFold(*locationInfo.Location, location) {
-					continue
-				}
-				if len(locationInfo.Zones) > 0 {
-					return true, nil
-				}
-			}
+		if len(availableZones(sku, location)) > 0 {
+			return true, nil
 		}
 	}
 	return false, nil

--- a/test/util/framework/vm_sku_selection.go
+++ b/test/util/framework/vm_sku_selection.go
@@ -1,0 +1,496 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/onsi/ginkgo/v2"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
+)
+
+// ErrNoUsableVMSize is returned by SelectVMSize when no VM size in the target
+// location satisfies the selector after restrictions and capability filtering
+// are applied. Callers decide whether this is a hard failure (general-purpose
+// SKUs are expected to exist everywhere) or a reason to Skip the test (e.g. GPU
+// capacity, which is genuinely scarce and often restricted per subscription).
+//
+// Encountering this error for a general-purpose selector almost always points
+// at a configuration/quota issue with the test subscription/region (the chosen
+// SKUs are restricted or unavailable there), not at a product defect.
+var ErrNoUsableVMSize = errors.New("no unrestricted VM size satisfied the selector in the test location; " +
+	"this typically indicates a VM SKU restriction or quota issue with the test subscription/region, not a product defect")
+
+// Historical default SKUs. They are kept as the first preference in their
+// selectors so behaviour is unchanged whenever they are available and
+// unrestricted in the target subscription/region; selection only diverges when
+// the preferred SKU is genuinely unusable.
+const (
+	DefaultWorkerVMSize = "Standard_D8s_v3"
+	SmallWorkerVMSize   = "Standard_D4s_v3"
+	JumpboxVMSize       = "Standard_D2s_v3"
+)
+
+// DefaultDiskStorageAccountType is the OS disk storage account type used by the
+// default node pool params. It is centralized here so the node pool param
+// constructors and tests share a single source of truth.
+const DefaultDiskStorageAccountType = "StandardSSD_LRS"
+
+const (
+	capabilityVCPUs                    = "vCPUs"
+	capabilityGPUs                     = "GPUs"
+	capabilityCPUArchitecture          = "CPUArchitectureType"
+	capabilityEphemeralOSDiskSupported = "EphemeralOSDiskSupported"
+)
+
+// VMSizeSelector describes the requirements a VM size must satisfy. SelectVMSize
+// tries Preferred entries in order first, then falls back to a deterministic
+// (sorted) pick among the remaining SKUs that match NamePattern and the
+// capability constraints.
+type VMSizeSelector struct {
+	// Name identifies the selector in logs and errors, e.g. "default-worker".
+	Name string
+	// Preferred is an ordered list of SKU names to try before any discovery.
+	Preferred []string
+	// NamePattern, when set, restricts fallback discovery candidates to SKU
+	// names matching the pattern. It does not constrain Preferred entries.
+	NamePattern *regexp.Regexp
+	// MinVCPUs, when > 0, requires the SKU to advertise at least this many vCPUs.
+	MinVCPUs int
+	// CPUArchitecture, when set (e.g. "x64" or "Arm64"), requires the SKU's
+	// CPUArchitectureType capability to match (case-insensitive).
+	CPUArchitecture string
+	// RequireGPU, when true, requires the SKU to advertise at least one GPU.
+	RequireGPU bool
+	// RequireZones, when true, requires the SKU to expose at least one
+	// non-restricted availability zone in the target location.
+	RequireZones bool
+	// RequireEphemeralOSDisk, when true, requires the SKU to advertise the
+	// EphemeralOSDiskSupported capability ("True"). SKUs without local/cache
+	// storage (e.g. Dsv5) do not support ephemeral OS disks and are excluded.
+	RequireEphemeralOSDisk bool
+}
+
+// SelectVMSize queries the Azure Resource SKUs API for the test location and
+// returns a VM size satisfying the selector, honouring subscription/location/
+// zone restrictions. It logs the full decision trace (which preferred
+// candidates were tried, which were skipped, and the final pick) for
+// debuggability.
+func (tc *perItOrDescribeTestContext) SelectVMSize(ctx context.Context, selector VMSizeSelector) (string, error) {
+	location := tc.Location()
+
+	skus, err := tc.listVirtualMachineResourceSKUs(ctx, location)
+	if err != nil {
+		return "", err
+	}
+
+	selected, trace, err := selectVMSize(skus, location, selector)
+	logVMSizeSelection(selector, location, trace, err)
+	if err != nil {
+		return "", err
+	}
+
+	return selected, nil
+}
+
+// vmSizeSelectionTrace records how SelectVMSize reached its decision so it can
+// be logged. It makes it obvious in CI output when a preferred candidate was
+// unavailable and selection fell through to the next entry (or the fallback).
+type vmSizeSelectionTrace struct {
+	// preferredAttempts lists each preferred candidate in order and whether it
+	// was usable (available + unrestricted + passed capability filters).
+	preferredAttempts []vmSizePreferredAttempt
+	// fallbackCandidates is the sorted set of NamePattern-matching usable SKUs
+	// considered only when no preferred candidate was usable.
+	fallbackCandidates []string
+	// selected is the chosen SKU ("" when none was found).
+	selected string
+	// viaFallback is true when selection used the deterministic fallback rather
+	// than a preferred candidate.
+	viaFallback bool
+}
+
+type vmSizePreferredAttempt struct {
+	name   string
+	usable bool
+}
+
+// logVMSizeSelection writes a human-readable decision trace to the Ginkgo
+// writer so CI logs clearly show the selection path.
+func logVMSizeSelection(selector VMSizeSelector, location string, trace vmSizeSelectionTrace, selErr error) {
+	fmt.Fprintf(ginkgo.GinkgoWriter, "VM size selection for selector %q in %s:\n", selector.Name, location)
+	for _, attempt := range trace.preferredAttempts {
+		if attempt.usable {
+			fmt.Fprintf(ginkgo.GinkgoWriter, "  preferred candidate %q: available/usable\n", attempt.name)
+		} else {
+			fmt.Fprintf(ginkgo.GinkgoWriter, "  preferred candidate %q: NOT available/usable in this subscription/region (skipping)\n", attempt.name)
+		}
+	}
+	switch {
+	case selErr != nil:
+		fmt.Fprintf(ginkgo.GinkgoWriter, "  -> no usable VM size found (fallback candidates: %v)\n", trace.fallbackCandidates)
+	case trace.viaFallback:
+		fmt.Fprintf(ginkgo.GinkgoWriter, "  no preferred candidate was usable; deterministic fallback among %v\n", trace.fallbackCandidates)
+		fmt.Fprintf(ginkgo.GinkgoWriter, "  -> selected VM size %q (via fallback)\n", trace.selected)
+	default:
+		fmt.Fprintf(ginkgo.GinkgoWriter, "  -> selected VM size %q (preferred)\n", trace.selected)
+	}
+}
+
+// listVirtualMachineResourceSKUs returns the Resource SKUs of type
+// "virtualMachines" advertised in the given location.
+func (tc *perItOrDescribeTestContext) listVirtualMachineResourceSKUs(ctx context.Context, location string) ([]*armcompute.ResourceSKU, error) {
+	tc.perBinaryInvocationTestContext.contextLock.RLock()
+	if cached, ok := tc.perBinaryInvocationTestContext.virtualMachineResourceSKUsByLocation[location]; ok {
+		defer tc.perBinaryInvocationTestContext.contextLock.RUnlock()
+		return cloneResourceSKUSlice(cached), nil
+	}
+	tc.perBinaryInvocationTestContext.contextLock.RUnlock()
+
+	clientFactory, err := tc.GetARMComputeClientFactory(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ARM compute client factory: %w", err)
+	}
+
+	filter := fmt.Sprintf("location eq '%s'", location)
+	pager := clientFactory.NewResourceSKUsClient().NewListPager(&armcompute.ResourceSKUsClientListOptions{
+		Filter: &filter,
+	})
+
+	var skus []*armcompute.ResourceSKU
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list resource SKUs in %s: %w", location, err)
+		}
+		for _, sku := range page.Value {
+			if sku == nil || sku.ResourceType == nil || *sku.ResourceType != "virtualMachines" {
+				continue
+			}
+			skus = append(skus, sku)
+		}
+	}
+
+	tc.perBinaryInvocationTestContext.contextLock.Lock()
+	if cached, ok := tc.perBinaryInvocationTestContext.virtualMachineResourceSKUsByLocation[location]; ok {
+		tc.perBinaryInvocationTestContext.contextLock.Unlock()
+		return cloneResourceSKUSlice(cached), nil
+	}
+	tc.perBinaryInvocationTestContext.virtualMachineResourceSKUsByLocation[location] = cloneResourceSKUSlice(skus)
+	tc.perBinaryInvocationTestContext.contextLock.Unlock()
+
+	return cloneResourceSKUSlice(skus), nil
+}
+
+func cloneResourceSKUSlice(skus []*armcompute.ResourceSKU) []*armcompute.ResourceSKU {
+	return append([]*armcompute.ResourceSKU(nil), skus...)
+}
+
+// selectVMSize is the pure selection logic over a list of Resource SKUs. It returns
+// the selected SKU together with a trace describing how the decision was reached.
+func selectVMSize(skus []*armcompute.ResourceSKU, location string, selector VMSizeSelector) (string, vmSizeSelectionTrace, error) {
+	usable := map[string]struct{}{}
+	for _, sku := range skus {
+		if sku == nil || sku.Name == nil {
+			continue
+		}
+		if !skuUsable(sku, location, selector) {
+			continue
+		}
+		usable[*sku.Name] = struct{}{}
+	}
+
+	var trace vmSizeSelectionTrace
+
+	// Preferred entries win when they survive restriction/capability filtering.
+	// Record every attempt (including misses) so the caller can log the path.
+	for _, name := range selector.Preferred {
+		_, ok := usable[name]
+		trace.preferredAttempts = append(trace.preferredAttempts, vmSizePreferredAttempt{name: name, usable: ok})
+	}
+	for _, attempt := range trace.preferredAttempts {
+		if attempt.usable {
+			trace.selected = attempt.name
+			return attempt.name, trace, nil
+		}
+	}
+
+	// Deterministic fallback: sorted pick among matching usable SKUs.
+	fallback := make([]string, 0, len(usable))
+	for name := range usable {
+		if selector.NamePattern != nil && !selector.NamePattern.MatchString(name) {
+			continue
+		}
+		fallback = append(fallback, name)
+	}
+	sort.Strings(fallback)
+	trace.fallbackCandidates = fallback
+	if len(fallback) > 0 {
+		trace.selected = fallback[0]
+		trace.viaFallback = true
+		return fallback[0], trace, nil
+	}
+
+	return "", trace, fmt.Errorf("selector %q matched no usable VM size in %s: %w", selector.Name, location, ErrNoUsableVMSize)
+}
+
+// skuUsable reports whether a single SKU satisfies the location, restriction and
+// capability constraints (it intentionally ignores NamePattern, which only
+// narrows fallback discovery).
+func skuUsable(sku *armcompute.ResourceSKU, location string, selector VMSizeSelector) bool {
+	if !skuAdvertisedInLocation(sku, location) {
+		return false
+	}
+	if skuRestrictedInLocation(sku, location) {
+		return false
+	}
+	if selector.MinVCPUs > 0 {
+		vcpus, ok := skuCapabilityInt(sku, capabilityVCPUs)
+		if !ok || vcpus < selector.MinVCPUs {
+			return false
+		}
+	}
+	if selector.CPUArchitecture != "" {
+		arch, ok := skuCapabilityString(sku, capabilityCPUArchitecture)
+		if !ok || !strings.EqualFold(arch, selector.CPUArchitecture) {
+			return false
+		}
+	}
+	if selector.RequireGPU {
+		gpus, ok := skuCapabilityInt(sku, capabilityGPUs)
+		if !ok || gpus < 1 {
+			return false
+		}
+	}
+	if selector.RequireZones && len(availableZones(sku, location)) == 0 {
+		return false
+	}
+	if selector.RequireEphemeralOSDisk {
+		val, ok := skuCapabilityString(sku, capabilityEphemeralOSDiskSupported)
+		if !ok || !strings.EqualFold(val, "True") {
+			return false
+		}
+	}
+	return true
+}
+
+func skuAdvertisedInLocation(sku *armcompute.ResourceSKU, location string) bool {
+	for _, info := range sku.LocationInfo {
+		if info != nil && info.Location != nil && strings.EqualFold(*info.Location, location) {
+			return true
+		}
+	}
+	// Some SKUs only populate the top-level Locations list.
+	for _, loc := range sku.Locations {
+		if loc != nil && strings.EqualFold(*loc, location) {
+			return true
+		}
+	}
+	return false
+}
+
+// skuRestrictedInLocation reports whether the SKU is entirely unavailable in the
+// location, e.g. NotAvailableForSubscription or a Location-type restriction
+// covering the region.
+func skuRestrictedInLocation(sku *armcompute.ResourceSKU, location string) bool {
+	for _, restriction := range sku.Restrictions {
+		if restriction == nil || restriction.Type == nil {
+			continue
+		}
+		if *restriction.Type != armcompute.ResourceSKURestrictionsTypeLocation {
+			continue
+		}
+		if restrictionCoversLocation(restriction, location) {
+			return true
+		}
+	}
+	return false
+}
+
+// availableZones returns the availability zones for the SKU in the location
+// minus any zones removed by Zone-type restrictions.
+func availableZones(sku *armcompute.ResourceSKU, location string) []string {
+	zones := map[string]struct{}{}
+	for _, info := range sku.LocationInfo {
+		if info == nil || info.Location == nil || !strings.EqualFold(*info.Location, location) {
+			continue
+		}
+		for _, zone := range info.Zones {
+			if zone != nil {
+				zones[*zone] = struct{}{}
+			}
+		}
+	}
+
+	for _, restriction := range sku.Restrictions {
+		if restriction == nil || restriction.Type == nil || *restriction.Type != armcompute.ResourceSKURestrictionsTypeZone {
+			continue
+		}
+		if restriction.RestrictionInfo == nil || !restrictionCoversLocation(restriction, location) {
+			continue
+		}
+		for _, zone := range restriction.RestrictionInfo.Zones {
+			if zone != nil {
+				delete(zones, *zone)
+			}
+		}
+	}
+
+	remaining := make([]string, 0, len(zones))
+	for zone := range zones {
+		remaining = append(remaining, zone)
+	}
+	sort.Strings(remaining)
+	return remaining
+}
+
+func restrictionCoversLocation(restriction *armcompute.ResourceSKURestrictions, location string) bool {
+	if restriction.RestrictionInfo != nil {
+		for _, loc := range restriction.RestrictionInfo.Locations {
+			if loc != nil && strings.EqualFold(*loc, location) {
+				return true
+			}
+		}
+	}
+	for _, value := range restriction.Values {
+		if value != nil && strings.EqualFold(*value, location) {
+			return true
+		}
+	}
+	return false
+}
+
+func skuCapabilityString(sku *armcompute.ResourceSKU, name string) (string, bool) {
+	for _, capability := range sku.Capabilities {
+		if capability == nil || capability.Name == nil || capability.Value == nil {
+			continue
+		}
+		if strings.EqualFold(*capability.Name, name) {
+			return *capability.Value, true
+		}
+	}
+	return "", false
+}
+
+func skuCapabilityInt(sku *armcompute.ResourceSKU, name string) (int, bool) {
+	value, ok := skuCapabilityString(sku, name)
+	if !ok {
+		return 0, false
+	}
+	parsed, err := strconv.Atoi(strings.TrimSpace(value))
+	if err != nil {
+		return 0, false
+	}
+	return parsed, true
+}
+
+// DefaultWorkerVMSizeSelector selects the general-purpose worker SKU used by the
+// default node pool. Standard_D8s_v3 is preferred to preserve historical
+// behaviour; the fallback keeps the D-series general-purpose, >=8 vCPU shape.
+//
+// The fallback pattern is capped at D8 (8 vCPUs) to avoid selecting large SKUs
+// (D32, D64, D96) that are slow to provision and easily exhaust subscription
+// quota in test environments. The [^p] exclusion prevents matching Arm64 "p"
+// variants (e.g. Standard_D8ps_v6).
+func DefaultWorkerVMSizeSelector() VMSizeSelector {
+	return VMSizeSelector{
+		Name:        "default-worker",
+		Preferred:   []string{DefaultWorkerVMSize, "Standard_D8ds_v5", "Standard_D8as_v5", "Standard_D8lds_v6"},
+		NamePattern: regexp.MustCompile(`^Standard_D[4-8][^p]*s_v[3456]$`),
+		MinVCPUs:    8,
+	}
+}
+
+// SmallWorkerVMSizeSelector selects a smaller general-purpose worker SKU used by
+// tests that want faster provisioning.
+//
+// The fallback pattern is capped at D4 to keep provisioning fast and quota use
+// low. The [^p] exclusion prevents matching Arm64 variants.
+func SmallWorkerVMSizeSelector() VMSizeSelector {
+	return VMSizeSelector{
+		Name:        "small-worker",
+		Preferred:   []string{SmallWorkerVMSize, "Standard_D4ds_v5", "Standard_D4as_v5", "Standard_D4lds_v6"},
+		NamePattern: regexp.MustCompile(`^Standard_D[2-4][^p]*s_v[3456]$`),
+		MinVCPUs:    4,
+	}
+}
+
+// JumpboxVMSizeSelector selects a small general-purpose SKU used for throwaway
+// helper VMs (e.g. the connectivity test's kubectl client).
+//
+// The fallback pattern is capped at D4 to keep provisioning fast and quota use
+// low. The [^p] exclusion prevents matching Arm64 variants.
+func JumpboxVMSizeSelector() VMSizeSelector {
+	return VMSizeSelector{
+		Name:        "jumpbox",
+		Preferred:   []string{JumpboxVMSize, "Standard_D2s_v4", "Standard_D2ds_v5", "Standard_D2lds_v6"},
+		NamePattern: regexp.MustCompile(`^Standard_D[2-4][^p]*s_v[3456]$`),
+		MinVCPUs:    2,
+	}
+}
+
+// EphemeralOSDiskWorkerVMSizeSelector selects a general-purpose worker SKU that
+// supports ephemeral OS disks (requires local/cache storage). Standard_D8s_v3
+// is preferred because its cache disk supports ephemeral placement; the dd
+// variants (Ddsv5) and lds variants (Dldsv6, NVMe placement) are fallbacks.
+//
+// SKUs without local storage (e.g. Dsv5) are automatically excluded via the
+// RequireEphemeralOSDisk constraint. The [^p] exclusion prevents matching Arm64
+// variants.
+func EphemeralOSDiskWorkerVMSizeSelector() VMSizeSelector {
+	return VMSizeSelector{
+		Name:                   "ephemeral-osdisk-worker",
+		Preferred:              []string{DefaultWorkerVMSize, "Standard_D8ds_v5", "Standard_D8ads_v5", "Standard_D8lds_v6"},
+		NamePattern:            regexp.MustCompile(`^Standard_D[4-8][^p]*s_v[3456]$`),
+		MinVCPUs:               8,
+		RequireEphemeralOSDisk: true,
+	}
+}
+
+// ARM64NodePoolVMSizeSelector selects a small ARM64-capable worker SKU. The
+// pattern matches a subset of the smallest (2GiB) ARM64-capable VM sizes listed
+// in https://issues.redhat.com/browse/ARO-22443.
+func ARM64NodePoolVMSizeSelector() VMSizeSelector {
+	return VMSizeSelector{
+		Name:            "arm64-worker",
+		NamePattern:     regexp.MustCompile(`^Standard_D(?:2|4)pl(?:d)?s_v6$`),
+		CPUArchitecture: "Arm64",
+	}
+}
+
+// GPUNodePoolVMSizeSelector selects a GPU-capable worker SKU. The historical
+// GPU sizes are preferred; the fallback accepts any N-series SKU that advertises
+// a GPU. Callers should treat ErrNoUsableVMSize as a reason to Skip, since GPU
+// capacity is scarce and frequently restricted per subscription/region.
+func GPUNodePoolVMSizeSelector() VMSizeSelector {
+	return VMSizeSelector{
+		Name: "gpu-worker",
+		Preferred: []string{
+			"Standard_NC4as_T4_v3",
+			"Standard_NC8as_T4_v3",
+			"Standard_NC16as_T4_v3",
+			"Standard_NC64as_T4_v3",
+		},
+		NamePattern: regexp.MustCompile(`^Standard_N`),
+		RequireGPU:  true,
+	}
+}

--- a/test/util/framework/vm_sku_selection_test.go
+++ b/test/util/framework/vm_sku_selection_test.go
@@ -1,0 +1,317 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"errors"
+	"regexp"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
+)
+
+const testLocation = "uksouth"
+
+type skuOpt func(*armcompute.ResourceSKU)
+
+func withCapability(name, value string) skuOpt {
+	return func(s *armcompute.ResourceSKU) {
+		s.Capabilities = append(s.Capabilities, &armcompute.ResourceSKUCapabilities{
+			Name:  to.Ptr(name),
+			Value: to.Ptr(value),
+		})
+	}
+}
+
+func withZones(location string, zones ...string) skuOpt {
+	return func(s *armcompute.ResourceSKU) {
+		zonePtrs := make([]*string, 0, len(zones))
+		for _, z := range zones {
+			zonePtrs = append(zonePtrs, to.Ptr(z))
+		}
+		s.LocationInfo = append(s.LocationInfo, &armcompute.ResourceSKULocationInfo{
+			Location: to.Ptr(location),
+			Zones:    zonePtrs,
+		})
+	}
+}
+
+func withLocationRestriction(location string) skuOpt {
+	return func(s *armcompute.ResourceSKU) {
+		s.Restrictions = append(s.Restrictions, &armcompute.ResourceSKURestrictions{
+			Type:       to.Ptr(armcompute.ResourceSKURestrictionsTypeLocation),
+			ReasonCode: to.Ptr(armcompute.ResourceSKURestrictionsReasonCodeNotAvailableForSubscription),
+			RestrictionInfo: &armcompute.ResourceSKURestrictionInfo{
+				Locations: []*string{to.Ptr(location)},
+			},
+			Values: []*string{to.Ptr(location)},
+		})
+	}
+}
+
+func withZoneRestriction(location string, zones ...string) skuOpt {
+	return func(s *armcompute.ResourceSKU) {
+		zonePtrs := make([]*string, 0, len(zones))
+		for _, z := range zones {
+			zonePtrs = append(zonePtrs, to.Ptr(z))
+		}
+		s.Restrictions = append(s.Restrictions, &armcompute.ResourceSKURestrictions{
+			Type:       to.Ptr(armcompute.ResourceSKURestrictionsTypeZone),
+			ReasonCode: to.Ptr(armcompute.ResourceSKURestrictionsReasonCodeNotAvailableForSubscription),
+			RestrictionInfo: &armcompute.ResourceSKURestrictionInfo{
+				Locations: []*string{to.Ptr(location)},
+				Zones:     zonePtrs,
+			},
+		})
+	}
+}
+
+func makeSKU(name, location string, opts ...skuOpt) *armcompute.ResourceSKU {
+	sku := &armcompute.ResourceSKU{
+		Name:         to.Ptr(name),
+		ResourceType: to.Ptr("virtualMachines"),
+		Locations:    []*string{to.Ptr(location)},
+	}
+	// Default LocationInfo with no zones so the SKU is advertised in the location.
+	sku.LocationInfo = []*armcompute.ResourceSKULocationInfo{{Location: to.Ptr(location)}}
+	for _, opt := range opts {
+		opt(sku)
+	}
+	return sku
+}
+
+func TestSelectVMSize(t *testing.T) {
+	dPattern := regexp.MustCompile(`^Standard_D\d+s_v[345]$`)
+
+	tests := []struct {
+		name     string
+		skus     []*armcompute.ResourceSKU
+		selector VMSizeSelector
+		want     string
+		wantErr  error
+	}{
+		{
+			name: "preferred SKU is chosen when usable",
+			skus: []*armcompute.ResourceSKU{
+				makeSKU("Standard_D8s_v3", testLocation, withCapability(capabilityVCPUs, "8")),
+				makeSKU("Standard_D8s_v5", testLocation, withCapability(capabilityVCPUs, "8")),
+			},
+			selector: VMSizeSelector{
+				Name:        "default-worker",
+				Preferred:   []string{"Standard_D8s_v3", "Standard_D8s_v5"},
+				NamePattern: dPattern,
+				MinVCPUs:    8,
+			},
+			want: "Standard_D8s_v3",
+		},
+		{
+			name: "first usable preferred wins when earlier is restricted",
+			skus: []*armcompute.ResourceSKU{
+				makeSKU("Standard_D8s_v3", testLocation, withCapability(capabilityVCPUs, "8"), withLocationRestriction(testLocation)),
+				makeSKU("Standard_D8s_v5", testLocation, withCapability(capabilityVCPUs, "8")),
+			},
+			selector: VMSizeSelector{
+				Name:      "default-worker",
+				Preferred: []string{"Standard_D8s_v3", "Standard_D8s_v5"},
+				MinVCPUs:  8,
+			},
+			want: "Standard_D8s_v5",
+		},
+		{
+			name: "falls back to deterministic sorted pick when no preferred usable",
+			skus: []*armcompute.ResourceSKU{
+				makeSKU("Standard_D8s_v3", testLocation, withCapability(capabilityVCPUs, "8"), withLocationRestriction(testLocation)),
+				makeSKU("Standard_D16s_v5", testLocation, withCapability(capabilityVCPUs, "16")),
+				makeSKU("Standard_D8s_v4", testLocation, withCapability(capabilityVCPUs, "8")),
+			},
+			selector: VMSizeSelector{
+				Name:        "default-worker",
+				Preferred:   []string{"Standard_D8s_v3"},
+				NamePattern: dPattern,
+				MinVCPUs:    8,
+			},
+			want: "Standard_D16s_v5", // sorts before Standard_D8s_v4
+		},
+		{
+			name: "SKU not advertised in location is excluded",
+			skus: []*armcompute.ResourceSKU{
+				makeSKU("Standard_D8s_v3", "westeurope", withCapability(capabilityVCPUs, "8")),
+			},
+			selector: VMSizeSelector{
+				Name:      "default-worker",
+				Preferred: []string{"Standard_D8s_v3"},
+				MinVCPUs:  8,
+			},
+			wantErr: ErrNoUsableVMSize,
+		},
+		{
+			name: "MinVCPUs filters out too-small SKUs",
+			skus: []*armcompute.ResourceSKU{
+				makeSKU("Standard_D2s_v3", testLocation, withCapability(capabilityVCPUs, "2")),
+			},
+			selector: VMSizeSelector{
+				Name:        "default-worker",
+				NamePattern: dPattern,
+				MinVCPUs:    8,
+			},
+			wantErr: ErrNoUsableVMSize,
+		},
+		{
+			name: "CPUArchitecture constraint is enforced",
+			skus: []*armcompute.ResourceSKU{
+				makeSKU("Standard_D4ps_v6", testLocation, withCapability(capabilityCPUArchitecture, "Arm64")),
+				makeSKU("Standard_D4s_v5", testLocation, withCapability(capabilityCPUArchitecture, "x64")),
+			},
+			selector: VMSizeSelector{
+				Name:            "arm64",
+				NamePattern:     regexp.MustCompile(`^Standard_`),
+				CPUArchitecture: "Arm64",
+			},
+			want: "Standard_D4ps_v6",
+		},
+		{
+			name: "RequireGPU selects only GPU SKUs",
+			skus: []*armcompute.ResourceSKU{
+				makeSKU("Standard_D8s_v3", testLocation, withCapability(capabilityVCPUs, "8")),
+				makeSKU("Standard_NC4as_T4_v3", testLocation, withCapability(capabilityGPUs, "1")),
+			},
+			selector: VMSizeSelector{
+				Name:        "gpu",
+				Preferred:   []string{"Standard_NC4as_T4_v3"},
+				NamePattern: regexp.MustCompile(`^Standard_N`),
+				RequireGPU:  true,
+			},
+			want: "Standard_NC4as_T4_v3",
+		},
+		{
+			name: "RequireZones excludes zoneless SKUs",
+			skus: []*armcompute.ResourceSKU{
+				makeSKU("Standard_D8s_v3", testLocation, withCapability(capabilityVCPUs, "8")),
+			},
+			selector: VMSizeSelector{
+				Name:         "zoned",
+				Preferred:    []string{"Standard_D8s_v3"},
+				RequireZones: true,
+			},
+			wantErr: ErrNoUsableVMSize,
+		},
+		{
+			name: "RequireZones accepts SKU with a non-restricted zone",
+			skus: []*armcompute.ResourceSKU{
+				makeSKU("Standard_D8s_v3", testLocation, withCapability(capabilityVCPUs, "8"), withZones(testLocation, "1", "2", "3")),
+			},
+			selector: VMSizeSelector{
+				Name:         "zoned",
+				Preferred:    []string{"Standard_D8s_v3"},
+				RequireZones: true,
+			},
+			want: "Standard_D8s_v3",
+		},
+		{
+			name: "RequireZones excludes SKU whose only zones are restricted",
+			skus: []*armcompute.ResourceSKU{
+				makeSKU("Standard_D8s_v3", testLocation,
+					withCapability(capabilityVCPUs, "8"),
+					withZones(testLocation, "1"),
+					withZoneRestriction(testLocation, "1"),
+				),
+			},
+			selector: VMSizeSelector{
+				Name:         "zoned",
+				Preferred:    []string{"Standard_D8s_v3"},
+				RequireZones: true,
+			},
+			wantErr: ErrNoUsableVMSize,
+		},
+		{
+			name: "NamePattern does not constrain preferred entries",
+			skus: []*armcompute.ResourceSKU{
+				makeSKU("Standard_NC4as_T4_v3", testLocation, withCapability(capabilityGPUs, "1")),
+			},
+			selector: VMSizeSelector{
+				Name:        "gpu",
+				Preferred:   []string{"Standard_NC4as_T4_v3"},
+				NamePattern: dPattern, // would not match the preferred name
+				RequireGPU:  true,
+			},
+			want: "Standard_NC4as_T4_v3",
+		},
+		{
+			name:     "no SKUs yields ErrNoUsableVMSize",
+			skus:     nil,
+			selector: VMSizeSelector{Name: "default-worker", Preferred: []string{"Standard_D8s_v3"}},
+			wantErr:  ErrNoUsableVMSize,
+		},
+		{
+			name: "RequireEphemeralOSDisk selects SKU with EphemeralOSDiskSupported=True",
+			skus: []*armcompute.ResourceSKU{
+				makeSKU("Standard_D8s_v5", testLocation, withCapability(capabilityVCPUs, "8")),
+				makeSKU("Standard_D8ds_v5", testLocation, withCapability(capabilityVCPUs, "8"), withCapability(capabilityEphemeralOSDiskSupported, "True")),
+			},
+			selector: VMSizeSelector{
+				Name:                   "ephemeral",
+				Preferred:              []string{"Standard_D8s_v5", "Standard_D8ds_v5"},
+				MinVCPUs:               8,
+				RequireEphemeralOSDisk: true,
+			},
+			want: "Standard_D8ds_v5",
+		},
+		{
+			name: "RequireEphemeralOSDisk excludes all SKUs when none support ephemeral",
+			skus: []*armcompute.ResourceSKU{
+				makeSKU("Standard_D8s_v5", testLocation, withCapability(capabilityVCPUs, "8")),
+			},
+			selector: VMSizeSelector{
+				Name:                   "ephemeral",
+				Preferred:              []string{"Standard_D8s_v5"},
+				NamePattern:            regexp.MustCompile(`^Standard_D`),
+				RequireEphemeralOSDisk: true,
+			},
+			wantErr: ErrNoUsableVMSize,
+		},
+		{
+			name: "RequireEphemeralOSDisk preferred ordering is preserved",
+			skus: []*armcompute.ResourceSKU{
+				makeSKU("Standard_D8s_v3", testLocation, withCapability(capabilityVCPUs, "8"), withCapability(capabilityEphemeralOSDiskSupported, "True")),
+				makeSKU("Standard_D8ds_v5", testLocation, withCapability(capabilityVCPUs, "8"), withCapability(capabilityEphemeralOSDiskSupported, "True")),
+			},
+			selector: VMSizeSelector{
+				Name:                   "ephemeral",
+				Preferred:              []string{"Standard_D8s_v3", "Standard_D8ds_v5"},
+				RequireEphemeralOSDisk: true,
+			},
+			want: "Standard_D8s_v3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _, err := selectVMSize(tt.skus, testLocation, tt.selector)
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("expected error %v, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("expected %q, got %q", tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The E2E suite hardcoded VM SKUs (mainly Standard_D8s_v3), which fails when a SKU is quota-restricted (e.g. NotAvailableForSubscription) in a particular subscription/region. This makes onboarding new subscriptions for E2E brittle.

Extend the suite's dynamic SKU discovery to be restriction-aware using the Azure Resource SKUs API: SelectVMSize filters out SKUs restricted in the current subscription/location/zone, applies capability constraints, prefers the historical SKU first (unchanged behaviour when available), then falls back to a deterministic pick. Returns ErrNoUsableVMSize when nothing fits.

Route all general-purpose, arm64 and GPU SKU choices through it. Default node pool params leave VMSize empty and CreateNodePoolFromParam resolves it. The GPU test now uses the same mechanism and Skips when no unrestricted GPU SKU exists.

