### PR TITLE
feat: add KMS etcd encryption SLI observability stack

### DIFF
--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arohcp_monitor.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arohcp_monitor.yaml
@@ -67712,6 +67712,21 @@ data:
             type: StateSet
           help: Cluster progressing condition
           name: progressing
+        - each:
+            stateSet:
+              labelName: status
+              list:
+              - "True"
+              - "False"
+              - Unknown
+              path:
+              - status
+              - conditions
+              - '[type=ValidAzureKMSConfig]'
+              - status
+            type: StateSet
+          help: Azure KMS configuration validity condition
+          name: valid_azure_kms_config
 ---
 # Source: hcp-prometheus/templates/ama-metrics-settings-configmap.yaml
 kind: ConfigMap

--- a/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_mgmt_resources.yaml
+++ b/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_mgmt_resources.yaml
@@ -67712,6 +67712,21 @@ data:
             type: StateSet
           help: Cluster progressing condition
           name: progressing
+        - each:
+            stateSet:
+              labelName: status
+              list:
+              - "True"
+              - "False"
+              - Unknown
+              path:
+              - status
+              - conditions
+              - '[type=ValidAzureKMSConfig]'
+              - status
+            type: StateSet
+          help: Azure KMS configuration validity condition
+          name: valid_azure_kms_config
 ---
 # Source: hcp-prometheus/templates/ama-metrics-settings-configmap.yaml
 kind: ConfigMap

--- a/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_mgmt_resources_unset.yaml
+++ b/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_mgmt_resources_unset.yaml
@@ -67712,6 +67712,21 @@ data:
             type: StateSet
           help: Cluster progressing condition
           name: progressing
+        - each:
+            stateSet:
+              labelName: status
+              list:
+              - "True"
+              - "False"
+              - Unknown
+              path:
+              - status
+              - conditions
+              - '[type=ValidAzureKMSConfig]'
+              - status
+            type: StateSet
+          help: Azure KMS configuration validity condition
+          name: valid_azure_kms_config
 ---
 # Source: hcp-prometheus/templates/ama-metrics-settings-configmap.yaml
 kind: ConfigMap

--- a/observability/prometheus/values-mgmt.yaml
+++ b/observability/prometheus/values-mgmt.yaml
@@ -128,6 +128,14 @@ kube-prometheus-stack:
                   path: [status, conditions, "[type=Progressing]", status]
                   labelName: status
                   list: ["True", "False", "Unknown"]
+            - name: "valid_azure_kms_config"
+              help: "Azure KMS configuration validity condition"
+              each:
+                type: StateSet
+                stateSet:
+                  path: [status, conditions, "[type=ValidAzureKMSConfig]", status]
+                  labelName: status
+                  list: ["True", "False", "Unknown"]
 # this is our own config for the files in templates/
 prometheusSpec:
   image:


### PR DESCRIPTION
## Summary

Expose the `ValidAzureKMSConfig` HostedCluster condition as a Prometheus gauge via kube-state-metrics custom resource state config ([ARO-25913](https://redhat.atlassian.net/browse/ARO-25913)).

This is the **metrics collection foundation** for the KMS etcd encryption user journey. It ships only the KSM metric — recording rules, alerts, and a Grafana dashboard will follow in a separate PR after metrics have soaked in production.

### What this PR adds

| Component | File | Purpose |
|-----------|------|---------| 
| KSM metric | `observability/prometheus/values-mgmt.yaml` | Exposes `ValidAzureKMSConfig` condition as `hostedClusterAPI_valid_azure_kms_config` Prometheus gauge (StateSet: True/False/Unknown) |

### What's deferred (follow-up PR)

| Deferred | Why |
|----------|-----|
| KMS availability recording rules | Need production data soak before setting alert thresholds |
| KMS alerts (availability + errors + latency + saturation) | Need soak + alert-tester validation |
| Envelope recording rules (`apiserver_envelope_encryption_*`) | Raw KAS pod metrics not scraped — blocked by HyperShift ServiceMonitor bug |
| Grafana dashboard | Depends on recording rules + envelope metrics |

### E2E verification

- [x] KSM metric verified on personal dev mgmt cluster (`pers-usw3haow-mgmt-1`)
- [x] Metric `hostedClusterAPI_valid_azure_kms_config{status="True"}` confirmed flowing to Azure Monitor Workspace
- [x] Helm fixture tests regenerated and passing

## Test plan

- [x] `make test` passes (helm template fixtures updated)
- [x] KSM metric produces correct StateSet values for `haowang` test HCP cluster