### PR TITLE
hcpctl: snapshot: grab CS inflights, provision steps

### DIFF
--- a/tooling/hcpctl/pkg/snapshot/queries.go
+++ b/tooling/hcpctl/pkg/snapshot/queries.go
@@ -541,6 +541,30 @@ var allQueries = []querySpec{
 		requiredWhen:  isClusterOrNodePool,
 	},
 	{
+		component:    "clustersService",
+		queryName:    "inflightChecks",
+		templatePath: "queries/clustersService/inflightChecks/query.kql",
+		database:     "service",
+		category:     categoryLogs,
+		ready: func(d queryData) bool {
+			return d.ResourceID != "" && isClusterType(d)
+		},
+		prerequisites: "ResourceID, ResourceType is cluster",
+		requiredWhen:  isClusterType,
+	},
+	{
+		component:    "clustersService",
+		queryName:    "provisionSteps",
+		templatePath: "queries/clustersService/provisionSteps/query.kql",
+		database:     "service",
+		category:     categoryLogs,
+		ready: func(d queryData) bool {
+			return d.ResourceID != "" && isClusterType(d)
+		},
+		prerequisites: "ResourceID, ResourceType is cluster",
+		requiredWhen:  isClusterType,
+	},
+	{
 		component:    "maestro",
 		queryName:    "serverLogs",
 		templatePath: "queries/maestro/serverLogs/query.kql",

--- a/tooling/hcpctl/pkg/snapshot/queries/clustersService/inflightChecks/README.md
+++ b/tooling/hcpctl/pkg/snapshot/queries/clustersService/inflightChecks/README.md
@@ -1,0 +1,32 @@
+# clustersService / inflightChecks
+
+## Summary
+
+Aggregates inflight check activity for a cluster, showing each check's lifecycle (creating, enqueued, running, passed, or error) grouped by check name in chronological order.
+
+## What to Look For
+
+Each inflight check should progress through creating, enqueued, running, and then pass. A healthy cluster will show all checks reaching a `passed` verb with a single occurrence of each:
+
+| step_name                                         | verb                   | error_detail | first_occurrence             | last_occurrence              | occurrences |
+|---------------------------------------------------|------------------------|--------------|------------------------------|------------------------------|-------------|
+| rp-registration-inflight                          | creating missing       |              | 6/17/2026, 12:19:23.875 PM  | 6/17/2026, 12:19:23.875 PM  | 1           |
+| rp-registration-inflight                          | enqueued newly created |              | 6/17/2026, 12:19:23.884 PM  | 6/17/2026, 12:19:23.884 PM  | 1           |
+| rp-registration-inflight                          | running                |              | 6/17/2026, 12:19:23.914 PM  | 6/17/2026, 12:19:23.914 PM  | 1           |
+| rp-registration-inflight                          | passed                 |              | 6/17/2026, 12:19:25.864 PM  | 6/17/2026, 12:19:25.864 PM  | 1           |
+| cluster-managed-identities-inflight               | creating missing       |              | 6/17/2026, 12:19:23.892 PM  | 6/17/2026, 12:19:23.892 PM  | 1           |
+| cluster-managed-identities-inflight               | enqueued newly created |              | 6/17/2026, 12:19:23.9 PM    | 6/17/2026, 12:19:23.9 PM    | 1           |
+| cluster-managed-identities-inflight               | running                |              | 6/17/2026, 12:19:23.997 PM  | 6/17/2026, 12:19:23.997 PM  | 1           |
+| cluster-managed-identities-inflight               | enqueued               |              | 6/17/2026, 12:19:28.87 PM   | 6/17/2026, 12:19:28.87 PM   | 1           |
+| cluster-managed-identities-inflight               | passed                 |              | 6/17/2026, 12:19:29.817 PM  | 6/17/2026, 12:19:29.817 PM  | 1           |
+| ...                                               | ...                    | ...          | ...                          | ...                          | ...         |
+
+Watch for:
+- Checks that never reach `passed` -- the cluster is stuck in the `validating` phase waiting for that check.
+- Checks with `verb=error` -- the `error_detail` column will contain the failure reason.
+- High `occurrences` on `running` without a corresponding `passed` -- indicates a check that is being retried repeatedly.
+
+## Where to Go Next
+
+- If all inflight checks passed but the cluster did not advance, review `clustersService/phases` and `clustersService/logs` for what happened after validation.
+- If a check has errors, the `error_detail` column shows the Azure API response or other failure detail.

--- a/tooling/hcpctl/pkg/snapshot/queries/clustersService/inflightChecks/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/clustersService/inflightChecks/query.kql
@@ -1,0 +1,28 @@
+cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('clustersServiceLogs')
+| where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
+{{- if and .ServiceClusterName .ManagementClusterName }}
+| where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
+{{- end }}
+| where log.aro_hcp_cluster_resource_id =~ '{{ .ResourceID }}'
+| where isempty(log.aro_hcp_node_pool_resource_id)
+| where log.msg has "inflight check"
+| extend msg = tostring(log.msg)
+| extend step_name = extract("'([^']+)'", 1, msg),
+         verb = coalesce(
+             extract("^(.+?)\\s+inflight check\\s+'", 1, msg),
+             extract("'\\s+(.+?)(?:\\s+for cluster|\\s*$)", 1, msg)
+         ),
+         error_detail = extract("returned an error:\\s*([\\s\\S]*)", 1, msg)
+| extend verb = tolower(trim_end("[.,:;\\s]+", verb))
+| extend verb = iff(isnotempty(error_detail), "error", verb)
+| summarize
+    first_occurrence = min(timestamp),
+    last_occurrence = max(timestamp),
+    occurrences = count()
+  by step_name, verb, error_detail
+| as hint.materialized=true T
+| join kind=leftouter (
+    T | summarize step_first = min(first_occurrence) by step_name
+  ) on step_name
+| order by step_first asc, first_occurrence asc
+| project-away step_first, step_name1

--- a/tooling/hcpctl/pkg/snapshot/queries/clustersService/phases/README.md
+++ b/tooling/hcpctl/pkg/snapshot/queries/clustersService/phases/README.md
@@ -28,5 +28,6 @@ Node pools do something similar, without an uninstalling phase:
 ## Where to Go Next
 
 If the cluster or node pool:
-- never reaches the 'installing' phase, review the `logs/clustersService/logs.md` query output for failed Azure infrastructure provisioning or Maestro interactions.
-- reaches the 'installing' but never reaches the 'ready' phase, review `conditions/hypershift/hostedClusterConditions.md` or `conditions/hypershift/nodePoolConditions.md` for the next layer of the stack
+- reaches `validating` but not `pending`, review `clustersService/inflightChecks` to see which inflight check is stuck or failing.
+- reaches `pending` but not `installing`, review `clustersService/provisionSteps` to see which provision step is stuck or failing.
+- reaches `installing` but not `ready`, review the `clustersService/logs` output paying attention to timestamps, and review `conditions/hypershift/hostedClusterConditions` or `conditions/hypershift/nodePoolConditions` for the next layer of the stack.

--- a/tooling/hcpctl/pkg/snapshot/queries/clustersService/provisionSteps/README.md
+++ b/tooling/hcpctl/pkg/snapshot/queries/clustersService/provisionSteps/README.md
@@ -1,0 +1,45 @@
+# clustersService / provisionSteps
+
+## Summary
+
+Aggregates provision step activity for a cluster, showing each step's lifecycle (running, succeeded, error, or not yet completed) grouped by step name in chronological order.
+
+## What to Look For
+
+Each provision step should progress from running to succeeded. Steps are re-run on each reconciliation loop, so `occurrences > 1` is normal. A healthy cluster will show all steps eventually reaching `succeeded`:
+
+| step_name                                                              | verb                   | error_detail | first_occurrence            | last_occurrence             | occurrences |
+|------------------------------------------------------------------------|------------------------|--------------|-----------------------------|-----------------------------|-------------|
+| managed-resource-group-provision-step                                  | running                |              | 6/17/2026, 12:19:36.919 PM | 6/17/2026, 12:22:41.094 PM | 17          |
+| managed-resource-group-provision-step                                  | succeeded              |              | 6/17/2026, 12:19:49.339 PM | 6/17/2026, 12:22:41.409 PM | 17          |
+| run-arm-helper-step                                                    | running                |              | 6/17/2026, 12:19:49.339 PM | 6/17/2026, 12:22:41.409 PM | 17          |
+| run-arm-helper-step                                                    | succeeded              |              | 6/17/2026, 12:19:49.339 PM | 6/17/2026, 12:22:41.409 PM | 17          |
+| ...                                                                    | ...                    | ...          | ...                         | ...                         | ...         |
+| control-plane-identities-role-assignment-on-managed-resource-group-step | running                |              | 6/17/2026, 12:19:52.407 PM | 6/17/2026, 12:22:41.421 PM | 17          |
+| control-plane-identities-role-assignment-on-managed-resource-group-step | error                  | GET https://management.azure.com/.../roleAssignments/356ccc48-... | 6/17/2026, 12:19:52.728 PM | 6/17/2026, 12:19:55.307 PM | 2 |
+| control-plane-identities-role-assignment-on-managed-resource-group-step | error                  | PUT https://management.azure.com/.../roleAssignments/c35ea678-... | 6/17/2026, 12:20:01.274 PM | 6/17/2026, 12:20:01.274 PM | 1 |
+| control-plane-identities-role-assignment-on-managed-resource-group-step | succeeded              |              | 6/17/2026, 12:20:26.693 PM | 6/17/2026, 12:22:42.737 PM | 5           |
+| ...                                                                    | ...                    | ...          | ...                         | ...                         | ...         |
+| node-pools-egress-public-ip-provision-step                             | running                |              | 6/17/2026, 12:21:41.466 PM | 6/17/2026, 12:22:54.535 PM | 5           |
+| node-pools-egress-public-ip-provision-step                             | has not completed yet  |              | 6/17/2026, 12:21:46.369 PM | 6/17/2026, 12:21:46.369 PM | 1           |
+| node-pools-egress-public-ip-provision-step                             | succeeded              |              | 6/17/2026, 12:22:00.434 PM | 6/17/2026, 12:22:54.535 PM | 4           |
+| ...                                                                    | ...                    | ...          | ...                         | ...                         | ...         |
+| hosted-cluster-provision-step                                          | running                |              | 6/17/2026, 12:22:39.624 PM | 6/17/2026, 12:22:56.226 PM | 2           |
+| hosted-cluster-provision-step                                          | has not completed yet  |              | 6/17/2026, 12:22:41.029 PM | 6/17/2026, 12:22:41.029 PM | 1           |
+| hosted-cluster-provision-step                                          | succeeded              |              | 6/17/2026, 12:22:57.605 PM | 6/17/2026, 12:22:57.605 PM | 1           |
+| set-cluster-to-installing-state-step                                   | running                |              | 6/17/2026, 12:22:57.605 PM | 6/17/2026, 12:22:57.605 PM | 1           |
+| set-cluster-to-installing-state-step                                   | succeeded              |              | 6/17/2026, 12:22:57.638 PM | 6/17/2026, 12:22:57.638 PM | 1           |
+
+The example above shows a healthy cluster where transient authorization errors on the role assignment step were retried and eventually succeeded, and long-running async steps (`node-pools-egress-public-ip`, `tls-certificates`, `hosted-cluster`) showed `has not completed yet` before succeeding.
+
+Watch for:
+- Steps with `verb=error` -- the `error_detail` column will contain the Azure API response or other failure detail.
+- Steps with `verb=running` but no corresponding `succeeded` -- the cluster is stuck at that provision step.
+- Steps with `verb=has not completed yet` followed by `succeeded` -- normal for long-running steps, but high `occurrences` may indicate slowness.
+- High `occurrences` on `error` for the same step -- indicates a step that is failing repeatedly before eventually succeeding (or not).
+
+## Where to Go Next
+
+- If a step has errors, the `error_detail` column shows the Azure API response. Common issues include authorization failures (403) and quota exhaustion.
+- If all provision steps succeeded but the cluster did not reach `installing`, review `clustersService/phases` and `clustersService/logs` for what happened after provisioning.
+- If the cluster reached `installing` but not `ready`, review `conditions/hypershift/hostedClusterConditions` for the next layer of the stack.

--- a/tooling/hcpctl/pkg/snapshot/queries/clustersService/provisionSteps/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/clustersService/provisionSteps/query.kql
@@ -1,0 +1,28 @@
+cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('clustersServiceLogs')
+| where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
+{{- if and .ServiceClusterName .ManagementClusterName }}
+| where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
+{{- end }}
+| where log.aro_hcp_cluster_resource_id =~ '{{ .ResourceID }}'
+| where isempty(log.aro_hcp_node_pool_resource_id)
+| where log.msg has "provision step"
+| extend msg = tostring(log.msg)
+| extend step_name = extract("'([^']+)'", 1, msg),
+         verb = coalesce(
+             extract("^(.+?)\\s+provision step\\s+'", 1, msg),
+             extract("'\\s+(.+?)(?:\\s+for cluster|\\s*$)", 1, msg)
+         ),
+         error_detail = extract("returned an error:\\s*([\\s\\S]*)", 1, msg)
+| extend verb = tolower(trim_end("[.,:;\\s]+", verb))
+| extend verb = iff(isnotempty(error_detail), "error", verb)
+| summarize
+    first_occurrence = min(timestamp),
+    last_occurrence = max(timestamp),
+    occurrences = count()
+  by step_name, verb, error_detail
+| as hint.materialized=true T
+| join kind=leftouter (
+    T | summarize step_first = min(first_occurrence) by step_name
+  ) on step_name
+| order by step_first asc, first_occurrence asc
+| project-away step_first, step_name1


### PR DESCRIPTION
We want to be able to give the LLM a concise view of these semi-structured bits from CS logs.
