### PR TITLE
feat(observability): filter internal subscriptions from RP IcM lane

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedHCPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedHCPPrometheusAlertingRules.bicep
@@ -1948,7 +1948,7 @@ resource hcpHostedclusterMonitorRules 'Microsoft.AlertsManagement/prometheusRule
           summary: 'High KubeAPIServer error budget burn for HostedCluster {{ $labels.name }}'
           title: 'High KubeAPIServer error budget burn for HostedCluster {{ $labels.name }}'
         }
-        expression: '1 - (hostedClusterAPI_kubeapiserver_available:sum_over_time_2h / hostedClusterAPI_kubeapiserver_available:count_over_time_2h) > (3 * (1 - 0.9995)) and hostedClusterAPI_kubeapiserver_available:count_over_time_2h > 120 and 1 - sum by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available:ratio_avg_1d) > (3 * (1 - 0.9995)) and hostedClusterAPI_kubeapiserver_available:count_over_time_1d > 1440'
+        expression: '1 - (hostedClusterAPI_kubeapiserver_available:sum_over_time_2h / hostedClusterAPI_kubeapiserver_available:count_over_time_2h) > (3 * (1 - 0.9995)) and hostedClusterAPI_kubeapiserver_available:count_over_time_2h > 120 and 1 - sum by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available:ratio_avg_1d) > (3 * (1 - 0.9995)) and hostedClusterAPI_kubeapiserver_available:count_over_time_1d > 1440'
         for: 'PT1H'
         severity: 4
       }
@@ -1978,7 +1978,7 @@ resource hcpHostedclusterMonitorRules 'Microsoft.AlertsManagement/prometheusRule
           summary: 'High KubeAPIServer error budget burn for HostedCluster {{ $labels.name }}'
           title: 'High KubeAPIServer error budget burn for HostedCluster {{ $labels.name }}'
         }
-        expression: '1 - (hostedClusterAPI_kubeapiserver_available:sum_over_time_6h / hostedClusterAPI_kubeapiserver_available:count_over_time_6h) > (1 * (1 - 0.9995)) and hostedClusterAPI_kubeapiserver_available:count_over_time_6h > 360 and 1 - sum by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available:ratio_avg_3d) > (1 * (1 - 0.9995)) and hostedClusterAPI_kubeapiserver_available:count_over_time_3d > 4320'
+        expression: '1 - (hostedClusterAPI_kubeapiserver_available:sum_over_time_6h / hostedClusterAPI_kubeapiserver_available:count_over_time_6h) > (1 * (1 - 0.9995)) and hostedClusterAPI_kubeapiserver_available:count_over_time_6h > 360 and 1 - sum by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available:ratio_avg_3d) > (1 * (1 - 0.9995)) and hostedClusterAPI_kubeapiserver_available:count_over_time_3d > 4320'
         for: 'PT3H'
         severity: 4
       }

--- a/dev-infrastructure/modules/metrics/rules/generatedHCPRecordingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedHCPRecordingRules.bicep
@@ -14,83 +14,83 @@ resource hcpKmsRecordingRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2
     rules: [
       {
         record: 'hostedClusterAPI_kubeapiserver_available:ratio_avg_30d'
-        expression: 'avg by (name, namespace, _id, cluster) (avg_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[30d])) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
+        expression: 'avg by (name, namespace, _id, cluster, subscription_id) (avg_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[30d])) and on (name, namespace, _id, cluster, subscription_id) count by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available)'
       }
       {
         record: 'hostedClusterAPI_kubeapiserver_available:ratio_avg_7d'
-        expression: 'avg by (name, namespace, _id, cluster) (avg_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[7d])) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
+        expression: 'avg by (name, namespace, _id, cluster, subscription_id) (avg_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[7d])) and on (name, namespace, _id, cluster, subscription_id) count by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available)'
       }
       {
         record: 'hostedClusterAPI_kubeapiserver_available:ratio_avg_1d'
-        expression: 'avg by (name, namespace, _id, cluster) (avg_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[1d])) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
+        expression: 'avg by (name, namespace, _id, cluster, subscription_id) (avg_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[1d])) and on (name, namespace, _id, cluster, subscription_id) count by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available)'
       }
       {
         record: 'hostedClusterAPI_kubeapiserver_available:ratio_avg_3d'
-        expression: 'avg by (name, namespace, _id, cluster) (avg_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[3d])) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
+        expression: 'avg by (name, namespace, _id, cluster, subscription_id) (avg_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[3d])) and on (name, namespace, _id, cluster, subscription_id) count by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available)'
       }
       {
         record: 'hostedClusterAPI_kubeapiserver_available:sum_over_time_30m'
-        expression: 'sum by (name, namespace, _id, cluster) (sum_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[30m])) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
+        expression: 'sum by (name, namespace, _id, cluster, subscription_id) (sum_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[30m])) and on (name, namespace, _id, cluster, subscription_id) count by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available)'
       }
       {
         record: 'hostedClusterAPI_kubeapiserver_available:sum_over_time_1h'
-        expression: 'sum by (name, namespace, _id, cluster) (sum_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[1h])) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
+        expression: 'sum by (name, namespace, _id, cluster, subscription_id) (sum_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[1h])) and on (name, namespace, _id, cluster, subscription_id) count by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available)'
       }
       {
         record: 'hostedClusterAPI_kubeapiserver_available:sum_over_time_2h'
-        expression: 'sum by (name, namespace, _id, cluster) (sum_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[2h])) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
+        expression: 'sum by (name, namespace, _id, cluster, subscription_id) (sum_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[2h])) and on (name, namespace, _id, cluster, subscription_id) count by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available)'
       }
       {
         record: 'hostedClusterAPI_kubeapiserver_available:sum_over_time_6h'
-        expression: 'sum by (name, namespace, _id, cluster) (sum_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[6h])) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
+        expression: 'sum by (name, namespace, _id, cluster, subscription_id) (sum_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[6h])) and on (name, namespace, _id, cluster, subscription_id) count by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available)'
       }
       {
         record: 'hostedClusterAPI_kubeapiserver_available:count_over_time_30m'
-        expression: 'sum by (name, namespace, _id, cluster) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[30m])) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
+        expression: 'sum by (name, namespace, _id, cluster, subscription_id) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[30m])) and on (name, namespace, _id, cluster, subscription_id) count by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available)'
       }
       {
         record: 'hostedClusterAPI_kubeapiserver_available:count_over_time_1h'
-        expression: 'sum by (name, namespace, _id, cluster) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[1h])) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
+        expression: 'sum by (name, namespace, _id, cluster, subscription_id) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[1h])) and on (name, namespace, _id, cluster, subscription_id) count by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available)'
       }
       {
         record: 'hostedClusterAPI_kubeapiserver_available:count_over_time_2h'
-        expression: 'sum by (name, namespace, _id, cluster) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[2h])) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
+        expression: 'sum by (name, namespace, _id, cluster, subscription_id) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[2h])) and on (name, namespace, _id, cluster, subscription_id) count by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available)'
       }
       {
         record: 'hostedClusterAPI_kubeapiserver_available:count_over_time_6h'
-        expression: 'sum by (name, namespace, _id, cluster) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[6h])) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
+        expression: 'sum by (name, namespace, _id, cluster, subscription_id) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[6h])) and on (name, namespace, _id, cluster, subscription_id) count by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available)'
       }
       {
         record: 'hostedClusterAPI_kubeapiserver_available:count_over_time_1d'
-        expression: 'sum by (name, namespace, _id, cluster) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[1d])) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
+        expression: 'sum by (name, namespace, _id, cluster, subscription_id) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[1d])) and on (name, namespace, _id, cluster, subscription_id) count by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available)'
       }
       {
         record: 'hostedClusterAPI_kubeapiserver_available:count_over_time_3d'
-        expression: 'sum by (name, namespace, _id, cluster) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[3d])) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
+        expression: 'sum by (name, namespace, _id, cluster, subscription_id) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[3d])) and on (name, namespace, _id, cluster, subscription_id) count by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available)'
       }
       {
         record: 'hostedClusterAPI_kubeapiserver_available:sli_sum_15m'
-        expression: 'sum by (name, namespace, _id, cluster) ( sum_over_time( ( hostedClusterAPI_kubeapiserver_available{status="True"} and on (name, namespace, _id, cluster) max by (name, namespace, _id, cluster) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0) )[15m:1m] ) ) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
+        expression: 'sum by (name, namespace, _id, cluster, subscription_id) ( sum_over_time( ( hostedClusterAPI_kubeapiserver_available{status="True"} and on (name, namespace, _id, cluster, subscription_id) max by (name, namespace, _id, cluster, subscription_id) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0) )[15m:1m] ) ) and on (name, namespace, _id, cluster, subscription_id) count by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available)'
       }
       {
         record: 'hostedClusterAPI_kubeapiserver_available:sli_count_15m'
-        expression: 'sum by (name, namespace, _id, cluster) ( count_over_time( ( max by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available) and on (name, namespace, _id, cluster) max by (name, namespace, _id, cluster) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0) )[15m:1m] ) ) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
+        expression: 'sum by (name, namespace, _id, cluster, subscription_id) ( count_over_time( ( max by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available) and on (name, namespace, _id, cluster, subscription_id) max by (name, namespace, _id, cluster, subscription_id) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0) )[15m:1m] ) ) and on (name, namespace, _id, cluster, subscription_id) count by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available)'
       }
       {
         record: 'hostedClusterAPI_kubeapiserver_available:sli_sum_6h'
-        expression: 'sum by (name, namespace, _id, cluster) ( sum_over_time( ( hostedClusterAPI_kubeapiserver_available{status="True"} and on (name, namespace, _id, cluster) max by (name, namespace, _id, cluster) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0) )[6h:5m] ) ) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
+        expression: 'sum by (name, namespace, _id, cluster, subscription_id) ( sum_over_time( ( hostedClusterAPI_kubeapiserver_available{status="True"} and on (name, namespace, _id, cluster, subscription_id) max by (name, namespace, _id, cluster, subscription_id) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0) )[6h:5m] ) ) and on (name, namespace, _id, cluster, subscription_id) count by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available)'
       }
       {
         record: 'hostedClusterAPI_kubeapiserver_available:sli_count_6h'
-        expression: 'sum by (name, namespace, _id, cluster) ( count_over_time( ( max by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available) and on (name, namespace, _id, cluster) max by (name, namespace, _id, cluster) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0) )[6h:5m] ) ) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
+        expression: 'sum by (name, namespace, _id, cluster, subscription_id) ( count_over_time( ( max by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available) and on (name, namespace, _id, cluster, subscription_id) max by (name, namespace, _id, cluster, subscription_id) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0) )[6h:5m] ) ) and on (name, namespace, _id, cluster, subscription_id) count by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available)'
       }
       {
         record: 'hostedClusterAPI_kubeapiserver_available:sli_sum_3d'
-        expression: 'sum by (name, namespace, _id, cluster) ( sum_over_time( ( hostedClusterAPI_kubeapiserver_available{status="True"} and on (name, namespace, _id, cluster) max by (name, namespace, _id, cluster) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0) )[3d:30m] ) ) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
+        expression: 'sum by (name, namespace, _id, cluster, subscription_id) ( sum_over_time( ( hostedClusterAPI_kubeapiserver_available{status="True"} and on (name, namespace, _id, cluster, subscription_id) max by (name, namespace, _id, cluster, subscription_id) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0) )[3d:30m] ) ) and on (name, namespace, _id, cluster, subscription_id) count by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available)'
       }
       {
         record: 'hostedClusterAPI_kubeapiserver_available:sli_count_3d'
-        expression: 'sum by (name, namespace, _id, cluster) ( count_over_time( ( max by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available) and on (name, namespace, _id, cluster) max by (name, namespace, _id, cluster) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0) )[3d:30m] ) ) and on (name, namespace, _id, cluster) count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)'
+        expression: 'sum by (name, namespace, _id, cluster, subscription_id) ( count_over_time( ( max by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available) and on (name, namespace, _id, cluster, subscription_id) max by (name, namespace, _id, cluster, subscription_id) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0) )[3d:30m] ) ) and on (name, namespace, _id, cluster, subscription_id) count by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available)'
       }
     ]
   }

--- a/dev-infrastructure/modules/metrics/rules/generatedRPHCPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRPHCPPrometheusAlertingRules.bicep
@@ -45,7 +45,7 @@ Management Cluster: {{ $labels.cluster }}/{{ $labels.namespace }}
           summary: '[HCP] [{{ $labels.name }}] KubeAPIServer Fast Error Budget Burn (1h/5m)'
           title: '[HCP] [{{ $labels.name }}] KubeAPIServer Fast Error Budget Burn (1h/5m)'
         }
-        expression: '( 1 - (hostedClusterAPI_kubeapiserver_available:sli_sum_5m / hostedClusterAPI_kubeapiserver_available:sli_count_5m) > (14.4 * (1 - 0.9995)) and on (name, namespace, _id, cluster) hostedClusterAPI_kubeapiserver_available:sli_count_5m > 3 ) and on (name, namespace, _id, cluster) ( 1 - (hostedClusterAPI_kubeapiserver_available:sli_sum_1h / hostedClusterAPI_kubeapiserver_available:sli_count_1h) > (14.4 * (1 - 0.9995)) and on (name, namespace, _id, cluster) hostedClusterAPI_kubeapiserver_available:sli_count_1h > 54 )'
+        expression: '((( 1 - (hostedClusterAPI_kubeapiserver_available:sli_sum_5m / hostedClusterAPI_kubeapiserver_available:sli_count_5m) > (14.4 * (1 - 0.9995)) and on (name, namespace, _id, cluster) hostedClusterAPI_kubeapiserver_available:sli_count_5m > 3 ) and on (name, namespace, _id, cluster) ( 1 - (hostedClusterAPI_kubeapiserver_available:sli_sum_1h / hostedClusterAPI_kubeapiserver_available:sli_count_1h) > (14.4 * (1 - 0.9995)) and on (name, namespace, _id, cluster) hostedClusterAPI_kubeapiserver_available:sli_count_1h > 54 )) unless on(_id, cluster) internal_subscription:hostedcluster:info) unless on(subscription_id) internal_subscription:info'
         for: 'PT10M'
         severity: 2
       }
@@ -81,7 +81,7 @@ Management Cluster: {{ $labels.cluster }}/{{ $labels.namespace }}
           summary: '[HCP] [{{ $labels.name }}] KubeAPIServer Medium Error Budget Burn (6h/30m)'
           title: '[HCP] [{{ $labels.name }}] KubeAPIServer Medium Error Budget Burn (6h/30m)'
         }
-        expression: '( 1 - (hostedClusterAPI_kubeapiserver_available:sli_sum_30m / hostedClusterAPI_kubeapiserver_available:sli_count_30m) > (6 * (1 - 0.9995)) and on (name, namespace, _id, cluster) hostedClusterAPI_kubeapiserver_available:sli_count_30m > 27 ) and on (name, namespace, _id, cluster) ( 1 - (hostedClusterAPI_kubeapiserver_available:sli_sum_6h / hostedClusterAPI_kubeapiserver_available:sli_count_6h) > (6 * (1 - 0.9995)) and on (name, namespace, _id, cluster) hostedClusterAPI_kubeapiserver_available:sli_count_6h > 64 )'
+        expression: '((( 1 - (hostedClusterAPI_kubeapiserver_available:sli_sum_30m / hostedClusterAPI_kubeapiserver_available:sli_count_30m) > (6 * (1 - 0.9995)) and on (name, namespace, _id, cluster) hostedClusterAPI_kubeapiserver_available:sli_count_30m > 27 ) and on (name, namespace, _id, cluster) ( 1 - (hostedClusterAPI_kubeapiserver_available:sli_sum_6h / hostedClusterAPI_kubeapiserver_available:sli_count_6h) > (6 * (1 - 0.9995)) and on (name, namespace, _id, cluster) hostedClusterAPI_kubeapiserver_available:sli_count_6h > 64 )) unless on(_id, cluster) internal_subscription:hostedcluster:info) unless on(subscription_id) internal_subscription:info'
         for: 'PT30M'
         severity: 2
       }
@@ -117,7 +117,7 @@ Management Cluster: {{ $labels.cluster }}/{{ $labels.namespace }}
           summary: '[HCP] [{{ $labels.name }}] KubeAPIServer Slow Error Budget Burn (3d/6h)'
           title: '[HCP] [{{ $labels.name }}] KubeAPIServer Slow Error Budget Burn (3d/6h)'
         }
-        expression: '( 1 - (hostedClusterAPI_kubeapiserver_available:sli_sum_6h / hostedClusterAPI_kubeapiserver_available:sli_count_6h) > (1 * (1 - 0.9995)) and on (name, namespace, _id, cluster) hostedClusterAPI_kubeapiserver_available:sli_count_6h > 64 ) and on (name, namespace, _id, cluster) ( 1 - (hostedClusterAPI_kubeapiserver_available:sli_sum_3d / hostedClusterAPI_kubeapiserver_available:sli_count_3d) > (1 * (1 - 0.9995)) and on (name, namespace, _id, cluster) hostedClusterAPI_kubeapiserver_available:sli_count_3d > 130 )'
+        expression: '((( 1 - (hostedClusterAPI_kubeapiserver_available:sli_sum_6h / hostedClusterAPI_kubeapiserver_available:sli_count_6h) > (1 * (1 - 0.9995)) and on (name, namespace, _id, cluster) hostedClusterAPI_kubeapiserver_available:sli_count_6h > 64 ) and on (name, namespace, _id, cluster) ( 1 - (hostedClusterAPI_kubeapiserver_available:sli_sum_3d / hostedClusterAPI_kubeapiserver_available:sli_count_3d) > (1 * (1 - 0.9995)) and on (name, namespace, _id, cluster) hostedClusterAPI_kubeapiserver_available:sli_count_3d > 130 )) unless on(_id, cluster) internal_subscription:hostedcluster:info) unless on(subscription_id) internal_subscription:info'
         for: 'PT3H'
         severity: 3
       }

--- a/observability/alerts-rp-hcps.yaml
+++ b/observability/alerts-rp-hcps.yaml
@@ -5,3 +5,10 @@ prometheusRules:
   testDependencies:
   - recording-rules-hcps.yaml
   outputBicep: ../dev-infrastructure/modules/metrics/rules/generatedRPHCPPrometheusAlertingRules.bicep
+internalSubscriptionFilter:
+  enabled: true
+  lookupTables:
+  - matchLabels: [_id, cluster]
+    table: internal_subscription:hostedcluster:info
+  - matchLabels: [subscription_id]
+    table: internal_subscription:info

--- a/observability/alerts/HCPkasMonitor-prometheusRule-KSM.yaml
+++ b/observability/alerts/HCPkasMonitor-prometheusRule-KSM.yaml
@@ -31,7 +31,7 @@ spec:
         description: "HostedCluster {{ $labels.name }} (ID: {{ $labels._id }}) KubeAPIServer availability is below SLO (current value: {{ $value }})"
         correlationId: "hostedcluster-KubeAPIServer-ErrorBudgetBurn/{{ $labels.cluster }}/{{ $labels._id }}"
     - alert: hostedcluster-KubeAPIServer-ErrorBudgetBurn
-      expr: 1 - (hostedClusterAPI_kubeapiserver_available:sum_over_time_2h / hostedClusterAPI_kubeapiserver_available:count_over_time_2h) > (3 * (1 - 0.9995)) and hostedClusterAPI_kubeapiserver_available:count_over_time_2h > 120 and 1 - sum by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available:ratio_avg_1d) > (3 * (1 - 0.9995)) and hostedClusterAPI_kubeapiserver_available:count_over_time_1d > 1440
+      expr: 1 - (hostedClusterAPI_kubeapiserver_available:sum_over_time_2h / hostedClusterAPI_kubeapiserver_available:count_over_time_2h) > (3 * (1 - 0.9995)) and hostedClusterAPI_kubeapiserver_available:count_over_time_2h > 120 and 1 - sum by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available:ratio_avg_1d) > (3 * (1 - 0.9995)) and hostedClusterAPI_kubeapiserver_available:count_over_time_1d > 1440
       for: 1h
       labels:
         long_window: 1d
@@ -42,7 +42,7 @@ spec:
         description: "HostedCluster {{ $labels.name }} (ID: {{ $labels._id }}) KubeAPIServer availability is below SLO (current value: {{ $value }})"
         correlationId: "hostedcluster-KubeAPIServer-ErrorBudgetBurn/{{ $labels.cluster }}/{{ $labels._id }}"
     - alert: hostedcluster-KubeAPIServer-ErrorBudgetBurn
-      expr: 1 - (hostedClusterAPI_kubeapiserver_available:sum_over_time_6h / hostedClusterAPI_kubeapiserver_available:count_over_time_6h) > (1 * (1 - 0.9995)) and hostedClusterAPI_kubeapiserver_available:count_over_time_6h > 360 and 1 - sum by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available:ratio_avg_3d) > (1 * (1 - 0.9995)) and hostedClusterAPI_kubeapiserver_available:count_over_time_3d > 4320
+      expr: 1 - (hostedClusterAPI_kubeapiserver_available:sum_over_time_6h / hostedClusterAPI_kubeapiserver_available:count_over_time_6h) > (1 * (1 - 0.9995)) and hostedClusterAPI_kubeapiserver_available:count_over_time_6h > 360 and 1 - sum by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available:ratio_avg_3d) > (1 * (1 - 0.9995)) and hostedClusterAPI_kubeapiserver_available:count_over_time_3d > 4320
       for: 3h
       labels:
         long_window: 3d

--- a/observability/alerts/HCPkasMonitor-prometheusRule-KSM_test.yaml
+++ b/observability/alerts/HCPkasMonitor-prometheusRule-KSM_test.yaml
@@ -7,7 +7,7 @@ tests:
 - interval: 1m
   name: "Test 1: Normal operation - perfect availability, no alerts"
   input_series:
-  - series: 'hostedClusterAPI_kubeapiserver_available{status="True", name="test-cluster", namespace="clusters", _id="abc-123", cluster="mgmt-cluster"}'
+  - series: 'hostedClusterAPI_kubeapiserver_available{status="True", name="test-cluster", namespace="clusters", _id="abc-123", cluster="mgmt-cluster", subscription_id="sub-001"}'
     values: "1+0x4500" # Perfect availability for 75 hours (3+ days)
   alert_rule_test:
   - eval_time: 4500m
@@ -17,7 +17,7 @@ tests:
 - interval: 30s # Generate data every 30 seconds to meet sample count requirements
   name: "Test 2: KubeAPIServer fast burn - complete failure triggers 30m/1h alert"
   input_series:
-  - series: 'hostedClusterAPI_kubeapiserver_available{status="True", name="test-cluster", namespace="clusters", _id="abc-123", cluster="mgmt-cluster"}'
+  - series: 'hostedClusterAPI_kubeapiserver_available{status="True", name="test-cluster", namespace="clusters", _id="abc-123", cluster="mgmt-cluster", subscription_id="sub-001"}'
     # Complete failure: 0% availability
     # With 30s interval: 30m window has 60 samples (>5 ✓), 1h window has 120 samples (>60 ✓)
     # Alert condition: 1 - (0/60) > 0.0072 AND 1 - (0/120) > 0.0072 = TRUE
@@ -38,6 +38,7 @@ tests:
         namespace: clusters
         _id: abc-123
         cluster: mgmt-cluster
+        subscription_id: sub-001
       exp_annotations:
         summary: "High KubeAPIServer error budget burn for HostedCluster test-cluster"
         description: "HostedCluster test-cluster (ID: abc-123) KubeAPIServer availability is below SLO (current value: 1)"
@@ -46,7 +47,7 @@ tests:
 - interval: 30s
   name: "Test 3: KubeAPIServer medium burn - triggers 30m/6h alert"
   input_series:
-  - series: 'hostedClusterAPI_kubeapiserver_available{status="True", name="test-cluster", namespace="clusters", _id="abc-123", cluster="mgmt-cluster"}'
+  - series: 'hostedClusterAPI_kubeapiserver_available{status="True", name="test-cluster", namespace="clusters", _id="abc-123", cluster="mgmt-cluster", subscription_id="sub-001"}'
     # Complete failure for sufficient duration
     # With 30s interval: 30m window has 60 samples (>30 ✓), 6h window has 720 samples (>360 ✓)
     values: "0+0x800" # Complete failure for 400+ minutes (800 * 30s = 400m)
@@ -62,6 +63,7 @@ tests:
         namespace: clusters
         _id: abc-123
         cluster: mgmt-cluster
+        subscription_id: sub-001
       exp_annotations:
         summary: "High KubeAPIServer error budget burn for HostedCluster test-cluster"
         description: "HostedCluster test-cluster (ID: abc-123) KubeAPIServer availability is below SLO (current value: 1)"
@@ -78,6 +80,7 @@ tests:
         namespace: clusters
         _id: abc-123
         cluster: mgmt-cluster
+        subscription_id: sub-001
       exp_annotations:
         summary: "High KubeAPIServer error budget burn for HostedCluster test-cluster"
         description: "HostedCluster test-cluster (ID: abc-123) KubeAPIServer availability is below SLO (current value: 1)"
@@ -90,6 +93,7 @@ tests:
         namespace: clusters
         _id: abc-123
         cluster: mgmt-cluster
+        subscription_id: sub-001
       exp_annotations:
         summary: "High KubeAPIServer error budget burn for HostedCluster test-cluster"
         description: "HostedCluster test-cluster (ID: abc-123) KubeAPIServer availability is below SLO (current value: 1)"
@@ -99,7 +103,7 @@ tests:
 - interval: 30s
   name: "Test 4: KubeAPIServer all alerts fire after prolonged failure"
   input_series:
-  - series: 'hostedClusterAPI_kubeapiserver_available{status="True", name="test-cluster", namespace="clusters", _id="abc-123", cluster="mgmt-cluster"}'
+  - series: 'hostedClusterAPI_kubeapiserver_available{status="True", name="test-cluster", namespace="clusters", _id="abc-123", cluster="mgmt-cluster", subscription_id="sub-001"}'
     # Complete failure for 3+ days to satisfy all four alert time windows
     values: "0+0x9000" # 4500 minutes = 75 hours = 3+ days of failure
   alert_rule_test:
@@ -114,6 +118,7 @@ tests:
         namespace: clusters
         _id: abc-123
         cluster: mgmt-cluster
+        subscription_id: sub-001
       exp_annotations:
         summary: "High KubeAPIServer error budget burn for HostedCluster test-cluster"
         description: "HostedCluster test-cluster (ID: abc-123) KubeAPIServer availability is below SLO (current value: 1)"
@@ -126,6 +131,7 @@ tests:
         namespace: clusters
         _id: abc-123
         cluster: mgmt-cluster
+        subscription_id: sub-001
       exp_annotations:
         summary: "High KubeAPIServer error budget burn for HostedCluster test-cluster"
         description: "HostedCluster test-cluster (ID: abc-123) KubeAPIServer availability is below SLO (current value: 1)"
@@ -138,6 +144,7 @@ tests:
         namespace: clusters
         _id: abc-123
         cluster: mgmt-cluster
+        subscription_id: sub-001
       exp_annotations:
         summary: "High KubeAPIServer error budget burn for HostedCluster test-cluster"
         description: "HostedCluster test-cluster (ID: abc-123) KubeAPIServer availability is below SLO (current value: 1)"
@@ -150,6 +157,7 @@ tests:
         namespace: clusters
         _id: abc-123
         cluster: mgmt-cluster
+        subscription_id: sub-001
       exp_annotations:
         summary: "High KubeAPIServer error budget burn for HostedCluster test-cluster"
         description: "HostedCluster test-cluster (ID: abc-123) KubeAPIServer availability is below SLO (current value: 1)"
@@ -158,7 +166,7 @@ tests:
 - interval: 30s
   name: "Test 5: Partial failure below threshold - no alert fires"
   input_series:
-  - series: 'hostedClusterAPI_kubeapiserver_available{status="True", name="test-cluster", namespace="clusters", _id="abc-123", cluster="mgmt-cluster"}'
+  - series: 'hostedClusterAPI_kubeapiserver_available{status="True", name="test-cluster", namespace="clusters", _id="abc-123", cluster="mgmt-cluster", subscription_id="sub-001"}'
     # Simulate 99.96% availability (0.04% error rate, below 0.5% threshold)
     # Pattern: mostly available with very occasional failures
     values: "1+0x10 0 1+0x2500" # One brief failure in 2500+ samples

--- a/observability/alerts/HCPkasRecord-prometheusRule-KSM.yaml
+++ b/observability/alerts/HCPkasRecord-prometheusRule-KSM.yaml
@@ -13,77 +13,77 @@ spec:
     # Long-window averages for slow-burn alerts
     - record: hostedClusterAPI_kubeapiserver_available:ratio_avg_30d
       expr: |
-        avg by (name, namespace, _id, cluster) (avg_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[30d]))
-        and on (name, namespace, _id, cluster)
-        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
+        avg by (name, namespace, _id, cluster, subscription_id) (avg_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[30d]))
+        and on (name, namespace, _id, cluster, subscription_id)
+        count by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available)
     - record: hostedClusterAPI_kubeapiserver_available:ratio_avg_7d
       expr: |
-        avg by (name, namespace, _id, cluster) (avg_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[7d]))
-        and on (name, namespace, _id, cluster)
-        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
+        avg by (name, namespace, _id, cluster, subscription_id) (avg_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[7d]))
+        and on (name, namespace, _id, cluster, subscription_id)
+        count by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available)
     - record: hostedClusterAPI_kubeapiserver_available:ratio_avg_1d
       expr: |
-        avg by (name, namespace, _id, cluster) (avg_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[1d]))
-        and on (name, namespace, _id, cluster)
-        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
+        avg by (name, namespace, _id, cluster, subscription_id) (avg_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[1d]))
+        and on (name, namespace, _id, cluster, subscription_id)
+        count by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available)
     - record: hostedClusterAPI_kubeapiserver_available:ratio_avg_3d
       expr: |
-        avg by (name, namespace, _id, cluster) (avg_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[3d]))
-        and on (name, namespace, _id, cluster)
-        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
+        avg by (name, namespace, _id, cluster, subscription_id) (avg_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[3d]))
+        and on (name, namespace, _id, cluster, subscription_id)
+        count by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available)
     # Short-window sum_over_time for burn-rate calculations
     - record: hostedClusterAPI_kubeapiserver_available:sum_over_time_30m
       expr: |
-        sum by (name, namespace, _id, cluster) (sum_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[30m]))
-        and on (name, namespace, _id, cluster)
-        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
+        sum by (name, namespace, _id, cluster, subscription_id) (sum_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[30m]))
+        and on (name, namespace, _id, cluster, subscription_id)
+        count by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available)
     - record: hostedClusterAPI_kubeapiserver_available:sum_over_time_1h
       expr: |
-        sum by (name, namespace, _id, cluster) (sum_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[1h]))
-        and on (name, namespace, _id, cluster)
-        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
+        sum by (name, namespace, _id, cluster, subscription_id) (sum_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[1h]))
+        and on (name, namespace, _id, cluster, subscription_id)
+        count by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available)
     - record: hostedClusterAPI_kubeapiserver_available:sum_over_time_2h
       expr: |
-        sum by (name, namespace, _id, cluster) (sum_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[2h]))
-        and on (name, namespace, _id, cluster)
-        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
+        sum by (name, namespace, _id, cluster, subscription_id) (sum_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[2h]))
+        and on (name, namespace, _id, cluster, subscription_id)
+        count by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available)
     - record: hostedClusterAPI_kubeapiserver_available:sum_over_time_6h
       expr: |
-        sum by (name, namespace, _id, cluster) (sum_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[6h]))
-        and on (name, namespace, _id, cluster)
-        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
+        sum by (name, namespace, _id, cluster, subscription_id) (sum_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[6h]))
+        and on (name, namespace, _id, cluster, subscription_id)
+        count by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available)
     # Short-window count_over_time for burn-rate calculations
     - record: hostedClusterAPI_kubeapiserver_available:count_over_time_30m
       expr: |
-        sum by (name, namespace, _id, cluster) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[30m]))
-        and on (name, namespace, _id, cluster)
-        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
+        sum by (name, namespace, _id, cluster, subscription_id) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[30m]))
+        and on (name, namespace, _id, cluster, subscription_id)
+        count by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available)
     - record: hostedClusterAPI_kubeapiserver_available:count_over_time_1h
       expr: |
-        sum by (name, namespace, _id, cluster) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[1h]))
-        and on (name, namespace, _id, cluster)
-        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
+        sum by (name, namespace, _id, cluster, subscription_id) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[1h]))
+        and on (name, namespace, _id, cluster, subscription_id)
+        count by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available)
     - record: hostedClusterAPI_kubeapiserver_available:count_over_time_2h
       expr: |
-        sum by (name, namespace, _id, cluster) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[2h]))
-        and on (name, namespace, _id, cluster)
-        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
+        sum by (name, namespace, _id, cluster, subscription_id) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[2h]))
+        and on (name, namespace, _id, cluster, subscription_id)
+        count by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available)
     - record: hostedClusterAPI_kubeapiserver_available:count_over_time_6h
       expr: |
-        sum by (name, namespace, _id, cluster) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[6h]))
-        and on (name, namespace, _id, cluster)
-        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
+        sum by (name, namespace, _id, cluster, subscription_id) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[6h]))
+        and on (name, namespace, _id, cluster, subscription_id)
+        count by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available)
     # Long-window count_over_time for sample-count guards
     - record: hostedClusterAPI_kubeapiserver_available:count_over_time_1d
       expr: |
-        sum by (name, namespace, _id, cluster) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[1d]))
-        and on (name, namespace, _id, cluster)
-        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
+        sum by (name, namespace, _id, cluster, subscription_id) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[1d]))
+        and on (name, namespace, _id, cluster, subscription_id)
+        count by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available)
     - record: hostedClusterAPI_kubeapiserver_available:count_over_time_3d
       expr: |
-        sum by (name, namespace, _id, cluster) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[3d]))
-        and on (name, namespace, _id, cluster)
-        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
+        sum by (name, namespace, _id, cluster, subscription_id) (count_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[3d]))
+        and on (name, namespace, _id, cluster, subscription_id)
+        count by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available)
     # SLI rules using 15m offset blackout to exclude newly-provisioned clusters.
     # The offset blackout ensures a cluster existed at least 15 minutes ago before
     # contributing to SLI calculations, preventing provisioning noise from skewing
@@ -91,79 +91,79 @@ spec:
     # all samples (any status via max by) so downtime is counted as 0, not skipped.
     - record: hostedClusterAPI_kubeapiserver_available:sli_sum_15m
       expr: |
-        sum by (name, namespace, _id, cluster) (
+        sum by (name, namespace, _id, cluster, subscription_id) (
           sum_over_time(
             (
               hostedClusterAPI_kubeapiserver_available{status="True"}
-              and on (name, namespace, _id, cluster)
-              max by (name, namespace, _id, cluster) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0)
+              and on (name, namespace, _id, cluster, subscription_id)
+              max by (name, namespace, _id, cluster, subscription_id) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0)
             )[15m:1m]
           )
         )
-        and on (name, namespace, _id, cluster)
-        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
+        and on (name, namespace, _id, cluster, subscription_id)
+        count by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available)
     - record: hostedClusterAPI_kubeapiserver_available:sli_count_15m
       expr: |
-        sum by (name, namespace, _id, cluster) (
+        sum by (name, namespace, _id, cluster, subscription_id) (
           count_over_time(
             (
-              max by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
-              and on (name, namespace, _id, cluster)
-              max by (name, namespace, _id, cluster) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0)
+              max by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available)
+              and on (name, namespace, _id, cluster, subscription_id)
+              max by (name, namespace, _id, cluster, subscription_id) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0)
             )[15m:1m]
           )
         )
-        and on (name, namespace, _id, cluster)
-        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
+        and on (name, namespace, _id, cluster, subscription_id)
+        count by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available)
     - record: hostedClusterAPI_kubeapiserver_available:sli_sum_6h
       expr: |
-        sum by (name, namespace, _id, cluster) (
+        sum by (name, namespace, _id, cluster, subscription_id) (
           sum_over_time(
             (
               hostedClusterAPI_kubeapiserver_available{status="True"}
-              and on (name, namespace, _id, cluster)
-              max by (name, namespace, _id, cluster) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0)
+              and on (name, namespace, _id, cluster, subscription_id)
+              max by (name, namespace, _id, cluster, subscription_id) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0)
             )[6h:5m]
           )
         )
-        and on (name, namespace, _id, cluster)
-        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
+        and on (name, namespace, _id, cluster, subscription_id)
+        count by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available)
     - record: hostedClusterAPI_kubeapiserver_available:sli_count_6h
       expr: |
-        sum by (name, namespace, _id, cluster) (
+        sum by (name, namespace, _id, cluster, subscription_id) (
           count_over_time(
             (
-              max by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
-              and on (name, namespace, _id, cluster)
-              max by (name, namespace, _id, cluster) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0)
+              max by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available)
+              and on (name, namespace, _id, cluster, subscription_id)
+              max by (name, namespace, _id, cluster, subscription_id) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0)
             )[6h:5m]
           )
         )
-        and on (name, namespace, _id, cluster)
-        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
+        and on (name, namespace, _id, cluster, subscription_id)
+        count by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available)
     - record: hostedClusterAPI_kubeapiserver_available:sli_sum_3d
       expr: |
-        sum by (name, namespace, _id, cluster) (
+        sum by (name, namespace, _id, cluster, subscription_id) (
           sum_over_time(
             (
               hostedClusterAPI_kubeapiserver_available{status="True"}
-              and on (name, namespace, _id, cluster)
-              max by (name, namespace, _id, cluster) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0)
+              and on (name, namespace, _id, cluster, subscription_id)
+              max by (name, namespace, _id, cluster, subscription_id) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0)
             )[3d:30m]
           )
         )
-        and on (name, namespace, _id, cluster)
-        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
+        and on (name, namespace, _id, cluster, subscription_id)
+        count by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available)
     - record: hostedClusterAPI_kubeapiserver_available:sli_count_3d
       expr: |
-        sum by (name, namespace, _id, cluster) (
+        sum by (name, namespace, _id, cluster, subscription_id) (
           count_over_time(
             (
-              max by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
-              and on (name, namespace, _id, cluster)
-              max by (name, namespace, _id, cluster) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0)
+              max by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available)
+              and on (name, namespace, _id, cluster, subscription_id)
+              max by (name, namespace, _id, cluster, subscription_id) ((hostedClusterAPI_kubeapiserver_available offset 15m) >= 0)
             )[3d:30m]
           )
         )
-        and on (name, namespace, _id, cluster)
-        count by (name, namespace, _id, cluster) (hostedClusterAPI_kubeapiserver_available)
+        and on (name, namespace, _id, cluster, subscription_id)
+        count by (name, namespace, _id, cluster, subscription_id) (hostedClusterAPI_kubeapiserver_available)

--- a/observability/alerts/HCPkasRecord-prometheusRule-KSM_test.yaml
+++ b/observability/alerts/HCPkasRecord-prometheusRule-KSM_test.yaml
@@ -5,7 +5,7 @@ tests:
 # Test 1: 100% Availability (Perfect Success)
 - interval: 1m
   input_series:
-  - series: 'hostedClusterAPI_kubeapiserver_available{status="True", name="test-cluster-1", namespace="clusters", _id="abc-123", cluster="mgmt-cluster"}'
+  - series: 'hostedClusterAPI_kubeapiserver_available{status="True", name="test-cluster-1", namespace="clusters", _id="abc-123", cluster="mgmt-cluster", subscription_id="sub-001"}'
     # Generate 10 data points with a value of 1, over 10 minutes.
     values: "1+0x9"
   promql_expr_test:
@@ -13,91 +13,91 @@ tests:
   - expr: hostedClusterAPI_kubeapiserver_available:ratio_avg_30d{name="test-cluster-1", namespace="clusters"}
     eval_time: 10m
     exp_samples:
-    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_30d", name="test-cluster-1", namespace="clusters", _id="abc-123", cluster="mgmt-cluster"}'
+    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_30d", name="test-cluster-1", namespace="clusters", _id="abc-123", cluster="mgmt-cluster", subscription_id="sub-001"}'
       value: 1
   # Test the 7d rule
   - expr: hostedClusterAPI_kubeapiserver_available:ratio_avg_7d{name="test-cluster-1", namespace="clusters"}
     eval_time: 10m
     exp_samples:
-    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_7d", name="test-cluster-1", namespace="clusters", _id="abc-123", cluster="mgmt-cluster"}'
+    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_7d", name="test-cluster-1", namespace="clusters", _id="abc-123", cluster="mgmt-cluster", subscription_id="sub-001"}'
       value: 1
   # Test the 1d rule
   - expr: hostedClusterAPI_kubeapiserver_available:ratio_avg_1d{name="test-cluster-1", namespace="clusters"}
     eval_time: 10m
     exp_samples:
-    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_1d", name="test-cluster-1", namespace="clusters", _id="abc-123", cluster="mgmt-cluster"}'
+    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_1d", name="test-cluster-1", namespace="clusters", _id="abc-123", cluster="mgmt-cluster", subscription_id="sub-001"}'
       value: 1
   # Test the 3d rule
   - expr: hostedClusterAPI_kubeapiserver_available:ratio_avg_3d{name="test-cluster-1", namespace="clusters"}
     eval_time: 10m
     exp_samples:
-    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_3d", name="test-cluster-1", namespace="clusters", _id="abc-123", cluster="mgmt-cluster"}'
+    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_3d", name="test-cluster-1", namespace="clusters", _id="abc-123", cluster="mgmt-cluster", subscription_id="sub-001"}'
       value: 1
 # Test 2: 50% Availability (Intermittent Failures)
 - interval: 1m
   input_series:
-  - series: 'hostedClusterAPI_kubeapiserver_available{status="True", name="test-cluster-2", namespace="clusters", _id="def-456", cluster="mgmt-cluster"}'
+  - series: 'hostedClusterAPI_kubeapiserver_available{status="True", name="test-cluster-2", namespace="clusters", _id="def-456", cluster="mgmt-cluster", subscription_id="sub-001"}'
     values: "1 0 1 0 1 0 1 0 1 0"
   promql_expr_test:
   # Test the 30d rule
   - expr: hostedClusterAPI_kubeapiserver_available:ratio_avg_30d{name="test-cluster-2", namespace="clusters"}
     eval_time: 10m
     exp_samples:
-    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_30d", name="test-cluster-2", namespace="clusters", _id="def-456", cluster="mgmt-cluster"}'
+    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_30d", name="test-cluster-2", namespace="clusters", _id="def-456", cluster="mgmt-cluster", subscription_id="sub-001"}'
       value: 0.5
   # Test the 7d rule
   - expr: hostedClusterAPI_kubeapiserver_available:ratio_avg_7d{name="test-cluster-2", namespace="clusters"}
     eval_time: 10m
     exp_samples:
-    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_7d", name="test-cluster-2", namespace="clusters", _id="def-456", cluster="mgmt-cluster"}'
+    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_7d", name="test-cluster-2", namespace="clusters", _id="def-456", cluster="mgmt-cluster", subscription_id="sub-001"}'
       value: 0.5
   # Test the 1d rule
   - expr: hostedClusterAPI_kubeapiserver_available:ratio_avg_1d{name="test-cluster-2", namespace="clusters"}
     eval_time: 10m
     exp_samples:
-    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_1d", name="test-cluster-2", namespace="clusters", _id="def-456", cluster="mgmt-cluster"}'
+    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_1d", name="test-cluster-2", namespace="clusters", _id="def-456", cluster="mgmt-cluster", subscription_id="sub-001"}'
       value: 0.5
   # Test the 3d rule
   - expr: hostedClusterAPI_kubeapiserver_available:ratio_avg_3d{name="test-cluster-2", namespace="clusters"}
     eval_time: 10m
     exp_samples:
-    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_3d", name="test-cluster-2", namespace="clusters", _id="def-456", cluster="mgmt-cluster"}'
+    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_3d", name="test-cluster-2", namespace="clusters", _id="def-456", cluster="mgmt-cluster", subscription_id="sub-001"}'
       value: 0.5
 # Test 3: 0% Availability (Complete Failure)
 - interval: 1m
   input_series:
-  - series: 'hostedClusterAPI_kubeapiserver_available{status="True", name="test-cluster-3", namespace="clusters", _id="ghi-789", cluster="mgmt-cluster"}'
+  - series: 'hostedClusterAPI_kubeapiserver_available{status="True", name="test-cluster-3", namespace="clusters", _id="ghi-789", cluster="mgmt-cluster", subscription_id="sub-001"}'
     values: "0+0x9"
   promql_expr_test:
   # Test the 30d rule
   - expr: hostedClusterAPI_kubeapiserver_available:ratio_avg_30d{name="test-cluster-3", namespace="clusters"}
     eval_time: 10m
     exp_samples:
-    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_30d", name="test-cluster-3", namespace="clusters", _id="ghi-789", cluster="mgmt-cluster"}'
+    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_30d", name="test-cluster-3", namespace="clusters", _id="ghi-789", cluster="mgmt-cluster", subscription_id="sub-001"}'
       value: 0
   # Test the 7d rule
   - expr: hostedClusterAPI_kubeapiserver_available:ratio_avg_7d{name="test-cluster-3", namespace="clusters"}
     eval_time: 10m
     exp_samples:
-    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_7d", name="test-cluster-3", namespace="clusters", _id="ghi-789", cluster="mgmt-cluster"}'
+    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_7d", name="test-cluster-3", namespace="clusters", _id="ghi-789", cluster="mgmt-cluster", subscription_id="sub-001"}'
       value: 0
   # Test the 1d rule
   - expr: hostedClusterAPI_kubeapiserver_available:ratio_avg_1d{name="test-cluster-3", namespace="clusters"}
     eval_time: 10m
     exp_samples:
-    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_1d", name="test-cluster-3", namespace="clusters", _id="ghi-789", cluster="mgmt-cluster"}'
+    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_1d", name="test-cluster-3", namespace="clusters", _id="ghi-789", cluster="mgmt-cluster", subscription_id="sub-001"}'
       value: 0
   # Test the 3d rule
   - expr: hostedClusterAPI_kubeapiserver_available:ratio_avg_3d{name="test-cluster-3", namespace="clusters"}
     eval_time: 10m
     exp_samples:
-    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_3d", name="test-cluster-3", namespace="clusters", _id="ghi-789", cluster="mgmt-cluster"}'
+    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:ratio_avg_3d", name="test-cluster-3", namespace="clusters", _id="ghi-789", cluster="mgmt-cluster", subscription_id="sub-001"}'
       value: 0
 # Test 4: Burn-rate recording rules (sum_over_time and count_over_time)
 - interval: 1m
   name: "Test 4: Burn-rate recording rules - all successes"
   input_series:
-  - series: 'hostedClusterAPI_kubeapiserver_available{status="True", name="test-cluster-4", namespace="clusters", _id="xyz-789", cluster="mgmt-cluster"}'
+  - series: 'hostedClusterAPI_kubeapiserver_available{status="True", name="test-cluster-4", namespace="clusters", _id="xyz-789", cluster="mgmt-cluster", subscription_id="sub-001"}'
     # Perfect availability for 2+ hours
     values: "1+0x150"
   promql_expr_test:
@@ -105,25 +105,25 @@ tests:
   - expr: hostedClusterAPI_kubeapiserver_available:sum_over_time_30m{name="test-cluster-4"}
     eval_time: 90m
     exp_samples:
-    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:sum_over_time_30m", name="test-cluster-4", namespace="clusters", _id="xyz-789", cluster="mgmt-cluster"}'
+    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:sum_over_time_30m", name="test-cluster-4", namespace="clusters", _id="xyz-789", cluster="mgmt-cluster", subscription_id="sub-001"}'
       value: 30
   # Test count_over_time_30m
   - expr: hostedClusterAPI_kubeapiserver_available:count_over_time_30m{name="test-cluster-4"}
     eval_time: 90m
     exp_samples:
-    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:count_over_time_30m", name="test-cluster-4", namespace="clusters", _id="xyz-789", cluster="mgmt-cluster"}'
+    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:count_over_time_30m", name="test-cluster-4", namespace="clusters", _id="xyz-789", cluster="mgmt-cluster", subscription_id="sub-001"}'
       value: 30
   # Test sum_over_time_1h (1h window is left-open: (30m, 90m] = 60 samples)
   - expr: hostedClusterAPI_kubeapiserver_available:sum_over_time_1h{name="test-cluster-4"}
     eval_time: 90m
     exp_samples:
-    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:sum_over_time_1h", name="test-cluster-4", namespace="clusters", _id="xyz-789", cluster="mgmt-cluster"}'
+    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:sum_over_time_1h", name="test-cluster-4", namespace="clusters", _id="xyz-789", cluster="mgmt-cluster", subscription_id="sub-001"}'
       value: 60
   # Test count_over_time_1h
   - expr: hostedClusterAPI_kubeapiserver_available:count_over_time_1h{name="test-cluster-4"}
     eval_time: 90m
     exp_samples:
-    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:count_over_time_1h", name="test-cluster-4", namespace="clusters", _id="xyz-789", cluster="mgmt-cluster"}'
+    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:count_over_time_1h", name="test-cluster-4", namespace="clusters", _id="xyz-789", cluster="mgmt-cluster", subscription_id="sub-001"}'
       value: 60
 # Test 5: SLI recording rules - perfect availability
 # The sli_* rules use a 15m offset blackout gate and [15m:1m] subquery.
@@ -132,18 +132,18 @@ tests:
 - interval: 1m
   name: "Test 5: SLI recording rules - perfect availability"
   input_series:
-  - series: 'hostedClusterAPI_kubeapiserver_available{status="True", name="test-cluster-5", namespace="clusters", _id="sli-100", cluster="mgmt-cluster"}'
+  - series: 'hostedClusterAPI_kubeapiserver_available{status="True", name="test-cluster-5", namespace="clusters", _id="sli-100", cluster="mgmt-cluster", subscription_id="sub-001"}'
     values: "1+0x60"
   promql_expr_test:
   - expr: hostedClusterAPI_kubeapiserver_available:sli_sum_15m{name="test-cluster-5"}
     eval_time: 35m
     exp_samples:
-    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:sli_sum_15m", name="test-cluster-5", namespace="clusters", _id="sli-100", cluster="mgmt-cluster"}'
+    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:sli_sum_15m", name="test-cluster-5", namespace="clusters", _id="sli-100", cluster="mgmt-cluster", subscription_id="sub-001"}'
       value: 15
   - expr: hostedClusterAPI_kubeapiserver_available:sli_count_15m{name="test-cluster-5"}
     eval_time: 35m
     exp_samples:
-    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:sli_count_15m", name="test-cluster-5", namespace="clusters", _id="sli-100", cluster="mgmt-cluster"}'
+    - labels: '{__name__="hostedClusterAPI_kubeapiserver_available:sli_count_15m", name="test-cluster-5", namespace="clusters", _id="sli-100", cluster="mgmt-cluster", subscription_id="sub-001"}'
       value: 15
 # Test 6: SLI offset blackout - newly provisioned cluster excluded
 # A cluster with only 10m of data should produce no SLI values because
@@ -151,7 +151,7 @@ tests:
 - interval: 1m
   name: "Test 6: SLI offset blackout - new cluster excluded"
   input_series:
-  - series: 'hostedClusterAPI_kubeapiserver_available{status="True", name="test-cluster-6", namespace="clusters", _id="sli-new", cluster="mgmt-cluster"}'
+  - series: 'hostedClusterAPI_kubeapiserver_available{status="True", name="test-cluster-6", namespace="clusters", _id="sli-new", cluster="mgmt-cluster", subscription_id="sub-001"}'
     values: "1+0x10"
   promql_expr_test:
   - expr: hostedClusterAPI_kubeapiserver_available:sli_sum_15m{name="test-cluster-6"}

--- a/tooling/prometheus-rules/README.md
+++ b/tooling/prometheus-rules/README.md
@@ -14,6 +14,7 @@ This tool converts Kubernetes PrometheusRule custom resources (used by the Prome
 - Maps Prometheus severity labels to IcM (Incident Management) severity levels
 - Automatically generates IcM correlation IDs for proper incident aggregation
 - Supports expression replacements for platform-specific adjustments
+- Supports lane-level internal subscription filtering for alert expressions
 
 ## Recent Change
 
@@ -83,6 +84,13 @@ prometheusRules:
   outputReplacements:
     - from: 'original_expression'
       to: 'replaced_expression'
+
+internalSubscriptionFilter:
+  enabled: true
+  lookupTables:
+    - matchLabels: [_id, cluster]
+      table: internal_subscription:hostedcluster:info
+  excludeAlerts: []
 ```
 
 ## Rule Testing

--- a/tooling/prometheus-rules/internal/generator.go
+++ b/tooling/prometheus-rules/internal/generator.go
@@ -60,10 +60,23 @@ type GroupAlerts struct {
 	Alerts    []string `json:"alerts"`
 }
 
+type InternalSubscriptionLookupTable struct {
+	MatchLabels []string `json:"matchLabels,omitempty"`
+	Table       string   `json:"table"`
+}
+
+type InternalSubscriptionFilter struct {
+	Enabled       bool                              `json:"enabled,omitempty"`
+	LookupTables  []InternalSubscriptionLookupTable `json:"lookupTables,omitempty"`
+	ExcludeAlerts []string                          `json:"excludeAlerts,omitempty"`
+}
+
 type Options struct {
 	promtoolPath            string
 	outputBicep             string
 	includedAlerts          map[string][]string
+	internalSubFilter       InternalSubscriptionFilter
+	excludedFilterAlerts    set.Set[string]
 	labelsToExtract         []string
 	ruleFiles               []alertingRuleFile
 	outputReplacements      []Replacements
@@ -85,7 +98,8 @@ type PrometheusRulesConfig struct {
 }
 
 type CliConfig struct {
-	PrometheusRules PrometheusRulesConfig `json:"prometheusRules"`
+	PrometheusRules            PrometheusRulesConfig      `json:"prometheusRules"`
+	InternalSubscriptionFilter InternalSubscriptionFilter `json:"internalSubscriptionFilter,omitempty"`
 }
 
 func NewOptions() *Options {
@@ -156,6 +170,26 @@ func (o *Options) Complete(configFilePath string, promtoolPath string) error {
 	o.outputBicep = path.Join(baseDirectory, config.PrometheusRules.OutputBicep)
 	o.groupNamePrefix = config.PrometheusRules.GroupNamePrefix
 	o.labelsToExtract = append([]string{}, config.PrometheusRules.LabelsToExtract...)
+	o.internalSubFilter = config.InternalSubscriptionFilter
+	o.excludedFilterAlerts = set.New[string](config.InternalSubscriptionFilter.ExcludeAlerts...)
+
+	for i, lookupTable := range o.internalSubFilter.LookupTables {
+		if len(lookupTable.MatchLabels) == 0 || lookupTable.Table == "" {
+			return fmt.Errorf("internalSubscriptionFilter lookup tables must have both matchLabels and table fields configured")
+		}
+		for j, label := range lookupTable.MatchLabels {
+			trimmed := strings.TrimSpace(label)
+			if trimmed == "" || strings.ContainsAny(trimmed, " \t{}()=~!,") {
+				return fmt.Errorf("internalSubscriptionFilter lookupTable[%d].matchLabels[%d] %q is not a valid PromQL label name", i, j, label)
+			}
+			o.internalSubFilter.LookupTables[i].MatchLabels[j] = trimmed
+		}
+		trimmedTable := strings.TrimSpace(lookupTable.Table)
+		if strings.ContainsAny(trimmedTable, " \t{}()=~!,") {
+			return fmt.Errorf("internalSubscriptionFilter lookupTable[%d].table %q is not a valid metric name", i, lookupTable.Table)
+		}
+		o.internalSubFilter.LookupTables[i].Table = trimmedTable
+	}
 
 	// Convert includedAlertsByGroup to a map
 	o.includedAlerts = make(map[string][]string)
@@ -356,6 +390,24 @@ func (o *Options) labelsFromTextInConfiguredOrder(text string) []string {
 	return orderedLabels
 }
 
+func (o *Options) appendInternalSubscriptionFilters(alertName, expression string, logger *logrus.Entry) string {
+	if !o.internalSubFilter.Enabled || o.excludedFilterAlerts.Has(alertName) {
+		return expression
+	}
+
+	if len(o.internalSubFilter.LookupTables) == 0 {
+		logger.WithField("alert", alertName).Warn("internal subscription filter enabled but no lookup tables are configured")
+		return expression
+	}
+
+	filteredExpression := expression
+	for _, lookupTable := range o.internalSubFilter.LookupTables {
+		filteredExpression = fmt.Sprintf("(%s) unless on(%s) %s", filteredExpression, strings.Join(lookupTable.MatchLabels, ", "), lookupTable.Table)
+	}
+
+	return filteredExpression
+}
+
 func (o *Options) Generate() error {
 	output, err := os.Create(o.outputBicep)
 	if err != nil {
@@ -390,8 +442,7 @@ param location string = resourceGroup().location
 			return err
 		}
 	} else {
-		if _, err := output.Write([]byte(`
-param azureMonitoring string
+		if _, err := output.Write([]byte(`param azureMonitoring string
 
 param location string = resourceGroup().location
 `)); err != nil {
@@ -510,18 +561,19 @@ param location string = resourceGroup().location
 
 				// Filter rules based on the output file type
 				if rule.Alert != "" && isAlertingRulesFile {
+					expression := strings.TrimSpace(
+						whitespaceMatcher.ReplaceAllString(rule.Expr.String(), " "),
+					)
+					expression = o.appendInternalSubscriptionFilters(rule.Alert, expression, logger)
+
 					armGroup.Properties.Rules = append(armGroup.Properties.Rules, &armprometheusrulegroups.PrometheusRule{
 						Alert:       ptr.To(rule.Alert),
 						Enabled:     ptr.To(true),
 						Labels:      labels,
 						Annotations: annotations,
 						For:         parseToAzureDurationString(rule.For),
-						Expression: ptr.To(
-							strings.TrimSpace(
-								whitespaceMatcher.ReplaceAllString(rule.Expr.String(), " "),
-							),
-						),
-						Severity: severityFor(labels),
+						Expression:  ptr.To(expression),
+						Severity:    severityFor(labels),
 					})
 				} else if rule.Record != "" && isRecordingRulesFile {
 					armGroup.Properties.Rules = append(armGroup.Properties.Rules, &armprometheusrulegroups.PrometheusRule{

--- a/tooling/prometheus-rules/internal/generator_test.go
+++ b/tooling/prometheus-rules/internal/generator_test.go
@@ -27,6 +27,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
+	"k8s.io/utils/set"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/prometheusrulegroups/armprometheusrulegroups"
 )
@@ -256,6 +257,45 @@ spec:
 			configFile:  `invalid: yaml: content:`,
 			expectError: true,
 			errorMsg:    "error unmarshaling configFile",
+		},
+		{
+			name: "config with internal subscription filter",
+			configFile: `
+prometheusRules:
+  untestedRules:
+  - untested.yaml
+  outputBicep: generated.bicep
+internalSubscriptionFilter:
+  enabled: true
+  lookupTables:
+  - matchLabels: [_id, cluster]
+    table: internal_subscription:hostedcluster:info
+  excludeAlerts:
+  - IgnoredAlert
+`,
+			setupFiles: func(tmpDir string) error {
+				ruleContent := `
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: test-rules
+spec:
+  groups:
+  - name: test.rules
+    rules:
+    - alert: IncludedAlert
+      expr: up == 0
+`
+				return os.WriteFile(filepath.Join(tmpDir, "untested.yaml"), []byte(ruleContent), 0644)
+			},
+			expectError: false,
+			validateFunc: func(t *testing.T, opts *Options) {
+				require.True(t, opts.internalSubFilter.Enabled)
+				require.Len(t, opts.internalSubFilter.LookupTables, 1)
+				require.Equal(t, []string{"_id", "cluster"}, opts.internalSubFilter.LookupTables[0].MatchLabels)
+				require.Equal(t, "internal_subscription:hostedcluster:info", opts.internalSubFilter.LookupTables[0].Table)
+				require.True(t, opts.excludedFilterAlerts.Has("IgnoredAlert"))
+			},
 		},
 		{
 			name: "config with labelsToExtract",
@@ -591,6 +631,152 @@ func TestOptionsGenerate(t *testing.T) {
 		generated := string(content)
 		assert.Contains(t, generated, "alert: 'AllowedAlert'")
 		assert.NotContains(t, generated, "alert: 'BlockedAlert'")
+	})
+
+	t.Run("appends internal subscription filter when enabled", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		outputFile := filepath.Join(tmpDir, "generatedAlertingRules.bicep")
+
+		opts := &Options{
+			outputBicep: outputFile,
+			internalSubFilter: InternalSubscriptionFilter{
+				Enabled: true,
+				LookupTables: []InternalSubscriptionLookupTable{
+					{
+						MatchLabels: []string{"_id", "cluster"},
+						Table:       "internal_subscription:hostedcluster:info",
+					},
+				},
+			},
+			excludedFilterAlerts: set.New[string](),
+			ruleFiles: []alertingRuleFile{
+				{
+					Rules: monitoringv1.PrometheusRule{
+						Spec: monitoringv1.PrometheusRuleSpec{
+							Groups: []monitoringv1.RuleGroup{
+								{
+									Name: "test-group",
+									Rules: []monitoringv1.Rule{
+										{
+											Alert: "FilteredAlert",
+											Expr:  intstr.FromString("up == 0"),
+											Labels: map[string]string{
+												"severity": "critical",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := opts.Generate()
+		require.NoError(t, err)
+
+		content, err := os.ReadFile(outputFile)
+		require.NoError(t, err)
+		assert.Contains(t, string(content), "expression: '(up == 0) unless on(_id, cluster) internal_subscription:hostedcluster:info'")
+	})
+
+	t.Run("does not append internal subscription filter for excluded alerts", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		outputFile := filepath.Join(tmpDir, "generatedAlertingRules.bicep")
+
+		opts := &Options{
+			outputBicep: outputFile,
+			internalSubFilter: InternalSubscriptionFilter{
+				Enabled: true,
+				LookupTables: []InternalSubscriptionLookupTable{
+					{
+						MatchLabels: []string{"_id", "cluster"},
+						Table:       "internal_subscription:hostedcluster:info",
+					},
+				},
+			},
+			excludedFilterAlerts: set.New[string]("ExcludedAlert"),
+			ruleFiles: []alertingRuleFile{
+				{
+					Rules: monitoringv1.PrometheusRule{
+						Spec: monitoringv1.PrometheusRuleSpec{
+							Groups: []monitoringv1.RuleGroup{
+								{
+									Name: "test-group",
+									Rules: []monitoringv1.Rule{
+										{
+											Alert: "ExcludedAlert",
+											Expr:  intstr.FromString("up == 0"),
+											Labels: map[string]string{
+												"severity": "critical",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := opts.Generate()
+		require.NoError(t, err)
+
+		content, err := os.ReadFile(outputFile)
+		require.NoError(t, err)
+		assert.Contains(t, string(content), "expression: 'up == 0'")
+		assert.NotContains(t, string(content), "internal_subscription:hostedcluster:info")
+	})
+
+	t.Run("does not append internal subscription filter when disabled", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		outputFile := filepath.Join(tmpDir, "generatedAlertingRules.bicep")
+
+		opts := &Options{
+			outputBicep: outputFile,
+			internalSubFilter: InternalSubscriptionFilter{
+				Enabled: false,
+				LookupTables: []InternalSubscriptionLookupTable{
+					{
+						MatchLabels: []string{"_id", "cluster"},
+						Table:       "internal_subscription:hostedcluster:info",
+					},
+				},
+			},
+			excludedFilterAlerts: set.New[string](),
+			ruleFiles: []alertingRuleFile{
+				{
+					Rules: monitoringv1.PrometheusRule{
+						Spec: monitoringv1.PrometheusRuleSpec{
+							Groups: []monitoringv1.RuleGroup{
+								{
+									Name: "test-group",
+									Rules: []monitoringv1.Rule{
+										{
+											Alert: "UnfilteredAlert",
+											Expr:  intstr.FromString("up == 0"),
+											Labels: map[string]string{
+												"severity": "critical",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := opts.Generate()
+		require.NoError(t, err)
+
+		content, err := os.ReadFile(outputFile)
+		require.NoError(t, err)
+		assert.Contains(t, string(content), "expression: 'up == 0'")
+		assert.NotContains(t, string(content), "internal_subscription:hostedcluster:info")
 	})
 
 	t.Run("preserves per-alert correlationId override", func(t *testing.T) {


### PR DESCRIPTION
## Why
The RP lane is the customer-facing IcM queue. As alert coverage grows, it must not page on failures from Microsoft-internal subscriptions (BAMI billing tests, e2e CI, dev/test subs). This dilutes signal and trains responders to ignore the queue.

## What
Adds a generator-time mechanism that appends `unless on(_id, cluster) internal_subscription:hostedcluster:info` to all RP-lane alert expressions. The recording rule lives in sdp-pipelines (private; subscription IDs never in public repo).

### Changes:
1. **Recording-rule key retention** (`HCPkasRecord-prometheusRule-KSM.yaml`): Add `subscription_id` to aggregation keys
2. **Generator extension** (`generator.go`): `InternalSubscriptionFilter` config + auto-injection of `unless` clauses
3. **RP lane config** (`alerts-rp-services.yaml`): Enable filter
4. **Tests** (`generator_test.go`): Verify injection, exclusion, and disabled state
5. **Regenerated Bicep**: RP alerting rules include `unless` clause; HCP recording rules include `subscription_id`

### Safety:
- `unless` against non-existent recording rule = no-op (empty set excludes nothing). Safe to merge before sdp-pipelines deploys the rule.
- Existing PVC `unless` exclusion pattern is the precedent.
- No subscription IDs anywhere in this PR.

### Rollout:
1. This PR merges (no-op until recording rule exists)
2. Separate sdp-pipelines PR deploys the recording rule with internal sub regex
3. Filter activates automatically

Jira: [ARO-27686](https://redhat.atlassian.net/browse/ARO-27686)