### PR TITLE
feat(recreate-broken-pools): detect empty NIC ipConfigurations + remove NRP-KVS storm trigger (AROSLSRE-1190, AROSLSRE-1191)

### DIFF
--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -273,16 +273,10 @@ resourceGroups:
     action: Shell
     command: ./scripts/recreate-broken-pools/recreate-broken-pools
     workingDir: .
-    # Internal overallTimeoutMin = 120. The extra 30m headroom accommodates
-    # the deferred forced-evidence cleanup contexts (abort + restore are
-    # rooted in context.Background and can run for up to ~23m past the
-    # parent ctx after a forced-evidence probe).
-    timeout: '150m'
-    automatedRetry:
-      errorContainsAny:
-      - "restore forced-evidence pool spec"
-      maximumRetryCount: 2
-      durationBetweenRetries: 5m
+    # Internal overallTimeoutMin = 120. The small extra headroom accommodates
+    # the per-pool drain/delete/recreate LRO pollers that can run briefly past
+    # the orchestrator deadline during cleanup.
+    timeout: '130m'
     shellIdentity:
       input:
         resourceGroup: global
@@ -300,12 +294,6 @@ resourceGroups:
         name: subscriptionId
     - name: NODEPOOL_TAG
       value: 'worker'
-    - name: NRP_FAIL_THRESHOLD
-      value: '10'
-    - name: NRP_FAIL_WINDOW_MIN
-      value: '360'
-    - name: FORCED_EVIDENCE_TIMEOUT_MIN
-      value: '20'
     dependsOn:
     - resourceGroup: management
       step: recreate-system-pool-if-broken

--- a/dev-infrastructure/scripts/recreate-broken-pools/go.mod
+++ b/dev-infrastructure/scripts/recreate-broken-pools/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6 v6.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v6 v6.6.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor v0.11.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6 v6.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0
 	k8s.io/api v0.35.3
 	k8s.io/apimachinery v0.35.3

--- a/dev-infrastructure/scripts/recreate-broken-pools/go.sum
+++ b/dev-infrastructure/scripts/recreate-broken-pools/go.sum
@@ -22,6 +22,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanage
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups v1.2.0/go.mod h1:8wzvopPfyZYPaQUoKW87Zfdul7jmJMDfp/k7YY3oJyA=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor v0.11.0 h1:Ds0KRF8ggpEGg4Vo42oX1cIt/IfOhHWJBikksZbVxeg=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor v0.11.0/go.mod h1:jj6P8ybImR+5topJ+eH6fgcemSFBmU6/6bFF8KkwuDI=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6 v6.2.0 h1:HYGD75g0bQ3VO/Omedm54v4LrD3B1cGImuRF3AJ5wLo=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6 v6.2.0/go.mod h1:ulHyBFJOI0ONiRL4vcJTmS7rx18jQQlEPmAgo80cRdM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armdeployments v0.2.0 h1:bYq3jfB2x36hslKMHyge3+esWzROtJNk/4dCjsKlrl4=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armdeployments v0.2.0/go.mod h1:fewgRjNVE84QVVh798sIMFb7gPXPp7NmnekGnboSnXk=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 h1:Dd+RhdJn0OTtVGaeDLZpcumkIVCtA/3/Fo42+eoYvVM=

--- a/dev-infrastructure/scripts/recreate-broken-pools/main.go
+++ b/dev-infrastructure/scripts/recreate-broken-pools/main.go
@@ -174,11 +174,14 @@ const (
 	swiftNodepoolTag      = "aks-nic-enable-multi-tenancy"
 	swiftNodepoolTagValue = "true"
 
-	// overallTimeoutMin caps the whole binary. The EV2 ShellExtension host
-	// honors the `timeout` field set on the corresponding Shell step in
-	// mgmt-pipeline.yaml, which must leave headroom above this value for the
-	// deferred LRO-abort cleanup context (rooted in context.Background) that
-	// can run a few minutes past the parent ctx.
+	// overallTimeoutMin caps the whole binary via the single
+	// context.WithTimeout in run(); every Azure LRO poller, drain, and
+	// pre/post-flight dump inherits that ctx, so nothing outlives it. The EV2
+	// ShellExtension host honors the `timeout` field set on the corresponding
+	// Shell step in mgmt-pipeline.yaml, which must stay strictly above this
+	// value so the binary reaches its own deadline first and returns a logged
+	// timeout error (unwinding any in-flight pollers) instead of being
+	// force-killed by the host mid-operation.
 	overallTimeoutMin = 120
 
 	// nrpKVSErrorCode / vmssWriteOperation identify the NRP-KVS VMSS-write
@@ -931,6 +934,28 @@ func evalPoolWedge(provState string) (bool, string) {
 	return false, fmt.Sprintf("pool wedge FAIL: provisioningState=%q is not a recognized wedge-compatible state", provState)
 }
 
+// guardDecision resolves a single detection guard's outcome against the
+// SKIP_GUARDS operator override. It returns proceed=true when the run may
+// continue past the guard, plus a human-readable log line describing the
+// outcome:
+//   - guard passed              -> proceed, "<name> PASS"
+//   - guard failed, no override -> halt, the guard's reason (returned to the
+//     caller so the run exits no-op with that reason)
+//   - guard failed, skipGuards  -> proceed, "SKIP_GUARDS=true — overriding
+//     <name> failure: <reason>" (operator override; failure logged, not enforced)
+//
+// This is what makes SKIP_GUARDS actually bypass the cluster-state and
+// non-target-pool safety guards in detect(), matching its documented behavior.
+func guardDecision(name string, pass bool, reason string, skipGuards bool) (proceed bool, logMsg string) {
+	if pass {
+		return true, name + " PASS"
+	}
+	if skipGuards {
+		return true, fmt.Sprintf("SKIP_GUARDS=true — overriding %s failure: %s", name, reason)
+	}
+	return false, reason
+}
+
 func (c *clients) detect(ctx context.Context) ([]nodePoolTarget, string, error) {
 	mc, err := c.cluster.Get(ctx, c.cfg.resourceGroup, c.cfg.clusterName, nil)
 	if err != nil {
@@ -941,10 +966,12 @@ func (c *clients) detect(ctx context.Context) ([]nodePoolTarget, string, error) 
 		cs = *mc.Properties.ProvisioningState
 	}
 	logf("cluster state :: provisioningState=%s (accept: Succeeded/Canceled/Failed/Updating/Upgrading; reject: Creating/Deleting/unknown)", cs)
-	if pass, reason := evalClusterState(cs); !pass {
-		return nil, reason, nil
+	csPass, csReason := evalClusterState(cs)
+	proceed, msg := guardDecision("cluster state", csPass, csReason, c.cfg.skipGuards)
+	if !proceed {
+		return nil, msg, nil
 	}
-	logf("cluster state PASS")
+	logf("%s", msg)
 
 	pager := c.pools.NewListPager(c.cfg.resourceGroup, c.cfg.clusterName, nil)
 	var allPools []*armcs.AgentPool
@@ -956,11 +983,12 @@ func (c *clients) detect(ctx context.Context) ([]nodePoolTarget, string, error) 
 		allPools = append(allPools, page.Value...)
 	}
 
-	pass, reason := evalNonTargetPoolsHealthy(allPools)
-	if !pass {
-		return nil, reason, nil
+	ntPass, ntReason := evalNonTargetPoolsHealthy(allPools)
+	proceed, msg = guardDecision("cluster safety", ntPass, ntReason, c.cfg.skipGuards)
+	if !proceed {
+		return nil, msg, nil
 	}
-	logf("cluster safety PASS")
+	logf("%s", msg)
 
 	// Classify pools by role match without touching the Activity Log. The two
 	// ARM-only prechecks below give us a priori knowledge of which pools are

--- a/dev-infrastructure/scripts/recreate-broken-pools/main.go
+++ b/dev-infrastructure/scripts/recreate-broken-pools/main.go
@@ -40,34 +40,28 @@
 //   SUBSCRIPTION_ID             Azure subscription ID containing the AKS cluster
 //   NODEPOOL_TAG                aro-hcp.azure.com/role tag value selecting which
 //                               pools this run targets (e.g. "system", "user")
-//   NRP_FAIL_THRESHOLD          Failed-event count threshold (default 5)
-//   NRP_FAIL_WINDOW_MIN         Activity-log lookback window in min (default 15)
-//   FORCED_EVIDENCE_TIMEOUT_MIN Max minutes to wait for evidence after the
-//                               forced reconcile trigger (default 20)
-//   FORCED_EVIDENCE_THRESHOLD   Distinct NRP-KVS hits required during the
-//                               forced-evidence probe to confirm the wedge
-//                               (default 3)
 //   DRY_RUN                     "true" to print intended actions but make no writes
-//   SKIP_GUARDS                 "true" to bypass detection guards (proceeds even
-//                               when NRP-KVS storm check fails, operator override).
-//                               Has no effect when the confirmed target list is
-//                               empty: the run still exits no-op so that Step 2
-//                               (maybeAbortLRO) and Step 8 (reconcileTagPut) never
-//                               execute without a pool to recreate.
+//   SKIP_GUARDS                 "true" to bypass the cluster-state / non-target-pool
+//                               safety guards (operator override). Has no effect when
+//                               the confirmed target list is empty: the run still
+//                               exits no-op so that Step 2 (maybeAbortLRO) and Step 8
+//                               (reconcileTagPut) never execute without a pool to
+//                               recreate.
 //   LOG_VERBOSITY               integer logr verbosity for slog handler (default 0)
 //
-// Detection checks (ALL must pass; otherwise exit 0 no-op)
-// --------------------------------------------------------
+// Detection
+// ---------
 // Names below are the check labels used in log lines and reason
 // strings throughout this binary. Checks run in the order listed
-// (cluster state -> non-system pools -> system wedge -> NRP-KVS storm)
-// so the cheap ARM checks short-circuit before we query Activity Log.
+// (cluster state -> non-target pools -> ARM prechecks).
 //
-// Two ARM-only prechecks ([accel-net] and [empty ipconfig], below) run
-// before the Activity Log query and flag a pool broken on their own
-// direct evidence — independent of the NRP-KVS storm signal — so a pool
-// in either state is recreated even when the activity-log write storm
-// has not (yet) appeared.
+// Two ARM-only prechecks ([accel-net] and [empty ipconfig], below)
+// decide which pools to recreate on direct ARM evidence. They give us
+// a-priori knowledge of which pools WILL fail to scale up before scaling
+// is attempted, so detection no longer queries the reactive NRP-KVS
+// activity-log write storm (which only appears once AKS reconciles a
+// wedged pool and merely confirms what the ipConfigurations array already
+// shows). A pool flagged by either precheck is recreated directly.
 //
 //   [cluster state]      cluster provisioningState is recoverable:
 //                        Succeeded, Canceled, Failed (settled) OR
@@ -76,26 +70,15 @@
 //                        whether to abort the LRO). Creating and
 //                        Deleting are rejected; unknown states are
 //                        rejected conservatively.
-//   [non-system pools]   every non-system pool has count > 0.
-//   [system wedge]       system pool provisioningState is NOT
-//                        Succeeded — positive confirmation that this
-//                        specific pool is wedged. Accepts Failed,
-//                        Canceled, Updating, Upgrading (an NRP-KVS
-//                        wedge typically leaves the pool in Updating
-//                        while its parent cluster LRO retries forever
-//                        — AROSLSRE-880 — or in Failed/Canceled once
-//                        that LRO finally times out or is aborted).
-//                        Rejects Succeeded (no wedge) and
-//                        Creating/Deleting/unknown.
-//   [NRP-KVS storm]      >= NRP_FAIL_THRESHOLD Failed VMSS-write
-//                        events on the system pool's VMSS in the
-//                        last NRP_FAIL_WINDOW_MIN whose inner error
-//                        code is NetworkingInternalOperationError.
-//                        Other failure modes — quota/capacity/policy
-//                        / image pull / etc — never satisfy this
-//                        check, so they cannot trigger a destructive
-//                        pool recreation that would not address their
-//                        actual root cause.
+//   [non-target pools]   every pool not selected by NODEPOOL_TAG has
+//                        count > 0 (cluster-wide safety guard).
+//   [accel-net]          any selected Swift pool whose backing VMSS came
+//                        up with accelerated-networking DISABLED — its
+//                        delegated Swift NICs can never attach, so the
+//                        pool is broken regardless of provisioning state.
+//                        Direct ARM evidence; flags the pool for
+//                        recreation. Fails open: skipped when there are
+//                        no Swift pools or the VMSS list errors.
 //   [empty ipconfig]     any selected pool whose backing VMSS has a
 //                        realized instance NIC with an empty
 //                        ipConfigurations array — the ARM-visible
@@ -103,11 +86,9 @@
 //                        delegated Swift NIC was created but never
 //                        populated, so kubelet never registers). This
 //                        is authoritative direct evidence and flags the
-//                        pool for recreation regardless of the NRP-KVS
-//                        storm, which only surfaces once AKS reconciles
-//                        the pool. Fails open: pools with no backing
-//                        VMSS, no realized NICs yet, or whose NIC list
-//                        errors are skipped, never flagged.
+//                        pool for recreation. Fails open: pools with no
+//                        backing VMSS, no realized NICs yet, or whose
+//                        NIC list errors are skipped, never flagged.
 //
 // Action (only when all guards pass) — applied to every confirmed target pool
 // ----------------------------------------------------------------------------
@@ -164,13 +145,11 @@ import (
 )
 
 const (
-	defaultThreshold = 5
-	defaultWindowMin = 15
-	lroAbortAgeMin   = 30
-	lroLookupWindow  = "14d"
-	tempReadyTOMin   = 8
-	poolReadyTOMin   = 15
-	pollIntervalSec  = 30
+	lroAbortAgeMin  = 30
+	lroLookupWindow = "14d"
+	tempReadyTOMin  = 8
+	poolReadyTOMin  = 15
+	pollIntervalSec = 30
 
 	// vmssReadyTOMin caps how long we wait for AKS to materialize the
 	// backing VMSS of a freshly-created (0-node) agent pool before we can
@@ -197,13 +176,15 @@ const (
 
 	// overallTimeoutMin caps the whole binary. The EV2 ShellExtension host
 	// honors the `timeout` field set on the corresponding Shell step in
-	// mgmt-pipeline.yaml (currently `150m`, which leaves headroom for the
-	// deferred forced-evidence cleanup contexts that are rooted in
-	// context.Background and can run for ~20m past the parent ctx).
+	// mgmt-pipeline.yaml, which must leave headroom above this value for the
+	// deferred LRO-abort cleanup context (rooted in context.Background) that
+	// can run a few minutes past the parent ctx.
 	overallTimeoutMin = 120
 
-	// The NRP-KVS storm check requires this error code so other failure
-	// modes (quota / capacity / policy / etc) cannot trip the threshold.
+	// nrpKVSErrorCode / vmssWriteOperation identify the NRP-KVS VMSS-write
+	// failures surfaced in the post-flight activity-log dump (dumpPostflight,
+	// observability only). They no longer gate detection — empty-ipconfig and
+	// accelerated-networking prechecks decide which pools to recreate.
 	nrpKVSErrorCode    = "NetworkingInternalOperationError"
 	vmssWriteOperation = "Microsoft.Compute/virtualMachineScaleSets/write"
 
@@ -237,50 +218,15 @@ const (
 	activityLogAuthRetryTimeoutMin = 5
 	activityLogAuthRetryInitialSec = 10
 	activityLogAuthRetryMaxSec     = 60
-
-	// forcedEvidence forces an AKS RP reconcile of a suspected pool
-	// when the cluster-state / non-system-pools / system-wedge checks
-	// PASS but the NRP-KVS-storm check has no recent NRP-KVS events in
-	// the configured lookback window. The trigger gives the wedge a
-	// chance to produce fresh evidence (or to prove the wedge is not
-	// NRP-KVS). Times are short relative to the AKS RP retry cadence
-	// (~3 min) so threshold-many retries can accumulate during the wait
-	// window.
-	defaultForcedEvidenceTimeoutMin = 20 // wait at most this long for evidence
-	defaultForcedEvidenceThreshold  = 3  // distinct NRP-KVS hits to confirm the wedge during the probe
-	forcedEvidencePollIntervalSec   = 60 // re-query activity log every poll
-	forcedEvidenceWindowMin         = 30 // activity-log lookback for the wait loop (covers the probe window plus a small margin)
-
-	// forcedEvidenceAbortTimeoutMin caps the wait for cleanup of the LRO
-	// that forcedEvidencePath itself triggered. The abort runs with a
-	// fresh context derived from context.Background so it executes even
-	// when the parent run context has already expired (overall script
-	// timeout or pollForNRPEvidence consuming the full forced-evidence
-	// timeout budget). Without this, a cancelled parent context would
-	// silently skip the abort and leave the AKS RP retrying the wedged
-	// write.
-	forcedEvidenceAbortTimeoutMin = 8
-
-	// forcedEvidenceRestoreTimeoutMin caps the wait for the restorePoolSpec
-	// PUT + PollUntilDone that reverses an inconclusive forced-evidence
-	// scale-up before a no-op exit. This runs on its own context (also
-	// derived from context.Background) rather than sharing the abort budget.
-	// Without a dedicated context, an abort that consumed most of
-	// forcedEvidenceAbortTimeoutMin would silently skip the restore.
-	forcedEvidenceRestoreTimeoutMin = 5
 )
 
 const nodePoolRoleLabel = "aro-hcp.azure.com/role"
 
 type nodePoolTarget struct {
-	name              string
-	vmssPrefix        string
-	nrpFailures       int
-	suspected         bool
-	deletionInitiated bool
-	forcedEvidence    bool
-	accelNetBroken    bool
-	emptyIPConfig     bool
+	name           string
+	vmssPrefix     string
+	accelNetBroken bool
+	emptyIPConfig  bool
 }
 
 func poolVMSSPrefix(poolName string) string {
@@ -376,10 +322,6 @@ type orchestrator interface {
 	deletePool(ctx context.Context, pool string) error
 	recreatePool(ctx context.Context, poolName string, live *armcs.AgentPool) error
 	reconcileTagPut(ctx context.Context) error
-	triggerPoolReconcile(ctx context.Context, target nodePoolTarget, live *armcs.AgentPool) error
-	pollForNRPEvidence(ctx context.Context, target nodePoolTarget, timeout time.Duration, pollInterval time.Duration, windowMin int, threshold int) (int, error)
-	abortPoolReconcile(ctx context.Context, poolName string) error
-	restorePoolSpec(ctx context.Context, target nodePoolTarget, live *armcs.AgentPool) error
 }
 
 func run() error {
@@ -434,27 +376,6 @@ func runWith(ctx context.Context, cfg *config, orch orchestrator) error {
 		return fmt.Errorf("detection: %w", err)
 	}
 
-	var confirmed, suspected []nodePoolTarget
-	for _, target := range targets {
-		if target.suspected {
-			suspected = append(suspected, target)
-		} else {
-			confirmed = append(confirmed, target)
-		}
-	}
-	if len(confirmed) == 0 && len(suspected) > 0 && !cfg.skipGuards && !cfg.dryRun {
-		for _, target := range suspected {
-			logBanner(fmt.Sprintf("FORCED EVIDENCE :: pool %s", target.name))
-			confirmedTarget, err := forcedEvidencePath(ctx, cfg, orch, target)
-			if err != nil {
-				return err
-			}
-			if confirmedTarget != nil {
-				confirmed = append(confirmed, *confirmedTarget)
-			}
-		}
-	}
-	targets = confirmed
 	// Always exit no-op when no pools are confirmed broken, even if
 	// SKIP_GUARDS=true. With no targets there is nothing to recreate, so
 	// continuing past this point would only run Step 2 (maybeAbortLRO)
@@ -471,13 +392,7 @@ func runWith(ctx context.Context, cfg *config, orch orchestrator) error {
 	}
 	logf("SELECTED BROKEN NODE POOLS: %d pool(s) confirmed", len(targets))
 	for _, target := range targets {
-		logf("  pool=%s role=%s nrpFailures=%d accelNetBroken=%t emptyIPConfig=%t", target.name, cfg.nodePoolTag, target.nrpFailures, target.accelNetBroken, target.emptyIPConfig)
-	}
-	var forcedEvidenceTargets []nodePoolTarget
-	for _, target := range targets {
-		if target.forcedEvidence {
-			forcedEvidenceTargets = append(forcedEvidenceTargets, target)
-		}
+		logf("  pool=%s role=%s accelNetBroken=%t emptyIPConfig=%t", target.name, cfg.nodePoolTag, target.accelNetBroken, target.emptyIPConfig)
 	}
 
 	if cfg.dryRun {
@@ -515,47 +430,17 @@ func runWith(ctx context.Context, cfg *config, orch orchestrator) error {
 		return nil
 	}
 
-	// Remember which pools were confirmed via deletion-initiated before
-	// re-running detection. The post-LRO detect queries the activity log
-	// from scratch and will see 0 NRP-KVS events for these pools (the
-	// trigger was rejected, so no events were generated). Without this
-	// carry-forward, those pools would be reclassified as suspected and
-	// filtered out, deadlocking the remediation.
-	deletionInitiatedPools := map[string]bool{}
-	for _, t := range targets {
-		if t.deletionInitiated {
-			deletionInitiatedPools[t.name] = true
-		}
-	}
-
 	logBanner("STEP 2b :: re-check detection guards after LRO handling")
+	// The post-LRO detect re-issues the ARM prechecks (accelerated-networking
+	// disabled, empty NIC ipConfigurations) from scratch. These are direct,
+	// authoritative signals — unlike the old NRP-KVS storm probe, they do not
+	// depend on having just provoked a reconcile, so the re-detect reliably
+	// re-reports any pool that is still broken. We therefore trust its result
+	// outright with no pre-LRO carry-forward.
 	targets, reason, err = orch.detect(ctx)
 	if err != nil {
 		return fmt.Errorf("post-LRO detection: %w", err)
 	}
-	var postConfirmed []nodePoolTarget
-	for _, target := range targets {
-		if !target.suspected {
-			postConfirmed = append(postConfirmed, target)
-		} else if deletionInitiatedPools[target.name] {
-			target.suspected = false
-			target.deletionInitiated = true
-			logf("pool %s: carrying forward deletion-initiated confirmation from pre-LRO detection", target.name)
-			postConfirmed = append(postConfirmed, target)
-		}
-	}
-	seen := map[string]struct{}{}
-	for _, target := range postConfirmed {
-		seen[target.name] = struct{}{}
-	}
-	for _, target := range forcedEvidenceTargets {
-		if _, ok := seen[target.name]; ok {
-			continue
-		}
-		logf("preserving forced-evidence-confirmed target %s through post-LRO guard recheck", target.name)
-		postConfirmed = append(postConfirmed, target)
-	}
-	targets = postConfirmed
 	// Same rationale as the pre-LRO recheck: if nothing is confirmed
 	// broken after the LRO handling, there is no pool to recreate and we
 	// must not fall through to Step 8 reconcileTagPut. Apply the no-op
@@ -604,104 +489,6 @@ func runWith(ctx context.Context, cfg *config, orch orchestrator) error {
 	return nil
 }
 
-// forcedEvidencePath triggers a temporary scale-up on the live target
-// pool so the AKS RP attempts a fresh VMSS write. It then polls the
-// activity log for NRP-KVS Failed events and aborts the LRO it started.
-// If evidence is inconclusive, it restores the original pool spec before
-// returning no-op. Restore failure is fatal in that path because a
-// successful no-op exit would let downstream infra steps race the
-// in-flight nodepool operation. If evidence confirms the pool is broken,
-// skip restore and proceed to remediation: the restore PUT can hit the
-// same wedge, and the confirmed pool will be recreated instead.
-//
-// Returns (*nodePoolTarget, error). A non-nil target means evidence
-// reached the threshold and the caller should proceed with the
-// recreate flow on the returned (now-confirmed) target. A nil target
-// with no error means the scale-up trigger did not start a mutation, or
-// the trigger was inconclusive and any temporary mutation was restored;
-// the caller should treat this pool as a no-op.
-func forcedEvidencePath(ctx context.Context, cfg *config, orch orchestrator, target nodePoolTarget) (*nodePoolTarget, error) {
-	logf("initial NRP-KVS storm check saw no evidence for pool %s in last %dm", target.name, cfg.windowMin)
-
-	// triggerPoolReconcile builds a PUT body via agentPoolForScaleUpTrigger,
-	// which pins OrchestratorVersion to cfg.cpVersion. An empty cpVersion
-	// would either be rejected by AKS or, worse, silently sent as "" — and
-	// the main flow already refuses to act on an empty cpVersion further
-	// down. Treat empty cpVersion as inconclusive here so we do not issue
-	// an unnecessary (and potentially invalid) write during the probe.
-	if cfg.cpVersion == "" {
-		logf("WARN: cpVersion empty; skipping forced-evidence trigger for %s (cannot build a safe scale-up PUT)", target.name)
-		return nil, nil
-	}
-
-	live, err := orch.snapshotPool(ctx, target.name)
-	if err != nil {
-		return nil, fmt.Errorf("forced evidence snapshot %s: %w", target.name, err)
-	}
-
-	if err := orch.triggerPoolReconcile(ctx, target, live); err != nil {
-		if isDeletionInitiatedErr(err) {
-			logf("pool %s rejected scale-up: deletion has been initiated; confirming as broken (remediation will delete+recreate)", target.name)
-			target.suspected = false
-			target.deletionInitiated = true
-			return &target, nil
-		}
-		logf("WARN: triggerPoolReconcile for %s failed: %v; treating as no-op", target.name, err)
-		return nil, nil
-	}
-
-	logf("triggered pool %s reconcile; polling activity log every %ds for up to %dm", target.name, forcedEvidencePollIntervalSec, cfg.forcedEvidenceTimeoutMin)
-	hits, pollErr := orch.pollForNRPEvidence(
-		ctx,
-		target,
-		time.Duration(cfg.forcedEvidenceTimeoutMin)*time.Minute,
-		forcedEvidencePollIntervalSec*time.Second,
-		forcedEvidenceWindowMin,
-		cfg.forcedEvidenceThreshold,
-	)
-
-	abortCtx, abortCancel := context.WithTimeout(context.Background(), forcedEvidenceAbortTimeoutMin*time.Minute)
-	defer abortCancel()
-	if abortErr := orch.abortPoolReconcile(abortCtx, target.name); abortErr != nil {
-		logf("WARN: abortPoolReconcile for %s failed: %v", target.name, abortErr)
-	}
-	if pollErr != nil {
-		if restoreErr := restoreForcedEvidencePoolSpec(target, live, orch); restoreErr != nil {
-			return nil, fmt.Errorf("poll for NRP evidence on %s: %w; restore forced-evidence pool spec also failed: %w", target.name, pollErr, restoreErr)
-		}
-		return nil, fmt.Errorf("poll for NRP evidence on %s: %w", target.name, pollErr)
-	}
-	if hits < cfg.forcedEvidenceThreshold {
-		if restoreErr := restoreForcedEvidencePoolSpec(target, live, orch); restoreErr != nil {
-			return nil, restoreErr
-		}
-		logf("forced evidence inconclusive for %s: only %d NRP failures < %d after %dm", target.name, hits, cfg.forcedEvidenceThreshold, cfg.forcedEvidenceTimeoutMin)
-		return nil, nil
-	}
-	logf("forced evidence confirmed NRP-KVS for %s (%d hits >= threshold %d)", target.name, hits, cfg.forcedEvidenceThreshold)
-	target.nrpFailures = hits
-	target.suspected = false
-	target.forcedEvidence = true
-	return &target, nil
-}
-
-func restoreForcedEvidencePoolSpec(target nodePoolTarget, live *armcs.AgentPool, orch orchestrator) error {
-	// Restore runs on its own bounded context so sharing the abort budget
-	// cannot skip the restore when the abort consumed most of those 8m and
-	// leave the pool one node larger than the original snapshot.
-	restoreCtx, restoreCancel := context.WithTimeout(context.Background(), forcedEvidenceRestoreTimeoutMin*time.Minute)
-	defer restoreCancel()
-	if err := orch.restorePoolSpec(restoreCtx, target, live); err != nil {
-		return fmt.Errorf("restore forced-evidence pool spec for %s: %w", target.name, err)
-	}
-	return nil
-}
-
-// remediatePool is the single remediation flow applied to every confirmed
-// target pool, regardless of AKS Mode (System/User). It always brings up
-// a deterministic per-target temp pool first — waiting for the ARM LRO
-// AND the new k8s node to be Ready — before touching the broken pool,
-// so the cluster never loses the target pool's capacity "on faith".
 func remediatePool(ctx context.Context, orch orchestrator, target nodePoolTarget, live *armcs.AgentPool) error {
 	tmpName := tempPoolName(target.name)
 	logf("pool %s: creating temp %s, then drain+delete+recreate", target.name, tmpName)
@@ -731,32 +518,24 @@ func remediatePool(ctx context.Context, orch orchestrator, target nodePoolTarget
 // ---------------------------------------------------------------------------
 
 type config struct {
-	clusterName              string
-	resourceGroup            string
-	subscriptionID           string
-	nodeRG                   string
-	cpVersion                string
-	nodePoolTag              string
-	threshold                int
-	windowMin                int
-	forcedEvidenceTimeoutMin int
-	forcedEvidenceThreshold  int
-	dryRun                   bool
-	skipGuards               bool
+	clusterName    string
+	resourceGroup  string
+	subscriptionID string
+	nodeRG         string
+	cpVersion      string
+	nodePoolTag    string
+	dryRun         bool
+	skipGuards     bool
 }
 
 // parseEnvConfig builds a config from environment variables only. It does
 // not call any external tools or APIs, which makes it safe to unit-test.
 func parseEnvConfig(env func(string) string) (*config, error) {
 	c := &config{
-		clusterName:              env("CLUSTER_NAME"),
-		resourceGroup:            env("RESOURCE_GROUP"),
-		subscriptionID:           env("SUBSCRIPTION_ID"),
-		nodePoolTag:              env("NODEPOOL_TAG"),
-		threshold:                defaultThreshold,
-		windowMin:                defaultWindowMin,
-		forcedEvidenceTimeoutMin: defaultForcedEvidenceTimeoutMin,
-		forcedEvidenceThreshold:  defaultForcedEvidenceThreshold,
+		clusterName:    env("CLUSTER_NAME"),
+		resourceGroup:  env("RESOURCE_GROUP"),
+		subscriptionID: env("SUBSCRIPTION_ID"),
+		nodePoolTag:    env("NODEPOOL_TAG"),
 	}
 	if c.clusterName == "" {
 		return nil, errors.New("CLUSTER_NAME is required")
@@ -769,46 +548,6 @@ func parseEnvConfig(env func(string) string) (*config, error) {
 	}
 	if c.nodePoolTag == "" {
 		return nil, errors.New("NODEPOOL_TAG is required")
-	}
-	if v := env("NRP_FAIL_THRESHOLD"); v != "" {
-		n, err := strconv.Atoi(v)
-		if err != nil {
-			return nil, fmt.Errorf("NRP_FAIL_THRESHOLD: %w", err)
-		}
-		if n <= 0 {
-			return nil, fmt.Errorf("NRP_FAIL_THRESHOLD must be > 0, got %d", n)
-		}
-		c.threshold = n
-	}
-	if v := env("NRP_FAIL_WINDOW_MIN"); v != "" {
-		n, err := strconv.Atoi(v)
-		if err != nil {
-			return nil, fmt.Errorf("NRP_FAIL_WINDOW_MIN: %w", err)
-		}
-		if n <= 0 {
-			return nil, fmt.Errorf("NRP_FAIL_WINDOW_MIN must be > 0, got %d", n)
-		}
-		c.windowMin = n
-	}
-	if v := env("FORCED_EVIDENCE_TIMEOUT_MIN"); v != "" {
-		n, err := strconv.Atoi(v)
-		if err != nil {
-			return nil, fmt.Errorf("FORCED_EVIDENCE_TIMEOUT_MIN: %w", err)
-		}
-		if n <= 0 {
-			return nil, fmt.Errorf("FORCED_EVIDENCE_TIMEOUT_MIN must be > 0, got %d", n)
-		}
-		c.forcedEvidenceTimeoutMin = n
-	}
-	if v := env("FORCED_EVIDENCE_THRESHOLD"); v != "" {
-		n, err := strconv.Atoi(v)
-		if err != nil {
-			return nil, fmt.Errorf("FORCED_EVIDENCE_THRESHOLD: %w", err)
-		}
-		if n <= 0 {
-			return nil, fmt.Errorf("FORCED_EVIDENCE_THRESHOLD must be > 0, got %d", n)
-		}
-		c.forcedEvidenceThreshold = n
 	}
 	if v := strings.ToLower(strings.TrimSpace(env("DRY_RUN"))); v == "true" || v == "1" || v == "yes" {
 		c.dryRun = true
@@ -828,10 +567,6 @@ func (c *config) logEnv() {
 	logf("RESOURCE_GROUP=%s", c.resourceGroup)
 	logf("SUBSCRIPTION_ID=%s", c.subscriptionID)
 	logf("NODEPOOL_TAG=%s", c.nodePoolTag)
-	logf("NRP_FAIL_THRESHOLD=%d", c.threshold)
-	logf("NRP_FAIL_WINDOW_MIN=%d", c.windowMin)
-	logf("FORCED_EVIDENCE_TIMEOUT_MIN=%d", c.forcedEvidenceTimeoutMin)
-	logf("FORCED_EVIDENCE_THRESHOLD=%d", c.forcedEvidenceThreshold)
 	logf("DRY_RUN=%t", c.dryRun)
 	logf("SKIP_GUARDS=%t", c.skipGuards)
 }
@@ -943,21 +678,6 @@ func (c *clients) bootstrapKube(ctx context.Context, mc armcs.ManagedCluster) er
 	}
 	c.kube = kc
 	return nil
-}
-
-// isDeletionInitiatedErr reports whether err is an ARM OperationNotAllowed
-// response indicating that AKS has marked the pool for deletion and refuses
-// all operations except retrying the delete. This state is reached when a
-// previous delete was initiated but did not complete.
-func isDeletionInitiatedErr(err error) bool {
-	var re *azcore.ResponseError
-	if !errors.As(err, &re) {
-		return false
-	}
-	if re.ErrorCode != "OperationNotAllowed" {
-		return false
-	}
-	return strings.Contains(strings.ToLower(err.Error()), "deletion has been initiated")
 }
 
 // isNotFoundErr reports whether err is an azcore HTTP 404 ResponseError
@@ -1119,17 +839,6 @@ func nodeInternalIP(n *corev1.Node) string {
 // detection
 // ---------------------------------------------------------------------------
 
-// evalNRPStorm reports whether NRP-KVS failure count exceeds the threshold.
-func evalNRPStorm(failures, threshold int) (bool, string) {
-	if threshold <= 0 {
-		return false, fmt.Sprintf("NRP-KVS storm FAIL: threshold=%d (invalid)", threshold)
-	}
-	if failures < threshold {
-		return false, fmt.Sprintf("NRP-KVS storm FAIL: only %d NRP failures < %d", failures, threshold)
-	}
-	return true, ""
-}
-
 // evalClusterState reports whether the cluster is in a state where we can act.
 //
 // Acceptable:
@@ -1191,17 +900,15 @@ func evalNonTargetPoolsHealthy(pools []*armcs.AgentPool) (bool, string) {
 }
 
 // evalPoolWedge reports whether a single pool's provisioningState is in
-// a wedge-compatible state — a positive per-pool signal that refines
-// the cluster-wide NRP-KVS storm check.
+// a wedge-compatible state. It is used by evalNonTargetPoolsHealthy to
+// decide whether a non-target pool looks healthy enough to proceed.
 //
 // Accepts:
 //   - Failed   — RP gave up retrying the VMSS write chain.
 //   - Canceled — operator already aborted the parent LRO.
 //   - Updating / Upgrading — the cluster LRO is still retrying the
 //     pool update forever (AROSLSRE-880 / INT
-//     2026-05-16..18 signature). Guard 1 confirms
-//     that the retries are NRP errors and not a
-//     healthy upgrade.
+//     2026-05-16..18 signature).
 //
 // Rejects:
 //   - Succeeded — pool is healthy; no wedge.
@@ -1255,16 +962,13 @@ func (c *clients) detect(ctx context.Context) ([]nodePoolTarget, string, error) 
 	}
 	logf("cluster safety PASS")
 
-	// First pass: classify pools by role match and wedge state without
-	// touching Activity Log. This honors the file-header promise to
-	// short-circuit on cheap ARM checks before issuing the activity-log
-	// query (which costs an ARM List call and a throttling slot per run).
-	type wedgedPool struct {
-		target    nodePoolTarget
-		provState string
-	}
+	// Classify pools by role match without touching the Activity Log. The two
+	// ARM-only prechecks below give us a priori knowledge of which pools are
+	// broken (their NICs will never attach), so we no longer query the
+	// activity-log NRP-KVS write storm — that signal is reactive (it only
+	// appears after AKS reconciles a wedged pool) and merely confirms what the
+	// ipConfigurations array already tells us before any scale-up is attempted.
 	var selected []nodePoolTarget
-	var wedged []wedgedPool
 	var swiftSelected []nodePoolTarget
 	for _, p := range allPools {
 		if p == nil || p.Name == nil || p.Properties == nil {
@@ -1283,14 +987,6 @@ func (c *clients) detect(ctx context.Context) ([]nodePoolTarget, string, error) 
 		if poolIsSwift(p) {
 			swiftSelected = append(swiftSelected, t)
 		}
-		provState := strDeref(p.Properties.ProvisioningState)
-		if ok, _ := evalPoolWedge(provState); !ok {
-			continue
-		}
-		wedged = append(wedged, wedgedPool{
-			target:    t,
-			provState: provState,
-		})
 	}
 	if len(selected) == 0 {
 		return nil, fmt.Sprintf("no node pools found with %s=%q", nodePoolRoleLabel, c.cfg.nodePoolTag), nil
@@ -1298,116 +994,55 @@ func (c *clients) detect(ctx context.Context) ([]nodePoolTarget, string, error) 
 
 	// Accelerated-networking precheck (AROSLSRE-1172): a Swift pool whose
 	// backing VMSS came up with accelerated-networking DISABLED is broken
-	// regardless of provisioning state or NRP-KVS storm evidence — its Swift
-	// NICs can never attach — so it is flagged for recreation directly. This
-	// is at most one cheap VMSS List (far cheaper than the activity-log
-	// query, and skipped entirely when there are no Swift pools) and fails
-	// open, so it never regresses the existing NRP-driven behavior.
+	// regardless of provisioning state — its Swift NICs can never attach — so
+	// it is flagged for recreation directly. This is at most one cheap VMSS
+	// List (skipped entirely when there are no Swift pools) and fails open.
 	anBroken, anErr := c.detectAccelNetBrokenPools(ctx, swiftSelected)
 	if anErr != nil {
-		logf("WARN: accelerated-networking precheck failed: %v (continuing with NRP detection only)", anErr)
+		logf("WARN: accelerated-networking precheck failed: %v (continuing with empty-ipconfig detection only)", anErr)
 		anBroken = nil
 	}
 
 	// Empty-ipConfiguration precheck (Steve Kuznetsov, MSFT): a pool whose
 	// backing VMSS has realized instance NICs with an empty ipConfigurations
 	// array is broken by the NRP null-pointer defect (ICM 798003653) — the
-	// node never attaches its Swift NIC and kubelet never registers —
-	// regardless of provisioning state or NRP-KVS storm evidence. The
-	// activity-log write storm only surfaces once AKS reconciles the pool, so
-	// gating recreation on it lets broken pools linger and forces a slow
-	// one-by-one recovery across rollouts; detecting the empty ipConfigurations
-	// directly recreates every affected pool in a single pass. This runs over
-	// ALL selected role-matched pools (so it covers the system pool too, not
-	// just Swift-tagged ones), is ARM-only (cheaper than the activity-log
-	// query), and fails open so it never regresses existing behavior.
+	// node never attaches its Swift NIC and kubelet never registers. This is
+	// the a-priori predictor: it tells us which pools WILL fail to scale up
+	// before scaling is attempted, so we short-circuit the old
+	// detect-storm-then-recreate flow. The activity-log write storm only
+	// surfaces once AKS reconciles the pool, so gating recreation on it lets
+	// broken pools linger and forces a slow one-by-one recovery across
+	// rollouts; detecting the empty ipConfigurations directly recreates every
+	// affected pool in a single pass. This runs over ALL selected role-matched
+	// pools (so it covers the system pool too, not just Swift-tagged ones), is
+	// ARM-only, and fails open so it never regresses existing behavior.
 	emptyIPCfgBroken, eicErr := c.detectEmptyIPConfigPools(ctx, selected)
 	if eicErr != nil {
-		logf("WARN: empty-ipconfig precheck failed: %v (continuing with NRP detection only)", eicErr)
+		logf("WARN: empty-ipconfig precheck failed: %v (continuing with accelerated-networking detection only)", eicErr)
 		emptyIPCfgBroken = nil
 	}
 
-	if len(wedged) == 0 && len(anBroken) == 0 && len(emptyIPCfgBroken) == 0 {
-		return nil, fmt.Sprintf("no selected node pools with %s=%q are in wedge-compatible state, have Swift accelerated-networking disabled, or have empty NIC ipConfigurations", nodePoolRoleLabel, c.cfg.nodePoolTag), nil
+	if len(anBroken) == 0 && len(emptyIPCfgBroken) == 0 {
+		return nil, fmt.Sprintf("no selected node pools with %s=%q have Swift accelerated-networking disabled or empty NIC ipConfigurations", nodePoolRoleLabel, c.cfg.nodePoolTag), nil
 	}
 
+	// Both prechecks yield directly confirmed targets. Merge them, deduping a
+	// pool flagged by both so it carries both markers for observability.
 	var targets []nodePoolTarget
-	var confirmedCount int
-
-	if len(wedged) > 0 {
-		// Only now do we pay for the Activity Log list.
-		out, err := c.activityLogJSON(ctx, c.cfg.nodeRG, fmt.Sprintf("%dm", c.cfg.windowMin))
-		if err != nil {
-			return nil, "", fmt.Errorf("NRP-KVS storm activity-log query failed: %w", err)
-		}
-		for _, w := range wedged {
-			logf("pool %s: role=%s provisioningState=%s — wedge-compatible", w.target.name, c.cfg.nodePoolTag, w.provState)
-			hits, err := countNRPFailures(out, w.target.vmssPrefix)
-			if err != nil {
-				return nil, "", fmt.Errorf("NRP failure count for pool %s: %w", w.target.name, err)
-			}
-			logf("pool %s: NRP-KVS failures on %s*: %d (threshold %d)", w.target.name, w.target.vmssPrefix, hits, c.cfg.threshold)
-			target := w.target
-			target.nrpFailures = hits
-			if hits < c.cfg.threshold && !c.cfg.skipGuards {
-				target.suspected = true
-			} else {
-				confirmedCount++
-			}
-			targets = append(targets, target)
-		}
-	}
-
-	// Merge accelerated-networking-broken Swift pools as confirmed targets.
-	// AN-disabled is direct evidence of brokenness, so these skip the
-	// forced-evidence probe; a pool already surfaced (suspected) by the NRP
-	// path is upgraded to confirmed.
 	idxByName := map[string]int{}
-	for i := range targets {
-		idxByName[targets[i].name] = i
-	}
 	for _, ab := range anBroken {
 		logf("pool %s: confirmed broken by accelerated-networking precheck (Swift pool with AN disabled)", ab.name)
-		if i, ok := idxByName[ab.name]; ok {
-			if targets[i].suspected {
-				targets[i].suspected = false
-				confirmedCount++
-			}
-			targets[i].accelNetBroken = true
-			continue
-		}
-		confirmedCount++
+		idxByName[ab.name] = len(targets)
 		targets = append(targets, ab)
-	}
-
-	// Merge empty-ipConfiguration-broken pools as confirmed targets. An empty
-	// realized-NIC ipConfigurations array is direct evidence of the NRP
-	// null-pointer defect, so these skip the forced-evidence probe; a pool
-	// already surfaced (suspected) by the NRP path is upgraded to confirmed,
-	// and a pool already flagged by the accelerated-networking precheck just
-	// gains the emptyIPConfig marker for observability.
-	for i := range targets {
-		idxByName[targets[i].name] = i
 	}
 	for _, eb := range emptyIPCfgBroken {
 		logf("pool %s: confirmed broken by empty-ipconfig precheck (backing VMSS has NIC(s) with empty ipConfigurations)", eb.name)
 		if i, ok := idxByName[eb.name]; ok {
-			if targets[i].suspected {
-				targets[i].suspected = false
-				confirmedCount++
-			}
 			targets[i].emptyIPConfig = true
 			continue
 		}
-		confirmedCount++
+		idxByName[eb.name] = len(targets)
 		targets = append(targets, eb)
-	}
-	// When every candidate is below threshold the caller will either route
-	// through the forced-evidence path or log a no-op exit. Surface a
-	// non-empty reason so the operator log line is actionable rather than
-	// trailing an empty period ("...confirmed broken: .").
-	if confirmedCount == 0 {
-		return targets, fmt.Sprintf("%d candidate pool(s) all below NRP failure threshold %d in last %dm", len(targets), c.cfg.threshold, c.cfg.windowMin), nil
 	}
 	return targets, "", nil
 }
@@ -1688,30 +1323,6 @@ func agentPoolForCreate(live *armcs.AgentPool, cpVersion string) (*armcs.AgentPo
 		out.Properties.Tags = cloneStringPtrMapWithoutPrefix(out.Properties.Tags, "aks-managed-")
 	}
 	return &out, nil
-}
-
-// agentPoolForScaleUpTrigger returns a sanitized PUT body that increments
-// the target pool's Count (and MinCount / MaxCount when autoscale is
-// enabled) by 1. Used by triggerPoolReconcile to force the AKS RP to
-// schedule a fresh VMSS write — a no-op CreateOrUpdate with the same
-// Count is rejected by AKS as "no changes detected".
-func agentPoolForScaleUpTrigger(live *armcs.AgentPool, cpVersion string) (*armcs.AgentPool, error) {
-	body, err := agentPoolForCreate(live, cpVersion)
-	if err != nil {
-		return nil, fmt.Errorf("agentPoolForScaleUpTrigger: %w", err)
-	}
-	if body.Properties.Count != nil {
-		(*body.Properties.Count)++
-	} else {
-		body.Properties.Count = ptr(int32(2))
-	}
-	if body.Properties.EnableAutoScaling != nil && *body.Properties.EnableAutoScaling && body.Properties.MinCount != nil {
-		(*body.Properties.MinCount)++
-		if body.Properties.MaxCount != nil && *body.Properties.MinCount > *body.Properties.MaxCount {
-			*body.Properties.MaxCount = *body.Properties.MinCount
-		}
-	}
-	return body, nil
 }
 
 // ---------------------------------------------------------------------------
@@ -2551,112 +2162,6 @@ func (c *clients) reconcileTagPut(ctx context.Context) error {
 		},
 	}, nil)
 	return err
-}
-
-// ---------------------------------------------------------------------------
-// forced-evidence trigger (used only when cluster-state, non-system-pools,
-// and system-wedge checks PASS and the NRP-KVS-storm check FAILs
-// because the activity log has no recent NRP-KVS events)
-// ---------------------------------------------------------------------------
-
-// triggerPoolReconcile starts an AKS RP scale-up of the live target
-// pool by issuing a sanitized CreateOrUpdate with the snapshot spec plus
-// one node. It does not wait for the LRO to finish — the caller polls the
-// activity log for NRP-KVS evidence in parallel, aborts the LRO, and then
-// restores the original pool spec.
-func (c *clients) triggerPoolReconcile(ctx context.Context, target nodePoolTarget, live *armcs.AgentPool) error {
-	body, err := agentPoolForScaleUpTrigger(live, c.cfg.cpVersion)
-	if err != nil {
-		return fmt.Errorf("triggerPoolReconcile %s: %w", target.name, err)
-	}
-	logf("triggering scale-up on %q (count=%d) to force VMSS write", target.name, *body.Properties.Count)
-	if _, err := c.pools.BeginCreateOrUpdate(ctx, c.cfg.resourceGroup, c.cfg.clusterName, target.name, *body, nil); err != nil {
-		return fmt.Errorf("begin trigger pool scale-up %s: %w", target.name, err)
-	}
-	return nil
-}
-
-// pollForNRPEvidence re-queries the activity log on a fixed interval
-// until the NRP-KVS Failed-event count reaches threshold or the timeout
-// elapses. windowMin controls how far back each poll looks (a window
-// equal to the timeout makes every poll see all events since the
-// trigger).
-func (c *clients) pollForNRPEvidence(ctx context.Context, target nodePoolTarget, timeout time.Duration, pollInterval time.Duration, windowMin int, threshold int) (int, error) {
-	if pollInterval <= 0 {
-		pollInterval = 60 * time.Second
-	}
-	deadline := time.Now().Add(timeout)
-	last := 0
-	for {
-		resp, err := c.pools.Get(ctx, c.cfg.resourceGroup, c.cfg.clusterName, target.name, nil)
-		if err != nil {
-			logf("WARN: forced-evidence pool state check for %s failed: %v (continuing)", target.name, err)
-		} else if resp.Properties != nil && resp.Properties.ProvisioningState != nil && *resp.Properties.ProvisioningState == "Succeeded" {
-			logf("forced evidence: pool %s provisioningState=Succeeded; wedge resolved, returning early", target.name)
-			return 0, nil
-		}
-
-		out, err := c.activityLogJSON(ctx, c.cfg.nodeRG, fmt.Sprintf("%dm", windowMin))
-		if err != nil {
-			return last, fmt.Errorf("forced-evidence activity-log query for %s: %w", target.name, err)
-		}
-		hits, parseErr := countNRPFailures(out, target.vmssPrefix)
-		if parseErr != nil {
-			return last, fmt.Errorf("forced-evidence activity-log parse for %s: %w", target.name, parseErr)
-		}
-		last = hits
-		logf("forced evidence poll for %s: NRP-KVS hits=%d threshold=%d (window=%dm)", target.name, hits, threshold, windowMin)
-		if hits >= threshold {
-			return hits, nil
-		}
-		if !time.Now().Before(deadline) {
-			return hits, nil
-		}
-		sleep := pollInterval
-		if remaining := time.Until(deadline); remaining < sleep {
-			sleep = remaining
-		}
-		select {
-		case <-ctx.Done():
-			return last, ctx.Err()
-		case <-time.After(sleep):
-		}
-	}
-}
-
-// abortPoolReconcile aborts the latest LRO on the named agent pool,
-// which (when the forced-evidence trigger started one) cancels the
-// in-flight CreateOrUpdate. Used for both system and user pools.
-// Best-effort: failures here are logged by the caller but not propagated.
-func (c *clients) abortPoolReconcile(ctx context.Context, poolName string) error {
-	poller, err := c.pools.BeginAbortLatestOperation(ctx, c.cfg.resourceGroup, c.cfg.clusterName, poolName, nil)
-	if err != nil {
-		return fmt.Errorf("begin abort pool reconcile %s: %w", poolName, err)
-	}
-	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
-		return fmt.Errorf("poll abort pool reconcile %s: %w", poolName, err)
-	}
-	return nil
-}
-
-// restorePoolSpec re-PUTs the target pool with the snapshotted spec to
-// reverse the temporary scale-up issued by triggerPoolReconcile. Used
-// only on the forced-evidence path so the pool is restored to its
-// original size even when forced evidence ends inconclusive.
-func (c *clients) restorePoolSpec(ctx context.Context, target nodePoolTarget, live *armcs.AgentPool) error {
-	body, err := agentPoolForCreate(live, c.cfg.cpVersion)
-	if err != nil {
-		return fmt.Errorf("restorePoolSpec %s: %w", target.name, err)
-	}
-	logf("restoring original spec for pool %s", target.name)
-	poller, err := c.pools.BeginCreateOrUpdate(ctx, c.cfg.resourceGroup, c.cfg.clusterName, target.name, *body, nil)
-	if err != nil {
-		return fmt.Errorf("begin restore pool spec %s: %w", target.name, err)
-	}
-	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
-		return fmt.Errorf("poll restore pool spec %s: %w", target.name, err)
-	}
-	return nil
 }
 
 // ---------------------------------------------------------------------------

--- a/dev-infrastructure/scripts/recreate-broken-pools/main.go
+++ b/dev-infrastructure/scripts/recreate-broken-pools/main.go
@@ -63,6 +63,12 @@
 // (cluster state -> non-system pools -> system wedge -> NRP-KVS storm)
 // so the cheap ARM checks short-circuit before we query Activity Log.
 //
+// Two ARM-only prechecks ([accel-net] and [empty ipconfig], below) run
+// before the Activity Log query and flag a pool broken on their own
+// direct evidence — independent of the NRP-KVS storm signal — so a pool
+// in either state is recreated even when the activity-log write storm
+// has not (yet) appeared.
+//
 //   [cluster state]      cluster provisioningState is recoverable:
 //                        Succeeded, Canceled, Failed (settled) OR
 //                        Updating, Upgrading (mid-LRO — the NRP-KVS
@@ -90,6 +96,18 @@
 //                        check, so they cannot trigger a destructive
 //                        pool recreation that would not address their
 //                        actual root cause.
+//   [empty ipconfig]     any selected pool whose backing VMSS has a
+//                        realized instance NIC with an empty
+//                        ipConfigurations array — the ARM-visible
+//                        signature of the NRP null-pointer defect (the
+//                        delegated Swift NIC was created but never
+//                        populated, so kubelet never registers). This
+//                        is authoritative direct evidence and flags the
+//                        pool for recreation regardless of the NRP-KVS
+//                        storm, which only surfaces once AKS reconciles
+//                        the pool. Fails open: pools with no backing
+//                        VMSS, no realized NICs yet, or whose NIC list
+//                        errors are skipped, never flagged.
 //
 // Action (only when all guards pass) — applied to every confirmed target pool
 // ----------------------------------------------------------------------------
@@ -139,6 +157,7 @@ import (
 	armcompute "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
 	armcs "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v6"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor"
+	armnetwork "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 
 	mcclient "github.com/Azure/ARO-HCP/sessiongate/pkg/mc"
@@ -261,6 +280,7 @@ type nodePoolTarget struct {
 	deletionInitiated bool
 	forcedEvidence    bool
 	accelNetBroken    bool
+	emptyIPConfig     bool
 }
 
 func poolVMSSPrefix(poolName string) string {
@@ -451,7 +471,7 @@ func runWith(ctx context.Context, cfg *config, orch orchestrator) error {
 	}
 	logf("SELECTED BROKEN NODE POOLS: %d pool(s) confirmed", len(targets))
 	for _, target := range targets {
-		logf("  pool=%s role=%s nrpFailures=%d accelNetBroken=%t", target.name, cfg.nodePoolTag, target.nrpFailures, target.accelNetBroken)
+		logf("  pool=%s role=%s nrpFailures=%d accelNetBroken=%t emptyIPConfig=%t", target.name, cfg.nodePoolTag, target.nrpFailures, target.accelNetBroken, target.emptyIPConfig)
 	}
 	var forcedEvidenceTargets []nodePoolTarget
 	for _, target := range targets {
@@ -826,6 +846,7 @@ type clients struct {
 	pools        *armcs.AgentPoolsClient
 	cluster      *armcs.ManagedClustersClient
 	vmss         *armcompute.VirtualMachineScaleSetsClient
+	nics         *armnetwork.InterfacesClient
 	activityLogs *armmonitor.ActivityLogsClient
 	tags         *armresources.TagsClient
 	kube         kubernetes.Interface
@@ -853,6 +874,10 @@ func newAzureClients(cfg *config) (*clients, error) {
 	if err != nil {
 		return nil, fmt.Errorf("arm compute factory: %w", err)
 	}
+	networkFactory, err := armnetwork.NewClientFactory(cfg.subscriptionID, cred, nil)
+	if err != nil {
+		return nil, fmt.Errorf("arm network factory: %w", err)
+	}
 	activityLogs, err := armmonitor.NewActivityLogsClient(cfg.subscriptionID, cred, nil)
 	if err != nil {
 		return nil, fmt.Errorf("arm monitor activity logs client: %w", err)
@@ -867,6 +892,7 @@ func newAzureClients(cfg *config) (*clients, error) {
 		pools:        clientFactory.NewAgentPoolsClient(),
 		cluster:      clientFactory.NewManagedClustersClient(),
 		vmss:         computeFactory.NewVirtualMachineScaleSetsClient(),
+		nics:         networkFactory.NewInterfacesClient(),
 		activityLogs: activityLogs,
 		tags:         tags,
 	}, nil
@@ -1283,8 +1309,26 @@ func (c *clients) detect(ctx context.Context) ([]nodePoolTarget, string, error) 
 		anBroken = nil
 	}
 
-	if len(wedged) == 0 && len(anBroken) == 0 {
-		return nil, fmt.Sprintf("no selected node pools with %s=%q are in wedge-compatible state or have Swift accelerated-networking disabled", nodePoolRoleLabel, c.cfg.nodePoolTag), nil
+	// Empty-ipConfiguration precheck (Steve Kuznetsov, MSFT): a pool whose
+	// backing VMSS has realized instance NICs with an empty ipConfigurations
+	// array is broken by the NRP null-pointer defect (ICM 798003653) — the
+	// node never attaches its Swift NIC and kubelet never registers —
+	// regardless of provisioning state or NRP-KVS storm evidence. The
+	// activity-log write storm only surfaces once AKS reconciles the pool, so
+	// gating recreation on it lets broken pools linger and forces a slow
+	// one-by-one recovery across rollouts; detecting the empty ipConfigurations
+	// directly recreates every affected pool in a single pass. This runs over
+	// ALL selected role-matched pools (so it covers the system pool too, not
+	// just Swift-tagged ones), is ARM-only (cheaper than the activity-log
+	// query), and fails open so it never regresses existing behavior.
+	emptyIPCfgBroken, eicErr := c.detectEmptyIPConfigPools(ctx, selected)
+	if eicErr != nil {
+		logf("WARN: empty-ipconfig precheck failed: %v (continuing with NRP detection only)", eicErr)
+		emptyIPCfgBroken = nil
+	}
+
+	if len(wedged) == 0 && len(anBroken) == 0 && len(emptyIPCfgBroken) == 0 {
+		return nil, fmt.Sprintf("no selected node pools with %s=%q are in wedge-compatible state, have Swift accelerated-networking disabled, or have empty NIC ipConfigurations", nodePoolRoleLabel, c.cfg.nodePoolTag), nil
 	}
 
 	var targets []nodePoolTarget
@@ -1336,6 +1380,28 @@ func (c *clients) detect(ctx context.Context) ([]nodePoolTarget, string, error) 
 		targets = append(targets, ab)
 	}
 
+	// Merge empty-ipConfiguration-broken pools as confirmed targets. An empty
+	// realized-NIC ipConfigurations array is direct evidence of the NRP
+	// null-pointer defect, so these skip the forced-evidence probe; a pool
+	// already surfaced (suspected) by the NRP path is upgraded to confirmed,
+	// and a pool already flagged by the accelerated-networking precheck just
+	// gains the emptyIPConfig marker for observability.
+	for i := range targets {
+		idxByName[targets[i].name] = i
+	}
+	for _, eb := range emptyIPCfgBroken {
+		logf("pool %s: confirmed broken by empty-ipconfig precheck (backing VMSS has NIC(s) with empty ipConfigurations)", eb.name)
+		if i, ok := idxByName[eb.name]; ok {
+			if targets[i].suspected {
+				targets[i].suspected = false
+				confirmedCount++
+			}
+			targets[i].emptyIPConfig = true
+			continue
+		}
+		confirmedCount++
+		targets = append(targets, eb)
+	}
 	// When every candidate is below threshold the caller will either route
 	// through the forced-evidence path or log a no-op exit. Surface a
 	// non-empty reason so the operator log line is actionable rather than
@@ -1992,6 +2058,95 @@ func (c *clients) detectAccelNetBrokenPools(ctx context.Context, swiftPools []no
 			logf("accel-net precheck: swift pool %s VMSS has accelerated-networking DISABLED — flagging broken (Swift NICs cannot attach; pool must be recreated)", sp.name)
 			t := sp
 			t.accelNetBroken = true
+			broken = append(broken, t)
+		}
+	}
+	return broken, nil
+}
+
+// countEmptyIPConfigs reports how many of the given realized network interfaces
+// carry an empty ipConfigurations array, plus how many NICs were inspected. A
+// healthy NIC always has at least one ipConfiguration; an empty array is the
+// ARM-visible signature of the NRP null-pointer defect, where NRP brings the
+// (delegated) Swift NIC up but never populates its ipConfigurations. NICs with
+// nil Properties are not counted (indeterminate; fail-open).
+func countEmptyIPConfigs(nics []*armnetwork.Interface) (total, empty int) {
+	for _, nic := range nics {
+		if nic == nil || nic.Properties == nil {
+			continue
+		}
+		total++
+		if len(nic.Properties.IPConfigurations) == 0 {
+			empty++
+		}
+	}
+	return total, empty
+}
+
+// listVMSSInstanceNICs lists every realized per-instance network interface of
+// vmssName in the node resource group. This is the ARM equivalent of the
+// NRP_Entities networkinterfaces view used to triage the defect.
+func (c *clients) listVMSSInstanceNICs(ctx context.Context, vmssName string) ([]*armnetwork.Interface, error) {
+	if c.nics == nil {
+		return nil, errors.New("network interfaces client not initialized")
+	}
+	pager := c.nics.NewListVirtualMachineScaleSetNetworkInterfacesPager(c.cfg.nodeRG, vmssName, nil)
+	var all []*armnetwork.Interface
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("list NICs for VMSS %s in %s: %w", vmssName, c.cfg.nodeRG, err)
+		}
+		all = append(all, page.Value...)
+	}
+	return all, nil
+}
+
+// detectEmptyIPConfigPools inspects the realized instance NICs of each pool's
+// backing VMSS and returns those with at least one NIC whose ipConfigurations
+// array is empty — the ARM-visible signature of the NRP null-pointer defect
+// (ICM 798003653). Steve Kuznetsov (MSFT) established that this state is the
+// authoritative "broken" signal and that every VMSS exhibiting it must be
+// recreated, regardless of whether the Activity Log shows an NRP-KVS write
+// storm: the write failures only surface once AKS reconciles the pool, so
+// gating recreation on them lets broken pools linger across rollouts and forces
+// a slow one-by-one recovery. Flagging on empty ipConfigurations lets a single
+// run recreate every affected pool at once.
+//
+// It fails OPEN: a pool whose backing VMSS is missing, whose NIC listing
+// errors, or which has no realized NICs yet (a freshly-created or
+// scaling-to-zero pool) is skipped, never flagged. A pool is flagged only when
+// at least one realized NIC was observed AND at least one of them has an empty
+// ipConfigurations array.
+func (c *clients) detectEmptyIPConfigPools(ctx context.Context, pools []nodePoolTarget) ([]nodePoolTarget, error) {
+	if len(pools) == 0 {
+		return nil, nil
+	}
+	all, err := c.listNodeRGVMSS(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var broken []nodePoolTarget
+	for _, p := range pools {
+		vmssName, vmss := matchPoolVMSS(all, p.name)
+		if vmss == nil {
+			logf("empty-ipconfig precheck: pool %s has no backing VMSS yet; skipping (fail-open)", p.name)
+			continue
+		}
+		nics, err := c.listVMSSInstanceNICs(ctx, vmssName)
+		if err != nil {
+			logf("WARN: empty-ipconfig precheck: listing NICs for pool %s VMSS %s failed: %v (skipping, fail-open)", p.name, vmssName, err)
+			continue
+		}
+		total, empty := countEmptyIPConfigs(nics)
+		if total == 0 {
+			logf("empty-ipconfig precheck: pool %s VMSS %s has no realized instance NICs yet; skipping (fail-open)", p.name, vmssName)
+			continue
+		}
+		if empty > 0 {
+			logf("empty-ipconfig precheck: pool %s VMSS %s has %d/%d instance NIC(s) with empty ipConfigurations — flagging broken (NRP null-pointer; pool must be recreated)", p.name, vmssName, empty, total)
+			t := p
+			t.emptyIPConfig = true
 			broken = append(broken, t)
 		}
 	}

--- a/dev-infrastructure/scripts/recreate-broken-pools/main.go
+++ b/dev-infrastructure/scripts/recreate-broken-pools/main.go
@@ -1676,14 +1676,23 @@ func (c *clients) detectAccelNetBrokenPools(ctx context.Context, swiftPools []no
 }
 
 // countEmptyIPConfigs reports how many of the given realized network interfaces
-// carry an empty ipConfigurations array, plus how many NICs were inspected. A
-// healthy NIC always has at least one ipConfiguration; an empty array is the
-// ARM-visible signature of the NRP null-pointer defect, where NRP brings the
-// (delegated) Swift NIC up but never populates its ipConfigurations. NICs with
-// nil Properties are not counted (indeterminate; fail-open).
+// carry an empty ipConfigurations array, plus how many NICs gave a usable
+// reading. A healthy NIC always has at least one ipConfiguration; an empty
+// (but present) array is the ARM-visible signature of the NRP null-pointer
+// defect, where NRP brings the (delegated) Swift NIC up but never populates its
+// ipConfigurations. This mirrors Steve's triage query semantics
+// (array_length(ipConfigurations) == 0), which matches only an explicit empty
+// array — Kusto array_length(null) is null, not 0.
+//
+// Fail-open on indeterminate reads: NICs with nil Properties, OR with a nil
+// (omitted/null) IPConfigurations slice, are skipped entirely — they do not
+// count toward total or empty. Only a non-nil, zero-length slice is counted as
+// the defect. In the Azure SDK an ARM `[]` deserializes to a non-nil empty
+// slice while null/omitted deserializes to nil, so this distinction is exactly
+// the array_length==0 vs null distinction.
 func countEmptyIPConfigs(nics []*armnetwork.Interface) (total, empty int) {
 	for _, nic := range nics {
-		if nic == nil || nic.Properties == nil {
+		if nic == nil || nic.Properties == nil || nic.Properties.IPConfigurations == nil {
 			continue
 		}
 		total++

--- a/dev-infrastructure/scripts/recreate-broken-pools/main_test.go
+++ b/dev-infrastructure/scripts/recreate-broken-pools/main_test.go
@@ -68,18 +68,6 @@ func TestParseEnvConfig_MinimalRequiredFields(t *testing.T) {
 	if c.subscriptionID != "sub-0001" {
 		t.Errorf("subscriptionID=%q", c.subscriptionID)
 	}
-	if c.threshold != defaultThreshold {
-		t.Errorf("threshold=%d want default %d", c.threshold, defaultThreshold)
-	}
-	if c.windowMin != defaultWindowMin {
-		t.Errorf("windowMin=%d want default %d", c.windowMin, defaultWindowMin)
-	}
-	if c.forcedEvidenceTimeoutMin != defaultForcedEvidenceTimeoutMin {
-		t.Errorf("forcedEvidenceTimeoutMin=%d want default %d", c.forcedEvidenceTimeoutMin, defaultForcedEvidenceTimeoutMin)
-	}
-	if c.forcedEvidenceThreshold != defaultForcedEvidenceThreshold {
-		t.Errorf("forcedEvidenceThreshold=%d want default %d", c.forcedEvidenceThreshold, defaultForcedEvidenceThreshold)
-	}
 	if c.dryRun {
 		t.Errorf("dryRun=true, want false by default")
 	}
@@ -106,121 +94,6 @@ func TestParseEnvConfig_MissingSubscriptionID(t *testing.T) {
 	_, err := parseEnvConfig(env)
 	if err == nil || !strings.Contains(err.Error(), "SUBSCRIPTION_ID") {
 		t.Errorf("expected SUBSCRIPTION_ID error, got %v", err)
-	}
-}
-
-func TestParseEnvConfig_CustomThresholdAndWindow(t *testing.T) {
-	env := envFromMap(map[string]string{
-		"CLUSTER_NAME":        "c",
-		"RESOURCE_GROUP":      "rg",
-		"SUBSCRIPTION_ID":     "sub",
-		"NODEPOOL_TAG":        "user",
-		"NRP_FAIL_THRESHOLD":  "25",
-		"NRP_FAIL_WINDOW_MIN": "30",
-	})
-	c, err := parseEnvConfig(env)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if c.threshold != 25 || c.windowMin != 30 {
-		t.Errorf("threshold=%d windowMin=%d", c.threshold, c.windowMin)
-	}
-}
-
-func TestParseEnvConfig_CustomForcedEvidence(t *testing.T) {
-	env := envFromMap(map[string]string{
-		"CLUSTER_NAME":                "c",
-		"RESOURCE_GROUP":              "rg",
-		"SUBSCRIPTION_ID":             "sub",
-		"NODEPOOL_TAG":                "user",
-		"FORCED_EVIDENCE_TIMEOUT_MIN": "45",
-		"FORCED_EVIDENCE_THRESHOLD":   "7",
-	})
-	c, err := parseEnvConfig(env)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if c.forcedEvidenceTimeoutMin != 45 || c.forcedEvidenceThreshold != 7 {
-		t.Errorf("forcedEvidenceTimeoutMin=%d forcedEvidenceThreshold=%d", c.forcedEvidenceTimeoutMin, c.forcedEvidenceThreshold)
-	}
-}
-
-func TestParseEnvConfig_InvalidForcedEvidence(t *testing.T) {
-	cases := []struct {
-		name string
-		key  string
-		v    string
-	}{
-		{"timeout_non_numeric", "FORCED_EVIDENCE_TIMEOUT_MIN", "abc"},
-		{"timeout_zero", "FORCED_EVIDENCE_TIMEOUT_MIN", "0"},
-		{"timeout_negative", "FORCED_EVIDENCE_TIMEOUT_MIN", "-1"},
-		{"threshold_non_numeric", "FORCED_EVIDENCE_THRESHOLD", "xyz"},
-		{"threshold_zero", "FORCED_EVIDENCE_THRESHOLD", "0"},
-		{"threshold_negative", "FORCED_EVIDENCE_THRESHOLD", "-2"},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			env := envFromMap(map[string]string{
-				"CLUSTER_NAME":    "c",
-				"RESOURCE_GROUP":  "rg",
-				"SUBSCRIPTION_ID": "sub",
-				"NODEPOOL_TAG":    "user",
-				tc.key:            tc.v,
-			})
-			if _, err := parseEnvConfig(env); err == nil {
-				t.Errorf("expected error for %s=%q", tc.key, tc.v)
-			}
-		})
-	}
-}
-
-func TestParseEnvConfig_InvalidThreshold(t *testing.T) {
-	cases := []struct {
-		name string
-		v    string
-	}{
-		{"non-numeric", "abc"},
-		{"zero", "0"},
-		{"negative", "-5"},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			env := envFromMap(map[string]string{
-				"CLUSTER_NAME":       "c",
-				"RESOURCE_GROUP":     "rg",
-				"SUBSCRIPTION_ID":    "sub",
-				"NODEPOOL_TAG":       "user",
-				"NRP_FAIL_THRESHOLD": tc.v,
-			})
-			if _, err := parseEnvConfig(env); err == nil {
-				t.Errorf("expected error for threshold=%q", tc.v)
-			}
-		})
-	}
-}
-
-func TestParseEnvConfig_InvalidWindow(t *testing.T) {
-	cases := []struct {
-		name string
-		v    string
-	}{
-		{"non-numeric", "xyz"},
-		{"zero", "0"},
-		{"negative", "-1"},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			env := envFromMap(map[string]string{
-				"CLUSTER_NAME":        "c",
-				"RESOURCE_GROUP":      "rg",
-				"SUBSCRIPTION_ID":     "sub",
-				"NODEPOOL_TAG":        "user",
-				"NRP_FAIL_WINDOW_MIN": tc.v,
-			})
-			if _, err := parseEnvConfig(env); err == nil {
-				t.Errorf("expected error for window=%q", tc.v)
-			}
-		})
 	}
 }
 
@@ -261,34 +134,8 @@ func TestParseEnvConfig_DryRunFlag(t *testing.T) {
 }
 
 // =============================================================================
-// evalNRPStorm..4
+// evalClusterState
 // =============================================================================
-
-func TestEvalNRPStorm(t *testing.T) {
-	cases := []struct {
-		name                string
-		failures, threshold int
-		wantPass            bool
-	}{
-		{"below_threshold", 9, 10, false},
-		{"at_threshold", 10, 10, true},
-		{"above_threshold", 50, 10, true},
-		{"zero_failures", 0, 10, false},
-		{"invalid_threshold_zero", 100, 0, false},
-		{"invalid_threshold_negative", 100, -1, false},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			pass, reason := evalNRPStorm(tc.failures, tc.threshold)
-			if pass != tc.wantPass {
-				t.Errorf("failures=%d threshold=%d: pass=%t want %t (%s)", tc.failures, tc.threshold, pass, tc.wantPass, reason)
-			}
-			if !pass && reason == "" {
-				t.Errorf("non-pass result must have a reason")
-			}
-		})
-	}
-}
 
 func TestEvalClusterState(t *testing.T) {
 	cases := []struct {
@@ -653,55 +500,6 @@ func TestAgentPoolForCreate_DoesNotMutateInput(t *testing.T) {
 	}
 	if _, ok := live.Properties.Tags["aks-managed-foo"]; !ok {
 		t.Errorf("live.Tags was mutated")
-	}
-}
-
-func TestAgentPoolForScaleUpTrigger(t *testing.T) {
-	live := mkLiveSystemPool()
-	count := int32(3)
-	minCount := int32(3)
-	maxCount := int32(6)
-	autoscale := true
-	live.Properties.Count = &count
-	live.Properties.MinCount = &minCount
-	live.Properties.MaxCount = &maxCount
-	live.Properties.EnableAutoScaling = &autoscale
-
-	body, err := agentPoolForScaleUpTrigger(live, "1.35.4")
-	if err != nil {
-		t.Fatalf("agentPoolForScaleUpTrigger() error = %v", err)
-	}
-	if got := *body.Properties.Count; got != 4 {
-		t.Errorf("Count=%d want 4", got)
-	}
-	if got := *body.Properties.MinCount; got != 4 {
-		t.Errorf("MinCount=%d want 4", got)
-	}
-	if got := *body.Properties.MaxCount; got != 6 {
-		t.Errorf("MaxCount=%d want 6", got)
-	}
-}
-
-func TestAgentPoolForScaleUpTriggerRaisesMaxCount(t *testing.T) {
-	live := mkLiveSystemPool()
-	count := int32(3)
-	minCount := int32(3)
-	maxCount := int32(3)
-	autoscale := true
-	live.Properties.Count = &count
-	live.Properties.MinCount = &minCount
-	live.Properties.MaxCount = &maxCount
-	live.Properties.EnableAutoScaling = &autoscale
-
-	body, err := agentPoolForScaleUpTrigger(live, "1.35.4")
-	if err != nil {
-		t.Fatalf("agentPoolForScaleUpTrigger() error = %v", err)
-	}
-	if got := *body.Properties.MinCount; got != 4 {
-		t.Errorf("MinCount=%d want 4", got)
-	}
-	if got := *body.Properties.MaxCount; got != 4 {
-		t.Errorf("MaxCount=%d want 4", got)
 	}
 }
 
@@ -1667,32 +1465,6 @@ func TestIsActivityLogAuthorizationError(t *testing.T) {
 	}
 }
 
-func TestIsDeletionInitiatedErr(t *testing.T) {
-	cases := []struct {
-		name string
-		err  error
-		want bool
-	}{
-		{"nil", nil, false},
-		{"plain_error", errors.New("boom"), false},
-		{"operation_not_allowed_deletion", fmt.Errorf("begin trigger: %w",
-			fmt.Errorf("deletion has been initiated: %w",
-				&azcore.ResponseError{StatusCode: http.StatusBadRequest, ErrorCode: "OperationNotAllowed"})), true},
-		{"operation_not_allowed_other_reason", fmt.Errorf("quota exceeded: %w",
-			&azcore.ResponseError{StatusCode: http.StatusBadRequest, ErrorCode: "OperationNotAllowed"}), false},
-		{"different_error_code_with_deletion_text", fmt.Errorf("deletion has been initiated: %w",
-			&azcore.ResponseError{StatusCode: http.StatusBadRequest, ErrorCode: "BadRequest"}), false},
-		{"not_response_error", fmt.Errorf("deletion has been initiated: %w", errors.New("not azcore")), false},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := isDeletionInitiatedErr(tc.err); got != tc.want {
-				t.Errorf("got %t want %t", got, tc.want)
-			}
-		})
-	}
-}
-
 // =============================================================================
 // evalPoolWedge  (per-pool provisioningState == "Failed")
 // =============================================================================
@@ -1751,10 +1523,6 @@ type mockOrchestrator struct {
 	deletePoolFn             func(ctx context.Context, pool string) error
 	recreateSystemFn         func(ctx context.Context, live *armcs.AgentPool) error
 	reconcileTagPutFn        func(ctx context.Context) error
-	triggerSystemReconcileFn func(ctx context.Context, live *armcs.AgentPool) error
-	pollForNRPEvidenceFn     func(ctx context.Context, timeout time.Duration, pollInterval time.Duration, windowMin int, threshold int) (int, error)
-	abortSystemReconcileFn   func(ctx context.Context) error
-	restorePoolSpecFn        func(ctx context.Context, target nodePoolTarget, live *armcs.AgentPool) error
 }
 
 func (m *mockOrchestrator) record(name string) { m.calls = append(m.calls, name) }
@@ -1784,13 +1552,10 @@ func (m *mockOrchestrator) detect(ctx context.Context) ([]nodePoolTarget, string
 			return nil, reason, err
 		}
 		if !pass {
-			if strings.Contains(reason, "NRP-KVS storm FAIL") {
-				return []nodePoolTarget{{name: "system", vmssPrefix: poolVMSSPrefix("system"), suspected: true}}, reason, nil
-			}
 			return nil, reason, err
 		}
 	}
-	return []nodePoolTarget{{name: "system", vmssPrefix: poolVMSSPrefix("system"), nrpFailures: 10}}, "", nil
+	return []nodePoolTarget{{name: "system", vmssPrefix: poolVMSSPrefix("system"), emptyIPConfig: true}}, "", nil
 }
 
 func (m *mockOrchestrator) dumpPreflight(ctx context.Context) error {
@@ -1883,46 +1648,6 @@ func (m *mockOrchestrator) reconcileTagPut(ctx context.Context) error {
 	return nil
 }
 
-func (m *mockOrchestrator) triggerPoolReconcile(ctx context.Context, target nodePoolTarget, live *armcs.AgentPool) error {
-	if target.name == "system" {
-		m.record("triggerSystemReconcile")
-	} else {
-		m.record("triggerPoolReconcile:" + target.name)
-	}
-	if m.triggerSystemReconcileFn != nil {
-		return m.triggerSystemReconcileFn(ctx, live)
-	}
-	return nil
-}
-
-func (m *mockOrchestrator) pollForNRPEvidence(ctx context.Context, target nodePoolTarget, timeout time.Duration, pollInterval time.Duration, windowMin int, threshold int) (int, error) {
-	m.record("pollForNRPEvidence")
-	if m.pollForNRPEvidenceFn != nil {
-		return m.pollForNRPEvidenceFn(ctx, timeout, pollInterval, windowMin, threshold)
-	}
-	return threshold, nil
-}
-
-func (m *mockOrchestrator) abortPoolReconcile(ctx context.Context, poolName string) error {
-	if poolName == "system" {
-		m.record("abortSystemReconcile")
-	} else {
-		m.record("abortPoolReconcile:" + poolName)
-	}
-	if m.abortSystemReconcileFn != nil {
-		return m.abortSystemReconcileFn(ctx)
-	}
-	return nil
-}
-
-func (m *mockOrchestrator) restorePoolSpec(ctx context.Context, target nodePoolTarget, live *armcs.AgentPool) error {
-	m.record("restorePoolSpec:" + target.name)
-	if m.restorePoolSpecFn != nil {
-		return m.restorePoolSpecFn(ctx, target, live)
-	}
-	return nil
-}
-
 func TestRunWith(t *testing.T) {
 	dummyErr := errors.New("boom")
 	tmpSystem := tempPoolName("system")
@@ -1997,138 +1722,6 @@ func TestRunWith(t *testing.T) {
 			wantCalls: []string{"ensureCluster", "dumpPreflight", "adoptLeftoverTempPools"},
 		},
 		{
-			name: "guard1_fail_dry_run_skips_forced_evidence",
-			cfg:  &config{clusterName: "c", resourceGroup: "rg", subscriptionID: "sub", cpVersion: "1.30.0", dryRun: true},
-			setup: func(m *mockOrchestrator) {
-				m.adoptLeftoverTempPoolsFn = func(context.Context) error {
-					return errors.New("dry run must not adopt temp pools")
-				}
-				m.detectFn = func(_ context.Context, _ int) (bool, string, error) {
-					return false, "NRP-KVS storm FAIL: only 0 NRP failures < 10", nil
-				}
-			},
-			wantCalls: []string{"ensureCluster", "dumpPreflight", "detect:1"},
-		},
-		{
-			name: "guard1_fail_forced_evidence_inconclusive",
-			cfg:  &config{clusterName: "c", resourceGroup: "rg", subscriptionID: "sub", cpVersion: "1.30.0", threshold: 10, forcedEvidenceTimeoutMin: 20, forcedEvidenceThreshold: 3},
-			setup: func(m *mockOrchestrator) {
-				m.detectFn = func(_ context.Context, _ int) (bool, string, error) {
-					return false, "NRP-KVS storm FAIL: only 0 NRP failures < 10", nil
-				}
-				m.pollForNRPEvidenceFn = func(context.Context, time.Duration, time.Duration, int, int) (int, error) {
-					return 2, nil
-				}
-			},
-			wantCalls: []string{
-				"ensureCluster", "dumpPreflight", "detect:1",
-				"snapshotSystem", "triggerSystemReconcile", "pollForNRPEvidence", "abortSystemReconcile", "restorePoolSpec:system",
-			},
-		},
-		{
-			name: "guard1_fail_forced_evidence_inconclusive_restore_failure_fails_closed",
-			cfg:  &config{clusterName: "c", resourceGroup: "rg", subscriptionID: "sub", cpVersion: "1.30.0", threshold: 10, forcedEvidenceTimeoutMin: 20, forcedEvidenceThreshold: 3},
-			setup: func(m *mockOrchestrator) {
-				m.detectFn = func(_ context.Context, _ int) (bool, string, error) {
-					return false, "NRP-KVS storm FAIL: only 0 NRP failures < 10", nil
-				}
-				m.pollForNRPEvidenceFn = func(context.Context, time.Duration, time.Duration, int, int) (int, error) {
-					return 2, nil
-				}
-				m.restorePoolSpecFn = func(ctx context.Context, _ nodePoolTarget, _ *armcs.AgentPool) error {
-					deadline, ok := ctx.Deadline()
-					if !ok {
-						t.Fatalf("restorePoolSpec context has no deadline")
-					}
-					remaining := time.Until(deadline)
-					if remaining <= 0 || remaining > forcedEvidenceRestoreTimeoutMin*time.Minute {
-						t.Fatalf("restorePoolSpec deadline remaining=%s, want <= %dm and > 0", remaining, forcedEvidenceRestoreTimeoutMin)
-					}
-					if remaining < (forcedEvidenceRestoreTimeoutMin*time.Minute)-10*time.Second {
-						t.Fatalf("restorePoolSpec deadline remaining=%s, want near %dm", remaining, forcedEvidenceRestoreTimeoutMin)
-					}
-					return dummyErr
-				}
-			},
-			wantErr: "restore forced-evidence pool spec for system:",
-			wantCalls: []string{
-				"ensureCluster", "dumpPreflight", "detect:1",
-				"snapshotSystem", "triggerSystemReconcile", "pollForNRPEvidence", "abortSystemReconcile", "restorePoolSpec:system",
-			},
-		},
-		{
-			name: "guard1_fail_forced_evidence_confirms_nrp",
-			cfg:  &config{clusterName: "c", resourceGroup: "rg", subscriptionID: "sub", cpVersion: "1.30.0", threshold: 10, forcedEvidenceTimeoutMin: 20, forcedEvidenceThreshold: 3},
-			setup: func(m *mockOrchestrator) {
-				m.detectFn = func(_ context.Context, n int) (bool, string, error) {
-					if n == 1 {
-						return false, "NRP-KVS storm FAIL: only 0 NRP failures < 10", nil
-					}
-					return false, "NRP-KVS storm FAIL: only 5 NRP failures < 10", nil
-				}
-				m.pollForNRPEvidenceFn = func(context.Context, time.Duration, time.Duration, int, int) (int, error) {
-					return 12, nil
-				}
-			},
-			wantCalls: []string{
-				"ensureCluster", "dumpPreflight", "detect:1",
-				"snapshotSystem", "triggerSystemReconcile", "pollForNRPEvidence", "abortSystemReconcile",
-				"bootstrapKube", "dumpPreflight",
-				"snapshotSystem", "maybeAbortLRO", "detect:2", "adoptLeftoverTempPool:system", "snapshotSystem",
-				"addTempPool:system",
-				"drainPool:system", "deletePool:system",
-				"recreateSystem",
-				"drainPool:" + tmpSystem, "deletePool:" + tmpSystem,
-				"reconcileTagPut", "dumpPostflight",
-			},
-		},
-		{
-			name: "guard1_fail_trigger_failure_exits_noop",
-			cfg:  &config{clusterName: "c", resourceGroup: "rg", subscriptionID: "sub", cpVersion: "1.30.0", threshold: 10},
-			setup: func(m *mockOrchestrator) {
-				m.detectFn = func(_ context.Context, _ int) (bool, string, error) {
-					return false, "NRP-KVS storm FAIL: only 0 NRP failures < 10", nil
-				}
-				m.triggerSystemReconcileFn = func(context.Context, *armcs.AgentPool) error {
-					return errors.New("conflict")
-				}
-			},
-			wantCalls: []string{
-				"ensureCluster", "dumpPreflight", "detect:1",
-				"snapshotSystem", "triggerSystemReconcile",
-			},
-		},
-		{
-			// Deletion-initiated: detect:1 sees 0 NRP events (suspected),
-			// forced evidence trigger is rejected with OperationNotAllowed
-			// "deletion has been initiated", pool is confirmed. detect:2
-			// also sees 0 NRP events (suspected again), but the
-			// deletion-initiated flag carries forward through Step 2b.
-			name: "guard1_fail_trigger_deletion_initiated_confirms",
-			cfg:  &config{clusterName: "c", resourceGroup: "rg", subscriptionID: "sub", cpVersion: "1.30.0", threshold: 10, forcedEvidenceTimeoutMin: 20, forcedEvidenceThreshold: 3},
-			setup: func(m *mockOrchestrator) {
-				m.detectFn = func(_ context.Context, _ int) (bool, string, error) {
-					return false, "NRP-KVS storm FAIL: only 0 NRP failures < 10", nil
-				}
-				m.triggerSystemReconcileFn = func(context.Context, *armcs.AgentPool) error {
-					return fmt.Errorf("begin trigger pool scale-up system: %w",
-						fmt.Errorf("Cannot run operation on node pool system because deletion has been initiated: %w",
-							&azcore.ResponseError{StatusCode: http.StatusBadRequest, ErrorCode: "OperationNotAllowed"}))
-				}
-			},
-			wantCalls: []string{
-				"ensureCluster", "dumpPreflight", "detect:1",
-				"snapshotSystem", "triggerSystemReconcile",
-				"bootstrapKube", "dumpPreflight",
-				"snapshotSystem", "maybeAbortLRO", "detect:2", "adoptLeftoverTempPool:system", "snapshotSystem",
-				"addTempPool:system",
-				"drainPool:system", "deletePool:system",
-				"recreateSystem",
-				"drainPool:" + tmpSystem, "deletePool:" + tmpSystem,
-				"reconcileTagPut", "dumpPostflight",
-			},
-		},
-		{
 			name: "detect_error",
 			cfg:  &config{clusterName: "c", resourceGroup: "rg", subscriptionID: "sub", cpVersion: "1.30.0"},
 			setup: func(m *mockOrchestrator) {
@@ -2166,26 +1759,25 @@ func TestRunWith(t *testing.T) {
 		},
 		{
 			// SKIP_GUARDS must not turn an empty confirmed-target list
-			// into a destructive run. Even though SKIP_GUARDS=true, the
-			// forced-evidence path is skipped (gated by !skipGuards), so
-			// targets = confirmed = []. We must exit no-op before Step 2
-			// (maybeAbortLRO) and Step 8 (reconcileTagPut) fire.
+			// into a destructive run. When detection finds no broken
+			// pool, targets = []. We must exit no-op before Step 2
+			// (maybeAbortLRO) and Step 8 (reconcileTagPut) fire, even
+			// with SKIP_GUARDS=true.
 			name: "skip_guards_pre_lro_empty_targets_exits_noop",
 			cfg:  &config{clusterName: "c", resourceGroup: "rg", subscriptionID: "sub", cpVersion: "1.30.0", skipGuards: true},
 			setup: func(m *mockOrchestrator) {
 				m.detectFn = func(_ context.Context, _ int) (bool, string, error) {
-					// NRP-KVS storm FAIL injects a suspected target via the
-					// mock, but with skipGuards=true the forced-evidence
-					// probe is skipped, so confirmed stays empty.
-					return false, "NRP-KVS storm FAIL: only 0 NRP failures < 10", nil
+					// No broken pool detected: the mock returns an empty
+					// target list, so there is nothing to recreate.
+					return false, "no broken pools detected", nil
 				}
 			},
 			wantCalls: []string{"ensureCluster", "dumpPreflight", "detect:1"},
 		},
 		{
 			// Same protection at the post-LRO recheck gate: detect:1
-			// confirms a target so we reach Step 2; detect:2 returns
-			// only a suspected target which gets filtered out. With
+			// confirms a target so we reach Step 2; detect:2 finds the
+			// pool healthy and returns an empty list. With
 			// skipGuards=true we must still exit before reconcileTagPut.
 			name: "skip_guards_post_lro_empty_targets_exits_noop",
 			cfg:  &config{clusterName: "c", resourceGroup: "rg", subscriptionID: "sub", cpVersion: "1.30.0", skipGuards: true},
@@ -2194,7 +1786,7 @@ func TestRunWith(t *testing.T) {
 					if n == 1 {
 						return true, "", nil
 					}
-					return false, "NRP-KVS storm FAIL after LRO", nil
+					return false, "no broken pools detected after LRO", nil
 				}
 			},
 			wantCalls: []string{

--- a/dev-infrastructure/scripts/recreate-broken-pools/main_test.go
+++ b/dev-infrastructure/scripts/recreate-broken-pools/main_test.go
@@ -307,6 +307,70 @@ func TestEvalNonTargetPoolsHealthy_TempPoolSkipped(t *testing.T) {
 }
 
 // =============================================================================
+// guardDecision
+// =============================================================================
+
+func TestGuardDecision(t *testing.T) {
+	cases := []struct {
+		name        string
+		guard       string
+		pass        bool
+		reason      string
+		skipGuards  bool
+		wantProceed bool
+		wantMsg     string
+	}{
+		{
+			name:        "pass_ignores_skip_guards",
+			guard:       "cluster state",
+			pass:        true,
+			reason:      "",
+			skipGuards:  false,
+			wantProceed: true,
+			wantMsg:     "cluster state PASS",
+		},
+		{
+			name:        "pass_with_skip_guards_still_pass",
+			guard:       "cluster safety",
+			pass:        true,
+			reason:      "",
+			skipGuards:  true,
+			wantProceed: true,
+			wantMsg:     "cluster safety PASS",
+		},
+		{
+			name:        "fail_without_override_halts",
+			guard:       "cluster state",
+			pass:        false,
+			reason:      "provisioningState=\"Creating\" rejected",
+			skipGuards:  false,
+			wantProceed: false,
+			wantMsg:     "provisioningState=\"Creating\" rejected",
+		},
+		{
+			name:        "fail_with_override_proceeds",
+			guard:       "cluster safety",
+			pass:        false,
+			reason:      "non-target pool unhealthy",
+			skipGuards:  true,
+			wantProceed: true,
+			wantMsg:     "SKIP_GUARDS=true — overriding cluster safety failure: non-target pool unhealthy",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			proceed, msg := guardDecision(tc.guard, tc.pass, tc.reason, tc.skipGuards)
+			if proceed != tc.wantProceed {
+				t.Errorf("proceed = %t, want %t", proceed, tc.wantProceed)
+			}
+			if msg != tc.wantMsg {
+				t.Errorf("msg = %q, want %q", msg, tc.wantMsg)
+			}
+		})
+	}
+}
+
+// =============================================================================
 // agentPoolForCreate
 // =============================================================================
 

--- a/dev-infrastructure/scripts/recreate-broken-pools/main_test.go
+++ b/dev-infrastructure/scripts/recreate-broken-pools/main_test.go
@@ -36,6 +36,8 @@ import (
 	armcompute "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
 	computefake "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6/fake"
 	armcs "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v6"
+	armnetwork "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
+	networkfake "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6/fake"
 )
 
 // =============================================================================
@@ -2829,4 +2831,119 @@ func TestDetectAccelNetBrokenPools(t *testing.T) {
 			t.Fatalf("empty input should return (nil,nil), got (%v,%v)", got, err)
 		}
 	})
+}
+
+// =============================================================================
+// empty-ipConfiguration detection (Steve Kuznetsov, MSFT): a pool whose backing
+// VMSS has realized instance NICs with an empty ipConfigurations array is broken
+// by the NRP null-pointer defect and must be recreated regardless of the
+// activity-log storm signal.
+// =============================================================================
+
+// nic builds a realized network interface with the given number of
+// ipConfigurations (n==0 reproduces the NRP null-pointer signature).
+func nic(ipConfigs int) *armnetwork.Interface {
+	cfgs := make([]*armnetwork.InterfaceIPConfiguration, 0, ipConfigs)
+	for i := 0; i < ipConfigs; i++ {
+		cfgs = append(cfgs, &armnetwork.InterfaceIPConfiguration{})
+	}
+	return &armnetwork.Interface{
+		Properties: &armnetwork.InterfacePropertiesFormat{IPConfigurations: cfgs},
+	}
+}
+
+func TestCountEmptyIPConfigs(t *testing.T) {
+	cases := []struct {
+		name      string
+		nics      []*armnetwork.Interface
+		wantTotal int
+		wantEmpty int
+	}{
+		{name: "nil_slice", nics: nil, wantTotal: 0, wantEmpty: 0},
+		{name: "all_healthy", nics: []*armnetwork.Interface{nic(1), nic(2)}, wantTotal: 2, wantEmpty: 0},
+		{name: "one_empty", nics: []*armnetwork.Interface{nic(1), nic(0)}, wantTotal: 2, wantEmpty: 1},
+		{name: "all_empty", nics: []*armnetwork.Interface{nic(0), nic(0)}, wantTotal: 2, wantEmpty: 2},
+		{name: "nil_nic_skipped", nics: []*armnetwork.Interface{nil, nic(0)}, wantTotal: 1, wantEmpty: 1},
+		{name: "nil_properties_skipped", nics: []*armnetwork.Interface{{Properties: nil}, nic(1)}, wantTotal: 1, wantEmpty: 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			total, empty := countEmptyIPConfigs(tc.nics)
+			if total != tc.wantTotal || empty != tc.wantEmpty {
+				t.Fatalf("got (total=%d empty=%d), want (total=%d empty=%d)", total, empty, tc.wantTotal, tc.wantEmpty)
+			}
+		})
+	}
+}
+
+// newFakeNICsClient builds a real armnetwork InterfacesClient whose VMSS-NIC
+// list reads from nicsByVMSS (keyed by VMSS name). A VMSS absent from the map
+// returns an empty NIC list, mirroring ARM for a scaled-to-zero VMSS.
+func newFakeNICsClient(t *testing.T, nicsByVMSS map[string][]*armnetwork.Interface) *armnetwork.InterfacesClient {
+	t.Helper()
+	srv := networkfake.InterfacesServer{
+		NewListVirtualMachineScaleSetNetworkInterfacesPager: func(_ string, vmssName string, _ *armnetwork.InterfacesClientListVirtualMachineScaleSetNetworkInterfacesOptions) (resp azfake.PagerResponder[armnetwork.InterfacesClientListVirtualMachineScaleSetNetworkInterfacesResponse]) {
+			resp.AddPage(http.StatusOK, armnetwork.InterfacesClientListVirtualMachineScaleSetNetworkInterfacesResponse{
+				InterfaceListResult: armnetwork.InterfaceListResult{Value: nicsByVMSS[vmssName]},
+			}, nil)
+			return
+		},
+	}
+	client, err := armnetwork.NewInterfacesClient(
+		"00000000-0000-0000-0000-000000000000",
+		&azfake.TokenCredential{},
+		&azcorearm.ClientOptions{ClientOptions: azcore.ClientOptions{
+			Transport: networkfake.NewInterfacesServerTransport(&srv),
+		}},
+	)
+	if err != nil {
+		t.Fatalf("build fake NICs client: %v", err)
+	}
+	return client
+}
+
+func TestDetectEmptyIPConfigPools(t *testing.T) {
+	const (
+		brokenVMSS  = "aks-userswft3-12345678-vmss"
+		healthyVMSS = "aks-system-87654321-vmss"
+		zeroVMSS    = "aks-userswft2-11112222-vmss"
+	)
+	store := newFakeVMSSStore(
+		namedVMSS(brokenVMSS, "userswft3", ptr(true)),
+		namedVMSS(healthyVMSS, "system", ptr(true)),
+		namedVMSS(zeroVMSS, "userswft2", ptr(true)),
+		// "nomvss" intentionally absent: no backing VMSS yet.
+	)
+	nicsByVMSS := map[string][]*armnetwork.Interface{
+		brokenVMSS:  {nic(1), nic(0)}, // one NIC lost its ipConfigurations
+		healthyVMSS: {nic(1), nic(1)}, // all NICs healthy
+		zeroVMSS:    {},               // no realized NICs yet
+	}
+	c := &clients{
+		cfg:  &config{nodeRG: "MC_rg_cluster_region"},
+		vmss: newFakeVMSSClient(t, store),
+		nics: newFakeNICsClient(t, nicsByVMSS),
+	}
+
+	pools := []nodePoolTarget{
+		{name: "userswft3"}, {name: "system"}, {name: "userswft2"}, {name: "nomvss"},
+	}
+	broken, err := c.detectEmptyIPConfigPools(context.Background(), pools)
+	if err != nil {
+		t.Fatalf("detectEmptyIPConfigPools: %v", err)
+	}
+	if len(broken) != 1 {
+		t.Fatalf("expected exactly 1 broken pool, got %d: %+v", len(broken), broken)
+	}
+	if broken[0].name != "userswft3" || !broken[0].emptyIPConfig {
+		t.Fatalf("got %+v, want pool=userswft3 emptyIPConfig=true", broken[0])
+	}
+}
+
+func TestDetectEmptyIPConfigPools_EmptyInput(t *testing.T) {
+	c := &clients{cfg: &config{nodeRG: "rg"}}
+	got, err := c.detectEmptyIPConfigPools(context.Background(), nil)
+	if err != nil || got != nil {
+		t.Fatalf("empty input should return (nil,nil), got (%v,%v)", got, err)
+	}
 }

--- a/dev-infrastructure/scripts/recreate-broken-pools/main_test.go
+++ b/dev-infrastructure/scripts/recreate-broken-pools/main_test.go
@@ -2457,6 +2457,11 @@ func TestCountEmptyIPConfigs(t *testing.T) {
 		{name: "all_empty", nics: []*armnetwork.Interface{nic(0), nic(0)}, wantTotal: 2, wantEmpty: 2},
 		{name: "nil_nic_skipped", nics: []*armnetwork.Interface{nil, nic(0)}, wantTotal: 1, wantEmpty: 1},
 		{name: "nil_properties_skipped", nics: []*armnetwork.Interface{{Properties: nil}, nic(1)}, wantTotal: 1, wantEmpty: 0},
+		// nil (omitted/null) IPConfigurations is indeterminate, NOT the
+		// empty-array defect: it is skipped entirely (not counted toward
+		// total or empty), matching array_length(null) != 0.
+		{name: "nil_ipconfigs_skipped", nics: []*armnetwork.Interface{{Properties: &armnetwork.InterfacePropertiesFormat{IPConfigurations: nil}}, nic(1)}, wantTotal: 1, wantEmpty: 0},
+		{name: "only_nil_ipconfigs_indeterminate", nics: []*armnetwork.Interface{{Properties: &armnetwork.InterfacePropertiesFormat{IPConfigurations: nil}}}, wantTotal: 0, wantEmpty: 0},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Closes [AROSLSRE-1190](https://issues.redhat.com/browse/AROSLSRE-1190)
Closes [AROSLSRE-1191](https://issues.redhat.com/browse/AROSLSRE-1191)

### What

Replaces the reactive NRP-KVS Activity-Log storm detection in `recreate-broken-pools` with direct, ARM-visible evidence of the NRP null-pointer defect. Two commits:

1. **Detect empty NIC `ipConfigurations`** ([AROSLSRE-1190](https://issues.redhat.com/browse/AROSLSRE-1190)) — an ARM-only precheck flags a pool broken when its backing VMSS has realized instance NICs with `len(ipConfigurations) == 0`, runs over all selected role-matched pools (incl. the system pool), and recreates it via the existing action path.
2. **Remove the NRP-KVS storm trigger + forced-evidence subsystem** ([AROSLSRE-1191](https://issues.redhat.com/browse/AROSLSRE-1191)) — detection now relies solely on the two ARM prechecks (accelerated-networking disabled + empty `ipConfigurations`); the provoke-then-observe storm machinery is deleted (`evalNRPStorm`, `triggerPoolReconcile`, `pollForNRPEvidence`, `abortPoolReconcile`, `restorePoolSpec`, the forced-evidence config + `NRP_FAIL_*`/`FORCED_EVIDENCE_TIMEOUT_MIN` env, and the step `automatedRetry`). Step timeout trimmed 150m → 130m.

### Why

The NRP null-pointer defect (ICM 798003653) leaves a node's delegated Swift NIC realized but with an empty `ipConfigurations` array, so kubelet never registers. The old trigger only fired once the NRP-KVS write storm appeared in the Activity Log — which happens **after** AKS reconciles the pool — so broken pools lingered and recovery crawled one pool per rollout. As @stevekuznetsov established, the empty `ipConfigurations` array is the **a-priori** signature: it tells us which pools *will* fail to scale up before scaling is attempted, so a single run recreates every affected pool at once. It is the ARM equivalent of Steve's triage query:

```kusto
NRP_Entities
| where EntityType contains "networkinterfaces"
| extend j = parse_json(JsonValue)
| where array_length(j.properties.ipConfigurations) == 0
```

### Testing

- `go build ./...`, `go vet ./...`, `gofmt -l` clean, `go test ./...` all green.
- Unit coverage of the new condition: `TestCountEmptyIPConfigs` (8 cases incl. nil-vs-empty/indeterminate), `TestDetectEmptyIPConfigPools` (selects exactly the pool whose VMSS NIC has empty `ipConfigurations`; healthy / scaled-to-zero / no-backing-VMSS skipped fail-open), `TestDetectEmptyIPConfigPools_EmptyInput`, plus `TestRunWith` (21 cases) for the full `run()` orchestration.
- **Live validation under the real EV2 RBAC** in a personal-dev mgmt cluster: ran the binary in-cluster as a workload identity holding **only** the pipeline identity's subscription Contributor+Reader, `DRY_RUN=true`. The full read-path (cluster Get, pool list, AN precheck VMSS list, **new empty-ipConfig VMSS-instance-NIC list**) completed with **no 403** and correctly no-op'd on a healthy cluster; `SKIP_GUARDS=true` confirmed the guard-bypass path. See the testing comment below for the timeline and why a live *positive* cannot be reproduced locally.

### Special notes for your reviewer

- The signal is on the **realized per-instance NICs** (`Microsoft.Network/networkInterfaces`), not the VMSS model template (whose `NetworkInterfaceConfigurations[].IPConfigurations` is always populated).
- **Fails open**: pools with no backing VMSS, no realized NICs yet (fresh/scaled-to-zero), or whose NIC listing errors are skipped — never flagged.
- **Coverage tradeoff**: the removed storm path caught *any* NetworkingInternalOperationError write storm — broader than empty-`ipConfig`. Auto-remediation now narrows to the null-pointer defect; a hypothetical non-null-pointer NRP-KVS wedge would no longer self-heal. This matches @stevekuznetsov guidance to recreate every pool with `array_length(ipConfigurations) == 0` directly.
- Adds `armnetwork/v6 v6.2.0` (already used by 4 other modules in the repo). Sibling to the accelerated-networking precheck ([AROSLSRE-1172](https://issues.redhat.com/browse/AROSLSRE-1172)).

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
