### PR TITLE
feat(observability): add HCP Namespace Deep Dive dashboard (ARO-26981)

### DIFF
--- a/observability/grafana-dashboards/sre/user-journey/hcp_namespace_deepdive.json
+++ b/observability/grafana-dashboards/sre/user-journey/hcp_namespace_deepdive.json
@@ -477,7 +477,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${datasource_hcp}"
+        "uid": "${datasource_svc}"
       },
       "description": "How many pods are in each state right now (Running, Pending, Failed, Succeeded).",
       "fieldConfig": {
@@ -627,7 +627,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${datasource_hcp}"
+        "uid": "${datasource_svc}"
       },
       "description": "Container restarts in the last hour per pod (more useful for triage than total restarts since pod started).",
       "fieldConfig": {
@@ -723,7 +723,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${datasource_hcp}"
+        "uid": "${datasource_svc}"
       },
       "description": "OOMKilled events timeline. Note: changes() counts value transitions not discrete events - may miss kills between scrapes.",
       "fieldConfig": {
@@ -819,7 +819,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${datasource_hcp}"
+        "uid": "${datasource_svc}"
       },
       "description": "Why each container exited last time (OOMKilled, Error, Completed, etc).",
       "fieldConfig": {

--- a/observability/grafana-dashboards/sre/user-journey/hcp_namespace_deepdive.json
+++ b/observability/grafana-dashboards/sre/user-journey/hcp_namespace_deepdive.json
@@ -477,7 +477,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${datasource_svc}"
+        "uid": "${datasource_hcp}"
       },
       "description": "How many pods are in each state right now (Running, Pending, Failed, Succeeded).",
       "fieldConfig": {
@@ -587,36 +587,44 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource_svc}"
+            "uid": "${datasource_hcp}"
           },
-          "expr": "sum(kube_pod_status_phase{cluster=\"$cluster\", namespace=\"$namespace\", phase=\"Running\"})",
+          "expr": "sum(kube_pod_status_phase{cluster=\"$cluster\", namespace=\"$namespace\", phase=\"running\"})",
+          "instant": true,
+          "range": false,
           "legendFormat": "Running",
           "refId": "A"
         },
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource_svc}"
+            "uid": "${datasource_hcp}"
           },
-          "expr": "sum(kube_pod_status_phase{cluster=\"$cluster\", namespace=\"$namespace\", phase=\"Pending\"})",
+          "expr": "sum(kube_pod_status_phase{cluster=\"$cluster\", namespace=\"$namespace\", phase=\"pending\"})",
+          "instant": true,
+          "range": false,
           "legendFormat": "Pending",
           "refId": "B"
         },
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource_svc}"
+            "uid": "${datasource_hcp}"
           },
-          "expr": "sum(kube_pod_status_phase{cluster=\"$cluster\", namespace=\"$namespace\", phase=\"Failed\"})",
+          "expr": "sum(kube_pod_status_phase{cluster=\"$cluster\", namespace=\"$namespace\", phase=\"failed\"})",
+          "instant": true,
+          "range": false,
           "legendFormat": "Failed",
           "refId": "C"
         },
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource_svc}"
+            "uid": "${datasource_hcp}"
           },
-          "expr": "sum(kube_pod_status_phase{cluster=\"$cluster\", namespace=\"$namespace\", phase=\"Succeeded\"})",
+          "expr": "sum(kube_pod_status_phase{cluster=\"$cluster\", namespace=\"$namespace\", phase=\"succeeded\"})",
+          "instant": true,
+          "range": false,
           "legendFormat": "Succeeded",
           "refId": "D"
         }
@@ -627,7 +635,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${datasource_svc}"
+        "uid": "${datasource_hcp}"
       },
       "description": "Container restarts in the last hour per pod (more useful for triage than total restarts since pod started).",
       "fieldConfig": {
@@ -710,7 +718,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource_svc}"
+            "uid": "${datasource_hcp}"
           },
           "expr": "sum by (pod) (increase(kube_pod_container_status_restarts_total{cluster=\"$cluster\", namespace=\"$namespace\"}[1h]))",
           "legendFormat": "{{pod}}",
@@ -723,7 +731,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${datasource_svc}"
+        "uid": "${datasource_hcp}"
       },
       "description": "OOMKilled events timeline. Note: changes() counts value transitions not discrete events - may miss kills between scrapes.",
       "fieldConfig": {
@@ -806,7 +814,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource_svc}"
+            "uid": "${datasource_hcp}"
           },
           "expr": "sum by (container) (changes(kube_pod_container_status_terminated_reason{cluster=\"$cluster\", namespace=\"$namespace\", reason=\"OOMKilled\"}[5m]))",
           "legendFormat": "{{container}}",
@@ -819,7 +827,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${datasource_svc}"
+        "uid": "${datasource_hcp}"
       },
       "description": "Why each container exited last time (OOMKilled, Error, Completed, etc).",
       "fieldConfig": {
@@ -884,7 +892,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource_svc}"
+            "uid": "${datasource_hcp}"
           },
           "expr": "kube_pod_container_status_last_terminated_reason{cluster=\"$cluster\", namespace=\"$namespace\"}",
           "format": "table",

--- a/observability/grafana-dashboards/sre/user-journey/hcp_namespace_deepdive.json
+++ b/observability/grafana-dashboards/sre/user-journey/hcp_namespace_deepdive.json
@@ -1,0 +1,1872 @@
+{
+  "uid": "hcp-namespace-deepdive",
+  "title": "HCP Namespace Deep Dive",
+  "description": "Drill-down view for investigating specific HCP instances on MGMT clusters. Shows per-container resource breakdown, pod lifecycle, and etcd health.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": [],
+      "title": "Container Resource Breakdown",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource_svc}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "CPU Cores",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*kube-apiserver.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*etcd.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*kube-controller-manager.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*openshift-apiserver.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource_svc}"
+          },
+          "expr": "sum by (container) (rate(container_cpu_usage_seconds_total{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", container!=\"POD\"}[5m]))",
+          "legendFormat": "{{container}}",
+          "refId": "A"
+        }
+      ],
+      "title": "CPU Usage per Container",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource_svc}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Memory",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource_svc}"
+          },
+          "expr": "sum by (container) (container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", container!=\"POD\"})",
+          "legendFormat": "{{container}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Memory Working Set per Container",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource_svc}"
+      },
+      "description": "Shows memory usage vs ClusterSizingConfig request. HCPs have NO limits, only requests. Tiers: small=8Gi, medium=16Gi, large=32Gi, xlarge=64Gi, xxlarge=96Gi",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.7
+              },
+              {
+                "color": "red",
+                "value": 0.9
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Container"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 250
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Usage (Gi)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Request (Gi)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 4,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Usage/Request Ratio"
+          }
+        ]
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource_svc}"
+          },
+          "expr": "sum by (container) (container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", container!=\"POD\"})",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "refId": "Usage"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource_svc}"
+          },
+          "expr": "sum by (container) (kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"})",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "refId": "Request"
+        }
+      ],
+      "title": "Memory Usage vs ClusterSizingConfig Request",
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "container",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Time 1": true,
+              "Time 2": true,
+              "__name__": true,
+              "__name__ 1": true,
+              "__name__ 2": true,
+              "cluster": true,
+              "cluster 1": true,
+              "cluster 2": true,
+              "job": true,
+              "job 1": true,
+              "job 2": true,
+              "namespace": true,
+              "namespace 1": true,
+              "namespace 2": true,
+              "resource": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Value #Request": "Request",
+              "Value #Usage": "Usage",
+              "container": "Container"
+            }
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Usage/Request Ratio",
+            "binary": {
+              "left": "Usage (Gi)",
+              "operator": "/",
+              "right": "Request (Gi)"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 5,
+      "panels": [],
+      "title": "Pod Status",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource_svc}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Running"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Pending"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Failed"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Succeeded"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 18
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource_svc}"
+          },
+          "expr": "sum(kube_pod_status_phase{cluster=\"$cluster\", namespace=\"$namespace\", phase=\"Running\"})",
+          "legendFormat": "Running",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource_svc}"
+          },
+          "expr": "sum(kube_pod_status_phase{cluster=\"$cluster\", namespace=\"$namespace\", phase=\"Pending\"})",
+          "legendFormat": "Pending",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource_svc}"
+          },
+          "expr": "sum(kube_pod_status_phase{cluster=\"$cluster\", namespace=\"$namespace\", phase=\"Failed\"})",
+          "legendFormat": "Failed",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource_svc}"
+          },
+          "expr": "sum(kube_pod_status_phase{cluster=\"$cluster\", namespace=\"$namespace\", phase=\"Succeeded\"})",
+          "legendFormat": "Succeeded",
+          "refId": "D"
+        }
+      ],
+      "title": "Current Pod Phase",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource_svc}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Restart Count",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 16,
+        "x": 8,
+        "y": 18
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource_svc}"
+          },
+          "expr": "sum by (pod) (kube_pod_container_status_restarts_total{cluster=\"$cluster\", namespace=\"$namespace\"})",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Container Restart Count per Pod",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource_svc}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "OOM Events",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 100,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [
+            "sum"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource_svc}"
+          },
+          "expr": "sum by (container) (increase(kube_pod_container_status_terminated_reason{cluster=\"$cluster\", namespace=\"$namespace\", reason=\"OOMKilled\"}[5m]))",
+          "legendFormat": "{{container}}",
+          "refId": "A"
+        }
+      ],
+      "title": "OOMKilled Events Timeline",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource_svc}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Termination Reason"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 200
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 9,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource_svc}"
+          },
+          "expr": "kube_pod_container_status_last_terminated_reason{cluster=\"$cluster\", namespace=\"$namespace\"}",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Last Terminated Reason per Container",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "cluster": true,
+              "job": true,
+              "namespace": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Value": "Active",
+              "container": "Container",
+              "pod": "Pod",
+              "reason": "Termination Reason"
+            }
+          }
+        },
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "greater",
+                  "options": {
+                    "value": 0
+                  }
+                },
+                "fieldName": "Active"
+              }
+            ],
+            "match": "any",
+            "type": "include"
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 30
+      },
+      "id": 10,
+      "panels": [],
+      "title": "Network I/O",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource_svc}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Receive Rate",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 31
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource_svc}"
+          },
+          "expr": "sum by (pod) (rate(container_network_receive_bytes_total{cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Network Receive Bytes per Pod",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource_svc}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Transmit Rate",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 31
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource_svc}"
+          },
+          "expr": "sum by (pod) (rate(container_network_transmit_bytes_total{cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Network Transmit Bytes per Pod",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource_svc}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Errors/s",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 39
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource_svc}"
+          },
+          "expr": "sum by (pod) (rate(container_network_receive_errors_total{cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
+          "legendFormat": "{{pod}} - RX Errors",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource_svc}"
+          },
+          "expr": "sum by (pod) (rate(container_network_transmit_errors_total{cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
+          "legendFormat": "{{pod}} - TX Errors",
+          "refId": "B"
+        }
+      ],
+      "title": "Network Error Rate",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 45
+      },
+      "id": 14,
+      "panels": [],
+      "title": "Disk I/O",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource_svc}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Usage",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 8589934592
+              },
+              {
+                "color": "red",
+                "value": 21474836480
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 46
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource_svc}"
+          },
+          "expr": "sum by (container) (container_fs_usage_bytes{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", container!=\"POD\"})",
+          "legendFormat": "{{container}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Filesystem Usage per Container",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource_svc}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Read Rate",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 54
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource_svc}"
+          },
+          "expr": "sum by (container) (rate(container_fs_reads_bytes_total{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", container!=\"POD\"}[5m]))",
+          "legendFormat": "{{container}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Disk Read Bytes per Container",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource_svc}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Write Rate",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 54
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource_svc}"
+          },
+          "expr": "sum by (container) (rate(container_fs_writes_bytes_total{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", container!=\"POD\"}[5m]))",
+          "legendFormat": "{{container}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Disk Write Bytes per Container",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 62
+      },
+      "id": 18,
+      "panels": [],
+      "title": "etcd Health",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource_hcp}"
+      },
+      "description": "etcd metrics from HCP AMW (hcps-{region}). WAL fsync latency should be <10ms for healthy etcd.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Latency",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.01
+              },
+              {
+                "color": "red",
+                "value": 0.1
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 63
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource_hcp}"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (le, pod))",
+          "legendFormat": "{{pod}} - p99 WAL fsync",
+          "refId": "A"
+        }
+      ],
+      "title": "etcd Disk WAL fsync Latency (p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource_hcp}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 2147483648
+              },
+              {
+                "color": "red",
+                "value": 8589934592
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 63
+      },
+      "id": 20,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource_hcp}"
+          },
+          "expr": "sum(etcd_mvcc_db_total_size_in_bytes{cluster=\"$cluster\", namespace=\"$namespace\"})",
+          "refId": "A"
+        }
+      ],
+      "title": "etcd DB Size",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource_hcp}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 5
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 63
+      },
+      "id": 21,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource_hcp}"
+          },
+          "expr": "sum(increase(etcd_server_leader_changes_seen_total{cluster=\"$cluster\", namespace=\"$namespace\"}[1h]))",
+          "refId": "A"
+        }
+      ],
+      "title": "etcd Leader Changes (Last 1h)",
+      "type": "stat"
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": [
+    "hcp",
+    "namespace",
+    "mgmt-cluster",
+    "deep-dive",
+    "sre"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "name": "datasource_svc",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "^Managed_Prometheus_services-.*$",
+        "type": "datasource"
+      },
+      {
+        "current": {},
+        "name": "datasource_hcp",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "^Managed_Prometheus_hcps-.*$",
+        "type": "datasource"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource_hcp}"
+        },
+        "definition": "label_values(apiserver_audit_event_total, cluster)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Cluster (MGMT)",
+        "multi": false,
+        "name": "cluster",
+        "options": [],
+        "query": {
+          "query": "label_values(apiserver_audit_event_total, cluster)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "^.*-mgmt-\\d+$",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource_hcp}"
+        },
+        "definition": "label_values(apiserver_audit_event_total, namespace)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Namespace (HCP)",
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "query": "label_values(apiserver_audit_event_total, namespace)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "^ocm-.*$",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "version": 0,
+  "weekStart": ""
+}

--- a/observability/grafana-dashboards/sre/user-journey/hcp_namespace_deepdive.json
+++ b/observability/grafana-dashboards/sre/user-journey/hcp_namespace_deepdive.json
@@ -26,7 +26,7 @@
         "type": "prometheus",
         "uid": "${datasource_svc}"
       },
-      "description": "CPU usage rate (cores) per container, averaged over 5m. Colored by control plane component.",
+      "description": "CPU usage rate (cores) per container. Colored by control plane component.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -168,8 +168,8 @@
             "type": "prometheus",
             "uid": "${datasource_svc}"
           },
-          "expr": "sum by (container) (rate(container_cpu_usage_seconds_total{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", container!=\"POD\"}[5m]))",
-          "legendFormat": "{{container}}",
+          "expr": "sum by (pod, container) (rate(container_cpu_usage_seconds_total{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", container!=\"POD\"}[$__rate_interval]))",
+          "legendFormat": "{{pod}}/{{container}}",
           "refId": "A"
         }
       ],
@@ -262,8 +262,8 @@
             "type": "prometheus",
             "uid": "${datasource_svc}"
           },
-          "expr": "sum by (container) (container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", container!=\"POD\"})",
-          "legendFormat": "{{container}}",
+          "expr": "sum by (pod, container) (container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", container!=\"POD\"})",
+          "legendFormat": "{{pod}}/{{container}}",
           "refId": "A"
         }
       ],
@@ -275,7 +275,7 @@
         "type": "prometheus",
         "uid": "${datasource_svc}"
       },
-      "description": "Shows memory usage vs ClusterSizingConfig request. HCPs have NO limits, only requests. Tiers: small=8Gi, medium=16Gi, large=32Gi, xlarge=64Gi, xxlarge=96Gi",
+      "description": "Memory working set per container (actual usage from cadvisor metrics)",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -295,18 +295,10 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 0.7
-              },
-              {
-                "color": "red",
-                "value": 0.9
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "bytes"
         },
         "overrides": [
           {
@@ -317,39 +309,7 @@
             "properties": [
               {
                 "id": "custom.width",
-                "value": 250
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Usage"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "bytes"
-              },
-              {
-                "id": "decimals",
-                "value": 2
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Request"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "bytes"
-              },
-              {
-                "id": "decimals",
-                "value": 2
+                "value": 200
               }
             ]
           }
@@ -357,7 +317,7 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 24,
+        "w": 12,
         "x": 0,
         "y": 9
       },
@@ -376,7 +336,7 @@
         "sortBy": [
           {
             "desc": true,
-            "displayName": "Usage/Request Ratio"
+            "displayName": "Value"
           }
         ]
       },
@@ -390,71 +350,125 @@
           "expr": "sum by (container) (container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", container!=\"POD\"})",
           "format": "table",
           "instant": true,
+          "range": false,
           "legendFormat": "__auto",
-          "refId": "Usage"
+          "refId": "A"
+        }
+      ],
+      "title": "Memory Usage per Container",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "renameByName": {
+              "Value": "Usage (bytes)",
+              "container": "Container"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource_hcp}"
+      },
+      "description": "Memory requests per container from kube-state-metrics (pod spec resource requests). HCPs have NO limits, only requests. Tiers: small=8Gi, medium=16Gi, large=32Gi, xlarge=64Gi, xxlarge=96Gi",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
         },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Container"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 200
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "id": 22,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Value"
+          }
+        ]
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource_svc}"
+            "uid": "${datasource_hcp}"
           },
-          "expr": "sum by (container) (kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"})",
+          "expr": "sum by (container) (kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\", container!=\"\", container!=\"POD\"})",
           "format": "table",
           "instant": true,
+          "range": false,
           "legendFormat": "__auto",
-          "refId": "Request"
+          "refId": "A"
         }
       ],
-      "title": "Memory Usage vs ClusterSizingConfig Request",
+      "title": "Memory Requests per Container",
       "transformations": [
-        {
-          "id": "joinByField",
-          "options": {
-            "byField": "container",
-            "mode": "outer"
-          }
-        },
         {
           "id": "organize",
           "options": {
             "excludeByName": {
               "Time": true,
-              "Time 1": true,
-              "Time 2": true,
-              "__name__": true,
-              "__name__ 1": true,
-              "__name__ 2": true,
-              "cluster": true,
-              "cluster 1": true,
-              "cluster 2": true,
-              "job": true,
-              "job 1": true,
-              "job 2": true,
-              "namespace": true,
-              "namespace 1": true,
-              "namespace 2": true,
               "resource": true
             },
-            "indexByName": {},
             "renameByName": {
-              "Value #Request": "Request",
-              "Value #Usage": "Usage",
+              "Value": "Request (bytes)",
               "container": "Container"
-            }
-          }
-        },
-        {
-          "id": "calculateField",
-          "options": {
-            "alias": "Usage/Request Ratio",
-            "binary": {
-              "left": "Usage",
-              "operator": "/",
-              "right": "Request"
-            },
-            "mode": "binary",
-            "reduce": {
-              "reducer": "sum"
             }
           }
         }
@@ -816,7 +830,7 @@
             "type": "prometheus",
             "uid": "${datasource_hcp}"
           },
-          "expr": "sum by (container) (changes(kube_pod_container_status_terminated_reason{cluster=\"$cluster\", namespace=\"$namespace\", reason=\"OOMKilled\"}[5m]))",
+          "expr": "sum by (container) (changes(kube_pod_container_status_terminated_reason{cluster=\"$cluster\", namespace=\"$namespace\", reason=\"OOMKilled\"}[$__rate_interval]))",
           "legendFormat": "{{container}}",
           "refId": "A"
         }
@@ -1041,7 +1055,7 @@
             "type": "prometheus",
             "uid": "${datasource_svc}"
           },
-          "expr": "sum by (pod) (rate(container_network_receive_bytes_total{cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
+          "expr": "sum by (pod) (rate(container_network_receive_bytes_total{cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval]))",
           "legendFormat": "{{pod}}",
           "refId": "A"
         }
@@ -1135,7 +1149,7 @@
             "type": "prometheus",
             "uid": "${datasource_svc}"
           },
-          "expr": "sum by (pod) (rate(container_network_transmit_bytes_total{cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
+          "expr": "sum by (pod) (rate(container_network_transmit_bytes_total{cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval]))",
           "legendFormat": "{{pod}}",
           "refId": "A"
         }
@@ -1232,7 +1246,7 @@
             "type": "prometheus",
             "uid": "${datasource_svc}"
           },
-          "expr": "sum by (pod) (rate(container_network_receive_errors_total{cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
+          "expr": "sum by (pod) (rate(container_network_receive_errors_total{cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval]))",
           "legendFormat": "{{pod}} - RX Errors",
           "refId": "A"
         },
@@ -1241,7 +1255,7 @@
             "type": "prometheus",
             "uid": "${datasource_svc}"
           },
-          "expr": "sum by (pod) (rate(container_network_transmit_errors_total{cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
+          "expr": "sum by (pod) (rate(container_network_transmit_errors_total{cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval]))",
           "legendFormat": "{{pod}} - TX Errors",
           "refId": "B"
         }
@@ -1267,7 +1281,7 @@
         "type": "prometheus",
         "uid": "${datasource_svc}"
       },
-      "description": "How much disk space each container is using (warning at 8GB, critical at 20GB).",
+      "description": "Persistent volume usage per PVC in the namespace (from kubelet_volume_stats_used_bytes). Shows actual disk usage for each etcd data volume.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1302,7 +1316,7 @@
               "mode": "none"
             },
             "thresholdsStyle": {
-              "mode": "off"
+              "mode": "line"
             }
           },
           "mappings": [],
@@ -1315,11 +1329,11 @@
               },
               {
                 "color": "yellow",
-                "value": 8589934592
+                "value": 21474836480
               },
               {
                 "color": "red",
-                "value": 21474836480
+                "value": 28991029248
               }
             ]
           },
@@ -1355,12 +1369,12 @@
             "type": "prometheus",
             "uid": "${datasource_svc}"
           },
-          "expr": "sum by (container) (container_fs_usage_bytes{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", container!=\"POD\"})",
-          "legendFormat": "{{container}}",
+          "expr": "kubelet_volume_stats_used_bytes{cluster=\"$cluster\", namespace=\"$namespace\"}",
+          "legendFormat": "{{persistentvolumeclaim}}",
           "refId": "A"
         }
       ],
-      "title": "Filesystem Usage per Container",
+      "title": "Filesystem Usage per Volume",
       "type": "timeseries"
     },
     {
@@ -1449,8 +1463,8 @@
             "type": "prometheus",
             "uid": "${datasource_svc}"
           },
-          "expr": "sum by (container) (rate(container_fs_reads_bytes_total{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", container!=\"POD\"}[5m]))",
-          "legendFormat": "{{container}}",
+          "expr": "sum by (pod, container) (rate(container_fs_reads_bytes_total{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", container!=\"POD\"}[$__rate_interval]))",
+          "legendFormat": "{{pod}}/{{container}}",
           "refId": "A"
         }
       ],
@@ -1543,8 +1557,8 @@
             "type": "prometheus",
             "uid": "${datasource_svc}"
           },
-          "expr": "sum by (container) (rate(container_fs_writes_bytes_total{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", container!=\"POD\"}[5m]))",
-          "legendFormat": "{{container}}",
+          "expr": "sum by (pod, container) (rate(container_fs_writes_bytes_total{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", container!=\"POD\"}[$__rate_interval]))",
+          "legendFormat": "{{pod}}/{{container}}",
           "refId": "A"
         }
       ],
@@ -1569,7 +1583,7 @@
         "type": "prometheus",
         "uid": "${datasource_hcp}"
       },
-      "description": "etcd metrics from HCP AMW (hcps-{region}). WAL fsync latency should be <10ms for healthy etcd.",
+      "description": "p99 WAL fsync latency per etcd member. Warning at 10ms, critical at 20ms. Azure rarely meets the etcd-recommended 10ms SLO, and latency varies by region.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1621,7 +1635,7 @@
               },
               {
                 "color": "red",
-                "value": 0.1
+                "value": 0.02
               }
             ]
           },
@@ -1658,7 +1672,7 @@
             "type": "prometheus",
             "uid": "${datasource_hcp}"
           },
-          "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (le, pod))",
+          "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])) by (le, pod))",
           "legendFormat": "{{pod}} - p99 WAL fsync",
           "refId": "A"
         }
@@ -1677,6 +1691,7 @@
           "color": {
             "mode": "thresholds"
           },
+          "decimals": 2,
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -1687,15 +1702,15 @@
               },
               {
                 "color": "yellow",
-                "value": 2147483648
+                "value": 2
               },
               {
                 "color": "red",
-                "value": 8589934592
+                "value": 8
               }
             ]
           },
-          "unit": "bytes"
+          "unit": "decgbytes"
         },
         "overrides": []
       },
@@ -1729,11 +1744,14 @@
             "type": "prometheus",
             "uid": "${datasource_hcp}"
           },
-          "expr": "sum(etcd_mvcc_db_total_size_in_bytes{cluster=\"$cluster\", namespace=\"$namespace\"})",
+          "expr": "etcd_mvcc_db_total_size_in_bytes{cluster=\"$cluster\", namespace=\"$namespace\"} / 1024 / 1024 / 1024",
+          "instant": true,
+          "legendFormat": "{{pod}}",
+          "range": false,
           "refId": "A"
         }
       ],
-      "title": "etcd DB Size",
+      "title": "etcd DB Size (GB)",
       "type": "stat"
     },
     {
@@ -1799,7 +1817,10 @@
             "type": "prometheus",
             "uid": "${datasource_hcp}"
           },
-          "expr": "sum(increase(etcd_server_leader_changes_seen_total{cluster=\"$cluster\", namespace=\"$namespace\"}[1h]))",
+          "expr": "increase(etcd_server_leader_changes_seen_total{cluster=\"$cluster\", namespace=\"$namespace\"}[1h])",
+          "instant": true,
+          "legendFormat": "{{pod}}",
+          "range": false,
           "refId": "A"
         }
       ],

--- a/observability/grafana-dashboards/sre/user-journey/hcp_namespace_deepdive.json
+++ b/observability/grafana-dashboards/sre/user-journey/hcp_namespace_deepdive.json
@@ -322,7 +322,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Usage (Gi)"
+              "options": "Usage"
             },
             "properties": [
               {
@@ -338,7 +338,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Request (Gi)"
+              "options": "Request"
             },
             "properties": [
               {
@@ -446,9 +446,9 @@
           "options": {
             "alias": "Usage/Request Ratio",
             "binary": {
-              "left": "Usage (Gi)",
+              "left": "Usage",
               "operator": "/",
-              "right": "Request (Gi)"
+              "right": "Request"
             },
             "mode": "binary",
             "reduce": {
@@ -803,7 +803,7 @@
             "type": "prometheus",
             "uid": "${datasource_svc}"
           },
-          "expr": "sum by (container) (increase(kube_pod_container_status_terminated_reason{cluster=\"$cluster\", namespace=\"$namespace\", reason=\"OOMKilled\"}[5m]))",
+          "expr": "sum by (container) (changes(kube_pod_container_status_terminated_reason{cluster=\"$cluster\", namespace=\"$namespace\", reason=\"OOMKilled\"}[5m]))",
           "legendFormat": "{{container}}",
           "refId": "A"
         }
@@ -1819,7 +1819,7 @@
           "type": "prometheus",
           "uid": "${datasource_hcp}"
         },
-        "definition": "label_values(apiserver_audit_event_total, cluster)",
+        "definition": "label_values(apiserver_request_total, cluster)",
         "hide": 0,
         "includeAll": false,
         "label": "Cluster (MGMT)",
@@ -1827,7 +1827,7 @@
         "name": "cluster",
         "options": [],
         "query": {
-          "query": "label_values(apiserver_audit_event_total, cluster)",
+          "query": "label_values(apiserver_request_total, cluster)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -1842,7 +1842,7 @@
           "type": "prometheus",
           "uid": "${datasource_hcp}"
         },
-        "definition": "label_values(apiserver_audit_event_total, namespace)",
+        "definition": "label_values(apiserver_request_total{cluster=\"$cluster\"}, namespace)",
         "hide": 0,
         "includeAll": false,
         "label": "Namespace (HCP)",
@@ -1850,7 +1850,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(apiserver_audit_event_total, namespace)",
+          "query": "label_values(apiserver_request_total{cluster=\"$cluster\"}, namespace)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,
@@ -1866,7 +1866,8 @@
     "to": "now"
   },
   "timepicker": {},
-  "timezone": "",
+  "timezone": "utc",
+  "refresh": "30s",
   "version": 0,
   "weekStart": ""
 }

--- a/observability/grafana-dashboards/sre/user-journey/hcp_namespace_deepdive.json
+++ b/observability/grafana-dashboards/sre/user-journey/hcp_namespace_deepdive.json
@@ -26,6 +26,7 @@
         "type": "prometheus",
         "uid": "${datasource_svc}"
       },
+      "description": "CPU usage rate (cores) per container, averaged over 5m. Colored by control plane component.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -180,6 +181,7 @@
         "type": "prometheus",
         "uid": "${datasource_svc}"
       },
+      "description": "How much memory each container is actively using (doesn't include reclaimable cache).",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -475,8 +477,9 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${datasource_svc}"
+        "uid": "${datasource_hcp}"
       },
+      "description": "How many pods are in each state right now (Running, Pending, Failed, Succeeded).",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -624,8 +627,9 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${datasource_svc}"
+        "uid": "${datasource_hcp}"
       },
+      "description": "Container restarts in the last hour per pod (more useful for triage than total restarts since pod started).",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -708,7 +712,7 @@
             "type": "prometheus",
             "uid": "${datasource_svc}"
           },
-          "expr": "sum by (pod) (kube_pod_container_status_restarts_total{cluster=\"$cluster\", namespace=\"$namespace\"})",
+          "expr": "sum by (pod) (increase(kube_pod_container_status_restarts_total{cluster=\"$cluster\", namespace=\"$namespace\"}[1h]))",
           "legendFormat": "{{pod}}",
           "refId": "A"
         }
@@ -719,8 +723,9 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${datasource_svc}"
+        "uid": "${datasource_hcp}"
       },
+      "description": "OOMKilled events timeline. Note: changes() counts value transitions not discrete events - may miss kills between scrapes.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -814,8 +819,9 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${datasource_svc}"
+        "uid": "${datasource_hcp}"
       },
+      "description": "Why each container exited last time (OOMKilled, Error, Completed, etc).",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -946,6 +952,7 @@
         "type": "prometheus",
         "uid": "${datasource_svc}"
       },
+      "description": "How much network traffic each pod is receiving.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1039,6 +1046,7 @@
         "type": "prometheus",
         "uid": "${datasource_svc}"
       },
+      "description": "How much network traffic each pod is sending out.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1132,6 +1140,7 @@
         "type": "prometheus",
         "uid": "${datasource_svc}"
       },
+      "description": "Network errors (both receiving and sending) - sustained errors mean there's a network problem.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1250,6 +1259,7 @@
         "type": "prometheus",
         "uid": "${datasource_svc}"
       },
+      "description": "How much disk space each container is using (warning at 8GB, critical at 20GB).",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1350,6 +1360,7 @@
         "type": "prometheus",
         "uid": "${datasource_svc}"
       },
+      "description": "How fast each container is reading from disk.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1443,6 +1454,7 @@
         "type": "prometheus",
         "uid": "${datasource_svc}"
       },
+      "description": "How fast each container is writing to disk.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1651,6 +1663,7 @@
         "type": "prometheus",
         "uid": "${datasource_hcp}"
       },
+      "description": "Size of the etcd database (warning at 2GB, critical at 8GB near quota limit).",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1720,6 +1733,7 @@
         "type": "prometheus",
         "uid": "${datasource_hcp}"
       },
+      "description": "How many times the etcd leader changed in the last hour (frequent changes = instability).",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1797,6 +1811,8 @@
     "list": [
       {
         "current": {},
+        "description": "Pick the services datasource for your region (e.g., Managed_Prometheus_services-eastus). Must match where your namespace lives.",
+        "includeAll": false,
         "name": "datasource_svc",
         "options": [],
         "query": "prometheus",
@@ -1806,6 +1822,8 @@
       },
       {
         "current": {},
+        "description": "Pick the HCP datasource for your region (e.g., Managed_Prometheus_hcps-eastus). Must match where your namespace lives.",
+        "includeAll": false,
         "name": "datasource_hcp",
         "options": [],
         "query": "prometheus",


### PR DESCRIPTION

What
Adds a new Grafana Dashboard for per-HCP namespace deep dive metrics on MGMT clusters.

Why
This will help SREs identify noisy-neighbor containers, pod lifecycle issues, and etcd health for a specific HCP namespace without having to run manual kubectl commands.

Testing
The Grafana dashboard was served locally first to confirm functionality of the queries

special notes for your reviewer

PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows Conventional Commits forma
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included - 
[grafana dashboard .pdf](https://github.com/user-attachments/files/29900295/grafana.dashboard.pdf)

<img width="1508" height="901" alt="image" src="https://github.com/user-attachments/assets/696d7f0f-179c-4845-96ba-468eb4a1b669" />

<img width="1510" height="910" alt="image" src="https://github.com/user-attachments/assets/1e18424b-0e45-42b8-9b19-38bee8a5ccd8" />




- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [x] Commit history is clean (rebased/squashed)
- [x] Specific reviewers tagged
- [x] All comment threads resolved before merge

