### PR TITLE
fix: build templatize before parallel build-services fan-out (ARO-27706)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -396,7 +396,7 @@ generate-kiota:
 #
 PERS_OVERRIDE_FILE ?= /tmp/personal-dev-override.yaml
 
-build-services:
+build-services: $(TEMPLATIZE)
 	$(MAKE) $(BUILD_SERVICES_OPTS) build-frontend build-backend build-admin build-sessiongate build-mgmt-agent build-kube-applier build-fleet
 .PHONY: build-services
 

--- a/Makefile
+++ b/Makefile
@@ -397,7 +397,7 @@ generate-kiota:
 #
 PERS_OVERRIDE_FILE ?= /tmp/personal-dev-override.yaml
 
-build-services:
+build-services: $(TEMPLATIZE)
 	$(MAKE) $(BUILD_SERVICES_OPTS) build-frontend build-backend build-admin build-sessiongate build-mgmt-agent build-kube-applier build-fleet build-aro-hcp-exporter
 .PHONY: build-services
 


### PR DESCRIPTION
### What

Add $(TEMPLATIZE) as a prerequisite to build-services so it's built once before the -j7 parallel fan-out.

### Why

After a rebase that touches tooling/templatize/ sources, all 7 sub-makes race to rebuild the same binary, causing Text file busy errors and resource exhaustion.

### Testing

Verified the Makefile dependency chain. No functional change. Just prerequisite ordering