### PR TITLE
Update documentation to match code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # ARO-HCP
 
 # Description
-The RP for the ARO-HCP project.
+This repository contains the code, configuration, and deployment pipelines for Red Hat OpenShift on Azure (ARO) using the Hosted Control Planes (HCP) architecture. It includes the ARM Resource Provider (frontend/backend), Cluster Service integration, management cluster controllers, and all Azure infrastructure as code.
 
-The components for HCP are each encapsulated in a top-level directory and each directory contains its own Makefile. There's a single Makefile in the root directory that allows building all HCP components.
+Each component is encapsulated in a top-level directory with its own Makefile. A root Makefile provides targets for building all components and managing deployments.
+
+For a full overview, see the [documentation index](./docs/README.md) and the [high-level architecture](./docs/high-level-architecture.md).
 
 > [!TIP] Make Options
 > [Make Options](./docs/make-options.md) describes how to customize the make build e.g. by defining the container engine to be used or limiting parallel jobs.

--- a/backend/README.md
+++ b/backend/README.md
@@ -17,7 +17,7 @@ Using the `make run` target, the Backend binary can be run locally.
 
 The local code can also be deployed directly into a personal DEV environment by running `make deploy`. Understand that this requires such an environment to be created first via `make personal-dev-env` from the root of the repository.
 
-`make deploy` builds a custom developer image from the local code and uploads it to the DEV service ACR (`arohcpsvcdev`) into a developer specific repository. This way developer images will not conflict with other develooper images or CI built ones. The actual deployment is delegated to the pipeline/AdminAPI target in the root of the repository, providing a configuration override for `frontend.image.repository` and `frontend.image.digest` respectively.
+`make deploy` builds a custom developer image from the local code and uploads it to the DEV service ACR (`arohcpsvcdev`) into a developer specific repository. This way developer images will not conflict with other developer images or CI built ones. The actual deployment is delegated to the pipeline/RP.Backend target in the root of the repository, providing a configuration override for `backend.image.repository` and `backend.image.digest` respectively.
 
 ## Deployment
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,10 @@ Welcome to the **ARO HCP** documentation. This guide provides an overview of the
 - System overview, scopes and key components
 - Major services and how they interact
 
+### [Service Components](service-components.md)
+
+- Per-component purpose, pipeline target, and deployment overview
+
 ### Environments
 
 - [Overview](environments.md)
@@ -19,7 +23,6 @@ Welcome to the **ARO HCP** documentation. This guide provides an overview of the
 - Red Hat development tenant deployment environments
   - [Personal ARO HCP environment](personal-dev.md)
   - [CS PR environment](cspr.md)
-  - [Personal perfscale environment](perscale-deployment.md)
 - MSFT deployment environments
   - [MSIT INT](environments.md#msit-corp-tenant-msft-int-tenant)
 
@@ -39,6 +42,17 @@ Welcome to the **ARO HCP** documentation. This guide provides an overview of the
 - [DNS](dns.md)
   - Overview of the DNS hierarchies and how they are managed
   - SVC and CX zones
+- [MISE](mise.md)
+  - Microsoft Identity Service Essentials: token validation and authorization
+
+### API
+
+- [API Conventions](api-conventions.md)
+  - API review requirements and design conventions
+- [API Version Defaults and Storage](api-version-defaults-and-storage.md)
+  - DDR: API version defaults and storage consistency decisions
+- [CLI Generation](cli-generation.md)
+  - Workflow for generating Azure CLI extensions from ARO HCP swagger
 
 ### [Configuration Management](configuration.md)
 
@@ -51,6 +65,10 @@ Welcome to the **ARO HCP** documentation. This guide provides an overview of the
 - [Pipelines Concept](pipeline-concept.md)
 - [Pipeline Topology](pipeline-topology.md)
 - [Service Deployment Concept](service-deployment-concept.md)
+- [Infrastructure Rollout Timings](infra-timing.md)
+  - How to investigate infrastructure rollout timing data
+- [Testing Under Constrained Pipeline Identity](testing-constrained-pipeline-identity.md)
+  - How to test tools running under restricted EV2 shellIdentity
 - Deployment artifacts
   - [Azure infrastructure Bicep templates](bicep.md)
   - [Helm Charts](service-deployment-concept.md#helm-chart)
@@ -63,8 +81,10 @@ Welcome to the **ARO HCP** documentation. This guide provides an overview of the
 - [EV2 Deployment](ev2-deployment.md)
   - Deployment process from pipeline.yaml to EV2 deployment
   - Building and executing an ADO pipeline
-- [Secret Syncronization](secret-sync.md)
+- [Secret Synchronization](secret-sync.md)
   - documents tools/processes to sync secrets
+- [Make Options](make-options.md)
+  - How to customize make targets (container engine, parallel jobs, etc.)
 
 ### Testing and CI
 
@@ -101,15 +121,21 @@ Welcome to the **ARO HCP** documentation. This guide provides an overview of the
 - [CI Operations](ci/operations.md)
   - How to trigger, inspect, troubleshoot, and change CI
   - Tiny source-of-truth appendix for job families
+- [Snapshot Gathering and Analysis](snapshot-analysis.md)
+  - Using `hcpctl snapshot` to gather diagnostics and run LLM-driven root cause analysis
 
 ### Observability
 
+- [Monitoring](monitoring.md)
+  - Prometheus and Azure Monitor architecture; metrics collection and remote-write
 - [Alerts](alerts.md)
   - How to write, test, and deploy Prometheus alerting rules
   - CorrelationID behavior, severity mapping, IcM integration
 - [Grafana Dashboards](grafana-dashboards.md)
 - [Logging](logging.md)
 - [Prometheus Rules](prometheus-rules.md)
+- [HCP Metrics Architecture](sre/hcp-metrics.md)
+  - How metrics flow from HCP components to Azure Monitor; extending collection
 
 ### Guides and Operations
 
@@ -124,10 +150,42 @@ Welcome to the **ARO HCP** documentation. This guide provides an overview of the
 - [Resource Creation Diagram](resource-creation.md)
   - Detailed diagram of the resource creation flow (frontend, backend, Cluster Service, Maestro)
   - Covers HCPOpenShiftCluster, NodePool, and ExternalAuth resource types
+- [PostgreSQL](ops/postgres.md)
+  - PostgreSQL usage for Clusters Service and Maestro
 - [Postgres Breakglass](ops/postgres-breakglass.md)
   - How to access the Postgres database
+- [Kubernetes Provisioning Diagnostics](ops/kubernetes-provisioning-diagnostics.md)
+  - Dashboard for pod health, restarts, node pressure, and scheduling delays
+- [Cleanup Stuck Cluster Deletion](ops/cleanup-stuck-cluster-deletion.md)
+  - Procedure for manually cleaning up clusters stuck on deletion
+- [Fix Maestro Stale Resource Bundle](ops/fix-maestro-stale-resource-bundle.md)
+  - How to resolve Maestro resource bundle staleness issues
+- [Node Rollout Pre-Merge Check](node-rollout-premerge-check.md)
+  - Pre-merge check procedure to avoid unexpected node rollouts in production
 - [Tenant Quota Collector](../tooling/tenant-quota/README.md)
   - Tool-local deployment, configuration, and troubleshooting reference for `tenant-quota`
   - For CI relevance, see [CI Quota Monitoring](ci/quota-monitoring.md)
+
+### SOPs
+
+- [Renew the Prow Token](sops/renew-prow-token.md)
+  - How to renew the `prow-token` used by EV2 to trigger Prow E2E gating jobs
+- [Dump Custom Resources](sops/dump-crs.md)
+  - How to use `hcpctl mc dump-crs` to dump CRs for a HostedCluster
+- [Gather Logs](sops/gather-logs.md)
+  - `hcpctl must-gather` commands for legacy-query and clean subcommands
+- [MSIT INT Credential Setup](sops/msit-int-credential-setup.md)
+  - Setting up first-party, MSI mock, and ARM helper credentials for MSIT INT
+- [Test Tenant Access](sops/test-test-tenant-access.md)
+  - Requesting access to the Test Test ARO tenant used for E2E in Stage and Prod
+
+### AI Agent Hints
+
+These documents are primarily intended for AI coding assistants and agentic debugging workflows.
+
+- [Agentic Debugging](ai/debugging.md)
+- [Grafana Debugging Hints](ai/grafana-debugging.md)
+- [Kusto Debugging Hints](ai/kusto-debugging.md)
+- [Kusto Query Cookbook](ai/query-cookbook.md)
 
 ### [Terminology](terminology.md)

--- a/docs/acrs-and-images.md
+++ b/docs/acrs-and-images.md
@@ -28,7 +28,7 @@ Image mirroring ensures ARO HCP environments maintain current OpenShift releases
 
 ### ACR Cache Rules
 
-ACR Cache copies images from a connected registry over upon requesting the image the first time. It is configured for OCP Images in the corresponding bicep: [global-acr.bicep](..dev-infrastructure/templates/global-acr.bicep)
+ACR Cache copies images from a connected registry over upon requesting the image the first time. It is configured for OCP Images in the corresponding bicep: [global-acr.bicep](../dev-infrastructure/templates/global-acr.bicep)
 We rely on `quay.io/openshift-release-dev/*` images in all environments. 
 
 ### On-demand Sync

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -158,7 +158,7 @@ steps:
       configRef: frontend.cosmosDB.name
 ```
 
-For more details on shell steps, refer to the **Shell Step Documentation**.
+For more details on shell steps, refer to the [Shell Step Documentation](pipeline-concept.md#shell-step).
 
 ### Bicep Templates
 

--- a/docs/ev2-deployment.md
+++ b/docs/ev2-deployment.md
@@ -2,12 +2,6 @@
 
 This document describes the deployment process of ARO HCP instances into Microsoft tenants using EV2 tying in all artifact types and configuration.
 
-> [!NOTE]
-> Please note that this document does not cover the following details yet
->
-> * using the EV2 portal
-> * AME deployments
-
 ## Overview
 
 Deployments of ARO HCP instances into Microsoft tenants are managed through a combination of Azure DevOps (ADO) pipelines and [EV2](terminology.md#ev2). Different aspects of an ARO HCP instance, such as infrastructure and services, are deployed by distinct [ADO pipelines](pipelines.md).

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -11,7 +11,7 @@ ARO-HCP uses Azure Data Explorer (Kusto) for centralized log aggregation. Logs f
 Kusto clusters are group by Geography, according to the Geos defined in the Ev2 configuration: https://github.com/Azure/ARO-Tools/blob/main/config/ev2config/config.yaml
 
 Names follow this convention:
- - rg: "hcp-kusto-{{ .ctx.environment }}-{{ .ev2.geoShortId
+ - rg: "hcp-kusto-{{ .ctx.environment }}-{{ .ev2.geoShortId }}"
  - kustoName: "hcp-{{ .ctx.environment }}-{{ .ev2.geoShortId }}"
 
 *instance list*: https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/components-and-architecture/kusto

--- a/docs/ops/hcp-cluster-creation-flow.md
+++ b/docs/ops/hcp-cluster-creation-flow.md
@@ -3,7 +3,7 @@
 
 This document describes the high level cluster creation flow of an ARO HCP cluster. It is meant to be a quick reference for developers and engineers working on the ARO HCP service. It is not a comprehensive overview of the ARO HCP architecture or a complete SOP/TSG for debugging during oncall.
 
-The individual components are described in the [service components overview](service-components.md). The flowchart below shows the rough flow of the cluster creation process through the individual service components. Helpful debug commands are provided for each component in their respective sections.
+The individual components are described in the [service components overview](../service-components.md). The flowchart below shows the rough flow of the cluster creation process through the individual service components. Helpful debug commands are provided for each component in their respective sections.
 
 ## Cluster Creation Flow Happy Path in a Nutshell
 

--- a/docs/ops/hcp-cluster-creation-flow.md
+++ b/docs/ops/hcp-cluster-creation-flow.md
@@ -3,7 +3,7 @@
 
 This document describes the high level cluster creation flow of an ARO HCP cluster. It is meant to be a quick reference for developers and engineers working on the ARO HCP service. It is not a comprehensive overview of the ARO HCP architecture or a complete SOP/TSG for debugging during oncall.
 
-The individual components are described in the [service components overview (todo)](service-components.md). The flowchart below shows the rough flow of the cluster creation process through the individual service components. Helpful debug commands are provided for each component in their respective sections.
+The individual components are described in the [service components overview](service-components.md). The flowchart below shows the rough flow of the cluster creation process through the individual service components. Helpful debug commands are provided for each component in their respective sections.
 
 ## Cluster Creation Flow Happy Path in a Nutshell
 

--- a/docs/personal-dev.md
+++ b/docs/personal-dev.md
@@ -2,7 +2,7 @@
 
 A personal DEV environment is a fully-fledged ARO HCP service stack that provides all major infrastructure and service components required to create hosted control planes in a region. Each ARO HCP team member creates their own personal DEV environment for development purposes.
 
-These environments are hosted in the Red Hat Azure tenant, meaning that all [restrictions](environments.md#aro-hcp-azure-tenant-overview) of that tenant apply.
+These environments are hosted in the Red Hat Azure tenant, meaning that all [restrictions](environments.md#azure-tenants) of that tenant apply.
 
 This document will describe how to create and manage a personal DEV environment and how to access them for development purposes.
 

--- a/docs/service-deployment-concept.md
+++ b/docs/service-deployment-concept.md
@@ -86,7 +86,7 @@ Using the `make run` target, the Frontend binary can be run locally.
 
 ### Personal DEV Environment deployment
 
-The local code can also be deployed directly into a personal DEV environment by running `make deploy`. Understand that this requires such an environment to be created first via `make persional-dev-env` from the root of the repository.
+The local code can also be deployed directly into a personal DEV environment by running `make deploy`. Understand that this requires such an environment to be created first via `make personal-dev-env` from the root of the repository.
 
 `make deploy` builds a custom developer image from the local code and uploads it to the DEV service ACR (`arohcpsvcdev`) into a developer specific repository. This way developer images will not conflict with other developer images or CI built ones. The actual deployment is delegated to the pipeline/<service-group-suffix> target in the root of the repository, providing a configuration override for `<component>.image.repository` and `<component>.image.digest` respectively.
 

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -1,9 +1,5 @@
 # ARO HCP Terminology
 
-- **Definition**:
-- **Abbreviation**:
-- **References**:
-
 ## Azure Terminology
 
 ### Azure Resource Manager
@@ -31,7 +27,7 @@
 
 ### Hosted Control Plane
 
-- **Definition:** OCP control plane running as Pods on a Kubernetes cluster. These Pods are managed by [Hypershift](#hosted-control-plane).
+- **Definition:** OCP control plane running as Pods on a Kubernetes cluster. These Pods are managed by [Hypershift](#hypershift).
 - **Abbreviation:** HCP
 - **References**:
   - [Blog](https://www.redhat.com/en/blog/red-hat-openshift-service-aws-hosted-control-planes-now-available)
@@ -45,7 +41,7 @@
 
 ### Service Cluster
 
-- **Definition**: Hosts the regional entry point services like [RP](#resource-provider) and [CS](#service-cluster) for HCP creation and management
+- **Definition**: Hosts the regional entry point services like [RP](#resource-provider) and [CS](#clusters-service) for HCP creation and management
 - **Abbreviation**: SC, SVC
 - **References**:
   - [High Level Architecture](high-level-architecture.md#service-cluster)

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -17,7 +17,7 @@ Using the `make run` target, the Frontend binary can be run locally.
 
 The local code can also be deployed directly into a personal DEV environment by running `make deploy`. Understand that this requires such an environment to be created first via `make personal-dev-env` from the root of the repository.
 
-`make deploy` builds a custom developer image from the local code and uploads it to the DEV service ACR (`arohcpsvcdev`) into a developer specific repository. This way developer images will not conflict with other develooper images or CI built ones. The actual deployment is delegated to the pipeline/AdminAPI target in the root of the repository, providing a configuration override for `frontend.image.repository` and `frontend.image.digest` respectively.
+`make deploy` builds a custom developer image from the local code and uploads it to the DEV service ACR (`arohcpsvcdev`) into a developer specific repository. This way developer images will not conflict with other developer images or CI built ones. The actual deployment is delegated to the pipeline/RP.Frontend target in the root of the repository, providing a configuration override for `frontend.image.repository` and `frontend.image.digest` respectively.
 
 ## Deployment
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -76,7 +76,7 @@ Create or Update a HcpOpenShiftClusterResource
 ```bash
 curl -X PUT "localhost:8443/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/dev-test-rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/dev-test-cluster?api-version=2024-06-10-preview" \
   -H "X-Ms-Arm-Resource-System-Data: {\"createdBy\": \"aro-hcp-local-testing\", \"createdByType\": \"User\", \"createdAt\": \"2024-06-06T19:26:56+00:00\"}" \
-  -H "X-Ms-Identity-Url": https://dummyhost.identity.azure.net" \
+  -H "X-Ms-Identity-Url: https://dummyhost.identity.azure.net" \
   --json @cluster.json
 ```
 

--- a/kube-applier/readme.md
+++ b/kube-applier/readme.md
@@ -21,10 +21,10 @@ We'll probably actually use a larger burst and smaller QPS, but it's an easy sca
 The scale of a region is larger, but is handled by cosmos so it will scale far beyond our needs.
 
 ## API structure
-The API types for this will live in `internal/api/kubeapplier`.
+The API types for this live in `internal/api/kubeapplier`.
 
-Every `*Desire` API will interact with a single kubernetes resource instance.
-We will not support lists, we will not support label selection, and we will not support list all.
+Every `*Desire` API interacts with a single kubernetes resource instance.
+Lists, label selection, and list all are not supported.
 This is for simplicity in reasoning about the status.
 We may eventually add support for `ReadManyDesire`, but only if we find a need for it.
 
@@ -33,7 +33,7 @@ Every `*Desire` API has a `.spec.managementCluster` field.
 This is the name of the management cluster that the `kube-applier` is running in.
 It matches the value the kube-applier binary was started with via `--management-cluster`,
 and it is used as the Cosmos partition key inside that management cluster's container.
-It is reasonably likely that will someday before an `*azcorearm.ResourceID`, but if that happens we'll adjust the string format first,
+It is reasonably likely that this will someday become an `*azcorearm.ResourceID`, but if that happens we'll adjust the string format first,
 rewrite everything, then change the type.
 No need to do so now since the type is a string.
 
@@ -101,7 +101,7 @@ The `internal/database/informers`, `internal/database/listers`, and
 `*Desire` APIs.
 
 ## Controller structure
-The `kube-applier` binary will be controller-based with many controllers structured similarly to the `backend` binary today.
+The `kube-applier` binary is controller-based with many controllers structured similarly to the `backend` binary.
 Instead of using the `Controller` type to communicate `Degraded` status, that will be communicated on the `*Desire` `.status.conditions["Degraded"]` field.
 Several controllers will exist
 


### PR DESCRIPTION
<!-- Link to Jira issue -->
https://redhat.atlassian.net/browse/ARO-27207

### What

Fix a range of documentation issues across the repo:

- **frontend/README.md, backend/README.md**: Fix copy-paste errors — wrong pipeline targets (`pipeline/AdminAPI` → `pipeline/RP.Frontend`/`pipeline/RP.Backend`), wrong image config keys in backend (`frontend.image.*` → `backend.image.*`), "develooper" typo
- **frontend/README.md**: Fix broken curl `-H` flag syntax (colon outside quotes)
- **docs/README.md**: Add all previously unlisted docs files (SOPs, AI hints, API, monitoring, ops runbooks, etc.); fix broken `perscale-deployment.md` link; fix "Syncronization" typo
- **docs/terminology.md**: Remove unfilled template placeholder lines; fix two broken anchors (`#hosted-control-plane` → `#hypershift`, `#service-cluster` → `#clusters-service`)
- **docs/acrs-and-images.md**: Fix broken relative link (missing slash: `..dev-infrastructure` → `../dev-infrastructure`)
- **docs/personal-dev.md**: Fix broken anchor (`#aro-hcp-azure-tenant-overview` → `#azure-tenants`)
- **docs/logging.md**: Restore truncated Go template string
- **docs/service-deployment-concept.md**: Fix typo `persional-dev-env` → `personal-dev-env`
- **docs/configuration.md**: Turn unlinked bold "Shell Step Documentation" into an actual hyperlink
- **docs/ev2-deployment.md**: Remove stale NOTE claiming the doc doesn't cover EV2 portal/AME deployments
- **docs/ops/hcp-cluster-creation-flow.md**: Remove `(todo)` marker from service-components link
- **kube-applier/readme.md**: Convert design-doc future tense to present tense (kube-applier is deployed); fix grammatical error ("will someday before" → "will someday become")
- **README.md**: Expand sparse description to reflect full project scope; add links to docs index and architecture overview

### Why

Documentation had accumulated a number of broken links, stale content, typos and copy-paste errors that made it harder to navigate and could mislead developers. The docs/README.md was missing roughly half the files in docs/.

### Testing

Manual review of all changed files. Links verified against actual file/anchor existence in the repo.

### Special notes for your reviewer

The `docs/README.md` change is the largest — it adds all previously unlisted doc files in the appropriate sections. No content was changed in those files, only index entries added.

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge