### PR TITLE
refactor(logging): standardize controller logger seeding across backend and kube-applier

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,6 +198,12 @@ Each service follows consistent patterns:
   - `Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster")` — not `Expect(err).NotTo(HaveOccurred())`
   - `Expect(resp.Properties).NotTo(BeNil(), "cluster response Properties was nil")` — not `Expect(resp.Properties).NotTo(BeNil())`
 
+- **Every controller has a name constant and seeds its logger from it.** Each controller package defines `const XxxControllerName = "..."` and uses that single value for: the `name` field on the controller struct, the workqueue `Name` (which surfaces as a Prometheus label), `utils.ContextWithControllerName(ctx, name)`, and `utils.LogValues{}.AddControllerName(name)`. Hardcoded string literals in those four call sites are a review-blocker — they cause silent drift between metrics labels, ctx values, and log fields.
+
+- **Workqueue keys implement `utils.LoggableKey`.** Any struct used as a controller workqueue key must implement `AddLoggerValues(logger logr.Logger) logr.Logger` (declared in `internal/utils/context.go` alongside `LogValues`). The standard implementation builds the key's `*azcorearm.ResourceID` and calls `utils.LogValues{}.AddLogValuesForResourceID(...)` so every log line from a reconcile carries the same `subscription_id` / `resource_group` / `resource_id` / `hcp_cluster_name` set — uniform across backend and kube-applier, and consistent with the Kusto indexes. Backend examples: `HCPClusterKey`, `HCPNodePoolKey`, `OperationKey` in `backend/pkg/controllers/controllerutils/util.go`. Kube-applier examples: `ApplyDesireKey`, `DeleteDesireKey`, `ReadDesireKey` in `kube-applier/pkg/controllers/keys/keys.go`.
+
+- **Worker loops seed per-key logger via `utils.AddLoggerValues`.** Every controller's `processNext` (or equivalent) must call `logger := utils.AddLoggerValues(utils.LoggerFromContext(ctx), key)` and `ctx = utils.ContextWithLogger(ctx, logger)` after pulling a key off the queue but before invoking `SyncOnce`. The backend's `genericWatchingController` does this once; kube-applier controllers, which run their own worker loops, must do it themselves.
+
 ### API Versioning
 ARM API versions live under `internal/api/v<YYYYMMDD>preview/` (e.g. `v20240610preview`, `v20251223preview`). Each version directory has a `generated/` subdirectory with auto-generated types and a `register.go` that wires the version into the API registry. Conversion between API versions and internal types happens in the `*_methods.go` files. The internal (versionless) types live in `internal/api/`.
 

--- a/backend/pkg/controllers/controllerutils/generic_watching_controller.go
+++ b/backend/pkg/controllers/controllerutils/generic_watching_controller.go
@@ -128,7 +128,7 @@ func (c *genericWatchingController[T]) processNextWorkItem(ctx context.Context) 
 	defer c.queue.Done(ref)
 
 	logger := utils.LoggerFromContext(ctx)
-	logger = AddLoggerValues(logger, ref)
+	logger = utils.AddLoggerValues(logger, ref)
 	ctx = utils.ContextWithLogger(ctx, logger)
 
 	ReconcileTotal.WithLabelValues(c.name).Inc()
@@ -207,7 +207,7 @@ func (c *genericWatchingController[T]) EnqueueResourceIDAddWithMaxDepth(resource
 
 	logger := utils.DefaultLogger()
 	logger = logger.WithValues(utils.LogValues{}.AddControllerName(c.name)...)
-	logger = AddLoggerValues(logger, key)
+	logger = utils.AddLoggerValues(logger, key)
 	ctx := logr.NewContext(context.TODO(), logger)
 	ctx = utils.ContextWithControllerName(ctx, c.name)
 

--- a/backend/pkg/controllers/controllerutils/util.go
+++ b/backend/pkg/controllers/controllerutils/util.go
@@ -40,20 +40,6 @@ type Controller interface {
 	Run(ctx context.Context, threadiness int)
 }
 
-type LoggableKey interface {
-	AddLoggerValues(logger logr.Logger) logr.Logger
-}
-
-func AddLoggerValues(logger logr.Logger, key any) logr.Logger {
-	switch castKey := key.(type) {
-	case LoggableKey:
-		return castKey.AddLoggerValues(logger)
-	default:
-		logger = logger.WithValues("controllerKey", key)
-		return logger
-	}
-}
-
 // OperationKey is for driving workqueues keyed for operations
 type OperationKey struct {
 	SubscriptionID   string `json:"subscriptionID"`

--- a/internal/utils/context.go
+++ b/internal/utils/context.go
@@ -256,3 +256,31 @@ func (lv LogValues) AddLogValuesForResourceIDString(resourceIDString string) Log
 	}
 	return lv.AddLogValuesForResourceID(resourceID)
 }
+
+// LoggableKey is the contract a controller workqueue key implements so that
+// the generic worker loop can seed its per-reconcile logger with the key's
+// identifying fields. Implementations typically build the key's
+// resourceID and call utils.LogValues{}.AddLogValuesForResourceID(...).
+//
+// Every controller key type in this repo must implement LoggableKey so that
+// the structured-log fields ("subscription_id", "resource_group", "resource_id",
+// etc.) are uniform across controllers and the indexes in Kusto stay coherent.
+type LoggableKey interface {
+	AddLoggerValues(logger logr.Logger) logr.Logger
+}
+
+// AddLoggerValues seeds logger with the key's identifying fields. If the key
+// satisfies LoggableKey, its AddLoggerValues method is used; otherwise the key
+// is logged under the catch-all "controllerKey" field so an opaque key still
+// shows up in the logs (without silently dropping it).
+//
+// This is the helper the generic worker loop calls after pulling a key off
+// the workqueue; controllers should not need to call it directly.
+func AddLoggerValues(logger logr.Logger, key any) logr.Logger {
+	switch castKey := key.(type) {
+	case LoggableKey:
+		return castKey.AddLoggerValues(logger)
+	default:
+		return logger.WithValues("controllerKey", key)
+	}
+}

--- a/kube-applier/pkg/controllers/apply_desire/controller.go
+++ b/kube-applier/pkg/controllers/apply_desire/controller.go
@@ -55,6 +55,12 @@ import (
 // is the owner, distinct from any native Kubernetes "kube-..." manager.
 const FieldManager = "aro-hcp-kube-applier"
 
+// ApplyDesireControllerName is the per-controller identifier emitted in the
+// "controller_name" log key, used as the workqueue name (so it surfaces as a
+// Prometheus label), and threaded into ctx via utils.ContextWithControllerName.
+// Mirrors the backend convention (e.g. NodepoolVersionControllerName).
+const ApplyDesireControllerName = "ApplyDesireController"
+
 // DefaultCooldownPeriod is the minimum interval between two reconciles
 // of an unchanged ApplyDesire. The informer's handler resync fires
 // frequently (at the informer's check period); the cooldown gate is what
@@ -133,7 +139,7 @@ func NewApplyDesireController(
 	cooldownChecker := controllerutils.NewTimeBasedCooldownChecker(cfg.CooldownPeriod)
 	cooldownChecker.SetClock(cfg.Clock)
 	c := &ApplyDesireController{
-		name:                "ApplyDesireController",
+		name:                ApplyDesireControllerName,
 		applyDesireInformer: applyDesireInformer,
 		fetcher:             fetcher,
 		dyn:                 dyn,
@@ -143,7 +149,7 @@ func NewApplyDesireController(
 		),
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[keys.ApplyDesireKey](),
-			workqueue.TypedRateLimitingQueueConfig[keys.ApplyDesireKey]{Name: "ApplyDesireController"},
+			workqueue.TypedRateLimitingQueueConfig[keys.ApplyDesireKey]{Name: ApplyDesireControllerName},
 		),
 		cfg:      cfg,
 		cooldown: cooldownChecker,
@@ -174,8 +180,8 @@ func (c *ApplyDesireController) Run(ctx context.Context, threadiness int) {
 	ctx = utils.ContextWithControllerName(ctx, c.name)
 	logger := utils.LoggerFromContext(ctx).WithValues(utils.LogValues{}.AddControllerName(c.name)...)
 	ctx = utils.ContextWithLogger(ctx, logger)
-	logger.Info("starting ApplyDesireController")
-	defer logger.Info("stopped ApplyDesireController")
+	logger.Info("starting controller")
+	defer logger.Info("stopped controller")
 
 	for i := 0; i < threadiness; i++ {
 		go wait.UntilWithContext(ctx, c.runWorker, time.Second)
@@ -254,6 +260,12 @@ func (c *ApplyDesireController) processNext(ctx context.Context) bool {
 		return false
 	}
 	defer c.queue.Done(key)
+
+	// Seed the per-reconcile logger with the key's identifying fields so every
+	// log line from SyncOnce carries subscription_id / resource_group /
+	// resource_id, matching the backend generic worker loop's behavior.
+	logger := utils.AddLoggerValues(utils.LoggerFromContext(ctx), key)
+	ctx = utils.ContextWithLogger(ctx, logger)
 
 	if err := c.SyncOnce(ctx, key); err != nil {
 		utilruntime.HandleErrorWithContext(ctx, err, "sync error; requeuing", "key", key)

--- a/kube-applier/pkg/controllers/delete_desire/controller.go
+++ b/kube-applier/pkg/controllers/delete_desire/controller.go
@@ -60,6 +60,11 @@ import (
 // kube-apiserver Get traffic bounded.
 const DefaultCooldownPeriod = 1 * time.Minute
 
+// DeleteDesireControllerName is the per-controller identifier emitted in the
+// "controller_name" log key and used as the workqueue name. Mirrors the backend
+// convention.
+const DeleteDesireControllerName = "DeleteDesireController"
+
 // Config tunes the DeleteDesireController's cooldown behavior. Zero-valued
 // fields take the Default* constants; tests pass shorter durations and a
 // fake clock.
@@ -126,7 +131,7 @@ func NewDeleteDesireController(
 	cooldownChecker := controllerutil.NewTimeBasedCooldownChecker(cfg.CooldownPeriod)
 	cooldownChecker.SetClock(cfg.Clock)
 	c := &DeleteDesireController{
-		name:                 "DeleteDesireController",
+		name:                 DeleteDesireControllerName,
 		deleteDesireInformer: deleteDesireInformer,
 		fetcher:              fetcher,
 		dyn:                  dyn,
@@ -136,7 +141,7 @@ func NewDeleteDesireController(
 		),
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[keys.DeleteDesireKey](),
-			workqueue.TypedRateLimitingQueueConfig[keys.DeleteDesireKey]{Name: "DeleteDesireController"},
+			workqueue.TypedRateLimitingQueueConfig[keys.DeleteDesireKey]{Name: DeleteDesireControllerName},
 		),
 		cfg:      cfg,
 		cooldown: cooldownChecker,
@@ -163,8 +168,8 @@ func (c *DeleteDesireController) Run(ctx context.Context, threadiness int) {
 	ctx = utils.ContextWithControllerName(ctx, c.name)
 	logger := utils.LoggerFromContext(ctx).WithValues(utils.LogValues{}.AddControllerName(c.name)...)
 	ctx = utils.ContextWithLogger(ctx, logger)
-	logger.Info("starting DeleteDesireController")
-	defer logger.Info("stopped DeleteDesireController")
+	logger.Info("starting controller")
+	defer logger.Info("stopped controller")
 
 	for i := 0; i < threadiness; i++ {
 		go wait.UntilWithContext(ctx, c.runWorker, time.Second)
@@ -229,6 +234,12 @@ func (c *DeleteDesireController) processNext(ctx context.Context) bool {
 		return false
 	}
 	defer c.queue.Done(key)
+
+	// Seed the per-reconcile logger with the key's identifying fields so every
+	// log line from SyncOnce carries subscription_id / resource_group /
+	// resource_id, matching the backend generic worker loop's behavior.
+	logger := utils.AddLoggerValues(utils.LoggerFromContext(ctx), key)
+	ctx = utils.ContextWithLogger(ctx, logger)
 
 	if err := c.SyncOnce(ctx, key); err != nil {
 		utilruntime.HandleErrorWithContext(ctx, err, "sync error; requeuing", "key", key)

--- a/kube-applier/pkg/controllers/keys/keys.go
+++ b/kube-applier/pkg/controllers/keys/keys.go
@@ -22,11 +22,14 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/go-logr/logr"
+
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/kubeapplier"
 	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/utils"
 )
 
 // ApplyDesireKey identifies a single ApplyDesire by the parts of its resource ID
@@ -50,6 +53,28 @@ func (k ApplyDesireKey) CRUD(client database.KubeApplierApplyDesireCRUD) (databa
 	return client.ApplyDesiresForCluster(k.SubscriptionID, k.ResourceGroupName, k.ClusterName)
 }
 
+// GetResourceID returns the desire's full resource ID. It uses the
+// cluster-scoped or node-pool-scoped builder depending on the key's shape.
+func (k ApplyDesireKey) GetResourceID() *azcorearm.ResourceID {
+	var s string
+	if k.IsNodePoolScoped() {
+		s = kubeapplier.ToNodePoolScopedApplyDesireResourceIDString(
+			k.SubscriptionID, k.ResourceGroupName, k.ClusterName, k.NodePoolName, k.Name)
+	} else {
+		s = kubeapplier.ToClusterScopedApplyDesireResourceIDString(
+			k.SubscriptionID, k.ResourceGroupName, k.ClusterName, k.Name)
+	}
+	return api.Must(azcorearm.ParseResourceID(s))
+}
+
+// AddLoggerValues implements utils.LoggableKey so the generic worker loop seeds
+// per-reconcile logger fields straight from the resource ID — same key set the
+// backend uses (subscription_id, resource_group, resource_name, resource_id,
+// hcp_cluster_name).
+func (k ApplyDesireKey) AddLoggerValues(logger logr.Logger) logr.Logger {
+	return logger.WithValues(utils.LogValues{}.AddLogValuesForResourceID(k.GetResourceID())...)
+}
+
 // DeleteDesireKey identifies a single DeleteDesire.
 type DeleteDesireKey struct {
 	SubscriptionID    string
@@ -70,6 +95,26 @@ func (k DeleteDesireKey) CRUD(client database.KubeApplierDeleteDesireCRUD) (data
 	return client.DeleteDesiresForCluster(k.SubscriptionID, k.ResourceGroupName, k.ClusterName)
 }
 
+// GetResourceID returns the desire's full resource ID. It uses the
+// cluster-scoped or node-pool-scoped builder depending on the key's shape.
+func (k DeleteDesireKey) GetResourceID() *azcorearm.ResourceID {
+	var s string
+	if k.IsNodePoolScoped() {
+		s = kubeapplier.ToNodePoolScopedDeleteDesireResourceIDString(
+			k.SubscriptionID, k.ResourceGroupName, k.ClusterName, k.NodePoolName, k.Name)
+	} else {
+		s = kubeapplier.ToClusterScopedDeleteDesireResourceIDString(
+			k.SubscriptionID, k.ResourceGroupName, k.ClusterName, k.Name)
+	}
+	return api.Must(azcorearm.ParseResourceID(s))
+}
+
+// AddLoggerValues implements utils.LoggableKey so the generic worker loop seeds
+// per-reconcile logger fields straight from the resource ID.
+func (k DeleteDesireKey) AddLoggerValues(logger logr.Logger) logr.Logger {
+	return logger.WithValues(utils.LogValues{}.AddLogValuesForResourceID(k.GetResourceID())...)
+}
+
 // ReadDesireKey identifies a single ReadDesire.
 type ReadDesireKey struct {
 	SubscriptionID    string
@@ -88,6 +133,26 @@ func (k ReadDesireKey) CRUD(client database.KubeApplierReadDesireCRUD) (database
 		return client.ReadDesiresForNodePool(k.SubscriptionID, k.ResourceGroupName, k.ClusterName, k.NodePoolName)
 	}
 	return client.ReadDesiresForCluster(k.SubscriptionID, k.ResourceGroupName, k.ClusterName)
+}
+
+// GetResourceID returns the desire's full resource ID. It uses the
+// cluster-scoped or node-pool-scoped builder depending on the key's shape.
+func (k ReadDesireKey) GetResourceID() *azcorearm.ResourceID {
+	var s string
+	if k.IsNodePoolScoped() {
+		s = kubeapplier.ToNodePoolScopedReadDesireResourceIDString(
+			k.SubscriptionID, k.ResourceGroupName, k.ClusterName, k.NodePoolName, k.Name)
+	} else {
+		s = kubeapplier.ToClusterScopedReadDesireResourceIDString(
+			k.SubscriptionID, k.ResourceGroupName, k.ClusterName, k.Name)
+	}
+	return api.Must(azcorearm.ParseResourceID(s))
+}
+
+// AddLoggerValues implements utils.LoggableKey so the generic worker loop seeds
+// per-reconcile logger fields straight from the resource ID.
+func (k ReadDesireKey) AddLoggerValues(logger logr.Logger) logr.Logger {
+	return logger.WithValues(utils.LogValues{}.AddLogValuesForResourceID(k.GetResourceID())...)
 }
 
 // FromResourceID parses an ApplyDesireKey out of a *Desire's resource ID. The

--- a/kube-applier/pkg/controllers/read_desire_kubernetes/controller.go
+++ b/kube-applier/pkg/controllers/read_desire_kubernetes/controller.go
@@ -51,6 +51,12 @@ import (
 // into status. Aligns with the readme's "every 60 seconds" requirement.
 const ResyncDuration = 60 * time.Second
 
+// ReadDesireKubernetesControllerName is the per-controller identifier emitted
+// in the "controller_name" log key. Each per-instance controller shares this
+// name; the per-instance fields (subscription_id, resource_id, ...) are
+// supplied by the key via utils.AddLoggerValues.
+const ReadDesireKubernetesControllerName = "ReadDesireKubernetesController"
+
 // listWatchWithoutWatchListSemantics opts out of the WatchList streaming mode
 // enabled by default in client-go v0.35+. Mirrors the unexported wrapper in
 // client-go/tools/cache/listwatch.go. The dynamic client's Watch (whether
@@ -117,7 +123,7 @@ func NewReadDesireKubernetesController(
 			workqueue.TypedRateLimitingQueueConfig[keys.ReadDesireKey]{
 				// Underscores rather than slashes: this name surfaces as a
 				// Prometheus label and slashes complicate downstream tooling.
-				Name: fmt.Sprintf("ReadDesireKubernetesController_%s_%s_%s", key.ClusterName, key.NodePoolName, key.Name),
+				Name: fmt.Sprintf("%s_%s_%s_%s", ReadDesireKubernetesControllerName, key.ClusterName, key.NodePoolName, key.Name),
 			},
 		),
 		writer: desirestatuswriter.New[kubeapplier.ReadDesire, keys.ReadDesireKey, *kubeapplier.ReadDesire](
@@ -155,10 +161,16 @@ func (c *ReadDesireKubernetesController) Run(ctx context.Context) {
 	defer utilruntime.HandleCrash()
 	defer c.queue.ShutDown()
 
-	logger := utils.LoggerFromContext(ctx).WithValues("readDesire", c.key.Name, "cluster", c.key.ClusterName)
+	// Seed the per-controller logger with controller_name and the desire's
+	// identifying fields (subscription_id, resource_group, resource_id, ...).
+	// Since this controller is per-instance, the key fields are constant for
+	// its entire lifetime and belong on the Run-level logger.
+	ctx = utils.ContextWithControllerName(ctx, ReadDesireKubernetesControllerName)
+	logger := utils.LoggerFromContext(ctx).WithValues(utils.LogValues{}.AddControllerName(ReadDesireKubernetesControllerName)...)
+	logger = utils.AddLoggerValues(logger, c.key)
 	ctx = utils.ContextWithLogger(ctx, logger)
-	logger.Info("starting ReadDesireKubernetesController")
-	defer logger.Info("stopped ReadDesireKubernetesController")
+	logger.Info("starting controller")
+	defer logger.Info("stopped controller")
 
 	go c.informer.RunWithContext(ctx)
 
@@ -210,6 +222,16 @@ func (c *ReadDesireKubernetesController) processNext(ctx context.Context) bool {
 		return false
 	}
 	defer c.queue.Done(key)
+
+	// Seed the per-reconcile logger with the key's identifying fields so every
+	// log line from SyncOnce carries subscription_id / resource_group /
+	// resource_id, matching the backend generic worker loop's behavior and
+	// the convention shared with apply_desire / delete_desire / read_desire_manager.
+	// All keys here are identical (this controller is per-instance), but doing
+	// the seeding in processNext keeps the pattern uniform across kube-applier.
+	logger := utils.AddLoggerValues(utils.LoggerFromContext(ctx), key)
+	ctx = utils.ContextWithLogger(ctx, logger)
+
 	if err := c.SyncOnce(ctx); err != nil {
 		utilruntime.HandleErrorWithContext(ctx, err, "sync error; requeuing", "key", key)
 		c.queue.AddRateLimited(key)

--- a/kube-applier/pkg/controllers/read_desire_manager/controller.go
+++ b/kube-applier/pkg/controllers/read_desire_manager/controller.go
@@ -55,6 +55,11 @@ import (
 // (re)launched or stopped promptly.
 const DefaultCooldownPeriod = 10 * time.Minute
 
+// ReadDesireInformerManagingControllerName is the per-controller identifier
+// emitted in the "controller_name" log key and used as the workqueue name.
+// Mirrors the backend convention.
+const ReadDesireInformerManagingControllerName = "ReadDesireInformerManagingController"
+
 // Config tunes the manager's cooldown behavior. Zero-valued fields take the
 // Default* constants; tests pass shorter durations and a fake clock.
 type Config struct {
@@ -102,6 +107,7 @@ type PerInstanceFactory interface {
 //     promptly when a ReadDesire is removed from Cosmos.
 //   - On error the workqueue's rate limiter requeues the key with backoff.
 type ReadDesireInformerManagingController struct {
+	name               string
 	readDesireInformer cache.SharedIndexInformer
 	fetcher            *readDesireFetcher
 	factory            PerInstanceFactory
@@ -149,12 +155,13 @@ func NewReadDesireInformerManagingController(
 	cooldownChecker := controllerutil.NewTimeBasedCooldownChecker(cfg.CooldownPeriod)
 	cooldownChecker.SetClock(cfg.Clock)
 	c := &ReadDesireInformerManagingController{
+		name:               ReadDesireInformerManagingControllerName,
 		readDesireInformer: readDesireInformer,
 		fetcher:            fetcher,
 		factory:            &realPerInstanceFactory{dyn: dyn, crudByParent: crudByParent},
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[keys.ReadDesireKey](),
-			workqueue.TypedRateLimitingQueueConfig[keys.ReadDesireKey]{Name: "ReadDesireInformerManagingController"},
+			workqueue.TypedRateLimitingQueueConfig[keys.ReadDesireKey]{Name: ReadDesireInformerManagingControllerName},
 		),
 		writer: desirestatuswriter.New[kubeapplier.ReadDesire, keys.ReadDesireKey, *kubeapplier.ReadDesire](
 			fetcher,
@@ -202,10 +209,11 @@ func (c *ReadDesireInformerManagingController) Run(ctx context.Context, threadin
 	defer c.queue.ShutDown()
 	defer c.stopAll()
 
-	logger := utils.LoggerFromContext(ctx).WithValues(utils.LogValues{}.AddControllerName("ReadDesireInformerManagingController")...)
+	ctx = utils.ContextWithControllerName(ctx, c.name)
+	logger := utils.LoggerFromContext(ctx).WithValues(utils.LogValues{}.AddControllerName(c.name)...)
 	ctx = utils.ContextWithLogger(ctx, logger)
-	logger.Info("starting ReadDesireInformerManagingController")
-	defer logger.Info("stopped ReadDesireInformerManagingController")
+	logger.Info("starting controller")
+	defer logger.Info("stopped controller")
 
 	if threadiness < 1 {
 		threadiness = 1
@@ -290,6 +298,13 @@ func (c *ReadDesireInformerManagingController) processNext(ctx context.Context) 
 		return false
 	}
 	defer c.queue.Done(key)
+
+	// Seed the per-reconcile logger with the key's identifying fields so every
+	// log line from SyncOnce carries subscription_id / resource_group /
+	// resource_id, matching the backend generic worker loop's behavior.
+	logger := utils.AddLoggerValues(utils.LoggerFromContext(ctx), key)
+	ctx = utils.ContextWithLogger(ctx, logger)
+
 	if err := c.SyncOnce(ctx, key); err != nil {
 		utilruntime.HandleErrorWithContext(ctx, err, "sync error; requeuing", "key", key)
 		c.queue.AddRateLimited(key)


### PR DESCRIPTION
Move LoggableKey + AddLoggerValues helper from
backend/pkg/controllers/controllerutils to internal/utils/context.go so both backend and kube-applier can share one contract. Give every kube-applier workqueue key a GetResourceID + AddLoggerValues method, add XxxControllerName constants for each kube-applier controller, and seed per-key loggers in every worker loop so each reconcile carries uniform structured-log fields (subscription_id, resource_group, resource_id, hcp_cluster_name) — matching what the backend's genericWatchingController already produces. Encode the rule in CLAUDE.md so future controllers inherit the pattern.
