### PR TITLE
chore(config): register Microsoft.Cdn and Microsoft.Support for global subscription bootstrap (AROSLSRE-1231)

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -63,6 +63,8 @@ defaults:
             poll: true
         'Microsoft.Kusto':
           poll: true
+        'Microsoft.Support':
+          poll: true
     rg: global-shared-resources
     billing:
       rg: "placeholder"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -42,6 +42,8 @@ defaults:
       key: hcp-global
       displayName: "Azure Red Hat OpenShift HCP - {{ .ctx.environment }} - Global"
       providers:
+        'Microsoft.Cdn':
+          poll: true
         'Microsoft.Dashboard':
           poll: true
         'Microsoft.Network':

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -397,6 +397,8 @@ global:
     displayName: Azure Red Hat OpenShift HCP - ci00 - Global
     key: ARO Hosted Control Planes (EA Subscription 1)
     providers:
+      Microsoft.Cdn:
+        poll: true
       Microsoft.Compute:
         features:
         - name: EncryptionAtHost

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -418,6 +418,8 @@ global:
         - name: AllowBringYourOwnPublicIpAddress
           poll: true
         poll: true
+      Microsoft.Support:
+        poll: true
 hcpRecovery:
   image:
     digest: ""

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -418,6 +418,8 @@ global:
         - name: AllowBringYourOwnPublicIpAddress
           poll: true
         poll: true
+      Microsoft.Support:
+        poll: true
 hcpRecovery:
   image:
     digest: ""

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -397,6 +397,8 @@ global:
     displayName: Azure Red Hat OpenShift HCP - ci01 - Global
     key: ARO Hosted Control Planes (EA Subscription 1)
     providers:
+      Microsoft.Cdn:
+        poll: true
       Microsoft.Compute:
         features:
         - name: EncryptionAtHost

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -397,6 +397,8 @@ global:
     displayName: Azure Red Hat OpenShift HCP - cspr - Global
     key: ARO Hosted Control Planes (EA Subscription 1)
     providers:
+      Microsoft.Cdn:
+        poll: true
       Microsoft.Compute:
         features:
         - name: EncryptionAtHost

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -418,6 +418,8 @@ global:
         - name: AllowBringYourOwnPublicIpAddress
           poll: true
         poll: true
+      Microsoft.Support:
+        poll: true
 hcpRecovery:
   image:
     digest: ""

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -397,6 +397,8 @@ global:
     displayName: Azure Red Hat OpenShift HCP - dev - Global
     key: ARO Hosted Control Planes (EA Subscription 1)
     providers:
+      Microsoft.Cdn:
+        poll: true
       Microsoft.Compute:
         features:
         - name: EncryptionAtHost

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -418,6 +418,8 @@ global:
         - name: AllowBringYourOwnPublicIpAddress
           poll: true
         poll: true
+      Microsoft.Support:
+        poll: true
 hcpRecovery:
   image:
     digest: ""

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -397,6 +397,8 @@ global:
     displayName: Azure Red Hat OpenShift HCP - perf - Global
     key: ARO Hosted Control Planes (EA Subscription 1)
     providers:
+      Microsoft.Cdn:
+        poll: true
       Microsoft.Compute:
         features:
         - name: EncryptionAtHost

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -418,6 +418,8 @@ global:
         - name: AllowBringYourOwnPublicIpAddress
           poll: true
         poll: true
+      Microsoft.Support:
+        poll: true
 hcpRecovery:
   image:
     digest: ""

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -397,6 +397,8 @@ global:
     displayName: Azure Red Hat OpenShift HCP - pers - Global
     key: ARO Hosted Control Planes (EA Subscription 1)
     providers:
+      Microsoft.Cdn:
+        poll: true
       Microsoft.Compute:
         features:
         - name: EncryptionAtHost

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -418,6 +418,8 @@ global:
         - name: AllowBringYourOwnPublicIpAddress
           poll: true
         poll: true
+      Microsoft.Support:
+        poll: true
 hcpRecovery:
   image:
     digest: ""


### PR DESCRIPTION
[AROSLSRE-1231](https://issues.redhat.com/browse/AROSLSRE-1231)

### What

Add two resource providers to `global.subscription.providers` in `config/config.yaml` (and regenerate the materialized dev configs) so the global subscription bootstrap pipeline's `provider-feature-registration` step registers them:

- **`Microsoft.Cdn`** — Front Door provider.
- **`Microsoft.Support`** — Support API provider.

### Why

The bootstrap's `provider-feature-registration` step runs as the privileged EV2 MSI; the read-only operator identity cannot run `register/action`, so any RP the subscription needs must be registered here.

- `global-infra.bicep` deploys an Azure Front Door (Premium) profile — a `Microsoft.Cdn/profiles` resource — but `Microsoft.Cdn` was missing from the list. On the new dedicated STG Global subscription it showed `NotRegistered`, which would fail the later Front Door deploy.
- `Microsoft.Support` enables filing quota support tickets via the Support REST API on the subscription (e.g. the STG Global PaaS quota bumps), instead of relying on a portal-only flow.

### Testing

- `make -C config/ materialize` — regenerated rendered dev configs (only the two provider additions).
- `make -C config/ validate` — passes.

No functional/runtime tests apply; this only adds RPs to the registration list, which is idempotent (the shared int/prod global sub already runs Front Door, so its RP is already registered there).

### Special notes for your reviewer

Only `config/rendered/dev/*` are materialized in this repo; the STG/prod rendered pipelines are generated in `sdp-pipelines`, which picks up the config change separately. The change lives in the `defaults` block (no STG overlay override), so it applies to every global subscription.

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
