### PR TITLE
Add per-cluster oncall drill-in Grafana dashboard

### DIFF
--- a/observability/grafana-dashboards/sre/cluster-health/README.md
+++ b/observability/grafana-dashboards/sre/cluster-health/README.md
@@ -1,0 +1,48 @@
+# SRE Cluster Health Dashboards
+
+Grafana dashboards for ARO-HCP SRE oncall and fleet health monitoring.
+
+## Dashboards
+
+| Dashboard | Purpose |
+|---|---|
+| `resource-state.json` | Fleet-wide cluster provisioning state, clusters per region, nodepool health |
+| `operations-overview.json` | Fleet-wide in-flight operations, stuck/failed ops, duration distribution |
+| `per-cluster-drill-in.json` | Single-cluster oncall triage: KAS, etcd, provisioning state, nodepools |
+
+## Datasource Model
+
+Each region has two Azure Monitor Workspaces exposed as Prometheus datasources:
+
+- **Services AMW** (`Managed_Prometheus_services-<region>`) — metrics from all namespaces except `ocm-<env>.*`. Used for backend provisioning state, operations, and nodepool metrics.
+- **HCPs AMW** (`Managed_Prometheus_hcps-<region>`) — metrics from `ocm-<env>.*` HCP namespaces only. Used for KAS, etcd, and control-plane component signals.
+
+### Datasource Variable Conventions
+
+Fleet-wide dashboards use `-- Mixed --` datasource with a `$datasource` variable for fan-out across all regions.
+
+Per-cluster dashboards use two datasource variables:
+- `$ds_services` — selects a single Services AMW (env+region)
+- `$ds_hcps` — selects a single HCPs AMW (same env+region)
+
+### Datasource Regex
+
+Regex patterns exclude obsolete datasource suffixes (`-ln`, `-yt`, `-chn`):
+
+```
+^Managed_Prometheus_services-(?!.*-(ln|yt|chn)$).*$
+^Managed_Prometheus_hcps-(?!.*-(ln|yt|chn)$).*$
+```
+
+See [docs/ai/grafana-debugging.md](../../../../docs/ai/grafana-debugging.md) for details on obsolete datasources.
+
+## Extending
+
+1. Add or edit dashboard JSON in this folder.
+2. The folder is registered in [`observability/observability.yaml`](../../../observability.yaml) as `SRE Cluster Health`.
+3. The `GrafanaDashboards` EV2 step deploys all JSON files in this folder to the `SRE Cluster Health` Grafana folder in INT, STG, and PROD.
+4. No manual upload is needed — merge to `main` and the pipeline handles deployment.
+
+## Kusto / ADX Integration (Planned)
+
+Regional Kusto clusters host `ServiceLogs` and `HostedControlPlaneLogs` databases. Error log volume panels from these sources are planned but not yet implemented — no existing dashboards in this repo use ADX datasources today.

--- a/observability/grafana-dashboards/sre/cluster-health/README.md
+++ b/observability/grafana-dashboards/sre/cluster-health/README.md
@@ -27,14 +27,14 @@ Per-cluster dashboards use two datasource variables:
 
 ### Datasource Regex
 
-Regex patterns exclude obsolete datasource suffixes (`-ln`, `-yt`, `-chn`):
+Regex patterns exclude obsolete datasources that end with 2-3 letter shortcodes (e.g. `am`, `bn`, `cbn`, `ln`, `yt`):
 
 ```
-^Managed_Prometheus_services-(?!.*-(ln|yt|chn)$).*$
-^Managed_Prometheus_hcps-(?!.*-(ln|yt|chn)$).*$
+^Managed_Prometheus_services-(?![a-z]{2,3}$).+$
+^Managed_Prometheus_hcps-(?![a-z]{2,3}$).+$
 ```
 
-See [docs/ai/grafana-debugging.md](../../../../docs/ai/grafana-debugging.md) for details on obsolete datasources.
+Valid datasources end with full Azure region names (4+ chars), so this pattern safely excludes all legacy short suffixes. See [docs/ai/grafana-debugging.md](../../../../docs/ai/grafana-debugging.md) for details.
 
 ## Extending
 

--- a/observability/grafana-dashboards/sre/cluster-health/per-cluster-drill-in.json
+++ b/observability/grafana-dashboards/sre/cluster-health/per-cluster-drill-in.json
@@ -43,6 +43,78 @@
       "tooltip": "Fleet-wide in-flight operations overview",
       "type": "link",
       "url": "/d/sre-cluster-health-operations-overview/operations-overview-fleet-wide"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": true,
+      "title": "KAS Golden Signals",
+      "tooltip": "Per-HCP KAS availability, errors, latency, traffic, saturation",
+      "type": "link",
+      "url": "/d/hcp-kas-golden-signals/hcp-kas-golden-signals?var-namespace=$namespace"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": true,
+      "title": "Backend",
+      "tooltip": "Backend health and Maestro gRPC signals",
+      "type": "link",
+      "url": "/d/bepcy70a38jk0d/backend"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": true,
+      "title": "Clusters Service",
+      "tooltip": "Clusters Service availability and latency SLOs",
+      "type": "link",
+      "url": "/d/aro-hcp-cluster-service-slo/cluster-service-slo"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": true,
+      "title": "Maestro",
+      "tooltip": "Maestro server and agent signals",
+      "type": "link",
+      "url": "/d/maestro-server/maestro-server"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": true,
+      "title": "Frontend",
+      "tooltip": "Frontend request handling",
+      "type": "link",
+      "url": "/d/dem2p0rbqegaof/frontend"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": true,
+      "title": "etcd Availability",
+      "tooltip": "Fleet etcd availability and health",
+      "type": "link",
+      "url": "/d/etcd-availability/etcd-availability"
     }
   ],
   "panels": [
@@ -65,7 +137,7 @@
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "### Per-Cluster Oncall Drill-in\n\nSingle-cluster health view for oncall triage.\n\n**How to use:** Select a services datasource (env+region), then pick an HCPs datasource for the same region. Choose a namespace to drill into a specific hosted cluster.\n\n**Datasources:** Services AMW for provisioning state and backend metrics. HCPs AMW for KAS, etcd, and control-plane signals.",
+        "content": "### Per-Cluster Oncall Drill-in\n\nSingle-cluster health view for oncall triage.\n\n**How to use:** Select a services datasource (env+region), then pick an HCPs datasource for the same region. Choose a namespace to drill into a specific hosted cluster.\n\n**Datasources:** Services AMW for provisioning state and backend metrics. HCPs AMW for KAS, etcd, and control-plane signals.\n\n**Planned:** Kusto/ADX panels for error log volume from ServiceLogs and HostedControlPlaneLogs (pending ADX datasource integration -- no existing dashboards use Kusto today).",
         "mode": "markdown"
       },
       "pluginVersion": "11.6.9",
@@ -713,6 +785,196 @@
         "x": 0,
         "y": 22
       },
+      "id": 15,
+      "panels": [],
+      "title": "Control Plane Components",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_hcps"
+      },
+      "description": "KAS saturation: in-flight requests and long-running requests",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Requests",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green" }]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 23
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_hcps"
+          },
+          "editorMode": "code",
+          "expr": "sum by (request_kind) (apiserver_current_inflight_requests{namespace=~\"$namespace\"})",
+          "range": true,
+          "legendFormat": "inflight: {{request_kind}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_hcps"
+          },
+          "editorMode": "code",
+          "expr": "sum(apiserver_longrunning_requests{namespace=~\"$namespace\"})",
+          "range": true,
+          "legendFormat": "long-running",
+          "refId": "B"
+        }
+      ],
+      "title": "KAS Saturation (Inflight & Long-running)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_hcps"
+      },
+      "description": "etcd backend commit and peer round-trip latencies",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green" },
+              { "color": "red", "value": 0.025 }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 23
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_hcps"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(etcd_disk_backend_commit_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])))",
+          "range": true,
+          "legendFormat": "Backend Commit p99",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_hcps"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(etcd_network_peer_round_trip_time_seconds_bucket{namespace=~\"$namespace\"}[5m])))",
+          "range": true,
+          "legendFormat": "Peer RTT p99",
+          "refId": "B"
+        }
+      ],
+      "title": "etcd Backend Commit & Peer RTT (p99)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 31
+      },
       "id": 20,
       "panels": [],
       "title": "etcd Health",
@@ -770,7 +1032,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 23
+        "y": 32
       },
       "id": 21,
       "options": {
@@ -850,7 +1112,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 23
+        "y": 32
       },
       "id": 22,
       "options": {
@@ -931,7 +1193,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 23
+        "y": 32
       },
       "id": 23,
       "options": {
@@ -966,7 +1228,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 31
+        "y": 40
       },
       "id": 30,
       "panels": [],
@@ -1027,7 +1289,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 32
+        "y": 41
       },
       "id": 31,
       "options": {
@@ -1092,7 +1354,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 40
+        "y": 49
       },
       "id": 40,
       "panels": [],
@@ -1158,7 +1420,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 41
+        "y": 50
       },
       "id": 41,
       "options": {
@@ -1205,7 +1467,7 @@
         "query": "prometheus",
         "queryValue": "",
         "refresh": 1,
-        "regex": "^Managed_Prometheus_services-.*$",
+        "regex": "^Managed_Prometheus_services-(?!.*-(ln|yt|chn)$).*$",
         "skipUrlSync": false,
         "type": "datasource"
       },
@@ -1220,7 +1482,7 @@
         "query": "prometheus",
         "queryValue": "",
         "refresh": 1,
-        "regex": "^Managed_Prometheus_hcps-.*$",
+        "regex": "^Managed_Prometheus_hcps-(?!.*-(ln|yt|chn)$).*$",
         "skipUrlSync": false,
         "type": "datasource"
       },

--- a/observability/grafana-dashboards/sre/cluster-health/per-cluster-drill-in.json
+++ b/observability/grafana-dashboards/sre/cluster-health/per-cluster-drill-in.json
@@ -111,6 +111,10 @@
           {
             "matcher": { "id": "byName", "options": "accepted" },
             "properties": [{ "id": "color", "value": { "fixedColor": "blue", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "updating" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "purple", "mode": "fixed" } }]
           }
         ]
       },
@@ -1184,7 +1188,9 @@
       "type": "timeseries"
     }
   ],
-  "schemaVersion": 40,
+  "preload": false,
+  "refresh": "5m",
+  "schemaVersion": 41,
   "tags": ["aro-hcp", "sre", "oncall", "per-cluster"],
   "templating": {
     "list": [

--- a/observability/grafana-dashboards/sre/cluster-health/per-cluster-drill-in.json
+++ b/observability/grafana-dashboards/sre/cluster-health/per-cluster-drill-in.json
@@ -1,0 +1,1280 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": true,
+      "title": "Fleet: Resource State",
+      "tooltip": "Fleet-wide cluster provisioning state overview",
+      "type": "link",
+      "url": "/d/sre-cluster-health-resource-state/resource-state-fleet-wide"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": true,
+      "title": "Fleet: Operations Overview",
+      "tooltip": "Fleet-wide in-flight operations overview",
+      "type": "link",
+      "url": "/d/sre-cluster-health-operations-overview/operations-overview-fleet-wide"
+    }
+  ],
+  "panels": [
+    {
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "### Per-Cluster Oncall Drill-in\n\nSingle-cluster health view for oncall triage.\n\n**How to use:** Select a services datasource (env+region), then pick an HCPs datasource for the same region. Choose a namespace to drill into a specific hosted cluster.\n\n**Datasources:** Services AMW for provisioning state and backend metrics. HCPs AMW for KAS, etcd, and control-plane signals.",
+        "mode": "markdown"
+      },
+      "pluginVersion": "11.6.9",
+      "title": "Dashboard Info",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_services"
+      },
+      "description": "Current provisioning phase of the selected cluster",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "text" }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "succeeded" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "failed" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "provisioning" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "yellow", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "deleting" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "accepted" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "blue", "mode": "fixed" } }]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 8,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "name",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_services"
+          },
+          "editorMode": "code",
+          "expr": "backend_cluster_provision_state{resource_id=\"$resource_id\"} == 1",
+          "instant": true,
+          "range": false,
+          "legendFormat": "{{phase}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Cluster State",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_hcps"
+      },
+      "description": "KAS availability from KSM condition probe",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red" },
+              { "color": "yellow", "value": 0.95 },
+              { "color": "green", "value": 0.99 }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_hcps"
+          },
+          "editorMode": "code",
+          "expr": "hostedClusterAPI_kubeapiserver_available:ratio_avg_7d{namespace=~\"$namespace\"}",
+          "instant": true,
+          "range": false,
+          "legendFormat": "KAS 7d Avail",
+          "refId": "A"
+        }
+      ],
+      "title": "KAS Availability (7d)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_hcps"
+      },
+      "description": "etcd leader changes in the last hour",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green" },
+              { "color": "yellow", "value": 3 },
+              { "color": "red", "value": 10 }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 16,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_hcps"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(etcd_server_leader_changes_seen_total{namespace=~\"$namespace\"}[1h]))",
+          "instant": true,
+          "range": false,
+          "legendFormat": "Leader Changes/1h",
+          "refId": "A"
+        }
+      ],
+      "title": "etcd Leader Changes (1h)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_services"
+      },
+      "description": "Number of nodepools in succeeded state for this cluster's subscription",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "blue" }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 20,
+        "y": 0
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_services"
+          },
+          "editorMode": "code",
+          "expr": "count(backend_node_pool_provision_state{resource_id=~\".*$resource_id.*\", phase=\"succeeded\"} == 1) or vector(0)",
+          "instant": true,
+          "range": false,
+          "legendFormat": "Nodepools",
+          "refId": "A"
+        }
+      ],
+      "title": "Nodepools (Succeeded)",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 10,
+      "panels": [],
+      "title": "KAS Health",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_hcps"
+      },
+      "description": "KAS availability over time from KSM condition",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green" }]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull", "min"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_hcps"
+          },
+          "editorMode": "code",
+          "expr": "hostedClusterAPI_kubeapiserver_available:sli_sum_15m{namespace=~\"$namespace\"} / hostedClusterAPI_kubeapiserver_available:sli_count_15m{namespace=~\"$namespace\"}",
+          "range": true,
+          "legendFormat": "KAS Availability (15m window)",
+          "refId": "A"
+        }
+      ],
+      "title": "KAS Availability Over Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_hcps"
+      },
+      "description": "API server request error rate (5xx) over time",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "red",
+            "mode": "fixed"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Errors/sec",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green" }]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_hcps"
+          },
+          "editorMode": "code",
+          "expr": "sum by (code) (rate(apiserver_request_total{namespace=~\"$namespace\", code=~\"5..\"}[5m]))",
+          "range": true,
+          "legendFormat": "{{code}}",
+          "refId": "A"
+        }
+      ],
+      "title": "KAS 5xx Error Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_hcps"
+      },
+      "description": "API server request latency percentiles",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Latency",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green" }]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_hcps"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(apiserver_request_sli_duration_seconds_bucket{namespace=~\"$namespace\", verb!~\"WATCH|CONNECT\"}[5m])))",
+          "range": true,
+          "legendFormat": "p99",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_hcps"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by (le) (rate(apiserver_request_sli_duration_seconds_bucket{namespace=~\"$namespace\", verb!~\"WATCH|CONNECT\"}[5m])))",
+          "range": true,
+          "legendFormat": "p90",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_hcps"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(apiserver_request_sli_duration_seconds_bucket{namespace=~\"$namespace\", verb!~\"WATCH|CONNECT\"}[5m])))",
+          "range": true,
+          "legendFormat": "p50",
+          "refId": "C"
+        }
+      ],
+      "title": "KAS Request Latency (p50/p90/p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_hcps"
+      },
+      "description": "API server request rate by verb",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Requests/sec",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "normal" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green" }]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 14
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_hcps"
+          },
+          "editorMode": "code",
+          "expr": "sum by (verb) (rate(apiserver_request_total{namespace=~\"$namespace\", verb!=\"WATCH\"}[5m]))",
+          "range": true,
+          "legendFormat": "{{verb}}",
+          "refId": "A"
+        }
+      ],
+      "title": "KAS Request Rate by Verb",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 22
+      },
+      "id": 20,
+      "panels": [],
+      "title": "etcd Health",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_hcps"
+      },
+      "description": "etcd leader changes over time",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "orange",
+            "mode": "fixed"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Changes",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green" }]
+          },
+          "unit": "none",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 23
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": ["sum"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_hcps"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(etcd_server_leader_changes_seen_total{namespace=~\"$namespace\"}[1h]))",
+          "range": true,
+          "legendFormat": "Leader Changes/1h",
+          "refId": "A"
+        }
+      ],
+      "title": "etcd Leader Changes",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_hcps"
+      },
+      "description": "etcd WAL fsync p99 latency (target <10ms)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green" },
+              { "color": "red", "value": 0.01 }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 23
+      },
+      "id": 22,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_hcps"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])))",
+          "range": true,
+          "legendFormat": "WAL fsync p99",
+          "refId": "A"
+        }
+      ],
+      "title": "etcd WAL Fsync Latency (p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_hcps"
+      },
+      "description": "etcd database size",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "purple",
+            "mode": "fixed"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green" },
+              { "color": "red", "value": 4294967296 }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 23
+      },
+      "id": 23,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_hcps"
+          },
+          "editorMode": "code",
+          "expr": "max(etcd_mvcc_db_total_size_in_bytes{namespace=~\"$namespace\"})",
+          "range": true,
+          "legendFormat": "DB Size",
+          "refId": "A"
+        }
+      ],
+      "title": "etcd Database Size",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 31
+      },
+      "id": 30,
+      "panels": [],
+      "title": "Provisioning & Operations",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_services"
+      },
+      "description": "In-flight operations for this cluster's resource ID",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": { "type": "auto" },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green" }]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Phase" },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": { "mode": "basic", "type": "color-background" }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "succeeded": { "color": "green", "index": 0 },
+                      "failed": { "color": "red", "index": 1 },
+                      "provisioning": { "color": "yellow", "index": 2 },
+                      "deleting": { "color": "orange", "index": 3 },
+                      "accepted": { "color": "blue", "index": 4 },
+                      "updating": { "color": "purple", "index": 5 }
+                    },
+                    "type": "value"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 32
+      },
+      "id": 31,
+      "options": {
+        "cellHeight": "sm",
+        "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false },
+        "showHeader": true,
+        "sortBy": [{ "desc": false, "displayName": "Phase" }]
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_services"
+          },
+          "editorMode": "code",
+          "expr": "backend_resource_operation_phase_info{resource_id=\"$resource_id\"} == 1",
+          "instant": true,
+          "range": false,
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Operations",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "__name__": true,
+              "container": true,
+              "endpoint": true,
+              "instance": true,
+              "job": true,
+              "namespace": true,
+              "pod": true,
+              "prometheus": true,
+              "prometheus_replica": true,
+              "receive": true,
+              "replica": true,
+              "service": true,
+              "tenant_id": true,
+              "cluster": true
+            },
+            "renameByName": {
+              "operation_type": "Operation",
+              "phase": "Phase",
+              "resource_id": "Resource ID",
+              "resource_type": "Resource Type",
+              "subscription_id": "Subscription"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 40
+      },
+      "id": 40,
+      "panels": [],
+      "title": "NodePool Health",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_services"
+      },
+      "description": "Provisioning state of all nodepools for this cluster",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Count",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "normal" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green" }]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "succeeded" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "failed" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "provisioning" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "yellow", "mode": "fixed" } }]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 41
+      },
+      "id": 41,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_services"
+          },
+          "editorMode": "code",
+          "expr": "count by (phase) (backend_node_pool_provision_state{resource_id=~\".*$resource_id.*\"} == 1)",
+          "range": true,
+          "legendFormat": "{{phase}}",
+          "refId": "A"
+        }
+      ],
+      "title": "NodePool Provisioning State Over Time",
+      "type": "timeseries"
+    }
+  ],
+  "schemaVersion": 40,
+  "tags": ["aro-hcp", "sre", "oncall", "per-cluster"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Services Datasource",
+        "multi": false,
+        "name": "ds_services",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "^Managed_Prometheus_services-.*$",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "HCPs Datasource",
+        "multi": false,
+        "name": "ds_hcps",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "^Managed_Prometheus_hcps-.*$",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$ds_hcps"
+        },
+        "definition": "label_values(hostedClusterAPI_kubeapiserver_available, namespace)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "HCP Namespace",
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(hostedClusterAPI_kubeapiserver_available, namespace)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$ds_services"
+        },
+        "definition": "label_values(backend_cluster_provision_state, resource_id)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Cluster Resource ID",
+        "multi": false,
+        "name": "resource_id",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(backend_cluster_provision_state, resource_id)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Per-Cluster Oncall Drill-in",
+  "uid": "sre-cluster-health-per-cluster-drill-in",
+  "version": 1
+}

--- a/observability/grafana-dashboards/sre/cluster-health/per-cluster-drill-in.json
+++ b/observability/grafana-dashboards/sre/cluster-health/per-cluster-drill-in.json
@@ -1467,7 +1467,7 @@
         "query": "prometheus",
         "queryValue": "",
         "refresh": 1,
-        "regex": "^Managed_Prometheus_services-(?!.*-(ln|yt|chn)$).*$",
+        "regex": "^Managed_Prometheus_services-(?![a-z]{2,3}$).+$",
         "skipUrlSync": false,
         "type": "datasource"
       },
@@ -1482,7 +1482,7 @@
         "query": "prometheus",
         "queryValue": "",
         "refresh": 1,
-        "regex": "^Managed_Prometheus_hcps-(?!.*-(ln|yt|chn)$).*$",
+        "regex": "^Managed_Prometheus_hcps-(?![a-z]{2,3}$).+$",
         "skipUrlSync": false,
         "type": "datasource"
       },


### PR DESCRIPTION
﻿## Summary

- Adds a new **Per-Cluster Oncall Drill-in** Grafana dashboard for single-cluster health triage during oncall
- Uses dual datasource variables (Services AMW for provisioning/backend, HCPs AMW for KAS/etcd/control-plane)
- Template variables: Services Datasource, HCPs Datasource, HCP Namespace, Cluster Resource ID

### Panels included

**Top-level stats:** Cluster State (with phase-colored background), KAS Availability (7d), etcd Leader Changes (1h), Nodepools (Succeeded)

**KAS Health:** Availability over time, 5xx error rate, request latency (p50/p90/p99), request rate by verb

**etcd Health:** Leader changes over time, WAL fsync latency p99 (10ms threshold), database size (4GB threshold)

**Provisioning & Operations:** Active operations table (operation type, phase, resource type, subscription)

**NodePool Health:** NodePool provisioning state over time (stacked by phase)

**Dashboard links:** Quick navigation to fleet-level Resource State and Operations Overview dashboards

## Test plan

- [x] Imported and tested in local dev Grafana (mmazur's grafana-datasource plugin) with live INT/STG/PROD data
- [x] Verified KAS availability, error rate, latency, traffic panels show real data
- [x] Verified etcd leader changes, WAL fsync, DB size panels show real data
- [x] Verified Cluster State stat panel shows provisioning phase with correct color coding
- [x] Verified template variables populate correctly from both services and hcps datasources
- [x] CI pipeline validation

Jira: [AROSLSRE-1148](https://redhat.atlassian.net/browse/AROSLSRE-1148)
