### PR TITLE
chore: Add an OWNERS file to /test-integration

### DIFF
--- a/test-integration/OWNERS
+++ b/test-integration/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+- mbarnes
+- deads2k
+- geoberle
+- miguelsorianod


### PR DESCRIPTION
### What

Adds a `/test-integration/OWNERS` file to extend approvers for this directory.

### Why

Hacking on the RP frontend or storage API will likely entail changes to Cosmos DB integration tests. Extend approval rights to existing approvers for `/frontend` and `/internal` to relieve a development bottleneck.

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [x] All comment threads resolved before merge
