### PR TITLE
Revert "workaround: skip nightly nodepool upgrade/downgrade tests

### DIFF
--- a/test/e2e/nodepool_version_upgrade.go
+++ b/test/e2e/nodepool_version_upgrade.go
@@ -382,13 +382,6 @@ var _ = Describe("Customer", func() {
 		func(ctx context.Context, nodePoolMinor string, targetMinor string) {
 			channelGroup := framework.DefaultOpenshiftChannelGroup()
 
-			// Workaround: skip on nightly until CS fixes the nightly→ACR image substitution
-			// on the nodepool upgrade path (PatchNodePoolCR writes quay.io instead of ACR).
-			// See ARO-27687.
-			if channelGroup == "nightly" {
-				Skip("nightly nodepool upgrade blocked by CS image substitution bug; see ARO-27687")
-			}
-
 			// On nightly, Cincinnati returns bare GA versions that don't exist in CS as nightly builds.
 			// Use GetLatestInstallVersion (release stream API) for nightly; GetLatestVersionInMinor
 			// (Cincinnati) for non-nightly to preserve existing behavior.
@@ -665,13 +658,6 @@ var _ = Describe("Customer", func() {
 	DescribeTable("should downgrade a nodepool to a lower minor version",
 		func(ctx context.Context, cpMinor string, targetMinor string) {
 			channelGroup := framework.DefaultOpenshiftChannelGroup()
-
-			// Workaround: skip on nightly until CS fixes the nightly→ACR image substitution
-			// on the nodepool upgrade path (PatchNodePoolCR writes quay.io instead of ACR).
-			// See ARO-27687.
-			if channelGroup == "nightly" {
-				Skip("nightly nodepool downgrade blocked by CS image substitution bug; see ARO-27687")
-			}
 
 			// On nightly, Cincinnati returns bare GA versions that don't exist in CS as nightly builds.
 			// Use GetLatestInstallVersion (release stream API) for nightly; GetLatestVersionInMinor


### PR DESCRIPTION
[ARO-27808](https://redhat.atlassian.net/browse/ARO-27808)

Revert workaround (23626e4f0e78d4df7f3df609f9f4e5a838aff0f9): skip nightly nodepool upgrade/downgrade tests ([ARO-27687](https://redhat.atlassian.net/browse/ARO-27687))

The fix [ARO-27344](https://redhat.atlassian.net/browse/ARO-27344) for this issue has been deployed and this workaround is no longer needed. 

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

Both group of tests must pass in stage-e2e-parallel-ocp-nightly

- [x] Customer should upgrade a nodepool skipping one minor version (+2) from X.Y.z to X.Y'.zLatest
- [x] Customer should downgrade a nodepool to a lower minor version from X.Y.zLatest to X.Y”.zLatest

