### PR TITLE
deps: bump ARO-Tools helm + prow-job-executor (AROSLSRE-1234, AROSLSRE-1228)

### DIFF
--- a/test/go.mod
+++ b/test/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/Azure/ARO-HCP/tooling/templatize v0.0.0-00010101000000-000000000000
 	github.com/Azure/ARO-HCP/tooling/utilitytypes v0.0.0-00010101000000-000000000000
 	github.com/Azure/ARO-Tools/config v0.0.0-20260617060128-2277df76598b
-	github.com/Azure/ARO-Tools/tools/prow-job-executor v0.0.0-20260618114223-e64276f10667
+	github.com/Azure/ARO-Tools/tools/prow-job-executor v0.0.0-20260625140822-7cf3574ac01b
 	github.com/Azure/azure-kusto-go/azkustodata v1.2.1
 	github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/v2 v2.0.2
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/alertsmanagement/armalertsmanagement v0.11.0
@@ -72,7 +72,7 @@ require (
 	github.com/Azure/ARO-Tools/pipelines v0.0.0-20260617060128-2277df76598b // indirect
 	github.com/Azure/ARO-Tools/tools/cmdutils v0.0.0-20260617060128-2277df76598b // indirect
 	github.com/Azure/ARO-Tools/tools/grafanactl v0.0.0-20260617060128-2277df76598b // indirect
-	github.com/Azure/ARO-Tools/tools/helm v0.0.0-20260617060128-2277df76598b // indirect
+	github.com/Azure/ARO-Tools/tools/helm v0.0.0-20260625140822-7cf3574ac01b // indirect
 	github.com/Azure/ARO-Tools/tools/registration v0.0.0-20260617060128-2277df76598b // indirect
 	github.com/Azure/ARO-Tools/tools/secret-sync v0.0.0-20260617060128-2277df76598b // indirect
 	github.com/Azure/ARO-Tools/tools/yamlwrap v0.0.0-20260617060128-2277df76598b // indirect

--- a/test/go.sum
+++ b/test/go.sum
@@ -77,10 +77,10 @@ github.com/Azure/ARO-Tools/tools/cmdutils v0.0.0-20260617060128-2277df76598b h1:
 github.com/Azure/ARO-Tools/tools/cmdutils v0.0.0-20260617060128-2277df76598b/go.mod h1:bin6OKbbloNkD5EYEgXz6d6JGQsWhClgcbVUQrEJ2BQ=
 github.com/Azure/ARO-Tools/tools/grafanactl v0.0.0-20260617060128-2277df76598b h1:op983BIuyIJVMhmoAS5JkSsb2V4OQl3eIiH1BS07H1E=
 github.com/Azure/ARO-Tools/tools/grafanactl v0.0.0-20260617060128-2277df76598b/go.mod h1:zxoZ1tIwd5xvd3O25IGAcsai1XbeGua4FsGrN4PZZl4=
-github.com/Azure/ARO-Tools/tools/helm v0.0.0-20260617060128-2277df76598b h1:kVlzxjHIRVada/BDNAJGheR5tMcLgxNPJNpSO0VcV+Q=
-github.com/Azure/ARO-Tools/tools/helm v0.0.0-20260617060128-2277df76598b/go.mod h1:lIkHJvdueu5ohSmqw44WHzrgVURREiNRcupKN4Wbvbk=
-github.com/Azure/ARO-Tools/tools/prow-job-executor v0.0.0-20260618114223-e64276f10667 h1:8OD3Kw2WD+M5AsFBYNMpj6erV5FxICKqCG5e8H0fNeA=
-github.com/Azure/ARO-Tools/tools/prow-job-executor v0.0.0-20260618114223-e64276f10667/go.mod h1:Lebj7qAq+p0aVbPFPWFdmfQemftahaNroS4TbBb3pVY=
+github.com/Azure/ARO-Tools/tools/helm v0.0.0-20260625140822-7cf3574ac01b h1:zR5p1/s8HXeaJSE099mTfMoVD2lH/J/CtZ3FbX2C4cA=
+github.com/Azure/ARO-Tools/tools/helm v0.0.0-20260625140822-7cf3574ac01b/go.mod h1:lIkHJvdueu5ohSmqw44WHzrgVURREiNRcupKN4Wbvbk=
+github.com/Azure/ARO-Tools/tools/prow-job-executor v0.0.0-20260625140822-7cf3574ac01b h1:flhFOOLJJQKhqOakjnsccppZUv7AGja9HO7NTQSdCI0=
+github.com/Azure/ARO-Tools/tools/prow-job-executor v0.0.0-20260625140822-7cf3574ac01b/go.mod h1:fvoVGXRN5GarxJSv7WxEJ5MJgwYtmbx9E6y0Kt9JbzQ=
 github.com/Azure/ARO-Tools/tools/registration v0.0.0-20260617060128-2277df76598b h1:IZbY+Ew5oCWRLIBExnBl9+Bp3THXSpMf2oU6w442+zQ=
 github.com/Azure/ARO-Tools/tools/registration v0.0.0-20260617060128-2277df76598b/go.mod h1:mysDRYIRDp0PQm75Qkbuudbtv8ZN+xVjrkFdCOx/XU8=
 github.com/Azure/ARO-Tools/tools/secret-sync v0.0.0-20260617060128-2277df76598b h1:SOhpCzBXvl9DB4UJAYE639xDuZO4I0PWh7Z6kKky6KM=

--- a/tooling/templatize/go.mod
+++ b/tooling/templatize/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/Azure/ARO-Tools/testutil v0.0.0-20260617060128-2277df76598b
 	github.com/Azure/ARO-Tools/tools/cmdutils v0.0.0-20260617060128-2277df76598b
 	github.com/Azure/ARO-Tools/tools/grafanactl v0.0.0-20260617060128-2277df76598b
-	github.com/Azure/ARO-Tools/tools/helm v0.0.0-20260617060128-2277df76598b
-	github.com/Azure/ARO-Tools/tools/prow-job-executor v0.0.0-20260618114223-e64276f10667
+	github.com/Azure/ARO-Tools/tools/helm v0.0.0-20260625140822-7cf3574ac01b
+	github.com/Azure/ARO-Tools/tools/prow-job-executor v0.0.0-20260625140822-7cf3574ac01b
 	github.com/Azure/ARO-Tools/tools/registration v0.0.0-20260617060128-2277df76598b
 	github.com/Azure/ARO-Tools/tools/secret-sync v0.0.0-20260617060128-2277df76598b
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1

--- a/tooling/templatize/go.sum
+++ b/tooling/templatize/go.sum
@@ -77,10 +77,10 @@ github.com/Azure/ARO-Tools/tools/cmdutils v0.0.0-20260617060128-2277df76598b h1:
 github.com/Azure/ARO-Tools/tools/cmdutils v0.0.0-20260617060128-2277df76598b/go.mod h1:bin6OKbbloNkD5EYEgXz6d6JGQsWhClgcbVUQrEJ2BQ=
 github.com/Azure/ARO-Tools/tools/grafanactl v0.0.0-20260617060128-2277df76598b h1:op983BIuyIJVMhmoAS5JkSsb2V4OQl3eIiH1BS07H1E=
 github.com/Azure/ARO-Tools/tools/grafanactl v0.0.0-20260617060128-2277df76598b/go.mod h1:zxoZ1tIwd5xvd3O25IGAcsai1XbeGua4FsGrN4PZZl4=
-github.com/Azure/ARO-Tools/tools/helm v0.0.0-20260617060128-2277df76598b h1:kVlzxjHIRVada/BDNAJGheR5tMcLgxNPJNpSO0VcV+Q=
-github.com/Azure/ARO-Tools/tools/helm v0.0.0-20260617060128-2277df76598b/go.mod h1:lIkHJvdueu5ohSmqw44WHzrgVURREiNRcupKN4Wbvbk=
-github.com/Azure/ARO-Tools/tools/prow-job-executor v0.0.0-20260618114223-e64276f10667 h1:8OD3Kw2WD+M5AsFBYNMpj6erV5FxICKqCG5e8H0fNeA=
-github.com/Azure/ARO-Tools/tools/prow-job-executor v0.0.0-20260618114223-e64276f10667/go.mod h1:Lebj7qAq+p0aVbPFPWFdmfQemftahaNroS4TbBb3pVY=
+github.com/Azure/ARO-Tools/tools/helm v0.0.0-20260625140822-7cf3574ac01b h1:zR5p1/s8HXeaJSE099mTfMoVD2lH/J/CtZ3FbX2C4cA=
+github.com/Azure/ARO-Tools/tools/helm v0.0.0-20260625140822-7cf3574ac01b/go.mod h1:lIkHJvdueu5ohSmqw44WHzrgVURREiNRcupKN4Wbvbk=
+github.com/Azure/ARO-Tools/tools/prow-job-executor v0.0.0-20260625140822-7cf3574ac01b h1:flhFOOLJJQKhqOakjnsccppZUv7AGja9HO7NTQSdCI0=
+github.com/Azure/ARO-Tools/tools/prow-job-executor v0.0.0-20260625140822-7cf3574ac01b/go.mod h1:fvoVGXRN5GarxJSv7WxEJ5MJgwYtmbx9E6y0Kt9JbzQ=
 github.com/Azure/ARO-Tools/tools/registration v0.0.0-20260617060128-2277df76598b h1:IZbY+Ew5oCWRLIBExnBl9+Bp3THXSpMf2oU6w442+zQ=
 github.com/Azure/ARO-Tools/tools/registration v0.0.0-20260617060128-2277df76598b/go.mod h1:mysDRYIRDp0PQm75Qkbuudbtv8ZN+xVjrkFdCOx/XU8=
 github.com/Azure/ARO-Tools/tools/secret-sync v0.0.0-20260617060128-2277df76598b h1:SOhpCzBXvl9DB4UJAYE639xDuZO4I0PWh7Z6kKky6KM=


### PR DESCRIPTION
Bumps `github.com/Azure/ARO-Tools/tools/helm` and `github.com/Azure/ARO-Tools/tools/prow-job-executor` to ARO-Tools main HEAD (`v0.0.0-20260625140822-7cf3574ac01b`) in the `test` and `tooling/templatize` modules.

This consolidates two dependency bumps that touch the identical go.mod/go.sum files:

- **AROSLSRE-1234** — `tools/helm`: IMDS/MSI retry-on-transient-failure (Azure/ARO-Tools#254) and the `helmdeploy` stale-lock detection/diagnostics work (Azure/ARO-Tools#253, [AROSLSRE-997](https://redhat.atlassian.net/browse/AROSLSRE-997)).
- **[AROSLSRE-1228](https://redhat.atlassian.net/browse/AROSLSRE-1228)** — `tools/prow-job-executor`: Key Vault retry handling (Azure/ARO-Tools#252).

Supersedes and replaces #5749 (prow-job-executor-only bump), which is now closed.

Only go.mod/go.sum are changed (4 files).