### PR TITLE
feat(observability): add explicit Azure CEN severity values to the alert generator

### DIFF
--- a/docs/alerts.md
+++ b/docs/alerts.md
@@ -52,7 +52,7 @@ spec:
         sum by (cluster) (rate(errors_total{namespace="aro-hcp"}[5m])) > 0.05
       for: 10m
       labels:
-        severity: warning
+        severity: "3"
       annotations:
         summary: 'Short title for the alert'
         description: 'Detailed description. Can reference labels: {{ $labels.cluster }} and value: {{ $value }}.'
@@ -75,7 +75,7 @@ spec:
 
 Severity is the customer-impact class of the alert and follows the Azure Common Engineering Naming (CEN) standard so alerts route cleanly into Microsoft IcM. It is a property of the impact the alert represents and is set independently of burn rate: burn rate decides *when* an alert fires, severity decides *who* is paged at what urgency.
 
-Use the explicit `2` / `3` / `4` values (the severity label is the IcM Sev number). The legacy `critical` / `warning` / `info` values are still accepted (deprecated). `1` is intentionally rejected by the generator: Azure CEN reserves Sev 1 for declared major incidents, so alerts must not self-classify as Sev 1. Any other value fails generation.
+Use the explicit `2` / `3` / `4` values (the severity label is the IcM Sev number). The legacy `critical` / `warning` / `info` values are still accepted (deprecated). `1` is intentionally rejected by the generator: Azure CEN reserves Sev 1 for declared major incidents, so alerts must not self-classify as Sev 1. Any other value fails generation. The label is a string, so both `severity: "3"` and `severity: 3` are accepted (the generator parses the value as a string).
 
 | Label | IcM Severity | Impact criterion |
 |---|---|---|

--- a/docs/alerts.md
+++ b/docs/alerts.md
@@ -65,7 +65,7 @@ spec:
 |---|---|
 | `alert` | Alert name in PascalCase (e.g. `BackendControllerPanic`) |
 | `expr` | PromQL expression that evaluates to true when the alert should fire |
-| `labels.severity` | One of `critical`, `warning`, `info` |
+| `labels.severity` | One of `2`, `3`, `4` (canonical, the IcM Sev number); `critical`, `warning`, `info` accepted but deprecated |
 | `annotations.summary` | Short title -- becomes the IcM incident title |
 | `annotations.description` | Detailed explanation, can use `{{ $labels.X }}` and `{{ $value }}` |
 | `annotations.runbook_url` | Link to the troubleshooting guide for this alert |
@@ -73,13 +73,15 @@ spec:
 
 ### Severity mapping
 
-The generator maps severity labels to Azure Monitor / IcM severity levels:
+Severity is the customer-impact class of the alert and follows the Azure Common Engineering Naming (CEN) standard so alerts route cleanly into Microsoft IcM. It is a property of the impact the alert represents and is set independently of burn rate: burn rate decides *when* an alert fires, severity decides *who* is paged at what urgency.
 
-| Label | Azure Severity | IcM Behavior |
+Use the explicit `2` / `3` / `4` values (the severity label is the IcM Sev number). The legacy `critical` / `warning` / `info` values are still accepted (deprecated). `1` is intentionally rejected by the generator: Azure CEN reserves Sev 1 for declared major incidents, so alerts must not self-classify as Sev 1. Any other value fails generation.
+
+| Label | IcM Severity | Impact criterion |
 |---|---|---|
-| `critical` | SEV 3 | Urgent, high business impact |
-| `warning` | SEV 3 | Urgent, high business impact |
-| `info` | SEV 4 | Not urgent, no SLA impact |
+| `2` (or `critical`) | SEV 2 | Direct or imminent violation of the customer SLA (e.g. hosted control plane kube-apiserver). |
+| `3` (or `warning`) | SEV 3 | Customer-facing user journey degraded or failing, but the SLA is not violated yet (e.g. cluster create, node pool, upgrade, accessing the cluster). |
+| `4` (or `info`) | SEV 4 | Component-internal issue with no current customer impact, or precursor signals (saturation, capacity). |
 
 ### The `summary` annotation and IcM titles
 

--- a/docs/alerts.md
+++ b/docs/alerts.md
@@ -65,7 +65,7 @@ spec:
 |---|---|
 | `alert` | Alert name in PascalCase (e.g. `BackendControllerPanic`) |
 | `expr` | PromQL expression that evaluates to true when the alert should fire |
-| `labels.severity` | One of `2`, `3`, `4` (canonical, the IcM Sev number); `critical`, `warning`, `info` accepted but deprecated |
+| `labels.severity` | One of `2`, `2.5`, `3`, `4` (canonical, the IcM Sev number); `critical`, `warning`, `info` accepted but deprecated |
 | `annotations.summary` | Short title -- becomes the IcM incident title |
 | `annotations.description` | Detailed explanation, can use `{{ $labels.X }}` and `{{ $value }}` |
 | `annotations.runbook_url` | Link to the troubleshooting guide for this alert |
@@ -73,15 +73,16 @@ spec:
 
 ### Severity mapping
 
-Severity is the customer-impact class of the alert and follows the Azure Common Engineering Naming (CEN) standard so alerts route cleanly into Microsoft IcM. It is a property of the impact the alert represents and is set independently of burn rate: burn rate decides *when* an alert fires, severity decides *who* is paged at what urgency.
+Severity follows the Azure Common Engineering Naming (CEN) standard so alerts route cleanly into Microsoft IcM. It is set independently of burn rate: burn rate decides *when* an alert fires, severity decides *who* is paged at what urgency.
 
-Use the explicit `2` / `3` / `4` values (the severity label is the IcM Sev number). The legacy `critical` / `warning` / `info` values are still accepted (deprecated). `1` is intentionally rejected by the generator: Azure CEN reserves Sev 1 for declared major incidents, so alerts must not self-classify as Sev 1. Any other value fails generation. The label is a string, so both `severity: "3"` and `severity: 3` are accepted (the generator parses the value as a string).
+Use the explicit `2` / `2.5` / `3` / `4` values (the severity label is the IcM Sev number). The legacy `critical` / `warning` / `info` values are still accepted (deprecated). `1` is intentionally rejected by the generator: Azure CEN reserves Sev 1 for declared major incidents, so alerts must not self-classify as Sev 1. Any other value fails generation. The label is a string, so both `severity: "3"` and `severity: 3` are accepted (the generator parses the value as a string).
 
-| Label | IcM Severity | Impact criterion |
+| Label | IcM Severity | Urgency |
 |---|---|---|
-| `2` (or `critical`) | SEV 2 | Direct or imminent violation of the customer SLA (e.g. hosted control plane kube-apiserver). |
-| `3` (or `warning`) | SEV 3 | Customer-facing user journey degraded or failing, but the SLA is not violated yet (e.g. cluster create, node pool, upgrade, accessing the cluster). |
-| `4` (or `info`) | SEV 4 | Component-internal issue with no current customer impact, or precursor signals (saturation, capacity). |
+| `2` (or `critical`) | SEV 2 | Needs immediate attention. |
+| `2.5` (or `25`) | SEV 2.5 | Needs attention at start of next shift. |
+| `3` (or `warning`) | SEV 3 | Needs prompt investigation. |
+| `4` (or `info`) | SEV 4 | Can wait; no immediate action required. |
 
 ### The `summary` annotation and IcM titles
 

--- a/tooling/prometheus-rules/README.md
+++ b/tooling/prometheus-rules/README.md
@@ -95,13 +95,17 @@ Tests are executed using `promtool test rules` during the generation process. If
 
 ## Severity Mapping
 
-The tool maps Prometheus severity labels to Azure Monitor/IcM severity levels:
+Severity is the customer-impact class of the alert and follows the Azure Common Engineering Naming (CEN) standard so alerts route cleanly into IcM. It is set independently of burn rate: burn rate decides when an alert fires, severity decides who is paged at what urgency.
 
-| Prometheus Severity | Description               | IcM Severity | IcM Severity Description                    |
-|---------------------|---------------------------|--------------|---------------------------------------------|
-| Critical            | Important component       | 2            | Single service SLA impact.                  |
-| Warning             | Component degradation     | 3            | Urgent/high business impact, no SLA impact. |
-| Info                | Something may be going on | 4            | Not urgent, no SLA impact.                  |
+Use the IcM severity number as the `severity` label: `2`, `3`, or `4`. The legacy `critical` / `warning` / `info` labels are still accepted (deprecated) and map to the same numbers. `1` is rejected (Azure CEN reserves Sev 1 for declared major incidents), and any other value fails generation rather than silently defaulting to Sev 4.
+
+| Severity label      | IcM Severity | Impact criterion                                                        |
+|---------------------|--------------|-------------------------------------------------------------------------|
+| `2` (or `critical`) | 2            | Direct or imminent customer SLA violation.                              |
+| `3` (or `warning`)  | 3            | Customer-facing user journey degraded, but the SLA is not violated yet. |
+| `4` (or `info`)     | 4            | Component-internal issue with no current customer impact.               |
+
+Severity validation runs over every input rule, including upstream-managed `untestedRules` such as `kubernetesControlPlane-prometheusRule.yaml` (refreshed by `make -C observability sync-upstream`). A future upstream resync that introduces an unmapped severity will fail generation by design; if that happens, extend the mapping in `severityFor` when the new value is legitimate rather than disabling the check.
 
 See: [IcM best practices - Severity levels](https://msazure.visualstudio.com/AzureRedHatOpenShift/_wiki/wikis/ARO.wiki/838022/IcM-best-practices?anchor=severity-levels)
 

--- a/tooling/prometheus-rules/README.md
+++ b/tooling/prometheus-rules/README.md
@@ -95,15 +95,16 @@ Tests are executed using `promtool test rules` during the generation process. If
 
 ## Severity Mapping
 
-Severity is the customer-impact class of the alert and follows the Azure Common Engineering Naming (CEN) standard so alerts route cleanly into IcM. It is set independently of burn rate: burn rate decides when an alert fires, severity decides who is paged at what urgency.
+Severity follows the Azure Common Engineering Naming (CEN) standard so alerts route cleanly into IcM. It is set independently of burn rate: burn rate decides when an alert fires, severity decides who is paged at what urgency.
 
-Use the IcM severity number as the `severity` label: `2`, `3`, or `4`. The legacy `critical` / `warning` / `info` labels are still accepted (deprecated) and map to the same numbers. `1` is rejected (Azure CEN reserves Sev 1 for declared major incidents), and any other value fails generation rather than silently defaulting to Sev 4. The label value is a string, so both `severity: 3` and `severity: "3"` are accepted.
+Use the IcM severity number as the `severity` label: `2`, `2.5`, `3`, or `4`. The legacy `critical` / `warning` / `info` labels are still accepted (deprecated) and map to the same numbers. `1` is rejected (Azure CEN reserves Sev 1 for declared major incidents), and any other value fails generation rather than silently defaulting to Sev 4. The label value is a string, so both `severity: 3` and `severity: "3"` are accepted.
 
-| Severity label      | IcM Severity | Impact criterion                                                        |
-|---------------------|--------------|-------------------------------------------------------------------------|
-| `2` (or `critical`) | 2            | Direct or imminent customer SLA violation.                              |
-| `3` (or `warning`)  | 3            | Customer-facing user journey degraded, but the SLA is not violated yet. |
-| `4` (or `info`)     | 4            | Component-internal issue with no current customer impact.               |
+| Severity label       | IcM Severity | Urgency                                     |
+|----------------------|--------------|-----------------------------------------------|
+| `2` (or `critical`)  | 2            | Needs immediate attention.                    |
+| `2.5` (or `25`)      | 2.5          | Needs attention at start of next shift.       |
+| `3` (or `warning`)   | 3            | Needs prompt investigation.                   |
+| `4` (or `info`)      | 4            | Can wait; no immediate action required.       |
 
 Severity validation runs over every input rule, including upstream-managed `untestedRules` such as `kubernetesControlPlane-prometheusRule.yaml` (refreshed by `make -C observability sync-upstream`). A future upstream resync that introduces an unmapped severity will fail generation by design; if that happens, extend the mapping in `severityFor` when the new value is legitimate rather than disabling the check.
 

--- a/tooling/prometheus-rules/README.md
+++ b/tooling/prometheus-rules/README.md
@@ -97,7 +97,7 @@ Tests are executed using `promtool test rules` during the generation process. If
 
 Severity is the customer-impact class of the alert and follows the Azure Common Engineering Naming (CEN) standard so alerts route cleanly into IcM. It is set independently of burn rate: burn rate decides when an alert fires, severity decides who is paged at what urgency.
 
-Use the IcM severity number as the `severity` label: `2`, `3`, or `4`. The legacy `critical` / `warning` / `info` labels are still accepted (deprecated) and map to the same numbers. `1` is rejected (Azure CEN reserves Sev 1 for declared major incidents), and any other value fails generation rather than silently defaulting to Sev 4.
+Use the IcM severity number as the `severity` label: `2`, `3`, or `4`. The legacy `critical` / `warning` / `info` labels are still accepted (deprecated) and map to the same numbers. `1` is rejected (Azure CEN reserves Sev 1 for declared major incidents), and any other value fails generation rather than silently defaulting to Sev 4. The label value is a string, so both `severity: 3` and `severity: "3"` are accepted.
 
 | Severity label      | IcM Severity | Impact criterion                                                        |
 |---------------------|--------------|-------------------------------------------------------------------------|

--- a/tooling/prometheus-rules/internal/generator.go
+++ b/tooling/prometheus-rules/internal/generator.go
@@ -727,17 +727,19 @@ func severityFor(labels map[string]*string) (*int32, error) {
 		return nil, nil
 	}
 
-	// Severity is the customer-impact class of the alert (Azure CEN), set
-	// independently of burn rate, and maps directly to the IcM severity.
+	// Severity follows the Azure CEN standard and maps directly to the
+	// IcM severity number. Set independently of burn rate.
 	// https://msazure.visualstudio.com/AzureRedHatOpenShift/_wiki/wikis/ARO.wiki/838022/IcM-best-practices?anchor=severity-levels
 	switch *severity {
 	// Canonical Azure CEN vocabulary: the severity label is the IcM Sev number.
 	case "2":
-		return ptr.To(int32(2)), nil // Sev 2: direct or imminent customer SLA violation.
+		return ptr.To(int32(2)), nil
+	case "2.5", "25":
+		return ptr.To(int32(25)), nil // IcM encodes Sev 2.5 as integer 25
 	case "3":
-		return ptr.To(int32(3)), nil // Sev 3: customer-facing user journey degraded, SLA not yet violated.
+		return ptr.To(int32(3)), nil
 	case "4":
-		return ptr.To(int32(4)), nil // Sev 4: component-internal issue, no current customer impact.
+		return ptr.To(int32(4)), nil
 	// Deprecated vocabulary, retained for backward compatibility.
 	case "critical":
 		return ptr.To(int32(2)), nil
@@ -748,9 +750,9 @@ func severityFor(labels map[string]*string) (*int32, error) {
 	// Azure CEN reserves Sev 1 for declared major incidents, so alerts must not
 	// self-classify as Sev 1. Reject it with an explicit message.
 	case "1":
-		return nil, fmt.Errorf(`invalid severity label "1": Sev 1 is reserved for declared major incidents (use 2, 3, or 4)`)
+		return nil, fmt.Errorf(`invalid severity label "1": Sev 1 is reserved for declared major incidents (use 2, 2.5, 3, or 4)`)
 	default:
 		// Fail fast rather than silently defaulting to Sev 4.
-		return nil, fmt.Errorf("invalid severity label %q (use 2, 3, or 4)", *severity)
+		return nil, fmt.Errorf("invalid severity label %q (use 2, 2.5, 3, or 4)", *severity)
 	}
 }

--- a/tooling/prometheus-rules/internal/generator.go
+++ b/tooling/prometheus-rules/internal/generator.go
@@ -513,6 +513,10 @@ param location string = resourceGroup().location
 
 				// Filter rules based on the output file type
 				if rule.Alert != "" && isAlertingRulesFile {
+					severity, err := severityFor(labels)
+					if err != nil {
+						return fmt.Errorf("alert %q: %w", rule.Alert, err)
+					}
 					armGroup.Properties.Rules = append(armGroup.Properties.Rules, &armprometheusrulegroups.PrometheusRule{
 						Alert:       ptr.To(rule.Alert),
 						Enabled:     ptr.To(true),
@@ -524,7 +528,7 @@ param location string = resourceGroup().location
 								whitespaceMatcher.ReplaceAllString(rule.Expr.String(), " "),
 							),
 						),
-						Severity: severityFor(labels),
+						Severity: severity,
 					})
 				} else if rule.Record != "" && isRecordingRulesFile {
 					armGroup.Properties.Rules = append(armGroup.Properties.Rules, &armprometheusrulegroups.PrometheusRule{
@@ -717,24 +721,34 @@ func parseToAzureDurationString(d *monitoringv1.Duration) *string {
 	return ptr.To("PT" + strings.ToUpper(parsedDuration.String()))
 }
 
-func severityFor(labels map[string]*string) *int32 {
+func severityFor(labels map[string]*string) (*int32, error) {
 	severity, ok := labels["severity"]
 	if !ok || severity == nil {
-		return nil
+		return nil, nil
 	}
 
-	// Severity level mapping
+	// Severity is the customer-impact class of the alert (Azure CEN), set
+	// independently of burn rate, and maps directly to the IcM severity.
 	// https://msazure.visualstudio.com/AzureRedHatOpenShift/_wiki/wikis/ARO.wiki/838022/IcM-best-practices?anchor=severity-levels
-
 	switch *severity {
+	// Canonical Azure CEN vocabulary: the severity label is the IcM Sev number.
+	case "2":
+		return ptr.To(int32(2)), nil // Sev 2: direct or imminent customer SLA violation.
+	case "3":
+		return ptr.To(int32(3)), nil // Sev 3: customer-facing user journey degraded, SLA not yet violated.
+	case "4":
+		return ptr.To(int32(4)), nil // Sev 4: component-internal issue, no current customer impact.
+	// Deprecated vocabulary, retained for backward compatibility.
 	case "critical":
-		return ptr.To(int32(2)) // SEV 2: Single service SLA impact.
+		return ptr.To(int32(2)), nil
 	case "warning":
-		return ptr.To(int32(3)) // SEV 3: Urgent/high business impact, no SLA impact.
+		return ptr.To(int32(3)), nil
 	case "info":
-		return ptr.To(int32(4)) // SEV 4: Not urgent, no SLA impact.
+		return ptr.To(int32(4)), nil
 	default:
-		logrus.Warnf("unknown severity label %q, defaulting to verbose", *severity)
-		return ptr.To(int32(4)) // Sev 4 - Verbose
+		// Fail fast rather than silently defaulting to Sev 4. "1" is rejected on
+		// purpose: Azure CEN reserves Sev 1 for declared major incidents, so
+		// alerts must not self-classify as Sev 1.
+		return nil, fmt.Errorf("invalid severity label %q (use 2, 3, or 4)", *severity)
 	}
 }

--- a/tooling/prometheus-rules/internal/generator.go
+++ b/tooling/prometheus-rules/internal/generator.go
@@ -745,10 +745,12 @@ func severityFor(labels map[string]*string) (*int32, error) {
 		return ptr.To(int32(3)), nil
 	case "info":
 		return ptr.To(int32(4)), nil
+	// Azure CEN reserves Sev 1 for declared major incidents, so alerts must not
+	// self-classify as Sev 1. Reject it with an explicit message.
+	case "1":
+		return nil, fmt.Errorf(`invalid severity label "1": Sev 1 is reserved for declared major incidents (use 2, 3, or 4)`)
 	default:
-		// Fail fast rather than silently defaulting to Sev 4. "1" is rejected on
-		// purpose: Azure CEN reserves Sev 1 for declared major incidents, so
-		// alerts must not self-classify as Sev 1.
+		// Fail fast rather than silently defaulting to Sev 4.
 		return nil, fmt.Errorf("invalid severity label %q (use 2, 3, or 4)", *severity)
 	}
 }

--- a/tooling/prometheus-rules/internal/generator_test.go
+++ b/tooling/prometheus-rules/internal/generator_test.go
@@ -885,6 +885,8 @@ func TestSeverityFor(t *testing.T) {
 	}{
 		// Canonical Azure CEN vocabulary: the severity label is the IcM Sev number.
 		{map[string]*string{"severity": ptr.To("2")}, ptr.To(int32(2)), false},
+		{map[string]*string{"severity": ptr.To("2.5")}, ptr.To(int32(25)), false},
+		{map[string]*string{"severity": ptr.To("25")}, ptr.To(int32(25)), false},
 		{map[string]*string{"severity": ptr.To("3")}, ptr.To(int32(3)), false},
 		{map[string]*string{"severity": ptr.To("4")}, ptr.To(int32(4)), false},
 		// Deprecated vocabulary, still accepted.

--- a/tooling/prometheus-rules/internal/generator_test.go
+++ b/tooling/prometheus-rules/internal/generator_test.go
@@ -879,20 +879,36 @@ func TestParseToAzureDurationString(t *testing.T) {
 
 func TestSeverityFor(t *testing.T) {
 	tests := []struct {
-		labels   map[string]*string
-		expected *int32
+		labels    map[string]*string
+		expected  *int32
+		expectErr bool
 	}{
-		{map[string]*string{"severity": ptr.To("critical")}, ptr.To(int32(2))},
-		{map[string]*string{"severity": ptr.To("warning")}, ptr.To(int32(3))},
-		{map[string]*string{"severity": ptr.To("info")}, ptr.To(int32(4))},
-		{map[string]*string{"severity": ptr.To("unknown")}, ptr.To(int32(4))},
-		{map[string]*string{}, nil},
-		{map[string]*string{"other": ptr.To("value")}, nil},
+		// Canonical Azure CEN vocabulary: the severity label is the IcM Sev number.
+		{map[string]*string{"severity": ptr.To("2")}, ptr.To(int32(2)), false},
+		{map[string]*string{"severity": ptr.To("3")}, ptr.To(int32(3)), false},
+		{map[string]*string{"severity": ptr.To("4")}, ptr.To(int32(4)), false},
+		// Deprecated vocabulary, still accepted.
+		{map[string]*string{"severity": ptr.To("critical")}, ptr.To(int32(2)), false},
+		{map[string]*string{"severity": ptr.To("warning")}, ptr.To(int32(3)), false},
+		{map[string]*string{"severity": ptr.To("info")}, ptr.To(int32(4)), false},
+		// "1" (Sev 1) is rejected: Azure CEN reserves Sev 1 for declared incidents.
+		{map[string]*string{"severity": ptr.To("1")}, nil, true},
+		// Unknown values fail fast instead of silently defaulting to Sev 4.
+		{map[string]*string{"severity": ptr.To("unknown")}, nil, true},
+		// No severity label: nil, no error.
+		{map[string]*string{}, nil, false},
+		{map[string]*string{"other": ptr.To("value")}, nil, false},
 	}
 
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("labels_%v", tt.labels), func(t *testing.T) {
-			result := severityFor(tt.labels)
+			result, err := severityFor(tt.labels)
+			if tt.expectErr {
+				require.Error(t, err)
+				assert.Nil(t, result)
+				return
+			}
+			require.NoError(t, err)
 			if tt.expected == nil {
 				assert.Nil(t, result)
 			} else {


### PR DESCRIPTION
[ARO-27807](https://redhat.atlassian.net/browse/ARO-27807)

### What

Adds the explicit Azure CEN severity values `2`/`2.5`/`3`/`4` to the alert generator (keeping `critical`/`warning`/`info` as deprecated aliases) and makes unknown or `1` severities fail generation instead of silently defaulting to Sev 4. Severity descriptions use urgency-based framing per reviewer feedback.

### Why

Severity drives IcM paging and should use the IcM Sev number directly, and the old silent-default behavior could mask author mistakes. Sev 2.5 covers high-priority issues that can wait until start of next shift (weekend use case).

### Testing

`cd tooling/prometheus-rules && go test ./...` and `go vet ./...` pass, and the generator runs clean over all five alert configs with no severity-value drift.

### Special notes for your reviewer

Generator-only change that relabels no existing alert, with follow-ups to move specific alerts (KAS, node pool) onto the explicit values.