### PR TITLE
feat: add transient STG global V2 parallel pipelines for dedicated-subscription migration

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -22,6 +22,27 @@ clouds:
           # This must be defined here, so our ci jobs can know this
           kusto:
             kustoName: "hcp-stg-uk-2"
+          # TRANSIENT — STG-global "V2" migration: real globally-unique names +
+          # dedicated DNS zones for the parallel infra deployed into the dedicated
+          # STG-global subscription during coexistence. Overrides the public.defaults
+          # empty-sentinel; only stg gets real values. "2" suffix is the only literal
+          # vs the canonical names. Live stg.defaults names (acr.svc.name etc.) are
+          # untouched until cutover. Removed at decommission.
+          stgGlobalV2:
+            acrSvcName: "arohcpsvc{{ .ctx.environment }}2"
+            acrOcpName: "arohcpocp{{ .ctx.environment }}2"
+            globalKeyVaultName: "arohcp{{ .ctx.environment }}2-global"
+            genevaKeyVaultName: "arohcp{{ .ctx.environment }}2-geneva-kv"
+            frontDoorName: "arohcp{{ .ctx.environment }}2"
+            frontDoorKeyVaultName: "ah-{{ .ctx.environment }}2-afd"
+            oidcStorageAccountName: "arohcp{{ .ctx.environment }}2oidc{{ .ctx.regionShort }}"
+            # DNS: dedicated stg zones (delegated from azure.com via SafeDNS),
+            # replacing the shared aro-hcp.azure.com / aroapp-hcp.io. Owned by the
+            # DNS track (AROSLSRE-1204) — confirm before deploy.
+            svcParentZoneName: "aro-hcp-{{ .ctx.environment }}.azure.com"
+            cxParentZoneName: "aroapp-hcp-{{ .ctx.environment }}.azure.com"
+            # New Kusto cluster (live stg is hcp-stg-uk-2; this is the next one).
+            kustoName: "hcp-{{ .ctx.environment }}-uk-3"
           # E2E
           e2e:
             regionTest:

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -3292,6 +3292,55 @@
         "ocp"
       ]
     },
+    "stgGlobalV2": {
+      "type": "object",
+      "description": "TRANSIENT: distinct globally-unique resource names for the parallel STG-global 'V2' pipelines that deploy into a dedicated STG-global subscription during coexistence with the shared subscription. Real values are set in the cloud overlay for stg; defaults are empty-sentinel. Removed once the migration is decommissioned.",
+      "properties": {
+        "acrSvcName": {
+          "type": "string"
+        },
+        "acrOcpName": {
+          "type": "string"
+        },
+        "globalKeyVaultName": {
+          "type": "string"
+        },
+        "genevaKeyVaultName": {
+          "type": "string"
+        },
+        "frontDoorName": {
+          "type": "string"
+        },
+        "frontDoorKeyVaultName": {
+          "type": "string"
+        },
+        "oidcStorageAccountName": {
+          "type": "string"
+        },
+        "svcParentZoneName": {
+          "type": "string"
+        },
+        "cxParentZoneName": {
+          "type": "string"
+        },
+        "kustoName": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "acrSvcName",
+        "acrOcpName",
+        "globalKeyVaultName",
+        "genevaKeyVaultName",
+        "frontDoorName",
+        "frontDoorKeyVaultName",
+        "oidcStorageAccountName",
+        "svcParentZoneName",
+        "cxParentZoneName",
+        "kustoName"
+      ]
+    },
     "releaseApprover": {
       "type": "object",
       "properties": {

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -100,6 +100,24 @@ defaults:
       untaggedImagesRetention:
         enabled: true
         days: 90
+  # TRANSIENT — STG-global "V2" migration scaffolding. Every pipeline (including
+  # the stg-only V2 copies) is preprocessed by helmtest against the dev render
+  # and by EV2 manifest generation for all public envs, and the renderer uses
+  # missingkey=error — so stgGlobalV2 must resolve in every cloud/env. Only stg
+  # supplies real values (config.msft.clouds-overlay.yaml); everything else stays
+  # empty-sentinel and is never consumed (V2 pipelines are stg/uksouth-only).
+  # Removed at decommission.
+  stgGlobalV2:
+    acrSvcName: "empty-sentinel"
+    acrOcpName: "empty-sentinel"
+    globalKeyVaultName: "empty-sentinel"
+    genevaKeyVaultName: "empty-sentinel"
+    frontDoorName: "empty-sentinel"
+    frontDoorKeyVaultName: "empty-sentinel"
+    oidcStorageAccountName: "empty-sentinel"
+    svcParentZoneName: "empty-sentinel"
+    cxParentZoneName: "empty-sentinel"
+    kustoName: "empty-sentinel"
   # Image Registry Policy
   imageRegistryPolicy:
     extraAllowedRegistries: ""

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -903,6 +903,17 @@ sessiongate:
     replicas: 2
     serviceAccountName: sessiongate
   managedIdentityName: sessiongate
+stgGlobalV2:
+  acrOcpName: empty-sentinel
+  acrSvcName: empty-sentinel
+  cxParentZoneName: empty-sentinel
+  frontDoorKeyVaultName: empty-sentinel
+  frontDoorName: empty-sentinel
+  genevaKeyVaultName: empty-sentinel
+  globalKeyVaultName: empty-sentinel
+  kustoName: empty-sentinel
+  oidcStorageAccountName: empty-sentinel
+  svcParentZoneName: empty-sentinel
 svc:
   aks:
     clusterOutboundIPAddressIPTags: ""

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -903,6 +903,17 @@ sessiongate:
     replicas: 2
     serviceAccountName: sessiongate
   managedIdentityName: sessiongate
+stgGlobalV2:
+  acrOcpName: empty-sentinel
+  acrSvcName: empty-sentinel
+  cxParentZoneName: empty-sentinel
+  frontDoorKeyVaultName: empty-sentinel
+  frontDoorName: empty-sentinel
+  genevaKeyVaultName: empty-sentinel
+  globalKeyVaultName: empty-sentinel
+  kustoName: empty-sentinel
+  oidcStorageAccountName: empty-sentinel
+  svcParentZoneName: empty-sentinel
 svc:
   aks:
     clusterOutboundIPAddressIPTags: ""

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -901,6 +901,17 @@ sessiongate:
     replicas: 2
     serviceAccountName: sessiongate
   managedIdentityName: sessiongate
+stgGlobalV2:
+  acrOcpName: empty-sentinel
+  acrSvcName: empty-sentinel
+  cxParentZoneName: empty-sentinel
+  frontDoorKeyVaultName: empty-sentinel
+  frontDoorName: empty-sentinel
+  genevaKeyVaultName: empty-sentinel
+  globalKeyVaultName: empty-sentinel
+  kustoName: empty-sentinel
+  oidcStorageAccountName: empty-sentinel
+  svcParentZoneName: empty-sentinel
 svc:
   aks:
     clusterOutboundIPAddressIPTags: ""

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -901,6 +901,17 @@ sessiongate:
     replicas: 2
     serviceAccountName: sessiongate
   managedIdentityName: sessiongate
+stgGlobalV2:
+  acrOcpName: empty-sentinel
+  acrSvcName: empty-sentinel
+  cxParentZoneName: empty-sentinel
+  frontDoorKeyVaultName: empty-sentinel
+  frontDoorName: empty-sentinel
+  genevaKeyVaultName: empty-sentinel
+  globalKeyVaultName: empty-sentinel
+  kustoName: empty-sentinel
+  oidcStorageAccountName: empty-sentinel
+  svcParentZoneName: empty-sentinel
 svc:
   aks:
     clusterOutboundIPAddressIPTags: ""

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -901,6 +901,17 @@ sessiongate:
     replicas: 2
     serviceAccountName: sessiongate
   managedIdentityName: sessiongate
+stgGlobalV2:
+  acrOcpName: empty-sentinel
+  acrSvcName: empty-sentinel
+  cxParentZoneName: empty-sentinel
+  frontDoorKeyVaultName: empty-sentinel
+  frontDoorName: empty-sentinel
+  genevaKeyVaultName: empty-sentinel
+  globalKeyVaultName: empty-sentinel
+  kustoName: empty-sentinel
+  oidcStorageAccountName: empty-sentinel
+  svcParentZoneName: empty-sentinel
 svc:
   aks:
     clusterOutboundIPAddressIPTags: ""

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -903,6 +903,17 @@ sessiongate:
     replicas: 2
     serviceAccountName: sessiongate
   managedIdentityName: sessiongate
+stgGlobalV2:
+  acrOcpName: empty-sentinel
+  acrSvcName: empty-sentinel
+  cxParentZoneName: empty-sentinel
+  frontDoorKeyVaultName: empty-sentinel
+  frontDoorName: empty-sentinel
+  genevaKeyVaultName: empty-sentinel
+  globalKeyVaultName: empty-sentinel
+  kustoName: empty-sentinel
+  oidcStorageAccountName: empty-sentinel
+  svcParentZoneName: empty-sentinel
 svc:
   aks:
     clusterOutboundIPAddressIPTags: ""

--- a/dev-infrastructure/configurations/geneva-identities-stg.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/geneva-identities-stg.tmpl.bicepparam
@@ -1,0 +1,23 @@
+// TRANSIENT: STG-global "V2" copy of geneva-identities.tmpl.bicepparam. Identical
+// to the canonical file except the global and Geneva Key Vault names are sourced
+// from the transient stgGlobalV2 block. Removed at decommission.
+using '../templates/geneva-identities.bicep'
+
+param ev2MsiName = '{{ .global.globalMSIName }}'
+
+param globalKeyVaultName = '{{ .stgGlobalV2.globalKeyVaultName }}'
+param genevaLogCertificateDomain = '{{ .geneva.logs.adminCertificateDomain }}'
+param genevaLogCertificateHostName = '{{ .geneva.logs.adminCertName }}'
+param genevaLogCertificateIssuer = '{{ .geneva.logs.certificateIssuer }}'
+param genevaLogsAccountAdmin = '{{ .geneva.logs.adminCertName }}'
+param genevaLogManageCertificates = {{ .geneva.logs.manageCertificates }}
+
+param genevaActionsKeyVaultName = '{{ .stgGlobalV2.genevaKeyVaultName }}'
+param genevaActionsCertificateDomain = '{{ .geneva.actions.certificate.name }}.{{ .dns.globalCertificatesDomain }}'
+param genevaActionsCertificateIssuer = '{{ .geneva.actions.certificate.issuer }}'
+param genevaActionsCertificateName = '{{ .geneva.actions.certificate.name }}'
+param genevaActionsManageCertificates = {{ .geneva.actions.certificate.manage }}
+param genevaActionApplicationUseSNI = {{ .geneva.actions.application.useSNI }}
+param genevaActionApplicationManage = {{ .geneva.actions.application.manage }}
+param genevaActionApplicationName = '{{ .geneva.actions.application.name }}'
+param entraAppOwnerIds = '{{ .entraAppOwnerIds }}'

--- a/dev-infrastructure/configurations/global-acr-stg.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/global-acr-stg.tmpl.bicepparam
@@ -1,0 +1,26 @@
+// TRANSIENT: STG-global "V2" copy of global-acr.tmpl.bicepparam. Identical to the
+// canonical file except the globally-unique resource names are sourced from the
+// transient stgGlobalV2 block so the parallel STG-global stack does not collide
+// with the live (shared-subscription) names. Removed at decommission.
+using '../templates/global-acr.bicep'
+
+param svcAcrName = '{{ .stgGlobalV2.acrSvcName }}'
+param svcAcrSku = 'Premium'
+param svcAcrUntaggedImagesRetentionEnabled = {{ .acr.svc.untaggedImagesRetention.enabled }}
+param svcAcrUntaggedImagesRetentionDays = {{ .acr.svc.untaggedImagesRetention.days }}
+
+param ocpAcrName = '{{ .stgGlobalV2.acrOcpName }}'
+param ocpAcrSku = 'Premium'
+param ocpAcrUntaggedImagesRetentionEnabled = {{ .acr.ocp.untaggedImagesRetention.enabled }}
+param ocpAcrUntaggedImagesRetentionDays = {{ .acr.ocp.untaggedImagesRetention.days }}
+
+param globalMSIName = '{{ .global.globalMSIName }}'
+
+param location = '{{ .global.region }}'
+
+param svcAcrZoneRedundantMode = '{{ .acr.svc.zoneRedundantMode }}'
+param ocpAcrZoneRedundantMode = '{{ .acr.ocp.zoneRedundantMode }}'
+
+param globalKeyVaultName = '{{ .stgGlobalV2.globalKeyVaultName }}'
+
+param deployMiseArtifactSync = {{ .mise.deploy }}

--- a/dev-infrastructure/configurations/global-image-sync-stg.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/global-image-sync-stg.tmpl.bicepparam
@@ -1,0 +1,20 @@
+// TRANSIENT: STG-global "V2" copy of global-image-sync.tmpl.bicepparam. Identical
+// to the canonical file except the globally-unique resource names are sourced from
+// the transient stgGlobalV2 block. Removed at decommission.
+using '../templates/global-image-sync.bicep'
+
+param containerAppEnvName = '{{ .imageSync.environmentName }}'
+param jobNamePrefix = '{{ .imageSync.ocMirror.jobNamePrefix }}'
+param containerAppOutboundServiceTags = '{{ .imageSync.outboundServiceTags }}'
+param location = '{{ .global.region }}'
+
+param acrResourceGroup = '{{ .global.rg }}'
+param keyVaultName = '{{ .stgGlobalV2.globalKeyVaultName }}'
+
+param svcAcrName = '{{ .stgGlobalV2.acrSvcName }}'
+
+param ocpAcrName = '{{ .stgGlobalV2.acrOcpName }}'
+param ocpPullSecretName = '{{ .imageSync.ocMirror.pullSecretName }}'
+param ocMirrorImage = '{{ .stgGlobalV2.acrSvcName }}.azurecr.io/{{ .imageSync.ocMirror.image.repository }}@{{ .imageSync.ocMirror.image.digest }}'
+param ocMirrorEnabled = {{ .imageSync.ocMirror.enabled }}
+param operatorVersionsToMirror = '{{ .imageSync.ocMirror.operatorVersionsToMirror }}'

--- a/dev-infrastructure/configurations/global-infra-stg.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/global-infra-stg.tmpl.bicepparam
@@ -1,0 +1,57 @@
+// TRANSIENT: STG-global "V2" copy of global-infra.tmpl.bicepparam. Identical to the
+// canonical file except the globally-unique resource names and DNS parent zones are
+// sourced from the transient stgGlobalV2 block so the parallel STG-global stack does
+// not collide with the live (shared-subscription) names/zones. Removed at decommission.
+using '../templates/global-infra.bicep'
+
+param location = '{{ .global.region }}'
+param globalMSIName = '{{ .global.globalMSIName }}'
+param cxParentZoneName = '{{ .stgGlobalV2.cxParentZoneName }}'
+param svcParentZoneName = '{{ .stgGlobalV2.svcParentZoneName }}'
+//  SafeDnsIntApplication object ID use to delegate child DNS
+param safeDnsIntAppObjectId = '{{ .global.safeDnsIntAppObjectId }}'
+
+param keyVaultName = '{{ .stgGlobalV2.globalKeyVaultName }}'
+param keyVaultPrivate = {{ .global.keyVault.private }}
+param keyVaultSoftDelete = {{ .global.keyVault.softDelete }}
+param keyVaultTagKey = '{{ .global.keyVault.tagKey }}'
+param keyVaultTagValue = '{{ .global.keyVault.tagValue }}'
+param keyVaultEncryptionKeyName = '{{ .global.keyVault.encryptionKeyName }}'
+
+param grafanaName = '{{ .monitoring.grafanaName }}'
+param grafanaMajorVersion = '{{ .monitoring.grafanaMajorVersion }}'
+param grafanaZoneRedundantMode = '{{ .monitoring.grafanaZoneRedundantMode }}'
+param grafanaRoles = '{{ .monitoring.grafanaRoles }}'
+param crossTenantSecurityGroup = '{{ .monitoring.crossTenantSecurityGroup }}'
+
+param globalNSPName = '{{ .global.nsp.name }}'
+param globalNSPAccessMode = '{{ .global.nsp.accessMode }}'
+
+// Azure Front Door
+param oidcSubdomain = '{{ .oidc.frontdoor.subdomain }}'
+param azureFrontDoorProfileName = '{{ .stgGlobalV2.frontDoorName }}'
+param azureFrontDoorSkuName = '{{ .oidc.frontdoor.sku }}'
+param azureFrontDoorKeyVaultName = '{{ .stgGlobalV2.frontDoorKeyVaultName }}'
+param azureFrontDoorKeyVaultTagKey = '{{ .oidc.frontdoor.keyVault.tagKey }}'
+param azureFrontDoorKeyVaultTagValue = '{{ .oidc.frontdoor.keyVault.tagValue }}'
+param azureFrontDoorUseManagedCertificates = {{ .oidc.frontdoor.useManagedCertificates }}
+param keyVaultAdminPrincipalId = '{{ .kvCertOfficerPrincipalId }}'
+param oidcMsiName = '{{ .oidc.frontdoor.msiName }}'
+param azureFrontDoorManage = {{ .oidc.frontdoor.manage }}
+
+// SP for KV certificate issuer registration
+param kvCertOfficerPrincipalId = '{{ .kvCertOfficerPrincipalId }}'
+
+// SP for EV2 certificate access, i.e. geneva log access
+param kvCertAccessPrincipalId = '{{ .kvCertAccessPrincipalId }}'
+param kvCertAccessRoleId = '{{ .kvCertAccessRoleId }}'
+
+// Geneva Actions
+param genevaKeyVaultName = '{{ .stgGlobalV2.genevaKeyVaultName }}'
+param genevaKeyVaultPrivate = {{ .geneva.actions.keyVault.private }}
+param genevaKeyVaultSoftDelete = {{ .geneva.actions.keyVault.softDelete }}
+param genevaKeyVaultTagKey = '{{ .geneva.actions.keyVault.tagKey }}'
+param genevaKeyVaultTagValue = '{{ .geneva.actions.keyVault.tagValue }}'
+
+param allowedAcisExtensions = '{{ .geneva.actions.allowedAcisExtensions }}'
+param genevaActionsPrincipalId = '{{ .geneva.actions.genevaActionsPrincipalId }}'

--- a/dev-infrastructure/configurations/kusto-stg.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/kusto-stg.tmpl.bicepparam
@@ -1,0 +1,34 @@
+// TRANSIENT: STG-global "V2" copy of kusto.tmpl.bicepparam. Identical to the
+// canonical file except the (globally-unique) Kusto cluster name is sourced from
+// the transient stgGlobalV2 block so it does not collide with the live cluster.
+// Removed at decommission.
+using '../templates/kusto.bicep'
+
+param location = '{{ .kusto.location }}'
+
+param sku = '{{ .kusto.sku }}'
+param tier = '{{ .kusto.tier }}'
+
+param kustoName = '{{ .stgGlobalV2.kustoName }}'
+
+param manageInstance = {{ .kusto.manageInstance }}
+
+param serviceLogsDatabase = '{{ .kusto.serviceLogsDatabase }}'
+
+param hostedControlPlaneLogsDatabase = '{{ .kusto.hostedControlPlaneLogsDatabase }}'
+
+param adminGroups = '{{ .kusto.adminGroups }}'
+
+param viewerGroups = '{{ .kusto.viewerGroups }}'
+
+param viewerIdentities = '{{ .kusto.viewerIdentities }}'
+
+param autoScaleMin = {{ .kusto.autoScaleMin }}
+
+param autoScaleMax = {{ .kusto.autoScaleMax }}
+
+param enableAutoScale = {{ .kusto.enableAutoScale }}
+
+param crossClusterServiceLogsScript = {{ if .kusto.crossClusterServiceLogsScript }}'''{{ .kusto.crossClusterServiceLogsScript }}'''{{ else }}''{{ end }}
+
+param crossClusterHostedControlPlaneLogsScript = {{ if .kusto.crossClusterHostedControlPlaneLogsScript }}'''{{ .kusto.crossClusterHostedControlPlaneLogsScript }}'''{{ else }}''{{ end }}

--- a/dev-infrastructure/configurations/output-global-stg.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/output-global-stg.tmpl.bicepparam
@@ -1,0 +1,14 @@
+// TRANSIENT: STG-global "V2" copy of output-global.tmpl.bicepparam. Identical to the
+// canonical file except the globally-unique resource names and DNS parent zones are
+// sourced from the transient stgGlobalV2 block. Removed at decommission.
+using '../templates/output-global.bicep'
+
+param svcAcrName = '{{ .stgGlobalV2.acrSvcName }}'
+param ocpAcrName = '{{ .stgGlobalV2.acrOcpName }}'
+param cxParentZoneName = '{{ .stgGlobalV2.cxParentZoneName }}'
+param svcParentZoneName = '{{ .stgGlobalV2.svcParentZoneName }}'
+param grafanaName = '{{ .monitoring.grafanaName }}'
+param azureFrontDoorProfileName = '{{ .stgGlobalV2.frontDoorName }}'
+param globalMSIName = '{{ .global.globalMSIName }}'
+param globalKVName = '{{ .stgGlobalV2.globalKeyVaultName }}'
+param genevaActionsKVName = '{{ .stgGlobalV2.genevaKeyVaultName }}'

--- a/dev-infrastructure/geography-pipeline-stg.yaml
+++ b/dev-infrastructure/geography-pipeline-stg.yaml
@@ -4,7 +4,7 @@
 # Deploys the geography-scoped Kusto cluster into the dedicated STG-global
 # subscription (hcp-stg-global). Differences from the canonical pipeline:
 #   * serviceGroup is Microsoft.Azure.ARO.HCP.Geography.StgGlobal (new subcomponent),
-#     a child of HCP.Global.StgGlobal under the new HCP.Global.V2 root entrypoint.
+#     a child of HCP.Global.StgGlobal under the new HCP.Global.StgGlobal root entrypoint.
 #   * subscription is hardcoded to 'hcp-stg-global'.
 #   * executionConstraints are stg/uksouth ONLY (prod & test render inert).
 #   * the globally-unique Kusto cluster name comes from stgGlobalV2.kustoName so it

--- a/dev-infrastructure/geography-pipeline-stg.yaml
+++ b/dev-infrastructure/geography-pipeline-stg.yaml
@@ -1,0 +1,34 @@
+#
+# TRANSIENT — STG-global "V2" parallel copy of geography-pipeline.yaml.
+#
+# Deploys the geography-scoped Kusto cluster into the dedicated STG-global
+# subscription (hcp-stg-global). Differences from the canonical pipeline:
+#   * serviceGroup is Microsoft.Azure.ARO.HCP.Geography.StgGlobal (new subcomponent),
+#     a child of HCP.Global.StgGlobal under the new HCP.Global.V2 root entrypoint.
+#   * subscription is hardcoded to 'hcp-stg-global'.
+#   * executionConstraints are stg/uksouth ONLY (prod & test render inert).
+#   * the globally-unique Kusto cluster name comes from stgGlobalV2.kustoName so it
+#     does not collide with the live cluster (hcp-stg-uk-2).
+# Removed at decommission.
+#
+$schema: pipeline.schema.v1
+rolloutName: Geography Rollout (STG V2)
+serviceGroup: Microsoft.Azure.ARO.HCP.Geography.StgGlobal
+resourceGroups:
+- name: kusto-infra
+  resourceGroup: '{{ .kusto.rg }}'
+  # Hardcoded on purpose — see global-pipeline-stg.yaml. Removed at decommission.
+  subscription: 'hcp-stg-global'
+  executionConstraints:
+  - clouds:
+    - public
+    environments:
+    - stg
+    regions:
+    - uksouth
+  steps:
+  - name: deploy
+    action: ARM
+    template: templates/kusto.bicep
+    parameters: configurations/kusto-stg.tmpl.bicepparam
+    deploymentLevel: ResourceGroup

--- a/dev-infrastructure/global-pipeline-stg.yaml
+++ b/dev-infrastructure/global-pipeline-stg.yaml
@@ -1,0 +1,250 @@
+#
+# TRANSIENT — STG-global "V2" parallel copy of global-pipeline.yaml.
+#
+# Deploys the global infrastructure into the dedicated STG-global subscription
+# (hcp-stg-global) so it can be built and validated alongside the existing shared
+# subscription without touching it. Differences from the canonical pipeline:
+#   * serviceGroup is Microsoft.Azure.ARO.HCP.Global.StgGlobal (new subcomponent),
+#     wired under the new HCP.Global.V2 root entrypoint — NOT the live HCP.Global,
+#     so EV2 never co-deploys this with the existing global rollout.
+#   * subscription is hardcoded to 'hcp-stg-global' (the canonical pipeline uses
+#     '{{ .global.subscription.key }}', which for stg still resolves to the shared
+#     'hcp-global' sub during coexistence).
+#   * executionConstraints are stg/uksouth ONLY, which makes the generated prod &
+#     test EV2 manifests inert (isInCloud:false).
+#   * globally-unique resource names and DNS parent zones come from the transient
+#     stgGlobalV2 config block (the '…2' names) instead of the canonical paths, so
+#     they don't collide with the live names that still render for stg.
+# Removed at decommission once stg cuts over to the new subscription.
+#
+# Managed Resources: see global-pipeline.yaml (global parent zones + delegation,
+# Grafana, global MSI, SVC/OCP ACRs, KeyVaults, Front Door, image mirroring jobs).
+#
+$schema: "pipeline.schema.v1"
+serviceGroup: Microsoft.Azure.ARO.HCP.Global.StgGlobal
+rolloutName: Global Resource Rollout (STG V2)
+resourceGroups:
+- name: singleton
+  resourceGroup: '{{ .global.rg }}'
+  # Hardcoded on purpose — do NOT templatize to '{{ .global.subscription.key }}':
+  # for stg that resolves to the shared 'hcp-global' sub. Removed at decommission.
+  subscription: 'hcp-stg-global'
+  # stg/uksouth ONLY. Do NOT add int/prod — that is what keeps the generated prod &
+  # test EV2 manifests inert (isInCloud:false).
+  executionConstraints:
+  - clouds:
+    - public
+    environments:
+    - stg
+    regions:
+    - uksouth
+  steps:
+  - name: infra
+    action: ARM
+    template: templates/global-infra.bicep
+    parameters: configurations/global-infra-stg.tmpl.bicepparam
+    deploymentLevel: ResourceGroup
+  - name: output
+    action: ARM
+    template: templates/output-global.bicep
+    parameters: configurations/output-global-stg.tmpl.bicepparam
+    deploymentLevel: ResourceGroup
+    outputOnly: true
+    dependsOn:
+    - resourceGroup: singleton
+      step: infra
+  - name: grafana-monitoring-reader
+    action: ARM
+    template: templates/grafana-monitoring-reader.bicep
+    parameters: configurations/grafana-monitoring-reader.tmpl.bicepparam
+    deploymentLevel: Subscription
+    variables:
+    - name: grafanaPrincipalId
+      input:
+        resourceGroup: singleton
+        step: output
+        name: grafanaPrincipalId
+    dependsOn:
+    - resourceGroup: singleton
+      step: output
+  - name: global-kv-private-issuer
+    action: SetCertificateIssuer
+    secretKeyVault:
+      configRef: ev2.assistedId.certificate.keyVault
+    secretName:
+      configRef: ev2.assistedId.certificate.name
+    applicationId:
+      configRef: ev2.assistedId.applicationId
+    vaultBaseUrl:
+      input:
+        resourceGroup: singleton
+        step: output
+        name: globalKeyVaultUrl
+    issuer:
+      value: OneCertV2-PrivateCA
+  - name: geneva-kv-private-issuer
+    action: SetCertificateIssuer
+    secretKeyVault:
+      configRef: ev2.assistedId.certificate.keyVault
+    secretName:
+      configRef: ev2.assistedId.certificate.name
+    applicationId:
+      configRef: ev2.assistedId.applicationId
+    vaultBaseUrl:
+      input:
+        resourceGroup: singleton
+        step: output
+        name: genevaActionKeyVaultUrl
+    issuer:
+      value: OneCertV2-PrivateCA
+  - name: geneva-identities
+    action: ARM
+    template: templates/geneva-identities.bicep
+    parameters: configurations/geneva-identities-stg.tmpl.bicepparam
+    deploymentLevel: ResourceGroup
+    dependsOn:
+    - resourceGroup: singleton
+      step: global-kv-private-issuer
+    - resourceGroup: singleton
+      step: geneva-kv-private-issuer
+    # The Entra app/service-principal owners relationships are written through
+    # Microsoft Graph, which intermittently fails to commit the relationship and
+    # asks the caller to retry later. Retry the deployment on that transient error.
+    automatedRetry:
+      errorContainsAny:
+      - "Failed to update one or more relationships in 'owners'"
+      maximumRetryCount: 3
+      durationBetweenRetries: 1m
+  - name: mise-identity
+    action: ARM
+    template: templates/mise-identity.bicep
+    parameters: configurations/mise-identity.tmpl.bicepparam
+    deploymentLevel: ResourceGroup
+  - name: housekeeping
+    action: Shell
+    command: ./global-housekeeping.sh
+    workingDir: ./scripts
+    variables:
+    - name: GLOBAL_RESOURCE_GROUP
+      configRef: global.rg
+    shellIdentity:
+      input:
+        resourceGroup: singleton
+        step: output
+        name: globalMSIId
+    dependsOn:
+    - resourceGroup: singleton
+      step: infra
+  - name: grafana-dashboards
+    action: GrafanaDashboards
+    grafanaName: "{{ .monitoring.grafanaName }}"
+    observabilityConfig: ./../observability/observability.yaml
+    identityFrom:
+      resourceGroup: singleton
+      step: output
+      name: globalMSIId
+    dependsOn:
+    - resourceGroup: singleton
+      step: housekeeping
+    - resourceGroup: singleton
+      step: output
+  # creates DNS delegation for the ARO HCP global SVC zone
+  - name: svcChildZone
+    action: DelegateChildZone
+    parentZone:
+      configRef: dns.parentZoneName
+    childZone:
+      configRef: stgGlobalV2.svcParentZoneName
+    secretKeyVault:
+      configRef: ev2.assistedId.certificate.keyVault
+    secretName:
+      configRef: ev2.assistedId.certificate.name
+    dstsHost:
+      configRef: ev2.assistedId.dstsHost
+    deploymentMode:
+      value: "Incremental"
+    dependsOn:
+    - resourceGroup: singleton
+      step: infra
+  # creates DNS delegation for the ARO HCP global CX zone
+  - name: cxChildZone
+    action: DelegateChildZone
+    parentZone:
+      configRef: dns.parentZoneName
+    childZone:
+      configRef: stgGlobalV2.cxParentZoneName
+    secretKeyVault:
+      configRef: ev2.assistedId.certificate.keyVault
+    secretName:
+      configRef: ev2.assistedId.certificate.name
+    dstsHost:
+      configRef: ev2.assistedId.dstsHost
+    deploymentMode:
+      value: "Incremental"
+    dependsOn:
+    - resourceGroup: singleton
+      step: infra
+  # create global ARO HCP ACRs for OCP and SVC images
+  - name: acrs
+    action: ARM
+    template: templates/global-acr.bicep
+    parameters: configurations/global-acr-stg.tmpl.bicepparam
+    deploymentLevel: ResourceGroup
+    dependsOn:
+    - resourceGroup: singleton
+      step: infra
+  # ingests secrets into the global KV
+  # NOTE: data/encryptedsecrets.yaml must be re-encrypted against the new global KV
+  # public key before this succeeds (the manual "re-encrypt" prerequisite).
+  - name: decrypt-and-ingest-secrets
+    action: SecretSync
+    keyVault: '{{ .stgGlobalV2.globalKeyVaultName }}'
+    configurationFile: 'data/encryptedsecrets.yaml'
+    encryptionKey: '{{ .global.keyVault.encryptionKeyName }}'
+    dependsOn:
+    - resourceGroup: singleton
+      step: infra
+    identityFrom:
+      resourceGroup: singleton
+      step: output
+      name: globalMSIId
+  # mirror oc-mirror image
+  - name: mirror-oc-mirror-image
+    action: ImageMirror
+    targetACR:
+      configRef: 'stgGlobalV2.acrSvcName'
+    sourceRegistry:
+      configRef: imageSync.ocMirror.image.registry
+    repository:
+      configRef: imageSync.ocMirror.image.repository
+    digest:
+      configRef: imageSync.ocMirror.image.digest
+    pullSecretKeyVault:
+      configRef: stgGlobalV2.globalKeyVaultName
+    pullSecretName:
+      configRef: imageSync.ondemandSync.pullSecretName
+    dependsOn:
+    - resourceGroup: singleton
+      step: acrs
+    - resourceGroup: singleton
+      step: decrypt-and-ingest-secrets
+    shellIdentity:
+      input:
+        resourceGroup: singleton
+        step: output
+        name: globalMSIId
+    automatedRetry:
+      errorContainsAny:
+      - "unknown_storage_failure"
+      - "unauthorized: authentication required"
+      maximumRetryCount: 5
+      durationBetweenRetries: 1m
+  # deploys the image mirror for the ACRs
+  - name: imagemirror
+    action: ARM
+    template: templates/global-image-sync.bicep
+    parameters: configurations/global-image-sync-stg.tmpl.bicepparam
+    deploymentLevel: ResourceGroup
+    dependsOn:
+    - resourceGroup: singleton
+      step: mirror-oc-mirror-image

--- a/dev-infrastructure/global-pipeline-stg.yaml
+++ b/dev-infrastructure/global-pipeline-stg.yaml
@@ -5,7 +5,7 @@
 # (hcp-stg-global) so it can be built and validated alongside the existing shared
 # subscription without touching it. Differences from the canonical pipeline:
 #   * serviceGroup is Microsoft.Azure.ARO.HCP.Global.StgGlobal (new subcomponent),
-#     wired under the new HCP.Global.V2 root entrypoint — NOT the live HCP.Global,
+#     wired under the new HCP.Global.StgGlobal root entrypoint — NOT the live HCP.Global,
 #     so EV2 never co-deploys this with the existing global rollout.
 #   * subscription is hardcoded to 'hcp-stg-global' (the canonical pipeline uses
 #     '{{ .global.subscription.key }}', which for stg still resolves to the shared

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -25,6 +25,8 @@ The tree of pipelines making up the ARO HCP service are documented here from the
         - Microsoft.Azure.ARO.HCP.Fleet.Registration ([ref](https://github.com/Azure/ARO-HCP/tree/main/fleet/registration/pipeline.yaml)): Register the stamp and management cluster in CosmosDB.
       - Microsoft.Azure.ARO.HCP.Monitoring ([ref](https://github.com/Azure/ARO-HCP/tree/main/dev-infrastructure/monitoring-pipeline.yaml)): Deploy the Monitoring resources (Monitoring)
       - Microsoft.Azure.ARO.HCP.E2E ([ref](https://github.com/Azure/ARO-HCP/tree/main/test/e2e-pipeline.yaml)): Run the E2E tests towards a region and gate SDP progression.
+- Microsoft.Azure.ARO.HCP.Global.StgGlobal ([ref](https://github.com/Azure/ARO-HCP/tree/main/dev-infrastructure/global-pipeline-stg.yaml)): Deploy global shared infrastructure (STG V2). (Global STG V2)
+  - Microsoft.Azure.ARO.HCP.Geography.StgGlobal ([ref](https://github.com/Azure/ARO-HCP/tree/main/dev-infrastructure/geography-pipeline-stg.yaml)): Deploy geography-level shared infrastructure (STG V2).
 - Microsoft.Azure.ARO.HCP.Management.Delete ([ref](https://github.com/Azure/ARO-HCP/tree/main/dev-infrastructure/cleanup/delete.mgmt.pipeline.yaml)): Delete the management resources and management resource group
 - Microsoft.Azure.ARO.HCP.Service.Delete ([ref](https://github.com/Azure/ARO-HCP/tree/main/dev-infrastructure/cleanup/delete.svc.pipeline.yaml)): Delete the service resources and service resource group
 - Microsoft.Azure.ARO.HCP.Region.Delete ([ref](https://github.com/Azure/ARO-HCP/tree/main/dev-infrastructure/cleanup/delete.region.pipeline.yaml)): Delete the region resources and resource group

--- a/topology.yaml
+++ b/topology.yaml
@@ -4,6 +4,12 @@ entrypoints:
     name: Global
     scopeDoc: high-level-architecture.md
     incremental: "true"
+# TRANSIENT - new root entrypoint for the parallel STG-global "V2" stack. Kept
+# separate from HCP.Global so EV2 never co-deploys the two. Removed at decommission.
+- identifier: 'Microsoft.Azure.ARO.HCP.Global.StgGlobal'
+  metadata:
+    name: Global STG V2
+    scopeDoc: high-level-architecture.md
 - identifier: 'Microsoft.Azure.ARO.HCP.Region'
   metadata:
     name: Region
@@ -85,6 +91,17 @@ services:
     purpose: Deploy geography-level shared infrastructure.
   pipelinePath: dev-infrastructure/global-pipeline.yaml
   purpose: Deploy global shared infrastructure.
+# TRANSIENT - STG-global "V2" parallel global stack under the new
+# HCP.Global.StgGlobal entrypoint (NOT under HCP.Global). Deploys global +
+# geography into the dedicated hcp-stg-global subscription during coexistence.
+# Removed at decommission.
+- serviceGroup: Microsoft.Azure.ARO.HCP.Global.StgGlobal
+  children:
+  - serviceGroup: Microsoft.Azure.ARO.HCP.Geography.StgGlobal
+    pipelinePath: dev-infrastructure/geography-pipeline-stg.yaml
+    purpose: Deploy geography-level shared infrastructure (STG V2).
+  pipelinePath: dev-infrastructure/global-pipeline-stg.yaml
+  purpose: Deploy global shared infrastructure (STG V2).
 # Cleanup pipelines
 - serviceGroup: Microsoft.Azure.ARO.HCP.Management.Delete
   pipelinePath: dev-infrastructure/cleanup/delete.mgmt.pipeline.yaml


### PR DESCRIPTION
## What

Adds a transient, parallel set of **STG global** infrastructure pipelines that deploy into a **dedicated STG global subscription**, alongside the existing shared-subscription infra. Purely additive and inert — nothing consumes the new infra until a later cutover, so live STG/PROD are unaffected.

New files / changes:

| File | Purpose |
|------|---------|
| `config/config.schema.json` | New optional top-level `stgGlobalV2` block (globally-unique name slots, DNS zone slots, kusto slot; `additionalProperties: false`) |
| `config/config.yaml` | `stgGlobalV2` defaults to `empty-sentinel` |
| `config/config.msft.clouds-overlay.yaml` | Real STG values (the `…2`-suffixed names, dedicated DNS zones, `hcp-stg-uk-3` kusto) |
| `dev-infrastructure/global-pipeline-stg.yaml` | STG/uksouth-only copy of `global-pipeline.yaml`, hardcoded to subscription `hcp-stg-global` |
| `dev-infrastructure/geography-pipeline-stg.yaml` | STG/uksouth-only copy of `geography-pipeline.yaml` |
| `dev-infrastructure/configurations/*-stg.tmpl.bicepparam` (×6) | bicepparam copies referencing `stgGlobalV2.*` for globally-unique names |
| `topology.yaml` | New `HCP.Global.StgGlobal` root entrypoint, **separate** from `HCP.Global` |

The two commits are split deliberately: source changes first, then the `make -C config/ materialize` output (`config/rendered/dev/**`) in its own commit for easy review.

## Why

In Azure, the subscription is the security/compliance boundary. Today STG shares the global subscription with PROD, which forces STG to inherit PROD-tier safeguards (SAW + JIT approvals, manual `ApprovalService` rollouts, no auto-merge). INT avoids all of this because it has its own subscription. Giving STG its own dedicated global subscription does the same and unlocks fully automated **INT → STG** promotion.

The migration is staged so each step merges independently and nothing breaks in between ("go on vacation between any two steps"). This PR is part of epic **AROSLSRE-525** and covers **AROSLSRE-1200** (Deploy New STG Global Infra — this is the build/config groundwork that unblocks the deploy) and **AROSLSRE-1204** (DNS Zones & SafeDNS Delegation for STG — the config + zone-creation portion). It is purely additive and does not deploy anything itself.

## Design notes

- **Why `stgGlobalV2` exists in base `config.yaml` as `empty-sentinel`:** the renderer uses `missingkey=error`, and both `helmtest` and EV2 manifest generation **preprocess every pipeline for every environment** (the stg-only `executionConstraints` does not gate preprocessing/rendering). So the V2 bicepparams that reference `.stgGlobalV2.*` must resolve in `dev`/`int`/`prod` too — where they default to `empty-sentinel` and are never consumed. Only `stg` (via the MSFT overlay) gets real values. This mirrors the existing `empty-sentinel` idiom already used in base config (e.g. the public-cloud `keyVault` field).
- **Separate root entrypoint** (`HCP.Global.StgGlobal`, not added to `HCP.Global`): keeps EV2 from co-deploying the V2 stack with the canonical one and contaminating existing rollouts.
- **`…2`-suffixed globally-unique names** (`arohcpsvcstg2`, `arohcpstg2-global`, …): ACR/Key Vault/Front Door names are globally unique and ACR has no rename, so the live canonical names can't be reused while the old infra still exists. The V2 names are distinct for coexistence.
- **Dedicated DNS zones** (`aro-hcp-stg.azure.com` / `aroapp-hcp-stg.azure.com`): the V2 `infra` step creates them and SafeDNS auto-delegates from `azure.com`, dropping STG's current reliance on PROD's shared zones.

## Testing

Validated locally against the same checks the presubmits run:

- `make -C config/ materialize` → **exit 0**, `TestHelmTemplate` **passes**, **zero** helm-fixture drift.
- `make -C docs pipelines.md` regenerated to include the new service groups (the `config-change-detection` gate also checks this generated inventory).
- `go run ./hack/verify-schema-additional-properties config/config.schema.json` → **exit 0**.
- Render confirms `stg` resolves real values (`arohcpsvcstg2`, `arohcpstg2-global`, …, `hcp-stg-uk-3`) while `dev`/`int`/`prod` stay `empty-sentinel`.
- Diff review confirms the change is **purely additive** — nothing outside the V2 files + config references `stgGlobalV2`, so live STG remains inert.

> Note: an earlier iteration placed `stgGlobalV2` only in the MSFT overlay; the `helmtest` gate correctly caught that `dev` (which never reads the overlay) then failed `missingkey=error`. Moving the `empty-sentinel` defaults into base `config.yaml` fixed it — included here.

The authoritative EV2-manifest validation runs downstream in `sdp-pipelines` (`make -C hcp validate-config`) after this merges and `Revision.mk` is bumped.

## Next steps (post-merge)

1. Bump `sdp-pipelines/hcp/Revision.mk` to this commit → `make -C hcp/ sync` → `make -C hcp/ validate-config` → `make -C hcp/ pipelines`.
2. Add the `sdp-pipelines`-side V2 copies that hang off this entrypoint: `Billing.StgGlobal`, `Geneva.StgGlobal` (`externalParent: HCP.Global.StgGlobal`), and `Cleanup.StgGlobal` (needs `kv-cert-rotate.sh` `TARGET_KVS` scoped to the new sub first).
3. Provision/quota for the new STG global subscription (long lead time) — **AROSLSRE-1205**.
4. Deploy + validate the parallel infra, then cut STG over, then decommission the old infra.

## Open questions for reviewers

These are working decisions, not yet ratified — happy to change:

- **Entrypoint name** `HCP.Global.StgGlobal` (chose this over `HCP.Global.V2` for consistency with the `*.StgGlobal` service-group names).
- **`kustoName: hcp-stg-uk-3`** (live STG is `hcp-stg-uk-2`).
- **DNS zone values** (`aro-hcp-stg.azure.com` / `aroapp-hcp-stg.azure.com`) — owned by the DNS track (**AROSLSRE-1204**); please confirm before deploy.

## Jira

Part of epic **AROSLSRE-525** — Enable Automated Rollouts to STG Environment.

Covers:
- **AROSLSRE-1200** — Deploy New STG Global Infra (build/config groundwork that unblocks the deploy)
- **AROSLSRE-1204** — DNS Zones & SafeDNS Delegation for STG (config + zone-creation portion)

The three open questions above still need a maintainer decision before deploy.