### PR TITLE
fix(cleanup-sweeper): expire all persist=true adhoc RGs after 15 days

### DIFF
--- a/docs/personal-dev.md
+++ b/docs/personal-dev.md
@@ -41,6 +41,13 @@ All other tools should be transparently installed by the `make` targets that req
 > A word of caution upfront: dev infrastructure is automatically deleted after 48h. If you want to keep your infrastructure indefinitely, run all the following commands with an env variable `PERSIST=true`.
 > Please consider the implication on cost if you decide to keep your infrastructure indefinitely.
 
+> [!CAUTION] Cleanup-sensitive naming patterns
+> The following resource group naming patterns trigger special cleanup rules. Avoid them for custom `DEPLOY_ENV` values or ad-hoc resource groups. See [`resourcegroups.policy.yaml`](../tooling/cleanup-sweeper/resourcegroups.policy.yaml) for details.
+>
+> **Prefixes:** `hcp-underlay-pers-`, `hcp-underlay-prow-`, `hcp-underlay-ci`, `hcp-underlay-cspr-`, `hcp-underlay-dev-`, `hcp-underlay-perf-`, `hcp-underlay-int-`, `hcp-underlay-stg-`, `hcp-underlay-prod-`
+>
+> **Suffixes:** `-shared-resources`
+
 The creation process can take up to 20 minutes.
 
    ```bash

--- a/docs/personal-dev.md
+++ b/docs/personal-dev.md
@@ -38,8 +38,8 @@ All other tools should be transparently installed by the `make` targets that req
 ## Full Personal DEV Environment Setup
 
 > [!IMPORTANT] Environment Cleanup
-> A word of caution upfront: dev infrastructure is automatically deleted after 48h. If you want to keep your infrastructure indefinitely, run all the following commands with an env variable `PERSIST=true`.
-> Please consider the implication on cost if you decide to keep your infrastructure indefinitely.
+> A word of caution upfront: dev infrastructure is automatically deleted after 48h. Setting `PERSIST=true` extends retention to 15 days instead of permanent.
+> Please consider the implication on cost if you decide to persist your infrastructure.
 
 > [!CAUTION] Cleanup-sensitive naming patterns
 > The following resource group naming patterns trigger special cleanup rules. Avoid them for custom `DEPLOY_ENV` values or ad-hoc resource groups. See [`resourcegroups.policy.yaml`](../tooling/cleanup-sweeper/resourcegroups.policy.yaml) for details.

--- a/tooling/cleanup-sweeper/pkg/policy/discovery_test.go
+++ b/tooling/cleanup-sweeper/pkg/policy/discovery_test.go
@@ -135,17 +135,6 @@ func TestSelectsResourceGroup_IntendedLegacyPolicyBehavior(t *testing.T) {
 			expectSelected: true,
 		},
 		{
-			name: "non-pers persist true is skipped by global persist protection",
-			rg: newResourceGroup(
-				"hcp-underlay-dev-usw3rvaz",
-				timePtr(now.Add(-72*time.Hour)),
-				map[string]string{"persist": "true"},
-				false,
-			),
-			excluded:       sets.New[string](),
-			expectSelected: false,
-		},
-		{
 			name: "non-pers older than 2 days is selected by global default",
 			rg: newResourceGroup(
 				"hcp-underlay-dev-usw3rvaz",

--- a/tooling/cleanup-sweeper/pkg/policy/discovery_test.go
+++ b/tooling/cleanup-sweeper/pkg/policy/discovery_test.go
@@ -15,6 +15,7 @@
 package policy
 
 import (
+	"regexp"
 	"testing"
 	"time"
 
@@ -242,6 +243,132 @@ func TestSelectsResourceGroup_ReturnsStructuredRuleReason(t *testing.T) {
 	}
 	if got, want := reason.String(), "rule[0]-expired"; got != want {
 		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestSelectsResourceGroup_PersistTrueDeleteAfter15d(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.March, 16, 15, 0, 0, 0, time.UTC)
+	pol := &RGDiscoveryPolicy{
+		Rules: []RGDiscoveryRule{
+			{
+				Name:   "skip-shared-env-persist-true",
+				Action: RGDiscoveryActionSkip,
+				Match:  RGDiscoveryMatch{NameRegex: regexp.MustCompile(`^hcp-underlay-(cspr|dev|perf|int|stg|prod)-`)},
+				Conditions: RGDiscoveryConditions{
+					TagsEq: map[string]string{"persist": "true"},
+				},
+			},
+			{
+				Name:   "persist-true-delete-after-15d",
+				Action: RGDiscoveryActionDelete,
+				Match:  RGDiscoveryMatch{Any: true},
+				Conditions: RGDiscoveryConditions{
+					TagsEq: map[string]string{"persist": "true"},
+				},
+				OlderThan: 15 * 24 * time.Hour,
+			},
+		},
+	}
+
+	excluded := sets.New("global", "dashboards", "opstool-westus3")
+
+	testCases := []struct {
+		name           string
+		rg             *armresources.ResourceGroup
+		expectSelected bool
+	}{
+		{
+			name: "custom env swft persist true older than 15d is selected",
+			rg: newResourceGroup(
+				"hcp-underlay-swft-usw3rvaz",
+				timePtr(now.Add(-16*24*time.Hour)),
+				map[string]string{"persist": "true"},
+				false,
+			),
+			expectSelected: true,
+		},
+		{
+			name: "custom env swft persist true younger than 15d is not selected",
+			rg: newResourceGroup(
+				"hcp-underlay-swft-usw3rvaz",
+				timePtr(now.Add(-10*24*time.Hour)),
+				map[string]string{"persist": "true"},
+				false,
+			),
+			expectSelected: false,
+		},
+		{
+			name: "adhoc RG zgalor-test persist true older than 15d is selected",
+			rg: newResourceGroup(
+				"zgalor-test",
+				timePtr(now.Add(-20*24*time.Hour)),
+				map[string]string{"persist": "true"},
+				false,
+			),
+			expectSelected: true,
+		},
+		{
+			name: "adhoc RG bbergen-net-rg-03 persist true older than 15d is selected",
+			rg: newResourceGroup(
+				"bbergen-net-rg-03",
+				timePtr(now.Add(-90*24*time.Hour)),
+				map[string]string{"persist": "true"},
+				false,
+			),
+			expectSelected: true,
+		},
+		{
+			name: "shared env dev persist true is skipped",
+			rg: newResourceGroup(
+				"hcp-underlay-dev-usw3rvaz",
+				timePtr(now.Add(-20*24*time.Hour)),
+				map[string]string{"persist": "true"},
+				false,
+			),
+			expectSelected: false,
+		},
+		{
+			name: "shared env cspr persist true is skipped",
+			rg: newResourceGroup(
+				"hcp-underlay-cspr-usw3rvaz",
+				timePtr(now.Add(-20*24*time.Hour)),
+				map[string]string{"persist": "true"},
+				false,
+			),
+			expectSelected: false,
+		},
+		{
+			name: "excluded infra RG is skipped regardless of persist",
+			rg: newResourceGroup(
+				"dashboards",
+				timePtr(now.Add(-90*24*time.Hour)),
+				map[string]string{"persist": "true"},
+				false,
+			),
+			expectSelected: false,
+		},
+		{
+			name: "RG without persist does not match",
+			rg: newResourceGroup(
+				"zgalor-test",
+				timePtr(now.Add(-72*time.Hour)),
+				nil,
+				false,
+			),
+			expectSelected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			selected, _ := pol.SelectsResourceGroup(tc.rg, excluded, now)
+			if selected != tc.expectSelected {
+				t.Fatalf("expected selected=%t, got selected=%t", tc.expectSelected, selected)
+			}
+		})
 	}
 }
 

--- a/tooling/cleanup-sweeper/resourcegroups.policy.yaml
+++ b/tooling/cleanup-sweeper/resourcegroups.policy.yaml
@@ -1,6 +1,7 @@
 # cleanup-sweeper rg-ordered discovery policy (first matching rule wins).
-# - excludedResourceGroups: never candidates (global, hcp-kusto-us, westus3-shared-resources).
+# - excludedResourceGroups: never candidates (see list below).
 # - Skip managed RGs (managedBy set).
+# - Skip *-shared-resources RGs.
 # - hcp-underlay-pers-*: delete after 15d if persist=true; after 2d if persist is absent or not "true".
 # - hcp-underlay-prow-*: delete after 6h (transitional, remove after rename rollout).
 # - Name prefix hcp-underlay-ci*: delete after 6h (covers ci00, ci01, etc.).
@@ -11,7 +12,6 @@
 rgOrdered:
   # Keep known long-lived/shared groups out of rg-ordered deletion candidates.
   excludedResourceGroups:
-  - centralus-shared-resources
   - cs-shared-oidc-storage
   - dashboards
   - global
@@ -21,9 +21,6 @@ rgOrdered:
   - opstool-westus3
   - perf-scale-rg
   - pr-check-e2e-tests-resources
-  - switzerlandnorth-shared-resources
-  - uksouth-shared-resources
-  - westus3-shared-resources
   discovery:
     # Rules are evaluated in order; first match wins.
     rules:
@@ -33,6 +30,10 @@ rgOrdered:
         any: true
       conditions:
         managedBySet: true
+    - name: skip-shared-resources
+      action: skip
+      match:
+        nameRegex: "-shared-resources$"
     - name: pers-persist-delete-after-15d
       action: delete
       match:

--- a/tooling/cleanup-sweeper/resourcegroups.policy.yaml
+++ b/tooling/cleanup-sweeper/resourcegroups.policy.yaml
@@ -4,16 +4,26 @@
 # - hcp-underlay-pers-*: delete after 15d if persist=true; after 2d if persist is absent or not "true".
 # - hcp-underlay-prow-*: delete after 6h (transitional, remove after rename rollout).
 # - Name prefix hcp-underlay-ci*: delete after 6h (covers ci00, ci01, etc.).
-# - Skip any RG with persist=true (after pers-* and CI rules).
+# - Known shared envs (cspr/dev/perf/int/stg/prod) with persist=true: skipped.
+# - Any RG with persist=true (not already matched above): delete after 15d.
 # - Default: delete any other RG after 2d.
 # Delete rules need a parseable tags.createdAt; see docs/cleanup.md and scripts/ for Azure Policy.
 rgOrdered:
   # Keep known long-lived/shared groups out of rg-ordered deletion candidates.
   excludedResourceGroups:
-  - global
-  - hcp-kusto-us
-  - westus3-shared-resources
   - centralus-shared-resources
+  - cs-shared-oidc-storage
+  - dashboards
+  - global
+  - hcp-eastus-shared-rg
+  - hcp-kusto-us
+  - hcp-westeurope-shared-rg
+  - opstool-westus3
+  - perf-scale-rg
+  - pr-check-e2e-tests-resources
+  - switzerlandnorth-shared-resources
+  - uksouth-shared-resources
+  - westus3-shared-resources
   discovery:
     # Rules are evaluated in order; first match wins.
     rules:
@@ -51,13 +61,21 @@ rgOrdered:
       match:
         namePrefix: "hcp-underlay-ci"
       olderThan: "6h"
-    - name: skip-persist-true-globally
+    - name: skip-shared-env-persist-true
       action: skip
+      match:
+        nameRegex: "^hcp-underlay-(cspr|dev|perf|int|stg|prod)-"
+      conditions:
+        tagsEq:
+          persist: "true"
+    - name: persist-true-delete-after-15d
+      action: delete
       match:
         any: true
       conditions:
         tagsEq:
           persist: "true"
+      olderThan: "360h"
     - name: global-default-delete-after-2d
       action: delete
       match:


### PR DESCRIPTION
[AROSLSRE-1245](https://issues.redhat.com/browse/AROSLSRE-1245)

### What

Replace blanket `skip-persist-true-globally` rule with targeted `skip-shared-env-persist-true` (protects cspr/dev/perf/int/stg/prod) and a new `persist-true-delete-after-15d` catch-all. Add `skip-shared-resources` rule for `*-shared-resources` suffix. Expand `excludedResourceGroups` from 3 to 9 entries (5 former entries moved to the skip rule). Document cleanup-sensitive naming patterns in `personal-dev.md`.

### Why

`persist=true` was intended as a "don't delete during my work session" flag, but acted as permanent immunity for any RG outside `hcp-underlay-pers-*`. Ad-hoc and custom-env RGs (`*-net-rg-03`, `zgalor-test*`, `jamesh-*`, `hcp-underlay-usepmore`, etc.) accumulated indefinitely, driving ~$16k/mo in wasted spend ([AROSLSRE-1245](https://redhat.atlassian.net/browse/AROSLSRE-1245)).

### Dry-run (2026-06-22)

74 deletion candidates out of 188 rule-eligible RGs. **54 are net-new** from `persist-true-delete-after-15d` — previously immortal under the old blanket skip. The other 20 come from pre-existing rules. 100% of eligible RGs match a rule; 101 survive correctly (young or protected).

<details>
<summary>54 newly-caught RGs</summary>

asam-net-rg-03, asampaio-net-rg-03, autoscaling-cluster-jgwrn6, bbergen-net-rg-03, bragazzi-net-rg-03, hawkowl-net-rg-03, hbhushan-net-rg-03, hcp-underlay-usepmore, hcp-underlay-usepmore-mgmt-1, imani-net-rg-03, jamesh-dev, jamesh-swift-dev, jamesh-swift-dev-2, jbtest-net-rg-03, jcueto-net-rg-03, jdgray-net-rg-03, kshimpi-net-rg-03, lkurien-net-rg-03, lszaszki-net-rg, lszaszki-net-rg-03, man-dev-test, marc-customer-rg, mbarnes-net-rg-03, mmazur-net-rg-03, mmazur2-net-rg-03, ms-aro-hcp-byovnet-rg-1, ms-aro-hcp-byovnet-rg-2, msoriano-net-rg-03, mukrishn-rg, muraee-net-rg-03, mvacula-net-rg-03, neel-01-resource-group, nshneor-net-rg-03, nshneor-test, oadler-net-rg-03, rajd-net-rg-03, rajs-net-rg-03, sjante-test, suraj-supa-external-RG, test-ahitacat-rg, test-zgalor, ves-net-rg-03, zg-private, zg-public, zgal-test, zgal2-test, zgal3-test, zgal4-test, zgalor-test, zgalor-test2, zgalor-test3, zgalor-test4, zgalor-test5, zgalor_test
</details>

### Testing

Unit tests added for the new rule interactions (`TestSelectsResourceGroup_PersistTrueDeleteAfter15d`): ad-hoc RGs caught, shared envs skipped, exclusion list honored, missing persist not matched. All existing tests pass.

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge