### PR TITLE
test: simplify pull secret E2E test to use simple workload

### DIFF
--- a/test/cmd/aro-hcp-tests/main.go
+++ b/test/cmd/aro-hcp-tests/main.go
@@ -247,7 +247,7 @@ func setupCli() *cobra.Command {
 	// 	specs = specs.AddLabel("SLOW")
 
 	// Specs can be globally filtered...
-	specs = specs.MustFilter([]string{`name.contains("manage pull secrets")`})
+	// specs = specs.MustFilter([]string{`name.contains("filter")`})
 
 	// Or walked...
 	// specs = specs.Walk(func(spec *extensiontests.ExtensionTestSpec) {

--- a/test/cmd/aro-hcp-tests/main.go
+++ b/test/cmd/aro-hcp-tests/main.go
@@ -247,7 +247,7 @@ func setupCli() *cobra.Command {
 	// 	specs = specs.AddLabel("SLOW")
 
 	// Specs can be globally filtered...
-	// specs = specs.MustFilter([]string{`name.contains("filter")`})
+	specs = specs.MustFilter([]string{`name.contains("manage pull secrets")`})
 
 	// Or walked...
 	// specs = specs.Walk(func(spec *extensiontests.ExtensionTestSpec) {

--- a/test/e2e/cluster_pullsecret.go
+++ b/test/e2e/cluster_pullsecret.go
@@ -275,6 +275,7 @@ var _ = Describe("Customer", func() {
 							SecurityContext: &corev1.SecurityContext{
 								AllowPrivilegeEscalation: to.Ptr(false),
 								RunAsNonRoot:             to.Ptr(true),
+								RunAsUser:                to.Ptr(int64(1000)),
 								SeccompProfile: &corev1.SeccompProfile{
 									Type: corev1.SeccompProfileTypeRuntimeDefault,
 								},

--- a/test/e2e/cluster_pullsecret.go
+++ b/test/e2e/cluster_pullsecret.go
@@ -275,7 +275,6 @@ var _ = Describe("Customer", func() {
 							SecurityContext: &corev1.SecurityContext{
 								AllowPrivilegeEscalation: to.Ptr(false),
 								RunAsNonRoot:             to.Ptr(true),
-								RunAsUser:                to.Ptr(int64(1000)),
 								SeccompProfile: &corev1.SeccompProfile{
 									Type: corev1.SeccompProfileTypeRuntimeDefault,
 								},
@@ -292,7 +291,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create pull-secret-test pod in %s", pullTestNamespace)
 
 			By("waiting for image from registry.redhat.io to be pulled successfully")
-			err = verifiers.VerifyImagePulled(pullTestNamespace, "registry.redhat.io", "ubi-minimal", imagePullTimeout).
+			err = verifiers.VerifyImagePulled(pullTestNamespace, redhatRegistryHost, "ubi-minimal", imagePullTimeout).
 				Verify(ctx, adminRESTConfig)
 			Expect(err).NotTo(HaveOccurred(), "failed to wait for image from registry.redhat.io to be pulled successfully with the added pull secret")
 		})

--- a/test/e2e/cluster_pullsecret.go
+++ b/test/e2e/cluster_pullsecret.go
@@ -44,7 +44,7 @@ var _ = Describe("Customer", func() {
 	})
 
 	// Tests the HyperShift HCCO global pull secret reconciliation flow:
-	// additional-pull-secret in kube-system -> HCCO merges into global-pull-secret -> DaemonSet syncs to nodes.
+	// additional-pull-secret in kube-system -> HCCO merges into global-pull-secret -> DaemonSet syncs to nodes
 	// Upstream documentation: https://hypershift.pages.dev/how-to/aws/global-pull-secret/
 	It("should be able to create an HCP cluster and manage pull secrets",
 		labels.RequireNothing,
@@ -158,7 +158,7 @@ var _ = Describe("Customer", func() {
 			)
 			Expect(err).NotTo(HaveOccurred(), "failed to create test docker config secret")
 
-			// HCCO watches specifically for a secret named "additional-pull-secret" in kube-system.
+			// HCCO watches specifically for a secret named "additional-pull-secret" in kube-system
 			By("creating the test pull secret in the cluster")
 			_, err = kubeClient.CoreV1().Secrets(pullSecretNamespace).Create(ctx, testPullSecret, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred(), "failed to create additional-pull-secret in kube-system namespace")
@@ -168,7 +168,7 @@ var _ = Describe("Customer", func() {
 				Verify(ctx, adminRESTConfig)
 			Expect(err).NotTo(HaveOccurred(), "failed to wait for additional pull secret to be merged into global-pull-secret by HCCO")
 
-			// The merged secret doesn't reach nodes until global-pull-secret-syncer syncs it to /var/lib/kubelet/config.json.
+			// The merged secret doesn't reach nodes until global-pull-secret-syncer syncs it to /var/lib/kubelet/config.json
 			By("verifying the DaemonSet for global pull secret synchronization is created")
 			err = verifiers.VerifyGlobalPullSecretSyncer(daemonSetSyncTimeout).
 				Verify(ctx, adminRESTConfig)

--- a/test/e2e/cluster_pullsecret.go
+++ b/test/e2e/cluster_pullsecret.go
@@ -64,7 +64,7 @@ var _ = Describe("Customer", func() {
 				// Timeouts for verifications
 				pullSecretMergeTimeout = 10 * time.Minute
 				daemonSetSyncTimeout   = 10 * time.Minute // moving from 5 to 10 minutes due to observed slowness in pre-merge CI
-				imagePullTimeout       = 1 * time.Minute
+				imagePullTimeout       = 3 * time.Minute
 
 				// Image pull test constants
 				pullTestNamespace = "pullsecret-image-test"

--- a/test/e2e/cluster_pullsecret.go
+++ b/test/e2e/cluster_pullsecret.go
@@ -29,10 +29,9 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 
 	"github.com/Azure/ARO-HCP/test/util/framework"
 	"github.com/Azure/ARO-HCP/test/util/labels"
@@ -44,6 +43,9 @@ var _ = Describe("Customer", func() {
 		// per test initialization
 	})
 
+	// Tests the HyperShift HCCO global pull secret reconciliation flow:
+	// additional-pull-secret in kube-system -> HCCO merges into global-pull-secret -> DaemonSet syncs to nodes.
+	// Upstream documentation: https://hypershift.pages.dev/how-to/aws/global-pull-secret/
 	It("should be able to create an HCP cluster and manage pull secrets",
 		labels.RequireNothing,
 		labels.Critical,
@@ -58,15 +60,15 @@ var _ = Describe("Customer", func() {
 				pullSecretName         = "additional-pull-secret"
 				pullSecretNamespace    = "kube-system"
 				redhatRegistryHost     = "registry.redhat.io"
-				catalogSourceName      = "redhat-operators"
-				catalogSourceNamespace = "openshift-marketplace"
-				nfdNamespace           = "openshift-nfd"
 
 				// Timeouts for verifications
 				pullSecretMergeTimeout = 10 * time.Minute
 				daemonSetSyncTimeout   = 10 * time.Minute // moving from 5 to 10 minutes due to observed slowness in pre-merge CI
-				catalogSourceTimeout   = 10 * time.Minute // moving from 5 to 10 minutes due to observed slowness in CI
-				operatorInstallTimeout = 10 * time.Minute
+				imagePullTimeout       = 1 * time.Minute
+
+				// Image pull test constants
+				pullTestNamespace = "pullsecret-image-test"
+				pullTestImage     = "registry.redhat.io/ubi9/ubi-minimal:latest"
 			)
 			tc := framework.NewTestContext()
 
@@ -95,7 +97,7 @@ var _ = Describe("Customer", func() {
 			clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,
 				resourceGroup,
 				clusterParams,
-				map[string]interface{}{},
+				map[string]any{},
 				TestArtifactsFS,
 				framework.RBACScopeResourceGroup,
 			)
@@ -156,6 +158,7 @@ var _ = Describe("Customer", func() {
 			)
 			Expect(err).NotTo(HaveOccurred(), "failed to create test docker config secret")
 
+			// HCCO watches specifically for a secret named "additional-pull-secret" in kube-system.
 			By("creating the test pull secret in the cluster")
 			_, err = kubeClient.CoreV1().Secrets(pullSecretNamespace).Create(ctx, testPullSecret, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred(), "failed to create additional-pull-secret in kube-system namespace")
@@ -165,6 +168,7 @@ var _ = Describe("Customer", func() {
 				Verify(ctx, adminRESTConfig)
 			Expect(err).NotTo(HaveOccurred(), "failed to wait for additional pull secret to be merged into global-pull-secret by HCCO")
 
+			// The merged secret doesn't reach nodes until global-pull-secret-syncer syncs it to /var/lib/kubelet/config.json.
 			By("verifying the DaemonSet for global pull secret synchronization is created")
 			err = verifiers.VerifyGlobalPullSecretSyncer(daemonSetSyncTimeout).
 				Verify(ctx, adminRESTConfig)
@@ -244,108 +248,51 @@ var _ = Describe("Customer", func() {
 			).Verify(ctx, adminRESTConfig)
 			Expect(err).NotTo(HaveOccurred(), "failed to verify registry.redhat.io auth data in global-pull-secret")
 
-			By("verifying redhat-operators catalog source is ready")
-			err = verifiers.VerifyCatalogSourceReady(catalogSourceNamespace, catalogSourceName, catalogSourceTimeout).
-				Verify(ctx, adminRESTConfig)
-			Expect(err).NotTo(HaveOccurred(), "failed to wait for redhat-operators catalog source to be ready before creating subscription")
-
-			By("creating dynamic client for operator installation")
-			dynamicClient, err := dynamic.NewForConfig(adminRESTConfig)
-			Expect(err).NotTo(HaveOccurred(), "failed to create dynamic kubernetes client")
-
-			By("creating namespace for NFD operator")
+			By("creating test namespace for image pull verification")
 			_, err = kubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: nfdNamespace,
+					Name: pullTestNamespace,
 				},
 			}, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred(), "failed to create namespace %s for NFD operator", nfdNamespace)
+			Expect(err).NotTo(HaveOccurred(), "failed to create namespace %s for image pull test", pullTestNamespace)
+			DeferCleanup(func(ctx context.Context) {
+				_ = kubeClient.CoreV1().Namespaces().Delete(ctx, pullTestNamespace, metav1.DeleteOptions{})
+			})
 
-			By("creating OperatorGroup for NFD operator")
-			operatorGroupGVR := schema.GroupVersionResource{
-				Group:    "operators.coreos.com",
-				Version:  "v1",
-				Resource: "operatorgroups",
-			}
-			operatorGroup := &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "operators.coreos.com/v1",
-					"kind":       "OperatorGroup",
-					"metadata": map[string]interface{}{
-						"name":      "nfd-operator-group",
-						"namespace": nfdNamespace,
-					},
-					"spec": map[string]interface{}{
-						"targetNamespaces": []interface{}{nfdNamespace},
-					},
+			By("creating a pod for image pull verification")
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pull-secret-test",
+					Namespace: pullTestNamespace,
 				},
-			}
-			_, err = dynamicClient.Resource(operatorGroupGVR).Namespace(nfdNamespace).Create(ctx, operatorGroup, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred(), "failed to create OperatorGroup for NFD operator in %s", nfdNamespace)
-
-			By("creating Subscription for NFD operator from redhat-operators catalog")
-			subscriptionGVR := schema.GroupVersionResource{
-				Group:    "operators.coreos.com",
-				Version:  "v1alpha1",
-				Resource: "subscriptions",
-			}
-			subscription := &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "operators.coreos.com/v1alpha1",
-					"kind":       "Subscription",
-					"metadata": map[string]interface{}{
-						"name":      "nfd",
-						"namespace": nfdNamespace,
-					},
-					"spec": map[string]interface{}{
-						"channel":             "stable",
-						"name":                "nfd",
-						"source":              "redhat-operators",
-						"sourceNamespace":     "openshift-marketplace",
-						"installPlanApproval": "Automatic",
-					},
-				},
-			}
-			_, err = dynamicClient.Resource(subscriptionGVR).Namespace(nfdNamespace).Create(ctx, subscription, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred(), "failed to create Subscription for NFD operator from redhat-operators catalog")
-
-			By("waiting for NFD operator to be installed")
-			err = verifiers.VerifyOperatorInstalled(nfdNamespace, "nfd", operatorInstallTimeout).
-				Verify(ctx, adminRESTConfig)
-			Expect(err).NotTo(HaveOccurred(), "failed to wait for NFD operator to be installed successfully")
-
-			By("creating NodeFeatureDiscovery CR to deploy NFD worker")
-			nfdGVR := schema.GroupVersionResource{
-				Group:    "nfd.openshift.io",
-				Version:  "v1",
-				Resource: "nodefeaturediscoveries",
-			}
-			nfdCR := &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "nfd.openshift.io/v1",
-					"kind":       "NodeFeatureDiscovery",
-					"metadata": map[string]interface{}{
-						"name":      "nfd-instance",
-						"namespace": nfdNamespace,
-					},
-					"spec": map[string]interface{}{
-						"operand": map[string]interface{}{
-							"image": "registry.redhat.io/openshift4/ose-node-feature-discovery:latest",
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:            "pull-test",
+							Image:           pullTestImage,
+							Command:         []string{"true"},
+							ImagePullPolicy: corev1.PullAlways,
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: to.Ptr(false),
+								RunAsNonRoot:             to.Ptr(true),
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeRuntimeDefault,
+								},
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{"ALL"},
+								},
+							},
 						},
 					},
+					RestartPolicy: corev1.RestartPolicyNever,
 				},
 			}
-			_, err = dynamicClient.Resource(nfdGVR).Namespace(nfdNamespace).Create(ctx, nfdCR, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred(), "failed to create NodeFeatureDiscovery CR in %s", nfdNamespace)
+			_, err = kubeClient.CoreV1().Pods(pullTestNamespace).Create(ctx, pod, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred(), "failed to create pull-secret-test pod in %s", pullTestNamespace)
 
-			By("waiting for NFD worker DaemonSet to be created")
-			err = verifiers.VerifyDaemonSetReady(nfdNamespace, "nfd-worker", operatorInstallTimeout).
+			By("waiting for image from registry.redhat.io to be pulled successfully")
+			err = verifiers.VerifyImagePulled(pullTestNamespace, "registry.redhat.io", "ubi-minimal", imagePullTimeout).
 				Verify(ctx, adminRESTConfig)
-			Expect(err).NotTo(HaveOccurred(), "failed to wait for NFD worker DaemonSet to be created and have ready pods")
-
-			By("waiting for NFD worker pods to be created and verify images from registry.redhat.io can be pulled")
-			err = verifiers.VerifyImagePulled(nfdNamespace, "registry.redhat.io", "ose-node-feature-discovery", operatorInstallTimeout).
-				Verify(ctx, adminRESTConfig)
-			Expect(err).NotTo(HaveOccurred(), "failed to wait for NFD worker images from registry.redhat.io to be pulled successfully with the added pull secret")
+			Expect(err).NotTo(HaveOccurred(), "failed to wait for image from registry.redhat.io to be pulled successfully with the added pull secret")
 		})
 })


### PR DESCRIPTION
[ARO-27527](https://redhat.atlassian.net/browse/ARO-27527)

### What

Removing the OLM/NFD code and associated catalog checks as well as any no longer used NFD related imports.

Replaced with a simple pod-based image pull test. 

Added basic upstream HyperShift documentation references. 

### Why

Remove unnecessary complexity of the test case. 

### Testing

PR modifies an existing E2E test case

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [ ] All comment threads resolved before merge
- [x] CRITICAL: revert MustFilter before merge
