### PR TITLE
fix: prevent automatically selected version to be lower than previous selected version

### DIFF
--- a/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
@@ -108,8 +108,10 @@ func (c *controlPlaneDesiredVersionSyncer) CooldownChecker() controllerutil.Cool
 //  1. Fetch the customer's desired cluster configuration and service provider state
 //  2. (Active versions are updated by the control plane active version controller.)
 //  3. Compute the desired z-stream version based on upgrade logic (initial/z-stream/y-stream)
-//  4. If the computed desired version differs from the previously stored desired version:
+//  4. If the computed desired version is greater than the previously stored desired version:
 //     - Update the DesiredVersion field
+//     Only SRE-enforced rollback targets are permitted to decrease desired; automatic graph
+//     resolution must not lower a previously selected z-stream.
 //  5. Save the updated service provider cluster state
 func (c *controlPlaneDesiredVersionSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPClusterKey) error {
 	logger := utils.LoggerFromContext(ctx)
@@ -183,7 +185,10 @@ func (c *controlPlaneDesiredVersionSyncer) SyncOnce(ctx context.Context, key con
 
 	previousDesiredVersion := existingServiceProviderCluster.Spec.ControlPlaneVersion.DesiredVersion
 	desiredVersionUpdated := false
-	if desiredVersion != nil && (previousDesiredVersion == nil || !desiredVersion.EQ(*previousDesiredVersion)) {
+	// Only advance stored desired when the newly resolved version is greater, so graph changes
+	// cannot automatically select a lower z-stream. When rollback support is added, relax this
+	// so that only SRE-enforced rollback targets can decrease desired.
+	if desiredVersion != nil && (previousDesiredVersion == nil || desiredVersion.GT(*previousDesiredVersion)) {
 		logger.Info("Selected desired version", "desiredVersion", desiredVersion, "previousDesiredVersion", previousDesiredVersion)
 		existingServiceProviderCluster.Spec.ControlPlaneVersion.DesiredVersion = desiredVersion
 		desiredVersionUpdated = true

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller_test.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller_test.go
@@ -1039,14 +1039,15 @@ func TestControlPlaneDesiredVersionSyncer_SyncOnce(t *testing.T) {
 	const testChannelGroup = "stable"
 
 	tests := []struct {
-		name                string
-		customerVersion     string
-		controlPlaneVersion string
-		setupCincinnati     func(mc *cincinnati.MockClient)
-		wantSyncErr         bool
-		wantErrContains     string
-		wantDesiredVersion  *semver.Version
-		wantIntentFailed    *metav1.Condition
+		name                   string
+		customerVersion        string
+		controlPlaneVersion    string
+		previousDesiredVersion *semver.Version
+		setupCincinnati        func(mc *cincinnati.MockClient)
+		wantSyncErr            bool
+		wantErrContains        string
+		wantDesiredVersion     *semver.Version
+		wantIntentFailed       *metav1.Condition
 	}{
 		{
 			name:                "successful resolution persists desired version and sets IntentFailed False",
@@ -1060,6 +1061,29 @@ func TestControlPlaneDesiredVersionSyncer_SyncOnce(t *testing.T) {
 					nil,
 				).Times(1)
 				mc.EXPECT().GetUpdates(gomock.Any(), stableURI, "multi", "multi", "stable-4.20", semver.MustParse("4.19.22")).Return(
+					configv1.Release{}, nil, nil, &cvocincinnati.Error{Reason: "VersionNotFound"},
+				).Times(1)
+			},
+			wantDesiredVersion: ptr.To(semver.MustParse("4.19.22")),
+			wantIntentFailed: &metav1.Condition{
+				Type:   api.ControllerConditionTypeIntentFailed,
+				Status: metav1.ConditionFalse,
+				Reason: api.ControllerConditionReasonAsExpected,
+			},
+		},
+		{
+			name:                   "lower resolved desired does not replace higher previously selected desired",
+			customerVersion:        "4.19",
+			controlPlaneVersion:    "4.19.15",
+			previousDesiredVersion: ptr.To(semver.MustParse("4.19.22")),
+			setupCincinnati: func(mc *cincinnati.MockClient) {
+				mc.EXPECT().GetUpdates(gomock.Any(), stableURI, "multi", "multi", "stable-4.19", semver.MustParse("4.19.15")).Return(
+					configv1.Release{},
+					[]configv1.Release{{Version: "4.19.18"}},
+					nil,
+					nil,
+				).Times(1)
+				mc.EXPECT().GetUpdates(gomock.Any(), stableURI, "multi", "multi", "stable-4.20", semver.MustParse("4.19.18")).Return(
 					configv1.Release{}, nil, nil, &cvocincinnati.Error{Reason: "VersionNotFound"},
 				).Times(1)
 			},
@@ -1126,7 +1150,7 @@ func TestControlPlaneDesiredVersionSyncer_SyncOnce(t *testing.T) {
 			mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
 
 			createTestHCPClusterWithCustomerVersion(t, ctx, mockResourcesDBClient, tt.customerVersion, testChannelGroup)
-			createServiceProviderClusterWithVersion(t, ctx, mockResourcesDBClient, tt.controlPlaneVersion)
+			createServiceProviderClusterWithActiveAndDesiredVersion(t, ctx, mockResourcesDBClient, semver.MustParse(tt.controlPlaneVersion), tt.previousDesiredVersion)
 
 			mockCincinnati := cincinnati.NewMockClient(ctrl)
 			tt.setupCincinnati(mockCincinnati)
@@ -1183,4 +1207,30 @@ func TestControlPlaneDesiredVersionSyncer_SyncOnce(t *testing.T) {
 			}
 		})
 	}
+}
+
+func createServiceProviderClusterWithActiveAndDesiredVersion(t *testing.T, ctx context.Context, mockResourcesDBClient *databasetesting.MockResourcesDBClient, activeVersion semver.Version, desiredVersion *semver.Version) {
+	t.Helper()
+
+	serviceProviderCluster := &api.ServiceProviderCluster{
+		CosmosMetadata: api.CosmosMetadata{
+			ResourceID: api.Must(azcorearm.ParseResourceID(
+				api.ToServiceProviderClusterResourceIDString(testSubscriptionID, testResourceGroupName, testClusterName),
+			)),
+		},
+		Spec: api.ServiceProviderClusterSpec{
+			ControlPlaneVersion: api.ServiceProviderClusterSpecVersion{
+				DesiredVersion: desiredVersion,
+			},
+		},
+		Status: api.ServiceProviderClusterStatus{
+			ControlPlaneVersion: api.ServiceProviderClusterStatusVersion{
+				ActiveVersions: []api.HCPClusterActiveVersion{
+					{Version: ptr.To(activeVersion), State: configv1.CompletedUpdate},
+				},
+			},
+		},
+	}
+	_, err := mockResourcesDBClient.ServiceProviderClusters(testSubscriptionID, testResourceGroupName, testClusterName).Create(ctx, serviceProviderCluster, nil)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
### What

fix: prevent automatically selected version to be lower than previous selected version

### Why

When Cincinnati graph edges change between sync cycles, the control plane desired version controller could re-resolve to a lower z-stream patch even though the cluster had already been steered toward a higher target. That produced visible desired-version flapping in ServiceLogs.

This has been observed from the kusto logs e.g

https://dataexplorer.azure.com/clusters/hcp-dev-us-2.eastus2/databases/ServiceLogs?query=H4sIAAAAAAAAA3VRPU%2FDMBDd%2BytOXdpKcWSbNipBnWBkQAIxsCDHPqUpiR2dnVRF%2FHhcCk0rES%2B%2Bj%2Fee7549BrAuUGe1CpWzd5NC6Q%2B05tGVfvIFLbkd6gChatAH1bQJ1K5MQNedD0gJWBUbrdL4foxiw9mgKov0k0eF%2FRYJBz4UGPaIdm5UwGN1LrnMGM%2BYEC%2FiNhcy56uUn87bAtIU%2FkNKkXOei%2FWAXJzf%2Bp0NNhuY6YoLtltlcrm%2Bkcz3enaGxT3%2BpvUwpZLplh18IFQN69qSlEG2ZFKyZVaUvZ6OEEdZn8222Y2xnrGOtqIBg76iePdIPvo%2Fhr%2BPEbn6qVYWH06U14HhyMR9i8OFzcrr0e9LzZXCqdYS9pXr%2FLX6N%2F0Ch4EgAgAA

| Timestamp (UTC)           | Desired version | Previous desired |
|---------------------------|-----------------|------------------|
| 11/06/2026, 20:09:07.241  | 4.21.19         | —                |
| 11/06/2026, 20:09:07.674  | 4.21.19         | —                |
| 11/06/2026, 20:15:33.127  | 4.21.18         | 4.21.19          |
| 11/06/2026, 20:16:03.736  | 4.21.19         | 4.21.18          |
| 11/06/2026, 20:16:58.177  | 4.21.18         | 4.21.19          |
| 11/06/2026, 20:17:13.361  | 4.21.17         | 4.21.18          |
| 11/06/2026, 20:17:13.838  | 4.21.19         | 4.21.17          |
| 11/06/2026, 20:18:21.650  | 4.21.18         | 4.21.19          |
| 11/06/2026, 20:18:29.042  | 4.21.19         | 4.21.18          |
| 11/06/2026, 20:19:34.639  | 4.21.18         | 4.21.19          |

Root cause: desired version resolution used only active control plane versions. When Cincinnati graph edges changed, candidate intersection could shift to a lower patch even though the previously selected desired was still the intended target.

To ensure we don't unintentionally rollback a previous selected level, we guard against it and only update desired version when it's greater than previous desired version.


### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer


NOTE: We'll allow SRE enforced rollbacks/downgrade to a previous installed z level as part of https://redhat.atlassian.net/browse/ARO-22684 - at which point, we'll allow rollback only in this scenario

Supersedes https://github.com/Azure/ARO-HCP/pull/5631 as we want to start small and build out from this; https://github.com/Azure/ARO-HCP/pull/5631#discussion_r3404857494

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
