### PR TITLE
add filename as context for yaml validation errors

### DIFF
--- a/tooling/helmtest/internal/resolve.go
+++ b/tooling/helmtest/internal/resolve.go
@@ -83,7 +83,7 @@ func recursiveLoadPipelineReturnHelmSteps(topologyDir string, service topology.S
 	pipelinePath := filepath.Join(topologyDir, service.PipelinePath)
 	pipeline, err := types.NewPipelineFromFile(pipelinePath, cfg)
 	if err != nil {
-		return nil, fmt.Errorf("error loading pipeline %s: %w", pipelinePath, err)
+		return nil, fmt.Errorf("failed to load pipeline %s: %w", pipelinePath, err)
 	}
 
 	// Collect all ImageMirrorSteps keyed by (resourceGroup, stepName)

--- a/tooling/helmtest/internal/resolve.go
+++ b/tooling/helmtest/internal/resolve.go
@@ -80,9 +80,10 @@ func FindHelmSteps(topologyDir, configPath string) ([]HelmStepWithPath, error) {
 }
 
 func recursiveLoadPipelineReturnHelmSteps(topologyDir string, service topology.Service, cfg configtypes.Configuration) ([]HelmStepWithPath, error) {
-	pipeline, err := types.NewPipelineFromFile(filepath.Join(topologyDir, service.PipelinePath), cfg)
+	pipelinePath := filepath.Join(topologyDir, service.PipelinePath)
+	pipeline, err := types.NewPipelineFromFile(pipelinePath, cfg)
 	if err != nil {
-		return nil, fmt.Errorf("error loading pipeline: %v", err)
+		return nil, fmt.Errorf("error loading pipeline %s: %w", pipelinePath, err)
 	}
 
 	// Collect all ImageMirrorSteps keyed by (resourceGroup, stepName)

--- a/tooling/templatize/cmd/entrypoint/entrypointutils/load.go
+++ b/tooling/templatize/cmd/entrypoint/entrypointutils/load.go
@@ -34,7 +34,7 @@ func LoadPipelines(
 	pipelineConfigFilePath := filepath.Join(topologyDir, root.PipelinePath)
 	pipe, err := types.NewPipelineFromFile(pipelineConfigFilePath, cfg)
 	if err != nil {
-		return fmt.Errorf("failed to precompile pipeline: %w", err)
+		return fmt.Errorf("failed to precompile pipeline %s: %w", pipelineConfigFilePath, err)
 	}
 	if pipe.ServiceGroup != root.ServiceGroup {
 		return fmt.Errorf("pipeline loaded from %s is for %s, not %s", pipelineConfigFilePath, pipe.ServiceGroup, root.ServiceGroup)


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-27961

### What

add filename as context for yaml validation errors when running e.g. `make -C config materialize`

### Why

to understand the underlying issue more easily and quickly find the file containing the error

### Testing

`make -C config materialize` with and without yaml errors

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [ ] All comment threads resolved before merge
