### PR TITLE
fix(infra): retry transient Graph owners failure in geneva-identities (AROSLSRE-1193)

### DIFF
--- a/dev-infrastructure/global-pipeline.yaml
+++ b/dev-infrastructure/global-pipeline.yaml
@@ -103,6 +103,15 @@ resourceGroups:
       step: global-kv-private-issuer
     - resourceGroup: singleton
       step: geneva-kv-private-issuer
+    # The Entra app/service-principal owners relationships are written through
+    # Microsoft Graph, which intermittently fails to commit the relationship and
+    # asks the caller to retry later. Retry the deployment on that transient error.
+    automatedRetry:
+      errorContainsAny:
+      - "Failed to update one or more relationships in 'owners'"
+      - "Please try again later"
+      maximumRetryCount: 3
+      durationBetweenRetries: 1m
   - name: mise-identity
     action: ARM
     template: templates/mise-identity.bicep

--- a/dev-infrastructure/global-pipeline.yaml
+++ b/dev-infrastructure/global-pipeline.yaml
@@ -109,7 +109,6 @@ resourceGroups:
     automatedRetry:
       errorContainsAny:
       - "Failed to update one or more relationships in 'owners'"
-      - "Please try again later"
       maximumRetryCount: 3
       durationBetweenRetries: 1m
   - name: mise-identity


### PR DESCRIPTION
<!-- https://issues.redhat.com/browse/AROSLSRE-1193 -->

### What

Add an `automatedRetry` block to the `geneva-identities` ARM step in `dev-infrastructure/global-pipeline.yaml` so the global rollout retries on the transient Microsoft Graph `owners` relationship error (up to 3 times, 1 minute apart).

### Why

The `geneva-actions-entra-app` Entra app/service-principal is created via `Microsoft.Graph/applications@beta` in `dev-infrastructure/modules/entra/app.bicep`, which writes `owners.relationships`. Graph intermittently fails to commit that relationship and asks the caller to retry, failing the whole ARM deployment and the rollout step:

```text
Code: BadRequest
Message: Failed to update one or more relationships in 'owners'. Please try again later.
Target: /resources/entraApp; inside Global.singleton.geneva-identities-uksouth-1 step
```

This is a known eventually-consistent Graph behaviour, so an automated retry is the right fix and matches the existing pipeline retry convention used elsewhere in the repo (e.g. `kube-applier`, `admin`, `acm`).

### Testing

`make validate-config-pipelines` passes (schema validation of all pipelines including `global-pipeline.yaml`).

### Special notes for your reviewer

`automatedRetry` is part of `stepMeta` in the `pipeline.schema.v1` schema and is valid on ARM steps; it maps to EV2 automated step retry. The matched error strings are taken verbatim from the failing deployment message.

### PR Checklist

- [x] Changes validated locally (`make validate-config-pipelines`)
- [x] Linked to Jira issue [AROSLSRE-1193](https://redhat.atlassian.net/browse/AROSLSRE-1193)
