### PR TITLE
fix: use configurable hcpNamespaceRegex for prometheus remote_write relabeling

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -787,6 +787,9 @@
             "retentionSize": {
               "type": "string",
               "pattern": "^$|^(0|([0-9]*[.])?[0-9]+((K|M|G|T|E|P)i?)?B)$"
+            },
+            "hcpNamespaceRegex": {
+              "type": "string"
             }
           }
         },

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -523,6 +523,7 @@ defaults:
             memory: NONE
         replicas: 2
         shards: 2
+        hcpNamespaceRegex: "^ocm-arohcp{{ .ctx.environment }}.*"
       prometheusConfigReloader:
         image:
           registry: mcr.microsoft.com/oss/v2
@@ -651,6 +652,7 @@ defaults:
             memory: NONE
         replicas: 2
         shards: 2
+        hcpNamespaceRegex: "^ocm-arohcp{{ .ctx.environment }}.*"
       prometheusConfigReloader:
         image:
           registry: mcr.microsoft.com/oss/v2
@@ -1363,6 +1365,9 @@ clouds:
               userAgentPool:
                 minCount: 2
                 maxCount: 12
+            prometheus:
+              prometheusSpec:
+                hcpNamespaceRegex: "^ocm-.*"
           mgmt:
             aks:
               systemAgentPool:
@@ -1378,6 +1383,9 @@ clouds:
                 osDiskSizeGB: 128
               enableSwiftV2Vnet: true
               enableSwiftV2Nodepools: true
+            prometheus:
+              prometheusSpec:
+                hcpNamespaceRegex: "^ocm-.*"
           # Geneva
           geneva:
             logs:

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -668,6 +668,7 @@ mgmt:
         sha: e7bbcd13ba6b9e1dec02a7f0fa882444b46d17fb06dc7f7bcde3f927b663c77e
       version: ""
     prometheusSpec:
+      hcpNamespaceRegex: ^ocm-arohcpci00.*
       image:
         registry: mcr.microsoft.com/oss/v2
         repository: prometheus/prometheus
@@ -988,6 +989,7 @@ svc:
         sha: e7bbcd13ba6b9e1dec02a7f0fa882444b46d17fb06dc7f7bcde3f927b663c77e
       version: ""
     prometheusSpec:
+      hcpNamespaceRegex: ^ocm-arohcpci00.*
       image:
         registry: mcr.microsoft.com/oss/v2
         repository: prometheus/prometheus

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -668,6 +668,7 @@ mgmt:
         sha: e7bbcd13ba6b9e1dec02a7f0fa882444b46d17fb06dc7f7bcde3f927b663c77e
       version: ""
     prometheusSpec:
+      hcpNamespaceRegex: ^ocm-arohcpci01.*
       image:
         registry: mcr.microsoft.com/oss/v2
         repository: prometheus/prometheus
@@ -988,6 +989,7 @@ svc:
         sha: e7bbcd13ba6b9e1dec02a7f0fa882444b46d17fb06dc7f7bcde3f927b663c77e
       version: ""
     prometheusSpec:
+      hcpNamespaceRegex: ^ocm-arohcpci01.*
       image:
         registry: mcr.microsoft.com/oss/v2
         repository: prometheus/prometheus

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -666,6 +666,7 @@ mgmt:
         sha: e7bbcd13ba6b9e1dec02a7f0fa882444b46d17fb06dc7f7bcde3f927b663c77e
       version: ""
     prometheusSpec:
+      hcpNamespaceRegex: ^ocm-.*
       image:
         registry: mcr.microsoft.com/oss/v2
         repository: prometheus/prometheus
@@ -984,6 +985,7 @@ svc:
         sha: e7bbcd13ba6b9e1dec02a7f0fa882444b46d17fb06dc7f7bcde3f927b663c77e
       version: ""
     prometheusSpec:
+      hcpNamespaceRegex: ^ocm-.*
       image:
         registry: mcr.microsoft.com/oss/v2
         repository: prometheus/prometheus

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -666,6 +666,7 @@ mgmt:
         sha: e7bbcd13ba6b9e1dec02a7f0fa882444b46d17fb06dc7f7bcde3f927b663c77e
       version: ""
     prometheusSpec:
+      hcpNamespaceRegex: ^ocm-arohcpdev.*
       image:
         registry: mcr.microsoft.com/oss/v2
         repository: prometheus/prometheus
@@ -984,6 +985,7 @@ svc:
         sha: e7bbcd13ba6b9e1dec02a7f0fa882444b46d17fb06dc7f7bcde3f927b663c77e
       version: ""
     prometheusSpec:
+      hcpNamespaceRegex: ^ocm-arohcpdev.*
       image:
         registry: mcr.microsoft.com/oss/v2
         repository: prometheus/prometheus

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -666,6 +666,7 @@ mgmt:
         sha: e7bbcd13ba6b9e1dec02a7f0fa882444b46d17fb06dc7f7bcde3f927b663c77e
       version: ""
     prometheusSpec:
+      hcpNamespaceRegex: ^ocm-arohcpperf.*
       image:
         registry: mcr.microsoft.com/oss/v2
         repository: prometheus/prometheus
@@ -984,6 +985,7 @@ svc:
         sha: e7bbcd13ba6b9e1dec02a7f0fa882444b46d17fb06dc7f7bcde3f927b663c77e
       version: ""
     prometheusSpec:
+      hcpNamespaceRegex: ^ocm-arohcpperf.*
       image:
         registry: mcr.microsoft.com/oss/v2
         repository: prometheus/prometheus

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -668,6 +668,7 @@ mgmt:
         sha: e7bbcd13ba6b9e1dec02a7f0fa882444b46d17fb06dc7f7bcde3f927b663c77e
       version: ""
     prometheusSpec:
+      hcpNamespaceRegex: ^ocm-arohcppers.*
       image:
         registry: mcr.microsoft.com/oss/v2
         repository: prometheus/prometheus
@@ -988,6 +989,7 @@ svc:
         sha: e7bbcd13ba6b9e1dec02a7f0fa882444b46d17fb06dc7f7bcde3f927b663c77e
       version: ""
     prometheusSpec:
+      hcpNamespaceRegex: ^ocm-arohcppers.*
       image:
         registry: mcr.microsoft.com/oss/v2
         repository: prometheus/prometheus

--- a/observability/prometheus/deploy/templates/prometheus.yaml
+++ b/observability/prometheus/deploy/templates/prometheus.yaml
@@ -117,10 +117,10 @@ spec:
       maxBackoff: 256s
     metadataConfig:
       send: false
-    {{- if .Values.environment }}
+    {{- if .Values.prometheusSpec.hcpNamespaceRegex }}
     writeRelabelConfigs:
       - sourceLabels: [namespace]
-        regex: '^ocm-{{ .Values.environment }}.*'
+        regex: '{{ .Values.prometheusSpec.hcpNamespaceRegex }}'
         action: drop
     {{- end -}}
   {{- if ne .Values.prometheusSpec.hcpRemoteWriteUrl "NONE" }}
@@ -138,10 +138,10 @@ spec:
       maxBackoff: 256s
     metadataConfig:
       send: false
-    {{- if .Values.environment }}
+    {{- if .Values.prometheusSpec.hcpNamespaceRegex }}
     writeRelabelConfigs:
       - sourceLabels: [namespace]
-        regex: '^ocm-{{ .Values.environment }}.*'
+        regex: '{{ .Values.prometheusSpec.hcpNamespaceRegex }}'
         action: keep
     {{- end }}
   {{- end }}

--- a/observability/prometheus/values-mgmt.yaml
+++ b/observability/prometheus/values-mgmt.yaml
@@ -143,6 +143,7 @@ prometheusSpec:
   hcpRemoteWriteUrl: "__hcpDcrRemoteWriteUrl__"
   zoneCount: {{ .azureRegionAvailabilityZoneCount }}
   maximumStartupDurationSeconds: 360
+  hcpNamespaceRegex: "{{ .mgmt.prometheus.prometheusSpec.hcpNamespaceRegex }}"
   resources:
     requests:
       cpu: {{ .mgmt.prometheus.prometheusSpec.resources.requests.cpu }}

--- a/observability/prometheus/values-opstool.yaml
+++ b/observability/prometheus/values-opstool.yaml
@@ -67,6 +67,7 @@ prometheusSpec:
   hcpRemoteWriteUrl: "__dcrRemoteWriteUrl__"
   zoneCount: 1
   maximumStartupDurationSeconds: 360
+  hcpNamespaceRegex: "^ocm-opstool.*"
   resources:
     requests:
       cpu: 500m

--- a/observability/prometheus/values-svc.yaml
+++ b/observability/prometheus/values-svc.yaml
@@ -93,6 +93,7 @@ prometheusSpec:
   hcpRemoteWriteUrl: "__hcpDcrRemoteWriteUrl__"
   zoneCount: {{ .azureRegionAvailabilityZoneCount }}
   maximumStartupDurationSeconds: 360
+  hcpNamespaceRegex: "{{ .svc.prometheus.prometheusSpec.hcpNamespaceRegex }}"
   resources:
     requests:
       cpu: {{ .svc.prometheus.prometheusSpec.resources.requests.cpu }}


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-1242

## Summary

- Adds a configurable `hcpNamespaceRegex` field to the Prometheus config to fix HCP metrics routing in CSPR
- In CSPR, the Clusters Service creates ephemeral OCM environments per PR run, and OCM assigns dynamic short IDs (e.g., `j-ah-846`) for namespace naming (`ocm-j-ah-846-<clusterID>`)
- The previous hardcoded regex `^ocm-arohcpcspr.*` never matched these namespaces, causing HCP metrics to be routed to the services workspace instead of the HCP workspace

## Why

The `services-cspr-usw3` Azure Monitor Workspace is at **124% events/min ingestion utilization** and actively dropping over 1M events per hour. Part of this overload is HCP metrics being sent to the wrong workspace because the `writeRelabelConfigs` regex doesn't match CSPR's dynamic namespace prefixes.

The HCP workspace (`hcps-cspr-usw3`) has been receiving **0 metrics** since the mgmt Prometheus was deployed, meaning HCP-specific dashboards and alerts are completely blind.

### Root cause

| Environment | CS `--environment` | OCM env ID | Namespace prefix | Regex match? |
|---|---|---|---|---|
| int/stg/prod | `arohcpint` | `arohcpint` (stable) | `ocm-arohcpint-*` | `^ocm-arohcpint.*` ✅ |
| CSPR | `arohcpcspr` | `j-ah-846` (dynamic per PR) | `ocm-j-ah-846-*` | `^ocm-arohcpcspr.*` ❌ |

In stable environments, OCM uses the environment name as the namespace prefix. In CSPR, OCM creates a new ephemeral environment per PR run and assigns a random short ID that doesn't match the `--environment` flag value.

### What this PR does

- Adds `hcpNamespaceRegex` to `prometheusSpec` in config, schema, and Helm values
- **Default** (all stable envs): `^ocm-arohcp<env>.*` — preserves existing behavior
- **CSPR override**: `^ocm-.*` — matches all OCM namespaces regardless of dynamic ID
- Updates the Prometheus template to use this configurable field instead of inline regex construction

## Test plan

- [x] `cd config && make materialize` passes
- [x] `make verify-schema` passes
- [x] Rendered configs verified:
  - CSPR: `hcpNamespaceRegex: ^ocm-.*`
  - dev: `hcpNamespaceRegex: ^ocm-arohcpdev.*`
  - pers: `hcpNamespaceRegex: ^ocm-arohcppers.*`
  - ci00: `hcpNamespaceRegex: ^ocm-arohcpci00.*`
- [ ] Deploy to CSPR and verify HCP metrics appear in `hcps-cspr-usw3` workspace