### PR TITLE
fix: ACR replication flag compat and Geography int/westus3 constraint

### DIFF
--- a/dev-infrastructure/geography-pipeline.yaml
+++ b/dev-infrastructure/geography-pipeline.yaml
@@ -12,6 +12,7 @@ resourceGroups:
     - int
     regions:
     - uksouth
+    - westus3
   - clouds:
     - public
     environments:

--- a/dev-infrastructure/scripts/manage-acr-replication.sh
+++ b/dev-infrastructure/scripts/manage-acr-replication.sh
@@ -52,6 +52,14 @@ execute() {
     fi
 }
 
+# --region-endpoint-enabled was renamed to --global-endpoint-routing in az CLI 2.86.0
+# and removed in 2.87.0. Detect which flag the installed az CLI supports.
+if az acr replication create --help 2>&1 | grep -q -- "--global-endpoint-routing"; then
+    ENDPOINT_ROUTING_FLAG="--global-endpoint-routing"
+else
+    ENDPOINT_ROUTING_FLAG="--region-endpoint-enabled"
+fi
+
 # Function to create a new replication
 create_replication() {
     echo "Creating replication $REPLICATION_REGION for ACR $ACR_NAME in region $REPLICATION_REGION..."
@@ -60,7 +68,7 @@ create_replication() {
         --resource-group "$RESOURCE_GROUP" \
         --location "$REPLICATION_REGION" \
         --name "$REPLICATION_REGION" \
-        --global-endpoint-routing true
+        "$ENDPOINT_ROUTING_FLAG" true
 
     echo "Successfully created replication $REPLICATION_REGION for ACR $ACR_NAME in region $REPLICATION_REGION"
 }


### PR DESCRIPTION
## Summary

- **ACR replication script**: PR #5551 replaced `--region-endpoint-enabled` with `--global-endpoint-routing`, but EV2 runs az CLI < 2.86.0 which doesn't have the new flag. Script now detects the supported flag from `--help` at startup, so it works on all az CLI versions.
- **Geography pipeline**: Added westus3 to int execution constraints. Kusto cluster creation was only running in uksouth, causing Region-level Kusto steps to fail in westus3.

## Test plan

- [x] Verify ACR replication script works in EV2 (az CLI < 2.86.0)
- [x] Verify ACR replication script works locally (az CLI 2.84.0)
- [ ] Run Global entrypoint pipeline for int/westus3 and confirm Geography steps execute

Ref: https://redhat.atlassian.net/browse/ARO-27812