### PR TITLE
fix: gate fleet registration on mgmt cluster core components

### DIFF
--- a/fleet/registration/pipeline.yaml
+++ b/fleet/registration/pipeline.yaml
@@ -119,6 +119,18 @@ resourceGroups:
     - serviceGroup: Microsoft.Azure.ARO.HCP.Fleet
       resourceGroup: service
       step: deploy
+    - serviceGroup: Microsoft.Azure.ARO.HCP.ACM
+      resourceGroup: management
+      step: deploy-policies
+    - serviceGroup: Microsoft.Azure.ARO.HCP.RP.HypershiftOperator
+      resourceGroup: management
+      step: deploy
+    - serviceGroup: Microsoft.Azure.ARO.HCP.KubeApplier
+      resourceGroup: management
+      step: deploy
+    - serviceGroup: Microsoft.Azure.ARO.HCP.Maestro.Agent
+      resourceGroup: management
+      step: deploy
     identityFrom:
       resourceGroup: global
       step: output

--- a/test/e2e/fleet_registration.go
+++ b/test/e2e/fleet_registration.go
@@ -16,7 +16,7 @@ package e2e
 
 import (
 	"context"
-	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -50,33 +50,33 @@ var _ = Describe("Fleet", func() {
 			currentIdentity, err := tc.GetCurrentAzureIdentityDetails(ctx)
 			Expect(err).NotTo(HaveOccurred(), "failed to get current Azure identity details")
 
-			By("listing all stamps via admin API")
-			stamps, err := tc.ListStamps(ctx, currentIdentity)
-			Expect(err).NotTo(HaveOccurred(), "failed to list stamps")
-			Expect(stamps).NotTo(BeEmpty(), "no stamps found — registration may not have run")
+			By("waiting for stamps to be registered with ready management clusters")
+			Eventually(func(g Gomega) {
+				stamps, err := tc.ListStamps(ctx, currentIdentity)
+				g.Expect(err).NotTo(HaveOccurred(), "failed to list stamps")
+				g.Expect(stamps).NotTo(BeEmpty(), "no stamps found — registration may not have run")
 
-			for _, s := range stamps {
-				Expect(s.ResourceID).NotTo(BeEmpty(), "stamp resourceId must not be empty")
-				By(fmt.Sprintf("verifying stamp %s", s.ResourceID))
+				for _, s := range stamps {
+					g.Expect(s.ResourceID).NotTo(BeEmpty(), "stamp resourceId must not be empty")
 
-				approvedCondition := apimeta.FindStatusCondition(s.Status.Conditions, string(fleet.StampConditionApproved))
-				Expect(approvedCondition).NotTo(BeNil(), "stamp must have Approved condition")
-				Expect(approvedCondition.Status).To(Equal(metav1.ConditionTrue), "stamp must be approved")
+					approvedCondition := apimeta.FindStatusCondition(s.Status.Conditions, string(fleet.StampConditionApproved))
+					g.Expect(approvedCondition).NotTo(BeNil(), "stamp %s must have Approved condition", s.ResourceID)
+					g.Expect(approvedCondition.Status).To(Equal(metav1.ConditionTrue), "stamp %s must be approved", s.ResourceID)
 
-				stampResourceID, err := azcorearm.ParseResourceID(s.ResourceID)
-				Expect(err).NotTo(HaveOccurred(), "failed to parse stamp resource ID %q", s.ResourceID)
-				stampIdentifier := stampResourceID.Name
+					stampResourceID, err := azcorearm.ParseResourceID(s.ResourceID)
+					g.Expect(err).NotTo(HaveOccurred(), "failed to parse stamp resource ID %q", s.ResourceID)
+					stampIdentifier := stampResourceID.Name
 
-				By(fmt.Sprintf("verifying management cluster for stamp %s", stampIdentifier))
-				managementCluster, err := tc.GetManagementCluster(ctx, stampIdentifier, fleet.ManagementClusterResourceName, currentIdentity)
-				Expect(err).NotTo(HaveOccurred(), "failed to get management cluster for stamp %s", stampIdentifier)
+					managementCluster, err := tc.GetManagementCluster(ctx, stampIdentifier, fleet.ManagementClusterResourceName, currentIdentity)
+					g.Expect(err).NotTo(HaveOccurred(), "failed to get management cluster for stamp %s", stampIdentifier)
 
-				Expect(managementCluster.ResourceID).NotTo(BeEmpty(), "management cluster resourceId must not be empty")
+					g.Expect(managementCluster.ResourceID).NotTo(BeEmpty(), "management cluster resourceId must not be empty")
 
-				readyCondition := apimeta.FindStatusCondition(managementCluster.Status.Conditions, string(fleet.ManagementClusterConditionReady))
-				Expect(readyCondition).NotTo(BeNil(), "management cluster must have Ready condition")
-				Expect(readyCondition.Status).To(Equal(metav1.ConditionTrue), "management cluster must be ready")
-			}
+					readyCondition := apimeta.FindStatusCondition(managementCluster.Status.Conditions, string(fleet.ManagementClusterConditionReady))
+					g.Expect(readyCondition).NotTo(BeNil(), "management cluster %s must have Ready condition", stampIdentifier)
+					g.Expect(readyCondition.Status).To(Equal(metav1.ConditionTrue), "management cluster %s must be ready", stampIdentifier)
+				}
+			}, 15*time.Minute, 30*time.Second).Should(Succeed(), "fleet registration did not complete in time")
 		},
 	)
 })


### PR DESCRIPTION
### What

Fleet registration was racing against management cluster component installation. Not really a problem but it makes sense to only promote the existance of a mgmt cluster when its components have a chance to register first try.

Add externalDependsOn entries so the registration pipeline only runs after all core management cluster components are deployed. Wrap the e2e fleet registration test in an Eventually loop (15 min timeout, 30s polling) so it tolerates the inherent delay between deployment completion and the controller reconciling Ready status.

_example E2E that failed too soon:
https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/Azure_ARO-HCP/5697/pull-ci-Azure-ARO-HCP-main-e2e-parallel/2069027530597208064
test fails 2 minutes after mgmt cluster record was created. condition it should wait for was present 2 minutes later_

### Why

<!-- Briefly explain why this change is needed -->

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
