### PR TITLE
Override suite parallelism

### DIFF
--- a/test/cmd/aro-hcp-tests/main.go
+++ b/test/cmd/aro-hcp-tests/main.go
@@ -51,16 +51,19 @@ func slowTestsOnly(query string) string {
 	return fmt.Sprintf("%s && labels.exists(l, l==\"%s\")", query, labels.Slow[0])
 }
 
-// suiteParallelism returns the overridden parallelism from
-// ARO_HCP_SUITE_PARALLELISM if set, otherwise the provided default.
-func suiteParallelism(defaultParallelism int) int {
-	if v := os.Getenv("ARO_HCP_SUITE_PARALLELISM"); v != "" {
-		n, err := strconv.Atoi(v)
-		if err == nil && n > 0 {
-			return n
-		}
+// parseSuiteParallelismOverride reads ARO_HCP_SUITE_PARALLELISM and
+// returns a non-nil pointer when a valid override is present.
+func parseSuiteParallelismOverride() *int {
+	v := os.Getenv("ARO_HCP_SUITE_PARALLELISM")
+	if v == "" {
+		return nil
 	}
-	return defaultParallelism
+	n, err := strconv.Atoi(v)
+	if err != nil || n <= 0 {
+		fmt.Fprintf(os.Stderr, "WARNING: ARO_HCP_SUITE_PARALLELISM=%q is not a valid positive integer, ignoring override\n", v)
+		return nil
+	}
+	return &n
 }
 
 func miDemandPriority(spec *et.ExtensionTestSpec) int {
@@ -78,6 +81,14 @@ func setupCli() *cobra.Command {
 	// content at some arbitrary length.
 	format.MaxLength = 0
 	format.MaxDepth = 0
+
+	parallelismOverride := parseSuiteParallelismOverride()
+	parallelism := func(defaultValue int) int {
+		if parallelismOverride != nil {
+			return *parallelismOverride
+		}
+		return defaultValue
+	}
 
 	// Extension registry
 	registry := e.NewRegistry()
@@ -99,7 +110,7 @@ func setupCli() *cobra.Command {
 		// Spec parallelism is limited by the leased identity containers. We set suite parallelism slightly above the number of
 		// leased identity containers to avoid multi-HCP tests blocking single-HCP tests from obtaining a lease.
 		// Override at runtime via ARO_HCP_SUITE_PARALLELISM.
-		Parallelism: suiteParallelism(24),
+		Parallelism: parallelism(24),
 		TestTimeout: &integrationTestTimeout,
 	})
 
@@ -111,7 +122,7 @@ func setupCli() *cobra.Command {
 		// Spec parallelism is limited by the leased identity containers. We set suite parallelism slightly above the number of
 		// leased identity containers to avoid multi-HCP tests blocking single-HCP tests from obtaining a lease.
 		// Override at runtime via ARO_HCP_SUITE_PARALLELISM.
-		Parallelism: suiteParallelism(24),
+		Parallelism: parallelism(24),
 		TestTimeout: &integrationTestTimeout,
 	})
 
@@ -125,7 +136,7 @@ func setupCli() *cobra.Command {
 		// Spec parallelism is limited by the leased identity containers. We set suite parallelism slightly above the number of
 		// leased identity containers to avoid multi-HCP tests blocking single-HCP tests from obtaining a lease.
 		// Override at runtime via ARO_HCP_SUITE_PARALLELISM.
-		Parallelism: suiteParallelism(34),
+		Parallelism: parallelism(34),
 		TestTimeout: &stageTestTimeout,
 	})
 	ext.AddSuite(e.Suite{
@@ -136,7 +147,7 @@ func setupCli() *cobra.Command {
 		// Spec parallelism is limited by the leased identity containers. We set suite parallelism slightly above the number of
 		// leased identity containers to avoid multi-HCP tests blocking single-HCP tests from obtaining a lease.
 		// Override at runtime via ARO_HCP_SUITE_PARALLELISM.
-		Parallelism: suiteParallelism(34),
+		Parallelism: parallelism(34),
 		TestTimeout: &stageTestTimeout,
 	})
 
@@ -150,7 +161,7 @@ func setupCli() *cobra.Command {
 		// Spec parallelism is limited by the leased identity containers. We set suite parallelism slightly above the number of
 		// leased identity containers to avoid multi-HCP tests blocking single-HCP tests from obtaining a lease.
 		// Override at runtime via ARO_HCP_SUITE_PARALLELISM.
-		Parallelism: suiteParallelism(19),
+		Parallelism: parallelism(19),
 		TestTimeout: &prodTestTimeout,
 	})
 	ext.AddSuite(e.Suite{
@@ -161,7 +172,7 @@ func setupCli() *cobra.Command {
 		// Spec parallelism is limited by the leased identity containers. We set suite parallelism slightly above the number of
 		// leased identity containers to avoid multi-HCP tests blocking single-HCP tests from obtaining a lease.
 		// Override at runtime via ARO_HCP_SUITE_PARALLELISM.
-		Parallelism: suiteParallelism(19),
+		Parallelism: parallelism(19),
 		TestTimeout: &prodTestTimeout,
 	})
 
@@ -174,7 +185,7 @@ func setupCli() *cobra.Command {
 			fmt.Sprintf(`labels.exists(l, l=="%s" ) && labels.exists(l, l=="%s")`, labels.AroRpApiCompatible[0], labels.Positive[0]),
 		},
 		// Override at runtime via ARO_HCP_SUITE_PARALLELISM.
-		Parallelism: suiteParallelism(20),
+		Parallelism: parallelism(20),
 	})
 
 	rpApiCompatBaseQualifier := fmt.Sprintf(`labels.exists(l, l=="%s")`, labels.AroRpApiCompatible[0])
@@ -192,7 +203,7 @@ func setupCli() *cobra.Command {
 		// Spec parallelism is limited by the leased identity containers. We set suite parallelism slightly above the number of
 		// leased identity containers to avoid multi-HCP tests blocking single-HCP tests from obtaining a lease.
 		// Override at runtime via ARO_HCP_SUITE_PARALLELISM.
-		Parallelism: suiteParallelism(24),
+		Parallelism: parallelism(24),
 		TestTimeout: &rpApiCompatTestTimeout,
 	})
 	ext.AddSuite(e.Suite{
@@ -201,7 +212,7 @@ func setupCli() *cobra.Command {
 		// Spec parallelism is limited by the leased identity containers. We set suite parallelism slightly above the number of
 		// leased identity containers to avoid multi-HCP tests blocking single-HCP tests from obtaining a lease.
 		// Override at runtime via ARO_HCP_SUITE_PARALLELISM.
-		Parallelism: suiteParallelism(24),
+		Parallelism: parallelism(24),
 		TestTimeout: &rpApiCompatTestTimeout,
 	})
 

--- a/test/cmd/aro-hcp-tests/main.go
+++ b/test/cmd/aro-hcp-tests/main.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strconv"
 	"time"
 
 	// If using ginkgo, import your tests here
@@ -48,6 +49,18 @@ func fastTestsOnly(query string) string {
 
 func slowTestsOnly(query string) string {
 	return fmt.Sprintf("%s && labels.exists(l, l==\"%s\")", query, labels.Slow[0])
+}
+
+// suiteParallelism returns the overridden parallelism from
+// ARO_HCP_SUITE_PARALLELISM if set, otherwise the provided default.
+func suiteParallelism(defaultParallelism int) int {
+	if v := os.Getenv("ARO_HCP_SUITE_PARALLELISM"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err == nil && n > 0 {
+			return n
+		}
+	}
+	return defaultParallelism
 }
 
 func miDemandPriority(spec *et.ExtensionTestSpec) int {
@@ -85,8 +98,8 @@ func setupCli() *cobra.Command {
 		},
 		// Spec parallelism is limited by the leased identity containers. We set suite parallelism slightly above the number of
 		// leased identity containers to avoid multi-HCP tests blocking single-HCP tests from obtaining a lease.
-		// LEASED_MSI_CONTAINERS=20
-		Parallelism: 24,
+		// Override at runtime via ARO_HCP_SUITE_PARALLELISM.
+		Parallelism: suiteParallelism(24),
 		TestTimeout: &integrationTestTimeout,
 	})
 
@@ -97,8 +110,8 @@ func setupCli() *cobra.Command {
 		},
 		// Spec parallelism is limited by the leased identity containers. We set suite parallelism slightly above the number of
 		// leased identity containers to avoid multi-HCP tests blocking single-HCP tests from obtaining a lease.
-		// LEASED_MSI_CONTAINERS=20
-		Parallelism: 24,
+		// Override at runtime via ARO_HCP_SUITE_PARALLELISM.
+		Parallelism: suiteParallelism(24),
 		TestTimeout: &integrationTestTimeout,
 	})
 
@@ -111,8 +124,8 @@ func setupCli() *cobra.Command {
 		},
 		// Spec parallelism is limited by the leased identity containers. We set suite parallelism slightly above the number of
 		// leased identity containers to avoid multi-HCP tests blocking single-HCP tests from obtaining a lease.
-		// LEASED_MSI_CONTAINERS=30
-		Parallelism: 34,
+		// Override at runtime via ARO_HCP_SUITE_PARALLELISM.
+		Parallelism: suiteParallelism(34),
 		TestTimeout: &stageTestTimeout,
 	})
 	ext.AddSuite(e.Suite{
@@ -122,8 +135,8 @@ func setupCli() *cobra.Command {
 		},
 		// Spec parallelism is limited by the leased identity containers. We set suite parallelism slightly above the number of
 		// leased identity containers to avoid multi-HCP tests blocking single-HCP tests from obtaining a lease.
-		// LEASED_MSI_CONTAINERS=30
-		Parallelism: 34,
+		// Override at runtime via ARO_HCP_SUITE_PARALLELISM.
+		Parallelism: suiteParallelism(34),
 		TestTimeout: &stageTestTimeout,
 	})
 
@@ -136,8 +149,8 @@ func setupCli() *cobra.Command {
 		},
 		// Spec parallelism is limited by the leased identity containers. We set suite parallelism slightly above the number of
 		// leased identity containers to avoid multi-HCP tests blocking single-HCP tests from obtaining a lease.
-		// LEASED_MSI_CONTAINERS=15
-		Parallelism: 19,
+		// Override at runtime via ARO_HCP_SUITE_PARALLELISM.
+		Parallelism: suiteParallelism(19),
 		TestTimeout: &prodTestTimeout,
 	})
 	ext.AddSuite(e.Suite{
@@ -147,8 +160,8 @@ func setupCli() *cobra.Command {
 		},
 		// Spec parallelism is limited by the leased identity containers. We set suite parallelism slightly above the number of
 		// leased identity containers to avoid multi-HCP tests blocking single-HCP tests from obtaining a lease.
-		// LEASED_MSI_CONTAINERS=15
-		Parallelism: 19,
+		// Override at runtime via ARO_HCP_SUITE_PARALLELISM.
+		Parallelism: suiteParallelism(19),
 		TestTimeout: &prodTestTimeout,
 	})
 
@@ -160,7 +173,8 @@ func setupCli() *cobra.Command {
 			// TODO: revisit labels to tweak which tests to select here
 			fmt.Sprintf(`labels.exists(l, l=="%s" ) && labels.exists(l, l=="%s")`, labels.AroRpApiCompatible[0], labels.Positive[0]),
 		},
-		Parallelism: 20,
+		// Override at runtime via ARO_HCP_SUITE_PARALLELISM.
+		Parallelism: suiteParallelism(20),
 	})
 
 	rpApiCompatBaseQualifier := fmt.Sprintf(`labels.exists(l, l=="%s")`, labels.AroRpApiCompatible[0])
@@ -177,8 +191,8 @@ func setupCli() *cobra.Command {
 		Qualifiers: []string{fastTestsOnly(rpApiCompatBaseQualifier)},
 		// Spec parallelism is limited by the leased identity containers. We set suite parallelism slightly above the number of
 		// leased identity containers to avoid multi-HCP tests blocking single-HCP tests from obtaining a lease.
-		// LEASED_MSI_CONTAINERS=20
-		Parallelism: 24,
+		// Override at runtime via ARO_HCP_SUITE_PARALLELISM.
+		Parallelism: suiteParallelism(24),
 		TestTimeout: &rpApiCompatTestTimeout,
 	})
 	ext.AddSuite(e.Suite{
@@ -186,8 +200,8 @@ func setupCli() *cobra.Command {
 		Qualifiers: []string{slowTestsOnly(rpApiCompatBaseQualifier)},
 		// Spec parallelism is limited by the leased identity containers. We set suite parallelism slightly above the number of
 		// leased identity containers to avoid multi-HCP tests blocking single-HCP tests from obtaining a lease.
-		// LEASED_MSI_CONTAINERS=20
-		Parallelism: 24,
+		// Override at runtime via ARO_HCP_SUITE_PARALLELISM.
+		Parallelism: suiteParallelism(24),
 		TestTimeout: &rpApiCompatTestTimeout,
 	})
 

--- a/test/e2e-config/e2e-slots.yaml
+++ b/test/e2e-config/e2e-slots.yaml
@@ -5,15 +5,6 @@ environments:
     - ci00
     - ci01
     pools:
-    # shard1: additional dev capacity for multi-subscription testing.
-    # Capacity is still limited to 4000 role assignments.
-    - subscription_name: "ARO HCP E2E Hosted Clusters 2 (EA Subscription)"
-      region: westus3
-      region_mode: runtime-selected
-      resource_type: aro-hcp-dev-shard1-slot
-      slot_count: 7
-      identity_container_prefix: aro-hcp-msi-container-dev-shard1
-      identity_container_count: 20
     # shard0: current CI dev capacity on the first customer subscription.
     # Jobs choose the runtime region; `region` is only the default when no runtime override is provided.
     # Identity containers are provisioned in westus3.
@@ -24,26 +15,33 @@ environments:
       slot_count: 15
       identity_container_prefix: aro-hcp-msi-container-dev-shard0
       identity_container_count: 20
+    # shard1: additional dev capacity for multi-subscription testing.
+    # Capacity is still limited to 4000 role assignments.
+    - subscription_name: "ARO HCP E2E Hosted Clusters 2 (EA Subscription)"
+      region: westus3
+      region_mode: runtime-selected
+      resource_type: aro-hcp-dev-shard1-slot
+      slot_count: 3
+      identity_container_prefix: aro-hcp-msi-container-dev-shard1
+      identity_container_count: 50
     # shard2: dedicated dev capacity on the third customer subscription.
-    # identity_container_count is higher than shard0/shard1 (40 vs 20) because this
-    # single-tenant subscription is sized to run the full DEV E2E suite in parallel.
+    # Capacity is still limited to 4000 role assignments.
     - subscription_name: "ARO HCP E2E Hosted Clusters - Dev - 02"
       region: westus3
       region_mode: runtime-selected
       resource_type: aro-hcp-dev-shard2-slot
-      slot_count: 1
+      slot_count: 3
       identity_container_prefix: aro-hcp-msi-container-dev-shard2
-      identity_container_count: 40
+      identity_container_count: 50
     # shard3: dedicated dev capacity on the fourth customer subscription.
-    # identity_container_count is higher than shard0/shard1 (40 vs 20) because this
-    # single-tenant subscription is sized to run the full DEV E2E suite in parallel.
+    # Capacity is still limited to 4000 role assignments.
     - subscription_name: "ARO HCP E2E Hosted Clusters - Dev - 03"
       region: westus3
       region_mode: runtime-selected
       resource_type: aro-hcp-dev-shard3-slot
-      slot_count: 1
+      slot_count: 3
       identity_container_prefix: aro-hcp-msi-container-dev-shard3
-      identity_container_count: 40
+      identity_container_count: 50
   int:
     deploy_envs:
     - int


### PR DESCRIPTION
This is the first PR in a series to switch e2e-parallel jobs to single-wave execution, where all HCPs are created in parallel rather than in multiple waves.

Today, suite parallelism is hardcoded in main.go and must match the number of identity containers leased by each job. As we move to single-wave execution with larger identity container pools, parallelism needs to flow from the slot configuration rather than being baked into the binary.

This PR adds an optional ARO_HCP_SUITE_PARALLELISM envvar that overrides the hardcoded parallelism defaults at runtime. When unset, behavior is unchanged. The envvar will be set in openshift/release job definitions to match the identity container count provided by each slot.