### PR TITLE
fix external auth Graph API failures with logging and clock skew handling

### DIFF
--- a/internal/graph/util/applications.go
+++ b/internal/graph/util/applications.go
@@ -106,9 +106,9 @@ func (c *Client) AddPassword(ctx context.Context, appID, displayName string, sta
 		result, err = c.graphClient.Applications().ByApplicationId(appID).AddPassword().Post(ctx, reqBody, nil)
 		if err != nil {
 			lastErr = err
-			// Retry on known transient errors (404, 429, 5xx). For unknown
-			// error shapes returned by the Graph SDK, also retry to tolerate
-			// eventual-consistency propagation delays.
+			// Retry all errors for the first 3 attempts to handle transient issues
+			// and eventual-consistency propagation delays. After 3 attempts, only
+			// retry known transient errors (404, 429, 5xx).
 			var odataErr *odataerrors.ODataError
 			if errors.As(err, &odataErr) {
 				code := odataErr.ResponseStatusCode

--- a/internal/graph/util/applications.go
+++ b/internal/graph/util/applications.go
@@ -95,6 +95,7 @@ func (c *Client) AddPassword(ctx context.Context, appID, displayName string, sta
 	reqBody.SetPasswordCredential(passwordCred)
 
 	// Add password to application with retry for eventual consistency
+	logger := logr.FromContextOrDiscard(ctx)
 	var result models.PasswordCredentialable
 	var lastErr error
 	attempts := 0
@@ -110,6 +111,19 @@ func (c *Client) AddPassword(ctx context.Context, appID, displayName string, sta
 			var odataErr *odataerrors.ODataError
 			if errors.As(err, &odataErr) {
 				code := odataErr.ResponseStatusCode
+				odataError := odataErr.GetErrorEscaped()
+				logger.Error(err, "Graph API AddPassword failed",
+					"attempt", attempts,
+					"statusCode", code,
+					"errorCode", odataError.GetCode(),
+					"errorMessage", odataError.GetMessage())
+
+				// Retry all errors for first 3 attempts to handle transient issues
+				if attempts <= 3 {
+					return false, nil
+				}
+
+				// After 3 attempts, only retry known transient codes
 				if code != http.StatusNotFound && code != http.StatusTooManyRequests && code < http.StatusInternalServerError {
 					// Non-transient typed OData error, stop retrying.
 					return false, err

--- a/internal/graph/util/applications.go
+++ b/internal/graph/util/applications.go
@@ -95,9 +95,10 @@ func (c *Client) AddPassword(ctx context.Context, appID, displayName string, sta
 	reqBody.SetPasswordCredential(passwordCred)
 
 	// Add password to application with retry for eventual consistency
-	logger := logr.FromContextOrDiscard(ctx)
 	var result models.PasswordCredentialable
 	var lastErr error
+	var lastStatusCode int
+	var lastErrorCode, lastErrorMessage string
 	attempts := 0
 	pollErr := wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
 		attempts++
@@ -111,17 +112,16 @@ func (c *Client) AddPassword(ctx context.Context, appID, displayName string, sta
 			var odataErr *odataerrors.ODataError
 			if errors.As(err, &odataErr) {
 				code := odataErr.ResponseStatusCode
+				lastStatusCode = code
 				odataError := odataErr.GetErrorEscaped()
-				logFields := []interface{}{
-					"attempt", attempts,
-					"statusCode", code,
-				}
 				if odataError != nil {
-					logFields = append(logFields,
-						"errorCode", odataError.GetCode(),
-						"errorMessage", odataError.GetMessage())
+					if errCode := odataError.GetCode(); errCode != nil {
+						lastErrorCode = *errCode
+					}
+					if errMsg := odataError.GetMessage(); errMsg != nil {
+						lastErrorMessage = *errMsg
+					}
 				}
-				logger.Error(err, "Graph API AddPassword failed", logFields...)
 
 				// Retry all errors for first 3 attempts to handle transient issues
 				if attempts <= 3 {
@@ -140,7 +140,15 @@ func (c *Client) AddPassword(ctx context.Context, appID, displayName string, sta
 	})
 	if pollErr != nil {
 		if lastErr != nil {
-			return nil, fmt.Errorf("add password after %d attempts; last attempt error: %w; polling error: %w", attempts, lastErr, pollErr)
+			// Include diagnostic details in error message for self-diagnosing failures
+			diagDetails := fmt.Sprintf("HTTP %d", lastStatusCode)
+			if lastErrorCode != "" {
+				diagDetails += fmt.Sprintf(", %s", lastErrorCode)
+			}
+			if lastErrorMessage != "" {
+				diagDetails += fmt.Sprintf(": %s", lastErrorMessage)
+			}
+			return nil, fmt.Errorf("add password after %d attempts; last attempt error (%s): %w; polling error: %w", attempts, diagDetails, lastErr, pollErr)
 		}
 		return nil, fmt.Errorf("add password after %d attempts: %w", attempts, pollErr)
 	}

--- a/internal/graph/util/applications.go
+++ b/internal/graph/util/applications.go
@@ -112,11 +112,16 @@ func (c *Client) AddPassword(ctx context.Context, appID, displayName string, sta
 			if errors.As(err, &odataErr) {
 				code := odataErr.ResponseStatusCode
 				odataError := odataErr.GetErrorEscaped()
-				logger.Error(err, "Graph API AddPassword failed",
+				logFields := []interface{}{
 					"attempt", attempts,
 					"statusCode", code,
-					"errorCode", odataError.GetCode(),
-					"errorMessage", odataError.GetMessage())
+				}
+				if odataError != nil {
+					logFields = append(logFields,
+						"errorCode", odataError.GetCode(),
+						"errorMessage", odataError.GetMessage())
+				}
+				logger.Error(err, "Graph API AddPassword failed", logFields...)
 
 				// Retry all errors for first 3 attempts to handle transient issues
 				if attempts <= 3 {

--- a/internal/graph/util/applications.go
+++ b/internal/graph/util/applications.go
@@ -133,6 +133,11 @@ func (c *Client) AddPassword(ctx context.Context, appID, displayName string, sta
 					// Non-transient typed OData error, stop retrying.
 					return false, err
 				}
+			} else {
+				// Not an OData error - reset diagnostic variables to avoid stale data
+				lastStatusCode = 0
+				lastErrorCode = ""
+				lastErrorMessage = ""
 			}
 			return false, nil
 		}
@@ -141,14 +146,17 @@ func (c *Client) AddPassword(ctx context.Context, appID, displayName string, sta
 	if pollErr != nil {
 		if lastErr != nil {
 			// Include diagnostic details in error message for self-diagnosing failures
-			diagDetails := fmt.Sprintf("HTTP %d", lastStatusCode)
-			if lastErrorCode != "" {
-				diagDetails += fmt.Sprintf(", %s", lastErrorCode)
+			if lastStatusCode != 0 {
+				diagDetails := fmt.Sprintf("HTTP %d", lastStatusCode)
+				if lastErrorCode != "" {
+					diagDetails += fmt.Sprintf(", %s", lastErrorCode)
+				}
+				if lastErrorMessage != "" {
+					diagDetails += fmt.Sprintf(": %s", lastErrorMessage)
+				}
+				return nil, fmt.Errorf("add password after %d attempts; last attempt error (%s): %w; polling error: %w", attempts, diagDetails, lastErr, pollErr)
 			}
-			if lastErrorMessage != "" {
-				diagDetails += fmt.Sprintf(": %s", lastErrorMessage)
-			}
-			return nil, fmt.Errorf("add password after %d attempts; last attempt error (%s): %w; polling error: %w", attempts, diagDetails, lastErr, pollErr)
+			return nil, fmt.Errorf("add password after %d attempts; last attempt error: %w; polling error: %w", attempts, lastErr, pollErr)
 		}
 		return nil, fmt.Errorf("add password after %d attempts: %w", attempts, pollErr)
 	}

--- a/internal/graph/util/applications.go
+++ b/internal/graph/util/applications.go
@@ -113,6 +113,8 @@ func (c *Client) AddPassword(ctx context.Context, appID, displayName string, sta
 			if errors.As(err, &odataErr) {
 				code := odataErr.ResponseStatusCode
 				lastStatusCode = code
+				// Reset diagnostic strings before re-reading to avoid stale values
+				lastErrorCode, lastErrorMessage = "", ""
 				odataError := odataErr.GetErrorEscaped()
 				if odataError != nil {
 					if errCode := odataError.GetCode(); errCode != nil {
@@ -138,6 +140,11 @@ func (c *Client) AddPassword(ctx context.Context, appID, displayName string, sta
 				lastStatusCode = 0
 				lastErrorCode = ""
 				lastErrorMessage = ""
+
+				// After 3 attempts, stop retrying non-OData errors
+				if attempts > 3 {
+					return false, err
+				}
 			}
 			return false, nil
 		}

--- a/test/e2e/cluster_authorized_cidrs_connectivity.go
+++ b/test/e2e/cluster_authorized_cidrs_connectivity.go
@@ -265,7 +265,8 @@ var _ = Describe("Authorized CIDRs", func() {
 				graphClient, err := tc.GetGraphClient(ctx)
 				Expect(err).NotTo(HaveOccurred(), "failed to get graph client")
 
-				pass, err := graphClient.AddPassword(ctx, app.ID, "cidr-external-auth-pass", time.Now().Add(-5*time.Minute), time.Now().Add(24*time.Hour))
+				baseTime := time.Now()
+				pass, err := graphClient.AddPassword(ctx, app.ID, "cidr-external-auth-pass", baseTime.Add(-5*time.Minute), baseTime.Add(24*time.Hour))
 				Expect(err).NotTo(HaveOccurred(), "failed to add password to app registration")
 
 				By("creating an external auth config with a prefix")

--- a/test/e2e/cluster_authorized_cidrs_connectivity.go
+++ b/test/e2e/cluster_authorized_cidrs_connectivity.go
@@ -266,6 +266,7 @@ var _ = Describe("Authorized CIDRs", func() {
 				Expect(err).NotTo(HaveOccurred(), "failed to get graph client")
 
 				baseTime := time.Now()
+				// Start time shifted 5 minutes into the past to handle clock skew between test runner and Graph API
 				pass, err := graphClient.AddPassword(ctx, app.ID, "cidr-external-auth-pass", baseTime.Add(-5*time.Minute), baseTime.Add(24*time.Hour))
 				Expect(err).NotTo(HaveOccurred(), "failed to add password to app registration")
 

--- a/test/e2e/cluster_authorized_cidrs_connectivity.go
+++ b/test/e2e/cluster_authorized_cidrs_connectivity.go
@@ -265,7 +265,7 @@ var _ = Describe("Authorized CIDRs", func() {
 				graphClient, err := tc.GetGraphClient(ctx)
 				Expect(err).NotTo(HaveOccurred(), "failed to get graph client")
 
-				pass, err := graphClient.AddPassword(ctx, app.ID, "cidr-external-auth-pass", time.Now(), time.Now().Add(24*time.Hour))
+				pass, err := graphClient.AddPassword(ctx, app.ID, "cidr-external-auth-pass", time.Now().Add(-5*time.Minute), time.Now().Add(24*time.Hour))
 				Expect(err).NotTo(HaveOccurred(), "failed to add password to app registration")
 
 				By("creating an external auth config with a prefix")

--- a/test/e2e/external_auth_create.go
+++ b/test/e2e/external_auth_create.go
@@ -129,6 +129,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to get Microsoft Graph client")
 
 			baseTime := time.Now()
+			// Start time shifted 5 minutes into the past to handle clock skew between test runner and Graph API
 			pass, err := graphClient.AddPassword(ctx, app.ID, "external-auth-pass", baseTime.Add(-5*time.Minute), baseTime.Add(24*time.Hour))
 			Expect(err).NotTo(HaveOccurred(), "failed to add password to app registration")
 

--- a/test/e2e/external_auth_create.go
+++ b/test/e2e/external_auth_create.go
@@ -128,7 +128,7 @@ var _ = Describe("Customer", func() {
 			graphClient, err := tc.GetGraphClient(ctx)
 			Expect(err).NotTo(HaveOccurred(), "failed to get Microsoft Graph client")
 
-			pass, err := graphClient.AddPassword(ctx, app.ID, "external-auth-pass", time.Now(), time.Now().Add(24*time.Hour))
+			pass, err := graphClient.AddPassword(ctx, app.ID, "external-auth-pass", time.Now().Add(-5*time.Minute), time.Now().Add(24*time.Hour))
 			Expect(err).NotTo(HaveOccurred(), "failed to add password to app registration")
 
 			By("creating an external auth config with a prefix")

--- a/test/e2e/external_auth_create.go
+++ b/test/e2e/external_auth_create.go
@@ -128,7 +128,8 @@ var _ = Describe("Customer", func() {
 			graphClient, err := tc.GetGraphClient(ctx)
 			Expect(err).NotTo(HaveOccurred(), "failed to get Microsoft Graph client")
 
-			pass, err := graphClient.AddPassword(ctx, app.ID, "external-auth-pass", time.Now().Add(-5*time.Minute), time.Now().Add(24*time.Hour))
+			baseTime := time.Now()
+			pass, err := graphClient.AddPassword(ctx, app.ID, "external-auth-pass", baseTime.Add(-5*time.Minute), baseTime.Add(24*time.Hour))
 			Expect(err).NotTo(HaveOccurred(), "failed to add password to app registration")
 
 			By("creating an external auth config with a prefix")


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-849

### What

Fix external auth E2E test failures when adding password credentials to Entra ID app registrations via Microsoft Graph API.

### Why

The Stage E2E test "Customer should be able to create a cluster with an external auth config" failed when calling `graphClient.AddPassword()`. The failure occurred after only 1 attempt with no diagnostic information, making root cause analysis impossible.

### Testing

- Code compiles successfully for `internal/graph/util` and `test/e2e` packages
- Will be validated by Prow E2E tests (the same test that was failing)
- Improved logging will make future failures self-diagnosing


### Special notes for your reviewer

Changes span 3 files:
- `internal/graph/util/applications.go`: Add error logging + improved retry logic (retry all errors for first 3 attempts)
- `test/e2e/external_auth_create.go`: Fix clock skew (`time.Now().Add(-5*time.Minute)`)
- `test/e2e/cluster_authorized_cidrs_connectivity.go`: Same clock skew fix



<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
