### PR TITLE
fix(observability): route KAS availability alerts to SRE lane at info severity

### DIFF
--- a/observability/alerts-rp-hcps.yaml
+++ b/observability/alerts-rp-hcps.yaml
@@ -1,6 +1,5 @@
 prometheusRules:
-  rulesFolders:
-  - ../observability/alerts/UJKubeApiserverAvailabilityMonitor-prometheusRule-KSM.yaml
+  rulesFolders: []
   untestedRules: []
   testDependencies:
   - recording-rules-hcps.yaml

--- a/observability/alerts-sre-hcps.yaml
+++ b/observability/alerts-sre-hcps.yaml
@@ -4,6 +4,7 @@ prometheusRules:
   - alerts/HCPkasRecord-prometheusRule-KSM.yaml
   - alerts/HCPkasMonitor-prometheusRule-KSM.yaml
   - alerts/HCPclusterHealth-prometheusRule.yaml
+  - alerts/UJKubeApiserverAvailabilityMonitor-prometheusRule-KSM.yaml
   untestedRules:
   - alerts/kubernetesControlPlane-prometheusRule.yaml
   testDependencies:

--- a/observability/alerts/UJKubeApiserverAvailabilityMonitor-prometheusRule-KSM.yaml
+++ b/observability/alerts/UJKubeApiserverAvailabilityMonitor-prometheusRule-KSM.yaml
@@ -26,7 +26,7 @@ spec:
       labels:
         long_window: 1h
         short_window: 5m
-        severity: critical
+        severity: info
         slo: kas-availability
       annotations:
         summary: "[HCP] [{{ $labels.name }}] KubeAPIServer Fast Error Budget Burn (1h/5m)"
@@ -55,7 +55,7 @@ spec:
       labels:
         long_window: 6h
         short_window: 30m
-        severity: critical
+        severity: info
         slo: kas-availability
       annotations:
         summary: "[HCP] [{{ $labels.name }}] KubeAPIServer Medium Error Budget Burn (6h/30m)"
@@ -85,7 +85,7 @@ spec:
       labels:
         long_window: 3d
         short_window: 6h
-        severity: warning
+        severity: info
         slo: kas-availability
       annotations:
         summary: "[HCP] [{{ $labels.name }}] KubeAPIServer Slow Error Budget Burn (3d/6h)"


### PR DESCRIPTION
### What

Move UJ KAS availability alerts from the RP lane to the SRE lane and set severity to info (non-paging).

### Why

The RP lane did not have routing rules configured in IcM, causing alerts to page the wrong queue (MSFT triage). Routing through the SRE lane uses the established SRE-to-RP routing path.

### Testing

Lane reassignment and severity label change only; no functional change to alert expressions or recording rules.