### PR TITLE
test: fake dashboard with no datasource regex (do not merge)

### DIFF
--- a/observability/grafana-dashboards/infra-dashboards/fake-no-regex.json
+++ b/observability/grafana-dashboards/infra-dashboards/fake-no-regex.json
@@ -1,0 +1,41 @@
+{
+  "title": "Fake Dashboard No Regex",
+  "uid": "fake-no-regex",
+  "schemaVersion": 39,
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "options": [],
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Up",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "up"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
**Do not merge — test PR.**

Adds a proper Grafana dashboard (`infra-dashboards/fake-no-regex.json`) that has a datasource variable but leaves its `regex` empty, to observe how the `observability-verify` CI check handles it.

- **Current grafanactl:** this is only a *warning* — `verify dashboards` still passes (exit 0). So this CI run is expected to be **green**.
- **After Azure/ARO-Tools#249 merges** and the grafanactl dependency is bumped here, the missing regex becomes a hard **error** and this same dashboard would fail CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)