### PR TITLE
fix: prevent resource leaks in Maestro REST client and subscription metrics ticker

### DIFF
--- a/backend/pkg/maestro/maestro_client.go
+++ b/backend/pkg/maestro/maestro_client.go
@@ -76,10 +76,14 @@ func NewClient(
 	// connection pool. Callers tear the client down by cancelling ctx, so we
 	// drain the pool's idle connections on cancellation to avoid leaking TCP
 	// connections and file descriptors across repeated client creations.
-	context.AfterFunc(ctx, restHTTPClient.CloseIdleConnections)
+	stopDrainIdleConns := context.AfterFunc(ctx, restHTTPClient.CloseIdleConnections)
 
 	grpcClient, err := newGRPCSourceWorkClient(ctx, maestroGRPCAPIEndpoint, restClient, maestroSourceID)
 	if err != nil {
+		// Unregister the teardown callback so we don't retain references until
+		// ctx is cancelled when client creation fails here.
+		stopDrainIdleConns()
+		restHTTPClient.CloseIdleConnections()
 		return nil, utils.TrackError(fmt.Errorf("failed to create maestro grpc source work client: %w", err))
 	}
 

--- a/backend/pkg/maestro/maestro_client.go
+++ b/backend/pkg/maestro/maestro_client.go
@@ -71,7 +71,13 @@ func NewClient(
 	ctx context.Context,
 	maestroRESTAPIEndpoint string, maestroGRPCAPIEndpoint string, maestroConsumerName string, maestroSourceID string,
 ) (Client, error) {
-	restClient := newRESTClient(maestroRESTAPIEndpoint)
+	restClient, restHTTPClient := newRESTClient(maestroRESTAPIEndpoint)
+	// The REST client uses a cloned http.Transport, which owns its own
+	// connection pool. Callers tear the client down by cancelling ctx, so we
+	// drain the pool's idle connections on cancellation to avoid leaking TCP
+	// connections and file descriptors across repeated client creations.
+	context.AfterFunc(ctx, restHTTPClient.CloseIdleConnections)
+
 	grpcClient, err := newGRPCSourceWorkClient(ctx, maestroGRPCAPIEndpoint, restClient, maestroSourceID)
 	if err != nil {
 		return nil, utils.TrackError(fmt.Errorf("failed to create maestro grpc source work client: %w", err))
@@ -115,8 +121,14 @@ func GenerateMaestroSourceID(envName string, provisionShardID string) string {
 
 // newRESTClient creates a REST client for the Maestro API. The Maestro REST client
 // allows to perform a subset (but not all) of actions against the Maestro API.
-func newRESTClient(endpoint string) *maestroopenapi.APIClient {
+// It also returns the underlying *http.Client so its connection pool can be
+// drained (CloseIdleConnections) when the client is no longer needed.
+func newRESTClient(endpoint string) (*maestroopenapi.APIClient, *http.Client) {
 	httpClientTransport := http.DefaultTransport.(*http.Transport).Clone()
+	httpClient := &http.Client{
+		Transport: httpClientTransport,
+		Timeout:   30 * time.Second,
+	}
 	maestroRESTClientConfig := &maestroopenapi.Configuration{
 		DefaultHeader: map[string]string{},
 		UserAgent:     "ARO-HCP-Backend",
@@ -125,14 +137,11 @@ func newRESTClient(endpoint string) *maestroopenapi.APIClient {
 			URL: endpoint,
 		}},
 		OperationServers: map[string]maestroopenapi.ServerConfigurations{},
-		HTTPClient: &http.Client{
-			Transport: httpClientTransport,
-			Timeout:   30 * time.Second,
-		},
+		HTTPClient:       httpClient,
 	}
 
 	restClient := maestroopenapi.NewAPIClient(maestroRESTClientConfig)
-	return restClient
+	return restClient, httpClient
 }
 
 // newGRPCSourceWorkClient creates a new GRPC Source Work client for the Maestro API.

--- a/frontend/pkg/metrics/metrics.go
+++ b/frontend/pkg/metrics/metrics.go
@@ -107,6 +107,7 @@ func (sc *SubscriptionCollector) Run(ctx context.Context) {
 	sc.refresh(ctx)
 
 	t := time.NewTicker(30 * time.Second)
+	defer t.Stop()
 	for {
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
<!-- Link to Jira issue -->
NO-JIRA

### What

Fixes two resource leaks in long-running loops:

- **Backend (Maestro REST client):** `newRESTClient` clones `http.DefaultTransport`,
  giving each client its own connection pool. Tearing the client down via context
  cancellation only stopped the gRPC client and never drained the REST transport's
  idle connections, leaking TCP connections/FDs across repeated client creations.
  `newRESTClient` now returns the underlying `*http.Client`, and `NewClient` registers
  `context.AfterFunc(ctx, restHTTPClient.CloseIdleConnections)` so the existing
  cancellation-based teardown also drains the pool. The `AfterFunc` stop function is
  captured and invoked (with an immediate drain) on the gRPC-init error path so a
  failed construction doesn't retain the `http.Client` until `ctx` is cancelled.
- **Frontend (metrics ticker):** `SubscriptionCollector.Run` created a
  `time.NewTicker(30s)` that was never stopped; added `defer t.Stop()` to release the
  timer on shutdown.

### Why

The orphan/cleanup controllers rebuild Maestro clients every sync cycle. Without
draining the REST client's idle connection pool on teardown, idle TCP connections and
file descriptors accumulate for the process lifetime, risking FD exhaustion. Similarly,
a `time.Ticker` is not garbage-collected until `Stop()` is called, so the unstopped
ticker leaks its runtime timer when the collector loop exits.

### Testing

`go build ./...` and `go vet ./...` pass for the affected packages.
<!-- TODO: add unit test / manual FD-count verification over repeated client
     create+teardown cycles, if performed -->

### Special notes for your reviewer

`context.AfterFunc` requires Go 1.21+; this module targets Go 1.25.7 (`backend/go.mod`),
so it compiles cleanly. The PR bundles a small frontend ticker fix alongside the backend
teardown fix — both are self-contained "resource cleanup on teardown" changes. If you
prefer strict one-PR-per-task, the frontend change can be split into its own PR.

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
