### PR TITLE
[draft]feat: add Azure Lockbox breakglass session SLI observability stack

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
@@ -244,3 +244,239 @@ resource arohcpNodepoolSaturationAlerts 'Microsoft.AlertsManagement/prometheusRu
     ]
   }
 }
+
+resource lockboxAvailabilityRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'lockbox-availability-rules'
+  location: location
+  properties: {
+    interval: 'PT1M'
+    rules: [
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
+            }
+          }
+        ]
+        alert: 'UJLockboxAuditDegraded'
+        enabled: true
+        labels: {
+          severity: 'critical'
+          slo: 'lockbox-availability'
+        }
+        annotations: {
+          correlationId: 'UJLockboxAudit/{{ $labels.cluster }}'
+          description: '''The Admin API failed to connect to the audit server and is running
+with a no-op audit client. Breakglass session actions are NOT being
+audited — this is a compliance violation.
+Service Cluster: {{ $labels.cluster }}
+'''
+          info: '''The Admin API failed to connect to the audit server and is running
+with a no-op audit client. Breakglass session actions are NOT being
+audited — this is a compliance violation.
+Service Cluster: {{ $labels.cluster }}
+'''
+          runbook_url: 'https://aka.ms/arohcp-runbook-lockbox'
+          summary: '[SVC] Lockbox audit log connection degraded on {{ $labels.cluster }}'
+          title: '[SVC] Lockbox audit log connection degraded on {{ $labels.cluster }}'
+        }
+        expression: 'lockbox:audit_log_connection_degraded:max == 1'
+        for: 'PT5M'
+        severity: 2
+      }
+    ]
+    scopes: [
+      azureMonitoring
+    ]
+  }
+}
+
+resource lockboxErrorsRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'lockbox-errors-rules'
+  location: location
+  properties: {
+    interval: 'PT1M'
+    rules: [
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
+            }
+          }
+        ]
+        alert: 'UJLockboxAuditErrorRateHigh'
+        enabled: true
+        labels: {
+          severity: 'warning'
+          slo: 'lockbox-errors'
+        }
+        annotations: {
+          correlationId: 'UJLockboxAuditErrors/{{ $labels.cluster }}'
+          description: '''Audit log send error rate is {{ $value | humanizePercentage }} over the
+last hour. Some breakglass session audit records may be lost.
+Service Cluster: {{ $labels.cluster }}
+'''
+          info: '''Audit log send error rate is {{ $value | humanizePercentage }} over the
+last hour. Some breakglass session audit records may be lost.
+Service Cluster: {{ $labels.cluster }}
+'''
+          runbook_url: 'https://aka.ms/arohcp-runbook-lockbox'
+          summary: '[SVC] Lockbox audit log error rate >5% on {{ $labels.cluster }}'
+          title: '[SVC] Lockbox audit log error rate >5% on {{ $labels.cluster }}'
+        }
+        expression: 'lockbox:audit_log_error_rate:ratio_1h > 0.05'
+        for: 'PT5M'
+        severity: 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
+            }
+          }
+        ]
+        alert: 'UJLockboxKasProxyErrors'
+        enabled: true
+        labels: {
+          severity: 'warning'
+          slo: 'lockbox-errors'
+        }
+        annotations: {
+          correlationId: 'UJLockboxKasProxy/{{ $labels.cluster }}'
+          description: '''KAS proxy error rate is {{ $value | humanizePercentage }}. Support
+engineer\'s breakglass session may be unusable.
+Service Cluster: {{ $labels.cluster }}
+'''
+          info: '''KAS proxy error rate is {{ $value | humanizePercentage }}. Support
+engineer\'s breakglass session may be unusable.
+Service Cluster: {{ $labels.cluster }}
+'''
+          runbook_url: 'https://aka.ms/arohcp-runbook-lockbox'
+          summary: '[SVC] Lockbox KAS proxy error rate >10% on {{ $labels.cluster }}'
+          title: '[SVC] Lockbox KAS proxy error rate >10% on {{ $labels.cluster }}'
+        }
+        expression: '(lockbox:kas_proxy_errors_total:rate5m / lockbox:kas_proxy_requests_total:rate5m) > 0.1 and lockbox:kas_proxy_requests_total:rate5m > 0'
+        for: 'PT5M'
+        severity: 3
+      }
+    ]
+    scopes: [
+      azureMonitoring
+    ]
+  }
+}
+
+resource lockboxLatencyRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'lockbox-latency-rules'
+  location: location
+  properties: {
+    interval: 'PT1M'
+    rules: [
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
+            }
+          }
+        ]
+        alert: 'UJLockboxKasProxyLatencyHigh'
+        enabled: true
+        labels: {
+          severity: 'warning'
+          slo: 'lockbox-latency'
+        }
+        annotations: {
+          correlationId: 'UJLockboxLatency/{{ $labels.cluster }}'
+          description: '''KAS proxy p99 latency is {{ $value | humanizeDuration }}. Support
+engineer may experience slow cluster access during breakglass session.
+Service Cluster: {{ $labels.cluster }}
+'''
+          info: '''KAS proxy p99 latency is {{ $value | humanizeDuration }}. Support
+engineer may experience slow cluster access during breakglass session.
+Service Cluster: {{ $labels.cluster }}
+'''
+          runbook_url: 'https://aka.ms/arohcp-runbook-lockbox'
+          summary: '[SVC] Lockbox KAS proxy p99 latency >10s on {{ $labels.cluster }}'
+          title: '[SVC] Lockbox KAS proxy p99 latency >10s on {{ $labels.cluster }}'
+        }
+        expression: 'lockbox:kas_proxy_latency:p99_5m > 10'
+        for: 'PT5M'
+        severity: 3
+      }
+    ]
+    scopes: [
+      azureMonitoring
+    ]
+  }
+}
+
+resource lockboxSaturationRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'lockbox-saturation-rules'
+  location: location
+  properties: {
+    interval: 'PT1M'
+    rules: [
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+              'IcM.Description': '#$.annotations.info#'
+              'IcM.TsgId': '#$.annotations.runbook_url#'
+            }
+          }
+        ]
+        alert: 'UJLockboxHighActiveSessions'
+        enabled: true
+        labels: {
+          severity: 'info'
+          slo: 'lockbox-saturation'
+        }
+        annotations: {
+          correlationId: 'UJLockboxSaturation/{{ $labels.cluster }}'
+          description: '''More than 10 concurrent breakglass sessions are active. This may
+indicate an incident with widespread support access or a session
+cleanup issue.
+Service Cluster: {{ $labels.cluster }}
+'''
+          info: '''More than 10 concurrent breakglass sessions are active. This may
+indicate an incident with widespread support access or a session
+cleanup issue.
+Service Cluster: {{ $labels.cluster }}
+'''
+          runbook_url: 'https://aka.ms/arohcp-runbook-lockbox'
+          summary: '[SVC] High number of active breakglass sessions ({{ $value }}) on {{ $labels.cluster }}'
+          title: '[SVC] High number of active breakglass sessions ({{ $value }}) on {{ $labels.cluster }}'
+        }
+        expression: 'lockbox:sessiongate_active_sessions:max > 10'
+        for: 'PT15M'
+        severity: 4
+      }
+    ]
+    scopes: [
+      azureMonitoring
+    ]
+  }
+}

--- a/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
@@ -266,7 +266,7 @@ resource lockboxAvailabilityRules 'Microsoft.AlertsManagement/prometheusRuleGrou
         alert: 'UJLockboxAuditDegraded'
         enabled: true
         labels: {
-          severity: 'critical'
+          severity: 'warning'
           slo: 'lockbox-availability'
         }
         annotations: {
@@ -287,7 +287,7 @@ Service Cluster: {{ $labels.cluster }}
         }
         expression: 'lockbox:audit_log_connection_degraded:max == 1'
         for: 'PT5M'
-        severity: 2
+        severity: 3
       }
     ]
     scopes: [

--- a/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
@@ -419,7 +419,7 @@ Service Cluster: {{ $labels.cluster }}
           summary: '[SVC] Lockbox KAS proxy p99 latency >10s on {{ $labels.cluster }}'
           title: '[SVC] Lockbox KAS proxy p99 latency >10s on {{ $labels.cluster }}'
         }
-        expression: 'lockbox:kas_proxy_latency:p99_5m > 10'
+        expression: 'lockbox:kas_proxy_latency:avg_5m > 10'
         for: 'PT5M'
         severity: 3
       }

--- a/dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep
@@ -25,8 +25,8 @@ resource lockboxRecordingRules 'Microsoft.AlertsManagement/prometheusRuleGroups@
         expression: 'sum by (cluster) (rate(sessiongate_kas_proxy_requests_total{status!~"2.."}[5m]))'
       }
       {
-        record: 'lockbox:kas_proxy_latency:p99_5m'
-        expression: 'histogram_quantile(0.99, sum by (cluster, le) (rate(sessiongate_kas_proxy_requests_duration_seconds_bucket[5m])) )'
+        record: 'lockbox:kas_proxy_latency:avg_5m'
+        expression: 'sum by (cluster) (rate(sessiongate_kas_proxy_requests_duration_seconds_sum[5m])) / sum by (cluster) (rate(sessiongate_kas_proxy_requests_duration_seconds_count[5m]))'
       }
       {
         record: 'lockbox:audit_log_error_rate:ratio_1h'

--- a/dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep
@@ -1,3 +1,45 @@
 param azureMonitoring string
 
 param location string = resourceGroup().location
+
+resource lockboxRecordingRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'lockbox-recording-rules'
+  location: location
+  properties: {
+    scopes: [
+      azureMonitoring
+    ]
+    enabled: true
+    interval: 'PT1M'
+    rules: [
+      {
+        record: 'lockbox:sessiongate_active_sessions:max'
+        expression: 'max by (cluster) (sessiongate_active_sessions)'
+      }
+      {
+        record: 'lockbox:kas_proxy_requests_total:rate5m'
+        expression: 'sum by (cluster) (rate(sessiongate_kas_proxy_requests_total[5m]))'
+      }
+      {
+        record: 'lockbox:kas_proxy_errors_total:rate5m'
+        expression: 'sum by (cluster) (rate(sessiongate_kas_proxy_requests_total{status!~"2.."}[5m]))'
+      }
+      {
+        record: 'lockbox:kas_proxy_latency:p99_5m'
+        expression: 'histogram_quantile(0.99, sum by (cluster, le) (rate(sessiongate_kas_proxy_requests_duration_seconds_bucket[5m])) )'
+      }
+      {
+        record: 'lockbox:audit_log_error_rate:ratio_1h'
+        expression: '( sum by (cluster) (rate(otel_audit_log_send_errors_total{job="aro-hcp-admin-api-metrics"}[1h])) / sum by (cluster) (rate(otel_audit_log_records_total{job="aro-hcp-admin-api-metrics"}[1h])) )'
+      }
+      {
+        record: 'lockbox:audit_log_connection_degraded:max'
+        expression: 'max by (cluster) (otel_audit_log_connection_degraded{job="aro-hcp-admin-api-metrics"})'
+      }
+      {
+        record: 'lockbox:audit_log_records:rate5m'
+        expression: 'sum by (cluster) (rate(otel_audit_log_records_total{job="aro-hcp-admin-api-metrics"}[5m]))'
+      }
+    ]
+  }
+}

--- a/observability/alerts-rp-services.yaml
+++ b/observability/alerts-rp-services.yaml
@@ -1,6 +1,7 @@
 prometheusRules:
   rulesFolders:
   - alerts/nodepool-slo-prometheusRule.yaml
+  - alerts/lockbox-monitor-prometheusRule.yaml
   untestedRules: []
   testDependencies:
   - recording-rules-services.yaml

--- a/observability/alerts/lockbox-monitor-prometheusRule.yaml
+++ b/observability/alerts/lockbox-monitor-prometheusRule.yaml
@@ -20,7 +20,7 @@ spec:
       expr: lockbox:audit_log_connection_degraded:max == 1
       for: 5m
       labels:
-        severity: critical
+        severity: warning
         slo: lockbox-availability
       annotations:
         summary: "[SVC] Lockbox audit log connection degraded on {{ $labels.cluster }}"

--- a/observability/alerts/lockbox-monitor-prometheusRule.yaml
+++ b/observability/alerts/lockbox-monitor-prometheusRule.yaml
@@ -1,0 +1,102 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: lockbox-monitor-alerts
+  namespace: prometheus
+spec:
+  groups:
+  - name: lockbox-availability-rules
+    rules:
+    # Lockbox / Breakglass Session availability alerts.
+    # SLO: Audit pipeline available 99.95% of the time.
+    #
+    # Threshold-based alerts (deliberate exception from burn-rate):
+    # Breakglass sessions are rare events — only created during active support
+    # incidents with Lockbox approval. rate()[5m] returns 0 most of the time,
+    # making multi-window burn-rate math produce NaN.
+
+    # Audit pipeline down — compliance violation, must page
+    - alert: UJLockboxAuditDegraded
+      expr: lockbox:audit_log_connection_degraded:max == 1
+      for: 5m
+      labels:
+        severity: critical
+        slo: lockbox-availability
+      annotations:
+        summary: "[SVC] Lockbox audit log connection degraded on {{ $labels.cluster }}"
+        description: |
+          The Admin API failed to connect to the audit server and is running
+          with a no-op audit client. Breakglass session actions are NOT being
+          audited — this is a compliance violation.
+          Service Cluster: {{ $labels.cluster }}
+        runbook_url: "https://aka.ms/arohcp-runbook-lockbox"
+        correlationId: "UJLockboxAudit/{{ $labels.cluster }}"
+  - name: lockbox-errors-rules
+    rules:
+    # Audit log error rate — data loss risk
+    - alert: UJLockboxAuditErrorRateHigh
+      expr: lockbox:audit_log_error_rate:ratio_1h > 0.05
+      for: 5m
+      labels:
+        severity: warning
+        slo: lockbox-errors
+      annotations:
+        summary: "[SVC] Lockbox audit log error rate >5% on {{ $labels.cluster }}"
+        description: |
+          Audit log send error rate is {{ $value | humanizePercentage }} over the
+          last hour. Some breakglass session audit records may be lost.
+          Service Cluster: {{ $labels.cluster }}
+        runbook_url: "https://aka.ms/arohcp-runbook-lockbox"
+        correlationId: "UJLockboxAuditErrors/{{ $labels.cluster }}"
+    # KAS proxy errors — active session failing
+    - alert: UJLockboxKasProxyErrors
+      expr: |
+        (lockbox:kas_proxy_errors_total:rate5m / lockbox:kas_proxy_requests_total:rate5m) > 0.1
+        and lockbox:kas_proxy_requests_total:rate5m > 0
+      for: 5m
+      labels:
+        severity: warning
+        slo: lockbox-errors
+      annotations:
+        summary: "[SVC] Lockbox KAS proxy error rate >10% on {{ $labels.cluster }}"
+        description: |
+          KAS proxy error rate is {{ $value | humanizePercentage }}. Support
+          engineer's breakglass session may be unusable.
+          Service Cluster: {{ $labels.cluster }}
+        runbook_url: "https://aka.ms/arohcp-runbook-lockbox"
+        correlationId: "UJLockboxKasProxy/{{ $labels.cluster }}"
+  - name: lockbox-latency-rules
+    rules:
+    # KAS proxy latency — support engineer experience degraded
+    - alert: UJLockboxKasProxyLatencyHigh
+      expr: lockbox:kas_proxy_latency:p99_5m > 10
+      for: 5m
+      labels:
+        severity: warning
+        slo: lockbox-latency
+      annotations:
+        summary: "[SVC] Lockbox KAS proxy p99 latency >10s on {{ $labels.cluster }}"
+        description: |
+          KAS proxy p99 latency is {{ $value | humanizeDuration }}. Support
+          engineer may experience slow cluster access during breakglass session.
+          Service Cluster: {{ $labels.cluster }}
+        runbook_url: "https://aka.ms/arohcp-runbook-lockbox"
+        correlationId: "UJLockboxLatency/{{ $labels.cluster }}"
+  - name: lockbox-saturation-rules
+    rules:
+    # High concurrent sessions — unusual support access volume
+    - alert: UJLockboxHighActiveSessions
+      expr: lockbox:sessiongate_active_sessions:max > 10
+      for: 15m
+      labels:
+        severity: info
+        slo: lockbox-saturation
+      annotations:
+        summary: "[SVC] High number of active breakglass sessions ({{ $value }}) on {{ $labels.cluster }}"
+        description: |
+          More than 10 concurrent breakglass sessions are active. This may
+          indicate an incident with widespread support access or a session
+          cleanup issue.
+          Service Cluster: {{ $labels.cluster }}
+        runbook_url: "https://aka.ms/arohcp-runbook-lockbox"
+        correlationId: "UJLockboxSaturation/{{ $labels.cluster }}"

--- a/observability/alerts/lockbox-monitor-prometheusRule.yaml
+++ b/observability/alerts/lockbox-monitor-prometheusRule.yaml
@@ -69,7 +69,7 @@ spec:
     rules:
     # KAS proxy latency — support engineer experience degraded
     - alert: UJLockboxKasProxyLatencyHigh
-      expr: lockbox:kas_proxy_latency:p99_5m > 10
+      expr: lockbox:kas_proxy_latency:avg_5m > 10
       for: 5m
       labels:
         severity: warning

--- a/observability/alerts/lockbox-monitor-prometheusRule_test.yaml
+++ b/observability/alerts/lockbox-monitor-prometheusRule_test.yaml
@@ -1,0 +1,140 @@
+rule_files:
+- lockbox-monitor-prometheusRule.yaml
+evaluation_interval: 1m
+tests:
+# Test 1: Audit connection degraded fires after 5 minutes
+- interval: 1m
+  input_series:
+  - series: 'lockbox:audit_log_connection_degraded:max{cluster="svc-cluster-1"}'
+    values: "1+0x10"
+  alert_rule_test:
+  - eval_time: 3m
+    alertname: UJLockboxAuditDegraded
+    exp_alerts: []
+  - eval_time: 7m
+    alertname: UJLockboxAuditDegraded
+    exp_alerts:
+    - exp_labels:
+        severity: critical
+        slo: lockbox-availability
+        cluster: svc-cluster-1
+      exp_annotations:
+        summary: "[SVC] Lockbox audit log connection degraded on svc-cluster-1"
+        description: "The Admin API failed to connect to the audit server and is running\nwith a no-op audit client. Breakglass session actions are NOT being\naudited — this is a compliance violation.\nService Cluster: svc-cluster-1\n"
+        runbook_url: "https://aka.ms/arohcp-runbook-lockbox"
+        correlationId: "UJLockboxAudit/svc-cluster-1"
+# Test 2: Audit connection healthy — alert does not fire
+- interval: 1m
+  input_series:
+  - series: 'lockbox:audit_log_connection_degraded:max{cluster="svc-cluster-2"}'
+    values: "0+0x10"
+  alert_rule_test:
+  - eval_time: 7m
+    alertname: UJLockboxAuditDegraded
+    exp_alerts: []
+# Test 3: High audit error rate fires
+- interval: 1m
+  input_series:
+  - series: 'lockbox:audit_log_error_rate:ratio_1h{cluster="svc-cluster-3"}'
+    values: "0.08+0x10"
+  alert_rule_test:
+  - eval_time: 7m
+    alertname: UJLockboxAuditErrorRateHigh
+    exp_alerts:
+    - exp_labels:
+        severity: warning
+        slo: lockbox-errors
+        cluster: svc-cluster-3
+      exp_annotations:
+        summary: "[SVC] Lockbox audit log error rate >5% on svc-cluster-3"
+        description: "Audit log send error rate is 8% over the\nlast hour. Some breakglass session audit records may be lost.\nService Cluster: svc-cluster-3\n"
+        runbook_url: "https://aka.ms/arohcp-runbook-lockbox"
+        correlationId: "UJLockboxAuditErrors/svc-cluster-3"
+# Test 4: Low audit error rate — alert does not fire
+- interval: 1m
+  input_series:
+  - series: 'lockbox:audit_log_error_rate:ratio_1h{cluster="svc-cluster-4"}'
+    values: "0.02+0x10"
+  alert_rule_test:
+  - eval_time: 7m
+    alertname: UJLockboxAuditErrorRateHigh
+    exp_alerts: []
+# Test 5: KAS proxy errors fire when error rate exceeds 10% with active traffic
+- interval: 1m
+  input_series:
+  - series: 'lockbox:kas_proxy_errors_total:rate5m{cluster="svc-cluster-5"}'
+    values: "0.5+0x10"
+  - series: 'lockbox:kas_proxy_requests_total:rate5m{cluster="svc-cluster-5"}'
+    values: "2+0x10"
+  alert_rule_test:
+  - eval_time: 7m
+    alertname: UJLockboxKasProxyErrors
+    exp_alerts:
+    - exp_labels:
+        severity: warning
+        slo: lockbox-errors
+        cluster: svc-cluster-5
+      exp_annotations:
+        summary: "[SVC] Lockbox KAS proxy error rate >10% on svc-cluster-5"
+        description: "KAS proxy error rate is 25%. Support\nengineer's breakglass session may be unusable.\nService Cluster: svc-cluster-5\n"
+        runbook_url: "https://aka.ms/arohcp-runbook-lockbox"
+        correlationId: "UJLockboxKasProxy/svc-cluster-5"
+# Test 6: KAS proxy errors do NOT fire when there's no traffic
+- interval: 1m
+  input_series:
+  - series: 'lockbox:kas_proxy_errors_total:rate5m{cluster="svc-cluster-6"}'
+    values: "0+0x10"
+  - series: 'lockbox:kas_proxy_requests_total:rate5m{cluster="svc-cluster-6"}'
+    values: "0+0x10"
+  alert_rule_test:
+  - eval_time: 7m
+    alertname: UJLockboxKasProxyErrors
+    exp_alerts: []
+# Test 7: High active sessions fires after 15m pending
+- interval: 1m
+  input_series:
+  - series: 'lockbox:sessiongate_active_sessions:max{cluster="svc-cluster-7"}'
+    values: "15+0x20"
+  alert_rule_test:
+  - eval_time: 10m
+    alertname: UJLockboxHighActiveSessions
+    exp_alerts: []
+  - eval_time: 17m
+    alertname: UJLockboxHighActiveSessions
+    exp_alerts:
+    - exp_labels:
+        severity: info
+        slo: lockbox-saturation
+        cluster: svc-cluster-7
+      exp_annotations:
+        summary: "[SVC] High number of active breakglass sessions (15) on svc-cluster-7"
+        description: "More than 10 concurrent breakglass sessions are active. This may\nindicate an incident with widespread support access or a session\ncleanup issue.\nService Cluster: svc-cluster-7\n"
+        runbook_url: "https://aka.ms/arohcp-runbook-lockbox"
+        correlationId: "UJLockboxSaturation/svc-cluster-7"
+# Test 8: Normal active sessions — alert does not fire
+- interval: 1m
+  input_series:
+  - series: 'lockbox:sessiongate_active_sessions:max{cluster="svc-cluster-8"}'
+    values: "3+0x20"
+  alert_rule_test:
+  - eval_time: 17m
+    alertname: UJLockboxHighActiveSessions
+    exp_alerts: []
+# Test 9: KAS proxy latency fires when p99 exceeds 10s
+- interval: 1m
+  input_series:
+  - series: 'lockbox:kas_proxy_latency:p99_5m{cluster="svc-cluster-9"}'
+    values: "15+0x10"
+  alert_rule_test:
+  - eval_time: 7m
+    alertname: UJLockboxKasProxyLatencyHigh
+    exp_alerts:
+    - exp_labels:
+        severity: warning
+        slo: lockbox-latency
+        cluster: svc-cluster-9
+      exp_annotations:
+        summary: "[SVC] Lockbox KAS proxy p99 latency >10s on svc-cluster-9"
+        description: "KAS proxy p99 latency is 15s. Support\nengineer may experience slow cluster access during breakglass session.\nService Cluster: svc-cluster-9\n"
+        runbook_url: "https://aka.ms/arohcp-runbook-lockbox"
+        correlationId: "UJLockboxLatency/svc-cluster-9"

--- a/observability/alerts/lockbox-monitor-prometheusRule_test.yaml
+++ b/observability/alerts/lockbox-monitor-prometheusRule_test.yaml
@@ -123,7 +123,7 @@ tests:
 # Test 9: KAS proxy latency fires when p99 exceeds 10s
 - interval: 1m
   input_series:
-  - series: 'lockbox:kas_proxy_latency:p99_5m{cluster="svc-cluster-9"}'
+  - series: 'lockbox:kas_proxy_latency:avg_5m{cluster="svc-cluster-9"}'
     values: "15+0x10"
   alert_rule_test:
   - eval_time: 7m

--- a/observability/alerts/lockbox-monitor-prometheusRule_test.yaml
+++ b/observability/alerts/lockbox-monitor-prometheusRule_test.yaml
@@ -15,7 +15,7 @@ tests:
     alertname: UJLockboxAuditDegraded
     exp_alerts:
     - exp_labels:
-        severity: critical
+        severity: warning
         slo: lockbox-availability
         cluster: svc-cluster-1
       exp_annotations:

--- a/observability/alerts/lockbox-recording-rules-prometheusRule.yaml
+++ b/observability/alerts/lockbox-recording-rules-prometheusRule.yaml
@@ -25,12 +25,15 @@ spec:
     # ERRORS: KAS proxy error rate (non-2xx responses)
     - record: lockbox:kas_proxy_errors_total:rate5m
       expr: sum by (cluster) (rate(sessiongate_kas_proxy_requests_total{status!~"2.."}[5m]))
-    # LATENCY: KAS proxy p99 latency
-    - record: lockbox:kas_proxy_latency:p99_5m
+    # LATENCY: KAS proxy average latency
+    # Note: SessionGate uses native (exponential) histograms which don't produce
+    # classic le buckets, so histogram_quantile() returns NaN. Using avg (sum/count)
+    # instead, which is appropriate for these low-latency proxy operations.
+    - record: lockbox:kas_proxy_latency:avg_5m
       expr: |
-        histogram_quantile(0.99,
-          sum by (cluster, le) (rate(sessiongate_kas_proxy_requests_duration_seconds_bucket[5m]))
-        )
+        sum by (cluster) (rate(sessiongate_kas_proxy_requests_duration_seconds_sum[5m]))
+        /
+        sum by (cluster) (rate(sessiongate_kas_proxy_requests_duration_seconds_count[5m]))
     # AVAILABILITY: Audit log error ratio over 1 hour
     - record: lockbox:audit_log_error_rate:ratio_1h
       expr: |

--- a/observability/alerts/lockbox-recording-rules-prometheusRule.yaml
+++ b/observability/alerts/lockbox-recording-rules-prometheusRule.yaml
@@ -1,0 +1,47 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: lockbox-recording-rules
+  namespace: prometheus
+spec:
+  groups:
+  - name: lockbox-recording-rules
+    interval: 1m
+    rules:
+    # Lockbox / Breakglass Session recording rules for SLI/SLO monitoring.
+    # Source: sessiongate_* metrics from SessionGate pods on the service cluster,
+    #         otel_audit_log_* metrics from Admin API pods.
+    #
+    # Breakglass sessions are rare events (only during active support incidents).
+    # All alerts use threshold-based rules, not burn-rate (deliberate exception —
+    # rate()[5m] returns 0 most of the time on these metrics).
+
+    # TRAFFIC: Active breakglass sessions (gauge)
+    - record: lockbox:sessiongate_active_sessions:max
+      expr: max by (cluster) (sessiongate_active_sessions)
+    # ERRORS: KAS proxy request rate (total, for error ratio denominator)
+    - record: lockbox:kas_proxy_requests_total:rate5m
+      expr: sum by (cluster) (rate(sessiongate_kas_proxy_requests_total[5m]))
+    # ERRORS: KAS proxy error rate (non-2xx responses)
+    - record: lockbox:kas_proxy_errors_total:rate5m
+      expr: sum by (cluster) (rate(sessiongate_kas_proxy_requests_total{status!~"2.."}[5m]))
+    # LATENCY: KAS proxy p99 latency
+    - record: lockbox:kas_proxy_latency:p99_5m
+      expr: |
+        histogram_quantile(0.99,
+          sum by (cluster, le) (rate(sessiongate_kas_proxy_requests_duration_seconds_bucket[5m]))
+        )
+    # AVAILABILITY: Audit log error ratio over 1 hour
+    - record: lockbox:audit_log_error_rate:ratio_1h
+      expr: |
+        (
+          sum by (cluster) (rate(otel_audit_log_send_errors_total{job="aro-hcp-admin-api-metrics"}[1h]))
+          /
+          sum by (cluster) (rate(otel_audit_log_records_total{job="aro-hcp-admin-api-metrics"}[1h]))
+        )
+    # AVAILABILITY: Audit log connection health (1=degraded, 0=ok)
+    - record: lockbox:audit_log_connection_degraded:max
+      expr: max by (cluster) (otel_audit_log_connection_degraded{job="aro-hcp-admin-api-metrics"})
+    # TRAFFIC: Audit log volume (records per second)
+    - record: lockbox:audit_log_records:rate5m
+      expr: sum by (cluster) (rate(otel_audit_log_records_total{job="aro-hcp-admin-api-metrics"}[5m]))

--- a/observability/alerts/lockbox-recording-rules-prometheusRule_test.yaml
+++ b/observability/alerts/lockbox-recording-rules-prometheusRule_test.yaml
@@ -57,7 +57,20 @@ tests:
     exp_samples:
     - labels: '{__name__="lockbox:audit_log_connection_degraded:max", cluster="svc-cluster-4"}'
       value: 1
-# Test 5: No data (no breakglass sessions active)
+# Test 5: KAS proxy average latency
+- interval: 1m
+  input_series:
+  - series: 'sessiongate_kas_proxy_requests_duration_seconds_sum{cluster="svc-cluster-5", method="GET", status="404", route="/api"}'
+    values: "0+0.5x15"
+  - series: 'sessiongate_kas_proxy_requests_duration_seconds_count{cluster="svc-cluster-5", method="GET", status="404", route="/api"}'
+    values: "0+10x15"
+  promql_expr_test:
+  - expr: lockbox:kas_proxy_latency:avg_5m{cluster="svc-cluster-5"}
+    eval_time: 5m
+    exp_samples:
+    - labels: '{__name__="lockbox:kas_proxy_latency:avg_5m", cluster="svc-cluster-5"}'
+      value: 0.05
+# Test 6: No data (no breakglass sessions active)
 - interval: 1m
   input_series: []
   promql_expr_test:

--- a/observability/alerts/lockbox-recording-rules-prometheusRule_test.yaml
+++ b/observability/alerts/lockbox-recording-rules-prometheusRule_test.yaml
@@ -1,0 +1,66 @@
+rule_files:
+- lockbox-recording-rules-prometheusRule.yaml
+evaluation_interval: 1m
+tests:
+# Test 1: Active sessions gauge
+- interval: 1m
+  input_series:
+  - series: 'sessiongate_active_sessions{cluster="svc-cluster-1", instance="sessiongate-0"}'
+    values: "2+0x9"
+  - series: 'sessiongate_active_sessions{cluster="svc-cluster-1", instance="sessiongate-1"}'
+    values: "1+0x9"
+  promql_expr_test:
+  - expr: lockbox:sessiongate_active_sessions:max{cluster="svc-cluster-1"}
+    eval_time: 5m
+    exp_samples:
+    - labels: '{__name__="lockbox:sessiongate_active_sessions:max", cluster="svc-cluster-1"}'
+      value: 2
+# Test 2: KAS proxy request rate with errors
+- interval: 1m
+  input_series:
+  - series: 'sessiongate_kas_proxy_requests_total{cluster="svc-cluster-2", method="GET", status="200", route="/api"}'
+    values: "0+100x15"
+  - series: 'sessiongate_kas_proxy_requests_total{cluster="svc-cluster-2", method="GET", status="500", route="/api"}'
+    values: "0+5x15"
+  promql_expr_test:
+  - expr: lockbox:kas_proxy_requests_total:rate5m{cluster="svc-cluster-2"}
+    eval_time: 5m
+    exp_samples:
+    - labels: '{__name__="lockbox:kas_proxy_requests_total:rate5m", cluster="svc-cluster-2"}'
+      value: 1.75
+  - expr: lockbox:kas_proxy_errors_total:rate5m{cluster="svc-cluster-2"}
+    eval_time: 5m
+    exp_samples:
+    - labels: '{__name__="lockbox:kas_proxy_errors_total:rate5m", cluster="svc-cluster-2"}'
+      value: 0.08333333333333333
+# Test 3: Audit log error ratio
+- interval: 1m
+  input_series:
+  - series: 'otel_audit_log_records_total{cluster="svc-cluster-3", job="aro-hcp-admin-api-metrics"}'
+    values: "0+100x70"
+  - series: 'otel_audit_log_send_errors_total{cluster="svc-cluster-3", job="aro-hcp-admin-api-metrics"}'
+    values: "0+2x70"
+  promql_expr_test:
+  - expr: lockbox:audit_log_error_rate:ratio_1h{cluster="svc-cluster-3"}
+    eval_time: 70m
+    exp_samples:
+    - labels: '{__name__="lockbox:audit_log_error_rate:ratio_1h", cluster="svc-cluster-3"}'
+      value: 0.02
+# Test 4: Audit log connection degraded
+- interval: 1m
+  input_series:
+  - series: 'otel_audit_log_connection_degraded{cluster="svc-cluster-4", job="aro-hcp-admin-api-metrics", instance="admin-0"}'
+    values: "1+0x9"
+  promql_expr_test:
+  - expr: lockbox:audit_log_connection_degraded:max{cluster="svc-cluster-4"}
+    eval_time: 5m
+    exp_samples:
+    - labels: '{__name__="lockbox:audit_log_connection_degraded:max", cluster="svc-cluster-4"}'
+      value: 1
+# Test 5: No data (no breakglass sessions active)
+- interval: 1m
+  input_series: []
+  promql_expr_test:
+  - expr: lockbox:sessiongate_active_sessions:max
+    eval_time: 5m
+    exp_samples: []

--- a/observability/grafana-dashboards/sre/user-journey/lockbox-breakglass.json
+++ b/observability/grafana-dashboards/sre/user-journey/lockbox-breakglass.json
@@ -1,6 +1,19 @@
 {
   "annotations": {
-    "list": []
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
   },
   "editable": true,
   "fiscalYearStartMonth": 0,
@@ -297,7 +310,7 @@
       },
       "targets": [
         {
-          "expr": "(lockbox:kas_proxy_errors_total:rate5m or vector(0)) / (lockbox:kas_proxy_requests_total:rate5m > 0)",
+          "expr": "lockbox:kas_proxy_errors_total:rate5m / lockbox:kas_proxy_requests_total:rate5m",
           "legendFormat": "",
           "refId": "A",
           "datasource": {
@@ -687,5 +700,5 @@
   "timezone": "utc",
   "title": "Lockbox / Breakglass Sessions",
   "uid": "lockbox-breakglass-uj",
-  "version": 1
+  "version": null
 }

--- a/observability/grafana-dashboards/sre/user-journey/lockbox-breakglass.json
+++ b/observability/grafana-dashboards/sre/user-journey/lockbox-breakglass.json
@@ -81,13 +81,14 @@
       },
       "targets": [
         {
-          "expr": "lockbox:sessiongate_active_sessions:max",
+          "expr": "max(sessiongate_active_sessions) or vector(0)",
           "legendFormat": "",
           "refId": "A",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
-          }
+          },
+          "range": true
         }
       ]
     },
@@ -116,7 +117,28 @@
             ]
           },
           "unit": "short",
-          "mappings": [],
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "text": "OK",
+                  "color": "green",
+                  "index": 0
+                }
+              },
+              "type": "value"
+            },
+            {
+              "options": {
+                "1": {
+                  "text": "DEGRADED",
+                  "color": "red",
+                  "index": 1
+                }
+              },
+              "type": "value"
+            }
+          ],
           "color": {
             "mode": "thresholds"
           }
@@ -145,13 +167,14 @@
       },
       "targets": [
         {
-          "expr": "lockbox:audit_log_connection_degraded:max",
+          "expr": "max(otel_audit_log_connection_degraded{job=\"aro-hcp-admin-api-metrics\"}) or vector(0)",
           "legendFormat": "",
           "refId": "A",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
-          }
+          },
+          "range": true
         }
       ]
     },
@@ -209,13 +232,14 @@
       },
       "targets": [
         {
-          "expr": "lockbox:audit_log_error_rate:ratio_1h",
+          "expr": "lockbox:audit_log_error_rate:ratio_1h or vector(0)",
           "legendFormat": "",
           "refId": "A",
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
-          }
+          },
+          "range": true
         }
       ]
     },
@@ -279,7 +303,8 @@
           "datasource": {
             "type": "prometheus",
             "uid": "${datasource}"
-          }
+          },
+          "range": true
         }
       ]
     },
@@ -353,7 +378,7 @@
       },
       "targets": [
         {
-          "expr": "lockbox:sessiongate_active_sessions:max",
+          "expr": "max by (cluster) (sessiongate_active_sessions)",
           "legendFormat": "{{ cluster }}",
           "refId": "A",
           "datasource": {
@@ -609,7 +634,7 @@
       },
       "targets": [
         {
-          "expr": "lockbox:audit_log_records:rate5m",
+          "expr": "sum by (cluster) (rate(otel_audit_log_records_total{job=\"aro-hcp-admin-api-metrics\"}[5m]))",
           "legendFormat": "records/sec {{ cluster }}",
           "refId": "A",
           "datasource": {

--- a/observability/grafana-dashboards/sre/user-journey/lockbox-breakglass.json
+++ b/observability/grafana-dashboards/sre/user-journey/lockbox-breakglass.json
@@ -1,0 +1,666 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "id": 1,
+      "type": "text",
+      "title": "",
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "### Lockbox / Breakglass Sessions \u2014 User Journey SLIs\n\nMonitors the health of Azure Lockbox breakglass session lifecycle. Covers audit logging compliance, session creation, KAS proxy access, and concurrent session count.\n\n**SLO Targets:** Audit Available 99.95% | Audit Errors <5% | KAS Proxy Errors <10% | KAS Proxy p99 <10s"
+      }
+    },
+    {
+      "id": 2,
+      "title": "Active Sessions",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Number of active breakglass sessions. 0 is normal (no active support access). High values may indicate an incident.",
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 5
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "unit": "short",
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 3
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "expr": "lockbox:sessiongate_active_sessions:max",
+          "legendFormat": "",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Audit Log Health",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Audit log connection state. 0 = healthy, 1 = degraded (compliance violation \u2014 audit logs not being sent).",
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short",
+          "mappings": [],
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 3
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "expr": "lockbox:audit_log_connection_degraded:max",
+          "legendFormat": "",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Audit Error Rate",
+      "type": "gauge",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Audit log send error rate over 1 hour. >5% means audit records are being lost. SLO: <5%.",
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.01
+              },
+              {
+                "color": "red",
+                "value": 0.05
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 12,
+        "y": 3
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "expr": "lockbox:audit_log_error_rate:ratio_1h",
+          "legendFormat": "",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "KAS Proxy Error Rate",
+      "type": "gauge",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "KAS proxy error rate (non-2xx / total). Shows 0% when no traffic (idle). SLO: <10%.",
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.05
+              },
+              {
+                "color": "red",
+                "value": 0.1
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 3
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "expr": "(lockbox:kas_proxy_errors_total:rate5m or vector(0)) / (lockbox:kas_proxy_requests_total:rate5m > 0)",
+          "legendFormat": "",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "Active Sessions Over Time",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Number of active breakglass sessions over time. Spikes indicate support engineers accessing clusters.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "barAlignment": 0,
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "showPoints": "never",
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "axisBorderShow": false
+          },
+          "unit": "short",
+          "thresholds": {
+            "mode": "off",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "mappings": [],
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      },
+      "targets": [
+        {
+          "expr": "lockbox:sessiongate_active_sessions:max",
+          "legendFormat": "{{ cluster }}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "title": "KAS Proxy Request Rate",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "KAS proxy requests per second by HTTP status code. Shows support engineer cluster access activity.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "barAlignment": 0,
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "showPoints": "never",
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "axisBorderShow": false
+          },
+          "unit": "reqps",
+          "thresholds": {
+            "mode": "off",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "mappings": [],
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (cluster, status) (rate(sessiongate_kas_proxy_requests_total[5m]))",
+          "legendFormat": "{{ cluster }} - {{ status }}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "title": "KAS Proxy Latency (p99)",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "KAS proxy p99 latency. SLO target: <10s. High latency degrades support engineer experience.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "barAlignment": 0,
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "showPoints": "never",
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "axisBorderShow": false,
+            "thresholdsStyle": {
+              "mode": "dashed"
+            }
+          },
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "mappings": [],
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 17
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      },
+      "targets": [
+        {
+          "expr": "lockbox:kas_proxy_latency:p99_5m",
+          "legendFormat": "p99 {{ cluster }}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        },
+        {
+          "expr": "vector(10)",
+          "legendFormat": "SLO Target (10s)",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "title": "Audit Log Volume",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Audit log volume: records sent vs errors. Errors indicate audit data loss risk.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "barAlignment": 0,
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "showPoints": "never",
+            "pointSize": 5,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "axisBorderShow": false
+          },
+          "unit": "ops",
+          "thresholds": {
+            "mode": "off",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "mappings": [],
+          "color": {
+            "mode": "palette-classic"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 17
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      },
+      "targets": [
+        {
+          "expr": "lockbox:audit_log_records:rate5m",
+          "legendFormat": "records/sec {{ cluster }}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        },
+        {
+          "expr": "sum by (cluster) (rate(otel_audit_log_send_errors_total{job=\"aro-hcp-admin-api-metrics\"}[5m]))",
+          "legendFormat": "errors/sec {{ cluster }}",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          }
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": [
+    "user-journey",
+    "lockbox",
+    "sre"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "^Managed_Prometheus_services-.*$",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "utc",
+  "title": "Lockbox / Breakglass Sessions",
+  "uid": "lockbox-breakglass-uj",
+  "version": 1
+}

--- a/observability/grafana-dashboards/sre/user-journey/lockbox-breakglass.json
+++ b/observability/grafana-dashboards/sre/user-journey/lockbox-breakglass.json
@@ -33,7 +33,7 @@
       },
       "options": {
         "mode": "markdown",
-        "content": "### Lockbox / Breakglass Sessions \u2014 User Journey SLIs\n\nMonitors the health of Azure Lockbox breakglass session lifecycle. Covers audit logging compliance, session creation, KAS proxy access, and concurrent session count.\n\n**SLO Targets:** Audit Available 99.95% | Audit Errors <5% | KAS Proxy Errors <10% | KAS Proxy p99 <10s"
+        "content": "### Lockbox / Breakglass Sessions \u2014 User Journey SLIs\n\nMonitors the health of Azure Lockbox breakglass session lifecycle. Covers audit logging compliance, session creation, KAS proxy access, and concurrent session count.\n\n**SLO Targets:** Audit Available 99.95% | Audit Errors <5% | KAS Proxy Errors <10% | KAS Proxy avg <10s"
       }
     },
     {
@@ -483,13 +483,13 @@
     },
     {
       "id": 8,
-      "title": "KAS Proxy Latency (p99)",
+      "title": "KAS Proxy Latency (avg)",
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "KAS proxy p99 latency. SLO target: <10s. High latency degrades support engineer experience.",
+      "description": "KAS proxy average request latency. SLO target: <10s. SessionGate uses native histograms so p99 is unavailable; average latency is used instead.",
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -558,8 +558,8 @@
       },
       "targets": [
         {
-          "expr": "lockbox:kas_proxy_latency:p99_5m",
-          "legendFormat": "p99 {{ cluster }}",
+          "expr": "lockbox:kas_proxy_latency:avg_5m",
+          "legendFormat": "avg {{ cluster }}",
           "refId": "A",
           "datasource": {
             "type": "prometheus",

--- a/observability/recording-rules-services.yaml
+++ b/observability/recording-rules-services.yaml
@@ -1,4 +1,5 @@
 prometheusRules:
-  rulesFolders: []
+  rulesFolders:
+  - alerts/lockbox-recording-rules-prometheusRule.yaml
   untestedRules: []
   outputBicep: ../dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep

--- a/sessiongate/deploy/templates/metrics.service.yaml
+++ b/sessiongate/deploy/templates/metrics.service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: sessiongate-metrics
+  namespace: '{{ .Release.Namespace }}'
+  labels:
+    app: sessiongate-metrics
+spec:
+  selector:
+    app.kubernetes.io/name: sessiongate
+  ports:
+  - port: {{ .Values.service.port }}
+    protocol: TCP
+    targetPort: {{ .Values.service.port }}
+    name: metrics

--- a/sessiongate/deploy/templates/peerauthentication.yaml
+++ b/sessiongate/deploy/templates/peerauthentication.yaml
@@ -1,0 +1,12 @@
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: sessiongate-metrics
+  namespace: '{{ .Release.Namespace }}'
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: sessiongate
+  portLevelMtls:
+    {{ .Values.service.port }}:
+      mode: PERMISSIVE

--- a/sessiongate/deploy/templates/servicemonitor.yaml
+++ b/sessiongate/deploy/templates/servicemonitor.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: sessiongate
+  namespace: '{{ .Release.Namespace }}'
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - '{{ .Release.Namespace }}'
+  selector:
+    matchLabels:
+      app: sessiongate-metrics

--- a/sessiongate/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_sessiongate.yaml
+++ b/sessiongate/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_sessiongate.yaml
@@ -665,6 +665,20 @@ spec:
     - name: sessiongate
       port: 8080
 ---
+# Source: sessiongate/templates/peerauthentication.yaml
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: sessiongate-metrics
+  namespace: 'sessiongate'
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: sessiongate
+  portLevelMtls:
+    8080:
+      mode: PERMISSIVE
+---
 # Source: sessiongate/templates/requestauthentication.yaml
 apiVersion: security.istio.io/v1beta1
 kind: RequestAuthentication

--- a/sessiongate/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_sessiongate.yaml
+++ b/sessiongate/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_sessiongate.yaml
@@ -422,6 +422,23 @@ subjects:
   name: sessiongate
   namespace: sessiongate
 ---
+# Source: sessiongate/templates/metrics.service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: sessiongate-metrics
+  namespace: 'sessiongate'
+  labels:
+    app: sessiongate-metrics
+spec:
+  selector:
+    app.kubernetes.io/name: sessiongate
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+    name: metrics
+---
 # Source: sessiongate/templates/service.yaml
 apiVersion: v1
 kind: Service
@@ -703,4 +720,23 @@ spec:
       key: tls.crt
     - objectName: sessiongate-cert
       key: tls.key
+---
+# Source: sessiongate/templates/servicemonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: sessiongate
+  namespace: 'sessiongate'
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - 'sessiongate'
+  selector:
+    matchLabels:
+      app: sessiongate-metrics
 


### PR DESCRIPTION
## Summary

Add observability instrumentation for the Azure Lockbox / breakglass session user journey ([ARO-25910](https://redhat.atlassian.net/browse/ARO-25910)).

- Add SessionGate ServiceMonitor + metrics service + PeerAuthentication to enable Prometheus scraping of `sessiongate_active_sessions`, `sessiongate_kas_proxy_requests_total`, and `sessiongate_kas_proxy_requests_duration_seconds` metrics
- Add 7 recording rules for all 5 baseline SLIs in the services AMW
- Add 5 threshold-based alert rules in the RP services lane
- Add Grafana dashboard with 9 panels for breakglass session monitoring

### SLO targets

| SLI | SLO | Alert | Severity |
|-----|-----|-------|----------|
| Availability (audit pipeline) | 99.95% uptime | `UJLockboxAuditDegraded` | warning (Sev3) |
| Errors (audit send) | < 5% error rate | `UJLockboxAuditErrorRateHigh` | warning |
| Errors (KAS proxy) | < 10% error rate | `UJLockboxKasProxyErrors` | warning |
| Latency (KAS proxy p99) | < 10s | `UJLockboxKasProxyLatencyHigh` | warning |
| Saturation (active sessions) | < 10 concurrent | `UJLockboxHighActiveSessions` | info |

**Why threshold-based (not burn-rate):** Breakglass sessions are extremely rare events — only created during active support incidents with Lockbox approval. `rate()[5m]` returns 0 most of the time, making multi-window burn-rate math produce NaN.

### Key findings during implementation

1. **SessionGate was missing a ServiceMonitor** — metrics endpoint existed on port 8080 but was never scraped
2. **Istio mTLS blocked Prometheus scraping** — needed a `PeerAuthentication` with `PERMISSIVE` mode on the metrics port (same pattern as Admin API)
3. **Grafana datasource URL was stale** — `services-usw3haow` datasource had old AMW endpoint; fixed during E2E

## Test plan

- [x] `cd observability && make recording-rules` — promtool tests pass
- [x] `cd observability && make alerts` — promtool tests pass (9 test cases)
- [x] `cd config && make materialize` — Helm fixtures and Bicep regenerated
- [x] E2E on personal dev:
  - [x] SessionGate ServiceMonitor deployed, Prometheus targets healthy (`up`)
  - [x] `sessiongate_active_sessions` flowing to services AMW (2 series, val=0)
  - [x] Recording rules producing data (3/7 active, 4/7 correctly 0 — no breakglass traffic)
  - [x] 5 alert rule groups deployed to Azure
  - [x] Alerts correctly NOT firing on healthy system
  - [x] Dashboard rendering: Active Sessions=0, Audit Health=OK, Audit Error Rate=0%