### PR TITLE
fix: Add npm ci target and dependency on all npm run commands 

### DIFF
--- a/api/.gitignore
+++ b/api/.gitignore
@@ -1,0 +1,1 @@
+.npm-install.stamp

--- a/api/Makefile
+++ b/api/Makefile
@@ -24,12 +24,12 @@ endif
 generate: swagger models
 
 .PHONY: swagger
-swagger:
+swagger: .npm-install.stamp
 	npm run format-check
 	npm run compile
 
 .PHONY: models
-models: $(GOIMPORTS)
+models: .npm-install.stamp $(GOIMPORTS)
 	VERSION=${VERSION} npm run models
 	$(GOIMPORTS) -w -local github.com/Azure/ARO-HCP ../internal
 	# Remove the client API, leave only the constants and models.
@@ -39,12 +39,12 @@ models: $(GOIMPORTS)
 	rm $(RM_FORCE) ${AUTOREST_OUTPUT_DIR}/responses.go
 
 .PHONY: testsdk
-testsdk: $(GOIMPORTS)
+testsdk: .npm-install.stamp $(GOIMPORTS)
 	VERSION=${VERSION} npm run testsdk
 	$(GOIMPORTS) -w -local github.com/Azure/ARO-HCP ../test/sdk
 
 .PHONY: fmt
-fmt:
+fmt: .npm-install.stamp
 	npm run format
 
 .PHONY: validate-examples
@@ -73,3 +73,7 @@ lint-openapi:
 			--tag=package-$$version \
 			$(SPEC_BASE_DIR)/readme.md || exit 1; \
 	done
+
+.npm-install.stamp: package-lock.json
+	npm ci
+	touch $@


### PR DESCRIPTION
No jira

### What

Adds an `npm ci` dependency on any `npm run` commands as we need the dependencies installed in order to succeed first.


### Why

if dependencies are updated, this will force the user to have the latest dependencies for generation.  

### Testing

api validation should cover this from a prowjob
### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
