### PR TITLE
observability: multi-line klog support

### DIFF
--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arobit.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arobit.yaml
@@ -56,6 +56,21 @@ data:
         Time_Format %Y-%m-%dT%H:%M:%S.%L
         Time_Keep   On
 
+    [MULTILINE_PARSER]
+        name          klog
+        type          regex
+        flush_timeout 1000
+        # A klog line starts with [IWEF] followed by 4 digits (mmdd) and a space
+        rule          "start_state"  "/^[IWEF]\d{4} /"               "cont"
+        # A JSON log line starts with { — treat as its own entry
+        rule          "start_state"  "/^\{/"                          "cont"
+        # A structured log line starts with an ISO 8601 timestamp
+        rule          "start_state"  "/^\d{4}-\d{2}-\d{2}T\d{2}:/"   "cont"
+        # Anything else is a continuation of the previous multiline entry
+        rule          "cont"         "/^[^IWEF{\d]/"                  "cont"
+        rule          "cont"         "/^[IWEF][^0-9]/"                "cont"
+        rule          "cont"         "/^\d(?!\d{3}-\d{2}-\d{2}T\d{2}:)/"  "cont"
+
   input.conf: |
     [INPUT]
         Name              tail
@@ -111,6 +126,13 @@ data:
         Threaded          On
         storage.type      filesystem
   filter.conf: |
+    [FILTER]
+        Name                  multiline
+        Alias                 filter.multiline_klog
+        Match                 kubernetes.*
+        multiline.parser      klog
+        multiline.key_content log
+
     [FILTER]
         Name modify
         Match systemd.*
@@ -477,7 +499,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: cd5122a269e290d68855c8e985850f6285837621ffb5d7a77cc7186239589491
+        checksum/configmap: faf9063ea68eec91acfd9c546d5a570271f5b76b7e9c0b0560cb8aab2c26891c
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_arobit.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_arobit.yaml
@@ -56,6 +56,21 @@ data:
         Time_Format %Y-%m-%dT%H:%M:%S.%L
         Time_Keep   On
 
+    [MULTILINE_PARSER]
+        name          klog
+        type          regex
+        flush_timeout 1000
+        # A klog line starts with [IWEF] followed by 4 digits (mmdd) and a space
+        rule          "start_state"  "/^[IWEF]\d{4} /"               "cont"
+        # A JSON log line starts with { — treat as its own entry
+        rule          "start_state"  "/^\{/"                          "cont"
+        # A structured log line starts with an ISO 8601 timestamp
+        rule          "start_state"  "/^\d{4}-\d{2}-\d{2}T\d{2}:/"   "cont"
+        # Anything else is a continuation of the previous multiline entry
+        rule          "cont"         "/^[^IWEF{\d]/"                  "cont"
+        rule          "cont"         "/^[IWEF][^0-9]/"                "cont"
+        rule          "cont"         "/^\d(?!\d{3}-\d{2}-\d{2}T\d{2}:)/"  "cont"
+
   input.conf: |
     [INPUT]
         Name              tail
@@ -111,6 +126,13 @@ data:
         Threaded          On
         storage.type      filesystem
   filter.conf: |
+    [FILTER]
+        Name                  multiline
+        Alias                 filter.multiline_klog
+        Match                 kubernetes.*
+        multiline.parser      klog
+        multiline.key_content log
+
     [FILTER]
         Name modify
         Match systemd.*
@@ -453,7 +475,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 0858c9949924c8fd83d44c44a2c7802e75a42e106f92cdfe1f7e7064e0fc557f
+        checksum/configmap: 9330c83bf7894aa7297fbbeb5ebedda74252ac22a15de3b2c7465468cd7d5714
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/observability/arobit/deploy/templates/forwarder-configmap.yaml
+++ b/observability/arobit/deploy/templates/forwarder-configmap.yaml
@@ -62,6 +62,21 @@ data:
         Time_Format %Y-%m-%dT%H:%M:%S.%L
         Time_Keep   On
 
+    [MULTILINE_PARSER]
+        name          klog
+        type          regex
+        flush_timeout 1000
+        # A klog line starts with [IWEF] followed by 4 digits (mmdd) and a space
+        rule          "start_state"  "/^[IWEF]\d{4} /"               "cont"
+        # A JSON log line starts with { — treat as its own entry
+        rule          "start_state"  "/^\{/"                          "cont"
+        # A structured log line starts with an ISO 8601 timestamp
+        rule          "start_state"  "/^\d{4}-\d{2}-\d{2}T\d{2}:/"   "cont"
+        # Anything else is a continuation of the previous multiline entry
+        rule          "cont"         "/^[^IWEF{\d]/"                  "cont"
+        rule          "cont"         "/^[IWEF][^0-9]/"                "cont"
+        rule          "cont"         "/^\d(?!\d{3}-\d{2}-\d{2}T\d{2}:)/"  "cont"
+
   input.conf: |
     [INPUT]
         Name              tail
@@ -117,6 +132,13 @@ data:
         Threaded          On
         storage.type      filesystem
   filter.conf: |
+    [FILTER]
+        Name                  multiline
+        Alias                 filter.multiline_klog
+        Match                 kubernetes.*
+        multiline.parser      klog
+        multiline.key_content log
+
     [FILTER]
         Name modify
         Match systemd.*

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_buffering_disabled_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_buffering_disabled_svc.yaml
@@ -56,6 +56,21 @@ data:
         Time_Format %Y-%m-%dT%H:%M:%S.%L
         Time_Keep   On
 
+    [MULTILINE_PARSER]
+        name          klog
+        type          regex
+        flush_timeout 1000
+        # A klog line starts with [IWEF] followed by 4 digits (mmdd) and a space
+        rule          "start_state"  "/^[IWEF]\d{4} /"               "cont"
+        # A JSON log line starts with { — treat as its own entry
+        rule          "start_state"  "/^\{/"                          "cont"
+        # A structured log line starts with an ISO 8601 timestamp
+        rule          "start_state"  "/^\d{4}-\d{2}-\d{2}T\d{2}:/"   "cont"
+        # Anything else is a continuation of the previous multiline entry
+        rule          "cont"         "/^[^IWEF{\d]/"                  "cont"
+        rule          "cont"         "/^[IWEF][^0-9]/"                "cont"
+        rule          "cont"         "/^\d(?!\d{3}-\d{2}-\d{2}T\d{2}:)/"  "cont"
+
   input.conf: |
     [INPUT]
         Name              tail
@@ -111,6 +126,13 @@ data:
         Threaded          On
         storage.type      filesystem
   filter.conf: |
+    [FILTER]
+        Name                  multiline
+        Alias                 filter.multiline_klog
+        Match                 kubernetes.*
+        multiline.parser      klog
+        multiline.key_content log
+
     [FILTER]
         Name modify
         Match systemd.*
@@ -382,7 +404,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 5b891460ab85da3ee7c86ce445403f9619fb0c8749673c1764d18d65003c26e6
+        checksum/configmap: 2843b3a2383e2310df023cedc168e97340477c20aabe2ca5e7913a9a9f248ea9
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_disabled_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_disabled_svc.yaml
@@ -55,6 +55,21 @@ data:
         Time_Format %Y-%m-%dT%H:%M:%S.%L
         Time_Keep   On
 
+    [MULTILINE_PARSER]
+        name          klog
+        type          regex
+        flush_timeout 1000
+        # A klog line starts with [IWEF] followed by 4 digits (mmdd) and a space
+        rule          "start_state"  "/^[IWEF]\d{4} /"               "cont"
+        # A JSON log line starts with { — treat as its own entry
+        rule          "start_state"  "/^\{/"                          "cont"
+        # A structured log line starts with an ISO 8601 timestamp
+        rule          "start_state"  "/^\d{4}-\d{2}-\d{2}T\d{2}:/"   "cont"
+        # Anything else is a continuation of the previous multiline entry
+        rule          "cont"         "/^[^IWEF{\d]/"                  "cont"
+        rule          "cont"         "/^[IWEF][^0-9]/"                "cont"
+        rule          "cont"         "/^\d(?!\d{3}-\d{2}-\d{2}T\d{2}:)/"  "cont"
+
   input.conf: |
     [INPUT]
         Name              tail
@@ -110,6 +125,13 @@ data:
         Threaded          On
         storage.type      filesystem
   filter.conf: |
+    [FILTER]
+        Name                  multiline
+        Alias                 filter.multiline_klog
+        Match                 kubernetes.*
+        multiline.parser      klog
+        multiline.key_content log
+
     [FILTER]
         Name modify
         Match systemd.*
@@ -452,7 +474,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 628a879b72e634b58a975868d7489abf9df991e7b65e4687c7ccad2d32d9d5df
+        checksum/configmap: 61983b89ba6ae411e8e038595cac82ee9899ff7676ac3f2ad1226838a61ad117
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_unlimited_memory_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_unlimited_memory_svc.yaml
@@ -56,6 +56,21 @@ data:
         Time_Format %Y-%m-%dT%H:%M:%S.%L
         Time_Keep   On
 
+    [MULTILINE_PARSER]
+        name          klog
+        type          regex
+        flush_timeout 1000
+        # A klog line starts with [IWEF] followed by 4 digits (mmdd) and a space
+        rule          "start_state"  "/^[IWEF]\d{4} /"               "cont"
+        # A JSON log line starts with { — treat as its own entry
+        rule          "start_state"  "/^\{/"                          "cont"
+        # A structured log line starts with an ISO 8601 timestamp
+        rule          "start_state"  "/^\d{4}-\d{2}-\d{2}T\d{2}:/"   "cont"
+        # Anything else is a continuation of the previous multiline entry
+        rule          "cont"         "/^[^IWEF{\d]/"                  "cont"
+        rule          "cont"         "/^[IWEF][^0-9]/"                "cont"
+        rule          "cont"         "/^\d(?!\d{3}-\d{2}-\d{2}T\d{2}:)/"  "cont"
+
   input.conf: |
     [INPUT]
         Name              tail
@@ -111,6 +126,13 @@ data:
         Threaded          On
         storage.type      filesystem
   filter.conf: |
+    [FILTER]
+        Name                  multiline
+        Alias                 filter.multiline_klog
+        Match                 kubernetes.*
+        multiline.parser      klog
+        multiline.key_content log
+
     [FILTER]
         Name modify
         Match systemd.*
@@ -453,7 +475,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 68128ea60942447faf7d7878e397a840733957d67bfa6792e3a6d802049212ec
+        checksum/configmap: ba7d5df25ab803bb668e6715d589726b054dd9f4388fc2ecf0805a0c09f6e6e1
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_mgmt.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_mgmt.yaml
@@ -58,6 +58,21 @@ data:
         Time_Format %Y-%m-%dT%H:%M:%S.%L
         Time_Keep   On
 
+    [MULTILINE_PARSER]
+        name          klog
+        type          regex
+        flush_timeout 1000
+        # A klog line starts with [IWEF] followed by 4 digits (mmdd) and a space
+        rule          "start_state"  "/^[IWEF]\d{4} /"               "cont"
+        # A JSON log line starts with { — treat as its own entry
+        rule          "start_state"  "/^\{/"                          "cont"
+        # A structured log line starts with an ISO 8601 timestamp
+        rule          "start_state"  "/^\d{4}-\d{2}-\d{2}T\d{2}:/"   "cont"
+        # Anything else is a continuation of the previous multiline entry
+        rule          "cont"         "/^[^IWEF{\d]/"                  "cont"
+        rule          "cont"         "/^[IWEF][^0-9]/"                "cont"
+        rule          "cont"         "/^\d(?!\d{3}-\d{2}-\d{2}T\d{2}:)/"  "cont"
+
   input.conf: |
     [INPUT]
         Name              tail
@@ -113,6 +128,13 @@ data:
         Threaded          On
         storage.type      filesystem
   filter.conf: |
+    [FILTER]
+        Name                  multiline
+        Alias                 filter.multiline_klog
+        Match                 kubernetes.*
+        multiline.parser      klog
+        multiline.key_content log
+
     [FILTER]
         Name modify
         Match systemd.*
@@ -665,7 +687,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 8743b6ac573e877d3c368705e1de705ab4421ab0d7b1f43eec338a1dc1b6a409
+        checksum/configmap: 4b7e794ca0f7152eea405b4930eb430387a0d60fd3b162230415a37fb6fb075d
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_svc.yaml
@@ -56,6 +56,21 @@ data:
         Time_Format %Y-%m-%dT%H:%M:%S.%L
         Time_Keep   On
 
+    [MULTILINE_PARSER]
+        name          klog
+        type          regex
+        flush_timeout 1000
+        # A klog line starts with [IWEF] followed by 4 digits (mmdd) and a space
+        rule          "start_state"  "/^[IWEF]\d{4} /"               "cont"
+        # A JSON log line starts with { — treat as its own entry
+        rule          "start_state"  "/^\{/"                          "cont"
+        # A structured log line starts with an ISO 8601 timestamp
+        rule          "start_state"  "/^\d{4}-\d{2}-\d{2}T\d{2}:/"   "cont"
+        # Anything else is a continuation of the previous multiline entry
+        rule          "cont"         "/^[^IWEF{\d]/"                  "cont"
+        rule          "cont"         "/^[IWEF][^0-9]/"                "cont"
+        rule          "cont"         "/^\d(?!\d{3}-\d{2}-\d{2}T\d{2}:)/"  "cont"
+
   input.conf: |
     [INPUT]
         Name              tail
@@ -111,6 +126,13 @@ data:
         Threaded          On
         storage.type      filesystem
   filter.conf: |
+    [FILTER]
+        Name                  multiline
+        Alias                 filter.multiline_klog
+        Match                 kubernetes.*
+        multiline.parser      klog
+        multiline.key_content log
+
     [FILTER]
         Name modify
         Match systemd.*
@@ -453,7 +475,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: c52d2b1d949e076a51fe0381dc3677c6a07e48733fc99c9e090929f27523d94a
+        checksum/configmap: 787e14120d5e8180ba95a0d8e1f70252697c8ca54cf6eb4849e5eaef3eb86e9e
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/tooling/hcpctl/pkg/snapshot/queries/hypershift/clusterAPILogs/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/hypershift/clusterAPILogs/query.kql
@@ -5,13 +5,16 @@ cluster('{{ .ClusterURI }}').database('{{ .HCPDatabase }}').table('containerLogs
 {{- end }}
 | where namespace_name == '{{ .HostedControlPlaneNamespace }}'
 | where pod_name has 'cluster-api-'
-| extend msg = extract(@']\s+"([^"]+)"', 1, tostring(log))
-| extend err = extract(@'err="((?:[^"\\]|\\.)*)"', 1, tostring(log))
-| extend controller = extract(@'controller="([^"]*)"', 1, tostring(log))
-| extend controllerGroup = extract(@'controllerGroup="([^"]*)"', 1, tostring(log))
-| extend controllerKind = extract(@'controllerKind="([^"]*)"', 1, tostring(log))
-| extend name = extract(@'\sname="([^"]*)"', 1, tostring(log))
-| extend namespace = extract(@'namespace="([^"]*)"', 1, tostring(log))
+| extend logStr = tostring(log)
+| extend msg = extract(@']\s+"([^"]+)"', 1, logStr)
+| extend err = coalesce(
+    extract(@'err=<\n([\s\S]*?)\n\s*>', 1, logStr),
+    extract(@'err="((?:[^"\\]|\\.)*)"', 1, logStr))
+| extend controller = extract(@'controller="([^"]*)"', 1, logStr)
+| extend controllerGroup = extract(@'controllerGroup="([^"]*)"', 1, logStr)
+| extend controllerKind = extract(@'controllerKind="([^"]*)"', 1, logStr)
+| extend name = extract(@'\sname="([^"]*)"', 1, logStr)
+| extend namespace = extract(@'namespace="([^"]*)"', 1, logStr)
 | where controller contains 'machine'
 | project timestamp, msg, err, controller, controllerGroup, controllerKind, name, namespace
 | summarize

--- a/tooling/hcpctl/pkg/snapshot/queries/hypershift/clusterAPIProviderLogs/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/hypershift/clusterAPIProviderLogs/query.kql
@@ -5,13 +5,16 @@ cluster('{{ .ClusterURI }}').database('{{ .HCPDatabase }}').table('containerLogs
 {{- end }}
 | where namespace_name == '{{ .HostedControlPlaneNamespace }}'
 | where pod_name has 'capi-provider-'
-| extend msg = extract(@']\s+"([^"]+)"', 1, tostring(log))
-| extend err = extract(@'err="((?:[^"\\]|\\.)*)"', 1, tostring(log))
-| extend controller = extract(@'controller="([^"]*)"', 1, tostring(log))
-| extend controllerGroup = extract(@'controllerGroup="([^"]*)"', 1, tostring(log))
-| extend controllerKind = extract(@'controllerKind="([^"]*)"', 1, tostring(log))
-| extend name = extract(@'\sname="([^"]*)"', 1, tostring(log))
-| extend namespace = extract(@'namespace="([^"]*)"', 1, tostring(log))
+| extend logStr = tostring(log)
+| extend msg = extract(@']\s+"([^"]+)"', 1, logStr)
+| extend err = coalesce(
+    extract(@'err=<\n([\s\S]*?)\n\s*>', 1, logStr),
+    extract(@'err="((?:[^"\\]|\\.)*)"', 1, logStr))
+| extend controller = extract(@'controller="([^"]*)"', 1, logStr)
+| extend controllerGroup = extract(@'controllerGroup="([^"]*)"', 1, logStr)
+| extend controllerKind = extract(@'controllerKind="([^"]*)"', 1, logStr)
+| extend name = extract(@'\sname="([^"]*)"', 1, logStr)
+| extend namespace = extract(@'namespace="([^"]*)"', 1, logStr)
 | where controller contains 'azure'
 | project timestamp, msg, err, controller, controllerGroup, controllerKind, name, namespace
 | summarize


### PR DESCRIPTION
We would like to capture multi-line output from klog in one logical 'line' for Kusto, as some of the most high-value logs we get - Azure error traces - are multi-line, and we need to be able to, for instance, trace an error to the reconciler that encountered it.
