### PR TITLE
fix(tracing): replace make deploy with inline kubectl apply -k (AROSLSRE-1211)

### DIFF
--- a/observability/tracing/pipeline.yaml
+++ b/observability/tracing/pipeline.yaml
@@ -19,7 +19,11 @@ resourceGroups:
   - name: deploy
     aksCluster: '{{ .svc.aks.name }}'
     action: Shell
-    command: make deploy
+    command: |
+      kubectl apply -k deploy/
+      kubectl wait --for=condition=Available deployment -n observability otel-collector --timeout=60s
+      kubectl wait --for=condition=Available deployment -n observability jaeger --timeout=60s
+      kubectl wait --for=condition=Available deployment -n observability lgtm --timeout=60s
     shellIdentity:
       input:
         resourceGroup: global
@@ -32,7 +36,11 @@ resourceGroups:
   - name: deploy
     aksCluster: '{{ .mgmt.aks.name }}'
     action: Shell
-    command: make deploy
+    command: |
+      kubectl apply -k deploy/
+      kubectl wait --for=condition=Available deployment -n observability otel-collector --timeout=60s
+      kubectl wait --for=condition=Available deployment -n observability jaeger --timeout=60s
+      kubectl wait --for=condition=Available deployment -n observability lgtm --timeout=60s
     shellIdentity:
       input:
         resourceGroup: global


### PR DESCRIPTION
<!-- Link to Jira issue -->
[AROSLSRE-1211](https://redhat.atlassian.net/browse/AROSLSRE-1211) · part of [AROSLSRE-1207](https://redhat.atlassian.net/browse/AROSLSRE-1207)

### What

Replace the two `make deploy` Shell steps in `observability/tracing/pipeline.yaml` (svc + mgmt AKS) with the inline commands that `make deploy` expands to.

### Why

The EV2 shell extension image was bumped from `adm-mariner-20-l` v11 (Mariner 2.0, ships `make`) to `adm-azurelinux-30-l` v2 (Azure Linux 3.0, no `make`) in sdp-pipelines [PR 16123282](https://dev.azure.com/msazure/AzureRedHatOpenShift/_git/sdp-pipelines/pullrequest/16123282). This broke any Shell step that calls `make`, failing with `make: command not found` (exit 127).

A hotfix revert of the image bump is in progress ([sdp-pipelines PR 16139152](https://dev.azure.com/msazure/AzureRedHatOpenShift/_git/sdp-pipelines/pullrequest/16139152)). This PR removes the `make` dependency from the tracing pipeline so the Azure Linux 3.0 bump can be re-applied without breaking anything.

`make deploy` in `observability/tracing/Makefile` expands to:
```bash
kubectl apply -k deploy/
kubectl wait --for=condition=Available deployment -n observability otel-collector --timeout=60s
kubectl wait --for=condition=Available deployment -n observability jaeger --timeout=60s
kubectl wait --for=condition=Available deployment -n observability lgtm --timeout=60s
```

The Makefile target is kept unchanged for local development.

### Testing

- `make deploy` still works locally (Makefile untouched).
- Inline commands are a direct translation of what `make deploy` was executing.

### Special notes for your reviewer

This is one of two fixes for the Azure Linux 3.0 migration. The other (`cluster-service/pipeline.yaml`) is tracked separately in [AROSLSRE-1212](https://redhat.atlassian.net/browse/AROSLSRE-1212) as it requires a full `action: Helm` migration.

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge