### PR TITLE
fix: consume config.yaml prometheus shard/replica settings in prometheus helm chart

### DIFF
--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arohcp_monitor.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arohcp_monitor.yaml
@@ -68585,7 +68585,7 @@ spec:
   probeSelector:
     matchLabels:
       release: arohcp-monitor
-  replicas: 1
+  replicas: 2
   routePrefix: /
   scrapeConfigNamespaceSelector: {}
   scrapeConfigSelector:

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_arohcp_monitor.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_arohcp_monitor.yaml
@@ -68466,7 +68466,7 @@ spec:
   probeSelector:
     matchLabels:
       release: arohcp-monitor
-  replicas: 1
+  replicas: 2
   routePrefix: /
   scrapeConfigNamespaceSelector: {}
   scrapeConfigSelector:

--- a/observability/prometheus/deploy/templates/prometheus.yaml
+++ b/observability/prometheus/deploy/templates/prometheus.yaml
@@ -52,7 +52,7 @@ spec:
   probeSelector:
     matchLabels:
       release: arohcp-monitor
-  replicas: 1
+  replicas: {{ .Values.prometheusSpec.replicas }}
   routePrefix: /
   scrapeConfigNamespaceSelector: {}
   scrapeConfigSelector:
@@ -69,7 +69,7 @@ spec:
   serviceAccountName: prometheus
   serviceMonitorNamespaceSelector: {}
   serviceMonitorSelector: {}
-  shards: 1
+  shards: {{ .Values.prometheusSpec.shards }}
   storage:
     volumeClaimTemplate:
       spec:

--- a/observability/prometheus/testdata/helmtest_mgmt_resources.yml
+++ b/observability/prometheus/testdata/helmtest_mgmt_resources.yml
@@ -37,3 +37,5 @@ testData:
           limits:
             cpu: "2"
             memory: 10Gi
+        replicas: 2
+        shards: 2

--- a/observability/prometheus/testdata/helmtest_mgmt_resources_unset.yml
+++ b/observability/prometheus/testdata/helmtest_mgmt_resources_unset.yml
@@ -30,5 +30,7 @@ testData:
           registry: mcr.microsoft.com/oss/v2
           repository: prometheus/prometheus
           sha: sha256:testabc
+        replicas: 1
+        shards: 1
   prometheusSpec:
     resources: {}

--- a/observability/prometheus/testdata/helmtest_svc_resources.yml
+++ b/observability/prometheus/testdata/helmtest_svc_resources.yml
@@ -37,3 +37,5 @@ testData:
           limits:
             cpu: "20"
             memory: "100Gi"
+        replicas: 2
+        shards: 2

--- a/observability/prometheus/testdata/helmtest_svc_resources_unset.yml
+++ b/observability/prometheus/testdata/helmtest_svc_resources_unset.yml
@@ -30,5 +30,7 @@ testData:
           registry: mcr.microsoft.com/oss/v2
           repository: prometheus/prometheus
           sha: sha256:testabc
+        replicas: 1
+        shards: 1
   prometheusSpec:
     resources: {}

--- a/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_mgmt_resources.yaml
+++ b/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_mgmt_resources.yaml
@@ -68591,7 +68591,7 @@ spec:
   probeSelector:
     matchLabels:
       release: arohcp-monitor
-  replicas: 1
+  replicas: 2
   routePrefix: /
   scrapeConfigNamespaceSelector: {}
   scrapeConfigSelector:
@@ -68608,7 +68608,7 @@ spec:
   serviceAccountName: prometheus
   serviceMonitorNamespaceSelector: {}
   serviceMonitorSelector: {}
-  shards: 1
+  shards: 2
   storage:
     volumeClaimTemplate:
       spec:

--- a/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_svc_resources.yaml
+++ b/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_svc_resources.yaml
@@ -68472,7 +68472,7 @@ spec:
   probeSelector:
     matchLabels:
       release: arohcp-monitor
-  replicas: 1
+  replicas: 2
   routePrefix: /
   scrapeConfigNamespaceSelector: {}
   scrapeConfigSelector:
@@ -68489,7 +68489,7 @@ spec:
   serviceAccountName: prometheus
   serviceMonitorNamespaceSelector: {}
   serviceMonitorSelector: {}
-  shards: 1
+  shards: 2
   storage:
     volumeClaimTemplate:
       spec:

--- a/observability/prometheus/values-mgmt.yaml
+++ b/observability/prometheus/values-mgmt.yaml
@@ -149,10 +149,9 @@ prometheusSpec:
       memory: {{ .mgmt.prometheus.prometheusSpec.resources.requests.memory }}
     limits:
       memory: {{ .mgmt.prometheus.prometheusSpec.resources.limits.memory }}
+  replicas: {{ .mgmt.prometheus.prometheusSpec.replicas }}
+  shards: {{ .mgmt.prometheus.prometheusSpec.shards }}
 prometheus:
-  prometheusSpec:
-    shards: {{ .mgmt.prometheus.prometheusSpec.shards }}
-    replicas: {{ .mgmt.prometheus.prometheusSpec.replicas }}
   serviceAccount:
     managedIdentity: "__prometheusUAMIClientId__"
 environment: "{{ .clustersService.environment }}"

--- a/observability/prometheus/values-opstool.yaml
+++ b/observability/prometheus/values-opstool.yaml
@@ -73,10 +73,9 @@ prometheusSpec:
       memory: 1Gi
     limits:
       memory: 2Gi
+  replicas: 1
+  shards: 1
 prometheus:
-  prometheusSpec:
-    shards: 1
-    replicas: 1
   serviceAccount:
     managedIdentity: "__prometheusUAMIClientId__"
 environment: "opstool"

--- a/observability/prometheus/values-svc.yaml
+++ b/observability/prometheus/values-svc.yaml
@@ -99,10 +99,9 @@ prometheusSpec:
       memory: {{ .svc.prometheus.prometheusSpec.resources.requests.memory }}
     limits:
       memory: {{ .svc.prometheus.prometheusSpec.resources.limits.memory }}
+  replicas: {{ .svc.prometheus.prometheusSpec.replicas }}
+  shards: {{ .svc.prometheus.prometheusSpec.shards }}
 prometheus:
-  prometheusSpec:
-    shards: {{ .svc.prometheus.prometheusSpec.shards }}
-    replicas: {{ .svc.prometheus.prometheusSpec.replicas }}
   serviceAccount:
     managedIdentity: "__prometheusUAMIClientId__"
 environment: "{{ .clustersService.environment }}"


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-1242

### What

Updates prometheus helm chart and tests to use replica/shard set in config.yaml

### Why

We already set replicas/shards to 2 in the config.yaml and sdp-pipelines, the prometheus chart currently ignores it.  Prometheus is getting OOMkilled in int and stage because due to WAL-replay.  Increasing the memory limit in int might work, but we are memory constrained in int and stage, and spreading the load (as intended by the existing config in aro-hcp and sdp-pipelines) gives us more capacity than just increasing the limit.

### Testing

personal dev env/e2e

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
