### PR TITLE
fix: pin hypershift operator to avoid registry override regression (AROSLSRE-1318)

### DIFF
--- a/tooling/image-updater/config.yaml
+++ b/tooling/image-updater/config.yaml
@@ -23,7 +23,7 @@ images:
     group: hypershift-stack
     source:
       image: quay.io/redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
-      tag: "latest"
+      tag: "a101e6697af02eba43e6cfd04fc4c00277b72a64" # pinned: latest includes openshift/hypershift#8509 which breaks registry overrides for digest images (OCPBUGS-92034, unpin: AROSLSRE-1318)
       multiArch: true # Use multi-arch manifest
       useAuth: true
       keyVault:


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-1318

### What

Pins the HyperShift operator image tag in `tooling/image-updater/config.yaml` from `latest` to `a101e6697af02eba43e6cfd04fc4c00277b72a64` (the current known-good build from 2026-06-05) to prevent the automated bumper from picking up the broken image.

No `config/config.yaml` change needed — the current digest on main (`sha256:e30b97d...` from Jun 19) is pre-regression and safe.

### Why

The latest HyperShift operator image includes a regression in `registryoverride.Replace` ([openshift/hypershift#8509](https://github.com/openshift/hypershift/pull/8509), merged 2026-06-22). The bug causes repository-level `--registry-overrides` to fail for digest-based images (`@sha256:...`), because the code only accepts `/` as a valid separator after the source prefix.

This breaks all CAPI and component image rewrites in ARO-HCP environments where `quay.io/openshift-release-dev/ocp-v4.0-art-dev` is overridden to the mirrored ACR. The CPO tries to pull from `quay.io` directly and gets `unauthorized`, blocking cluster creation. The automated bumper PR [#5740](https://github.com/Azure/ARO-HCP/pull/5740) has been failing e2e consistently with:

```
critical error: failed to get controlPlaneOperatorImageLabels: failed to look up image metadata for
quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:...: unauthorized
```

**Upstream bug**: [OCPBUGS-92034](https://redhat.atlassian.net/browse/OCPBUGS-92034)
**Upstream fix**: [openshift/hypershift#8824](https://github.com/openshift/hypershift/pull/8824) — approved, CI green, waiting on `/lgtm`

### Unpin

Revert `tag` back to `"latest"` in `tooling/image-updater/config.yaml` once [openshift/hypershift#8824](https://github.com/openshift/hypershift/pull/8824) merges and a new image is published. Tracked in [AROSLSRE-1318](https://redhat.atlassian.net/browse/AROSLSRE-1318).

### Testing

- `make yamlfmt` — passes (no formatting changes)
- Only file changed: `tooling/image-updater/config.yaml` (tag pin, no config.yaml or rendered config changes)

### Previous precedent

Same pattern as [#5371](https://github.com/Azure/ARO-HCP/pull/5371) ([AROSLSRE-919](https://redhat.atlassian.net/browse/AROSLSRE-919)) → unpinned in [#5401](https://github.com/Azure/ARO-HCP/pull/5401) ([AROSLSRE-921](https://redhat.atlassian.net/browse/AROSLSRE-921)).