### PR TITLE
deps: bump ARO-Tools prow-job-executor for Key Vault prow-token retry

### DIFF
--- a/test/go.mod
+++ b/test/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/Azure/ARO-HCP/tooling/templatize v0.0.0-00010101000000-000000000000
 	github.com/Azure/ARO-HCP/tooling/utilitytypes v0.0.0-00010101000000-000000000000
 	github.com/Azure/ARO-Tools/config v0.0.0-20260617060128-2277df76598b
-	github.com/Azure/ARO-Tools/tools/prow-job-executor v0.0.0-20260618114223-e64276f10667
+	github.com/Azure/ARO-Tools/tools/prow-job-executor v0.0.0-20260623115542-4b47beb2064a
 	github.com/Azure/azure-kusto-go/azkustodata v1.2.1
 	github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/v2 v2.0.2
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/alertsmanagement/armalertsmanagement v0.11.0

--- a/test/go.sum
+++ b/test/go.sum
@@ -79,8 +79,8 @@ github.com/Azure/ARO-Tools/tools/grafanactl v0.0.0-20260617060128-2277df76598b h
 github.com/Azure/ARO-Tools/tools/grafanactl v0.0.0-20260617060128-2277df76598b/go.mod h1:zxoZ1tIwd5xvd3O25IGAcsai1XbeGua4FsGrN4PZZl4=
 github.com/Azure/ARO-Tools/tools/helm v0.0.0-20260617060128-2277df76598b h1:kVlzxjHIRVada/BDNAJGheR5tMcLgxNPJNpSO0VcV+Q=
 github.com/Azure/ARO-Tools/tools/helm v0.0.0-20260617060128-2277df76598b/go.mod h1:lIkHJvdueu5ohSmqw44WHzrgVURREiNRcupKN4Wbvbk=
-github.com/Azure/ARO-Tools/tools/prow-job-executor v0.0.0-20260618114223-e64276f10667 h1:8OD3Kw2WD+M5AsFBYNMpj6erV5FxICKqCG5e8H0fNeA=
-github.com/Azure/ARO-Tools/tools/prow-job-executor v0.0.0-20260618114223-e64276f10667/go.mod h1:Lebj7qAq+p0aVbPFPWFdmfQemftahaNroS4TbBb3pVY=
+github.com/Azure/ARO-Tools/tools/prow-job-executor v0.0.0-20260623115542-4b47beb2064a h1:WNOMRu/pTBAA4+hdCqcQqoRqT+RjPTXvppf/hLYB1TU=
+github.com/Azure/ARO-Tools/tools/prow-job-executor v0.0.0-20260623115542-4b47beb2064a/go.mod h1:fvoVGXRN5GarxJSv7WxEJ5MJgwYtmbx9E6y0Kt9JbzQ=
 github.com/Azure/ARO-Tools/tools/registration v0.0.0-20260617060128-2277df76598b h1:IZbY+Ew5oCWRLIBExnBl9+Bp3THXSpMf2oU6w442+zQ=
 github.com/Azure/ARO-Tools/tools/registration v0.0.0-20260617060128-2277df76598b/go.mod h1:mysDRYIRDp0PQm75Qkbuudbtv8ZN+xVjrkFdCOx/XU8=
 github.com/Azure/ARO-Tools/tools/secret-sync v0.0.0-20260617060128-2277df76598b h1:SOhpCzBXvl9DB4UJAYE639xDuZO4I0PWh7Z6kKky6KM=

--- a/tooling/templatize/go.mod
+++ b/tooling/templatize/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/Azure/ARO-Tools/tools/cmdutils v0.0.0-20260617060128-2277df76598b
 	github.com/Azure/ARO-Tools/tools/grafanactl v0.0.0-20260617060128-2277df76598b
 	github.com/Azure/ARO-Tools/tools/helm v0.0.0-20260617060128-2277df76598b
-	github.com/Azure/ARO-Tools/tools/prow-job-executor v0.0.0-20260618114223-e64276f10667
+	github.com/Azure/ARO-Tools/tools/prow-job-executor v0.0.0-20260623115542-4b47beb2064a
 	github.com/Azure/ARO-Tools/tools/registration v0.0.0-20260617060128-2277df76598b
 	github.com/Azure/ARO-Tools/tools/secret-sync v0.0.0-20260617060128-2277df76598b
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1

--- a/tooling/templatize/go.sum
+++ b/tooling/templatize/go.sum
@@ -79,8 +79,8 @@ github.com/Azure/ARO-Tools/tools/grafanactl v0.0.0-20260617060128-2277df76598b h
 github.com/Azure/ARO-Tools/tools/grafanactl v0.0.0-20260617060128-2277df76598b/go.mod h1:zxoZ1tIwd5xvd3O25IGAcsai1XbeGua4FsGrN4PZZl4=
 github.com/Azure/ARO-Tools/tools/helm v0.0.0-20260617060128-2277df76598b h1:kVlzxjHIRVada/BDNAJGheR5tMcLgxNPJNpSO0VcV+Q=
 github.com/Azure/ARO-Tools/tools/helm v0.0.0-20260617060128-2277df76598b/go.mod h1:lIkHJvdueu5ohSmqw44WHzrgVURREiNRcupKN4Wbvbk=
-github.com/Azure/ARO-Tools/tools/prow-job-executor v0.0.0-20260618114223-e64276f10667 h1:8OD3Kw2WD+M5AsFBYNMpj6erV5FxICKqCG5e8H0fNeA=
-github.com/Azure/ARO-Tools/tools/prow-job-executor v0.0.0-20260618114223-e64276f10667/go.mod h1:Lebj7qAq+p0aVbPFPWFdmfQemftahaNroS4TbBb3pVY=
+github.com/Azure/ARO-Tools/tools/prow-job-executor v0.0.0-20260623115542-4b47beb2064a h1:WNOMRu/pTBAA4+hdCqcQqoRqT+RjPTXvppf/hLYB1TU=
+github.com/Azure/ARO-Tools/tools/prow-job-executor v0.0.0-20260623115542-4b47beb2064a/go.mod h1:fvoVGXRN5GarxJSv7WxEJ5MJgwYtmbx9E6y0Kt9JbzQ=
 github.com/Azure/ARO-Tools/tools/registration v0.0.0-20260617060128-2277df76598b h1:IZbY+Ew5oCWRLIBExnBl9+Bp3THXSpMf2oU6w442+zQ=
 github.com/Azure/ARO-Tools/tools/registration v0.0.0-20260617060128-2277df76598b/go.mod h1:mysDRYIRDp0PQm75Qkbuudbtv8ZN+xVjrkFdCOx/XU8=
 github.com/Azure/ARO-Tools/tools/secret-sync v0.0.0-20260617060128-2277df76598b h1:SOhpCzBXvl9DB4UJAYE639xDuZO4I0PWh7Z6kKky6KM=


### PR DESCRIPTION
Bumps `github.com/Azure/ARO-Tools/tools/prow-job-executor` from `v0.0.0-20260618114223-e64276f10667` → `v0.0.0-20260623115542-4b47beb2064a` in `test/` and `tooling/templatize/`.

This pins the Key Vault prow-token retry hardening merged in Azure/ARO-Tools#252 (commit `4b47beb`), so the generic `WithValue` retry helper becomes effective for the prow-token Key Vault fetch run by the EV2 E2E gate. This reduces spurious gate retries caused by transient Key Vault throttling / network errors.

Scoped strictly to the prow-job-executor pin — `go mod tidy` + `go work sync` leave all other ARO-Tools submodule pins (incl. `tools/helm`) unchanged. Mirrors the earlier SubmitJob 429 bump (#5707).

Jira: [AROSLSRE-1228](https://redhat.atlassian.net/browse/AROSLSRE-1228)