### PR TITLE
feat: add alerts-sl-hcps.yaml config for SL alerts on HCP workspace

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedSLHCPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedSLHCPPrometheusAlertingRules.bicep
@@ -1,0 +1,8 @@
+#disable-next-line no-unused-params
+param azureMonitoring string
+
+#disable-next-line no-unused-params
+param actionGroups array
+
+#disable-next-line no-unused-params
+param location string = resourceGroup().location

--- a/dev-infrastructure/modules/metrics/sl-hcp-rules.bicep
+++ b/dev-infrastructure/modules/metrics/sl-hcp-rules.bicep
@@ -1,0 +1,14 @@
+// SL alerts that apply to HCP clusters and route to the SL action group.
+
+@description('The Azure resource ID of the Azure Monitor Workspace (stores prometheus metrics for HCPs)')
+param azureMonitoringWorkspaceId string
+
+param actionGroups array
+
+module generatedAlerts 'rules/generatedSLHCPPrometheusAlertingRules.bicep' = {
+  name: 'generatedSLHCPPrometheusAlertingRules'
+  params: {
+    azureMonitoring: azureMonitoringWorkspaceId
+    actionGroups: actionGroups
+  }
+}

--- a/dev-infrastructure/templates/monitoring.bicep
+++ b/dev-infrastructure/templates/monitoring.bicep
@@ -114,6 +114,14 @@ module hcpAlerts '../modules/metrics/hcp-rules.bicep' = {
   }
 }
 
+module slHcpAlerts '../modules/metrics/sl-hcp-rules.bicep' = {
+  name: 'slHcpAlerts'
+  params: {
+    azureMonitoringWorkspaceId: hcpAzureMonitoringWorkspaceId
+    actionGroups: slActionGroups
+  }
+}
+
 module sreServiceAlerts '../modules/metrics/sre-service-rules.bicep' = {
   name: 'sreServiceAlerts'
   params: {

--- a/observability/alerts-sl-hcps.yaml
+++ b/observability/alerts-sl-hcps.yaml
@@ -1,0 +1,4 @@
+prometheusRules:
+  rulesFolders: []
+  untestedRules: []
+  outputBicep: ../dev-infrastructure/modules/metrics/rules/generatedSLHCPPrometheusAlertingRules.bicep

--- a/tooling/prometheus-rules/Makefile
+++ b/tooling/prometheus-rules/Makefile
@@ -23,7 +23,7 @@ fmt-devinfra:
 run: alerts recording-rules
 .PHONY: run
 
-alerts: run-sl-services run-sre-hcps run-sre-services run-rp-services run-rp-hcps run-msft-services
+alerts: run-sl-services run-sl-hcps run-sre-hcps run-sre-services run-rp-services run-rp-hcps run-msft-services
 	$(MAKE) fmt-devinfra
 .PHONY: alerts
 
@@ -34,6 +34,10 @@ recording-rules: run-recording-rules-services run-recording-rules-hcps
 run-sl-services:
 	go run ./...  --config-file ../../observability/alerts-sl-services.yaml $(EXTRA_FLAGS)
 .PHONY: run-sl-services
+
+run-sl-hcps:
+	go run ./...  --config-file ../../observability/alerts-sl-hcps.yaml $(EXTRA_FLAGS)
+.PHONY: run-sl-hcps
 
 run-sre-hcps:
 	go run ./...  --config-file ../../observability/alerts-sre-hcps.yaml $(EXTRA_FLAGS)


### PR DESCRIPTION
## Summary

- Add `alerts-sl-hcps.yaml` config for deploying SL-owned PromQL alerts against the HCP Azure Monitor Workspace (previously only SRE alerts had an HCP config)
- New `sl-hcp-rules.bicep` wrapper module and generated Bicep output
- Wire into `monitoring.bicep` with `hcpAzureMonitoringWorkspaceId` + `slActionGroups`
- Add `run-sl-hcps` Makefile target to the alert generation pipeline

## Why

SL-owned PromQL alerts currently can only target the svc workspace via `alerts-sl-services.yaml`. There was no equivalent config for the HCP workspace, so alerts that need to query HCP metrics had to be hand-written in Bicep, bypassing promtool validation and unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)