### PR TITLE
Add underlay_clusters source-of-truth metric for cluster-absence alerts

### DIFF
--- a/dev-infrastructure/modules/metrics/underlay-clusters-metric.bicep
+++ b/dev-infrastructure/modules/metrics/underlay-clusters-metric.bicep
@@ -1,0 +1,43 @@
+@description('Resource ID of the Azure Monitor Workspace the inventory series is emitted into')
+param azureMonitoringWorkspaceId string
+
+@description('Name of the underlay (service or management) cluster this series represents. Must match the `cluster` external label that this cluster\'s Prometheus stamps onto its metrics.')
+param clusterName string
+
+// Emits a static `underlay_clusters{cluster="<name>", source="bicep"} = 1` series for the
+// service or management cluster this deployment owns. Together, across every cluster deployment,
+// these series form the authoritative list -- declared at deploy time -- of which underlay
+// clusters should be running. Alerts join against it to detect a cluster that has gone
+// completely absent from the workspace (a case a plain `up`-based alert cannot see, because a
+// vanished cluster reports no `up` series at all).
+//
+// This module is instantiated from each cluster's own template (svc-cluster.bicep,
+// mgmt-cluster.bicep), so the series is tied to that cluster's lifecycle: when a (stamped)
+// cluster is decommissioned, its inventory series is torn down with it and the absence alert
+// does not false-fire for an intentionally-removed cluster.
+//
+// `vector(1)` produces a constant with no labels; the `labels` block stamps the cluster identity
+// onto it. The `source="bicep"` label distinguishes this declared-inventory series from any
+// metric the cluster reports about itself.
+resource underlayClusterInventory 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'underlay-clusters-metric-${clusterName}'
+  location: resourceGroup().location
+  properties: {
+    description: 'Authoritative list entry declaring that underlay cluster ${clusterName} should be running.'
+    scopes: [
+      azureMonitoringWorkspaceId
+    ]
+    enabled: true
+    interval: 'PT1M'
+    rules: [
+      {
+        record: 'underlay_clusters'
+        expression: 'vector(1)'
+        labels: {
+          cluster: clusterName
+          source: 'bicep'
+        }
+      }
+    ]
+  }
+}

--- a/dev-infrastructure/templates/mgmt-cluster.bicep
+++ b/dev-infrastructure/templates/mgmt-cluster.bicep
@@ -446,6 +446,17 @@ module dataCollection '../modules/metrics/datacollection.bicep' = {
   ]
 }
 
+// Declare this management cluster in the authoritative underlay-cluster inventory (see the module
+// for details). Instantiated per stamp, so each management cluster emits its own series and they
+// are torn down individually when a stamp is decommissioned.
+module underlayClusterMetric '../modules/metrics/underlay-clusters-metric.bicep' = {
+  name: 'underlay-clusters-metric'
+  params: {
+    azureMonitoringWorkspaceId: azureMonitoringWorkspaceId
+    clusterName: aksClusterName
+  }
+}
+
 //
 // K E Y V A U L T S
 //

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -757,6 +757,16 @@ module dataCollection '../modules/metrics/datacollection.bicep' = {
   ]
 }
 
+// Declare this service cluster in the authoritative underlay-cluster inventory (see the module
+// for details). Lets absence alerts detect when this cluster stops reporting to the workspace.
+module underlayClusterMetric '../modules/metrics/underlay-clusters-metric.bicep' = {
+  name: 'underlay-clusters-metric'
+  params: {
+    azureMonitoringWorkspaceId: azureMonitoringWorkspaceId
+    clusterName: aksClusterName
+  }
+}
+
 var frontendMI = mi.getManagedIdentityByName(managedIdentities.outputs.managedIdentities, frontendMIName)
 var backendMI = mi.getManagedIdentityByName(managedIdentities.outputs.managedIdentities, backendMIName)
 var adminApiMI = mi.getManagedIdentityByName(managedIdentities.outputs.managedIdentities, adminApiMIName)

--- a/docs/alerts.md
+++ b/docs/alerts.md
@@ -184,3 +184,71 @@ If your alert should also appear in the MSFT environment, add it to `observabili
 ```bash
 make -C observability/ alerts
 ```
+
+## Underlay clusters
+
+### Authoritative list of underlay clusters
+
+Every underlay cluster declares itself in an inventory of which clusters **should** be running.
+The `underlay-clusters-metric` Bicep module
+(`dev-infrastructure/modules/metrics/underlay-clusters-metric.bicep`) writes a single static
+recording rule into the services Azure Monitor Workspace:
+
+```
+underlay_clusters{cluster="<cluster-name>", source="bicep"} = 1
+```
+
+The module is instantiated from each cluster's own template -- `svc-cluster.bicep` for the
+service cluster and `mgmt-cluster.bicep` for each management cluster -- using that deployment's
+`aksClusterName`. Because management clusters are deployed once per EV2 stamp, each stamp emits
+its own series, and tearing a stamp down removes only that stamp's entry. The cluster name is
+the same value that sets the cluster's Prometheus `cluster` external label
+(`observability/prometheus/values-{svc,mgmt}.yaml`), so the inventory lines up exactly with the
+`cluster` label on real metrics. The `source="bicep"` label marks the series as
+deploy-time-declared inventory, distinct from anything a cluster reports about itself; the series
+is evaluated independently of whether the cluster is actually reachable.
+
+### Alerting on absent clusters
+
+Alerts that watch a per-cluster signal (e.g. `up`) can only fire for clusters that are
+**still reporting**. A cluster that has gone completely absent -- its Prometheus stopped
+remote-writing, or the cluster was never provisioned -- produces no series at all, so there is
+nothing for the alert to evaluate and nothing fires. PromQL `absent()` does not solve this on
+its own: the synthetic series it returns carries only the labels written literally in the
+selector, so it has no `cluster` label to key an incident on. This is why the tier configs
+rewrite `absent(up{job="..."} == 1)` into `count by (cluster) (up{job="..."} == 1) == 0` via
+`regexOutputReplacements` (see `observability/alerts-sre-hcps.yaml` and
+`observability/alerts-msft-services.yaml`) -- but that still only covers clusters whose `up` is
+present and `0`, not ones that have vanished entirely.
+
+The authoritative inventory closes that gap: an alert compares "should exist" against "is
+reporting" and fires -- with a real `cluster` label -- for any cluster present in the inventory
+but missing from the live signal:
+
+```yaml
+- alert: UnderlayClusterMetricsAbsent
+  expr: |
+    underlay_clusters unless on (cluster)
+      group by (cluster) (up{job="prometheus/prometheus", namespace="prometheus"})
+  for: 10m
+  labels:
+    severity: warning
+  annotations:
+    summary: 'No metrics received from underlay cluster'
+    description: 'Cluster {{ $labels.cluster }} is declared in the underlay inventory but is reporting no Prometheus self-metrics.'
+    runbook_url: 'https://eng.ms/docs/.../troubleshooting/prometheus.html'
+```
+
+Because the result keeps the `cluster` label, the generator's default
+`correlationId: <AlertName>/{{ $labels.cluster }}` and the `<cluster>: <summary>` IcM title
+resolve correctly -- one incident per genuinely-absent cluster.
+
+### Known limitation: new cluster bring-up
+
+A cluster declares itself in the inventory as part of its own deployment, before that cluster is
+fully up and its Prometheus is hooked up and remote-writing. There is therefore a window during
+the stand-up of a new (e.g. freshly stamped) management cluster where the inventory says the
+cluster should exist but no metrics are flowing yet, so an absence alert can fire transiently
+until all components are up. If this turns out to be a real problem in practice it will likely
+need a more comprehensive approach than adjusting this one metric -- other alerts may fire during
+bring-up too -- and we will only know once a few more management clusters have been stamped.


### PR DESCRIPTION
## Summary

Adds a `dev-infrastructure/modules/metrics/underlay-clusters-metric.bicep` module that emits a single static inventory series into the **services** Azure Monitor Workspace for the underlay cluster it is given:

```
underlay_clusters{cluster="<cluster-name>", source="bicep"} = 1
```

Across all cluster deployments, these series form the deploy-time **authoritative list of which underlay clusters should be running**. Alerts can join against it to detect a cluster that has gone *completely absent* from the workspace — a case a plain `up`-based alert cannot see, because a vanished cluster reports no `up` series at all. The existing `absent(up{...} == 1)` → `count by (cluster) (up{...} == 1) == 0` rewrite in the tier configs only covers clusters whose `up` is present and `0`, not ones that stopped reporting entirely; this metric closes that gap and carries a real `cluster` label so IcM correlation/title resolve per cluster.

## Details

- The module emits **exactly one cluster** (`record: underlay_clusters`, `expression: vector(1)`, with a `labels` block stamping `cluster` and `source="bicep"`).
- It is instantiated from each cluster's own template — `svc-cluster.bicep` for the service cluster and `mgmt-cluster.bicep` for each management cluster — using that deployment's `aksClusterName`. Management clusters are deployed once per EV2 stamp, so each stamp emits its own series and they are torn down individually when a stamp is decommissioned.
- The `clusterName` comes from `aksClusterName`, the same value that sets each cluster's Prometheus `cluster` external label (`observability/prometheus/values-{svc,mgmt}.yaml`), so the inventory labels match real metrics exactly. Scoped to the services AMW (`azureMonitoringWorkspaceId`).
- Documents the metric and the absent-cluster alerting pattern in `docs/alerts.md`, cross-referencing the existing `regexOutputReplacements` workaround.

A cluster declares itself in the inventory during its own deployment, before it is fully up and remote-writing, so an absence alert can fire transiently while a new (e.g. freshly stamped) cluster is being stood up — see the "Known limitation: new cluster bring-up" note in the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)