### PR TITLE
fix: return 503 status code when CS provisioning shard is not yet registered

### DIFF
--- a/internal/ocm/convert.go
+++ b/internal/ocm/convert.go
@@ -724,6 +724,12 @@ func CSErrorToCloudError(err error, resourceID *azcorearm.ResourceID) *arm.Cloud
 				arm.CloudErrorCodeInvalidRequestContent,
 				"", "%s", ocmError.Reason())
 		case http.StatusNotFound:
+			if strings.Contains(ocmError.Reason(), "Unable to find shard") {
+				return arm.NewCloudError(
+					http.StatusServiceUnavailable,
+					arm.CloudErrorCodeServiceUnavailable,
+					"", "Capacity is currently restricted, please try again later")
+			}
 			if resourceID != nil {
 				return arm.NewResourceNotFoundError(resourceID)
 			}

--- a/internal/ocm/convert_test.go
+++ b/internal/ocm/convert_test.go
@@ -18,6 +18,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -31,6 +33,7 @@ import (
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
 	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
 
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
@@ -1338,6 +1341,157 @@ func TestConvertCSManagementClusterToInternal(t *testing.T) {
 				if tt.validate != nil {
 					tt.validate(t, mc)
 				}
+			}
+		})
+	}
+}
+
+func TestCSErrorToCloudError(t *testing.T) {
+	t.Parallel()
+
+	resourceID, err := azcorearm.ParseResourceID(
+		"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRG/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/myCluster",
+	)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name               string
+		err                error
+		resourceID         *azcorearm.ResourceID
+		expectedStatusCode int
+		expectedCode       string
+		expectedMessage    string
+	}{
+		{
+			name: "CS 404 with shard-not-found returns 503",
+			err: func() error {
+				e, _ := ocmerrors.NewError().
+					Status(http.StatusNotFound).
+					Reason("Unable to find shard for cluster '123' in region 'westus3'").
+					Build()
+				return e
+			}(),
+			resourceID:         resourceID,
+			expectedStatusCode: http.StatusServiceUnavailable,
+			expectedCode:       arm.CloudErrorCodeServiceUnavailable,
+			expectedMessage:    "Capacity is currently restricted, please try again later",
+		},
+		{
+			name: "CS 404 with shard-not-found returns 503 even without resourceID",
+			err: func() error {
+				e, _ := ocmerrors.NewError().
+					Status(http.StatusNotFound).
+					Reason("Unable to find shard for cluster '456' in region 'eastus'").
+					Build()
+				return e
+			}(),
+			resourceID:         nil,
+			expectedStatusCode: http.StatusServiceUnavailable,
+			expectedCode:       arm.CloudErrorCodeServiceUnavailable,
+			expectedMessage:    "Capacity is currently restricted, please try again later",
+		},
+		{
+			name: "CS 404 without shard reason returns ResourceNotFound when resourceID present",
+			err: func() error {
+				e, _ := ocmerrors.NewError().
+					Status(http.StatusNotFound).
+					Reason("Cluster not found").
+					Build()
+				return e
+			}(),
+			resourceID:         resourceID,
+			expectedStatusCode: http.StatusNotFound,
+			expectedCode:       arm.CloudErrorCodeResourceNotFound,
+		},
+		{
+			name: "CS 404 without shard reason returns NotFound when resourceID is nil",
+			err: func() error {
+				e, _ := ocmerrors.NewError().
+					Status(http.StatusNotFound).
+					Reason("Cluster not found").
+					Build()
+				return e
+			}(),
+			resourceID:         nil,
+			expectedStatusCode: http.StatusNotFound,
+			expectedCode:       arm.CloudErrorCodeNotFound,
+			expectedMessage:    "Cluster not found",
+		},
+		{
+			name: "CS 400 returns InvalidRequestContent",
+			err: func() error {
+				e, _ := ocmerrors.NewError().
+					Status(http.StatusBadRequest).
+					Reason("Validation failed").
+					Build()
+				return e
+			}(),
+			resourceID:         resourceID,
+			expectedStatusCode: http.StatusBadRequest,
+			expectedCode:       arm.CloudErrorCodeInvalidRequestContent,
+			expectedMessage:    "Validation failed",
+		},
+		{
+			name: "CS 409 returns Conflict",
+			err: func() error {
+				e, _ := ocmerrors.NewError().
+					Status(http.StatusConflict).
+					Reason("Resource already exists").
+					Build()
+				return e
+			}(),
+			resourceID:         resourceID,
+			expectedStatusCode: http.StatusConflict,
+			expectedCode:       arm.CloudErrorCodeConflict,
+			expectedMessage:    "Resource already exists",
+		},
+		{
+			name: "CS 503 returns ServiceUnavailable",
+			err: func() error {
+				e, _ := ocmerrors.NewError().
+					Status(http.StatusServiceUnavailable).
+					Reason("Cluster limit reached").
+					Build()
+				return e
+			}(),
+			resourceID:         resourceID,
+			expectedStatusCode: http.StatusServiceUnavailable,
+			expectedCode:       arm.CloudErrorCodeServiceUnavailable,
+			expectedMessage:    "Cluster limit reached",
+		},
+		{
+			name:               "non-OCM error returns InternalServerError",
+			err:                errors.New("something went wrong"),
+			resourceID:         resourceID,
+			expectedStatusCode: http.StatusInternalServerError,
+			expectedCode:       arm.CloudErrorCodeInternalServerError,
+		},
+		{
+			name: "unhandled OCM status returns InternalServerError",
+			err: func() error {
+				e, _ := ocmerrors.NewError().
+					Status(http.StatusForbidden).
+					Reason("Forbidden").
+					Build()
+				return e
+			}(),
+			resourceID:         resourceID,
+			expectedStatusCode: http.StatusInternalServerError,
+			expectedCode:       arm.CloudErrorCodeInternalServerError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cloudErr := CSErrorToCloudError(tt.err, tt.resourceID)
+
+			require.NotNil(t, cloudErr)
+			assert.Equal(t, tt.expectedStatusCode, cloudErr.StatusCode)
+			assert.Equal(t, tt.expectedCode, cloudErr.Code)
+			if tt.expectedMessage != "" {
+				assert.Contains(t, cloudErr.Message, tt.expectedMessage)
 			}
 		})
 	}


### PR DESCRIPTION

no jira

### What

Returns a 503 status code instead of 404 when a user attempts to create a cluster but CS has no active provisioning shard.

### Why

> The fleet-controller's 2-minute CosmosDB polling cycle created a ~117-second gap between the `fleet-registration` job writing the Stamp and the CS provision shard becoming active; the test attempted cluster creation during this window, CS returned 404 'Unable to find shard', and the frontend incorrectly propagated this as an ARM `ResourceNotFound` error.

By returning a 503, the [azure-sdk-for-go default retry policy](https://github.com/Azure/azure-sdk-for-go/blob/922efdda6cf2a775b8a76f292562fd5a2c0940dc/sdk/azcore/runtime/policy_retry.go#L52) will attempt retries for 5 minutes, which will alleviate the above while #5759 speeds up the registration. 


### Testing

unit tests added

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
