### PR TITLE
fix: bump ACM/MCE bundles to 2.17 (acm-217 / mce-217)

### DIFF
--- a/acm/deploy/helm/multicluster-engine-config/charts/policy/Chart.yaml
+++ b/acm/deploy/helm/multicluster-engine-config/charts/policy/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2
-appVersion: v2.16.2
-version: v2.16.2
+appVersion: v2.17.0
+version: v2.17.0
 description: A Helm chart for ACM addons
 name: policy
 dependencies:
 - name: grc
-  version: v2.16.2
+  version: v2.17.0
 - name: cluster-lifecycle
-  version: v2.16.2
+  version: v2.17.0

--- a/acm/deploy/helm/multicluster-engine-config/charts/policy/charts/cluster-lifecycle/Chart.yaml
+++ b/acm/deploy/helm/multicluster-engine-config/charts/policy/charts/cluster-lifecycle/Chart.yaml
@@ -1,8 +1,8 @@
 # Copyright (c) 2024 Red Hat, Inc.
 # Copyright Contributors to the Open Cluster Management project
 apiVersion: v2
-appVersion: v2.16.2
+appVersion: v2.17.0
 description: Helm chart for deploying the cluster lifecycle
 kubeVersion: ">=1.11.0-0"
 name: cluster-lifecycle
-version: v2.16.2
+version: v2.17.0

--- a/acm/deploy/helm/multicluster-engine-config/charts/policy/charts/grc/Chart.yaml
+++ b/acm/deploy/helm/multicluster-engine-config/charts/policy/charts/grc/Chart.yaml
@@ -1,10 +1,10 @@
 # Copyright (c) 2024 Red Hat, Inc.
 # Copyright Contributors to the Open Cluster Management project
 apiVersion: v2
-appVersion: v2.16.2
+appVersion: v2.17.0
 description: A Helm chart for multicloud grc
 keywords:
 - acm
 - grc
 name: grc
-version: v2.16.2
+version: v2.17.0

--- a/acm/deploy/helm/multicluster-engine-config/charts/policy/crds/agent.open-cluster-management.io_klusterletaddonconfigs_crd.yaml
+++ b/acm/deploy/helm/multicluster-engine-config/charts/policy/crds/agent.open-cluster-management.io_klusterletaddonconfigs_crd.yaml
@@ -1,4 +1,5 @@
 # Copyright (c) 2020 Red Hat, Inc.
+
 # Copyright Contributors to the Open Cluster Management project
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/acm/deploy/helm/multicluster-engine-config/charts/policy/values.yaml
+++ b/acm/deploy/helm/multicluster-engine-config/charts/policy/values.yaml
@@ -1,11 +1,11 @@
 global:
   registryOverride: "registry.redhat.io/rhacm2"
   imageOverrides:
-    governance_policy_propagator: "governance-policy-propagator-rhel9@sha256:c97cb9fdf65a0b7ea99782bc9a24e46ecff1c25b06cfec2cc7d9d426f1c28dc4"
-    governance_policy_addon_controller: "acm-governance-policy-addon-controller-rhel9@sha256:0c400c29541f77841db36bdb794c430ae705024f9f90dc4a858142381622801a"
-    config_policy_controller: "config-policy-controller-rhel9@sha256:739146a6dd7a86d47829112282bb0c3fa9e58b4a389d82655fcdbdd8dd4a6bb0"
-    governance_policy_framework_addon: "acm-governance-policy-framework-addon-rhel9@sha256:7714cff7d81eea553c292d1366477f4478f5a7d43aa34e8ee7c0867917a6ef06"
-    klusterlet_addon_controller: "klusterlet-addon-controller-rhel9@sha256:035ae55c3c5b486b113424d510f5163ac558afa51c63bc4239a1ad4e2243d4d7"
+    governance_policy_propagator: "governance-policy-propagator-rhel9@sha256:aa6edf8433edd41ed263cb2c7b4ac037b9208b3ca09213fe2f86ea8a7cde5ba8"
+    governance_policy_addon_controller: "acm-governance-policy-addon-controller-rhel9@sha256:e861f94e2886bbc8a438a5dadff036e2b7738c771f99a62caa15d82c3f023b60"
+    config_policy_controller: "config-policy-controller-rhel9@sha256:feb26437e1c939614050baed0238ece29c22e8aa00eeb4f1b96ff331eda7057d"
+    governance_policy_framework_addon: "acm-governance-policy-framework-addon-rhel9@sha256:00801dd6c39203b2dbfde3db25b5c69598e110a382948823d78ad402fede41fe"
+    klusterlet_addon_controller: "klusterlet-addon-controller-rhel9@sha256:90b4c37ce8b786c5e34128410d07c31038eebfbe855b3bc3c4241e925307db68"
   namespace: multicluster-engine
   pullSecret: open-cluster-management-image-pull-credentials
   cma:

--- a/acm/deploy/helm/multicluster-engine-crds/Chart.yaml
+++ b/acm/deploy/helm/multicluster-engine-crds/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2.11.3
+appVersion: 2.17.0
 description: A Helm chart for multicluster-engine - CRDs
 keywords:
 - mce
@@ -7,6 +7,6 @@ keywords:
 - multiclusterengine
 name: multicluster-engine-crds
 sources:
-- quay.io/redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211@sha256:2fbd59d99219005e547eec97b7b7386f285993e9133c0478bd76c26f1251f621
+- quay.io/redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-217@sha256:91b812c7345d9ca143dce919865debe6bf3740c3dd6299644c047a920340f9cb
 type: application
-version: 2.11.3
+version: 2.17.0

--- a/acm/deploy/helm/multicluster-engine-crds/Chart.yaml
+++ b/acm/deploy/helm/multicluster-engine-crds/Chart.yaml
@@ -7,6 +7,6 @@ keywords:
 - multiclusterengine
 name: multicluster-engine-crds
 sources:
-- quay.io/redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-217@sha256:91b812c7345d9ca143dce919865debe6bf3740c3dd6299644c047a920340f9cb
+- quay.io/redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-217@sha256:e2fdc959410510af1f3a625fbf1469af41ab1f2e2765ea4ce0d1d9a0846bc747
 type: application
 version: 2.17.0

--- a/acm/deploy/helm/multicluster-engine-crds/templates/multiclusterengines.multicluster.openshift.io.customresourcedefinition.yaml
+++ b/acm/deploy/helm/multicluster-engine-crds/templates/multiclusterengines.multicluster.openshift.io.customresourcedefinition.yaml
@@ -31,6 +31,10 @@ spec:
       jsonPath: .status.desiredVersion
       name: DesiredVersion
       type: string
+    - description: Message from the most recent condition
+      jsonPath: .status.conditions[-1:].message
+      name: Message
+      type: string
     name: v1
     schema:
       openAPIV3Schema:

--- a/acm/deploy/helm/multicluster-engine/Chart.yaml
+++ b/acm/deploy/helm/multicluster-engine/Chart.yaml
@@ -7,6 +7,6 @@ keywords:
 - multiclusterengine
 name: multicluster-engine
 sources:
-- quay.io/redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-217@sha256:91b812c7345d9ca143dce919865debe6bf3740c3dd6299644c047a920340f9cb
+- quay.io/redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-217@sha256:e2fdc959410510af1f3a625fbf1469af41ab1f2e2765ea4ce0d1d9a0846bc747
 type: application
 version: 2.17.0

--- a/acm/deploy/helm/multicluster-engine/Chart.yaml
+++ b/acm/deploy/helm/multicluster-engine/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2.11.3
+appVersion: 2.17.0
 description: A Helm chart for multicluster-engine
 keywords:
 - mce
@@ -7,6 +7,6 @@ keywords:
 - multiclusterengine
 name: multicluster-engine
 sources:
-- quay.io/redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211@sha256:2fbd59d99219005e547eec97b7b7386f285993e9133c0478bd76c26f1251f621
+- quay.io/redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-217@sha256:91b812c7345d9ca143dce919865debe6bf3740c3dd6299644c047a920340f9cb
 type: application
-version: 2.11.3
+version: 2.17.0

--- a/acm/deploy/helm/multicluster-engine/templates/multicluster-engine-operator.deployment.yaml
+++ b/acm/deploy/helm/multicluster-engine/templates/multicluster-engine-operator.deployment.yaml
@@ -56,11 +56,11 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: OPERAND_IMAGE_ADDON_MANAGER
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/addon-manager-rhel9@sha256:3aa8a3496803c5fb0f2039bb5fa9244098e71a26ae48f176778cda979484be04'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/addon-manager-rhel9@sha256:64e9d8992f85d51fce93d7e525caae35547ea73c1d6f793373d162e8e853e89a'
         - name: OPERAND_IMAGE_AZURE_SERVICE_OPERATOR_RHEL9
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/azure-service-operator-rhel9@sha256:a3533c1160feae464ddd6e1288c492710ee8ec1af3a875d23e0d25deaaa03a8a'
         - name: OPERAND_IMAGE_BACKPLANE_MUST_GATHER
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/must-gather-rhel9@sha256:e5db11243d9db5c27989c6da46ed473b6b7ff19ad903e9d759c20db82169b40c'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/must-gather-rhel9@sha256:7b9dffec34d175a738dd0ca1456bf9cef2d428908ed1f7a28b1b6da3517c5c73'
         - name: OPERAND_IMAGE_BACKPLANE_OPERATOR
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/backplane-rhel9-operator@sha256:f5b1746ebfe705b07c69e66e413df3dbd61e247e8109fb6a119342daf5972117'
         - name: OPERAND_IMAGE_CLOUDEVENTS_CONDUCTOR
@@ -90,7 +90,7 @@ spec:
         - name: OPERAND_IMAGE_CLUSTER_PERMISSION
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-permission-rhel9@sha256:28fc281cf357f1ab7976b7ce816ed8e3d53345b4414287790a2804de9221b75e'
         - name: OPERAND_IMAGE_CLUSTER_PROXY
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-proxy-rhel9@sha256:f9a853d4b8290303e7302f09812ccb26e158d044ef78b9be6af2d2badc0117fe'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-proxy-rhel9@sha256:3d043d9a9bdac0e9aa66f02bd00d6cc212cc46bb56c43fd6384523829a5f8536'
         - name: OPERAND_IMAGE_CONSOLE_MCE
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/console-mce-rhel9@sha256:12de32198cdfa37af389289754495c8a7487d3665d621bed5eca923b76a21896'
         - name: OPERAND_IMAGE_DISCOVERY_OPERATOR
@@ -124,7 +124,7 @@ spec:
         - name: OPERAND_IMAGE_REGISTRATION_OPERATOR
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/registration-operator-rhel9@sha256:fdd09a0e774ca81d9f32f73c253e55089bb4a92ed245e3d7987fb88d20cbd9ae'
         - name: OPERAND_IMAGE_WORK
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/work-rhel9@sha256:ea05968916218f783e3d2688c893cfd3790accb9ecb7e30f06ac5d996bef06f2'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/work-rhel9@sha256:117fb78fc5e4d2345d7259c8355cd49ea83bcc4e4e25c62a55dfa7c1cb28b643'
         - name: OPERAND_IMAGE_ASSISTED_IMAGE_SERVICE
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/assisted-image-service-rhel9@sha256:baf96f08ab08a0dc1b038c469a503d26fabea7871adfd5e81c4dfbfff1cce55f'
         - name: OPERAND_IMAGE_ASSISTED_INSTALLER

--- a/acm/deploy/helm/multicluster-engine/templates/multicluster-engine-operator.deployment.yaml
+++ b/acm/deploy/helm/multicluster-engine/templates/multicluster-engine-operator.deployment.yaml
@@ -56,90 +56,98 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: OPERAND_IMAGE_ADDON_MANAGER
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/addon-manager-rhel9@sha256:4b499488b93d662526fe9aad7dc8710de8095e43481bb714d5c0dba2ad4f478c'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/addon-manager-rhel9@sha256:3aa8a3496803c5fb0f2039bb5fa9244098e71a26ae48f176778cda979484be04'
         - name: OPERAND_IMAGE_AZURE_SERVICE_OPERATOR_RHEL9
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/azure-service-operator-rhel9@sha256:c43dce152f9dbb080a6f47cf65d03d1219db5bedea8794fc96e3b67b43c6d1b4'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/azure-service-operator-rhel9@sha256:a3533c1160feae464ddd6e1288c492710ee8ec1af3a875d23e0d25deaaa03a8a'
         - name: OPERAND_IMAGE_BACKPLANE_MUST_GATHER
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/must-gather-rhel9@sha256:f1e80544fef0d8a31f36f8145ee1cf5a50d34be64282483f853d27738bfe3691'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/must-gather-rhel9@sha256:e5db11243d9db5c27989c6da46ed473b6b7ff19ad903e9d759c20db82169b40c'
         - name: OPERAND_IMAGE_BACKPLANE_OPERATOR
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/backplane-rhel9-operator@sha256:413e6c872d4a97d0094f0e82bd4b7ee95de1866c6cf4725768cc6d924a715f9c'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/backplane-rhel9-operator@sha256:f5b1746ebfe705b07c69e66e413df3dbd61e247e8109fb6a119342daf5972117'
+        - name: OPERAND_IMAGE_CLOUDEVENTS_CONDUCTOR
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cloudevents-conductor-rhel9@sha256:fdf7e191a0cec8d118e4479fe1fe849195592a8ee9828a2680adf428cd948313'
         - name: OPERAND_IMAGE_CLUSTER_API_PROVIDER_AGENT
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-api-provider-agent-rhel9@sha256:95c41d7f54523bc1f73ccbebba6a159a0deb213faba2e4793678fa45fda9f9c7'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-api-provider-agent-rhel9@sha256:0f3722e109fc228eeb909d24af48cef7cfc1d08c391e89db2a26deea94706137'
         - name: OPERAND_IMAGE_CLUSTER_API_PROVIDER_AWS_RHEL9
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-api-provider-aws-rhel9@sha256:dda12c053c3306bfce44bebba7028cb63525e7c7825756a0832250fa1af6312b'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-api-provider-aws-rhel9@sha256:175e33ee5b1b61c7c42bf02d7e6196d79d3c496a64bbcb114aa8f7af759f5ed9'
         - name: OPERAND_IMAGE_CLUSTER_API_PROVIDER_AZURE_RHEL9
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-api-provider-azure-rhel9@sha256:c78e5e3594fb95a0d80f1a6898d60a6bee35a6f8419a281cb9dde56b864cc56a'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-api-provider-azure-rhel9@sha256:3ea92904f03be5fa8f677fce0780f337b30a7bf04a549de9781253bd53f089ee'
         - name: OPERAND_IMAGE_CLUSTER_API_PROVIDER_KUBEVIRT
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-api-provider-kubevirt-rhel9@sha256:648d926dd2ac31f9bec84385f74742f66194b8f1398119cb2359b1d210b45ce6'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-api-provider-kubevirt-rhel9@sha256:19d09081f382790995ef809220cc160cac6815f6bf8eba3ac7572b5e5dafa42f'
         - name: OPERAND_IMAGE_CLUSTER_API_PROVIDER_OPENSHIFT_ASSISTED_BOOTSTRAP
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/capoa-bootstrap-rhel9@sha256:accd6b839b99903f2de274f1f03dc93ead955fd3309e3e0096bf1a44d1cbdded'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/capoa-bootstrap-rhel9@sha256:bef62e8a1ae06032b20e52d83ffe5b6f6c0fca707c83517b1b4075860e6d3c2e'
         - name: OPERAND_IMAGE_CLUSTER_API_PROVIDER_OPENSHIFT_ASSISTED_CONTROL_PLANE
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/capoa-control-plane-rhel9@sha256:ce1cae195f31b876319b22378655392b1231fc563c185699892c4624e645cdeb'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/capoa-control-plane-rhel9@sha256:77f2cf1dc2c631a41a8be370ece9844583455ba0fe7b38b5816f6dd148dd3220'
         - name: OPERAND_IMAGE_MCE_CAPI_WEBHOOK_CONFIG_RHEL9
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/mce-capi-webhook-config-rhel9@sha256:14c61daaef25434a55ee80f045673ed0eb28ad6c78a354a5b0808d4f34233c4b'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/mce-capi-webhook-config-rhel9@sha256:04851319fa48a7cff658ee0d83612cc6aa6c44de18991efa6848ba8d61ae5e99'
         - name: OPERAND_IMAGE_CLUSTERCLAIMS_CONTROLLER
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/clusterclaims-controller-rhel9@sha256:f96d97e62cb9dfc25a08713d7529053fc6a6e35ae12d99eb807a43f0aef371ac'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/clusterclaims-controller-rhel9@sha256:c1f767383ca70a4af60435b24b783f39f14cb632f18c98d417c2c3eeeeda3b3e'
         - name: OPERAND_IMAGE_CLUSTER_CURATOR_CONTROLLER
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-curator-controller-rhel9@sha256:9bd422e301605de926f9ae80ba6bd8f52e9619c552ae133145316bc8cf201c43'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-curator-controller-rhel9@sha256:bcd5930008a7ae40f6365de9254579cac9de5cc4e2ed5c6e7a3d8e237a8e1fa0'
         - name: OPERAND_IMAGE_CLUSTER_IMAGE_SET_CONTROLLER
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-image-set-controller-rhel9@sha256:6fbfdcf7c2ecc63d1897cb0aed416afb941c6eefec5db828218229a48da40cbd'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-image-set-controller-rhel9@sha256:051626eff7abeeb6d6a66fff5fd50a50f9f45e7730eeba9cbefe0b31b5a9a814'
         - name: OPERAND_IMAGE_CLUSTERLIFECYCLE_STATE_METRICS
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/clusterlifecycle-state-metrics-rhel9@sha256:8e10dc030c407b1a0701a69b4725aba1a52cae22196a7db832cf01da857e68b8'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/clusterlifecycle-state-metrics-rhel9@sha256:750126808b97bb49b7ab149112d783a7c38b3e64d8830cfba4b38b40d7a48394'
+        - name: OPERAND_IMAGE_CLUSTER_PERMISSION
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-permission-rhel9@sha256:28fc281cf357f1ab7976b7ce816ed8e3d53345b4414287790a2804de9221b75e'
         - name: OPERAND_IMAGE_CLUSTER_PROXY
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-proxy-rhel9@sha256:49efbdb69a463553cc6db3b0064f8ac28144a2557bb7081b6b56e9ea9e4b67d8'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-proxy-rhel9@sha256:f9a853d4b8290303e7302f09812ccb26e158d044ef78b9be6af2d2badc0117fe'
         - name: OPERAND_IMAGE_CONSOLE_MCE
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/console-mce-rhel9@sha256:4745c3ae1dfcb7dc293a3ea8edeacf4b9f596b1cab15211b98d1b9f50bb28e9b'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/console-mce-rhel9@sha256:12de32198cdfa37af389289754495c8a7487d3665d621bed5eca923b76a21896'
         - name: OPERAND_IMAGE_DISCOVERY_OPERATOR
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/discovery-rhel9@sha256:f305c303374f7632c1faed0629dfc78d24f019e51c29557e564c1c526a82df6e'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/discovery-rhel9@sha256:b9a90e3a704892d4bc71843fbc169be68ade40582d004172db84798c28bae9fb'
         - name: OPERAND_IMAGE_OPENSHIFT_HIVE
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/hive-rhel9@sha256:08857b67dc8d4b630bde2ff0af522f3b71a3863b4ca7a2d609ee36553532c127'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/hive-rhel9@sha256:358ccaa654a92f13b16251efb1fc2b2234c28ea912c1f0c86ff67f27fe5d9cb8'
         - name: OPERAND_IMAGE_HYPERSHIFT_ADDON_OPERATOR
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/hypershift-addon-rhel9-operator@sha256:fe8bf21575305b2afe9e5dda8067292663a63739b2a923a78846b28438f31017'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/hypershift-addon-rhel9-operator@sha256:f0552d481fb0527af46aba14c629fe1419f9f0ea340afecfea10b3e1200ad800'
         - name: OPERAND_IMAGE_HYPERSHIFT_CLI
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/hypershift-cli-rhel9@sha256:a0581b2f785b965a6c9872769f347f3bf8a68c1847af9147b4380c579328bba7'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/hypershift-cli-rhel9@sha256:75eca209a496c8ef1fbb69efeae2f3f12cc36086e58236afafb2d3a71a134996'
         - name: OPERAND_IMAGE_HYPERSHIFT_OPERATOR
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/hypershift-rhel9-operator@sha256:e754db014b694dfe3469261d36bb99ed90e568710a54f438244b4a9b0a3fad86'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/hypershift-rhel9-operator@sha256:7d39dadd30c21ab4ac64cdbdb1c7aa13a9199a57daf327a233461bea462ce471'
         - name: OPERAND_IMAGE_IMAGE_BASED_INSTALL_OPERATOR
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/image-based-install-rhel9@sha256:441232dd1a12afe481e48193395da939493583adcdfb02d8afbb083ffe5bf198'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/image-based-install-rhel9@sha256:67c3721ceac6ae3d92b19780ae46d97b7e22818b725522581d9331cb7a80c3cc'
         - name: OPERAND_IMAGE_KUBE_RBAC_PROXY_MCE
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/kube-rbac-proxy-mce-rhel9@sha256:1fa111b9fd0478a35d18ef89e51f058938d2ffead065ef865fc774da6158d26e'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/kube-rbac-proxy-mce-rhel9@sha256:6cd34165adb2c3b3a0dbb5d765276f9c21535ff87171112d5aac623f6438d4dd'
+        - name: OPERAND_IMAGE_MAESTRO
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/maestro-rhel9@sha256:a886be0e86a02d54c3a445da63980c60071341e5d19b0fc9d684cb0cf8628137'
         - name: OPERAND_IMAGE_MANAGEDCLUSTER_IMPORT_CONTROLLER
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/managedcluster-import-controller-rhel9@sha256:7265f20a767451762d71e058006fb7ebfdeeb3fc3d27a8fc56f0a18ff3ae934d'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/managedcluster-import-controller-rhel9@sha256:d7bd5b40f46d1d3cbef4d93cb66acf5386dd1e6860a1e377c59f1d21ddbf4217'
         - name: OPERAND_IMAGE_MANAGED_SERVICEACCOUNT
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/managed-serviceaccount-rhel9@sha256:6270079008ddaa493b09474324185a9224c3662bd93826c447f03f09cdd49a72'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/managed-serviceaccount-rhel9@sha256:1e9a60759859d1ec308167e8e4bfd4971e2f1035a50f3f7d19ff40bb5c268ae7'
         - name: OPERAND_IMAGE_MULTICLOUD_MANAGER
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/multicloud-manager-rhel9@sha256:db1f6513b062ed463e30189bd2919672f91bae2b6a29b9f217f7d76e4b5363cc'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/multicloud-manager-rhel9@sha256:366737a298dff9972b2fd23ea12f33bbc78f01cac45ac244e1b3575e7f8f85ae'
         - name: OPERAND_IMAGE_PROVIDER_CREDENTIAL_CONTROLLER
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/provider-credential-controller-rhel9@sha256:36c55551616e201c35af21bc9599873e0cf4aa16b71587534d5c797c92b48582'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/provider-credential-controller-rhel9@sha256:96113c7682a413aaac51872314c6b2613f523c3f12d79d9d81a6f5a8b26b4c5e'
         - name: OPERAND_IMAGE_PLACEMENT
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/placement-rhel9@sha256:54cb04d0de4b5167250e7d15d300c9600cd141b651db80877454987e83a5fd4c'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/placement-rhel9@sha256:1b178ede0ec6bd63c29e9665bc0d91ad81b4c99cea9a838c8557a71838c2ff9f'
         - name: OPERAND_IMAGE_REGISTRATION
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/registration-rhel9@sha256:a2a7f3171a5801a750b86f5f797e951f5106941ae1ba14a33a69a531446b33a0'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/registration-rhel9@sha256:5bf15e9e1c21ee21962fbbed3e63383b336a5952ee0dd1c5106c8f620c4b8498'
         - name: OPERAND_IMAGE_REGISTRATION_OPERATOR
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/registration-operator-rhel9@sha256:6bbc44d153aeb2be0482b5145b1b0177840b86aa159432529949542858e5b121'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/registration-operator-rhel9@sha256:fdd09a0e774ca81d9f32f73c253e55089bb4a92ed245e3d7987fb88d20cbd9ae'
         - name: OPERAND_IMAGE_WORK
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/work-rhel9@sha256:e30e384ecc1d10dec92cbe5f0292c2686260a4e337bb1d3f4381af538685a47a'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/work-rhel9@sha256:ea05968916218f783e3d2688c893cfd3790accb9ecb7e30f06ac5d996bef06f2'
         - name: OPERAND_IMAGE_ASSISTED_IMAGE_SERVICE
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/assisted-image-service-rhel9@sha256:48305470fa7e55e78165734d094022a14ac9d083573974036c1f40021c362ba1'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/assisted-image-service-rhel9@sha256:baf96f08ab08a0dc1b038c469a503d26fabea7871adfd5e81c4dfbfff1cce55f'
         - name: OPERAND_IMAGE_ASSISTED_INSTALLER
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/assisted-installer-rhel9@sha256:4dd8f3992fcc23dc8f1e14dbfe4e3c3e447b592d88152fbf5d92ccd469653377'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/assisted-installer-rhel9@sha256:ef61117a1ea46e59de08ac0c9c6d6b553f53bb0187daa2033cd9e7650b15a96d'
         - name: OPERAND_IMAGE_ASSISTED_INSTALLER_AGENT
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/assisted-installer-agent-rhel9@sha256:72427b669fe6feb4b46bcabf100bbd633ffd13bd0d3583b2e544f5709f680b73'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/assisted-installer-agent-rhel9@sha256:48a86801a012151d3fee1bd37513c7ec92b8f8585ee9bd482408f768b6e82d4b'
         - name: OPERAND_IMAGE_ASSISTED_INSTALLER_CONTROLLER
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/assisted-installer-controller-rhel9@sha256:b3d2b3c7c5bef17dfea7985eb854a6fe77720dfc185a968adc2db831081546ee'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/assisted-installer-controller-rhel9@sha256:e6e9d34647fcb61f13f1fff2de52ad9b916e53abe581488fb058f883604d9676'
         - name: OPERAND_IMAGE_ASSISTED_SERVICE_9
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/assisted-service-9-rhel9@sha256:eb11d23849d00fc2ec07284054335921158f00f6dd7e4347c54fd606e80c8a2e'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/assisted-service-9-rhel9@sha256:d473c6867f030d9679e919e0e794340e3730a2fca5e3052a697d87288f4db2e4'
         - name: OPERAND_IMAGE_OSE_CLUSTER_API_RHEL9
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/ose-cluster-api-rhel9@sha256:51e878723078611ace36ea3acc606a8a290f2da7d659bbdf56c9e7ef826d1fb0'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/ose-cluster-api-rhel9@sha256:d875a6c98809657b6d79ee9547a9089fdb20b251743eac6fdea43a8b1d792d2d'
         - name: OPERAND_IMAGE_OSE_BAREMETAL_CLUSTER_API_CONTROLLERS_RHEL9
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/ose-baremetal-cluster-api-controllers-rhel9@sha256:6cdee287d06f72c856ec0232be241f2ccb847cbc685b1108216772654c1e13d2'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/ose-baremetal-cluster-api-controllers-rhel9@sha256:84dcfe53a35142f9863317e5a9288b9c3498db31fbc8bb0728f4c4797ed7f571'
         - name: OPERAND_IMAGE_POSTGRESQL_13
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/postgresql-13@sha256:97b64c18a32944b86fd1a118aa0d1aa04ff1fad8068c3c20f6e94af24712ff36'
+        - name: OPERAND_IMAGE_POSTGRESQL_15
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/postgresql-15@sha256:285c5c740f9d6127d37b9322dec7057a45690c827c06b54270079faa30fdf46d'
         - name: OPERATOR_VERSION
-          value: 2.11.3
+          value: 2.17.0
         - name: OPERATOR_PACKAGE
           value: multicluster-engine
-        image: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/backplane-rhel9-operator@sha256:413e6c872d4a97d0094f0e82bd4b7ee95de1866c6cf4725768cc6d924a715f9c'
+        image: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/backplane-rhel9-operator@sha256:f5b1746ebfe705b07c69e66e413df3dbd61e247e8109fb6a119342daf5972117'
         livenessProbe:
           httpGet:
             path: /healthz

--- a/acm/deploy/helm/multicluster-engine/templates/multicluster-engine-x5d5x8b93c5mh334chde54vpu6bfnweigxlxg6wtmnd.clusterrole.yaml
+++ b/acm/deploy/helm/multicluster-engine/templates/multicluster-engine-x5d5x8b93c5mh334chde54vpu6bfnweigxlxg6wtmnd.clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: multicluster-engin-2jizw78jh572r0kmnx26lw5n2uj0ws375neqnn6jtbr7
+  name: multicluster-engine-x5d5x8b93c5mh334chde54vpu6bfnweigxlxg6wtmnd
 rules:
 - apiGroups:
   - ""
@@ -1085,6 +1085,7 @@ rules:
   - config.openshift.io
   resources:
   - apiservers
+  - authentications
   - clusteroperators
   - clusterversions
   - dnses

--- a/acm/deploy/helm/multicluster-engine/templates/multicluster-engine-x5d5x8b93c5mh334chde54vpu6bfnweigxlxg6wtmnd.clusterrolebinding.yaml
+++ b/acm/deploy/helm/multicluster-engine/templates/multicluster-engine-x5d5x8b93c5mh334chde54vpu6bfnweigxlxg6wtmnd.clusterrolebinding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: multicluster-engin-2jizw78jh572r0kmnx26lw5n2uj0ws375neqnn6jtbr7
+  name: multicluster-engine-x5d5x8b93c5mh334chde54vpu6bfnweigxlxg6wtmnd
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: multicluster-engin-2jizw78jh572r0kmnx26lw5n2uj0ws375neqnn6jtbr7
+  name: multicluster-engine-x5d5x8b93c5mh334chde54vpu6bfnweigxlxg6wtmnd
 subjects:
 - kind: ServiceAccount
   name: multicluster-engine-operator

--- a/acm/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_mce.yaml
+++ b/acm/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_mce.yaml
@@ -47,11 +47,11 @@ metadata:
   name: multicluster-engine-operator-config
   namespace: 'multicluster-engine'
 ---
-# Source: multicluster-engine/templates/multicluster-engin-2jizw78jh572r0kmnx26lw5n2uj0ws375neqnn6jtbr7.clusterrole.yaml
+# Source: multicluster-engine/templates/multicluster-engine-x5d5x8b93c5mh334chde54vpu6bfnweigxlxg6wtmnd.clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: multicluster-engin-2jizw78jh572r0kmnx26lw5n2uj0ws375neqnn6jtbr7
+  name: multicluster-engine-x5d5x8b93c5mh334chde54vpu6bfnweigxlxg6wtmnd
 rules:
 - apiGroups:
   - ""
@@ -1135,6 +1135,7 @@ rules:
   - config.openshift.io
   resources:
   - apiservers
+  - authentications
   - clusteroperators
   - clusterversions
   - dnses
@@ -3349,15 +3350,15 @@ rules:
   - update
   - watch
 ---
-# Source: multicluster-engine/templates/multicluster-engin-2jizw78jh572r0kmnx26lw5n2uj0ws375neqnn6jtbr7.clusterrolebinding.yaml
+# Source: multicluster-engine/templates/multicluster-engine-x5d5x8b93c5mh334chde54vpu6bfnweigxlxg6wtmnd.clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: multicluster-engin-2jizw78jh572r0kmnx26lw5n2uj0ws375neqnn6jtbr7
+  name: multicluster-engine-x5d5x8b93c5mh334chde54vpu6bfnweigxlxg6wtmnd
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: multicluster-engin-2jizw78jh572r0kmnx26lw5n2uj0ws375neqnn6jtbr7
+  name: multicluster-engine-x5d5x8b93c5mh334chde54vpu6bfnweigxlxg6wtmnd
 subjects:
 - kind: ServiceAccount
   name: multicluster-engine-operator
@@ -3499,6 +3500,8 @@ spec:
           value: 'arohcpsvcdev.azurecr.io/acm-d-cache/must-gather-rhel9@sha256:1234567890'
         - name: OPERAND_IMAGE_BACKPLANE_OPERATOR
           value: 'arohcpsvcdev.azurecr.io/acm-d-cache/backplane-rhel9-operator@sha256:1234567890'
+        - name: OPERAND_IMAGE_CLOUDEVENTS_CONDUCTOR
+          value: 'arohcpsvcdev.azurecr.io/acm-d-cache/cloudevents-conductor-rhel9@sha256:1234567890'
         - name: OPERAND_IMAGE_CLUSTER_API_PROVIDER_AGENT
           value: 'arohcpsvcdev.azurecr.io/acm-d-cache/cluster-api-provider-agent-rhel9@sha256:1234567890'
         - name: OPERAND_IMAGE_CLUSTER_API_PROVIDER_AWS_RHEL9
@@ -3521,6 +3524,8 @@ spec:
           value: 'arohcpsvcdev.azurecr.io/acm-d-cache/cluster-image-set-controller-rhel9@sha256:1234567890'
         - name: OPERAND_IMAGE_CLUSTERLIFECYCLE_STATE_METRICS
           value: 'arohcpsvcdev.azurecr.io/acm-d-cache/clusterlifecycle-state-metrics-rhel9@sha256:1234567890'
+        - name: OPERAND_IMAGE_CLUSTER_PERMISSION
+          value: 'arohcpsvcdev.azurecr.io/acm-d-cache/cluster-permission-rhel9@sha256:1234567890'
         - name: OPERAND_IMAGE_CLUSTER_PROXY
           value: 'arohcpsvcdev.azurecr.io/acm-d-cache/cluster-proxy-rhel9@sha256:1234567890'
         - name: OPERAND_IMAGE_CONSOLE_MCE
@@ -3539,6 +3544,8 @@ spec:
           value: 'arohcpsvcdev.azurecr.io/acm-d-cache/image-based-install-rhel9@sha256:1234567890'
         - name: OPERAND_IMAGE_KUBE_RBAC_PROXY_MCE
           value: 'arohcpsvcdev.azurecr.io/acm-d-cache/kube-rbac-proxy-mce-rhel9@sha256:1234567890'
+        - name: OPERAND_IMAGE_MAESTRO
+          value: 'arohcpsvcdev.azurecr.io/acm-d-cache/maestro-rhel9@sha256:1234567890'
         - name: OPERAND_IMAGE_MANAGEDCLUSTER_IMPORT_CONTROLLER
           value: 'arohcpsvcdev.azurecr.io/acm-d-cache/managedcluster-import-controller-rhel9@sha256:1234567890'
         - name: OPERAND_IMAGE_MANAGED_SERVICEACCOUNT
@@ -3571,8 +3578,10 @@ spec:
           value: 'arohcpsvcdev.azurecr.io/acm-d-cache/ose-baremetal-cluster-api-controllers-rhel9@sha256:1234567890'
         - name: OPERAND_IMAGE_POSTGRESQL_13
           value: 'arohcpsvcdev.azurecr.io/acm-d-cache/postgresql-13@sha256:1234567890'
+        - name: OPERAND_IMAGE_POSTGRESQL_15
+          value: 'arohcpsvcdev.azurecr.io/acm-d-cache/postgresql-15@sha256:1234567890'
         - name: OPERATOR_VERSION
-          value: 2.11.3
+          value: 2.17.0
         - name: OPERATOR_PACKAGE
           value: multicluster-engine
         image: 'arohcpsvcdev.azurecr.io/acm-d-cache/backplane-rhel9-operator@sha256:1234567890'

--- a/acm/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_mce_config.yaml
+++ b/acm/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_mce_config.yaml
@@ -1,7 +1,6 @@
 ---
 # Source: multicluster-engine-local-cluster/charts/policy/crds/agent.open-cluster-management.io_klusterletaddonconfigs_crd.yaml
 # Copyright (c) 2020 Red Hat, Inc.
-
 # Copyright Contributors to the Open Cluster Management project
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/acm/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_mce_config.yaml
+++ b/acm/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_mce_config.yaml
@@ -1,6 +1,7 @@
 ---
 # Source: multicluster-engine-local-cluster/charts/policy/crds/agent.open-cluster-management.io_klusterletaddonconfigs_crd.yaml
 # Copyright (c) 2020 Red Hat, Inc.
+
 # Copyright Contributors to the Open Cluster Management project
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/acm/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_mce_crds.yaml
+++ b/acm/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_mce_crds.yaml
@@ -33,6 +33,10 @@ spec:
       jsonPath: .status.desiredVersion
       name: DesiredVersion
       type: string
+    - description: Message from the most recent condition
+      jsonPath: .status.conditions[-1:].message
+      name: Message
+      type: string
     name: v1
     schema:
       openAPIV3Schema:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -941,12 +941,12 @@ defaults:
       bundle:
         registry: quay.io
         repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-217
-        digest: sha256:2a4a4c0b64b0e80edc499f7e8a5e5bc01c0cd1880becb213012e5a6985843a43 # v2.17.0-296 (2026-06-16 21:58)
+        digest: sha256:47ec04627d3a152b73916533e30733e107c255a8420808deb8905dbd9a046814 # v2.17.0-297 (2026-06-18 04:31)
     mce:
       bundle:
         registry: quay.io
         repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-217
-        digest: sha256:91b812c7345d9ca143dce919865debe6bf3740c3dd6299644c047a920340f9cb # v2.17.0-317 (2026-06-17 04:34)
+        digest: sha256:e2fdc959410510af1f3a625fbf1469af41ab1f2e2765ea4ce0d1d9a0846bc747 # v2.17.0-320 (2026-06-19 04:34)
   # Cluster Service
   clustersService:
     image:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -940,13 +940,13 @@ defaults:
     operator:
       bundle:
         registry: quay.io
-        repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
-        digest: sha256:c57efbcc1a6eaf381a6acfc8971426e72cb780df393cc87b37d36d5707cc1792 # bbdfc86822adfd6e5a1a9ea6ddfb1958c805601f (2026-06-15 22:49)
+        repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-217
+        digest: sha256:2a4a4c0b64b0e80edc499f7e8a5e5bc01c0cd1880becb213012e5a6985843a43 # v2.17.0-296 (2026-06-16 21:58)
     mce:
       bundle:
         registry: quay.io
-        repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211
-        digest: sha256:2fbd59d99219005e547eec97b7b7386f285993e9133c0478bd76c26f1251f621 # 4d9ba20bf5598163f7616e695e719481e12a59ca (2026-06-16 05:51)
+        repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-217
+        digest: sha256:91b812c7345d9ca143dce919865debe6bf3740c3dd6299644c047a920340f9cb # v2.17.0-317 (2026-06-17 04:34)
   # Cluster Service
   clustersService:
     image:

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -1,14 +1,14 @@
 acm:
   mce:
     bundle:
-      digest: sha256:2fbd59d99219005e547eec97b7b7386f285993e9133c0478bd76c26f1251f621
+      digest: sha256:91b812c7345d9ca143dce919865debe6bf3740c3dd6299644c047a920340f9cb
       registry: quay.io
-      repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211
+      repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-217
   operator:
     bundle:
-      digest: sha256:c57efbcc1a6eaf381a6acfc8971426e72cb780df393cc87b37d36d5707cc1792
+      digest: sha256:2a4a4c0b64b0e80edc499f7e8a5e5bc01c0cd1880becb213012e5a6985843a43
       registry: quay.io
-      repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
+      repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-217
 acr:
   ocp:
     name: arohcpocpdev

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -1,12 +1,12 @@
 acm:
   mce:
     bundle:
-      digest: sha256:91b812c7345d9ca143dce919865debe6bf3740c3dd6299644c047a920340f9cb
+      digest: sha256:e2fdc959410510af1f3a625fbf1469af41ab1f2e2765ea4ce0d1d9a0846bc747
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-217
   operator:
     bundle:
-      digest: sha256:2a4a4c0b64b0e80edc499f7e8a5e5bc01c0cd1880becb213012e5a6985843a43
+      digest: sha256:47ec04627d3a152b73916533e30733e107c255a8420808deb8905dbd9a046814
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-217
 acr:

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -1,14 +1,14 @@
 acm:
   mce:
     bundle:
-      digest: sha256:2fbd59d99219005e547eec97b7b7386f285993e9133c0478bd76c26f1251f621
+      digest: sha256:91b812c7345d9ca143dce919865debe6bf3740c3dd6299644c047a920340f9cb
       registry: quay.io
-      repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211
+      repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-217
   operator:
     bundle:
-      digest: sha256:c57efbcc1a6eaf381a6acfc8971426e72cb780df393cc87b37d36d5707cc1792
+      digest: sha256:2a4a4c0b64b0e80edc499f7e8a5e5bc01c0cd1880becb213012e5a6985843a43
       registry: quay.io
-      repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
+      repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-217
 acr:
   ocp:
     name: arohcpocpdev

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -1,12 +1,12 @@
 acm:
   mce:
     bundle:
-      digest: sha256:91b812c7345d9ca143dce919865debe6bf3740c3dd6299644c047a920340f9cb
+      digest: sha256:e2fdc959410510af1f3a625fbf1469af41ab1f2e2765ea4ce0d1d9a0846bc747
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-217
   operator:
     bundle:
-      digest: sha256:2a4a4c0b64b0e80edc499f7e8a5e5bc01c0cd1880becb213012e5a6985843a43
+      digest: sha256:47ec04627d3a152b73916533e30733e107c255a8420808deb8905dbd9a046814
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-217
 acr:

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -1,14 +1,14 @@
 acm:
   mce:
     bundle:
-      digest: sha256:2fbd59d99219005e547eec97b7b7386f285993e9133c0478bd76c26f1251f621
+      digest: sha256:91b812c7345d9ca143dce919865debe6bf3740c3dd6299644c047a920340f9cb
       registry: quay.io
-      repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211
+      repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-217
   operator:
     bundle:
-      digest: sha256:c57efbcc1a6eaf381a6acfc8971426e72cb780df393cc87b37d36d5707cc1792
+      digest: sha256:2a4a4c0b64b0e80edc499f7e8a5e5bc01c0cd1880becb213012e5a6985843a43
       registry: quay.io
-      repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
+      repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-217
 acr:
   ocp:
     name: arohcpocpdev

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -1,12 +1,12 @@
 acm:
   mce:
     bundle:
-      digest: sha256:91b812c7345d9ca143dce919865debe6bf3740c3dd6299644c047a920340f9cb
+      digest: sha256:e2fdc959410510af1f3a625fbf1469af41ab1f2e2765ea4ce0d1d9a0846bc747
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-217
   operator:
     bundle:
-      digest: sha256:2a4a4c0b64b0e80edc499f7e8a5e5bc01c0cd1880becb213012e5a6985843a43
+      digest: sha256:47ec04627d3a152b73916533e30733e107c255a8420808deb8905dbd9a046814
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-217
 acr:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -1,14 +1,14 @@
 acm:
   mce:
     bundle:
-      digest: sha256:2fbd59d99219005e547eec97b7b7386f285993e9133c0478bd76c26f1251f621
+      digest: sha256:91b812c7345d9ca143dce919865debe6bf3740c3dd6299644c047a920340f9cb
       registry: quay.io
-      repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211
+      repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-217
   operator:
     bundle:
-      digest: sha256:c57efbcc1a6eaf381a6acfc8971426e72cb780df393cc87b37d36d5707cc1792
+      digest: sha256:2a4a4c0b64b0e80edc499f7e8a5e5bc01c0cd1880becb213012e5a6985843a43
       registry: quay.io
-      repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
+      repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-217
 acr:
   ocp:
     name: arohcpocpdev

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -1,12 +1,12 @@
 acm:
   mce:
     bundle:
-      digest: sha256:91b812c7345d9ca143dce919865debe6bf3740c3dd6299644c047a920340f9cb
+      digest: sha256:e2fdc959410510af1f3a625fbf1469af41ab1f2e2765ea4ce0d1d9a0846bc747
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-217
   operator:
     bundle:
-      digest: sha256:2a4a4c0b64b0e80edc499f7e8a5e5bc01c0cd1880becb213012e5a6985843a43
+      digest: sha256:47ec04627d3a152b73916533e30733e107c255a8420808deb8905dbd9a046814
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-217
 acr:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -1,14 +1,14 @@
 acm:
   mce:
     bundle:
-      digest: sha256:2fbd59d99219005e547eec97b7b7386f285993e9133c0478bd76c26f1251f621
+      digest: sha256:91b812c7345d9ca143dce919865debe6bf3740c3dd6299644c047a920340f9cb
       registry: quay.io
-      repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211
+      repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-217
   operator:
     bundle:
-      digest: sha256:c57efbcc1a6eaf381a6acfc8971426e72cb780df393cc87b37d36d5707cc1792
+      digest: sha256:2a4a4c0b64b0e80edc499f7e8a5e5bc01c0cd1880becb213012e5a6985843a43
       registry: quay.io
-      repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
+      repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-217
 acr:
   ocp:
     name: arohcpocpdev

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -1,12 +1,12 @@
 acm:
   mce:
     bundle:
-      digest: sha256:91b812c7345d9ca143dce919865debe6bf3740c3dd6299644c047a920340f9cb
+      digest: sha256:e2fdc959410510af1f3a625fbf1469af41ab1f2e2765ea4ce0d1d9a0846bc747
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-217
   operator:
     bundle:
-      digest: sha256:2a4a4c0b64b0e80edc499f7e8a5e5bc01c0cd1880becb213012e5a6985843a43
+      digest: sha256:47ec04627d3a152b73916533e30733e107c255a8420808deb8905dbd9a046814
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-217
 acr:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -1,14 +1,14 @@
 acm:
   mce:
     bundle:
-      digest: sha256:2fbd59d99219005e547eec97b7b7386f285993e9133c0478bd76c26f1251f621
+      digest: sha256:91b812c7345d9ca143dce919865debe6bf3740c3dd6299644c047a920340f9cb
       registry: quay.io
-      repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211
+      repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-217
   operator:
     bundle:
-      digest: sha256:c57efbcc1a6eaf381a6acfc8971426e72cb780df393cc87b37d36d5707cc1792
+      digest: sha256:2a4a4c0b64b0e80edc499f7e8a5e5bc01c0cd1880becb213012e5a6985843a43
       registry: quay.io
-      repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
+      repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-217
 acr:
   ocp:
     name: arohcpocpdev

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -1,12 +1,12 @@
 acm:
   mce:
     bundle:
-      digest: sha256:91b812c7345d9ca143dce919865debe6bf3740c3dd6299644c047a920340f9cb
+      digest: sha256:e2fdc959410510af1f3a625fbf1469af41ab1f2e2765ea4ce0d1d9a0846bc747
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-217
   operator:
     bundle:
-      digest: sha256:2a4a4c0b64b0e80edc499f7e8a5e5bc01c0cd1880becb213012e5a6985843a43
+      digest: sha256:47ec04627d3a152b73916533e30733e107c255a8420808deb8905dbd9a046814
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-217
 acr:

--- a/tooling/image-updater/config.yaml
+++ b/tooling/image-updater/config.yaml
@@ -69,8 +69,8 @@ images:
   acm-operator:
     group: hypershift-stack
     source:
-      image: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
-      tagPattern: "^v\\d+\\.\\d+\\.\\d+-\\d+$"
+      image: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-217
+      tagPattern: "^v2\\.17\\.\\d+-\\d+$"
       repoVersionUpgrade:
         repoPrefix: "acm-operator-bundle-acm-"
     targets:
@@ -79,8 +79,8 @@ images:
   acm-mce:
     group: hypershift-stack
     source:
-      image: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211
-      tagPattern: "^v\\d+\\.\\d+\\.\\d+-\\d+$"
+      image: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-217
+      tagPattern: "^v2\\.17\\.\\d+-\\d+$"
       repoVersionUpgrade:
         repoPrefix: "mce-operator-bundle-mce-"
     targets:


### PR DESCRIPTION
[AROSLSRE-1187](https://redhat.atlassian.net/browse/AROSLSRE-1187)

What
Minor version upgrade of the ACM and MCE operator bundles to 2.17, moving to the new Konflux repos:

acm-operator: acm-operator-bundle-acm-216 → acm-operator-bundle-acm-217 (tracked via tagPattern: ^v2\.17\.\d+-\d+$, currently v2.17.0-296)
acm-mce: mce-operator-bundle-mce-211 → mce-operator-bundle-mce-217 (tracked via tagPattern: ^v2\.17\.\d+-\d+$, currently v2.17.0-317)
Updates the image path/repoPrefix in tooling/image-updater/config.yaml, the repository + digest in config/config.yaml, and regenerates the ACM helm charts (appVersion/version → 2.17) and rendered config.

Why
ACM/MCE have published the 2.17 minor release. This advances ARO-HCP from 2.16/2.11 to the 2.17 bundle repos so we pick up the new minor version.

Repos:

https://quay.io/repository/redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-217
https://quay.io/repository/redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-217
Testing
make -C tooling/image-updater update COMPONENTS=acm-operator,acm-mce — resolved 2.17 digests
make -C acm helm-charts — regenerated ACM/MCE charts for 2.17
make -C config materialize — re-rendered config + helm fixtures (verified idempotent)
make yamlfmt — clean
make verify — clean
Special notes for your reviewer
⚠️ This is a minor version bump (2.16/2.11 → 2.17). Please validate 2.17 compatibility with the current HyperShift/ACM integration before merging.

The jsonPath: .status.conditions[-1:].message in the regenerated MCE CRD is verbatim from the upstream MCE 2.17 bundle — we don't author it.