### PR TITLE
Switch ServiceProvider reads in controllers to cached listers

### DIFF
--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -539,7 +539,6 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 	clusterServiceMatchingClusterController := mismatchcontrollers.NewClusterServiceClusterMatchingController(b.options.ResourcesDBClient, subscriptionLister, b.options.ClustersServiceClient)
 	alwaysSuccessClusterValidationController := validationcontrollers.NewClusterValidationController(
 		validations.NewAlwaysSuccessValidation(),
-		activeOperationLister,
 		b.options.ResourcesDBClient,
 		serviceProviderClusterLister,
 		backendInformers,
@@ -555,7 +554,6 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		billingcontrollers.NewCreateBillingDocController(b.clock, b.options.AzureLocation, b.options.ResourcesDBClient, b.options.BillingDBClient, clusterLister, billingLister))
 	controlPlaneActiveVersionController := upgradecontrollers.NewControlPlaneActiveVersionController(
 		b.options.ResourcesDBClient,
-		activeOperationLister,
 		serviceProviderClusterLister,
 		backendInformers,
 		unionKubeApplierInformers,
@@ -654,14 +652,12 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 	)
 	createServiceProviderClusterController := controllers.NewCreateServiceProviderClusterController(
 		b.options.ResourcesDBClient,
-		activeOperationLister,
 		clusterLister,
 		serviceProviderClusterLister,
 		backendInformers,
 	)
 	createServiceProviderNodePoolController := controllers.NewCreateServiceProviderNodePoolController(
 		b.options.ResourcesDBClient,
-		activeOperationLister,
 		nodePoolLister,
 		serviceProviderNodePoolLister,
 		backendInformers,
@@ -677,7 +673,6 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 
 	azureRPRegistrationValidationController := validationcontrollers.NewClusterValidationController(
 		validations.NewAzureResourceProvidersRegistrationValidation(b.options.FPAClientBuilder),
-		activeOperationLister,
 		b.options.ResourcesDBClient,
 		serviceProviderClusterLister,
 		backendInformers,
@@ -685,7 +680,6 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 	)
 	azureClusterResourceGroupExistenceValidationController := validationcontrollers.NewClusterValidationController(
 		validations.NewAzureClusterResourceGroupExistenceValidation(b.options.FPAClientBuilder),
-		activeOperationLister,
 		b.options.ResourcesDBClient,
 		serviceProviderClusterLister,
 		backendInformers,
@@ -693,7 +687,6 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 	)
 	azureClusterManagedIdentitiesExistenceValidationController := validationcontrollers.NewClusterValidationController(
 		validations.NewAzureClusterManagedIdentitiesExistenceValidation(b.options.SMIClientBuilder),
-		activeOperationLister,
 		b.options.ResourcesDBClient,
 		serviceProviderClusterLister,
 		backendInformers,
@@ -715,7 +708,6 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 	triggerNodePoolUpgradeController := upgradecontrollers.NewTriggerNodePoolUpgradeController(
 		b.options.ResourcesDBClient,
 		b.options.ClustersServiceClient,
-		activeOperationLister,
 		serviceProviderNodePoolLister,
 		backendInformers,
 		unionKubeApplierInformers,

--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -426,6 +426,8 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		"ExternalAuthMetrics", externalAuthInformer, externalAuthHandler)
 
 	_, controllerLister := backendInformers.Controllers()
+	_, serviceProviderClusterLister := backendInformers.ServiceProviderClusters()
+	_, serviceProviderNodePoolLister := backendInformers.ServiceProviderNodePools()
 
 	subscriptionNonClusterDataDumpController := datadumpcontrollers.NewSubscriptionNonClusterDataDumpController(b.options.ResourcesDBClient, backendInformers)
 	clusterRecursiveDataDumpController := datadumpcontrollers.NewClusterRecursiveDataDumpController(b.options.ResourcesDBClient, b.options.KubeApplierDBClients, managementClusterLister, activeOperationLister, backendInformers, unionKubeApplierInformers)
@@ -537,7 +539,9 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 	clusterServiceMatchingClusterController := mismatchcontrollers.NewClusterServiceClusterMatchingController(b.options.ResourcesDBClient, subscriptionLister, b.options.ClustersServiceClient)
 	alwaysSuccessClusterValidationController := validationcontrollers.NewClusterValidationController(
 		validations.NewAlwaysSuccessValidation(),
+		activeOperationLister,
 		b.options.ResourcesDBClient,
+		serviceProviderClusterLister,
 		backendInformers,
 		unionKubeApplierInformers,
 	)
@@ -551,6 +555,8 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		billingcontrollers.NewCreateBillingDocController(b.clock, b.options.AzureLocation, b.options.ResourcesDBClient, b.options.BillingDBClient, clusterLister, billingLister))
 	controlPlaneActiveVersionController := upgradecontrollers.NewControlPlaneActiveVersionController(
 		b.options.ResourcesDBClient,
+		activeOperationLister,
+		serviceProviderClusterLister,
 		backendInformers,
 		unionKubeApplierInformers,
 		unionReadDesireLister,
@@ -560,6 +566,8 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		b.options.ResourcesDBClient,
 		b.options.ClustersServiceClient,
 		activeOperationLister,
+		serviceProviderClusterLister,
+		serviceProviderNodePoolLister,
 		backendInformers,
 		unionKubeApplierInformers,
 		unionReadDesireLister,
@@ -570,6 +578,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		b.options.ResourcesDBClient,
 		b.options.ClustersServiceClient,
 		activeOperationLister,
+		serviceProviderClusterLister,
 		backendInformers,
 		unionKubeApplierInformers,
 	)
@@ -627,11 +636,13 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 
 	createClusterScopedReadDesiresController := controllers.NewCreateClusterScopedReadDesiresController(
 		activeOperationLister, b.options.ResourcesDBClient, b.options.KubeApplierDBClients,
+		serviceProviderClusterLister,
 		backendInformers, b.options.MaestroSourceEnvironmentIdentifier,
 	)
 
 	createNodePoolScopedReadDesiresController := controllers.NewCreateNodePoolScopedReadDesiresController(
 		activeOperationLister, b.options.ResourcesDBClient, b.options.KubeApplierDBClients,
+		serviceProviderClusterLister,
 		backendInformers, b.options.MaestroSourceEnvironmentIdentifier,
 	)
 
@@ -640,6 +651,20 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		b.options.KubeApplierDBClients,
 		backendInformers,
 		5*time.Minute,
+	)
+	createServiceProviderClusterController := controllers.NewCreateServiceProviderClusterController(
+		b.options.ResourcesDBClient,
+		activeOperationLister,
+		clusterLister,
+		serviceProviderClusterLister,
+		backendInformers,
+	)
+	createServiceProviderNodePoolController := controllers.NewCreateServiceProviderNodePoolController(
+		b.options.ResourcesDBClient,
+		activeOperationLister,
+		nodePoolLister,
+		serviceProviderNodePoolLister,
+		backendInformers,
 	)
 
 	cleanOrphanedClusterManagedResourceGroupController := controllers.NewCleanOrphanedClusterManagedResourceGroupController(
@@ -652,19 +677,25 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 
 	azureRPRegistrationValidationController := validationcontrollers.NewClusterValidationController(
 		validations.NewAzureResourceProvidersRegistrationValidation(b.options.FPAClientBuilder),
+		activeOperationLister,
 		b.options.ResourcesDBClient,
+		serviceProviderClusterLister,
 		backendInformers,
 		unionKubeApplierInformers,
 	)
 	azureClusterResourceGroupExistenceValidationController := validationcontrollers.NewClusterValidationController(
 		validations.NewAzureClusterResourceGroupExistenceValidation(b.options.FPAClientBuilder),
+		activeOperationLister,
 		b.options.ResourcesDBClient,
+		serviceProviderClusterLister,
 		backendInformers,
 		unionKubeApplierInformers,
 	)
 	azureClusterManagedIdentitiesExistenceValidationController := validationcontrollers.NewClusterValidationController(
 		validations.NewAzureClusterManagedIdentitiesExistenceValidation(b.options.SMIClientBuilder),
+		activeOperationLister,
 		b.options.ResourcesDBClient,
+		serviceProviderClusterLister,
 		backendInformers,
 		unionKubeApplierInformers,
 	)
@@ -684,6 +715,8 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 	triggerNodePoolUpgradeController := upgradecontrollers.NewTriggerNodePoolUpgradeController(
 		b.options.ResourcesDBClient,
 		b.options.ClustersServiceClient,
+		activeOperationLister,
+		serviceProviderNodePoolLister,
 		backendInformers,
 		unionKubeApplierInformers,
 	)
@@ -873,6 +906,8 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 				go nodePoolActiveVersionController.Run(ctx, 20)
 				go createClusterScopedReadDesiresController.Run(ctx, 20)
 				go createNodePoolScopedReadDesiresController.Run(ctx, 20)
+				go createServiceProviderClusterController.Run(ctx, 20)
+				go createServiceProviderNodePoolController.Run(ctx, 20)
 				go cleanOrphanedClusterManagedResourceGroupController.Run(ctx, 20)
 				go triggerNodePoolUpgradeController.Run(ctx, 20)
 				go nodePoolDeletionClusterServiceDeleteDispatchController.Run(ctx, 20)

--- a/backend/pkg/controllers/create_cluster_scoped_read_desires_controller.go
+++ b/backend/pkg/controllers/create_cluster_scoped_read_desires_controller.go
@@ -46,8 +46,9 @@ import (
 type createClusterScopedReadDesiresSyncer struct {
 	activeOperationLister listers.ActiveOperationLister
 
-	resourcesDBClient    database.ResourcesDBClient
-	kubeApplierDBClients database.KubeApplierDBClients
+	resourcesDBClient            database.ResourcesDBClient
+	kubeApplierDBClients         database.KubeApplierDBClients
+	serviceProviderClusterLister listers.ServiceProviderClusterLister
 
 	// hostedClusterNamespaceEnvIdentifier is the "envName" segment of the
 	// CDNamespace (ocm-<envName>-<csClusterID>). Historically the maestro
@@ -66,6 +67,7 @@ func NewCreateClusterScopedReadDesiresController(
 	activeOperationLister listers.ActiveOperationLister,
 	resourcesDBClient database.ResourcesDBClient,
 	kubeApplierDBClients database.KubeApplierDBClients,
+	serviceProviderClusterLister listers.ServiceProviderClusterLister,
 	informers informers.BackendInformers,
 	hostedClusterNamespaceEnvIdentifier string,
 ) controllerutils.Controller {
@@ -73,6 +75,7 @@ func NewCreateClusterScopedReadDesiresController(
 		activeOperationLister:               activeOperationLister,
 		resourcesDBClient:                   resourcesDBClient,
 		kubeApplierDBClients:                kubeApplierDBClients,
+		serviceProviderClusterLister:        serviceProviderClusterLister,
 		hostedClusterNamespaceEnvIdentifier: hostedClusterNamespaceEnvIdentifier,
 	}
 
@@ -117,11 +120,15 @@ func (c *createClusterScopedReadDesiresSyncer) SyncOnce(ctx context.Context, key
 	// ServiceProviderCluster.Status.ManagementClusterResourceID; until that
 	// lands we have nowhere to write the ReadDesire, so skip and wait for
 	// the next reconcile cycle.
-	spc, err := database.GetOrCreateServiceProviderCluster(ctx, c.resourcesDBClient, key.GetResourceID())
-	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to get or create ServiceProviderCluster: %w", err))
+	serviceProviderCluster, err := c.serviceProviderClusterLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if database.IsNotFoundError(err) {
+		// CreateServiceProviderCluster will populate it; we'll be re-enqueued via the ServiceProviderCluster informer.
+		return nil
 	}
-	mcResourceID := spc.Status.ManagementClusterResourceID
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get ServiceProviderCluster: %w", err))
+	}
+	mcResourceID := serviceProviderCluster.Status.ManagementClusterResourceID
 	if mcResourceID == nil {
 		return nil
 	}

--- a/backend/pkg/controllers/create_nodepool_scoped_read_desires_controller.go
+++ b/backend/pkg/controllers/create_nodepool_scoped_read_desires_controller.go
@@ -41,8 +41,9 @@ import (
 type createNodePoolScopedReadDesiresSyncer struct {
 	activeOperationLister listers.ActiveOperationLister
 
-	resourcesDBClient    database.ResourcesDBClient
-	kubeApplierDBClients database.KubeApplierDBClients
+	resourcesDBClient            database.ResourcesDBClient
+	kubeApplierDBClients         database.KubeApplierDBClients
+	serviceProviderClusterLister listers.ServiceProviderClusterLister
 
 	hostedClusterNamespaceEnvIdentifier string
 }
@@ -53,6 +54,7 @@ func NewCreateNodePoolScopedReadDesiresController(
 	activeOperationLister listers.ActiveOperationLister,
 	resourcesDBClient database.ResourcesDBClient,
 	kubeApplierDBClients database.KubeApplierDBClients,
+	serviceProviderClusterLister listers.ServiceProviderClusterLister,
 	informers informers.BackendInformers,
 	hostedClusterNamespaceEnvIdentifier string,
 ) controllerutils.Controller {
@@ -60,6 +62,7 @@ func NewCreateNodePoolScopedReadDesiresController(
 		activeOperationLister:               activeOperationLister,
 		resourcesDBClient:                   resourcesDBClient,
 		kubeApplierDBClients:                kubeApplierDBClients,
+		serviceProviderClusterLister:        serviceProviderClusterLister,
 		hostedClusterNamespaceEnvIdentifier: hostedClusterNamespaceEnvIdentifier,
 	}
 
@@ -92,16 +95,19 @@ func (c *createNodePoolScopedReadDesiresSyncer) SyncOnce(ctx context.Context, ke
 	// Resolve the management cluster via the parent cluster's
 	// ServiceProviderCluster. Skip if the placement-sync controller hasn't
 	// populated it yet.
-	clusterKey := controllerutils.HCPClusterKey{
-		SubscriptionID:    key.SubscriptionID,
-		ResourceGroupName: key.ResourceGroupName,
-		HCPClusterName:    key.HCPClusterName,
+	serviceProviderCluster, err := c.serviceProviderClusterLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if database.IsNotFoundError(err) {
+		// CreateServiceProviderCluster will populate it. NodePoolWatchingController
+		// does not watch the ServiceProviderCluster informer (an SPC arrival
+		// can't be walked down to a specific node pool), so the next attempt
+		// happens on the controller's periodic resync or the next NodePool /
+		// ServiceProviderNodePool event for this node pool.
+		return nil
 	}
-	spc, err := database.GetOrCreateServiceProviderCluster(ctx, c.resourcesDBClient, clusterKey.GetResourceID())
 	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to get or create ServiceProviderCluster: %w", err))
+		return utils.TrackError(fmt.Errorf("failed to get ServiceProviderCluster: %w", err))
 	}
-	mcResourceID := spc.Status.ManagementClusterResourceID
+	mcResourceID := serviceProviderCluster.Status.ManagementClusterResourceID
 	if mcResourceID == nil {
 		return nil
 	}

--- a/backend/pkg/controllers/create_service_provider_cluster_controller.go
+++ b/backend/pkg/controllers/create_service_provider_cluster_controller.go
@@ -22,7 +22,6 @@ import (
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
 	"github.com/Azure/ARO-HCP/backend/pkg/informers"
 	"github.com/Azure/ARO-HCP/backend/pkg/listers"
-	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
@@ -37,7 +36,6 @@ import (
 // have the document in hand to validate the request before any controller
 // has a chance to run.
 type createServiceProviderClusterSyncer struct {
-	cooldownChecker              controllerutil.CooldownChecker
 	resourcesDBClient            database.ResourcesDBClient
 	clusterLister                listers.ClusterLister
 	serviceProviderClusterLister listers.ServiceProviderClusterLister
@@ -49,13 +47,11 @@ var _ controllerutils.ClusterSyncer = (*createServiceProviderClusterSyncer)(nil)
 // missing ServiceProviderCluster documents.
 func NewCreateServiceProviderClusterController(
 	resourcesDBClient database.ResourcesDBClient,
-	activeOperationLister listers.ActiveOperationLister,
 	clusterLister listers.ClusterLister,
 	serviceProviderClusterLister listers.ServiceProviderClusterLister,
 	backendInformers informers.BackendInformers,
 ) controllerutils.Controller {
 	syncer := &createServiceProviderClusterSyncer{
-		cooldownChecker:              controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
 		resourcesDBClient:            resourcesDBClient,
 		clusterLister:                clusterLister,
 		serviceProviderClusterLister: serviceProviderClusterLister,
@@ -69,10 +65,6 @@ func NewCreateServiceProviderClusterController(
 		1*time.Minute,
 		syncer,
 	)
-}
-
-func (c *createServiceProviderClusterSyncer) CooldownChecker() controllerutil.CooldownChecker {
-	return c.cooldownChecker
 }
 
 // SyncOnce creates a ServiceProviderCluster for the given HCPCluster when one

--- a/backend/pkg/controllers/create_service_provider_cluster_controller.go
+++ b/backend/pkg/controllers/create_service_provider_cluster_controller.go
@@ -1,0 +1,111 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// createServiceProviderClusterSyncer ensures a ServiceProviderCluster document
+// exists for every HCPCluster. Consumer backend controllers (validation,
+// version, etc.) read the ServiceProviderCluster through a cached lister and
+// bail out when it is missing; this syncer is the single place in backend
+// controllers that actually creates the document, so the GetOrCreate pattern
+// stays in one well-known location. The frontend admission path still calls
+// database.GetOrCreateServiceProviderCluster directly because admission must
+// have the document in hand to validate the request before any controller
+// has a chance to run.
+type createServiceProviderClusterSyncer struct {
+	cooldownChecker              controllerutil.CooldownChecker
+	resourcesDBClient            database.ResourcesDBClient
+	clusterLister                listers.ClusterLister
+	serviceProviderClusterLister listers.ServiceProviderClusterLister
+}
+
+var _ controllerutils.ClusterSyncer = (*createServiceProviderClusterSyncer)(nil)
+
+// NewCreateServiceProviderClusterController wires the controller that creates
+// missing ServiceProviderCluster documents.
+func NewCreateServiceProviderClusterController(
+	resourcesDBClient database.ResourcesDBClient,
+	activeOperationLister listers.ActiveOperationLister,
+	clusterLister listers.ClusterLister,
+	serviceProviderClusterLister listers.ServiceProviderClusterLister,
+	backendInformers informers.BackendInformers,
+) controllerutils.Controller {
+	syncer := &createServiceProviderClusterSyncer{
+		cooldownChecker:              controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		resourcesDBClient:            resourcesDBClient,
+		clusterLister:                clusterLister,
+		serviceProviderClusterLister: serviceProviderClusterLister,
+	}
+
+	return controllerutils.NewClusterWatchingController(
+		"CreateServiceProviderCluster",
+		resourcesDBClient,
+		backendInformers,
+		nil,
+		1*time.Minute,
+		syncer,
+	)
+}
+
+func (c *createServiceProviderClusterSyncer) CooldownChecker() controllerutil.CooldownChecker {
+	return c.cooldownChecker
+}
+
+// SyncOnce creates a ServiceProviderCluster for the given HCPCluster when one
+// does not already exist. The lister is consulted first so steady-state runs
+// avoid a Cosmos round-trip; if it is missing, GetOrCreate is called and any
+// 409 conflict is handled by the underlying helper.
+//
+// Once the parent cluster is marked for deletion the cluster deletion
+// pipeline removes the ServiceProviderCluster as a child resource; recreating
+// it here would prevent that pipeline from converging, so we short-circuit.
+func (c *createServiceProviderClusterSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPClusterKey) error {
+	existingCluster, err := c.clusterLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get HCPCluster from lister: %w", err))
+	}
+	if existingCluster.ServiceProviderProperties.DeletionTimestamp != nil {
+		return nil
+	}
+
+	_, err = c.serviceProviderClusterLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if err == nil {
+		return nil
+	}
+	if !database.IsNotFoundError(err) {
+		return utils.TrackError(fmt.Errorf("failed to get ServiceProviderCluster from lister: %w", err))
+	}
+
+	if _, err := database.GetOrCreateServiceProviderCluster(ctx, c.resourcesDBClient, key.GetResourceID()); err != nil {
+		return utils.TrackError(fmt.Errorf("failed to create ServiceProviderCluster: %w", err))
+	}
+
+	return nil
+}

--- a/backend/pkg/controllers/create_service_provider_cluster_controller_test.go
+++ b/backend/pkg/controllers/create_service_provider_cluster_controller_test.go
@@ -1,0 +1,239 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+const (
+	creatorTestSubscriptionID = "00000000-0000-0000-0000-000000000000"
+	creatorTestResourceGroup  = "test-rg"
+	creatorTestClusterName    = "test-cluster"
+)
+
+func newCreatorTestClusterKey() controllerutils.HCPClusterKey {
+	return controllerutils.HCPClusterKey{
+		SubscriptionID:    creatorTestSubscriptionID,
+		ResourceGroupName: creatorTestResourceGroup,
+		HCPClusterName:    creatorTestClusterName,
+	}
+}
+
+func newCreatorTestCluster(t *testing.T) *api.HCPOpenShiftCluster {
+	t.Helper()
+	resourceID := api.Must(api.ToClusterResourceID(creatorTestSubscriptionID, creatorTestResourceGroup, creatorTestClusterName))
+	return &api.HCPOpenShiftCluster{
+		CosmosMetadata: arm.CosmosMetadata{ResourceID: resourceID},
+		TrackedResource: arm.TrackedResource{
+			Resource: arm.Resource{
+				ID:   resourceID,
+				Name: creatorTestClusterName,
+				Type: api.ClusterResourceType.String(),
+			},
+			Location: "eastus",
+		},
+	}
+}
+
+// boomClusterLister returns the configured error from every Get call. Used to
+// exercise the "lister error is propagated" branch.
+type boomClusterLister struct {
+	listers.ClusterLister
+	err error
+}
+
+func (b *boomClusterLister) Get(_ context.Context, _, _, _ string) (*api.HCPOpenShiftCluster, error) {
+	return nil, b.err
+}
+
+// boomServiceProviderClusterLister returns the configured error from every
+// Get call.
+type boomServiceProviderClusterLister struct {
+	listers.ServiceProviderClusterLister
+	err error
+}
+
+func (b *boomServiceProviderClusterLister) Get(_ context.Context, _, _, _ string) (*api.ServiceProviderCluster, error) {
+	return nil, b.err
+}
+
+func TestCreateServiceProviderClusterSyncer_SyncOnce(t *testing.T) {
+	clusterResourceID := api.Must(api.ToClusterResourceID(creatorTestSubscriptionID, creatorTestResourceGroup, creatorTestClusterName))
+	listerBoom := errors.New("lister exploded")
+
+	tests := []struct {
+		name             string
+		buildSyncer      func(t *testing.T, mockDB *databasetesting.MockResourcesDBClient) *createServiceProviderClusterSyncer
+		seedDB           func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient)
+		wantErrSubstring string
+		// wantCreated indicates whether the syncer is expected to have written
+		// a ServiceProviderCluster to Cosmos by the end of the run.
+		wantCreated bool
+	}{
+		{
+			name: "cluster missing from lister returns nil and does not write",
+			buildSyncer: func(t *testing.T, mockDB *databasetesting.MockResourcesDBClient) *createServiceProviderClusterSyncer {
+				return &createServiceProviderClusterSyncer{
+					resourcesDBClient:            mockDB,
+					clusterLister:                &listertesting.SliceClusterLister{},
+					serviceProviderClusterLister: &listertesting.SliceServiceProviderClusterLister{},
+				}
+			},
+			wantCreated: false,
+		},
+		{
+			name: "cluster lister error is propagated",
+			buildSyncer: func(t *testing.T, mockDB *databasetesting.MockResourcesDBClient) *createServiceProviderClusterSyncer {
+				return &createServiceProviderClusterSyncer{
+					resourcesDBClient:            mockDB,
+					clusterLister:                &boomClusterLister{err: listerBoom},
+					serviceProviderClusterLister: &listertesting.SliceServiceProviderClusterLister{},
+				}
+			},
+			wantErrSubstring: "failed to get HCPCluster from lister",
+			wantCreated:      false,
+		},
+		{
+			name: "ServiceProviderCluster already in lister is a no-op",
+			buildSyncer: func(t *testing.T, mockDB *databasetesting.MockResourcesDBClient) *createServiceProviderClusterSyncer {
+				spcResourceID := api.Must(azcorearm.ParseResourceID(clusterResourceID.String() + "/" + api.ServiceProviderClusterResourceTypeName + "/" + api.ServiceProviderClusterResourceName))
+				return &createServiceProviderClusterSyncer{
+					resourcesDBClient: mockDB,
+					clusterLister: &listertesting.SliceClusterLister{
+						Clusters: []*api.HCPOpenShiftCluster{newCreatorTestCluster(t)},
+					},
+					serviceProviderClusterLister: &listertesting.SliceServiceProviderClusterLister{
+						ServiceProviderClusters: []*api.ServiceProviderCluster{{
+							CosmosMetadata: api.CosmosMetadata{ResourceID: spcResourceID},
+						}},
+					},
+				}
+			},
+			// Cosmos was never asked to create — verify by checking that no
+			// document exists in the mock DB after the call.
+			wantCreated: false,
+		},
+		{
+			name: "ServiceProviderCluster lister error other than NotFound is propagated",
+			buildSyncer: func(t *testing.T, mockDB *databasetesting.MockResourcesDBClient) *createServiceProviderClusterSyncer {
+				return &createServiceProviderClusterSyncer{
+					resourcesDBClient: mockDB,
+					clusterLister: &listertesting.SliceClusterLister{
+						Clusters: []*api.HCPOpenShiftCluster{newCreatorTestCluster(t)},
+					},
+					serviceProviderClusterLister: &boomServiceProviderClusterLister{err: listerBoom},
+				}
+			},
+			wantErrSubstring: "failed to get ServiceProviderCluster from lister",
+			wantCreated:      false,
+		},
+		{
+			name: "cluster marked for deletion is a no-op (do not recreate child during cleanup)",
+			buildSyncer: func(t *testing.T, mockDB *databasetesting.MockResourcesDBClient) *createServiceProviderClusterSyncer {
+				deletingCluster := newCreatorTestCluster(t)
+				deletingCluster.ServiceProviderProperties.DeletionTimestamp = ptr.To(metav1.Now())
+				return &createServiceProviderClusterSyncer{
+					resourcesDBClient: mockDB,
+					clusterLister: &listertesting.SliceClusterLister{
+						Clusters: []*api.HCPOpenShiftCluster{deletingCluster},
+					},
+					serviceProviderClusterLister: &listertesting.SliceServiceProviderClusterLister{},
+				}
+			},
+			wantCreated: false,
+		},
+		{
+			name: "missing ServiceProviderCluster is created",
+			buildSyncer: func(t *testing.T, mockDB *databasetesting.MockResourcesDBClient) *createServiceProviderClusterSyncer {
+				return &createServiceProviderClusterSyncer{
+					resourcesDBClient: mockDB,
+					clusterLister: &listertesting.SliceClusterLister{
+						Clusters: []*api.HCPOpenShiftCluster{newCreatorTestCluster(t)},
+					},
+					serviceProviderClusterLister: &listertesting.SliceServiceProviderClusterLister{},
+				}
+			},
+			wantCreated: true,
+		},
+		{
+			name: "create is idempotent when ServiceProviderCluster already exists in cosmos",
+			buildSyncer: func(t *testing.T, mockDB *databasetesting.MockResourcesDBClient) *createServiceProviderClusterSyncer {
+				return &createServiceProviderClusterSyncer{
+					resourcesDBClient: mockDB,
+					clusterLister: &listertesting.SliceClusterLister{
+						Clusters: []*api.HCPOpenShiftCluster{newCreatorTestCluster(t)},
+					},
+					// Lister is stale (does not know about the SPC yet) but
+					// Cosmos already has it — GetOrCreate must absorb the 409.
+					serviceProviderClusterLister: &listertesting.SliceServiceProviderClusterLister{},
+				}
+			},
+			seedDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
+				_, err := database.GetOrCreateServiceProviderCluster(ctx, mockDB, clusterResourceID)
+				require.NoError(t, err)
+			},
+			wantCreated: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+			mockDB := databasetesting.NewMockResourcesDBClient()
+
+			if tc.seedDB != nil {
+				tc.seedDB(t, ctx, mockDB)
+			}
+
+			syncer := tc.buildSyncer(t, mockDB)
+
+			err := syncer.SyncOnce(ctx, newCreatorTestClusterKey())
+			if tc.wantErrSubstring != "" {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tc.wantErrSubstring)
+			} else {
+				require.NoError(t, err)
+			}
+
+			_, getErr := mockDB.ServiceProviderClusters(creatorTestSubscriptionID, creatorTestResourceGroup, creatorTestClusterName).Get(ctx, api.ServiceProviderClusterResourceName)
+			if tc.wantCreated {
+				assert.NoError(t, getErr, "expected ServiceProviderCluster to exist in cosmos")
+			} else {
+				assert.True(t, database.IsNotFoundError(getErr), "expected ServiceProviderCluster to be absent, got err=%v", getErr)
+			}
+		})
+	}
+}

--- a/backend/pkg/controllers/create_service_provider_nodepool_controller.go
+++ b/backend/pkg/controllers/create_service_provider_nodepool_controller.go
@@ -1,0 +1,112 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// createServiceProviderNodePoolSyncer ensures a ServiceProviderNodePool
+// document exists for every HCPNodePool. Consumer backend controllers
+// (validation, version, upgrade) read the ServiceProviderNodePool through a
+// cached lister and bail out when it is missing; this syncer is the single
+// place in backend controllers that actually creates the document, so the
+// GetOrCreate pattern stays in one well-known location. The frontend
+// admission path still calls database.GetOrCreateServiceProviderNodePool
+// directly because admission must have the document in hand to validate the
+// request before any controller has a chance to run.
+type createServiceProviderNodePoolSyncer struct {
+	cooldownChecker               controllerutil.CooldownChecker
+	resourcesDBClient             database.ResourcesDBClient
+	nodePoolLister                listers.NodePoolLister
+	serviceProviderNodePoolLister listers.ServiceProviderNodePoolLister
+}
+
+var _ controllerutils.NodePoolSyncer = (*createServiceProviderNodePoolSyncer)(nil)
+
+// NewCreateServiceProviderNodePoolController wires the controller that creates
+// missing ServiceProviderNodePool documents.
+func NewCreateServiceProviderNodePoolController(
+	resourcesDBClient database.ResourcesDBClient,
+	activeOperationLister listers.ActiveOperationLister,
+	nodePoolLister listers.NodePoolLister,
+	serviceProviderNodePoolLister listers.ServiceProviderNodePoolLister,
+	backendInformers informers.BackendInformers,
+) controllerutils.Controller {
+	syncer := &createServiceProviderNodePoolSyncer{
+		cooldownChecker:               controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		resourcesDBClient:             resourcesDBClient,
+		nodePoolLister:                nodePoolLister,
+		serviceProviderNodePoolLister: serviceProviderNodePoolLister,
+	}
+
+	return controllerutils.NewNodePoolWatchingController(
+		"CreateServiceProviderNodePool",
+		resourcesDBClient,
+		backendInformers,
+		nil,
+		1*time.Minute,
+		syncer,
+	)
+}
+
+func (c *createServiceProviderNodePoolSyncer) CooldownChecker() controllerutil.CooldownChecker {
+	return c.cooldownChecker
+}
+
+// SyncOnce creates a ServiceProviderNodePool for the given HCPNodePool when
+// one does not already exist. The lister is consulted first so steady-state
+// runs avoid a Cosmos round-trip; if it is missing, GetOrCreate is called and
+// any 409 conflict is handled by the underlying helper.
+//
+// Once the parent node pool is marked for deletion the node-pool deletion
+// pipeline removes the ServiceProviderNodePool as a child resource;
+// recreating it here would prevent that pipeline from converging, so we
+// short-circuit.
+func (c *createServiceProviderNodePoolSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPNodePoolKey) error {
+	existingNodePool, err := c.nodePoolLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get HCPNodePool from lister: %w", err))
+	}
+	if existingNodePool.ServiceProviderProperties.DeletionTimestamp != nil {
+		return nil
+	}
+
+	_, err = c.serviceProviderNodePoolLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
+	if err == nil {
+		return nil
+	}
+	if !database.IsNotFoundError(err) {
+		return utils.TrackError(fmt.Errorf("failed to get ServiceProviderNodePool from lister: %w", err))
+	}
+
+	if _, err := database.GetOrCreateServiceProviderNodePool(ctx, c.resourcesDBClient, key.GetResourceID()); err != nil {
+		return utils.TrackError(fmt.Errorf("failed to create ServiceProviderNodePool: %w", err))
+	}
+
+	return nil
+}

--- a/backend/pkg/controllers/create_service_provider_nodepool_controller.go
+++ b/backend/pkg/controllers/create_service_provider_nodepool_controller.go
@@ -22,7 +22,6 @@ import (
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
 	"github.com/Azure/ARO-HCP/backend/pkg/informers"
 	"github.com/Azure/ARO-HCP/backend/pkg/listers"
-	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
@@ -37,7 +36,6 @@ import (
 // directly because admission must have the document in hand to validate the
 // request before any controller has a chance to run.
 type createServiceProviderNodePoolSyncer struct {
-	cooldownChecker               controllerutil.CooldownChecker
 	resourcesDBClient             database.ResourcesDBClient
 	nodePoolLister                listers.NodePoolLister
 	serviceProviderNodePoolLister listers.ServiceProviderNodePoolLister
@@ -49,13 +47,11 @@ var _ controllerutils.NodePoolSyncer = (*createServiceProviderNodePoolSyncer)(ni
 // missing ServiceProviderNodePool documents.
 func NewCreateServiceProviderNodePoolController(
 	resourcesDBClient database.ResourcesDBClient,
-	activeOperationLister listers.ActiveOperationLister,
 	nodePoolLister listers.NodePoolLister,
 	serviceProviderNodePoolLister listers.ServiceProviderNodePoolLister,
 	backendInformers informers.BackendInformers,
 ) controllerutils.Controller {
 	syncer := &createServiceProviderNodePoolSyncer{
-		cooldownChecker:               controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
 		resourcesDBClient:             resourcesDBClient,
 		nodePoolLister:                nodePoolLister,
 		serviceProviderNodePoolLister: serviceProviderNodePoolLister,
@@ -69,10 +65,6 @@ func NewCreateServiceProviderNodePoolController(
 		1*time.Minute,
 		syncer,
 	)
-}
-
-func (c *createServiceProviderNodePoolSyncer) CooldownChecker() controllerutil.CooldownChecker {
-	return c.cooldownChecker
 }
 
 // SyncOnce creates a ServiceProviderNodePool for the given HCPNodePool when

--- a/backend/pkg/controllers/create_service_provider_nodepool_controller_test.go
+++ b/backend/pkg/controllers/create_service_provider_nodepool_controller_test.go
@@ -1,0 +1,231 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+const creatorTestNodePoolName = "test-nodepool"
+
+func newCreatorTestNodePoolKey() controllerutils.HCPNodePoolKey {
+	return controllerutils.HCPNodePoolKey{
+		SubscriptionID:    creatorTestSubscriptionID,
+		ResourceGroupName: creatorTestResourceGroup,
+		HCPClusterName:    creatorTestClusterName,
+		HCPNodePoolName:   creatorTestNodePoolName,
+	}
+}
+
+func newCreatorTestNodePool(t *testing.T) *api.HCPOpenShiftClusterNodePool {
+	t.Helper()
+	resourceID := api.Must(api.ToNodePoolResourceID(creatorTestSubscriptionID, creatorTestResourceGroup, creatorTestClusterName, creatorTestNodePoolName))
+	return &api.HCPOpenShiftClusterNodePool{
+		CosmosMetadata: arm.CosmosMetadata{ResourceID: resourceID},
+		TrackedResource: arm.TrackedResource{
+			Resource: arm.Resource{
+				ID:   resourceID,
+				Name: creatorTestNodePoolName,
+				Type: api.NodePoolResourceType.String(),
+			},
+			Location: "eastus",
+		},
+	}
+}
+
+// boomNodePoolLister returns the configured error from every Get call.
+type boomNodePoolLister struct {
+	listers.NodePoolLister
+	err error
+}
+
+func (b *boomNodePoolLister) Get(_ context.Context, _, _, _, _ string) (*api.HCPOpenShiftClusterNodePool, error) {
+	return nil, b.err
+}
+
+// boomServiceProviderNodePoolLister returns the configured error from every
+// Get call.
+type boomServiceProviderNodePoolLister struct {
+	listers.ServiceProviderNodePoolLister
+	err error
+}
+
+func (b *boomServiceProviderNodePoolLister) Get(_ context.Context, _, _, _, _ string) (*api.ServiceProviderNodePool, error) {
+	return nil, b.err
+}
+
+func TestCreateServiceProviderNodePoolSyncer_SyncOnce(t *testing.T) {
+	nodePoolResourceID := api.Must(api.ToNodePoolResourceID(creatorTestSubscriptionID, creatorTestResourceGroup, creatorTestClusterName, creatorTestNodePoolName))
+	listerBoom := errors.New("lister exploded")
+
+	tests := []struct {
+		name             string
+		buildSyncer      func(t *testing.T, mockDB *databasetesting.MockResourcesDBClient) *createServiceProviderNodePoolSyncer
+		seedDB           func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient)
+		wantErrSubstring string
+		// wantCreated indicates whether the syncer is expected to have written
+		// a ServiceProviderNodePool to Cosmos by the end of the run.
+		wantCreated bool
+	}{
+		{
+			name: "node pool missing from lister returns nil and does not write",
+			buildSyncer: func(t *testing.T, mockDB *databasetesting.MockResourcesDBClient) *createServiceProviderNodePoolSyncer {
+				return &createServiceProviderNodePoolSyncer{
+					resourcesDBClient:             mockDB,
+					nodePoolLister:                &listertesting.SliceNodePoolLister{},
+					serviceProviderNodePoolLister: &listertesting.SliceServiceProviderNodePoolLister{},
+				}
+			},
+			wantCreated: false,
+		},
+		{
+			name: "node pool lister error is propagated",
+			buildSyncer: func(t *testing.T, mockDB *databasetesting.MockResourcesDBClient) *createServiceProviderNodePoolSyncer {
+				return &createServiceProviderNodePoolSyncer{
+					resourcesDBClient:             mockDB,
+					nodePoolLister:                &boomNodePoolLister{err: listerBoom},
+					serviceProviderNodePoolLister: &listertesting.SliceServiceProviderNodePoolLister{},
+				}
+			},
+			wantErrSubstring: "failed to get HCPNodePool from lister",
+			wantCreated:      false,
+		},
+		{
+			name: "ServiceProviderNodePool already in lister is a no-op",
+			buildSyncer: func(t *testing.T, mockDB *databasetesting.MockResourcesDBClient) *createServiceProviderNodePoolSyncer {
+				spnpResourceID := api.Must(azcorearm.ParseResourceID(nodePoolResourceID.String() + "/" + api.ServiceProviderNodePoolResourceTypeName + "/" + api.ServiceProviderNodePoolResourceName))
+				return &createServiceProviderNodePoolSyncer{
+					resourcesDBClient: mockDB,
+					nodePoolLister: &listertesting.SliceNodePoolLister{
+						NodePools: []*api.HCPOpenShiftClusterNodePool{newCreatorTestNodePool(t)},
+					},
+					serviceProviderNodePoolLister: &listertesting.SliceServiceProviderNodePoolLister{
+						ServiceProviderNodePools: []*api.ServiceProviderNodePool{{
+							CosmosMetadata: api.CosmosMetadata{ResourceID: spnpResourceID},
+						}},
+					},
+				}
+			},
+			wantCreated: false,
+		},
+		{
+			name: "ServiceProviderNodePool lister error other than NotFound is propagated",
+			buildSyncer: func(t *testing.T, mockDB *databasetesting.MockResourcesDBClient) *createServiceProviderNodePoolSyncer {
+				return &createServiceProviderNodePoolSyncer{
+					resourcesDBClient: mockDB,
+					nodePoolLister: &listertesting.SliceNodePoolLister{
+						NodePools: []*api.HCPOpenShiftClusterNodePool{newCreatorTestNodePool(t)},
+					},
+					serviceProviderNodePoolLister: &boomServiceProviderNodePoolLister{err: listerBoom},
+				}
+			},
+			wantErrSubstring: "failed to get ServiceProviderNodePool from lister",
+			wantCreated:      false,
+		},
+		{
+			name: "node pool marked for deletion is a no-op (do not recreate child during cleanup)",
+			buildSyncer: func(t *testing.T, mockDB *databasetesting.MockResourcesDBClient) *createServiceProviderNodePoolSyncer {
+				deletingNodePool := newCreatorTestNodePool(t)
+				deletingNodePool.ServiceProviderProperties.DeletionTimestamp = ptr.To(metav1.Now())
+				return &createServiceProviderNodePoolSyncer{
+					resourcesDBClient: mockDB,
+					nodePoolLister: &listertesting.SliceNodePoolLister{
+						NodePools: []*api.HCPOpenShiftClusterNodePool{deletingNodePool},
+					},
+					serviceProviderNodePoolLister: &listertesting.SliceServiceProviderNodePoolLister{},
+				}
+			},
+			wantCreated: false,
+		},
+		{
+			name: "missing ServiceProviderNodePool is created",
+			buildSyncer: func(t *testing.T, mockDB *databasetesting.MockResourcesDBClient) *createServiceProviderNodePoolSyncer {
+				return &createServiceProviderNodePoolSyncer{
+					resourcesDBClient: mockDB,
+					nodePoolLister: &listertesting.SliceNodePoolLister{
+						NodePools: []*api.HCPOpenShiftClusterNodePool{newCreatorTestNodePool(t)},
+					},
+					serviceProviderNodePoolLister: &listertesting.SliceServiceProviderNodePoolLister{},
+				}
+			},
+			wantCreated: true,
+		},
+		{
+			name: "create is idempotent when ServiceProviderNodePool already exists in cosmos",
+			buildSyncer: func(t *testing.T, mockDB *databasetesting.MockResourcesDBClient) *createServiceProviderNodePoolSyncer {
+				return &createServiceProviderNodePoolSyncer{
+					resourcesDBClient: mockDB,
+					nodePoolLister: &listertesting.SliceNodePoolLister{
+						NodePools: []*api.HCPOpenShiftClusterNodePool{newCreatorTestNodePool(t)},
+					},
+					serviceProviderNodePoolLister: &listertesting.SliceServiceProviderNodePoolLister{},
+				}
+			},
+			seedDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
+				_, err := database.GetOrCreateServiceProviderNodePool(ctx, mockDB, nodePoolResourceID)
+				require.NoError(t, err)
+			},
+			wantCreated: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+			mockDB := databasetesting.NewMockResourcesDBClient()
+
+			if tc.seedDB != nil {
+				tc.seedDB(t, ctx, mockDB)
+			}
+
+			syncer := tc.buildSyncer(t, mockDB)
+
+			err := syncer.SyncOnce(ctx, newCreatorTestNodePoolKey())
+			if tc.wantErrSubstring != "" {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tc.wantErrSubstring)
+			} else {
+				require.NoError(t, err)
+			}
+
+			_, getErr := mockDB.ServiceProviderNodePools(creatorTestSubscriptionID, creatorTestResourceGroup, creatorTestClusterName, creatorTestNodePoolName).Get(ctx, api.ServiceProviderNodePoolResourceName)
+			if tc.wantCreated {
+				assert.NoError(t, getErr, "expected ServiceProviderNodePool to exist in cosmos")
+			} else {
+				assert.True(t, database.IsNotFoundError(getErr), "expected ServiceProviderNodePool to be absent, got err=%v", getErr)
+			}
+		})
+	}
+}

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_update.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_update.go
@@ -275,7 +275,7 @@ func (c *operationClusterUpdate) desiredVersionResolutionOperationState(ctx cont
 	if intentFailedCondition == nil || intentFailedCondition.Status != metav1.ConditionTrue || intentFailedCondition.Reason != api.VersionUpgradeNotAcceptedReason {
 		// Customer desired minor differs from the service provider resolved version, and the
 		// ControlPlaneDesiredVersion controller has not yet set IntentFailed (VersionUpgradeNotAccepted).
-		// Stay Accepted while resolution runs; fail once elapsed exceeds 29s from the first
+		// Stay Accepted while resolution runs; fail once elapsed exceeds 129s from the first
 		// time this process observed the mismatch for this operation, so a
 		// controller restart does not immediately fail long-running operations.
 		pending := newOperationState(arm.ProvisioningStateAccepted, "customer desired version does not match resolved desired version")
@@ -284,11 +284,11 @@ func (c *operationClusterUpdate) desiredVersionResolutionOperationState(ctx cont
 			c.desiredVersionMismatchFirstSeen.Add(operation.ResourceID.String(), c.clock.Now())
 			return pending, nil
 		}
-		if c.clock.Since(firstSeen.(time.Time)) <= 29*time.Second {
+		if c.clock.Since(firstSeen.(time.Time)) <= 129*time.Second {
 			return pending, nil
 		}
 		msg := fmt.Sprintf(
-			"timed out after 29s waiting for resolution of desired version from '%s' cluster version",
+			"timed out after 129s waiting for resolution of desired version from '%s' cluster version",
 			existingCluster.CustomerProperties.Version.ID,
 		)
 		c.desiredVersionMismatchFirstSeen.Remove(operation.ResourceID.String())

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_update_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_update_test.go
@@ -295,12 +295,12 @@ func TestOperationClusterUpdate_SynchronizeOperation(t *testing.T) {
 			},
 		},
 		{
-			name:                           "customer minor mismatch without ControlPlaneDesiredVersion IntentFailed leaves operation accepted when first seen within 29s",
+			name:                           "customer minor mismatch without ControlPlaneDesiredVersion IntentFailed leaves operation accepted when first seen within 129s",
 			existingCluster:                newClusterWithCustomerVersion("4.20"),
 			existingOperation:              newOperationAccepted(),
 			existingServiceProviderCluster: newServiceProviderClusterWithSpecControlPlaneVersion("4.19"),
 			cachedHostedClusterReadDesire:  newPassingCachedHostedClusterReadDesire(),
-			seedMismatchFirstSeenAt:        testClockNow.Add(-20 * time.Second),
+			seedMismatchFirstSeenAt:        testClockNow.Add(-120 * time.Second),
 			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
 				mock.EXPECT().
 					GetCluster(gomock.Any(), fixture.clusterInternalID).
@@ -319,12 +319,12 @@ func TestOperationClusterUpdate_SynchronizeOperation(t *testing.T) {
 			},
 		},
 		{
-			name:                           "customer minor mismatch without IntentFailed fails when mismatch first seen exceeds 29s",
+			name:                           "customer minor mismatch without IntentFailed fails when mismatch first seen exceeds 129s",
 			existingCluster:                newClusterWithCustomerVersion("4.20"),
 			existingOperation:              newOperationAccepted(),
 			existingServiceProviderCluster: newServiceProviderClusterWithSpecControlPlaneVersion("4.19"),
 			cachedHostedClusterReadDesire:  newPassingCachedHostedClusterReadDesire(),
-			seedMismatchFirstSeenAt:        testClockNow.Add(-30 * time.Second),
+			seedMismatchFirstSeenAt:        testClockNow.Add(-130 * time.Second),
 			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
 				mock.EXPECT().
 					GetCluster(gomock.Any(), fixture.clusterInternalID).
@@ -340,7 +340,7 @@ func TestOperationClusterUpdate_SynchronizeOperation(t *testing.T) {
 				cluster, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
 				require.NoError(t, err)
 				wantMessageSubstr := fmt.Sprintf(
-					"timed out after 29s waiting for resolution of desired version from '%s' cluster version",
+					"timed out after 129s waiting for resolution of desired version from '%s' cluster version",
 					cluster.CustomerProperties.Version.ID,
 				)
 				assert.Contains(t, op.Error.Message, wantMessageSubstr)

--- a/backend/pkg/controllers/operationcontrollers/operation_node_pool_update.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_node_pool_update.go
@@ -281,7 +281,7 @@ func (c *operationNodePoolUpdate) desiredVersionResolutionOperationState(ctx con
 	// Customer desired version differs from the service provider resolved version, and the
 	// NodePoolVersion controller has not yet set IntentFailed (VersionUpgradeNotAccepted)
 	// for this version. Stay Accepted while resolution runs; fail once elapsed exceeds
-	// 59s from the first time this process observed the mismatch for this operation.
+	// 129s from the first time this process observed the mismatch for this operation.
 	// This avoids immediately failing long-running operations after controller restarts
 	// and is double the relistDuration of the nodepool and serviceProviderNodePool informers.
 	// This will not solve all the edge cases, but it will give enough time to the other controllers to act.
@@ -292,11 +292,11 @@ func (c *operationNodePoolUpdate) desiredVersionResolutionOperationState(ctx con
 			c.desiredVersionMismatchFirstSeen.Add(operationID, c.clock.Now())
 			return pending, nil
 		}
-		if c.clock.Since(firstSeen.(time.Time)) <= 59*time.Second {
+		if c.clock.Since(firstSeen.(time.Time)) <= 129*time.Second {
 			return pending, nil
 		}
 		msg := fmt.Sprintf(
-			"timed out after 59s waiting for resolution of desired version from '%s' node pool version",
+			"timed out after 129s waiting for resolution of desired version from '%s' node pool version",
 			existingNodePool.Properties.Version.ID,
 		)
 		c.desiredVersionMismatchFirstSeen.Remove(operationID)

--- a/backend/pkg/controllers/operationcontrollers/operation_node_pool_update_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_node_pool_update_test.go
@@ -275,7 +275,7 @@ func TestOperationNodePoolUpdate_SynchronizeOperation(t *testing.T) {
 			},
 		},
 		{
-			name:                            "customer version mismatch without NodePoolVersion IntentFailed leaves operation accepted when first seen within 59s",
+			name:                            "customer version mismatch without NodePoolVersion IntentFailed leaves operation accepted when first seen within 129s",
 			existingNodePool:                newNodePoolWithVersion("4.20.5"),
 			existingOperation:               newOperationAccepted(),
 			existingServiceProviderNodePool: newServiceProviderNodePoolWithDesiredVersion("4.20.4"),
@@ -283,7 +283,7 @@ func TestOperationNodePoolUpdate_SynchronizeOperation(t *testing.T) {
 				{Type: api.ControllerConditionTypeIntentFailed, Status: metav1.ConditionFalse},
 			}),
 			cachedNodePoolReadDesire: newPassingCachedNodePoolReadDesire(newNodePoolWithVersion("4.20.5")),
-			seedMismatchFirstSeenAt:  testClockNow.Add(-50 * time.Second),
+			seedMismatchFirstSeenAt:  testClockNow.Add(-120 * time.Second),
 			setupMockCSClient:        setupMockCSClientForNodePoolState(NodePoolStateReady),
 			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
@@ -297,7 +297,7 @@ func TestOperationNodePoolUpdate_SynchronizeOperation(t *testing.T) {
 			},
 		},
 		{
-			name:                            "customer version mismatch without IntentFailed fails when mismatch first seen exceeds 59s",
+			name:                            "customer version mismatch without IntentFailed fails when mismatch first seen exceeds 129s",
 			existingNodePool:                newNodePoolWithVersion("4.20.5"),
 			existingOperation:               newOperationAccepted(),
 			existingServiceProviderNodePool: newServiceProviderNodePoolWithDesiredVersion("4.20.4"),
@@ -305,7 +305,7 @@ func TestOperationNodePoolUpdate_SynchronizeOperation(t *testing.T) {
 				{Type: api.ControllerConditionTypeIntentFailed, Status: metav1.ConditionFalse},
 			}),
 			cachedNodePoolReadDesire: newPassingCachedNodePoolReadDesire(newNodePoolWithVersion("4.20.5")),
-			seedMismatchFirstSeenAt:  testClockNow.Add(-60 * time.Second),
+			seedMismatchFirstSeenAt:  testClockNow.Add(-130 * time.Second),
 			setupMockCSClient:        setupMockCSClientForNodePoolState(NodePoolStateReady),
 			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
@@ -317,7 +317,7 @@ func TestOperationNodePoolUpdate_SynchronizeOperation(t *testing.T) {
 				nodePool, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).NodePools(testClusterName).Get(ctx, testNodePoolName)
 				require.NoError(t, err)
 				wantMessageSubstr := fmt.Sprintf(
-					"timed out after 59s waiting for resolution of desired version from '%s' node pool version",
+					"timed out after 129s waiting for resolution of desired version from '%s' node pool version",
 					nodePool.Properties.Version.ID,
 				)
 				assert.Contains(t, op.Error.Message, wantMessageSubstr)

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_active_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_active_version_controller.go
@@ -40,7 +40,6 @@ import (
 // versions in ServiceProviderCluster status by reading the version from the per-cluster
 // ReadDesire kubeContent (the kube-applier's mirror of the management cluster's HostedCluster).
 type controlPlaneActiveVersionSyncer struct {
-	cooldownChecker              controllerutil.CooldownChecker
 	resourcesDBClient            database.ResourcesDBClient
 	readDesireLister             dblisters.ReadDesireLister
 	serviceProviderClusterLister listers.ServiceProviderClusterLister
@@ -53,14 +52,12 @@ var _ controllerutils.ClusterSyncer = (*controlPlaneActiveVersionSyncer)(nil)
 // observed HostedCluster.
 func NewControlPlaneActiveVersionController(
 	resourcesDBClient database.ResourcesDBClient,
-	activeOperationLister listers.ActiveOperationLister,
 	serviceProviderClusterLister listers.ServiceProviderClusterLister,
 	informers informers.BackendInformers,
 	kubeApplierInformers *unionkubeapplierinformers.UnionKubeApplierInformers,
 	readDesireLister dblisters.ReadDesireLister,
 ) controllerutils.Controller {
 	syncer := &controlPlaneActiveVersionSyncer{
-		cooldownChecker:              controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
 		resourcesDBClient:            resourcesDBClient,
 		readDesireLister:             readDesireLister,
 		serviceProviderClusterLister: serviceProviderClusterLister,
@@ -74,10 +71,6 @@ func NewControlPlaneActiveVersionController(
 		5*time.Minute,
 		syncer,
 	)
-}
-
-func (c *controlPlaneActiveVersionSyncer) CooldownChecker() controllerutil.CooldownChecker {
-	return c.cooldownChecker
 }
 
 // SyncOnce updates ServiceProviderCluster.Status.ControlPlaneVersion.ActiveVersions

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_active_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_active_version_controller.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
 	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
 	"github.com/Azure/ARO-HCP/backend/pkg/maestrohelpers"
 	"github.com/Azure/ARO-HCP/internal/api"
 	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
@@ -39,8 +40,10 @@ import (
 // versions in ServiceProviderCluster status by reading the version from the per-cluster
 // ReadDesire kubeContent (the kube-applier's mirror of the management cluster's HostedCluster).
 type controlPlaneActiveVersionSyncer struct {
-	resourcesDBClient database.ResourcesDBClient
-	readDesireLister  dblisters.ReadDesireLister
+	cooldownChecker              controllerutil.CooldownChecker
+	resourcesDBClient            database.ResourcesDBClient
+	readDesireLister             dblisters.ReadDesireLister
+	serviceProviderClusterLister listers.ServiceProviderClusterLister
 }
 
 var _ controllerutils.ClusterSyncer = (*controlPlaneActiveVersionSyncer)(nil)
@@ -50,13 +53,17 @@ var _ controllerutils.ClusterSyncer = (*controlPlaneActiveVersionSyncer)(nil)
 // observed HostedCluster.
 func NewControlPlaneActiveVersionController(
 	resourcesDBClient database.ResourcesDBClient,
+	activeOperationLister listers.ActiveOperationLister,
+	serviceProviderClusterLister listers.ServiceProviderClusterLister,
 	informers informers.BackendInformers,
 	kubeApplierInformers *unionkubeapplierinformers.UnionKubeApplierInformers,
 	readDesireLister dblisters.ReadDesireLister,
 ) controllerutils.Controller {
 	syncer := &controlPlaneActiveVersionSyncer{
-		resourcesDBClient: resourcesDBClient,
-		readDesireLister:  readDesireLister,
+		cooldownChecker:              controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		resourcesDBClient:            resourcesDBClient,
+		readDesireLister:             readDesireLister,
+		serviceProviderClusterLister: serviceProviderClusterLister,
 	}
 
 	return controllerutils.NewClusterWatchingController(
@@ -67,6 +74,10 @@ func NewControlPlaneActiveVersionController(
 		5*time.Minute,
 		syncer,
 	)
+}
+
+func (c *controlPlaneActiveVersionSyncer) CooldownChecker() controllerutil.CooldownChecker {
+	return c.cooldownChecker
 }
 
 // SyncOnce updates ServiceProviderCluster.Status.ControlPlaneVersion.ActiveVersions
@@ -99,22 +110,26 @@ func (c *controlPlaneActiveVersionSyncer) SyncOnce(ctx context.Context, key cont
 		return utils.TrackError(err)
 	}
 
-	existingServiceProviderCluster, err := database.GetOrCreateServiceProviderCluster(ctx, c.resourcesDBClient, key.GetResourceID())
+	cachedServiceProviderCluster, err := c.serviceProviderClusterLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if database.IsNotFoundError(err) {
+		// CreateServiceProviderCluster will populate it; we'll be re-enqueued via the ServiceProviderCluster informer.
+		return nil
+	}
 	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to get or create ServiceProviderCluster: %w", err))
+		return utils.TrackError(fmt.Errorf("failed to get ServiceProviderCluster: %w", err))
 	}
 	// Use NeedsUpdate (semantic equality) instead of slices.Equal: HCPClusterActiveVersion holds
 	// *semver.Version, and Go's `==` (which slices.Equal relies on) compares those pointers, not
 	// the represented version. Two independent reads/parses of the same version produce different
 	// pointer addresses, which previously caused a Replace on every reconciliation cycle even
 	// when the active versions were semantically identical.
-	oldActiveVersions := existingServiceProviderCluster.Status.ControlPlaneVersion.ActiveVersions
+	oldActiveVersions := cachedServiceProviderCluster.Status.ControlPlaneVersion.ActiveVersions
 	if !controllerutil.NeedsUpdate(oldActiveVersions, newActiveVersions) {
 		return nil
 	}
 	logger := utils.LoggerFromContext(ctx)
 	logger.Info("Active versions changed", "oldActiveVersions", oldActiveVersions, "newActiveVersions", newActiveVersions)
-	replacement := existingServiceProviderCluster.DeepCopy()
+	replacement := cachedServiceProviderCluster.DeepCopy()
 	replacement.Status.ControlPlaneVersion.ActiveVersions = newActiveVersions
 	serviceProviderClustersCosmosClient := c.resourcesDBClient.ServiceProviderClusters(key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
 	_, err = serviceProviderClustersCosmosClient.Replace(ctx, replacement, nil)

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_active_version_controller_test.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_active_version_controller_test.go
@@ -34,9 +34,11 @@ import (
 	hsv1beta1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/api/kubeapplier"
+	"github.com/Azure/ARO-HCP/internal/database"
 	internallistertesting "github.com/Azure/ARO-HCP/internal/database/listertesting"
 	"github.com/Azure/ARO-HCP/internal/databasetesting"
 	"github.com/Azure/ARO-HCP/internal/utils"
@@ -295,8 +297,10 @@ func TestControlPlaneActiveVersionSyncer_SyncOnce(t *testing.T) {
 			}
 
 			syncer := &controlPlaneActiveVersionSyncer{
-				resourcesDBClient: mockResourcesDBClient,
-				readDesireLister:  &internallistertesting.SliceReadDesireLister{Desires: desires},
+				cooldownChecker:              &alwaysSyncCooldownChecker{},
+				resourcesDBClient:            mockResourcesDBClient,
+				readDesireLister:             &internallistertesting.SliceReadDesireLister{Desires: desires},
+				serviceProviderClusterLister: &listertesting.DBServiceProviderClusterLister{ResourcesDBClient: mockResourcesDBClient},
 			}
 
 			err := syncer.SyncOnce(runCtx, testKey)
@@ -334,8 +338,10 @@ func TestControlPlaneActiveVersionSyncer_NoReplaceWhenVersionsUnchanged(t *testi
 	beforeETag := before.CosmosETag
 
 	syncer := &controlPlaneActiveVersionSyncer{
-		resourcesDBClient: mockResourcesDBClient,
-		readDesireLister:  &internallistertesting.SliceReadDesireLister{Desires: desires},
+		cooldownChecker:              &alwaysSyncCooldownChecker{},
+		resourcesDBClient:            mockResourcesDBClient,
+		readDesireLister:             &internallistertesting.SliceReadDesireLister{Desires: desires},
+		serviceProviderClusterLister: &listertesting.DBServiceProviderClusterLister{ResourcesDBClient: mockResourcesDBClient},
 	}
 	require.NoError(t, syncer.SyncOnce(runCtx, controllerutils.HCPClusterKey{
 		SubscriptionID:    testSubscriptionID,
@@ -350,6 +356,10 @@ func TestControlPlaneActiveVersionSyncer_NoReplaceWhenVersionsUnchanged(t *testi
 
 // createTestHCPCluster creates an HCP cluster in the mock database (no node pools).
 // Used as the parent resource for control plane active version sync.
+//
+// An empty ServiceProviderCluster is also seeded; this mirrors what the
+// CreateServiceProviderCluster controller would have populated by the time
+// any consumer syncer runs in production.
 func createTestHCPCluster(t *testing.T, ctx context.Context, mockResourcesDBClient *databasetesting.MockResourcesDBClient) {
 	t.Helper()
 
@@ -378,6 +388,9 @@ func createTestHCPCluster(t *testing.T, ctx context.Context, mockResourcesDBClie
 		},
 	}
 	_, err = mockResourcesDBClient.HCPClusters(testSubscriptionID, testResourceGroupName).Create(ctx, cluster, nil)
+	require.NoError(t, err)
+
+	_, err = database.GetOrCreateServiceProviderCluster(ctx, mockResourcesDBClient, clusterResourceID)
 	require.NoError(t, err)
 }
 

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_active_version_controller_test.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_active_version_controller_test.go
@@ -297,7 +297,6 @@ func TestControlPlaneActiveVersionSyncer_SyncOnce(t *testing.T) {
 			}
 
 			syncer := &controlPlaneActiveVersionSyncer{
-				cooldownChecker:              &alwaysSyncCooldownChecker{},
 				resourcesDBClient:            mockResourcesDBClient,
 				readDesireLister:             &internallistertesting.SliceReadDesireLister{Desires: desires},
 				serviceProviderClusterLister: &listertesting.DBServiceProviderClusterLister{ResourcesDBClient: mockResourcesDBClient},
@@ -338,7 +337,6 @@ func TestControlPlaneActiveVersionSyncer_NoReplaceWhenVersionsUnchanged(t *testi
 	beforeETag := before.CosmosETag
 
 	syncer := &controlPlaneActiveVersionSyncer{
-		cooldownChecker:              &alwaysSyncCooldownChecker{},
 		resourcesDBClient:            mockResourcesDBClient,
 		readDesireLister:             &internallistertesting.SliceReadDesireLister{Desires: desires},
 		serviceProviderClusterLister: &listertesting.DBServiceProviderClusterLister{ResourcesDBClient: mockResourcesDBClient},

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
@@ -39,7 +39,6 @@ import (
 	"github.com/Azure/ARO-HCP/internal/admission"
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/cincinnati"
-	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/database"
 	dblisters "github.com/Azure/ARO-HCP/internal/database/listers"
 	unionkubeapplierinformers "github.com/Azure/ARO-HCP/internal/database/unioninformers/kubeapplier"
@@ -62,7 +61,6 @@ const controlPlaneDesiredVersionControllerName = "ControlPlaneDesiredVersion"
 // version upgrades by selecting the appropriate z-stream within the user-desired minor version.
 type controlPlaneDesiredVersionSyncer struct {
 	clock                         utilsclock.PassiveClock
-	cooldownChecker               controllerutil.CooldownChecker
 	readDesireLister              dblisters.ReadDesireLister
 	resourcesDBClient             database.ResourcesDBClient
 	clusterServiceClient          ocm.ClusterServiceClientSpec
@@ -94,7 +92,6 @@ func NewControlPlaneDesiredVersionController(
 ) controllerutils.Controller {
 	syncer := &controlPlaneDesiredVersionSyncer{
 		clock:                         clock,
-		cooldownChecker:               controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
 		readDesireLister:              readDesireLister,
 		cincinnatiClientCache:         cincinnati.NewClientCache(),
 		graphClient:                   cincinnati.NewGraphClient(),
@@ -116,10 +113,6 @@ func NewControlPlaneDesiredVersionController(
 	)
 
 	return controller
-}
-
-func (c *controlPlaneDesiredVersionSyncer) CooldownChecker() controllerutil.CooldownChecker {
-	return c.cooldownChecker
 }
 
 // SyncOnce performs a single reconciliation of the desired control plane version for a given cluster.

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
@@ -39,6 +39,7 @@ import (
 	"github.com/Azure/ARO-HCP/internal/admission"
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/cincinnati"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/database"
 	dblisters "github.com/Azure/ARO-HCP/internal/database/listers"
 	unionkubeapplierinformers "github.com/Azure/ARO-HCP/internal/database/unioninformers/kubeapplier"
@@ -60,12 +61,15 @@ const controlPlaneDesiredVersionControllerName = "ControlPlaneDesiredVersion"
 // It handles automated (managed) z-stream (patch) upgrades and assists with y-stream (minor)
 // version upgrades by selecting the appropriate z-stream within the user-desired minor version.
 type controlPlaneDesiredVersionSyncer struct {
-	clock                 utilsclock.PassiveClock
-	readDesireLister      dblisters.ReadDesireLister
-	resourcesDBClient     database.ResourcesDBClient
-	clusterServiceClient  ocm.ClusterServiceClientSpec
-	subscriptionLister    listers.SubscriptionLister
-	activeOperationLister listers.ActiveOperationLister
+	clock                         utilsclock.PassiveClock
+	cooldownChecker               controllerutil.CooldownChecker
+	readDesireLister              dblisters.ReadDesireLister
+	resourcesDBClient             database.ResourcesDBClient
+	clusterServiceClient          ocm.ClusterServiceClientSpec
+	subscriptionLister            listers.SubscriptionLister
+	activeOperationLister         listers.ActiveOperationLister
+	serviceProviderClusterLister  listers.ServiceProviderClusterLister
+	serviceProviderNodePoolLister listers.ServiceProviderNodePoolLister
 
 	cincinnatiClientCache cincinnati.ClientCache
 	graphClient           cincinnati.GraphClient
@@ -81,20 +85,25 @@ func NewControlPlaneDesiredVersionController(
 	resourcesDBClient database.ResourcesDBClient,
 	clusterServiceClient ocm.ClusterServiceClientSpec,
 	activeOperationLister listers.ActiveOperationLister,
+	serviceProviderClusterLister listers.ServiceProviderClusterLister,
+	serviceProviderNodePoolLister listers.ServiceProviderNodePoolLister,
 	informers informers.BackendInformers,
 	kubeApplierInformers *unionkubeapplierinformers.UnionKubeApplierInformers,
 	readDesireLister dblisters.ReadDesireLister,
 	subscriptionLister listers.SubscriptionLister,
 ) controllerutils.Controller {
 	syncer := &controlPlaneDesiredVersionSyncer{
-		clock:                 clock,
-		readDesireLister:      readDesireLister,
-		cincinnatiClientCache: cincinnati.NewClientCache(),
-		graphClient:           cincinnati.NewGraphClient(),
-		resourcesDBClient:     resourcesDBClient,
-		clusterServiceClient:  clusterServiceClient,
-		subscriptionLister:    subscriptionLister,
-		activeOperationLister: activeOperationLister,
+		clock:                         clock,
+		cooldownChecker:               controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		readDesireLister:              readDesireLister,
+		cincinnatiClientCache:         cincinnati.NewClientCache(),
+		graphClient:                   cincinnati.NewGraphClient(),
+		resourcesDBClient:             resourcesDBClient,
+		clusterServiceClient:          clusterServiceClient,
+		subscriptionLister:            subscriptionLister,
+		activeOperationLister:         activeOperationLister,
+		serviceProviderClusterLister:  serviceProviderClusterLister,
+		serviceProviderNodePoolLister: serviceProviderNodePoolLister,
 	}
 
 	controller := controllerutils.NewClusterWatchingController(
@@ -107,6 +116,10 @@ func NewControlPlaneDesiredVersionController(
 	)
 
 	return controller
+}
+
+func (c *controlPlaneDesiredVersionSyncer) CooldownChecker() controllerutil.CooldownChecker {
+	return c.cooldownChecker
 }
 
 // SyncOnce performs a single reconciliation of the desired control plane version for a given cluster.
@@ -134,16 +147,20 @@ func (c *controlPlaneDesiredVersionSyncer) SyncOnce(ctx context.Context, key con
 		return nil
 	}
 
-	existingServiceProviderCluster, err := database.GetOrCreateServiceProviderCluster(ctx, c.resourcesDBClient, key.GetResourceID())
+	cachedServiceProviderCluster, err := c.serviceProviderClusterLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if database.IsNotFoundError(err) {
+		// CreateServiceProviderCluster will populate it; we'll be re-enqueued via the ServiceProviderCluster informer.
+		return nil
+	}
 	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to get or create ServiceProviderCluster: %w", err))
+		return utils.TrackError(fmt.Errorf("failed to get ServiceProviderCluster: %w", err))
 	}
 
 	// here we check to see if we should be determining upgrade versions. We do this by
 	// 1. if existingServiceProviderCluster.Spec.ControlPlaneVersion.DesiredVersion is empty, then we must run so we can fill it in.
 	// 2. if the cluster was created more than two hours ago, then we can run
 	// 3. if there is no active operation that is a create, then we can run
-	shouldRun, err := c.shouldDetermineDesiredVersion(ctx, existingCluster, existingServiceProviderCluster)
+	shouldRun, err := c.shouldDetermineDesiredVersion(ctx, existingCluster, cachedServiceProviderCluster)
 	if err != nil {
 		logger.Error(err, "error determining if desired version should be determined")
 	} else if !shouldRun {
@@ -163,7 +180,7 @@ func (c *controlPlaneDesiredVersionSyncer) SyncOnce(ctx context.Context, key con
 
 	customerDesiredMinor := existingCluster.CustomerProperties.Version.ID
 	channelGroup := existingCluster.CustomerProperties.Version.ChannelGroup
-	activeVersions := existingServiceProviderCluster.Status.ControlPlaneVersion.ActiveVersions
+	activeVersions := cachedServiceProviderCluster.Status.ControlPlaneVersion.ActiveVersions
 	subscription, err := c.subscriptionLister.Get(ctx, key.SubscriptionID)
 	if err != nil {
 		return utils.TrackError(err)
@@ -199,7 +216,7 @@ func (c *controlPlaneDesiredVersionSyncer) SyncOnce(ctx context.Context, key con
 		return utils.TrackError(err)
 	}
 
-	previousDesiredVersion := existingServiceProviderCluster.Spec.ControlPlaneVersion.DesiredVersion
+	previousDesiredVersion := cachedServiceProviderCluster.Spec.ControlPlaneVersion.DesiredVersion
 	// Only advance stored desired when the newly resolved version is greater, so graph changes
 	// cannot automatically select a lower z-stream. When rollback support is added, relax this
 	// so that only SRE-enforced rollback targets can decrease desired.
@@ -208,7 +225,7 @@ func (c *controlPlaneDesiredVersionSyncer) SyncOnce(ctx context.Context, key con
 		// on successful resolution of the desired version.
 		// update the ServiceProviderCluster first and only afterwards
 		// clear the IntentFailed condition
-		replacement := existingServiceProviderCluster.DeepCopy()
+		replacement := cachedServiceProviderCluster.DeepCopy()
 		replacement.Spec.ControlPlaneVersion.DesiredVersion = desiredVersion
 		serviceProviderClustersCosmosClient := c.resourcesDBClient.ServiceProviderClusters(key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
 		_, err := serviceProviderClustersCosmosClient.Replace(ctx, replacement, nil)
@@ -307,9 +324,14 @@ func (c *controlPlaneDesiredVersionSyncer) desiredControlPlaneZVersion(ctx conte
 		if err := validation.OpenshiftVersionAtMostOneMinorSkew(actualLatestMinorVersion.String(), desiredMinorVersion.String()); err != nil {
 			return nil, utils.TrackError(err)
 		}
-		clusterNodePools, err := c.listClusterAdmissionNodePools(ctx, clusterResourceID)
+		clusterNodePools, ready, err := c.listClusterAdmissionNodePools(ctx, clusterResourceID)
 		if err != nil {
 			return nil, utils.TrackError(err)
+		}
+		if !ready {
+			// Skip until every node pool has its ServiceProviderNodePool;
+			// without complete version data we can't validate minor skew.
+			return nil, nil
 		}
 		if err := admission.AdmitClusterNodePoolsMinorVersionSkew(ctx, clusterNodePools, desiredMinorVersion); err != nil {
 			return nil, utils.TrackError(err)
@@ -356,10 +378,19 @@ func (c *controlPlaneDesiredVersionSyncer) desiredControlPlaneZVersion(ctx conte
 // frontend.newClusterAdmissionContext builds for cluster admission. The upgrade
 // controller passes the result to admission.AdmitClusterNodePoolsMinorVersionSkew
 // directly so that admission code stays free of any DB dependency.
-func (c *controlPlaneDesiredVersionSyncer) listClusterAdmissionNodePools(ctx context.Context, clusterResourceID *azcorearm.ResourceID) ([]admission.ClusterAdmissionNodePool, error) {
+//
+// Returns (_, false, nil) when any node pool is missing its
+// ServiceProviderNodePool. CreateServiceProviderNodePool will populate it.
+// ClusterWatchingController does not watch the ServiceProviderNodePool
+// informer (a child-document arrival doesn't naturally route to its parent
+// cluster), so the retry happens on the controller's periodic resync or on
+// the next Cluster / ServiceProviderCluster event for this cluster.
+// Skipping admission avoids using stale or missing node-pool version data
+// for skew validation.
+func (c *controlPlaneDesiredVersionSyncer) listClusterAdmissionNodePools(ctx context.Context, clusterResourceID *azcorearm.ResourceID) ([]admission.ClusterAdmissionNodePool, bool, error) {
 	nodePoolIterator, err := c.resourcesDBClient.HCPClusters(clusterResourceID.SubscriptionID, clusterResourceID.ResourceGroupName).NodePools(clusterResourceID.Name).List(ctx, nil)
 	if err != nil {
-		return nil, utils.TrackError(err)
+		return nil, false, utils.TrackError(err)
 	}
 	var clusterNodePools []admission.ClusterAdmissionNodePool
 	for _, nodePool := range nodePoolIterator.Items(ctx) {
@@ -368,19 +399,22 @@ func (c *controlPlaneDesiredVersionSyncer) listClusterAdmissionNodePools(ctx con
 		if nodePool.ServiceProviderProperties.DeletionTimestamp != nil {
 			continue
 		}
-		spNodePool, err := database.GetOrCreateServiceProviderNodePool(ctx, c.resourcesDBClient, nodePool.ID)
+		serviceProviderNodePool, err := c.serviceProviderNodePoolLister.Get(ctx, clusterResourceID.SubscriptionID, clusterResourceID.ResourceGroupName, clusterResourceID.Name, nodePool.ID.Name)
+		if database.IsNotFoundError(err) {
+			return nil, false, nil
+		}
 		if err != nil {
-			return nil, utils.TrackError(err)
+			return nil, false, utils.TrackError(err)
 		}
 		clusterNodePools = append(clusterNodePools, admission.ClusterAdmissionNodePool{
 			NodePool:                nodePool,
-			ServiceProviderNodePool: spNodePool,
+			ServiceProviderNodePool: serviceProviderNodePool,
 		})
 	}
 	if err := nodePoolIterator.GetError(); err != nil {
-		return nil, utils.TrackError(err)
+		return nil, false, utils.TrackError(err)
 	}
-	return clusterNodePools, nil
+	return clusterNodePools, true, nil
 }
 
 // FindAllUpgradeTargetVersionsInMinor queries Cincinnati and finds the latest version within the specified target minor.

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller_test.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller_test.go
@@ -1250,7 +1250,6 @@ func TestControlPlaneDesiredVersionSyncer_SyncOnce(t *testing.T) {
 			mockClientCache.EXPECT().GetOrCreateClient(gomock.Any()).Return(mockCincinnati).AnyTimes()
 
 			syncer := &controlPlaneDesiredVersionSyncer{
-				cooldownChecker:               &alwaysSyncCooldownChecker{},
 				readDesireLister:              newValidHostedClusterReadDesireLister(t),
 				resourcesDBClient:             mockResourcesDBClient,
 				clusterServiceClient:          mockCS,
@@ -1547,7 +1546,6 @@ func TestControlPlaneDesiredVersionSyncer_SyncOnceSkipsWhenGated(t *testing.T) {
 
 	syncer := &controlPlaneDesiredVersionSyncer{
 		clock:                        clocktesting.NewFakePassiveClock(now),
-		cooldownChecker:              &alwaysSyncCooldownChecker{},
 		readDesireLister:             newValidHostedClusterReadDesireLister(t),
 		resourcesDBClient:            mockDB,
 		serviceProviderClusterLister: &listertesting.DBServiceProviderClusterLister{ResourcesDBClient: mockDB},

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller_test.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller_test.go
@@ -280,9 +280,12 @@ func TestDesiredControlPlaneZVersion_ZStreamManagedUpgrade(t *testing.T) {
 			mockCincinnatiClient := cincinnati.NewMockClient(ctrl)
 			tt.mockSetup(mockCincinnatiClient)
 
+			mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
 			syncer := &controlPlaneDesiredVersionSyncer{
-				resourcesDBClient: databasetesting.NewMockResourcesDBClient(),
-				graphClient:       mockGraphClient(ctrl, tt.channelExistence),
+				resourcesDBClient:             mockResourcesDBClient,
+				graphClient:                   mockGraphClient(ctrl, tt.channelExistence),
+				serviceProviderClusterLister:  &listertesting.DBServiceProviderClusterLister{ResourcesDBClient: mockResourcesDBClient},
+				serviceProviderNodePoolLister: &listertesting.DBServiceProviderNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
 			}
 
 			ctx := context.Background()
@@ -574,8 +577,10 @@ func TestDesiredControlPlaneZVersion_NextYStreamUpgrade(t *testing.T) {
 			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, tt.cosmosResources)
 			require.NoError(t, err)
 			syncer := &controlPlaneDesiredVersionSyncer{
-				resourcesDBClient: mockResourcesDBClient,
-				graphClient:       mockGraphClient(ctrl, tt.channelExistence),
+				resourcesDBClient:             mockResourcesDBClient,
+				graphClient:                   mockGraphClient(ctrl, tt.channelExistence),
+				serviceProviderClusterLister:  &listertesting.DBServiceProviderClusterLister{ResourcesDBClient: mockResourcesDBClient},
+				serviceProviderNodePoolLister: &listertesting.DBServiceProviderNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
 			}
 
 			result, err := syncer.desiredControlPlaneZVersion(ctx, mockCincinnatiClient, api.Must(api.ToClusterResourceID("6b690bec-0c16-4ecb-8f67-781caf40bba7", "test-rg", "test-cluster")), tt.customerDesiredMinor, tt.channelGroup, tt.activeVersions, false)
@@ -587,11 +592,15 @@ func TestDesiredControlPlaneZVersion_NextYStreamUpgrade(t *testing.T) {
 
 // testCosmosClusterWithWorkersNodePoolAtVersion returns a cluster and workers node pool for the subscription, resource group,
 // and cluster name shared by desiredControlPlaneZVersion tests. nodePoolVersionId is properties.version.id on the pool.
+// Also seeds an empty ServiceProviderCluster and an empty ServiceProviderNodePool the
+// way the production creator controllers would have populated them.
 func testCosmosClusterWithWorkersNodePoolAtVersion(nodePoolVersionId string) []any {
 	clusterResourceId, cluster := testCosmosClusterResource()
+	workersNodePool := testCosmosNodePool(clusterResourceId, "workers", nodePoolVersionId, false)
 	return []any{
 		cluster,
-		testCosmosNodePool(clusterResourceId, "workers", nodePoolVersionId, false),
+		workersNodePool,
+		testCosmosServiceProviderNodePool(workersNodePool.ResourceID),
 	}
 }
 
@@ -614,6 +623,20 @@ func testCosmosClusterResource() (*azcorearm.ResourceID, *api.HCPOpenShiftCluste
 		},
 	}
 	return clusterResourceId, cluster
+}
+
+// testCosmosServiceProviderNodePool returns an empty ServiceProviderNodePool nested under
+// the given node pool, the way CreateServiceProviderNodePool would have populated it in production.
+func testCosmosServiceProviderNodePool(nodePoolResourceId *azcorearm.ResourceID) *api.ServiceProviderNodePool {
+	spnpResourceId := api.Must(azcorearm.ParseResourceID(
+		nodePoolResourceId.String() + "/serviceProviderNodePools/" + api.ServiceProviderNodePoolResourceName,
+	))
+	return &api.ServiceProviderNodePool{
+		CosmosMetadata: arm.CosmosMetadata{
+			ResourceID:   spnpResourceId,
+			PartitionKey: strings.ToLower(spnpResourceId.SubscriptionID),
+		},
+	}
 }
 
 func testCosmosNodePool(clusterResourceId *azcorearm.ResourceID, name, nodePoolVersionId string, deleting bool) *api.HCPOpenShiftClusterNodePool {
@@ -639,12 +662,18 @@ func testCosmosNodePool(clusterResourceId *azcorearm.ResourceID, name, nodePoolV
 
 // testCosmosClusterWithActiveAndDeletingNodePools returns a cluster with one active node pool and one
 // node pool marked for deletion. Skew validation should consider only the active pool.
+// The active pool is also seeded with an empty ServiceProviderNodePool so that
+// listClusterAdmissionNodePools (which Gets the SPNP for every non-deleting pool)
+// returns a complete result.
 func testCosmosClusterWithActiveAndDeletingNodePools(activeNodePoolName, activeVersion, deletingNodePoolName, deletingVersion string) []any {
 	clusterResourceId, cluster := testCosmosClusterResource()
+	activeNodePool := testCosmosNodePool(clusterResourceId, activeNodePoolName, activeVersion, false)
+	deletingNodePool := testCosmosNodePool(clusterResourceId, deletingNodePoolName, deletingVersion, true)
 	return []any{
 		cluster,
-		testCosmosNodePool(clusterResourceId, activeNodePoolName, activeVersion, false),
-		testCosmosNodePool(clusterResourceId, deletingNodePoolName, deletingVersion, true),
+		activeNodePool,
+		deletingNodePool,
+		testCosmosServiceProviderNodePool(activeNodePool.ResourceID),
 	}
 }
 
@@ -736,7 +765,11 @@ func TestDesiredControlPlaneZVersion_Validations(t *testing.T) {
 			ctx := context.Background()
 			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, tt.cosmosResources)
 			require.NoError(t, err)
-			syncer := &controlPlaneDesiredVersionSyncer{resourcesDBClient: mockResourcesDBClient}
+			syncer := &controlPlaneDesiredVersionSyncer{
+				resourcesDBClient:             mockResourcesDBClient,
+				serviceProviderClusterLister:  &listertesting.DBServiceProviderClusterLister{ResourcesDBClient: mockResourcesDBClient},
+				serviceProviderNodePoolLister: &listertesting.DBServiceProviderNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
+			}
 
 			result, err := syncer.desiredControlPlaneZVersion(ctx, mockCincinnatiClient, api.Must(api.ToClusterResourceID("6b690bec-0c16-4ecb-8f67-781caf40bba7", "test-rg", "test-cluster")), tt.customerDesiredMinor, tt.channelGroup, tt.activeVersions, tt.experimentalReleaseFeatures)
 
@@ -871,8 +904,10 @@ func TestDesiredControlPlaneZVersion_CrossMajorUpgrade(t *testing.T) {
 			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, tt.cosmosResources)
 			require.NoError(t, err)
 			syncer := &controlPlaneDesiredVersionSyncer{
-				resourcesDBClient: mockResourcesDBClient,
-				graphClient:       mockGraphClient(ctrl, tt.channelExistence),
+				resourcesDBClient:             mockResourcesDBClient,
+				graphClient:                   mockGraphClient(ctrl, tt.channelExistence),
+				serviceProviderClusterLister:  &listertesting.DBServiceProviderClusterLister{ResourcesDBClient: mockResourcesDBClient},
+				serviceProviderNodePoolLister: &listertesting.DBServiceProviderNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
 			}
 
 			result, err := syncer.desiredControlPlaneZVersion(ctx, mockCincinnatiClient, api.Must(api.ToClusterResourceID("6b690bec-0c16-4ecb-8f67-781caf40bba7", "test-rg", "test-cluster")), tt.customerDesiredMinor, tt.channelGroup, tt.activeVersions, tt.experimentalReleaseFeatures)
@@ -1007,9 +1042,12 @@ func TestDesiredControlPlaneZVersion_InitialVersionSelection(t *testing.T) {
 			mockCincinnatiClient := cincinnati.NewMockClient(ctrl)
 			tt.mockSetup(mockCincinnatiClient)
 
+			mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
 			syncer := &controlPlaneDesiredVersionSyncer{
-				resourcesDBClient: databasetesting.NewMockResourcesDBClient(),
-				graphClient:       mockGraphClient(ctrl, tt.channelExistence),
+				resourcesDBClient:             mockResourcesDBClient,
+				graphClient:                   mockGraphClient(ctrl, tt.channelExistence),
+				serviceProviderClusterLister:  &listertesting.DBServiceProviderClusterLister{ResourcesDBClient: mockResourcesDBClient},
+				serviceProviderNodePoolLister: &listertesting.DBServiceProviderNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
 			}
 
 			// Empty active versions - simulating a new cluster
@@ -1212,12 +1250,15 @@ func TestControlPlaneDesiredVersionSyncer_SyncOnce(t *testing.T) {
 			mockClientCache.EXPECT().GetOrCreateClient(gomock.Any()).Return(mockCincinnati).AnyTimes()
 
 			syncer := &controlPlaneDesiredVersionSyncer{
-				readDesireLister:      newValidHostedClusterReadDesireLister(t),
-				resourcesDBClient:     mockResourcesDBClient,
-				clusterServiceClient:  mockCS,
-				subscriptionLister:    subscriptionLister,
-				cincinnatiClientCache: mockClientCache,
-				graphClient:           mockGraphClient(ctrl, tt.channelExistence),
+				cooldownChecker:               &alwaysSyncCooldownChecker{},
+				readDesireLister:              newValidHostedClusterReadDesireLister(t),
+				resourcesDBClient:             mockResourcesDBClient,
+				clusterServiceClient:          mockCS,
+				subscriptionLister:            subscriptionLister,
+				cincinnatiClientCache:         mockClientCache,
+				graphClient:                   mockGraphClient(ctrl, tt.channelExistence),
+				serviceProviderClusterLister:  &listertesting.DBServiceProviderClusterLister{ResourcesDBClient: mockResourcesDBClient},
+				serviceProviderNodePoolLister: &listertesting.DBServiceProviderNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
 			}
 
 			err := syncer.SyncOnce(ctx, clusterKey)
@@ -1505,10 +1546,12 @@ func TestControlPlaneDesiredVersionSyncer_SyncOnceSkipsWhenGated(t *testing.T) {
 	mockClientCache.EXPECT().GetOrCreateClient(gomock.Any()).Times(0)
 
 	syncer := &controlPlaneDesiredVersionSyncer{
-		clock:                clocktesting.NewFakePassiveClock(now),
-		readDesireLister:     newValidHostedClusterReadDesireLister(t),
-		resourcesDBClient:    mockDB,
-		clusterServiceClient: ocm.NewMockClusterServiceClientSpec(ctrl),
+		clock:                        clocktesting.NewFakePassiveClock(now),
+		cooldownChecker:              &alwaysSyncCooldownChecker{},
+		readDesireLister:             newValidHostedClusterReadDesireLister(t),
+		resourcesDBClient:            mockDB,
+		serviceProviderClusterLister: &listertesting.DBServiceProviderClusterLister{ResourcesDBClient: mockDB},
+		clusterServiceClient:         ocm.NewMockClusterServiceClientSpec(ctrl),
 		subscriptionLister: &listertesting.SliceSubscriptionLister{Subscriptions: []*arm.Subscription{{
 			ResourceID: api.Must(azcorearm.ParseResourceID("/subscriptions/" + testSubscriptionID)),
 			Properties: &arm.SubscriptionProperties{},

--- a/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller.go
@@ -85,7 +85,7 @@ func NewNodePoolVersionController(
 		cincinnatiClientCache:         cincinnati.NewClientCache(),
 	}
 
-	resyncDuration := 5 * time.Minute
+	resyncDuration := 1 * time.Minute
 	controller := controllerutils.NewNodePoolWatchingController(
 		NodepoolVersionControllerName,
 		resourcesDBClient,

--- a/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller_test.go
+++ b/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller_test.go
@@ -44,7 +44,6 @@ import (
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/api/kubeapplier"
 	"github.com/Azure/ARO-HCP/internal/cincinnati"
-	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/database"
 	dblisters "github.com/Azure/ARO-HCP/internal/database/listers"
 	internallistertesting "github.com/Azure/ARO-HCP/internal/database/listertesting"
@@ -61,14 +60,6 @@ const (
 	testCSNodePoolIDStr   = testCSClusterIDStr + "/node_pools/" + testNodePoolName
 	testClusterExternalID = "11111111-1111-1111-1111-111111111111"
 )
-
-type alwaysSyncCooldownChecker struct{}
-
-func (a *alwaysSyncCooldownChecker) CanSync(ctx context.Context, key any) bool {
-	return true
-}
-
-var _ controllerutil.CooldownChecker = &alwaysSyncCooldownChecker{}
 
 // createTestSubscription creates a subscription in the mock database.
 func createTestSubscription(t *testing.T, ctx context.Context, mockResourcesDBClient *databasetesting.MockResourcesDBClient) {

--- a/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller_test.go
+++ b/backend/pkg/controllers/upgradecontrollers/nodepool_version_controller_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/api/kubeapplier"
 	"github.com/Azure/ARO-HCP/internal/cincinnati"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/database"
 	dblisters "github.com/Azure/ARO-HCP/internal/database/listers"
 	internallistertesting "github.com/Azure/ARO-HCP/internal/database/listertesting"
@@ -60,6 +61,14 @@ const (
 	testCSNodePoolIDStr   = testCSClusterIDStr + "/node_pools/" + testNodePoolName
 	testClusterExternalID = "11111111-1111-1111-1111-111111111111"
 )
+
+type alwaysSyncCooldownChecker struct{}
+
+func (a *alwaysSyncCooldownChecker) CanSync(ctx context.Context, key any) bool {
+	return true
+}
+
+var _ controllerutil.CooldownChecker = &alwaysSyncCooldownChecker{}
 
 // createTestSubscription creates a subscription in the mock database.
 func createTestSubscription(t *testing.T, ctx context.Context, mockResourcesDBClient *databasetesting.MockResourcesDBClient) {
@@ -1470,7 +1479,11 @@ func assertSyncResult(t *testing.T, err error, expectedError bool, expectedError
 	}
 }
 
-// createServiceProviderClusterWithVersion creates a ServiceProviderCluster with the given control plane version.
+// createServiceProviderClusterWithVersion ensures a ServiceProviderCluster
+// exists with the given control plane version. If a sibling helper
+// (e.g. createTestHCPCluster) has already seeded an empty SPC via
+// GetOrCreateServiceProviderCluster, this updates that document in place via
+// Replace; otherwise it creates a new one.
 func createServiceProviderClusterWithVersion(t *testing.T, ctx context.Context, mockResourcesDBClient *databasetesting.MockResourcesDBClient, controlPlaneVersion string) {
 	t.Helper()
 
@@ -1481,6 +1494,20 @@ func createServiceProviderClusterWithVersion(t *testing.T, ctx context.Context, 
 	spClusterResourceID := clusterResourceID + "/" + api.ServiceProviderClusterResourceTypeName + "/" + api.ServiceProviderClusterResourceName
 
 	cpVersion := semver.MustParse(controlPlaneVersion)
+	spcCRUD := mockResourcesDBClient.ServiceProviderClusters(testSubscriptionID, testResourceGroupName, testClusterName)
+
+	existing, getErr := spcCRUD.Get(ctx, api.ServiceProviderClusterResourceName)
+	if getErr == nil {
+		replacement := existing.DeepCopy()
+		replacement.Status.ControlPlaneVersion.ActiveVersions = []api.HCPClusterActiveVersion{
+			{Version: &cpVersion, State: configv1.CompletedUpdate},
+		}
+		_, err := spcCRUD.Replace(ctx, replacement, nil)
+		require.NoError(t, err)
+		return
+	}
+	require.True(t, database.IsNotFoundError(getErr), "unexpected error reading SPC before seeding: %v", getErr)
+
 	spCluster := &api.ServiceProviderCluster{
 		CosmosMetadata: api.CosmosMetadata{
 			ResourceID:   api.Must(azcorearm.ParseResourceID(spClusterResourceID)),
@@ -1494,7 +1521,7 @@ func createServiceProviderClusterWithVersion(t *testing.T, ctx context.Context, 
 			},
 		},
 	}
-	_, err := mockResourcesDBClient.ServiceProviderClusters(testSubscriptionID, testResourceGroupName, testClusterName).Create(ctx, spCluster, nil)
+	_, err := spcCRUD.Create(ctx, spCluster, nil)
 	require.NoError(t, err)
 }
 

--- a/backend/pkg/controllers/upgradecontrollers/trigger_control_plane_upgrade_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/trigger_control_plane_upgrade_controller.go
@@ -29,7 +29,6 @@ import (
 	"github.com/Azure/ARO-HCP/backend/pkg/informers"
 	"github.com/Azure/ARO-HCP/backend/pkg/listers"
 	"github.com/Azure/ARO-HCP/internal/api"
-	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/database"
 	unionkubeapplierinformers "github.com/Azure/ARO-HCP/internal/database/unioninformers/kubeapplier"
 	"github.com/Azure/ARO-HCP/internal/ocm"
@@ -39,7 +38,6 @@ import (
 // triggerControlPlaneUpgradeSyncer is a Cluster syncer that triggers control plane upgrades
 type triggerControlPlaneUpgradeSyncer struct {
 	clock                        utilsclock.PassiveClock
-	cooldownChecker              controllerutil.CooldownChecker
 	resourcesDBClient            database.ResourcesDBClient
 	clusterServiceClient         ocm.ClusterServiceClientSpec
 	activeOperationLister        listers.ActiveOperationLister
@@ -66,7 +64,6 @@ func NewTriggerControlPlaneUpgradeController(
 ) controllerutils.Controller {
 	syncer := &triggerControlPlaneUpgradeSyncer{
 		clock:                        clock,
-		cooldownChecker:              controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
 		resourcesDBClient:            resourcesDBClient,
 		clusterServiceClient:         clusterServiceClient,
 		activeOperationLister:        activeOperationLister,
@@ -78,7 +75,7 @@ func NewTriggerControlPlaneUpgradeController(
 		resourcesDBClient,
 		informers,
 		kubeApplierInformers,
-		5*time.Minute,
+		1*time.Minute,
 		syncer,
 	)
 
@@ -92,10 +89,6 @@ func NewTriggerControlPlaneUpgradeController(
 //  2. Check if desiredVersion differs from latest actual version
 //  3. If different, call version service API to trigger upgrade
 //  4. The version service API is idempotent and handles the actual upgrade orchestration
-func (c *triggerControlPlaneUpgradeSyncer) CooldownChecker() controllerutil.CooldownChecker {
-	return c.cooldownChecker
-}
-
 func (c *triggerControlPlaneUpgradeSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPClusterKey) error {
 	logger := utils.LoggerFromContext(ctx)
 	existingCluster, err := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).Get(ctx, key.HCPClusterName)

--- a/backend/pkg/controllers/upgradecontrollers/trigger_control_plane_upgrade_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/trigger_control_plane_upgrade_controller.go
@@ -29,6 +29,7 @@ import (
 	"github.com/Azure/ARO-HCP/backend/pkg/informers"
 	"github.com/Azure/ARO-HCP/backend/pkg/listers"
 	"github.com/Azure/ARO-HCP/internal/api"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/database"
 	unionkubeapplierinformers "github.com/Azure/ARO-HCP/internal/database/unioninformers/kubeapplier"
 	"github.com/Azure/ARO-HCP/internal/ocm"
@@ -37,10 +38,12 @@ import (
 
 // triggerControlPlaneUpgradeSyncer is a Cluster syncer that triggers control plane upgrades
 type triggerControlPlaneUpgradeSyncer struct {
-	clock                 utilsclock.PassiveClock
-	resourcesDBClient     database.ResourcesDBClient
-	clusterServiceClient  ocm.ClusterServiceClientSpec
-	activeOperationLister listers.ActiveOperationLister
+	clock                        utilsclock.PassiveClock
+	cooldownChecker              controllerutil.CooldownChecker
+	resourcesDBClient            database.ResourcesDBClient
+	clusterServiceClient         ocm.ClusterServiceClientSpec
+	activeOperationLister        listers.ActiveOperationLister
+	serviceProviderClusterLister listers.ServiceProviderClusterLister
 }
 
 var _ controllerutils.ClusterSyncer = (*triggerControlPlaneUpgradeSyncer)(nil)
@@ -57,14 +60,17 @@ func NewTriggerControlPlaneUpgradeController(
 	resourcesDBClient database.ResourcesDBClient,
 	clusterServiceClient ocm.ClusterServiceClientSpec,
 	activeOperationLister listers.ActiveOperationLister,
+	serviceProviderClusterLister listers.ServiceProviderClusterLister,
 	informers informers.BackendInformers,
 	kubeApplierInformers *unionkubeapplierinformers.UnionKubeApplierInformers,
 ) controllerutils.Controller {
 	syncer := &triggerControlPlaneUpgradeSyncer{
-		clock:                 clock,
-		resourcesDBClient:     resourcesDBClient,
-		clusterServiceClient:  clusterServiceClient,
-		activeOperationLister: activeOperationLister,
+		clock:                        clock,
+		cooldownChecker:              controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		resourcesDBClient:            resourcesDBClient,
+		clusterServiceClient:         clusterServiceClient,
+		activeOperationLister:        activeOperationLister,
+		serviceProviderClusterLister: serviceProviderClusterLister,
 	}
 
 	controller := controllerutils.NewClusterWatchingController(
@@ -86,6 +92,10 @@ func NewTriggerControlPlaneUpgradeController(
 //  2. Check if desiredVersion differs from latest actual version
 //  3. If different, call version service API to trigger upgrade
 //  4. The version service API is idempotent and handles the actual upgrade orchestration
+func (c *triggerControlPlaneUpgradeSyncer) CooldownChecker() controllerutil.CooldownChecker {
+	return c.cooldownChecker
+}
+
 func (c *triggerControlPlaneUpgradeSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPClusterKey) error {
 	logger := utils.LoggerFromContext(ctx)
 	existingCluster, err := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).Get(ctx, key.HCPClusterName)
@@ -103,9 +113,13 @@ func (c *triggerControlPlaneUpgradeSyncer) SyncOnce(ctx context.Context, key con
 		return nil
 	}
 
-	existingServiceProviderCluster, err := database.GetOrCreateServiceProviderCluster(ctx, c.resourcesDBClient, key.GetResourceID())
+	existingServiceProviderCluster, err := c.serviceProviderClusterLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if database.IsNotFoundError(err) {
+		// CreateServiceProviderCluster will populate it; we'll be re-enqueued via the ServiceProviderCluster informer.
+		return nil
+	}
 	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to get or create ServiceProviderCluster: %w", err))
+		return utils.TrackError(fmt.Errorf("failed to get ServiceProviderCluster: %w", err))
 	}
 
 	// here we check to see if we should be triggering an upgrade. We do this by

--- a/backend/pkg/controllers/upgradecontrollers/trigger_node_pool_upgrade_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/trigger_node_pool_upgrade_controller.go
@@ -25,7 +25,9 @@ import (
 
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
 	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
 	"github.com/Azure/ARO-HCP/internal/api"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/database"
 	unionkubeapplierinformers "github.com/Azure/ARO-HCP/internal/database/unioninformers/kubeapplier"
 	"github.com/Azure/ARO-HCP/internal/ocm"
@@ -34,8 +36,10 @@ import (
 
 // triggerNodePoolUpgradeSyncer is a NodePool syncer that triggers node pool upgrades
 type triggerNodePoolUpgradeSyncer struct {
-	resourcesDBClient    database.ResourcesDBClient
-	clusterServiceClient ocm.ClusterServiceClientSpec
+	cooldownChecker               controllerutil.CooldownChecker
+	resourcesDBClient             database.ResourcesDBClient
+	clusterServiceClient          ocm.ClusterServiceClientSpec
+	serviceProviderNodePoolLister listers.ServiceProviderNodePoolLister
 }
 
 var _ controllerutils.NodePoolSyncer = (*triggerNodePoolUpgradeSyncer)(nil)
@@ -46,12 +50,16 @@ var _ controllerutils.NodePoolSyncer = (*triggerNodePoolUpgradeSyncer)(nil)
 func NewTriggerNodePoolUpgradeController(
 	resourcesDBClient database.ResourcesDBClient,
 	clusterServiceClient ocm.ClusterServiceClientSpec,
+	activeOperationLister listers.ActiveOperationLister,
+	serviceProviderNodePoolLister listers.ServiceProviderNodePoolLister,
 	informers informers.BackendInformers,
 	kubeApplierInformers *unionkubeapplierinformers.UnionKubeApplierInformers,
 ) controllerutils.Controller {
 	syncer := &triggerNodePoolUpgradeSyncer{
-		resourcesDBClient:    resourcesDBClient,
-		clusterServiceClient: clusterServiceClient,
+		cooldownChecker:               controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		resourcesDBClient:             resourcesDBClient,
+		clusterServiceClient:          clusterServiceClient,
+		serviceProviderNodePoolLister: serviceProviderNodePoolLister,
 	}
 
 	controller := controllerutils.NewNodePoolWatchingController(
@@ -73,6 +81,10 @@ func NewTriggerNodePoolUpgradeController(
 //  2. Skips upgrade trigger if no active versions exist yet (during installation)
 //  3. Check if desiredVersion differs from latest actual version
 //  4. If different, create a NodePoolUpgradePolicy to trigger upgrade
+func (c *triggerNodePoolUpgradeSyncer) CooldownChecker() controllerutil.CooldownChecker {
+	return c.cooldownChecker
+}
+
 func (c *triggerNodePoolUpgradeSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPNodePoolKey) error {
 	existingNodePool, err := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).
 		NodePools(key.HCPClusterName).Get(ctx, key.HCPNodePoolName)
@@ -90,9 +102,13 @@ func (c *triggerNodePoolUpgradeSyncer) SyncOnce(ctx context.Context, key control
 		return nil
 	}
 
-	existingServiceProviderNodePool, err := database.GetOrCreateServiceProviderNodePool(ctx, c.resourcesDBClient, key.GetResourceID())
+	existingServiceProviderNodePool, err := c.serviceProviderNodePoolLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
+	if database.IsNotFoundError(err) {
+		// CreateServiceProviderNodePool will populate it; we'll be re-enqueued via the ServiceProviderNodePool informer.
+		return nil
+	}
 	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to get or create ServiceProviderNodePool: %w", err))
+		return utils.TrackError(fmt.Errorf("failed to get ServiceProviderNodePool: %w", err))
 	}
 
 	desiredVersion := existingServiceProviderNodePool.Spec.NodePoolVersion.DesiredVersion

--- a/backend/pkg/controllers/upgradecontrollers/trigger_node_pool_upgrade_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/trigger_node_pool_upgrade_controller.go
@@ -27,7 +27,6 @@ import (
 	"github.com/Azure/ARO-HCP/backend/pkg/informers"
 	"github.com/Azure/ARO-HCP/backend/pkg/listers"
 	"github.com/Azure/ARO-HCP/internal/api"
-	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/database"
 	unionkubeapplierinformers "github.com/Azure/ARO-HCP/internal/database/unioninformers/kubeapplier"
 	"github.com/Azure/ARO-HCP/internal/ocm"
@@ -36,7 +35,6 @@ import (
 
 // triggerNodePoolUpgradeSyncer is a NodePool syncer that triggers node pool upgrades
 type triggerNodePoolUpgradeSyncer struct {
-	cooldownChecker               controllerutil.CooldownChecker
 	resourcesDBClient             database.ResourcesDBClient
 	clusterServiceClient          ocm.ClusterServiceClientSpec
 	serviceProviderNodePoolLister listers.ServiceProviderNodePoolLister
@@ -50,13 +48,11 @@ var _ controllerutils.NodePoolSyncer = (*triggerNodePoolUpgradeSyncer)(nil)
 func NewTriggerNodePoolUpgradeController(
 	resourcesDBClient database.ResourcesDBClient,
 	clusterServiceClient ocm.ClusterServiceClientSpec,
-	activeOperationLister listers.ActiveOperationLister,
 	serviceProviderNodePoolLister listers.ServiceProviderNodePoolLister,
 	informers informers.BackendInformers,
 	kubeApplierInformers *unionkubeapplierinformers.UnionKubeApplierInformers,
 ) controllerutils.Controller {
 	syncer := &triggerNodePoolUpgradeSyncer{
-		cooldownChecker:               controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
 		resourcesDBClient:             resourcesDBClient,
 		clusterServiceClient:          clusterServiceClient,
 		serviceProviderNodePoolLister: serviceProviderNodePoolLister,
@@ -81,10 +77,6 @@ func NewTriggerNodePoolUpgradeController(
 //  2. Skips upgrade trigger if no active versions exist yet (during installation)
 //  3. Check if desiredVersion differs from latest actual version
 //  4. If different, create a NodePoolUpgradePolicy to trigger upgrade
-func (c *triggerNodePoolUpgradeSyncer) CooldownChecker() controllerutil.CooldownChecker {
-	return c.cooldownChecker
-}
-
 func (c *triggerNodePoolUpgradeSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPNodePoolKey) error {
 	existingNodePool, err := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).
 		NodePools(key.HCPClusterName).Get(ctx, key.HCPNodePoolName)

--- a/backend/pkg/controllers/upgradecontrollers/trigger_node_pool_upgrade_controller_test.go
+++ b/backend/pkg/controllers/upgradecontrollers/trigger_node_pool_upgrade_controller_test.go
@@ -34,6 +34,7 @@ import (
 	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
 
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/databasetesting"
@@ -138,7 +139,8 @@ func TestTriggerNodePoolUpgradeSyncer_SyncOnce(t *testing.T) {
 			tt.seedDB(t, runCtx, mockDB)
 
 			syncer := &triggerNodePoolUpgradeSyncer{
-				resourcesDBClient: mockDB,
+				resourcesDBClient:             mockDB,
+				serviceProviderNodePoolLister: &listertesting.DBServiceProviderNodePoolLister{ResourcesDBClient: mockDB},
 			}
 
 			err := syncer.SyncOnce(runCtx, controllerutils.HCPNodePoolKey{

--- a/backend/pkg/controllers/validationcontrollers/cluster_validation_controller.go
+++ b/backend/pkg/controllers/validationcontrollers/cluster_validation_controller.go
@@ -27,7 +27,6 @@ import (
 	"github.com/Azure/ARO-HCP/backend/pkg/informers"
 	"github.com/Azure/ARO-HCP/backend/pkg/listers"
 	"github.com/Azure/ARO-HCP/internal/api"
-	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/database"
 	unionkubeapplierinformers "github.com/Azure/ARO-HCP/internal/database/unioninformers/kubeapplier"
 	"github.com/Azure/ARO-HCP/internal/utils"
@@ -36,7 +35,6 @@ import (
 // clusterValidationSyncer is a Cluster syncer that performs a Cluster
 // validation.
 type clusterValidationSyncer struct {
-	cooldownChecker              controllerutil.CooldownChecker
 	resourcesDBClient            database.ResourcesDBClient
 	serviceProviderClusterLister listers.ServiceProviderClusterLister
 
@@ -50,7 +48,6 @@ var _ controllerutils.ClusterSyncer = (*clusterValidationSyncer)(nil)
 // executes the provided Cluster validation on each cluster.
 func NewClusterValidationController(
 	validation validations.ClusterValidation,
-	activeOperationLister listers.ActiveOperationLister,
 	resourcesDBClient database.ResourcesDBClient,
 	serviceProviderClusterLister listers.ServiceProviderClusterLister,
 	informers informers.BackendInformers,
@@ -58,7 +55,6 @@ func NewClusterValidationController(
 ) controllerutils.Controller {
 
 	syncer := &clusterValidationSyncer{
-		cooldownChecker:              controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
 		resourcesDBClient:            resourcesDBClient,
 		serviceProviderClusterLister: serviceProviderClusterLister,
 		validation:                   validation,
@@ -74,10 +70,6 @@ func NewClusterValidationController(
 	)
 
 	return controller
-}
-
-func (c *clusterValidationSyncer) CooldownChecker() controllerutil.CooldownChecker {
-	return c.cooldownChecker
 }
 
 func (c *clusterValidationSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPClusterKey) error {

--- a/backend/pkg/controllers/validationcontrollers/cluster_validation_controller.go
+++ b/backend/pkg/controllers/validationcontrollers/cluster_validation_controller.go
@@ -25,7 +25,9 @@ import (
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/validationcontrollers/validations"
 	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
 	"github.com/Azure/ARO-HCP/internal/api"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/database"
 	unionkubeapplierinformers "github.com/Azure/ARO-HCP/internal/database/unioninformers/kubeapplier"
 	"github.com/Azure/ARO-HCP/internal/utils"
@@ -34,7 +36,9 @@ import (
 // clusterValidationSyncer is a Cluster syncer that performs a Cluster
 // validation.
 type clusterValidationSyncer struct {
-	resourcesDBClient database.ResourcesDBClient
+	cooldownChecker              controllerutil.CooldownChecker
+	resourcesDBClient            database.ResourcesDBClient
+	serviceProviderClusterLister listers.ServiceProviderClusterLister
 
 	// validation is the validation to perform on the cluster.
 	validation validations.ClusterValidation
@@ -46,14 +50,18 @@ var _ controllerutils.ClusterSyncer = (*clusterValidationSyncer)(nil)
 // executes the provided Cluster validation on each cluster.
 func NewClusterValidationController(
 	validation validations.ClusterValidation,
+	activeOperationLister listers.ActiveOperationLister,
 	resourcesDBClient database.ResourcesDBClient,
+	serviceProviderClusterLister listers.ServiceProviderClusterLister,
 	informers informers.BackendInformers,
 	kubeApplierInformers *unionkubeapplierinformers.UnionKubeApplierInformers,
 ) controllerutils.Controller {
 
 	syncer := &clusterValidationSyncer{
-		resourcesDBClient: resourcesDBClient,
-		validation:        validation,
+		cooldownChecker:              controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		resourcesDBClient:            resourcesDBClient,
+		serviceProviderClusterLister: serviceProviderClusterLister,
+		validation:                   validation,
 	}
 
 	controller := controllerutils.NewClusterWatchingController(
@@ -68,6 +76,10 @@ func NewClusterValidationController(
 	return controller
 }
 
+func (c *clusterValidationSyncer) CooldownChecker() controllerutil.CooldownChecker {
+	return c.cooldownChecker
+}
+
 func (c *clusterValidationSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPClusterKey) error {
 	existingCluster, err := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).Get(ctx, key.HCPClusterName)
 	if database.IsNotFoundError(err) {
@@ -80,15 +92,20 @@ func (c *clusterValidationSyncer) SyncOnce(ctx context.Context, key controllerut
 		return nil
 	}
 
-	existingServiceProviderCluster, err := database.GetOrCreateServiceProviderCluster(ctx, c.resourcesDBClient, key.GetResourceID())
+	cachedServiceProviderCluster, err := c.serviceProviderClusterLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if database.IsNotFoundError(err) {
+		// CreateServiceProviderCluster will populate it; we'll be re-enqueued via the ServiceProviderCluster informer.
+		return nil
+	}
 	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to get or create ServiceProviderCluster: %w", err))
+		return utils.TrackError(fmt.Errorf("failed to get ServiceProviderCluster: %w", err))
 	}
 
-	shouldProcess := c.shouldProcess(existingServiceProviderCluster)
+	shouldProcess := c.shouldProcess(cachedServiceProviderCluster)
 	if !shouldProcess {
 		return nil // no work to do
 	}
+	existingServiceProviderCluster := cachedServiceProviderCluster.DeepCopy()
 	subscription, err := c.resourcesDBClient.Subscriptions().Get(ctx, existingCluster.ID.SubscriptionID)
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to get Subscription: %w", err))

--- a/backend/pkg/controllers/validationcontrollers/nodepool_validation_controller.go
+++ b/backend/pkg/controllers/validationcontrollers/nodepool_validation_controller.go
@@ -27,6 +27,7 @@ import (
 	"github.com/Azure/ARO-HCP/backend/pkg/informers"
 	"github.com/Azure/ARO-HCP/backend/pkg/listers"
 	"github.com/Azure/ARO-HCP/internal/api"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/database"
 	unionkubeapplierinformers "github.com/Azure/ARO-HCP/internal/database/unioninformers/kubeapplier"
 	"github.com/Azure/ARO-HCP/internal/utils"
@@ -35,7 +36,9 @@ import (
 // nodePoolValidationSyncer is a NodePool syncer that performs a NodePool
 // validation.
 type nodePoolValidationSyncer struct {
-	resourcesDBClient database.ResourcesDBClient
+	cooldownChecker               controllerutil.CooldownChecker
+	resourcesDBClient             database.ResourcesDBClient
+	serviceProviderNodePoolLister listers.ServiceProviderNodePoolLister
 
 	// validation is the validation to perform on the node pool.
 	validation validations.NodePoolValidation
@@ -49,13 +52,16 @@ func NewNodePoolValidationController(
 	validation validations.NodePoolValidation,
 	activeOperationLister listers.ActiveOperationLister,
 	resourcesDBClient database.ResourcesDBClient,
+	serviceProviderNodePoolLister listers.ServiceProviderNodePoolLister,
 	informers informers.BackendInformers,
 	kubeApplierInformers *unionkubeapplierinformers.UnionKubeApplierInformers,
 ) controllerutils.Controller {
 
 	syncer := &nodePoolValidationSyncer{
-		resourcesDBClient: resourcesDBClient,
-		validation:        validation,
+		cooldownChecker:               controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		resourcesDBClient:             resourcesDBClient,
+		serviceProviderNodePoolLister: serviceProviderNodePoolLister,
+		validation:                    validation,
 	}
 
 	controller := controllerutils.NewNodePoolWatchingController(
@@ -68,6 +74,10 @@ func NewNodePoolValidationController(
 	)
 
 	return controller
+}
+
+func (c *nodePoolValidationSyncer) CooldownChecker() controllerutil.CooldownChecker {
+	return c.cooldownChecker
 }
 
 func (c *nodePoolValidationSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPNodePoolKey) error {
@@ -93,15 +103,20 @@ func (c *nodePoolValidationSyncer) SyncOnce(ctx context.Context, key controlleru
 		return nil
 	}
 
-	existingServiceProviderNodePool, err := database.GetOrCreateServiceProviderNodePool(ctx, c.resourcesDBClient, key.GetResourceID())
+	cachedServiceProviderNodePool, err := c.serviceProviderNodePoolLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
+	if database.IsNotFoundError(err) {
+		// CreateServiceProviderNodePool will populate it; we'll be re-enqueued via the ServiceProviderNodePool informer.
+		return nil
+	}
 	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to get or create ServiceProviderNodePool: %w", err))
+		return utils.TrackError(fmt.Errorf("failed to get ServiceProviderNodePool: %w", err))
 	}
 
-	shouldProcess := c.shouldProcess(existingServiceProviderNodePool)
+	shouldProcess := c.shouldProcess(cachedServiceProviderNodePool)
 	if !shouldProcess {
 		return nil // no work to do
 	}
+	existingServiceProviderNodePool := cachedServiceProviderNodePool.DeepCopy()
 	subscription, err := c.resourcesDBClient.Subscriptions().Get(ctx, existingNodePool.ID.SubscriptionID)
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to get Subscription: %w", err))

--- a/backend/pkg/controllers/validationcontrollers/nodepool_validation_controller.go
+++ b/backend/pkg/controllers/validationcontrollers/nodepool_validation_controller.go
@@ -27,7 +27,6 @@ import (
 	"github.com/Azure/ARO-HCP/backend/pkg/informers"
 	"github.com/Azure/ARO-HCP/backend/pkg/listers"
 	"github.com/Azure/ARO-HCP/internal/api"
-	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/database"
 	unionkubeapplierinformers "github.com/Azure/ARO-HCP/internal/database/unioninformers/kubeapplier"
 	"github.com/Azure/ARO-HCP/internal/utils"
@@ -36,7 +35,6 @@ import (
 // nodePoolValidationSyncer is a NodePool syncer that performs a NodePool
 // validation.
 type nodePoolValidationSyncer struct {
-	cooldownChecker               controllerutil.CooldownChecker
 	resourcesDBClient             database.ResourcesDBClient
 	serviceProviderNodePoolLister listers.ServiceProviderNodePoolLister
 
@@ -58,7 +56,6 @@ func NewNodePoolValidationController(
 ) controllerutils.Controller {
 
 	syncer := &nodePoolValidationSyncer{
-		cooldownChecker:               controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
 		resourcesDBClient:             resourcesDBClient,
 		serviceProviderNodePoolLister: serviceProviderNodePoolLister,
 		validation:                    validation,
@@ -74,10 +71,6 @@ func NewNodePoolValidationController(
 	)
 
 	return controller
-}
-
-func (c *nodePoolValidationSyncer) CooldownChecker() controllerutil.CooldownChecker {
-	return c.cooldownChecker
 }
 
 func (c *nodePoolValidationSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPNodePoolKey) error {

--- a/backend/pkg/controllers/validationcontrollers/nodepool_validation_controller_test.go
+++ b/backend/pkg/controllers/validationcontrollers/nodepool_validation_controller_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
-	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/databasetesting"
 	"github.com/Azure/ARO-HCP/internal/utils"
@@ -114,14 +113,6 @@ func newTestSubscription() *arm.Subscription {
 		State:      arm.SubscriptionStateRegistered,
 	}
 }
-
-type alwaysSyncCooldownChecker struct{}
-
-func (a *alwaysSyncCooldownChecker) CanSync(ctx context.Context, key any) bool {
-	return true
-}
-
-var _ controllerutil.CooldownChecker = &alwaysSyncCooldownChecker{}
 
 // mockNodePoolValidation implements validations.NodePoolValidation for tests.
 type mockNodePoolValidation struct {
@@ -236,7 +227,6 @@ func TestNodePoolValidationSyncer_SyncOnce(t *testing.T) {
 			}
 
 			syncer := &nodePoolValidationSyncer{
-				cooldownChecker:               &alwaysSyncCooldownChecker{},
 				resourcesDBClient:             mockDB,
 				serviceProviderNodePoolLister: &listertesting.DBServiceProviderNodePoolLister{ResourcesDBClient: mockDB},
 				validation:                    tc.validation,

--- a/backend/pkg/controllers/validationcontrollers/nodepool_validation_controller_test.go
+++ b/backend/pkg/controllers/validationcontrollers/nodepool_validation_controller_test.go
@@ -31,8 +31,11 @@ import (
 
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/validationcontrollers/validations"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/databasetesting"
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
@@ -112,6 +115,14 @@ func newTestSubscription() *arm.Subscription {
 	}
 }
 
+type alwaysSyncCooldownChecker struct{}
+
+func (a *alwaysSyncCooldownChecker) CanSync(ctx context.Context, key any) bool {
+	return true
+}
+
+var _ controllerutil.CooldownChecker = &alwaysSyncCooldownChecker{}
+
 // mockNodePoolValidation implements validations.NodePoolValidation for tests.
 type mockNodePoolValidation struct {
 	name        string
@@ -132,9 +143,14 @@ func TestNodePoolValidationSyncer_SyncOnce(t *testing.T) {
 		t.Helper()
 		_, err := mockDB.HCPClusters(testSubscriptionID, testResourceGroup).Create(ctx, newTestCluster(t), nil)
 		require.NoError(t, err)
-		_, err = mockDB.HCPClusters(testSubscriptionID, testResourceGroup).NodePools(testClusterName).Create(ctx, newTestNodePool(t), nil)
+		nodePool := newTestNodePool(t)
+		_, err = mockDB.HCPClusters(testSubscriptionID, testResourceGroup).NodePools(testClusterName).Create(ctx, nodePool, nil)
 		require.NoError(t, err)
 		_, err = mockDB.Subscriptions().Create(ctx, newTestSubscription(), nil)
+		require.NoError(t, err)
+		// Seed an empty ServiceProviderNodePool the way the production creator
+		// controller would have populated it by the time the syncer runs.
+		_, err = database.GetOrCreateServiceProviderNodePool(ctx, mockDB, nodePool.ID)
 		require.NoError(t, err)
 	}
 
@@ -190,28 +206,17 @@ func TestNodePoolValidationSyncer_SyncOnce(t *testing.T) {
 			setupDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
 				t.Helper()
 				defaultSetupDB(t, ctx, mockDB)
-				spnpResourceID := api.Must(azcorearm.ParseResourceID(
-					"/subscriptions/" + testSubscriptionID +
-						"/resourceGroups/" + testResourceGroup +
-						"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
-						"/nodePools/" + testNodePoolName +
-						"/serviceProviderNodePools/default"))
-				spnp := &api.ServiceProviderNodePool{
-					CosmosMetadata: arm.CosmosMetadata{
-						ResourceID:   spnpResourceID,
-						PartitionKey: strings.ToLower(spnpResourceID.SubscriptionID),
-					},
-					Status: api.ServiceProviderNodePoolStatus{
-						Validations: []metav1.Condition{
-							{
-								Type:   testValidationName,
-								Status: metav1.ConditionTrue,
-								Reason: "Succeeded",
-							},
-						},
+				spnpCRUD := mockDB.ServiceProviderNodePools(testSubscriptionID, testResourceGroup, testClusterName, testNodePoolName)
+				spnp, err := spnpCRUD.Get(ctx, api.ServiceProviderNodePoolResourceName)
+				require.NoError(t, err)
+				spnp.Status.Validations = []metav1.Condition{
+					{
+						Type:   testValidationName,
+						Status: metav1.ConditionTrue,
+						Reason: "Succeeded",
 					},
 				}
-				_, err := mockDB.ServiceProviderNodePools(testSubscriptionID, testResourceGroup, testClusterName, testNodePoolName).Create(ctx, spnp, nil)
+				_, err = spnpCRUD.Replace(ctx, spnp, nil)
 				require.NoError(t, err)
 			},
 			validation: &mockNodePoolValidation{
@@ -231,8 +236,10 @@ func TestNodePoolValidationSyncer_SyncOnce(t *testing.T) {
 			}
 
 			syncer := &nodePoolValidationSyncer{
-				resourcesDBClient: mockDB,
-				validation:        tc.validation,
+				cooldownChecker:               &alwaysSyncCooldownChecker{},
+				resourcesDBClient:             mockDB,
+				serviceProviderNodePoolLister: &listertesting.DBServiceProviderNodePoolLister{ResourcesDBClient: mockDB},
+				validation:                    tc.validation,
 			}
 
 			err := syncer.SyncOnce(ctx, newTestNodePoolKey())
@@ -245,7 +252,7 @@ func TestNodePoolValidationSyncer_SyncOnce(t *testing.T) {
 			if tc.wantConditionStatus != nil {
 				spnp, spnpErr := mockDB.ServiceProviderNodePools(
 					testSubscriptionID, testResourceGroup, testClusterName, testNodePoolName,
-				).Get(ctx, "default")
+				).Get(ctx, api.ServiceProviderNodePoolResourceName)
 				require.NoError(t, spnpErr)
 
 				cond := meta.FindStatusCondition(spnp.Status.Validations, testValidationName)

--- a/backend/pkg/listertesting/db_listers.go
+++ b/backend/pkg/listertesting/db_listers.go
@@ -232,7 +232,7 @@ func (l *DBServiceProviderClusterLister) List(ctx context.Context) ([]*api.Servi
 }
 
 func (l *DBServiceProviderClusterLister) Get(ctx context.Context, subscriptionID, resourceGroupName, clusterName string) (*api.ServiceProviderCluster, error) {
-	return l.ResourcesDBClient.ServiceProviderClusters(subscriptionID, resourceGroupName, clusterName).Get(ctx, "default")
+	return l.ResourcesDBClient.ServiceProviderClusters(subscriptionID, resourceGroupName, clusterName).Get(ctx, api.ServiceProviderClusterResourceName)
 }
 
 func (l *DBServiceProviderClusterLister) ListForCluster(ctx context.Context, subscriptionID, resourceGroupName, clusterName string) ([]*api.ServiceProviderCluster, error) {


### PR DESCRIPTION
Consumer controllers used to call database.GetOrCreateServiceProviderCluster / GetOrCreateServiceProviderNodePool on every sync, which both hit Cosmos and scattered the create path across many sites. Replace those calls with cached ServiceProvider{Cluster,NodePool}Lister Gets; when the document is absent the syncer returns nil and is re-enqueued by the existing ServiceProvider* informer event handlers once the document arrives.

A single dedicated controller per kind owns creation: CreateServiceProviderCluster and CreateServiceProviderNodePool consult the lister cache first and call GetOrCreate only on a miss, so the create-with-conflict-fallback pattern lives in exactly one place per resource.
