### PR TITLE
backend: expose specifics for cluster create in degraded condition

### DIFF
--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_create.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_create.go
@@ -157,7 +157,7 @@ func (c *operationClusterCreate) SynchronizeOperation(ctx context.Context, key c
 		// we want to require that the cosmos view of cluster creation is also complete before we mark it.  This ensures (among other things)
 		// that our ability to read maestro is successful.
 		// Once we have confidence in our ability to determine that cluster is functional, we'll stop checking cluster-service at all.
-		return fmt.Errorf("cosmos operation status is %q, but cluster-service operation status is %q", cosmosNewOperationState.provisioningState, newOperationStatus)
+		return fmt.Errorf("cosmos operation status is %q, but cluster-service operation status is %q: %s", cosmosNewOperationState.provisioningState, newOperationStatus, cosmosNewOperationState.message)
 	}
 
 	logger.Info("updating status")

--- a/backend/pkg/controllers/operationcontrollers/utils.go
+++ b/backend/pkg/controllers/operationcontrollers/utils.go
@@ -477,10 +477,10 @@ func convertClusterStatus(ctx context.Context, clusterServiceClient ocm.ClusterS
 		// no unique ProvisioningState values for them. They should
 		// only occur when ProvisioningState is Accepted.
 		if newOperationStatus != arm.ProvisioningStateAccepted {
-			err = fmt.Errorf("got ClusterState '%s' while ProvisioningState was '%s' instead of '%s'", state, newOperationStatus, arm.ProvisioningStateAccepted)
+			err = fmt.Errorf("got ClusterState '%s' (description: %q) while ProvisioningState was '%s' instead of '%s'", state, clusterStatus.Description(), newOperationStatus, arm.ProvisioningStateAccepted)
 		}
 	default:
-		err = fmt.Errorf("unhandled ClusterState '%s'", state)
+		err = fmt.Errorf("unhandled ClusterState '%s' (description: %q)", state, clusterStatus.Description())
 	}
 
 	return newOperationStatus, opError, err
@@ -537,7 +537,8 @@ func convertNodePoolStatus(operation *api.Operation, nodePoolStatus *arohcpv1alp
 		// no unique ProvisioningState values for them. They should
 		// only occur when ProvisioningState is Accepted.
 		if operation.Status != arm.ProvisioningStateAccepted {
-			err = fmt.Errorf("got NodePoolStatusValue '%s' while ProvisioningState was '%s' instead of '%s'", state, operation.Status, arm.ProvisioningStateAccepted)
+			msg, _ := nodePoolStatus.GetMessage()
+			err = fmt.Errorf("got NodePoolStatusValue '%s' (message: %q) while ProvisioningState was '%s' instead of '%s'", state, msg, operation.Status, arm.ProvisioningStateAccepted)
 		}
 	case NodePoolStateInstalling:
 		newOperationStatus = arm.ProvisioningStateProvisioning
@@ -563,7 +564,8 @@ func convertNodePoolStatus(operation *api.Operation, nodePoolStatus *arohcpv1alp
 			opError.Message = msg
 		}
 	default:
-		err = fmt.Errorf("unhandled NodePoolState '%s'", state)
+		msg, _ := nodePoolStatus.GetMessage()
+		err = fmt.Errorf("unhandled NodePoolState '%s' (message: %q)", state, msg)
 	}
 
 	return newOperationStatus, opError, err
@@ -590,7 +592,8 @@ func convertExternalAuthStatus(operation *api.Operation, externalAuthStatus *aro
 	case ExternalAuthStateUninstalling:
 		newOperationStatus = arm.ProvisioningStateDeleting
 	default:
-		err = fmt.Errorf("unhandled ExternalAuthState '%s'", state)
+		msg, _ := externalAuthStatus.GetMessage()
+		err = fmt.Errorf("unhandled ExternalAuthState '%s' (message: %q)", state, msg)
 	}
 	return newOperationStatus, opError, err
 }


### PR DESCRIPTION
backend: expose specifics for cluster create in degraded condition

We need to be specific in our conditions so that downstream users are
better able to debug issues from conditions alone.

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---

backend: update more conditions

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---

