### PR TITLE
fix: replace kube-state-metrics with kubelet as PrometheusJobUp anchor

### DIFF
--- a/dev-infrastructure/modules/metrics/amw-ingestion-alerts.bicep
+++ b/dev-infrastructure/modules/metrics/amw-ingestion-alerts.bicep
@@ -13,50 +13,10 @@ param enabled bool
 @description('Threshold (percent) below which the low event ingestion alert fires')
 param lowEventIngestionThreshold int
 
-@description('Runbook URL for Prometheus metrics absent alert')
-param prometheusRunbookUrl string = 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/troubleshooting/prometheus.html'
-
 var amwName = last(split(azureMonitorWorkspaceId, '/'))
 
 // Severity 4 (Informational): approaching limits — capacity planning signal
 // Severity 3 (Warning): high risk of throttling — matches all other production alerts in the repo
-
-resource prometheusMetricsAbsent 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
-  name: 'PrometheusMetricsAbsent - ${workspaceLabel} - ${amwName}'
-  location: resourceGroup().location
-  properties: {
-    enabled: enabled
-    scopes: [
-      azureMonitorWorkspaceId
-    ]
-    rules: [
-      {
-        alert: 'PrometheusMetricsAbsent'
-        expression: 'absent(up{job="prometheus/prometheus",namespace="prometheus"})'
-        for: 'PT10M'
-        severity: 3
-        enabled: true
-        annotations: {
-          description: 'The up metric for Prometheus in the prometheus namespace has been absent for the past 10 minutes. This indicates that Prometheus is not reporting any metrics, which means no data is being sent to the Azure Monitor Workspace. Check the status of the Prometheus pods, verify scrape configurations, and ensure remote write is functioning.'
-          runbook_url: prometheusRunbookUrl
-          summary: 'Prometheus up metric is absent.'
-        }
-        labels: {
-          severity: 'warning'
-        }
-        resolveConfiguration: {
-          autoResolved: true
-          timeToResolve: 'PT10M'
-        }
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-          }
-        ]
-      }
-    ]
-  }
-}
 
 resource approachingActiveTimeSeries 'Microsoft.Insights/metricAlerts@2018-03-01' = {
   name: 'AMW Approaching Active TimeSeries Limit - ${workspaceLabel} - ${amwName}'

--- a/dev-infrastructure/modules/metrics/rules/generatedMsftPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedMsftPrometheusAlertingRules.bicep
@@ -1108,7 +1108,7 @@ Check the status of the Prometheus pods, service endpoints, and network connecti
           summary: 'Prometheus is unreachable for 10 minutes.'
           title: 'Prometheus is unreachable for 10 minutes.'
         }
-        expression: 'group by (cluster) (up{job="kube-state-metrics"}) unless on(cluster) group by (cluster) (up{job="prometheus/prometheus",namespace="prometheus"} == 1)'
+        expression: 'group by (cluster) (up{job="kubelet"}) unless on(cluster) group by (cluster) (up{job="prometheus/prometheus",namespace="prometheus"} == 1)'
         for: 'PT10M'
         severity: 2
       }

--- a/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
@@ -44,7 +44,7 @@ Check the status of the Prometheus pods, service endpoints, and network connecti
           summary: 'Prometheus is unreachable for 10 minutes.'
           title: 'Prometheus is unreachable for 10 minutes.'
         }
-        expression: 'group by (cluster) (up{job="kube-state-metrics"}) unless on(cluster) group by (cluster) (up{job="prometheus/prometheus",namespace="prometheus"} == 1)'
+        expression: 'group by (cluster) (up{job="kubelet"}) unless on(cluster) group by (cluster) (up{job="prometheus/prometheus",namespace="prometheus"} == 1)'
         for: 'PT10M'
         severity: 2
       }

--- a/observability/alerts/prometheus-prometheusRule.yaml
+++ b/observability/alerts/prometheus-prometheusRule.yaml
@@ -13,7 +13,9 @@ spec:
   - name: prometheus-wip-rules
     rules:
     - alert: PrometheusJobUp
-      expr: group by (cluster) (up{job="kube-state-metrics"}) unless on(cluster) group by (cluster) (up{job="prometheus/prometheus",namespace="prometheus"} == 1)
+      # TODO: once PR #5732 (underlay_clusters source-of-truth metric) is merged and confirmed
+      # working in production, replace up{job="kubelet"} with underlay_clusters.
+      expr: group by (cluster) (up{job="kubelet"}) unless on(cluster) group by (cluster) (up{job="prometheus/prometheus",namespace="prometheus"} == 1)
       for: 10m
       labels:
         severity: critical

--- a/observability/alerts/prometheus-prometheusRule_test.yaml
+++ b/observability/alerts/prometheus-prometheusRule_test.yaml
@@ -5,7 +5,7 @@ tests:
 # prometheus-slo-rules group tests
 - interval: 1m
   input_series:
-  - series: 'up{job="kube-state-metrics",cluster="test"}'
+  - series: 'up{job="kubelet",cluster="test"}'
     values: "1+0x15"
   - series: 'up{job="prometheus/prometheus",namespace="prometheus",cluster="test"}'
     values: "0+0x15"
@@ -188,7 +188,7 @@ tests:
 # Additional test scenarios with multiple instances
 - interval: 1m
   input_series:
-  - series: 'up{job="kube-state-metrics",cluster="test"}'
+  - series: 'up{job="kubelet",cluster="test"}'
     values: "1+0x15"
   - series: 'up{job="prometheus/prometheus",namespace="prometheus",instance="prometheus-0",cluster="test"}'
     values: "0+0x15"
@@ -211,7 +211,7 @@ tests:
 # Test no alert scenario for PrometheusJobUp
 - interval: 1m
   input_series:
-  - series: 'up{job="kube-state-metrics",cluster="test"}'
+  - series: 'up{job="kubelet",cluster="test"}'
     values: "1+0x15"
   - series: 'up{job="prometheus/prometheus",namespace="prometheus",cluster="test"}'
     values: "1+0x15"
@@ -419,7 +419,7 @@ tests:
 # Test PrometheusJobUp with sustained outage
 - interval: 1m
   input_series:
-  - series: 'up{job="kube-state-metrics",cluster="test"}'
+  - series: 'up{job="kubelet",cluster="test"}'
     values: "1+0x15"
   - series: 'up{job="prometheus/prometheus",namespace="prometheus",cluster="test"}'
     values: "0+0x15" # Continuously down
@@ -664,7 +664,7 @@ tests:
 # Test that alert does not fire before for: 10m is reached
 - interval: 1m
   input_series:
-  - series: 'up{job="kube-state-metrics",cluster="test"}'
+  - series: 'up{job="kubelet",cluster="test"}'
     values: "1+0x10"
   - series: 'up{job="prometheus/prometheus",namespace="prometheus",cluster="test"}'
     values: "0+0x10"
@@ -675,7 +675,7 @@ tests:
 # Test that alert fires once for: 10m is reached
 - interval: 1m
   input_series:
-  - series: 'up{job="kube-state-metrics",cluster="test"}'
+  - series: 'up{job="kubelet",cluster="test"}'
     values: "1+0x15"
   - series: 'up{job="prometheus/prometheus",namespace="prometheus",cluster="test"}'
     values: "0+0x15"
@@ -766,7 +766,7 @@ tests:
 # Test recovery after alert condition
 - interval: 1m
   input_series:
-  - series: 'up{job="kube-state-metrics",cluster="test"}'
+  - series: 'up{job="kubelet",cluster="test"}'
     values: "1+0x25"
   - series: 'up{job="prometheus/prometheus",namespace="prometheus",cluster="test"}'
     values: "0+0x12 1+0x13" # Down for 12 minutes, then up
@@ -799,7 +799,7 @@ tests:
 # Test multiple namespaces and jobs
 - interval: 1m
   input_series:
-  - series: 'up{job="kube-state-metrics",cluster="test"}'
+  - series: 'up{job="kubelet",cluster="test"}'
     values: "1+0x15"
   - series: 'up{job="prometheus/prometheus",namespace="monitoring",cluster="test"}'
     values: "0+0x15"


### PR DESCRIPTION
Jira: https://redhat.atlassian.net/browse/AROSLSRE-1237

## Summary

- **Fix `PrometheusJobUp`** — its cluster anchor was `up{job="kube-state-metrics"}`, which our own Prometheus scrapes, so a dead Prometheus pod killed the anchor and the alert never fired. Swap to `up{job="kubelet"}` (scraped by AMA — Azure Monitor Agent — independent of our Prometheus).
- **Remove `PrometheusMetricsAbsent`** — it permanently fired on the HCP workspace, carried no cluster label for IcM, and only fires if all svc and mgmt clusters in a region lose metrics at the same time; `PrometheusJobUp` + `PrometheusUptime` already cover it per-cluster.

## Why — `PrometheusJobUp` was silent for the exact failure it guards

`PrometheusJobUp` uses an `unless on(cluster)` expression to detect clusters where Prometheus is absent. The left-hand side is the **cluster anchor** — a series that must survive when Prometheus itself is down.

The previous anchor, `up{job="kube-state-metrics"}`, is scraped by our Prometheus pod: those series carry `prometheus=prometheus/prometheus` and `prometheus_replica=prom-agent-prometheus-0`, both stamped by the Prometheus operator to identify the scraper. When the Prometheus pod dies it stops scraping kube-state-metrics too, so **both sides of the `unless` disappear simultaneously** and the alert is permanently silent — the exact failure mode it exists to catch.

### The fix

Replace the anchor with `up{job="kubelet"}`, written by **AMA (Azure Monitor Agent)** — a separate DaemonSet deployed by Azure as part of the AKS managed-Prometheus add-on. AMA scrapes kubelet independently of our Prometheus installation (confirmed by the absence of any `prometheus=` label on those series; AMA uses its own remote-write path to the AMW). When our Prometheus pod dies, AMA keeps writing kubelet metrics, so the anchor survives and the `unless` fires with a real `cluster` label — so the IcM title and correlationId resolve to the affected cluster instead of rendering empty.

```promql
# Before — anchor dies with Prometheus, alert never fires:
group by (cluster) (up{job="kube-state-metrics"})
  unless on(cluster) group by (cluster) (up{job="prometheus/prometheus",namespace="prometheus"} == 1)

# After — anchor is AMA-written, survives a Prometheus outage:
group by (cluster) (up{job="kubelet"})
  unless on(cluster) group by (cluster) (up{job="prometheus/prometheus",namespace="prometheus"} == 1)
```

## Why — `PrometheusMetricsAbsent` was removed

A hand-written Bicep alert watching `absent(up{job="prometheus/prometheus",namespace="prometheus"})`, scoped to both the services and HCP Azure Monitor Workspaces. It was broken in three independent ways and added no coverage beyond existing alerts:

1. **The HCP-scoped instance fired permanently.** That metric is never remote-written to the HCP AMW by design — the Prometheus pod writes its self-scrape only to the services AMW — so the alert fired from the moment it deployed, regardless of any cluster's actual health.
2. **No cluster context for IcM.** `absent()` produces a synthetic series carrying only the labels written literally in its selector (`job`, `namespace`) — no `cluster`. The alert also wired no `actionProperties`, so IcM could not say which cluster was affected.
3. **Useless at scale.** On a workspace shared by many clusters, `absent()` only fires when *every* cluster stops writing at once. As management clusters scale to ~10 per region, the chance of it catching a real single-cluster outage approaches zero.

`PrometheusJobUp` (now fixed above) and `PrometheusUptime` already cover these failure modes per-cluster with correct IcM routing, so the alert was dropped rather than patched.

## Future improvement

Once #5732 (`underlay_clusters` source-of-truth metric) is merged and confirmed in production, the `PrometheusJobUp` anchor should become `underlay_clusters{}` — the deploy-time declaration of which clusters should exist. That makes absence detection independent of any runtime scrape state (even AMA being down would not produce a false negative). A `TODO` comment in the YAML points at this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)