### PR TITLE
ci: resize shard0 pool

### DIFF
--- a/test/e2e-config/e2e-slots.yaml
+++ b/test/e2e-config/e2e-slots.yaml
@@ -12,9 +12,9 @@ environments:
       region: westus3
       region_mode: runtime-selected
       resource_type: aro-hcp-dev-shard0-slot
-      slot_count: 15
+      slot_count: 6
       identity_container_prefix: aro-hcp-msi-container-dev-shard0
-      identity_container_count: 20
+      identity_container_count: 50
     # shard1: additional dev capacity for multi-subscription testing.
     # Capacity is still limited to 4000 role assignments.
     - subscription_name: "ARO HCP E2E Hosted Clusters 2 (EA Subscription)"


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-27792

Adjust shard0 pool size for single wave e2e testing in e2e-parallel job. 

Must wait for https://github.com/openshift/release/pull/80714 to land and for shard0 identity pool to be resized.
