### PR TITLE
feat: speed up fleet registration for unregistered management clusters

### DIFF
--- a/fleet/pkg/controllers/base/registration_cooldown.go
+++ b/fleet/pkg/controllers/base/registration_cooldown.go
@@ -1,0 +1,82 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package base
+
+import (
+	"context"
+	"time"
+
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	utilsclock "k8s.io/utils/clock"
+
+	"github.com/Azure/ARO-HCP/internal/api/fleet"
+	"github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/database/listers"
+)
+
+const (
+	DefaultRegisteredCooldown   = 5 * time.Minute
+	DefaultUnregisteredCooldown = 10 * time.Second
+)
+
+var _ controllerutils.CooldownChecker = (*RegistrationAwareCooldown)(nil)
+
+// RegistrationAwareCooldown uses a shorter cooldown for management clusters
+// that are not yet Ready, mirroring the backend's
+// ActiveOperationBasedChecker pattern for clusters with active operations.
+type RegistrationAwareCooldown struct {
+	managementClusterLister listers.ManagementClusterLister
+	registeredTimer         *controllerutils.TimeBasedCooldownChecker
+	unregisteredTimer       *controllerutils.TimeBasedCooldownChecker
+}
+
+func DefaultRegistrationAwareCooldown(
+	managementClusterLister listers.ManagementClusterLister,
+) *RegistrationAwareCooldown {
+	return NewRegistrationAwareCooldown(managementClusterLister, DefaultRegisteredCooldown, DefaultUnregisteredCooldown)
+}
+
+func NewRegistrationAwareCooldown(
+	managementClusterLister listers.ManagementClusterLister,
+	registeredCooldown, unregisteredCooldown time.Duration,
+) *RegistrationAwareCooldown {
+	return &RegistrationAwareCooldown{
+		managementClusterLister: managementClusterLister,
+		registeredTimer:         controllerutils.NewTimeBasedCooldownChecker(registeredCooldown),
+		unregisteredTimer:       controllerutils.NewTimeBasedCooldownChecker(unregisteredCooldown),
+	}
+}
+
+func (c *RegistrationAwareCooldown) SetClock(clock utilsclock.PassiveClock) {
+	c.registeredTimer.SetClock(clock)
+	c.unregisteredTimer.SetClock(clock)
+}
+
+func (c *RegistrationAwareCooldown) CanSync(ctx context.Context, key any) bool {
+	stampKey, ok := key.(StampKey)
+	if !ok {
+		return c.unregisteredTimer.CanSync(ctx, key)
+	}
+
+	managementCluster, err := c.managementClusterLister.Get(ctx, stampKey.StampIdentifier)
+	if err != nil {
+		return c.unregisteredTimer.CanSync(ctx, key)
+	}
+
+	if apimeta.IsStatusConditionTrue(managementCluster.Status.Conditions, string(fleet.ManagementClusterConditionReady)) {
+		return c.registeredTimer.CanSync(ctx, key)
+	}
+	return c.unregisteredTimer.CanSync(ctx, key)
+}

--- a/fleet/pkg/controllers/base/registration_cooldown_test.go
+++ b/fleet/pkg/controllers/base/registration_cooldown_test.go
@@ -1,0 +1,182 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package base
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	testclock "k8s.io/utils/clock/testing"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/fleet"
+	"github.com/Azure/ARO-HCP/internal/database"
+)
+
+type fakeManagementClusterLister struct {
+	clusters map[string]*fleet.ManagementCluster
+}
+
+func (f *fakeManagementClusterLister) List(_ context.Context) ([]*fleet.ManagementCluster, error) {
+	result := make([]*fleet.ManagementCluster, 0, len(f.clusters))
+	for _, managementCluster := range f.clusters {
+		result = append(result, managementCluster)
+	}
+	return result, nil
+}
+
+func (f *fakeManagementClusterLister) Get(_ context.Context, stampIdentifier string) (*fleet.ManagementCluster, error) {
+	managementCluster, ok := f.clusters[stampIdentifier]
+	if !ok {
+		return nil, database.NewNotFoundError()
+	}
+	return managementCluster, nil
+}
+
+func (f *fakeManagementClusterLister) GetByCSProvisionShardID(_ context.Context, _ string) (*fleet.ManagementCluster, error) {
+	return nil, database.NewNotFoundError()
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+func testManagementCluster(stampIdentifier string, ready *bool) *fleet.ManagementCluster {
+	resourceID, _ := fleet.ToManagementClusterResourceID(stampIdentifier)
+	managementCluster := &fleet.ManagementCluster{
+		CosmosMetadata: api.CosmosMetadata{ResourceID: resourceID},
+	}
+	if ready != nil {
+		status := metav1.ConditionFalse
+		if *ready {
+			status = metav1.ConditionTrue
+		}
+		managementCluster.Status.Conditions = []metav1.Condition{
+			{
+				Type:   string(fleet.ManagementClusterConditionReady),
+				Status: status,
+			},
+		}
+	}
+	return managementCluster
+}
+
+func TestRegistrationAwareCooldown(t *testing.T) {
+	registeredCooldown := DefaultRegisteredCooldown
+	unregisteredCooldown := DefaultUnregisteredCooldown
+
+	tests := []struct {
+		name       string
+		clusters   map[string]*fleet.ManagementCluster
+		key        any
+		elapsed    time.Duration
+		wantFirst  bool
+		wantSecond bool
+	}{
+		{
+			name: "ready cluster uses registered (slow) cooldown - blocked within window",
+			clusters: map[string]*fleet.ManagementCluster{
+				"ready-mc": testManagementCluster("ready-mc", boolPtr(true)),
+			},
+			key:        StampKey{StampIdentifier: "ready-mc"},
+			elapsed:    registeredCooldown / 2,
+			wantFirst:  true,
+			wantSecond: false,
+		},
+		{
+			name: "ready cluster uses registered (slow) cooldown - allowed after window",
+			clusters: map[string]*fleet.ManagementCluster{
+				"ready-mc": testManagementCluster("ready-mc", boolPtr(true)),
+			},
+			key:        StampKey{StampIdentifier: "ready-mc"},
+			elapsed:    registeredCooldown + time.Second,
+			wantFirst:  true,
+			wantSecond: true,
+		},
+		{
+			name: "not-ready cluster uses unregistered (fast) cooldown - blocked within window",
+			clusters: map[string]*fleet.ManagementCluster{
+				"pending-mc": testManagementCluster("pending-mc", boolPtr(false)),
+			},
+			key:        StampKey{StampIdentifier: "pending-mc"},
+			elapsed:    unregisteredCooldown / 2,
+			wantFirst:  true,
+			wantSecond: false,
+		},
+		{
+			name: "not-ready cluster uses unregistered (fast) cooldown - allowed after window",
+			clusters: map[string]*fleet.ManagementCluster{
+				"pending-mc": testManagementCluster("pending-mc", boolPtr(false)),
+			},
+			key:        StampKey{StampIdentifier: "pending-mc"},
+			elapsed:    unregisteredCooldown + time.Second,
+			wantFirst:  true,
+			wantSecond: true,
+		},
+		{
+			name: "missing Ready condition uses unregistered (fast) cooldown",
+			clusters: map[string]*fleet.ManagementCluster{
+				"no-condition-mc": testManagementCluster("no-condition-mc", nil),
+			},
+			key:        StampKey{StampIdentifier: "no-condition-mc"},
+			elapsed:    unregisteredCooldown + time.Second,
+			wantFirst:  true,
+			wantSecond: true,
+		},
+		{
+			name: "Ready=False uses unregistered (fast) cooldown",
+			clusters: map[string]*fleet.ManagementCluster{
+				"false-mc": testManagementCluster("false-mc", boolPtr(false)),
+			},
+			key:        StampKey{StampIdentifier: "false-mc"},
+			elapsed:    unregisteredCooldown + time.Second,
+			wantFirst:  true,
+			wantSecond: true,
+		},
+		{
+			name:       "unknown cluster uses unregistered (fast) cooldown",
+			clusters:   map[string]*fleet.ManagementCluster{},
+			key:        StampKey{StampIdentifier: "unknown-mc"},
+			elapsed:    unregisteredCooldown + time.Second,
+			wantFirst:  true,
+			wantSecond: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			now := time.Now()
+			fakeClock := testclock.NewFakeClock(now)
+
+			lister := &fakeManagementClusterLister{clusters: tt.clusters}
+			cooldown := NewRegistrationAwareCooldown(lister, registeredCooldown, unregisteredCooldown)
+			cooldown.SetClock(fakeClock)
+
+			ctx := context.Background()
+
+			first := cooldown.CanSync(ctx, tt.key)
+			if first != tt.wantFirst {
+				t.Errorf("first CanSync: got %v, want %v", first, tt.wantFirst)
+			}
+
+			fakeClock.SetTime(now.Add(tt.elapsed))
+
+			second := cooldown.CanSync(ctx, tt.key)
+			if second != tt.wantSecond {
+				t.Errorf("second CanSync after %v: got %v, want %v", tt.elapsed, second, tt.wantSecond)
+			}
+		})
+	}
+}

--- a/fleet/pkg/controllers/base/stamp_watching_controller.go
+++ b/fleet/pkg/controllers/base/stamp_watching_controller.go
@@ -93,6 +93,10 @@ type StampSyncer interface {
 
 // StampWatchingControllerConfig tunes the controller's cooldown behavior.
 type StampWatchingControllerConfig struct {
+	// Cooldown overrides the default time-based cooldown checker.
+	// When set, CooldownPeriod and Clock are ignored.
+	Cooldown controllerutils.CooldownChecker
+
 	CooldownPeriod time.Duration
 	Clock          utilsclock.PassiveClock
 }
@@ -125,8 +129,15 @@ func NewStampWatchingController(
 	cfg StampWatchingControllerConfig,
 ) *StampWatchingController {
 	cfg = cfg.withDefaults()
-	cooldownChecker := controllerutils.NewTimeBasedCooldownChecker(cfg.CooldownPeriod)
-	cooldownChecker.SetClock(cfg.Clock)
+
+	var cooldown controllerutils.CooldownChecker
+	if cfg.Cooldown != nil {
+		cooldown = cfg.Cooldown
+	} else {
+		checker := controllerutils.NewTimeBasedCooldownChecker(cfg.CooldownPeriod)
+		checker.SetClock(cfg.Clock)
+		cooldown = checker
+	}
 
 	return &StampWatchingController{
 		name:   name,
@@ -135,7 +146,7 @@ func NewStampWatchingController(
 			workqueue.DefaultTypedControllerRateLimiter[StampKey](),
 			workqueue.TypedRateLimitingQueueConfig[StampKey]{Name: name},
 		),
-		cooldown: cooldownChecker,
+		cooldown: cooldown,
 	}
 }
 

--- a/fleet/pkg/manager/manager.go
+++ b/fleet/pkg/manager/manager.go
@@ -164,7 +164,8 @@ func (m *Manager) runControllersUnderLeaderElection(
 ) error {
 	logger := utils.LoggerFromContext(ctx)
 
-	fleetInformers := informers.NewFleetInformers(ctx, m.FleetDBClient.GlobalListers())
+	relistDuration := 10 * time.Second
+	fleetInformers := informers.NewFleetInformersWithRelistDuration(ctx, m.FleetDBClient.GlobalListers(), &relistDuration)
 
 	stampInformer, stampLister := fleetInformers.Stamps()
 	managementClusterInformer, managementClusterLister := fleetInformers.ManagementClusters()
@@ -176,7 +177,7 @@ func (m *Manager) runControllersUnderLeaderElection(
 		m.ClustersServiceClient,
 		stampLister,
 		m.Region,
-		base.StampWatchingControllerConfig{},
+		base.StampWatchingControllerConfig{Cooldown: base.DefaultRegistrationAwareCooldown(managementClusterLister)},
 	)
 
 	maestroRegistrationController := maestroregistration.NewMaestroRegistrationController(
@@ -185,13 +186,13 @@ func (m *Manager) runControllersUnderLeaderElection(
 		m.FleetDBClient,
 		m.MaestroConsumerClientFactory,
 		stampLister,
-		base.StampWatchingControllerConfig{},
+		base.StampWatchingControllerConfig{Cooldown: base.DefaultRegistrationAwareCooldown(managementClusterLister)},
 	)
 
 	lifecycleController := lifecycle.NewManagementClusterLifecycleController(
 		managementClusterInformer,
 		m.FleetDBClient,
-		base.StampWatchingControllerConfig{},
+		base.StampWatchingControllerConfig{Cooldown: base.DefaultRegistrationAwareCooldown(managementClusterLister)},
 	)
 
 	dataDumpController := datadump.NewStampDataDumpController(


### PR DESCRIPTION
### What

Management clusters that are not yet Ready now reconcile every ~10s instead of every ~10 minutes. This reduces the time E2E tests spend waiting in Prow for management cluster registration to complete before they can start running.

Two changes combine to achieve this:
- Cosmos relist interval for fleet informers reduced from 2m to 10s, so changes are detected faster (few records, cheap to poll)
- Registration-aware cooldown checker uses 10s cooldown for not-Ready management clusters vs 5m for Ready ones, mirroring the backend's ActiveOperationBasedChecker pattern

https://redhat.atlassian.net/browse/ARO-27946

### Why

<!-- Briefly explain why this change is needed -->

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
