### PR TITLE
ARO-26192: Add Access the Cluster SLO alert rules and tests

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
@@ -1071,14 +1071,14 @@ resource maestro 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
         }
         annotations: {
           correlationId: 'MaestroServerNoReadyReplicas/{{ $labels.cluster }}'
-          description: 'No maestro-server replicas have been Ready for 5 minutes. Readiness is gated on Postgres connectivity, so maestro is likely unable to reach its database; Clusters Service will get 503 and HCP cluster provisioning will stall.'
-          info: 'No maestro-server replicas have been Ready for 5 minutes. Readiness is gated on Postgres connectivity, so maestro is likely unable to reach its database; Clusters Service will get 503 and HCP cluster provisioning will stall.'
+          description: 'No maestro-server replicas have been Ready for 10 minutes. Readiness is gated on Postgres connectivity, so maestro is likely unable to reach its database; Clusters Service will get 503 and HCP cluster provisioning will stall.'
+          info: 'No maestro-server replicas have been Ready for 10 minutes. Readiness is gated on Postgres connectivity, so maestro is likely unable to reach its database; Clusters Service will get 503 and HCP cluster provisioning will stall.'
           runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/maestro/index.html'
           summary: 'No maestro-server replicas are Ready'
           title: 'No maestro-server replicas are Ready'
         }
         expression: 'kube_deployment_status_replicas_available{deployment="maestro",namespace="maestro"} == 0 and kube_deployment_spec_replicas{deployment="maestro",namespace="maestro"} > 0'
-        for: 'PT5M'
+        for: 'PT10M'
         severity: severityCeiling > 0 ? max(2, severityCeiling) : 2
       }
       {

--- a/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
@@ -45,7 +45,7 @@ Check the status of the Prometheus pods, service endpoints, and network connecti
           summary: 'Prometheus is unreachable for 10 minutes.'
           title: 'Prometheus is unreachable for 10 minutes.'
         }
-        expression: 'group by (cluster) (up{job="kubelet"}) unless on(cluster) group by (cluster) (up{job="prometheus/prometheus",namespace="prometheus"} == 1)'
+        expression: 'group by (cluster) (up{job="kubelet"}) unless on (cluster) group by (cluster) (up{job="prometheus/prometheus",namespace="prometheus"} == 1)'
         for: 'PT10M'
         severity: severityCeiling > 0 ? max(2, severityCeiling) : 2
       }
@@ -115,7 +115,7 @@ Investigate the health and performance of the remote storage endpoint, network l
           summary: 'Prometheus pending sample rate is above 40%.'
           title: 'Prometheus pending sample rate is above 40%.'
         }
-        expression: '( prometheus_remote_storage_samples_pending / prometheus_remote_storage_samples_in_flight ) > 0.4'
+        expression: '(prometheus_remote_storage_samples_pending / prometheus_remote_storage_samples_in_flight) > 0.4'
         for: 'PT15M'
         severity: severityCeiling > 0 ? max(2, severityCeiling) : 2
       }
@@ -152,7 +152,7 @@ Please check the health and performance of the remote storage endpoint, network 
           summary: 'Prometheus failed sample rate to remote storage is above 10%.'
           title: 'Prometheus failed sample rate to remote storage is above 10%.'
         }
-        expression: '( rate(prometheus_remote_storage_samples_failed_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) / clamp_min( rate(prometheus_remote_storage_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]), 1e-9 ) ) > 0.1'
+        expression: '(rate(prometheus_remote_storage_samples_failed_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) / clamp_min(rate(prometheus_remote_storage_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]), 0.000000001)) > 0.1'
         for: 'PT15M'
         severity: severityCeiling > 0 ? max(2, severityCeiling) : 2
       }
@@ -380,7 +380,7 @@ resource frontend 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' =
           summary: 'High 4xx|5xx Error Rate on Frontend Cluster Service'
           title: 'High 4xx|5xx Error Rate on Frontend Cluster Service'
         }
-        expression: '(sum by (cluster) (max without(prometheus_replica) (rate(frontend_clusters_service_client_request_count{code=~"4..|5.."}[1h])))) / (sum by (cluster) (max without(prometheus_replica) (rate(frontend_clusters_service_client_request_count[1h])))) > 0.05'
+        expression: '(sum by (cluster) (max without (prometheus_replica) (rate(frontend_clusters_service_client_request_count{code=~"4..|5.."}[1h])))) / (sum by (cluster) (max without (prometheus_replica) (rate(frontend_clusters_service_client_request_count[1h])))) > 0.05'
         for: 'PT15M'
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
@@ -407,7 +407,7 @@ resource frontend 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' =
           summary: 'High Frontend audit log error rate.'
           title: 'High Frontend audit log error rate.'
         }
-        expression: '( sum by (cluster) (rate(otel_audit_log_send_errors_total{job="aro-hcp-frontend-metrics"}[1h])) / sum by (cluster) (rate(otel_audit_log_records_total{job="aro-hcp-frontend-metrics"}[1h])) ) > 0.05'
+        expression: '(sum by (cluster) (rate(otel_audit_log_send_errors_total{job="aro-hcp-frontend-metrics"}[1h])) / sum by (cluster) (rate(otel_audit_log_records_total{job="aro-hcp-frontend-metrics"}[1h]))) > 0.05'
         for: 'PT15M'
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
@@ -461,7 +461,7 @@ resource frontend 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' =
           summary: 'Frontend is panicking during HTTP request handling'
           title: 'Frontend is panicking during HTTP request handling'
         }
-        expression: 'sum by (cluster) ( increase(frontend_http_request_panics_total[5m]) ) > 0'
+        expression: 'sum by (cluster) (increase(frontend_http_request_panics_total[5m])) > 0'
         for: 'PT1M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
@@ -503,7 +503,7 @@ resource arohcpCsSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometheusRul
           summary: 'Cluster Service API availability error budget burn rate is too high'
           title: 'Cluster Service API availability error budget burn rate is too high'
         }
-        expression: '( sum by(cluster, namespace, service) (max without(prometheus_replica) (availability:api_inbound_request_count:burnrate5m{namespace="clusters-service", service="clusters-service-metrics"})) > (13.44 * (1 - 0.99)) and sum by(cluster, namespace, service) (max without(prometheus_replica) (availability:api_inbound_request_count:burnrate1h{namespace="clusters-service", service="clusters-service-metrics"})) > (13.44 * (1 - 0.99)) ) or ( sum by(cluster, namespace, service) (max without(prometheus_replica) (availability:api_inbound_request_count:burnrate30m{namespace="clusters-service", service="clusters-service-metrics"})) > (5.6 * (1 - 0.99)) and sum by(cluster, namespace, service) (max without(prometheus_replica) (availability:api_inbound_request_count:burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > (5.6 * (1 - 0.99)) )'
+        expression: '(sum by (cluster, namespace, service) (max without (prometheus_replica) (availability:api_inbound_request_count:burnrate5m{namespace="clusters-service",service="clusters-service-metrics"})) > (13.44 * (1 - 0.99)) and sum by (cluster, namespace, service) (max without (prometheus_replica) (availability:api_inbound_request_count:burnrate1h{namespace="clusters-service",service="clusters-service-metrics"})) > (13.44 * (1 - 0.99))) or (sum by (cluster, namespace, service) (max without (prometheus_replica) (availability:api_inbound_request_count:burnrate30m{namespace="clusters-service",service="clusters-service-metrics"})) > (5.6 * (1 - 0.99)) and sum by (cluster, namespace, service) (max without (prometheus_replica) (availability:api_inbound_request_count:burnrate6h{namespace="clusters-service",service="clusters-service-metrics"})) > (5.6 * (1 - 0.99)))'
         for: 'PT5M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
@@ -531,7 +531,7 @@ resource arohcpCsSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometheusRul
           summary: 'API is slowly but steadily burning its 28 day availability error budget (99% SLO)'
           title: 'API is slowly but steadily burning its 28 day availability error budget (99% SLO)'
         }
-        expression: 'sum by(cluster, namespace, service) (max without(prometheus_replica) (availability:api_inbound_request_count:burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > (0.934 * (1 - 0.99)) and sum by(cluster, namespace, service) (max without(prometheus_replica) (availability:api_inbound_request_count:burnrate3d{namespace="clusters-service", service="clusters-service-metrics"})) > (0.934 * (1 - 0.99))'
+        expression: 'sum by (cluster, namespace, service) (max without (prometheus_replica) (availability:api_inbound_request_count:burnrate6h{namespace="clusters-service",service="clusters-service-metrics"})) > (0.934 * (1 - 0.99)) and sum by (cluster, namespace, service) (max without (prometheus_replica) (availability:api_inbound_request_count:burnrate3d{namespace="clusters-service",service="clusters-service-metrics"})) > (0.934 * (1 - 0.99))'
         for: 'PT30M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
@@ -561,7 +561,7 @@ resource arohcpCsSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometheusRul
           summary: 'Cluster Service API P99 latency error budget burn rate is too high'
           title: 'Cluster Service API P99 latency error budget burn rate is too high'
         }
-        expression: '( sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate5m{namespace="clusters-service", service="clusters-service-metrics"})) > (13.44 * (1 - 0.99)) and sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate1h{namespace="clusters-service", service="clusters-service-metrics"})) > (13.44 * (1 - 0.99)) ) or ( sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate30m{namespace="clusters-service", service="clusters-service-metrics"})) > (5.6 * (1 - 0.99)) and sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > (5.6 * (1 - 0.99)) )'
+        expression: '(sum by (cluster, namespace, service) (max without (prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate5m{namespace="clusters-service",service="clusters-service-metrics"})) > (13.44 * (1 - 0.99)) and sum by (cluster, namespace, service) (max without (prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate1h{namespace="clusters-service",service="clusters-service-metrics"})) > (13.44 * (1 - 0.99))) or (sum by (cluster, namespace, service) (max without (prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate30m{namespace="clusters-service",service="clusters-service-metrics"})) > (5.6 * (1 - 0.99)) and sum by (cluster, namespace, service) (max without (prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate6h{namespace="clusters-service",service="clusters-service-metrics"})) > (5.6 * (1 - 0.99)))'
         for: 'PT5M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
@@ -589,7 +589,7 @@ resource arohcpCsSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometheusRul
           summary: 'API is slowly but steadily burning its 28 day 1s latency error budget (99% SLO)'
           title: 'API is slowly but steadily burning its 28 day 1s latency error budget (99% SLO)'
         }
-        expression: 'sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > (0.934 * (1 - 0.99)) and sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate3d{namespace="clusters-service", service="clusters-service-metrics"})) > (0.934 * (1 - 0.99))'
+        expression: 'sum by (cluster, namespace, service) (max without (prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate6h{namespace="clusters-service",service="clusters-service-metrics"})) > (0.934 * (1 - 0.99)) and sum by (cluster, namespace, service) (max without (prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate3d{namespace="clusters-service",service="clusters-service-metrics"})) > (0.934 * (1 - 0.99))'
         for: 'PT30M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
@@ -619,7 +619,7 @@ resource arohcpCsSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometheusRul
           summary: 'Cluster Service API P90 latency error budget burn rate is too high'
           title: 'Cluster Service API P90 latency error budget burn rate is too high'
         }
-        expression: '( sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate5m{namespace="clusters-service", service="clusters-service-metrics"})) > (13.44 * (1 - 0.90)) and sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate1h{namespace="clusters-service", service="clusters-service-metrics"})) > (13.44 * (1 - 0.90)) ) or ( sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate30m{namespace="clusters-service", service="clusters-service-metrics"})) > (5.6 * (1 - 0.90)) and sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > (5.6 * (1 - 0.90)) )'
+        expression: '(sum by (cluster, namespace, service) (max without (prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate5m{namespace="clusters-service",service="clusters-service-metrics"})) > (13.44 * (1 - 0.9)) and sum by (cluster, namespace, service) (max without (prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate1h{namespace="clusters-service",service="clusters-service-metrics"})) > (13.44 * (1 - 0.9))) or (sum by (cluster, namespace, service) (max without (prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate30m{namespace="clusters-service",service="clusters-service-metrics"})) > (5.6 * (1 - 0.9)) and sum by (cluster, namespace, service) (max without (prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate6h{namespace="clusters-service",service="clusters-service-metrics"})) > (5.6 * (1 - 0.9)))'
         for: 'PT5M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
@@ -647,7 +647,7 @@ resource arohcpCsSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometheusRul
           summary: 'API is slowly but steadily burning its 28 day 0.1s latency error budget (90% SLO)'
           title: 'API is slowly but steadily burning its 28 day 0.1s latency error budget (90% SLO)'
         }
-        expression: 'sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > (0.934 * (1 - 0.90)) and sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate3d{namespace="clusters-service", service="clusters-service-metrics"})) > (0.934 * (1 - 0.90))'
+        expression: 'sum by (cluster, namespace, service) (max without (prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate6h{namespace="clusters-service",service="clusters-service-metrics"})) > (0.934 * (1 - 0.9)) and sum by (cluster, namespace, service) (max without (prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate3d{namespace="clusters-service",service="clusters-service-metrics"})) > (0.934 * (1 - 0.9))'
         for: 'PT30M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
@@ -687,7 +687,7 @@ resource backend 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
           summary: 'Backend controller workqueue depth is high'
           title: 'Backend controller workqueue depth is high'
         }
-        expression: 'max by (name, cluster) ( max without(prometheus_replica) ( workqueue_depth{namespace="aro-hcp"} ) ) > 10'
+        expression: 'max by (name, cluster) (max without (prometheus_replica) (workqueue_depth{namespace="aro-hcp"})) > 10'
         for: 'PT15M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
@@ -714,7 +714,7 @@ resource backend 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
           summary: 'Backend controller is panicking'
           title: 'Backend controller is panicking'
         }
-        expression: 'sum by (controller, cluster) ( increase(panic_total{namespace="aro-hcp"}[5m]) ) > 0'
+        expression: 'sum by (controller, cluster) (increase(panic_total{namespace="aro-hcp"}[5m])) > 0'
         for: 'PT1M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
@@ -741,7 +741,7 @@ resource backend 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
           summary: 'Orphaned cluster managed resource groups detected'
           title: 'Orphaned cluster managed resource groups detected'
         }
-        expression: 'sum by (location, cluster) ( max without(prometheus_replica) ( increase(aro_hcp_orphaned_managed_resource_groups_found_total[10m]) ) ) > 0'
+        expression: 'sum by (location, cluster) (max without (prometheus_replica) (increase(aro_hcp_orphaned_managed_resource_groups_found_total[10m]))) > 0'
         for: 'PT5M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
@@ -768,7 +768,7 @@ resource backend 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
           summary: 'Orphaned cluster managed resource group deletion is failing'
           title: 'Orphaned cluster managed resource group deletion is failing'
         }
-        expression: 'sum by (location, cluster) ( max without(prometheus_replica) ( increase(aro_hcp_orphaned_managed_resource_groups_deletion_failed_total[10m]) ) ) > 0'
+        expression: 'sum by (location, cluster) (max without (prometheus_replica) (increase(aro_hcp_orphaned_managed_resource_groups_deletion_failed_total[10m]))) > 0'
         for: 'PT10M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
@@ -808,7 +808,7 @@ resource fleet 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
           summary: 'Fleet controller workqueue retry hot loop'
           title: 'Fleet controller workqueue retry hot loop'
         }
-        expression: '( sum by (name, cluster) ( max without(prometheus_replica) ( rate(workqueue_retries_total{namespace="fleet"}[10m]) ) ) / sum by (name, cluster) ( max without(prometheus_replica) ( rate(workqueue_adds_total{namespace="fleet"}[10m]) ) ) ) > 0.5'
+        expression: '(sum by (name, cluster) (max without (prometheus_replica) (rate(workqueue_retries_total{namespace="fleet"}[10m]))) / sum by (name, cluster) (max without (prometheus_replica) (rate(workqueue_adds_total{namespace="fleet"}[10m])))) > 0.5'
         for: 'PT10M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
@@ -835,7 +835,7 @@ resource fleet 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
           summary: 'Fleet controller workqueue depth is high'
           title: 'Fleet controller workqueue depth is high'
         }
-        expression: 'max by (name, cluster) ( max without(prometheus_replica) ( workqueue_depth{namespace="fleet"} ) ) > 10'
+        expression: 'max by (name, cluster) (max without (prometheus_replica) (workqueue_depth{namespace="fleet"})) > 10'
         for: 'PT5M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
@@ -862,7 +862,7 @@ resource fleet 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
           summary: 'Fleet controller is panicking'
           title: 'Fleet controller is panicking'
         }
-        expression: 'sum by (controller, cluster) ( increase(panic_total{namespace="fleet"}[5m]) ) > 0'
+        expression: 'sum by (controller, cluster) (increase(panic_total{namespace="fleet"}[5m])) > 0'
         for: 'PT1M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
@@ -902,7 +902,7 @@ resource adminApi 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' =
           summary: 'High Admin API audit log error rate.'
           title: 'High Admin API audit log error rate.'
         }
-        expression: '( sum by (cluster) (rate(otel_audit_log_send_errors_total{job="aro-hcp-admin-api-metrics"}[1h])) / sum by (cluster) (rate(otel_audit_log_records_total{job="aro-hcp-admin-api-metrics"}[1h])) ) > 0.05'
+        expression: '(sum by (cluster) (rate(otel_audit_log_send_errors_total{job="aro-hcp-admin-api-metrics"}[1h])) / sum by (cluster) (rate(otel_audit_log_records_total{job="aro-hcp-admin-api-metrics"}[1h]))) > 0.05'
         for: 'PT5M'
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
@@ -996,7 +996,7 @@ resource maestro 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
           summary: 'Maestro REST API error rate is high'
           title: 'Maestro REST API error rate is high'
         }
-        expression: 'sum(rate(rest_api_inbound_request_count{namespace="maestro", code=~"5.."}[5m])) / sum(rate(rest_api_inbound_request_count{namespace="maestro"}[5m])) > 0.05'
+        expression: 'sum(rate(rest_api_inbound_request_count{code=~"5..",namespace="maestro"}[5m])) / sum(rate(rest_api_inbound_request_count{namespace="maestro"}[5m])) > 0.05'
         for: 'PT5M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
@@ -1023,7 +1023,7 @@ resource maestro 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
           summary: 'Maestro gRPC server error rate is high'
           title: 'Maestro gRPC server error rate is high'
         }
-        expression: 'sum(rate(grpc_server_processed_total{namespace="maestro", code!="OK"}[5m])) / sum(rate(grpc_server_processed_total{namespace="maestro"}[5m])) > 0.05'
+        expression: 'sum(rate(grpc_server_processed_total{code!="OK",namespace="maestro"}[5m])) / sum(rate(grpc_server_processed_total{namespace="maestro"}[5m])) > 0.05'
         for: 'PT5M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
@@ -1050,8 +1050,62 @@ resource maestro 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
           summary: 'Maestro spec controller reconcile error rate is high'
           title: 'Maestro spec controller reconcile error rate is high'
         }
-        expression: 'sum(rate(spec_controller_event_reconcile_total{namespace="maestro", status="error"}[5m])) / sum(rate(spec_controller_event_reconcile_total{namespace="maestro"}[5m])) > 0.1'
+        expression: 'sum(rate(spec_controller_event_reconcile_total{namespace="maestro",status="error"}[5m])) / sum(rate(spec_controller_event_reconcile_total{namespace="maestro"}[5m])) > 0.1'
         for: 'PT10M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'MaestroServerNoReadyReplicas'
+        enabled: true
+        labels: {
+          severity: 'critical'
+        }
+        annotations: {
+          correlationId: 'MaestroServerNoReadyReplicas/{{ $labels.cluster }}'
+          description: 'No maestro-server replicas have been Ready for 5 minutes. Readiness is gated on Postgres connectivity, so maestro is likely unable to reach its database; Clusters Service will get 503 and HCP cluster provisioning will stall.'
+          info: 'No maestro-server replicas have been Ready for 5 minutes. Readiness is gated on Postgres connectivity, so maestro is likely unable to reach its database; Clusters Service will get 503 and HCP cluster provisioning will stall.'
+          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/maestro/index.html'
+          summary: 'No maestro-server replicas are Ready'
+          title: 'No maestro-server replicas are Ready'
+        }
+        expression: 'kube_deployment_status_replicas_available{deployment="maestro",namespace="maestro"} == 0 and kube_deployment_spec_replicas{deployment="maestro",namespace="maestro"} > 0'
+        for: 'PT5M'
+        severity: severityCeiling > 0 ? max(2, severityCeiling) : 2
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'MaestroServerReplicaNotReady'
+        enabled: true
+        labels: {
+          severity: 'warning'
+        }
+        annotations: {
+          correlationId: 'MaestroServerReplicaNotReady/{{ $labels.cluster }}'
+          description: 'At least one maestro-server replica has been NotReady for 15 minutes (available {{ $value }} below desired). Readiness is gated on Postgres connectivity, so a persistently NotReady replica usually indicates database connectivity problems.'
+          info: 'At least one maestro-server replica has been NotReady for 15 minutes (available {{ $value }} below desired). Readiness is gated on Postgres connectivity, so a persistently NotReady replica usually indicates database connectivity problems.'
+          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/maestro/index.html'
+          summary: 'A maestro-server replica is not Ready'
+          title: 'A maestro-server replica is not Ready'
+        }
+        expression: 'kube_deployment_status_replicas_available{deployment="maestro",namespace="maestro"} > 0 and kube_deployment_status_replicas_available{deployment="maestro",namespace="maestro"} < kube_deployment_spec_replicas{deployment="maestro",namespace="maestro"}'
+        for: 'PT15M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
     ]
@@ -1092,7 +1146,7 @@ resource arobitRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01
           summary: 'Arobit forwarder metrics endpoint is unreachable on cluster {{ $labels.cluster }}.'
           title: 'Arobit forwarder metrics endpoint is unreachable on cluster {{ $labels.cluster }}.'
         }
-        expression: 'group by (cluster) (up{job="kube-state-metrics"}) unless on(cluster) group by (cluster) (up{job="arobit-forwarder",namespace="arobit"} == 1)'
+        expression: 'group by (cluster) (up{job="kube-state-metrics"}) unless on (cluster) group by (cluster) (up{job="arobit-forwarder",namespace="arobit"} == 1)'
         for: 'PT15M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
@@ -1125,7 +1179,7 @@ Investigate the Fluent Bit logs for the specific error details and check the Kus
           summary: 'Fluent Bit input ingestion paused due to backpressure.'
           title: 'Fluent Bit input ingestion paused due to backpressure.'
         }
-        expression: 'sum(fluentbit_input_ingestion_paused) by (cluster, pod) > 0'
+        expression: 'sum by (cluster, pod) (fluentbit_input_ingestion_paused) > 0'
         for: 'PT5M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
@@ -1158,7 +1212,7 @@ Investigate the Fluent Bit logs for the specific error details and check the Kus
           summary: 'High Kusto output retries'
           title: 'High Kusto output retries'
         }
-        expression: 'sum(increase(fluentbit_output_retries_total{name=~"azure_kusto.*"}[5m])) by (cluster, pod) > 3'
+        expression: 'sum by (cluster, pod) (increase(fluentbit_output_retries_total{name=~"azure_kusto.*"}[5m])) > 3'
         for: 'PT5M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
@@ -1189,7 +1243,7 @@ Investigate the Fluent Bit logs for the specific error details and check the Kus
           summary: 'Unrecoverable Kusto output errors - log data is being dropped.'
           title: 'Unrecoverable Kusto output errors - log data is being dropped.'
         }
-        expression: 'sum(increase(fluentbit_output_errors_total{name=~"azure_kusto.*"}[5m])) by (cluster, pod) > 0'
+        expression: 'sum by (cluster, pod) (increase(fluentbit_output_errors_total{name=~"azure_kusto.*"}[5m])) > 0'
         for: 'PT5M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
@@ -1220,7 +1274,7 @@ Investigate the Fluent Bit logs for the specific error details and check the Kus
           summary: 'Kusto output retries exhausted - chunks discarded after max retries.'
           title: 'Kusto output retries exhausted - chunks discarded after max retries.'
         }
-        expression: 'sum(increase(fluentbit_output_retries_failed_total{name=~"azure_kusto.*"}[5m])) by (cluster, pod) > 0'
+        expression: 'sum by (cluster, pod) (increase(fluentbit_output_retries_failed_total{name=~"azure_kusto.*"}[5m])) > 0'
         for: 'PT5M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
@@ -1378,7 +1432,7 @@ resource serviceTagCapacityRules 'Microsoft.AlertsManagement/prometheusRuleGroup
           summary: 'Service Tag IP Usage is reaching 80%'
           title: 'Service Tag IP Usage is reaching 80%'
         }
-        expression: 'public_ip_count_by_region_service_tag{service_tag_type="FirstPartyUsage",service_tag_value="/aro-hcp-prod-inbound-customerapi",region!="uswest2"} / 64 > 0.8'
+        expression: 'public_ip_count_by_region_service_tag{region!="uswest2",service_tag_type="FirstPartyUsage",service_tag_value="/aro-hcp-prod-inbound-customerapi"} / 64 > 0.8'
         for: 'PT15M'
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
@@ -1407,7 +1461,7 @@ resource serviceTagCapacityRules 'Microsoft.AlertsManagement/prometheusRuleGroup
           summary: 'Service Tag IP Usage is reaching 80%'
           title: 'Service Tag IP Usage is reaching 80%'
         }
-        expression: 'public_ip_count_by_region_service_tag{service_tag_type="FirstPartyUsage",service_tag_value="/aro-hcp-prod-inbound-customerapi",region="uswest2"} / 128 > 0.8'
+        expression: 'public_ip_count_by_region_service_tag{region="uswest2",service_tag_type="FirstPartyUsage",service_tag_value="/aro-hcp-prod-inbound-customerapi"} / 128 > 0.8'
         for: 'PT15M'
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
@@ -1607,7 +1661,7 @@ resource kubeContainerOomRules 'Microsoft.AlertsManagement/prometheusRuleGroups@
           summary: 'Container {{ $labels.container }} was OOMKilled'
           title: 'Container {{ $labels.container }} was OOMKilled'
         }
-        expression: 'kube_pod_container_status_last_terminated_reason{reason="OOMKilled", job="kube-state-metrics"} == 1'
+        expression: 'kube_pod_container_status_last_terminated_reason{job="kube-state-metrics",reason="OOMKilled"} == 1'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
     ]
@@ -1685,7 +1739,7 @@ resource imageRegistryPolicy 'Microsoft.AlertsManagement/prometheusRuleGroups@20
           summary: 'Image registry policy denied pod admission'
           title: 'Image registry policy denied pod admission'
         }
-        expression: 'sum by (cluster, policy, policy_binding) ( increase(apiserver_validating_admission_policy_check_total{ policy="image-registry-allowlist-policy", enforcement_action="deny", validation_result="denied" }[15m]) ) > 0'
+        expression: 'sum by (cluster, policy, policy_binding) (increase(apiserver_validating_admission_policy_check_total{enforcement_action="deny",policy="image-registry-allowlist-policy",validation_result="denied"}[15m])) > 0'
         for: 'PT1M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
@@ -1712,7 +1766,7 @@ resource imageRegistryPolicy 'Microsoft.AlertsManagement/prometheusRuleGroups@20
           summary: 'Image registry policy audit violation detected'
           title: 'Image registry policy audit violation detected'
         }
-        expression: 'sum by (cluster, policy, policy_binding) ( increase(apiserver_validating_admission_policy_check_total{ policy="image-registry-allowlist-policy", enforcement_action="audit", validation_result="denied" }[15m]) ) > 0'
+        expression: 'sum by (cluster, policy, policy_binding) (increase(apiserver_validating_admission_policy_check_total{enforcement_action="audit",policy="image-registry-allowlist-policy",validation_result="denied"}[15m])) > 0'
         for: 'PT5M'
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }

--- a/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
@@ -45,7 +45,7 @@ Check the status of the Prometheus pods, service endpoints, and network connecti
           summary: 'Prometheus is unreachable for 10 minutes.'
           title: 'Prometheus is unreachable for 10 minutes.'
         }
-        expression: 'group by (cluster) (up{job="kubelet"}) unless on (cluster) group by (cluster) (up{job="prometheus/prometheus",namespace="prometheus"} == 1)'
+        expression: 'group by (cluster) (up{job="kubelet"}) unless on(cluster) group by (cluster) (up{job="prometheus/prometheus",namespace="prometheus"} == 1)'
         for: 'PT10M'
         severity: severityCeiling > 0 ? max(2, severityCeiling) : 2
       }
@@ -115,7 +115,7 @@ Investigate the health and performance of the remote storage endpoint, network l
           summary: 'Prometheus pending sample rate is above 40%.'
           title: 'Prometheus pending sample rate is above 40%.'
         }
-        expression: '(prometheus_remote_storage_samples_pending / prometheus_remote_storage_samples_in_flight) > 0.4'
+        expression: '( prometheus_remote_storage_samples_pending / prometheus_remote_storage_samples_in_flight ) > 0.4'
         for: 'PT15M'
         severity: severityCeiling > 0 ? max(2, severityCeiling) : 2
       }
@@ -152,7 +152,7 @@ Please check the health and performance of the remote storage endpoint, network 
           summary: 'Prometheus failed sample rate to remote storage is above 10%.'
           title: 'Prometheus failed sample rate to remote storage is above 10%.'
         }
-        expression: '(rate(prometheus_remote_storage_samples_failed_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) / clamp_min(rate(prometheus_remote_storage_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]), 0.000000001)) > 0.1'
+        expression: '( rate(prometheus_remote_storage_samples_failed_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) / clamp_min( rate(prometheus_remote_storage_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]), 1e-9 ) ) > 0.1'
         for: 'PT15M'
         severity: severityCeiling > 0 ? max(2, severityCeiling) : 2
       }
@@ -380,7 +380,7 @@ resource frontend 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' =
           summary: 'High 4xx|5xx Error Rate on Frontend Cluster Service'
           title: 'High 4xx|5xx Error Rate on Frontend Cluster Service'
         }
-        expression: '(sum by (cluster) (max without (prometheus_replica) (rate(frontend_clusters_service_client_request_count{code=~"4..|5.."}[1h])))) / (sum by (cluster) (max without (prometheus_replica) (rate(frontend_clusters_service_client_request_count[1h])))) > 0.05'
+        expression: '(sum by (cluster) (max without(prometheus_replica) (rate(frontend_clusters_service_client_request_count{code=~"4..|5.."}[1h])))) / (sum by (cluster) (max without(prometheus_replica) (rate(frontend_clusters_service_client_request_count[1h])))) > 0.05'
         for: 'PT15M'
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
@@ -407,7 +407,7 @@ resource frontend 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' =
           summary: 'High Frontend audit log error rate.'
           title: 'High Frontend audit log error rate.'
         }
-        expression: '(sum by (cluster) (rate(otel_audit_log_send_errors_total{job="aro-hcp-frontend-metrics"}[1h])) / sum by (cluster) (rate(otel_audit_log_records_total{job="aro-hcp-frontend-metrics"}[1h]))) > 0.05'
+        expression: '( sum by (cluster) (rate(otel_audit_log_send_errors_total{job="aro-hcp-frontend-metrics"}[1h])) / sum by (cluster) (rate(otel_audit_log_records_total{job="aro-hcp-frontend-metrics"}[1h])) ) > 0.05'
         for: 'PT15M'
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
@@ -461,7 +461,7 @@ resource frontend 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' =
           summary: 'Frontend is panicking during HTTP request handling'
           title: 'Frontend is panicking during HTTP request handling'
         }
-        expression: 'sum by (cluster) (increase(frontend_http_request_panics_total[5m])) > 0'
+        expression: 'sum by (cluster) ( increase(frontend_http_request_panics_total[5m]) ) > 0'
         for: 'PT1M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
@@ -503,7 +503,7 @@ resource arohcpCsSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometheusRul
           summary: 'Cluster Service API availability error budget burn rate is too high'
           title: 'Cluster Service API availability error budget burn rate is too high'
         }
-        expression: '(sum by (cluster, namespace, service) (max without (prometheus_replica) (availability:api_inbound_request_count:burnrate5m{namespace="clusters-service",service="clusters-service-metrics"})) > (13.44 * (1 - 0.99)) and sum by (cluster, namespace, service) (max without (prometheus_replica) (availability:api_inbound_request_count:burnrate1h{namespace="clusters-service",service="clusters-service-metrics"})) > (13.44 * (1 - 0.99))) or (sum by (cluster, namespace, service) (max without (prometheus_replica) (availability:api_inbound_request_count:burnrate30m{namespace="clusters-service",service="clusters-service-metrics"})) > (5.6 * (1 - 0.99)) and sum by (cluster, namespace, service) (max without (prometheus_replica) (availability:api_inbound_request_count:burnrate6h{namespace="clusters-service",service="clusters-service-metrics"})) > (5.6 * (1 - 0.99)))'
+        expression: '( sum by(cluster, namespace, service) (max without(prometheus_replica) (availability:api_inbound_request_count:burnrate5m{namespace="clusters-service", service="clusters-service-metrics"})) > (13.44 * (1 - 0.99)) and sum by(cluster, namespace, service) (max without(prometheus_replica) (availability:api_inbound_request_count:burnrate1h{namespace="clusters-service", service="clusters-service-metrics"})) > (13.44 * (1 - 0.99)) ) or ( sum by(cluster, namespace, service) (max without(prometheus_replica) (availability:api_inbound_request_count:burnrate30m{namespace="clusters-service", service="clusters-service-metrics"})) > (5.6 * (1 - 0.99)) and sum by(cluster, namespace, service) (max without(prometheus_replica) (availability:api_inbound_request_count:burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > (5.6 * (1 - 0.99)) )'
         for: 'PT5M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
@@ -531,7 +531,7 @@ resource arohcpCsSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometheusRul
           summary: 'API is slowly but steadily burning its 28 day availability error budget (99% SLO)'
           title: 'API is slowly but steadily burning its 28 day availability error budget (99% SLO)'
         }
-        expression: 'sum by (cluster, namespace, service) (max without (prometheus_replica) (availability:api_inbound_request_count:burnrate6h{namespace="clusters-service",service="clusters-service-metrics"})) > (0.934 * (1 - 0.99)) and sum by (cluster, namespace, service) (max without (prometheus_replica) (availability:api_inbound_request_count:burnrate3d{namespace="clusters-service",service="clusters-service-metrics"})) > (0.934 * (1 - 0.99))'
+        expression: 'sum by(cluster, namespace, service) (max without(prometheus_replica) (availability:api_inbound_request_count:burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > (0.934 * (1 - 0.99)) and sum by(cluster, namespace, service) (max without(prometheus_replica) (availability:api_inbound_request_count:burnrate3d{namespace="clusters-service", service="clusters-service-metrics"})) > (0.934 * (1 - 0.99))'
         for: 'PT30M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
@@ -561,7 +561,7 @@ resource arohcpCsSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometheusRul
           summary: 'Cluster Service API P99 latency error budget burn rate is too high'
           title: 'Cluster Service API P99 latency error budget burn rate is too high'
         }
-        expression: '(sum by (cluster, namespace, service) (max without (prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate5m{namespace="clusters-service",service="clusters-service-metrics"})) > (13.44 * (1 - 0.99)) and sum by (cluster, namespace, service) (max without (prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate1h{namespace="clusters-service",service="clusters-service-metrics"})) > (13.44 * (1 - 0.99))) or (sum by (cluster, namespace, service) (max without (prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate30m{namespace="clusters-service",service="clusters-service-metrics"})) > (5.6 * (1 - 0.99)) and sum by (cluster, namespace, service) (max without (prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate6h{namespace="clusters-service",service="clusters-service-metrics"})) > (5.6 * (1 - 0.99)))'
+        expression: '( sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate5m{namespace="clusters-service", service="clusters-service-metrics"})) > (13.44 * (1 - 0.99)) and sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate1h{namespace="clusters-service", service="clusters-service-metrics"})) > (13.44 * (1 - 0.99)) ) or ( sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate30m{namespace="clusters-service", service="clusters-service-metrics"})) > (5.6 * (1 - 0.99)) and sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > (5.6 * (1 - 0.99)) )'
         for: 'PT5M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
@@ -589,7 +589,7 @@ resource arohcpCsSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometheusRul
           summary: 'API is slowly but steadily burning its 28 day 1s latency error budget (99% SLO)'
           title: 'API is slowly but steadily burning its 28 day 1s latency error budget (99% SLO)'
         }
-        expression: 'sum by (cluster, namespace, service) (max without (prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate6h{namespace="clusters-service",service="clusters-service-metrics"})) > (0.934 * (1 - 0.99)) and sum by (cluster, namespace, service) (max without (prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate3d{namespace="clusters-service",service="clusters-service-metrics"})) > (0.934 * (1 - 0.99))'
+        expression: 'sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > (0.934 * (1 - 0.99)) and sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p99_burnrate3d{namespace="clusters-service", service="clusters-service-metrics"})) > (0.934 * (1 - 0.99))'
         for: 'PT30M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
@@ -619,7 +619,7 @@ resource arohcpCsSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometheusRul
           summary: 'Cluster Service API P90 latency error budget burn rate is too high'
           title: 'Cluster Service API P90 latency error budget burn rate is too high'
         }
-        expression: '(sum by (cluster, namespace, service) (max without (prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate5m{namespace="clusters-service",service="clusters-service-metrics"})) > (13.44 * (1 - 0.9)) and sum by (cluster, namespace, service) (max without (prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate1h{namespace="clusters-service",service="clusters-service-metrics"})) > (13.44 * (1 - 0.9))) or (sum by (cluster, namespace, service) (max without (prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate30m{namespace="clusters-service",service="clusters-service-metrics"})) > (5.6 * (1 - 0.9)) and sum by (cluster, namespace, service) (max without (prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate6h{namespace="clusters-service",service="clusters-service-metrics"})) > (5.6 * (1 - 0.9)))'
+        expression: '( sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate5m{namespace="clusters-service", service="clusters-service-metrics"})) > (13.44 * (1 - 0.90)) and sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate1h{namespace="clusters-service", service="clusters-service-metrics"})) > (13.44 * (1 - 0.90)) ) or ( sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate30m{namespace="clusters-service", service="clusters-service-metrics"})) > (5.6 * (1 - 0.90)) and sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > (5.6 * (1 - 0.90)) )'
         for: 'PT5M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
@@ -647,7 +647,7 @@ resource arohcpCsSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometheusRul
           summary: 'API is slowly but steadily burning its 28 day 0.1s latency error budget (90% SLO)'
           title: 'API is slowly but steadily burning its 28 day 0.1s latency error budget (90% SLO)'
         }
-        expression: 'sum by (cluster, namespace, service) (max without (prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate6h{namespace="clusters-service",service="clusters-service-metrics"})) > (0.934 * (1 - 0.9)) and sum by (cluster, namespace, service) (max without (prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate3d{namespace="clusters-service",service="clusters-service-metrics"})) > (0.934 * (1 - 0.9))'
+        expression: 'sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate6h{namespace="clusters-service", service="clusters-service-metrics"})) > (0.934 * (1 - 0.90)) and sum by(cluster, namespace, service) (max without(prometheus_replica) (latency:api_inbound_request_duration:p90_burnrate3d{namespace="clusters-service", service="clusters-service-metrics"})) > (0.934 * (1 - 0.90))'
         for: 'PT30M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
@@ -687,7 +687,7 @@ resource backend 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
           summary: 'Backend controller workqueue depth is high'
           title: 'Backend controller workqueue depth is high'
         }
-        expression: 'max by (name, cluster) (max without (prometheus_replica) (workqueue_depth{namespace="aro-hcp"})) > 10'
+        expression: 'max by (name, cluster) ( max without(prometheus_replica) ( workqueue_depth{namespace="aro-hcp"} ) ) > 10'
         for: 'PT15M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
@@ -714,7 +714,7 @@ resource backend 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
           summary: 'Backend controller is panicking'
           title: 'Backend controller is panicking'
         }
-        expression: 'sum by (controller, cluster) (increase(panic_total{namespace="aro-hcp"}[5m])) > 0'
+        expression: 'sum by (controller, cluster) ( increase(panic_total{namespace="aro-hcp"}[5m]) ) > 0'
         for: 'PT1M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
@@ -741,7 +741,7 @@ resource backend 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
           summary: 'Orphaned cluster managed resource groups detected'
           title: 'Orphaned cluster managed resource groups detected'
         }
-        expression: 'sum by (location, cluster) (max without (prometheus_replica) (increase(aro_hcp_orphaned_managed_resource_groups_found_total[10m]))) > 0'
+        expression: 'sum by (location, cluster) ( max without(prometheus_replica) ( increase(aro_hcp_orphaned_managed_resource_groups_found_total[10m]) ) ) > 0'
         for: 'PT5M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
@@ -768,7 +768,7 @@ resource backend 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
           summary: 'Orphaned cluster managed resource group deletion is failing'
           title: 'Orphaned cluster managed resource group deletion is failing'
         }
-        expression: 'sum by (location, cluster) (max without (prometheus_replica) (increase(aro_hcp_orphaned_managed_resource_groups_deletion_failed_total[10m]))) > 0'
+        expression: 'sum by (location, cluster) ( max without(prometheus_replica) ( increase(aro_hcp_orphaned_managed_resource_groups_deletion_failed_total[10m]) ) ) > 0'
         for: 'PT10M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
@@ -808,7 +808,7 @@ resource fleet 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
           summary: 'Fleet controller workqueue retry hot loop'
           title: 'Fleet controller workqueue retry hot loop'
         }
-        expression: '(sum by (name, cluster) (max without (prometheus_replica) (rate(workqueue_retries_total{namespace="fleet"}[10m]))) / sum by (name, cluster) (max without (prometheus_replica) (rate(workqueue_adds_total{namespace="fleet"}[10m])))) > 0.5'
+        expression: '( sum by (name, cluster) ( max without(prometheus_replica) ( rate(workqueue_retries_total{namespace="fleet"}[10m]) ) ) / sum by (name, cluster) ( max without(prometheus_replica) ( rate(workqueue_adds_total{namespace="fleet"}[10m]) ) ) ) > 0.5'
         for: 'PT10M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
@@ -835,7 +835,7 @@ resource fleet 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
           summary: 'Fleet controller workqueue depth is high'
           title: 'Fleet controller workqueue depth is high'
         }
-        expression: 'max by (name, cluster) (max without (prometheus_replica) (workqueue_depth{namespace="fleet"})) > 10'
+        expression: 'max by (name, cluster) ( max without(prometheus_replica) ( workqueue_depth{namespace="fleet"} ) ) > 10'
         for: 'PT5M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
@@ -862,7 +862,7 @@ resource fleet 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
           summary: 'Fleet controller is panicking'
           title: 'Fleet controller is panicking'
         }
-        expression: 'sum by (controller, cluster) (increase(panic_total{namespace="fleet"}[5m])) > 0'
+        expression: 'sum by (controller, cluster) ( increase(panic_total{namespace="fleet"}[5m]) ) > 0'
         for: 'PT1M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
@@ -902,7 +902,7 @@ resource adminApi 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' =
           summary: 'High Admin API audit log error rate.'
           title: 'High Admin API audit log error rate.'
         }
-        expression: '(sum by (cluster) (rate(otel_audit_log_send_errors_total{job="aro-hcp-admin-api-metrics"}[1h])) / sum by (cluster) (rate(otel_audit_log_records_total{job="aro-hcp-admin-api-metrics"}[1h]))) > 0.05'
+        expression: '( sum by (cluster) (rate(otel_audit_log_send_errors_total{job="aro-hcp-admin-api-metrics"}[1h])) / sum by (cluster) (rate(otel_audit_log_records_total{job="aro-hcp-admin-api-metrics"}[1h])) ) > 0.05'
         for: 'PT5M'
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
@@ -996,7 +996,7 @@ resource maestro 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
           summary: 'Maestro REST API error rate is high'
           title: 'Maestro REST API error rate is high'
         }
-        expression: 'sum(rate(rest_api_inbound_request_count{code=~"5..",namespace="maestro"}[5m])) / sum(rate(rest_api_inbound_request_count{namespace="maestro"}[5m])) > 0.05'
+        expression: 'sum(rate(rest_api_inbound_request_count{namespace="maestro", code=~"5.."}[5m])) / sum(rate(rest_api_inbound_request_count{namespace="maestro"}[5m])) > 0.05'
         for: 'PT5M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
@@ -1023,7 +1023,7 @@ resource maestro 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
           summary: 'Maestro gRPC server error rate is high'
           title: 'Maestro gRPC server error rate is high'
         }
-        expression: 'sum(rate(grpc_server_processed_total{code!="OK",namespace="maestro"}[5m])) / sum(rate(grpc_server_processed_total{namespace="maestro"}[5m])) > 0.05'
+        expression: 'sum(rate(grpc_server_processed_total{namespace="maestro", code!="OK"}[5m])) / sum(rate(grpc_server_processed_total{namespace="maestro"}[5m])) > 0.05'
         for: 'PT5M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
@@ -1050,62 +1050,8 @@ resource maestro 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
           summary: 'Maestro spec controller reconcile error rate is high'
           title: 'Maestro spec controller reconcile error rate is high'
         }
-        expression: 'sum(rate(spec_controller_event_reconcile_total{namespace="maestro",status="error"}[5m])) / sum(rate(spec_controller_event_reconcile_total{namespace="maestro"}[5m])) > 0.1'
+        expression: 'sum(rate(spec_controller_event_reconcile_total{namespace="maestro", status="error"}[5m])) / sum(rate(spec_controller_event_reconcile_total{namespace="maestro"}[5m])) > 0.1'
         for: 'PT10M'
-        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
-      }
-      {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
-          }
-        ]
-        alert: 'MaestroServerNoReadyReplicas'
-        enabled: true
-        labels: {
-          severity: 'critical'
-        }
-        annotations: {
-          correlationId: 'MaestroServerNoReadyReplicas/{{ $labels.cluster }}'
-          description: 'No maestro-server replicas have been Ready for 10 minutes. Readiness is gated on Postgres connectivity, so maestro is likely unable to reach its database; Clusters Service will get 503 and HCP cluster provisioning will stall.'
-          info: 'No maestro-server replicas have been Ready for 10 minutes. Readiness is gated on Postgres connectivity, so maestro is likely unable to reach its database; Clusters Service will get 503 and HCP cluster provisioning will stall.'
-          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/maestro/index.html'
-          summary: 'No maestro-server replicas are Ready'
-          title: 'No maestro-server replicas are Ready'
-        }
-        expression: 'kube_deployment_status_replicas_available{deployment="maestro",namespace="maestro"} == 0 and kube_deployment_spec_replicas{deployment="maestro",namespace="maestro"} > 0'
-        for: 'PT10M'
-        severity: severityCeiling > 0 ? max(2, severityCeiling) : 2
-      }
-      {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
-          }
-        ]
-        alert: 'MaestroServerReplicaNotReady'
-        enabled: true
-        labels: {
-          severity: 'warning'
-        }
-        annotations: {
-          correlationId: 'MaestroServerReplicaNotReady/{{ $labels.cluster }}'
-          description: 'At least one maestro-server replica has been NotReady for 15 minutes (available {{ $value }} below desired). Readiness is gated on Postgres connectivity, so a persistently NotReady replica usually indicates database connectivity problems.'
-          info: 'At least one maestro-server replica has been NotReady for 15 minutes (available {{ $value }} below desired). Readiness is gated on Postgres connectivity, so a persistently NotReady replica usually indicates database connectivity problems.'
-          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/maestro/index.html'
-          summary: 'A maestro-server replica is not Ready'
-          title: 'A maestro-server replica is not Ready'
-        }
-        expression: 'kube_deployment_status_replicas_available{deployment="maestro",namespace="maestro"} > 0 and kube_deployment_status_replicas_available{deployment="maestro",namespace="maestro"} < kube_deployment_spec_replicas{deployment="maestro",namespace="maestro"}'
-        for: 'PT15M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
     ]
@@ -1146,7 +1092,7 @@ resource arobitRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01
           summary: 'Arobit forwarder metrics endpoint is unreachable on cluster {{ $labels.cluster }}.'
           title: 'Arobit forwarder metrics endpoint is unreachable on cluster {{ $labels.cluster }}.'
         }
-        expression: 'group by (cluster) (up{job="kube-state-metrics"}) unless on (cluster) group by (cluster) (up{job="arobit-forwarder",namespace="arobit"} == 1)'
+        expression: 'group by (cluster) (up{job="kube-state-metrics"}) unless on(cluster) group by (cluster) (up{job="arobit-forwarder",namespace="arobit"} == 1)'
         for: 'PT15M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
@@ -1179,7 +1125,7 @@ Investigate the Fluent Bit logs for the specific error details and check the Kus
           summary: 'Fluent Bit input ingestion paused due to backpressure.'
           title: 'Fluent Bit input ingestion paused due to backpressure.'
         }
-        expression: 'sum by (cluster, pod) (fluentbit_input_ingestion_paused) > 0'
+        expression: 'sum(fluentbit_input_ingestion_paused) by (cluster, pod) > 0'
         for: 'PT5M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
@@ -1212,7 +1158,7 @@ Investigate the Fluent Bit logs for the specific error details and check the Kus
           summary: 'High Kusto output retries'
           title: 'High Kusto output retries'
         }
-        expression: 'sum by (cluster, pod) (increase(fluentbit_output_retries_total{name=~"azure_kusto.*"}[5m])) > 3'
+        expression: 'sum(increase(fluentbit_output_retries_total{name=~"azure_kusto.*"}[5m])) by (cluster, pod) > 3'
         for: 'PT5M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
@@ -1243,7 +1189,7 @@ Investigate the Fluent Bit logs for the specific error details and check the Kus
           summary: 'Unrecoverable Kusto output errors - log data is being dropped.'
           title: 'Unrecoverable Kusto output errors - log data is being dropped.'
         }
-        expression: 'sum by (cluster, pod) (increase(fluentbit_output_errors_total{name=~"azure_kusto.*"}[5m])) > 0'
+        expression: 'sum(increase(fluentbit_output_errors_total{name=~"azure_kusto.*"}[5m])) by (cluster, pod) > 0'
         for: 'PT5M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
@@ -1274,7 +1220,7 @@ Investigate the Fluent Bit logs for the specific error details and check the Kus
           summary: 'Kusto output retries exhausted - chunks discarded after max retries.'
           title: 'Kusto output retries exhausted - chunks discarded after max retries.'
         }
-        expression: 'sum by (cluster, pod) (increase(fluentbit_output_retries_failed_total{name=~"azure_kusto.*"}[5m])) > 0'
+        expression: 'sum(increase(fluentbit_output_retries_failed_total{name=~"azure_kusto.*"}[5m])) by (cluster, pod) > 0'
         for: 'PT5M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
@@ -1432,7 +1378,7 @@ resource serviceTagCapacityRules 'Microsoft.AlertsManagement/prometheusRuleGroup
           summary: 'Service Tag IP Usage is reaching 80%'
           title: 'Service Tag IP Usage is reaching 80%'
         }
-        expression: 'public_ip_count_by_region_service_tag{region!="uswest2",service_tag_type="FirstPartyUsage",service_tag_value="/aro-hcp-prod-inbound-customerapi"} / 64 > 0.8'
+        expression: 'public_ip_count_by_region_service_tag{service_tag_type="FirstPartyUsage",service_tag_value="/aro-hcp-prod-inbound-customerapi",region!="uswest2"} / 64 > 0.8'
         for: 'PT15M'
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
@@ -1461,7 +1407,7 @@ resource serviceTagCapacityRules 'Microsoft.AlertsManagement/prometheusRuleGroup
           summary: 'Service Tag IP Usage is reaching 80%'
           title: 'Service Tag IP Usage is reaching 80%'
         }
-        expression: 'public_ip_count_by_region_service_tag{region="uswest2",service_tag_type="FirstPartyUsage",service_tag_value="/aro-hcp-prod-inbound-customerapi"} / 128 > 0.8'
+        expression: 'public_ip_count_by_region_service_tag{service_tag_type="FirstPartyUsage",service_tag_value="/aro-hcp-prod-inbound-customerapi",region="uswest2"} / 128 > 0.8'
         for: 'PT15M'
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
@@ -1661,7 +1607,7 @@ resource kubeContainerOomRules 'Microsoft.AlertsManagement/prometheusRuleGroups@
           summary: 'Container {{ $labels.container }} was OOMKilled'
           title: 'Container {{ $labels.container }} was OOMKilled'
         }
-        expression: 'kube_pod_container_status_last_terminated_reason{job="kube-state-metrics",reason="OOMKilled"} == 1'
+        expression: 'kube_pod_container_status_last_terminated_reason{reason="OOMKilled", job="kube-state-metrics"} == 1'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
     ]
@@ -1739,7 +1685,7 @@ resource imageRegistryPolicy 'Microsoft.AlertsManagement/prometheusRuleGroups@20
           summary: 'Image registry policy denied pod admission'
           title: 'Image registry policy denied pod admission'
         }
-        expression: 'sum by (cluster, policy, policy_binding) (increase(apiserver_validating_admission_policy_check_total{enforcement_action="deny",policy="image-registry-allowlist-policy",validation_result="denied"}[15m])) > 0'
+        expression: 'sum by (cluster, policy, policy_binding) ( increase(apiserver_validating_admission_policy_check_total{ policy="image-registry-allowlist-policy", enforcement_action="deny", validation_result="denied" }[15m]) ) > 0'
         for: 'PT1M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
@@ -1766,7 +1712,7 @@ resource imageRegistryPolicy 'Microsoft.AlertsManagement/prometheusRuleGroups@20
           summary: 'Image registry policy audit violation detected'
           title: 'Image registry policy audit violation detected'
         }
-        expression: 'sum by (cluster, policy, policy_binding) (increase(apiserver_validating_admission_policy_check_total{enforcement_action="audit",policy="image-registry-allowlist-policy",validation_result="denied"}[15m])) > 0'
+        expression: 'sum by (cluster, policy, policy_binding) ( increase(apiserver_validating_admission_policy_check_total{ policy="image-registry-allowlist-policy", enforcement_action="audit", validation_result="denied" }[15m]) ) > 0'
         for: 'PT5M'
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }

--- a/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
@@ -17,15 +17,13 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
     interval: 'PT1M'
     rules: [
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'UJAccessClusterErrors1h5m'
         enabled: true
         labels: {
@@ -36,8 +34,8 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         }
         annotations: {
           correlationId: 'UJAccessClusterErrors1h5m/{{ $labels.cluster }}'
-          description: 'More than 72% of credential operations (requestAdminCredential/revokeCredentials) are in failed state, indicating a fast error budget burn (14.4x) that would exhaust the 95% SLO budget in ~12 hours.'
-          info: 'More than 72% of credential operations (requestAdminCredential/revokeCredentials) are in failed state, indicating a fast error budget burn (14.4x) that would exhaust the 95% SLO budget in ~12 hours.'
+          description: 'More than 72% of credential operations (requestcredential/revokecredentials) are in failed state, indicating a fast error budget burn (14.4x) that would exhaust the 95% SLO budget in ~12 hours.'
+          info: 'More than 72% of credential operations (requestcredential/revokecredentials) are in failed state, indicating a fast error budget burn (14.4x) that would exhaust the 95% SLO budget in ~12 hours.'
           runbook_url: 'aka.ms/arohcp-runbook-access-cluster'
           summary: '{{ $labels.cluster }}: Credential operation error rate critically high (>72%)'
           title: '{{ $labels.cluster }}: Credential operation error rate critically high (>72%)'
@@ -47,15 +45,13 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         severity: 4
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'UJAccessClusterErrors6h30m'
         enabled: true
         labels: {
@@ -77,15 +73,13 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         severity: 4
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'UJAccessClusterErrors3d'
         enabled: true
         labels: {
@@ -106,15 +100,13 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         severity: 4
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'UJAccessClusterErrorsDegradation'
         enabled: true
         labels: {
@@ -134,15 +126,13 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         severity: 4
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'UJAccessClusterStuckOperation'
         enabled: true
         labels: {
@@ -174,15 +164,13 @@ resource arohcpAccessClusterSaturationAlerts 'Microsoft.AlertsManagement/prometh
     interval: 'PT1M'
     rules: [
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'UJAccessClusterSaturationQueueDepth'
         enabled: true
         labels: {
@@ -201,15 +189,13 @@ resource arohcpAccessClusterSaturationAlerts 'Microsoft.AlertsManagement/prometh
         severity: 4
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'UJAccessClusterSaturationRetryHotLoop'
         enabled: true
         labels: {
@@ -241,15 +227,13 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
     interval: 'PT1M'
     rules: [
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'UJNodePoolErrors1h5m'
         enabled: true
         labels: {
@@ -271,15 +255,13 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'UJNodePoolErrors6h30m'
         enabled: true
         labels: {
@@ -301,15 +283,13 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'UJNodePoolErrors3d'
         enabled: true
         labels: {
@@ -330,15 +310,13 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'UJNodePoolErrorsDegradation'
         enabled: true
         labels: {
@@ -358,15 +336,13 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'UJNodePoolStuckOperation'
         enabled: true
         labels: {
@@ -398,15 +374,13 @@ resource arohcpNodepoolSaturationAlerts 'Microsoft.AlertsManagement/prometheusRu
     interval: 'PT1M'
     rules: [
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'UJNodePoolSaturationQueueDepth'
         enabled: true
         labels: {
@@ -425,15 +399,13 @@ resource arohcpNodepoolSaturationAlerts 'Microsoft.AlertsManagement/prometheusRu
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'UJNodePoolSaturationRetryHotLoop'
         enabled: true
         labels: {

--- a/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
@@ -26,7 +26,7 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
             }
           }
         ]
-        alert: 'UJAccessClusterErrors1h5m'
+        alert: 'userJourneyAccessClusterErrors1h5m'
         enabled: true
         labels: {
           long_window: '1h'
@@ -35,7 +35,7 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
           slo: 'access-cluster-errors'
         }
         annotations: {
-          correlationId: 'UJAccessClusterErrors1h5m/{{ $labels.cluster }}'
+          correlationId: 'userJourneyAccessClusterErrors1h5m/{{ $labels.cluster }}'
           description: 'More than 72% of credential operations (requestcredential/revokecredentials) are in failed state, indicating a fast error budget burn (14.4x) that would exhaust the 95% SLO budget in ~12 hours.'
           info: 'More than 72% of credential operations (requestcredential/revokecredentials) are in failed state, indicating a fast error budget burn (14.4x) that would exhaust the 95% SLO budget in ~12 hours.'
           runbook_url: 'aka.ms/arohcp-runbook-access-cluster'
@@ -56,7 +56,7 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
             }
           }
         ]
-        alert: 'UJAccessClusterErrors6h30m'
+        alert: 'userJourneyAccessClusterErrors6h30m'
         enabled: true
         labels: {
           long_window: '6h'
@@ -65,7 +65,7 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
           slo: 'access-cluster-errors'
         }
         annotations: {
-          correlationId: 'UJAccessClusterErrors6h30m/{{ $labels.cluster }}'
+          correlationId: 'userJourneyAccessClusterErrors6h30m/{{ $labels.cluster }}'
           description: 'More than 30% of credential operations are in failed state sustained over 30 minutes, indicating a medium error budget burn (6x) that would exhaust the 95% SLO budget in ~28 hours.'
           info: 'More than 30% of credential operations are in failed state sustained over 30 minutes, indicating a medium error budget burn (6x) that would exhaust the 95% SLO budget in ~28 hours.'
           runbook_url: 'aka.ms/arohcp-runbook-access-cluster'
@@ -86,7 +86,7 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
             }
           }
         ]
-        alert: 'UJAccessClusterErrors3d'
+        alert: 'userJourneyAccessClusterErrors3d'
         enabled: true
         labels: {
           long_window: '3d'
@@ -94,7 +94,7 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
           slo: 'access-cluster-errors'
         }
         annotations: {
-          correlationId: 'UJAccessClusterErrors3d/{{ $labels.cluster }}'
+          correlationId: 'userJourneyAccessClusterErrors3d/{{ $labels.cluster }}'
           description: 'More than 5% of credential operations are in failed state sustained over 6 hours, indicating persistent degradation at the 95% SLO boundary that would exhaust the error budget in ~7 days.'
           info: 'More than 5% of credential operations are in failed state sustained over 6 hours, indicating persistent degradation at the 95% SLO boundary that would exhaust the error budget in ~7 days.'
           runbook_url: 'aka.ms/arohcp-runbook-access-cluster'
@@ -115,14 +115,14 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
             }
           }
         ]
-        alert: 'UJAccessClusterErrorsDegradation'
+        alert: 'userJourneyAccessClusterErrorsDegradation'
         enabled: true
         labels: {
           severity: 'info'
           slo: 'access-cluster-errors'
         }
         annotations: {
-          correlationId: 'UJAccessClusterErrorsDegradation/{{ $labels.cluster }}'
+          correlationId: 'userJourneyAccessClusterErrorsDegradation/{{ $labels.cluster }}'
           description: 'The credential operation failure rate has been above 15% for 30 minutes. This provides early warning of degradation before SLO-based burn rate alerts fire.'
           info: 'The credential operation failure rate has been above 15% for 30 minutes. This provides early warning of degradation before SLO-based burn rate alerts fire.'
           runbook_url: 'aka.ms/arohcp-runbook-access-cluster'
@@ -143,13 +143,13 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
             }
           }
         ]
-        alert: 'UJAccessClusterStuckOperation'
+        alert: 'userJourneyAccessClusterStuckOperation'
         enabled: true
         labels: {
           severity: 'info'
         }
         annotations: {
-          correlationId: 'UJAccessClusterStuckOperation/{{ $labels.cluster }}'
+          correlationId: 'userJourneyAccessClusterStuckOperation/{{ $labels.cluster }}'
           description: 'Credential operation for {{ $labels.resource_id }} has been in {{ $labels.phase }} phase for over 1 hour. Stuck operations are invisible to success/failure SLIs and require investigation.'
           info: 'Credential operation for {{ $labels.resource_id }} has been in {{ $labels.phase }} phase for over 1 hour. Stuck operations are invisible to success/failure SLIs and require investigation.'
           runbook_url: 'aka.ms/arohcp-runbook-access-cluster'
@@ -183,13 +183,13 @@ resource arohcpAccessClusterSaturationAlerts 'Microsoft.AlertsManagement/prometh
             }
           }
         ]
-        alert: 'UJAccessClusterSaturationQueueDepth'
+        alert: 'userJourneyAccessClusterSaturationQueueDepth'
         enabled: true
         labels: {
           severity: 'info'
         }
         annotations: {
-          correlationId: 'UJAccessClusterSaturationQueueDepth/{{ $labels.cluster }}'
+          correlationId: 'userJourneyAccessClusterSaturationQueueDepth/{{ $labels.cluster }}'
           description: 'Credential controller workqueue {{ $labels.name }} has had a depth > 10 for more than 5 minutes, indicating work is accumulating faster than it can be processed.'
           info: 'Credential controller workqueue {{ $labels.name }} has had a depth > 10 for more than 5 minutes, indicating work is accumulating faster than it can be processed.'
           runbook_url: 'aka.ms/arohcp-runbook-access-cluster'
@@ -210,13 +210,13 @@ resource arohcpAccessClusterSaturationAlerts 'Microsoft.AlertsManagement/prometh
             }
           }
         ]
-        alert: 'UJAccessClusterSaturationRetryHotLoop'
+        alert: 'userJourneyAccessClusterSaturationRetryHotLoop'
         enabled: true
         labels: {
           severity: 'info'
         }
         annotations: {
-          correlationId: 'UJAccessClusterSaturationRetryHotLoop/{{ $labels.cluster }}'
+          correlationId: 'userJourneyAccessClusterSaturationRetryHotLoop/{{ $labels.cluster }}'
           description: 'Credential controller workqueue {{ $labels.name }} has a retry ratio > 50% sustained over 10 minutes, indicating most queue activity is failed retries rather than fresh work.'
           info: 'Credential controller workqueue {{ $labels.name }} has a retry ratio > 50% sustained over 10 minutes, indicating most queue activity is failed retries rather than fresh work.'
           runbook_url: 'aka.ms/arohcp-runbook-access-cluster'

--- a/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
@@ -44,7 +44,7 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         }
         expression: 'errors:backend_credential_operation:error_rate > 0.72'
         for: 'PT5M'
-        severity: 4
+        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
         actions: [
@@ -74,7 +74,7 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         }
         expression: 'errors:backend_credential_operation:error_rate > 0.30'
         for: 'PT30M'
-        severity: 4
+        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
         actions: [
@@ -103,7 +103,7 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         }
         expression: 'errors:backend_credential_operation:error_rate > 0.05'
         for: 'PT6H'
-        severity: 4
+        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
         actions: [
@@ -131,7 +131,7 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         }
         expression: 'errors:backend_credential_operation:error_rate > 0.15'
         for: 'PT30M'
-        severity: 4
+        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
         actions: [
@@ -158,7 +158,7 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         }
         expression: '( (time() - backend_resource_operation_start_time_seconds{ resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type=~"requestcredential|revokecredentials" }) and backend_resource_operation_phase_info{ resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type=~"requestcredential|revokecredentials", phase=~"accepted|provisioning|deleting" } == 1 ) > 3600'
         for: 'PT15M'
-        severity: 4
+        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
     ]
     scopes: [
@@ -198,7 +198,7 @@ resource arohcpAccessClusterSaturationAlerts 'Microsoft.AlertsManagement/prometh
         }
         expression: 'max by (name, cluster) ( max without(prometheus_replica) ( workqueue_depth{namespace="aro-hcp", name=~".*(RequestCredential|RevokeCredentials).*"} ) ) > 10'
         for: 'PT5M'
-        severity: 4
+        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
         actions: [
@@ -225,7 +225,7 @@ resource arohcpAccessClusterSaturationAlerts 'Microsoft.AlertsManagement/prometh
         }
         expression: '( sum by (name, cluster) ( max without(prometheus_replica) ( rate(workqueue_retries_total{namespace="aro-hcp", name=~".*(RequestCredential|RevokeCredentials).*"}[10m]) ) ) / sum by (name, cluster) ( max without(prometheus_replica) ( rate(workqueue_adds_total{namespace="aro-hcp", name=~".*(RequestCredential|RevokeCredentials).*"}[10m]) ) ) ) > 0.5'
         for: 'PT10M'
-        severity: 4
+        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
     ]
     scopes: [

--- a/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
@@ -10,6 +10,230 @@ param severityCeiling int = 0
 #disable-next-line no-unused-params
 param location string = resourceGroup().location
 
+resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'arohcp_access_cluster_slo_error_alerts'
+  location: location
+  properties: {
+    interval: 'PT1M'
+    rules: [
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'UJAccessClusterErrors1h5m'
+        enabled: true
+        labels: {
+          long_window: '1h'
+          severity: 'info'
+          short_window: '5m'
+          slo: 'access-cluster-errors'
+        }
+        annotations: {
+          correlationId: 'UJAccessClusterErrors1h5m/{{ $labels.cluster }}'
+          description: 'More than 72% of credential operations (requestAdminCredential/revokeCredentials) are in failed state, indicating a fast error budget burn (14.4x) that would exhaust the 95% SLO budget in ~12 hours.'
+          info: 'More than 72% of credential operations (requestAdminCredential/revokeCredentials) are in failed state, indicating a fast error budget burn (14.4x) that would exhaust the 95% SLO budget in ~12 hours.'
+          runbook_url: 'aka.ms/arohcp-runbook-access-cluster'
+          summary: '{{ $labels.cluster }}: Credential operation error rate critically high (>72%)'
+          title: '{{ $labels.cluster }}: Credential operation error rate critically high (>72%)'
+        }
+        expression: 'errors:backend_credential_operation:error_rate > 0.72'
+        for: 'PT5M'
+        severity: 4
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'UJAccessClusterErrors6h30m'
+        enabled: true
+        labels: {
+          long_window: '6h'
+          severity: 'info'
+          short_window: '30m'
+          slo: 'access-cluster-errors'
+        }
+        annotations: {
+          correlationId: 'UJAccessClusterErrors6h30m/{{ $labels.cluster }}'
+          description: 'More than 30% of credential operations are in failed state sustained over 30 minutes, indicating a medium error budget burn (6x) that would exhaust the 95% SLO budget in ~28 hours.'
+          info: 'More than 30% of credential operations are in failed state sustained over 30 minutes, indicating a medium error budget burn (6x) that would exhaust the 95% SLO budget in ~28 hours.'
+          runbook_url: 'aka.ms/arohcp-runbook-access-cluster'
+          summary: '{{ $labels.cluster }}: Credential operation error rate elevated (>30%) for 30+ minutes'
+          title: '{{ $labels.cluster }}: Credential operation error rate elevated (>30%) for 30+ minutes'
+        }
+        expression: 'errors:backend_credential_operation:error_rate > 0.30'
+        for: 'PT30M'
+        severity: 4
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'UJAccessClusterErrors3d'
+        enabled: true
+        labels: {
+          long_window: '3d'
+          severity: 'info'
+          slo: 'access-cluster-errors'
+        }
+        annotations: {
+          correlationId: 'UJAccessClusterErrors3d/{{ $labels.cluster }}'
+          description: 'More than 5% of credential operations are in failed state sustained over 6 hours, indicating persistent degradation at the 95% SLO boundary that would exhaust the error budget in ~7 days.'
+          info: 'More than 5% of credential operations are in failed state sustained over 6 hours, indicating persistent degradation at the 95% SLO boundary that would exhaust the error budget in ~7 days.'
+          runbook_url: 'aka.ms/arohcp-runbook-access-cluster'
+          summary: '{{ $labels.cluster }}: Credential operation error rate exceeds SLO target (>5%) for 6+ hours'
+          title: '{{ $labels.cluster }}: Credential operation error rate exceeds SLO target (>5%) for 6+ hours'
+        }
+        expression: 'errors:backend_credential_operation:error_rate > 0.05'
+        for: 'PT6H'
+        severity: 4
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'UJAccessClusterErrorsDegradation'
+        enabled: true
+        labels: {
+          severity: 'info'
+          slo: 'access-cluster-errors'
+        }
+        annotations: {
+          correlationId: 'UJAccessClusterErrorsDegradation/{{ $labels.cluster }}'
+          description: 'The credential operation failure rate has been above 15% for 30 minutes. This provides early warning of degradation before SLO-based burn rate alerts fire.'
+          info: 'The credential operation failure rate has been above 15% for 30 minutes. This provides early warning of degradation before SLO-based burn rate alerts fire.'
+          runbook_url: 'aka.ms/arohcp-runbook-access-cluster'
+          summary: '{{ $labels.cluster }}: Credential operation failure rate exceeds 15% for 30 minutes'
+          title: '{{ $labels.cluster }}: Credential operation failure rate exceeds 15% for 30 minutes'
+        }
+        expression: 'errors:backend_credential_operation:error_rate > 0.15'
+        for: 'PT30M'
+        severity: 4
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'UJAccessClusterStuckOperation'
+        enabled: true
+        labels: {
+          severity: 'info'
+        }
+        annotations: {
+          correlationId: 'UJAccessClusterStuckOperation/{{ $labels.cluster }}'
+          description: 'Credential operation for {{ $labels.resource_id }} has been in {{ $labels.phase }} phase for over 1 hour. Stuck operations are invisible to success/failure SLIs and require investigation.'
+          info: 'Credential operation for {{ $labels.resource_id }} has been in {{ $labels.phase }} phase for over 1 hour. Stuck operations are invisible to success/failure SLIs and require investigation.'
+          runbook_url: 'aka.ms/arohcp-runbook-access-cluster'
+          summary: '{{ $labels.cluster }}: Credential operation stuck in {{ $labels.phase }} for over 1 hour'
+          title: '{{ $labels.cluster }}: Credential operation stuck in {{ $labels.phase }} for over 1 hour'
+        }
+        expression: '( (time() - backend_resource_operation_start_time_seconds{ resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type=~"requestcredential|revokecredentials" }) and backend_resource_operation_phase_info{ resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type=~"requestcredential|revokecredentials", phase=~"accepted|provisioning|deleting" } == 1 ) > 3600'
+        for: 'PT15M'
+        severity: 4
+      }
+    ]
+    scopes: [
+      azureMonitoring
+    ]
+  }
+}
+
+resource arohcpAccessClusterSaturationAlerts 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'arohcp_access_cluster_saturation_alerts'
+  location: location
+  properties: {
+    interval: 'PT1M'
+    rules: [
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'UJAccessClusterSaturationQueueDepth'
+        enabled: true
+        labels: {
+          severity: 'info'
+        }
+        annotations: {
+          correlationId: 'UJAccessClusterSaturationQueueDepth/{{ $labels.cluster }}'
+          description: 'Credential controller workqueue {{ $labels.name }} has had a depth > 10 for more than 5 minutes, indicating work is accumulating faster than it can be processed.'
+          info: 'Credential controller workqueue {{ $labels.name }} has had a depth > 10 for more than 5 minutes, indicating work is accumulating faster than it can be processed.'
+          runbook_url: 'aka.ms/arohcp-runbook-access-cluster'
+          summary: '{{ $labels.cluster }}: Credential controller workqueue {{ $labels.name }} depth is high'
+          title: '{{ $labels.cluster }}: Credential controller workqueue {{ $labels.name }} depth is high'
+        }
+        expression: 'max by (name, cluster) ( max without(prometheus_replica) ( workqueue_depth{namespace="aro-hcp", name=~".*(RequestCredential|RevokeCredentials).*"} ) ) > 10'
+        for: 'PT5M'
+        severity: 4
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'UJAccessClusterSaturationRetryHotLoop'
+        enabled: true
+        labels: {
+          severity: 'info'
+        }
+        annotations: {
+          correlationId: 'UJAccessClusterSaturationRetryHotLoop/{{ $labels.cluster }}'
+          description: 'Credential controller workqueue {{ $labels.name }} has a retry ratio > 50% sustained over 10 minutes, indicating most queue activity is failed retries rather than fresh work.'
+          info: 'Credential controller workqueue {{ $labels.name }} has a retry ratio > 50% sustained over 10 minutes, indicating most queue activity is failed retries rather than fresh work.'
+          runbook_url: 'aka.ms/arohcp-runbook-access-cluster'
+          summary: '{{ $labels.cluster }}: Credential controller workqueue {{ $labels.name }} retry hot loop'
+          title: '{{ $labels.cluster }}: Credential controller workqueue {{ $labels.name }} retry hot loop'
+        }
+        expression: '( sum by (name, cluster) ( max without(prometheus_replica) ( rate(workqueue_retries_total{namespace="aro-hcp", name=~".*(RequestCredential|RevokeCredentials).*"}[10m]) ) ) / sum by (name, cluster) ( max without(prometheus_replica) ( rate(workqueue_adds_total{namespace="aro-hcp", name=~".*(RequestCredential|RevokeCredentials).*"}[10m]) ) ) ) > 0.5'
+        for: 'PT10M'
+        severity: 4
+      }
+    ]
+    scopes: [
+      azureMonitoring
+    ]
+  }
+}
+
 resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
   name: 'arohcp_nodepool_slo_error_alerts'
   location: location

--- a/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
@@ -17,13 +17,15 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
     interval: 'PT1M'
     rules: [
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'UJAccessClusterErrors1h5m'
         enabled: true
         labels: {
@@ -45,13 +47,15 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         severity: 4
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'UJAccessClusterErrors6h30m'
         enabled: true
         labels: {
@@ -73,13 +77,15 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         severity: 4
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'UJAccessClusterErrors3d'
         enabled: true
         labels: {
@@ -100,13 +106,15 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         severity: 4
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'UJAccessClusterErrorsDegradation'
         enabled: true
         labels: {
@@ -126,13 +134,15 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         severity: 4
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'UJAccessClusterStuckOperation'
         enabled: true
         labels: {
@@ -164,13 +174,15 @@ resource arohcpAccessClusterSaturationAlerts 'Microsoft.AlertsManagement/prometh
     interval: 'PT1M'
     rules: [
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'UJAccessClusterSaturationQueueDepth'
         enabled: true
         labels: {
@@ -189,13 +201,15 @@ resource arohcpAccessClusterSaturationAlerts 'Microsoft.AlertsManagement/prometh
         severity: 4
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'UJAccessClusterSaturationRetryHotLoop'
         enabled: true
         labels: {
@@ -227,13 +241,15 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
     interval: 'PT1M'
     rules: [
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'UJNodePoolErrors1h5m'
         enabled: true
         labels: {
@@ -255,13 +271,15 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'UJNodePoolErrors6h30m'
         enabled: true
         labels: {
@@ -283,13 +301,15 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'UJNodePoolErrors3d'
         enabled: true
         labels: {
@@ -310,13 +330,15 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'UJNodePoolErrorsDegradation'
         enabled: true
         labels: {
@@ -336,13 +358,15 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'UJNodePoolStuckOperation'
         enabled: true
         labels: {
@@ -374,13 +398,15 @@ resource arohcpNodepoolSaturationAlerts 'Microsoft.AlertsManagement/prometheusRu
     interval: 'PT1M'
     rules: [
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'UJNodePoolSaturationQueueDepth'
         enabled: true
         labels: {
@@ -399,13 +425,15 @@ resource arohcpNodepoolSaturationAlerts 'Microsoft.AlertsManagement/prometheusRu
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'UJNodePoolSaturationRetryHotLoop'
         enabled: true
         labels: {

--- a/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
@@ -72,7 +72,7 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
           summary: '{{ $labels.cluster }}: Credential operation error rate elevated (>30%) for 30+ minutes'
           title: '{{ $labels.cluster }}: Credential operation error rate elevated (>30%) for 30+ minutes'
         }
-        expression: 'errors:backend_credential_operation:error_rate > 0.30'
+        expression: 'errors:backend_credential_operation:error_rate > 0.3'
         for: 'PT30M'
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
@@ -156,7 +156,7 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
           summary: '{{ $labels.cluster }}: Credential operation stuck in {{ $labels.phase }} for over 1 hour'
           title: '{{ $labels.cluster }}: Credential operation stuck in {{ $labels.phase }} for over 1 hour'
         }
-        expression: '( (time() - backend_resource_operation_start_time_seconds{ resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type=~"requestcredential|revokecredentials" }) and backend_resource_operation_phase_info{ resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type=~"requestcredential|revokecredentials", phase=~"accepted|provisioning|deleting" } == 1 ) > 3600'
+        expression: '((time() - backend_resource_operation_start_time_seconds{operation_type=~"requestcredential|revokecredentials",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters"}) and backend_resource_operation_phase_info{operation_type=~"requestcredential|revokecredentials",phase=~"accepted|provisioning|deleting",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters"} == 1) > 3600'
         for: 'PT15M'
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
@@ -196,7 +196,7 @@ resource arohcpAccessClusterSaturationAlerts 'Microsoft.AlertsManagement/prometh
           summary: '{{ $labels.cluster }}: Credential controller workqueue {{ $labels.name }} depth is high'
           title: '{{ $labels.cluster }}: Credential controller workqueue {{ $labels.name }} depth is high'
         }
-        expression: 'max by (name, cluster) ( max without(prometheus_replica) ( workqueue_depth{namespace="aro-hcp", name=~".*(RequestCredential|RevokeCredentials).*"} ) ) > 10'
+        expression: 'max by (name, cluster) (max without (prometheus_replica) (workqueue_depth{name=~".*(RequestCredential|RevokeCredentials).*",namespace="aro-hcp"})) > 10'
         for: 'PT5M'
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
@@ -223,7 +223,7 @@ resource arohcpAccessClusterSaturationAlerts 'Microsoft.AlertsManagement/prometh
           summary: '{{ $labels.cluster }}: Credential controller workqueue {{ $labels.name }} retry hot loop'
           title: '{{ $labels.cluster }}: Credential controller workqueue {{ $labels.name }} retry hot loop'
         }
-        expression: '( sum by (name, cluster) ( max without(prometheus_replica) ( rate(workqueue_retries_total{namespace="aro-hcp", name=~".*(RequestCredential|RevokeCredentials).*"}[10m]) ) ) / sum by (name, cluster) ( max without(prometheus_replica) ( rate(workqueue_adds_total{namespace="aro-hcp", name=~".*(RequestCredential|RevokeCredentials).*"}[10m]) ) ) ) > 0.5'
+        expression: '(sum by (name, cluster) (max without (prometheus_replica) (rate(workqueue_retries_total{name=~".*(RequestCredential|RevokeCredentials).*",namespace="aro-hcp"}[10m]))) / sum by (name, cluster) (max without (prometheus_replica) (rate(workqueue_adds_total{name=~".*(RequestCredential|RevokeCredentials).*",namespace="aro-hcp"}[10m])))) > 0.5'
         for: 'PT10M'
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }

--- a/dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep
@@ -14,15 +14,15 @@ resource arohcpAccessClusterSloRecordingRules 'Microsoft.AlertsManagement/promet
     rules: [
       {
         record: 'errors:backend_credential_operation:succeeded_total'
-        expression: 'count by (cluster) (backend_resource_operation_phase_info{ resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type=~"requestcredential|revokecredentials", phase="succeeded" })'
+        expression: 'count by (cluster) (backend_resource_operation_phase_info{operation_type=~"requestcredential|revokecredentials",phase="succeeded",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters"})'
       }
       {
         record: 'errors:backend_credential_operation:terminal_total'
-        expression: 'count by (cluster) (backend_resource_operation_phase_info{ resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type=~"requestcredential|revokecredentials", phase=~"succeeded|failed|canceled" })'
+        expression: 'count by (cluster) (backend_resource_operation_phase_info{operation_type=~"requestcredential|revokecredentials",phase=~"succeeded|failed|canceled",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters"})'
       }
       {
         record: 'errors:backend_credential_operation:error_rate'
-        expression: '( count by (cluster) (backend_resource_operation_phase_info{ resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type=~"requestcredential|revokecredentials", phase="failed" }) or 0 * count by (cluster) (backend_resource_operation_phase_info{ resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type=~"requestcredential|revokecredentials", phase=~"succeeded|failed|canceled" }) ) / clamp_min( count by (cluster) (backend_resource_operation_phase_info{ resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type=~"requestcredential|revokecredentials", phase=~"succeeded|failed|canceled" }), 1 )'
+        expression: '(count by (cluster) (backend_resource_operation_phase_info{operation_type=~"requestcredential|revokecredentials",phase="failed",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters"}) or 0 * count by (cluster) (backend_resource_operation_phase_info{operation_type=~"requestcredential|revokecredentials",phase=~"succeeded|failed|canceled",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters"})) / clamp_min(count by (cluster) (backend_resource_operation_phase_info{operation_type=~"requestcredential|revokecredentials",phase=~"succeeded|failed|canceled",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters"}), 1)'
       }
     ]
   }

--- a/dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep
@@ -1,3 +1,29 @@
 param azureMonitoring string
 
 param location string = resourceGroup().location
+
+resource arohcpAccessClusterSloRecordingRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'arohcp_access_cluster_slo_recording_rules'
+  location: location
+  properties: {
+    scopes: [
+      azureMonitoring
+    ]
+    enabled: true
+    interval: 'PT1M'
+    rules: [
+      {
+        record: 'errors:backend_credential_operation:succeeded_total'
+        expression: 'count by (cluster) (backend_resource_operation_phase_info{ resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type=~"requestcredential|revokecredentials", phase="succeeded" })'
+      }
+      {
+        record: 'errors:backend_credential_operation:terminal_total'
+        expression: 'count by (cluster) (backend_resource_operation_phase_info{ resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type=~"requestcredential|revokecredentials", phase=~"succeeded|failed|canceled" })'
+      }
+      {
+        record: 'errors:backend_credential_operation:error_rate'
+        expression: '( count by (cluster) (backend_resource_operation_phase_info{ resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type=~"requestcredential|revokecredentials", phase="failed" }) or 0 * count by (cluster) (backend_resource_operation_phase_info{ resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type=~"requestcredential|revokecredentials", phase=~"succeeded|failed|canceled" }) ) / clamp_min( count by (cluster) (backend_resource_operation_phase_info{ resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type=~"requestcredential|revokecredentials", phase=~"succeeded|failed|canceled" }), 1 )'
+      }
+    ]
+  }
+}

--- a/observability/alerts-rp-services.yaml
+++ b/observability/alerts-rp-services.yaml
@@ -1,5 +1,6 @@
 prometheusRules:
   rulesFolders:
+  - alerts/access-cluster-slo-prometheusRule.yaml
   - alerts/nodepool-slo-prometheusRule.yaml
   untestedRules: []
   testDependencies:

--- a/observability/alerts/access-cluster-slo-prometheusRule.yaml
+++ b/observability/alerts/access-cluster-slo-prometheusRule.yaml
@@ -14,7 +14,7 @@ spec:
   # Access the Cluster SLO Recording Rules
   # ========================================
   # These rules track the Errors SLO for credential operations
-  # (requestAdminCredential, revokeCredentials).
+  # (operation_type: requestcredential, revokecredentials).
   # SLO: 95% of credential operations should succeed (not reach "failed" terminal phase)
   # Error Budget: 5% (1 - 0.95)
   #
@@ -100,7 +100,7 @@ spec:
         short_window: 5m
       annotations:
         summary: "{{ $labels.cluster }}: Credential operation error rate critically high (>72%)"
-        description: "More than 72% of credential operations (requestAdminCredential/revokeCredentials) are in failed state, indicating a fast error budget burn (14.4x) that would exhaust the 95% SLO budget in ~12 hours."
+        description: "More than 72% of credential operations (requestcredential/revokecredentials) are in failed state, indicating a fast error budget burn (14.4x) that would exhaust the 95% SLO budget in ~12 hours."
         runbook_url: "aka.ms/arohcp-runbook-access-cluster"
     # ----------------------------------------
     # Medium Burn Alert (non-paging for now)

--- a/observability/alerts/access-cluster-slo-prometheusRule.yaml
+++ b/observability/alerts/access-cluster-slo-prometheusRule.yaml
@@ -1,0 +1,230 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app.kubernetes.io/name: kube-prometheus
+    app.kubernetes.io/part-of: kube-prometheus
+    prometheus: k8s
+    role: alert-rules
+  name: access-cluster-slo-rules
+  namespace: monitoring
+spec:
+  groups:
+  # ========================================
+  # Access the Cluster SLO Recording Rules
+  # ========================================
+  # These rules track the Errors SLO for credential operations
+  # (requestAdminCredential, revokeCredentials).
+  # SLO: 95% of credential operations should succeed (not reach "failed" terminal phase)
+  # Error Budget: 5% (1 - 0.95)
+  #
+  # Metrics are gauge-based (backend_resource_operation_phase_info) from Cosmos DB,
+  # so we use count() aggregations rather than rate() on counters.
+  #
+  # Scope: covers requestcredential and revokecredentials operations on
+  # hcpOpenShiftClusters (not nodepools).
+  - name: arohcp_access_cluster_slo_recording_rules
+    interval: 1m
+    rules:
+    # Instantaneous count of succeeded credential operations per cluster
+    - record: errors:backend_credential_operation:succeeded_total
+      expr: |
+        count by (cluster) (backend_resource_operation_phase_info{
+          resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
+          operation_type=~"requestcredential|revokecredentials",
+          phase="succeeded"
+        })
+    # Instantaneous count of all terminal credential operations per cluster
+    - record: errors:backend_credential_operation:terminal_total
+      expr: |
+        count by (cluster) (backend_resource_operation_phase_info{
+          resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
+          operation_type=~"requestcredential|revokecredentials",
+          phase=~"succeeded|failed|canceled"
+        })
+    # Instantaneous error rate per cluster: fraction of terminal operations that failed
+    - record: errors:backend_credential_operation:error_rate
+      expr: |
+        (
+          count by (cluster) (backend_resource_operation_phase_info{
+            resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
+            operation_type=~"requestcredential|revokecredentials",
+            phase="failed"
+          })
+          or
+          0 * count by (cluster) (backend_resource_operation_phase_info{
+            resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
+            operation_type=~"requestcredential|revokecredentials",
+            phase=~"succeeded|failed|canceled"
+          })
+        )
+        /
+        clamp_min(
+          count by (cluster) (backend_resource_operation_phase_info{
+            resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
+            operation_type=~"requestcredential|revokecredentials",
+            phase=~"succeeded|failed|canceled"
+          }),
+          1
+        )
+  # ========================================
+  # Access the Cluster SLO Alerts — Errors
+  # ========================================
+  # Multi-window burn-rate-style alerting adapted for gauge metrics.
+  # Naming convention: {Scope}{Subject}{Metric}{BurnRateTier} per ADR-001.
+  #
+  # Burn rate thresholds calculated from 95% SLO (5% error budget):
+  #   Fast (14.4x): 14.4 * 0.05 = 0.72 → 72% error rate
+  #   Medium (6x):  6 * 0.05 = 0.30 → 30% error rate
+  #   Slow (1x):    1 * 0.05 = 0.05 → 5% error rate
+  #
+  # The 'for' duration enforces sustained observation, approximating the
+  # short window of multi-window burn rate alerting. For gauge metrics
+  # (point-in-time state rather than event rates), this provides equivalent
+  # protection against transient spikes.
+  - name: arohcp_access_cluster_slo_error_alerts
+    rules:
+    # ----------------------------------------
+    # Fast Burn Alert (non-paging for now)
+    # ----------------------------------------
+    # 14.4x burn rate → >72% failure rate sustained for 5 minutes
+    # Would exhaust 7-day error budget in ~12 hours
+    - alert: UJAccessClusterErrors1h5m
+      expr: |
+        errors:backend_credential_operation:error_rate > 0.72
+      for: 5m
+      labels:
+        severity: info
+        slo: access-cluster-errors
+        long_window: 1h
+        short_window: 5m
+      annotations:
+        summary: "{{ $labels.cluster }}: Credential operation error rate critically high (>72%)"
+        description: "More than 72% of credential operations (requestAdminCredential/revokeCredentials) are in failed state, indicating a fast error budget burn (14.4x) that would exhaust the 95% SLO budget in ~12 hours."
+        runbook_url: "aka.ms/arohcp-runbook-access-cluster"
+    # ----------------------------------------
+    # Medium Burn Alert (non-paging for now)
+    # ----------------------------------------
+    # 6x burn rate → >30% failure rate sustained for 30 minutes
+    # Would exhaust 7-day error budget in ~28 hours
+    - alert: UJAccessClusterErrors6h30m
+      expr: |
+        errors:backend_credential_operation:error_rate > 0.30
+      for: 30m
+      labels:
+        severity: info
+        slo: access-cluster-errors
+        long_window: 6h
+        short_window: 30m
+      annotations:
+        summary: "{{ $labels.cluster }}: Credential operation error rate elevated (>30%) for 30+ minutes"
+        description: "More than 30% of credential operations are in failed state sustained over 30 minutes, indicating a medium error budget burn (6x) that would exhaust the 95% SLO budget in ~28 hours."
+        runbook_url: "aka.ms/arohcp-runbook-access-cluster"
+    # ----------------------------------------
+    # Slow Burn Alert (Sev 4 — ticket)
+    # ----------------------------------------
+    # Per ADR: slow burn alerts generate Jira ticket, not a page.
+    # 1x burn rate → >5% failure rate sustained for 6 hours
+    # Would exhaust 7-day error budget in ~7 days
+    - alert: UJAccessClusterErrors3d
+      expr: |
+        errors:backend_credential_operation:error_rate > 0.05
+      for: 6h
+      labels:
+        severity: info
+        slo: access-cluster-errors
+        long_window: 3d
+      annotations:
+        summary: "{{ $labels.cluster }}: Credential operation error rate exceeds SLO target (>5%) for 6+ hours"
+        description: "More than 5% of credential operations are in failed state sustained over 6 hours, indicating persistent degradation at the 95% SLO boundary that would exhaust the error budget in ~7 days."
+        runbook_url: "aka.ms/arohcp-runbook-access-cluster"
+    # ----------------------------------------
+    # Degradation Alert (Sev 4 — ticket)
+    # ----------------------------------------
+    # With a 95% SLO, the fast-burn threshold only fires at ~72% failure rate.
+    # This provides early warning at 15% failure rate before burn-rate alerts fire.
+    # Precursor signal → Sev 4 per ADR.
+    - alert: UJAccessClusterErrorsDegradation
+      expr: |
+        errors:backend_credential_operation:error_rate > 0.15
+      for: 30m
+      labels:
+        severity: info
+        slo: access-cluster-errors
+      annotations:
+        summary: "{{ $labels.cluster }}: Credential operation failure rate exceeds 15% for 30 minutes"
+        description: "The credential operation failure rate has been above 15% for 30 minutes. This provides early warning of degradation before SLO-based burn rate alerts fire."
+        runbook_url: "aka.ms/arohcp-runbook-access-cluster"
+    # ----------------------------------------
+    # Stuck Operations Alert
+    # ----------------------------------------
+    # Operations stuck in non-terminal phases are invisible to success/failure SLIs.
+    # Threshold: 1 hour (3600s) with 15m sustained observation.
+    # Credential operations are expected to complete faster than node pool operations
+    # (no VM provisioning), so 1 hour is appropriate (vs. 2 hours for node pools).
+    - alert: UJAccessClusterStuckOperation
+      expr: |
+        (
+          (time() - backend_resource_operation_start_time_seconds{
+            resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
+            operation_type=~"requestcredential|revokecredentials"
+          })
+          and
+          backend_resource_operation_phase_info{
+            resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
+            operation_type=~"requestcredential|revokecredentials",
+            phase=~"accepted|provisioning|deleting"
+          } == 1
+        ) > 3600
+      for: 15m
+      labels:
+        severity: info
+      annotations:
+        summary: "{{ $labels.cluster }}: Credential operation stuck in {{ $labels.phase }} for over 1 hour"
+        description: "Credential operation for {{ $labels.resource_id }} has been in {{ $labels.phase }} phase for over 1 hour. Stuck operations are invisible to success/failure SLIs and require investigation."
+        runbook_url: "aka.ms/arohcp-runbook-access-cluster"
+  # ========================================
+  # Access the Cluster Alerts — Saturation
+  # ========================================
+  # Queue depth and retry rates for credential controllers.
+  # Sev 4 (precursor).
+  - name: arohcp_access_cluster_saturation_alerts
+    rules:
+    # Queue depth: credential controller workqueue accumulating work
+    - alert: UJAccessClusterSaturationQueueDepth
+      expr: |
+        max by (name, cluster) (
+          max without(prometheus_replica) (
+            workqueue_depth{namespace="aro-hcp", name=~".*(RequestCredential|RevokeCredentials).*"}
+          )
+        ) > 10
+      for: 5m
+      labels:
+        severity: info
+      annotations:
+        summary: "{{ $labels.cluster }}: Credential controller workqueue {{ $labels.name }} depth is high"
+        description: "Credential controller workqueue {{ $labels.name }} has had a depth > 10 for more than 5 minutes, indicating work is accumulating faster than it can be processed."
+        runbook_url: "aka.ms/arohcp-runbook-access-cluster"
+    # Retry hot loop: high retry ratio on credential workqueue
+    - alert: UJAccessClusterSaturationRetryHotLoop
+      expr: |
+        (
+          sum by (name, cluster) (
+            max without(prometheus_replica) (
+              rate(workqueue_retries_total{namespace="aro-hcp", name=~".*(RequestCredential|RevokeCredentials).*"}[10m])
+            )
+          )
+          /
+          sum by (name, cluster) (
+            max without(prometheus_replica) (
+              rate(workqueue_adds_total{namespace="aro-hcp", name=~".*(RequestCredential|RevokeCredentials).*"}[10m])
+            )
+          )
+        ) > 0.5
+      for: 10m
+      labels:
+        severity: info
+      annotations:
+        summary: "{{ $labels.cluster }}: Credential controller workqueue {{ $labels.name }} retry hot loop"
+        description: "Credential controller workqueue {{ $labels.name }} has a retry ratio > 50% sustained over 10 minutes, indicating most queue activity is failed retries rather than fresh work."
+        runbook_url: "aka.ms/arohcp-runbook-access-cluster"

--- a/observability/alerts/access-cluster-slo-prometheusRule.yaml
+++ b/observability/alerts/access-cluster-slo-prometheusRule.yaml
@@ -11,63 +11,6 @@ metadata:
 spec:
   groups:
   # ========================================
-  # Access the Cluster SLO Recording Rules
-  # ========================================
-  # These rules track the Errors SLO for credential operations
-  # (operation_type: requestcredential, revokecredentials).
-  # SLO: 95% of credential operations should succeed (not reach "failed" terminal phase)
-  # Error Budget: 5% (1 - 0.95)
-  #
-  # Metrics are gauge-based (backend_resource_operation_phase_info) from Cosmos DB,
-  # so we use count() aggregations rather than rate() on counters.
-  #
-  # Scope: covers requestcredential and revokecredentials operations on
-  # hcpOpenShiftClusters (not nodepools).
-  - name: arohcp_access_cluster_slo_recording_rules
-    interval: 1m
-    rules:
-    # Instantaneous count of succeeded credential operations per cluster
-    - record: errors:backend_credential_operation:succeeded_total
-      expr: |
-        count by (cluster) (backend_resource_operation_phase_info{
-          resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
-          operation_type=~"requestcredential|revokecredentials",
-          phase="succeeded"
-        })
-    # Instantaneous count of all terminal credential operations per cluster
-    - record: errors:backend_credential_operation:terminal_total
-      expr: |
-        count by (cluster) (backend_resource_operation_phase_info{
-          resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
-          operation_type=~"requestcredential|revokecredentials",
-          phase=~"succeeded|failed|canceled"
-        })
-    # Instantaneous error rate per cluster: fraction of terminal operations that failed
-    - record: errors:backend_credential_operation:error_rate
-      expr: |
-        (
-          count by (cluster) (backend_resource_operation_phase_info{
-            resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
-            operation_type=~"requestcredential|revokecredentials",
-            phase="failed"
-          })
-          or
-          0 * count by (cluster) (backend_resource_operation_phase_info{
-            resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
-            operation_type=~"requestcredential|revokecredentials",
-            phase=~"succeeded|failed|canceled"
-          })
-        )
-        /
-        clamp_min(
-          count by (cluster) (backend_resource_operation_phase_info{
-            resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
-            operation_type=~"requestcredential|revokecredentials",
-            phase=~"succeeded|failed|canceled"
-          }),
-          1
-        )
-  # ========================================
   # Access the Cluster SLO Alerts — Errors
   # ========================================
   # Multi-window burn-rate-style alerting adapted for gauge metrics.
@@ -89,7 +32,7 @@ spec:
     # ----------------------------------------
     # 14.4x burn rate → >72% failure rate sustained for 5 minutes
     # Would exhaust 7-day error budget in ~12 hours
-    - alert: UJAccessClusterErrors1h5m
+    - alert: userJourneyAccessClusterErrors1h5m
       expr: |
         errors:backend_credential_operation:error_rate > 0.72
       for: 5m
@@ -107,7 +50,7 @@ spec:
     # ----------------------------------------
     # 6x burn rate → >30% failure rate sustained for 30 minutes
     # Would exhaust 7-day error budget in ~28 hours
-    - alert: UJAccessClusterErrors6h30m
+    - alert: userJourneyAccessClusterErrors6h30m
       expr: |
         errors:backend_credential_operation:error_rate > 0.30
       for: 30m
@@ -126,7 +69,7 @@ spec:
     # Per ADR: slow burn alerts generate Jira ticket, not a page.
     # 1x burn rate → >5% failure rate sustained for 6 hours
     # Would exhaust 7-day error budget in ~7 days
-    - alert: UJAccessClusterErrors3d
+    - alert: userJourneyAccessClusterErrors3d
       expr: |
         errors:backend_credential_operation:error_rate > 0.05
       for: 6h
@@ -144,7 +87,7 @@ spec:
     # With a 95% SLO, the fast-burn threshold only fires at ~72% failure rate.
     # This provides early warning at 15% failure rate before burn-rate alerts fire.
     # Precursor signal → Sev 4 per ADR.
-    - alert: UJAccessClusterErrorsDegradation
+    - alert: userJourneyAccessClusterErrorsDegradation
       expr: |
         errors:backend_credential_operation:error_rate > 0.15
       for: 30m
@@ -162,7 +105,7 @@ spec:
     # Threshold: 1 hour (3600s) with 15m sustained observation.
     # Credential operations are expected to complete faster than node pool operations
     # (no VM provisioning), so 1 hour is appropriate (vs. 2 hours for node pools).
-    - alert: UJAccessClusterStuckOperation
+    - alert: userJourneyAccessClusterStuckOperation
       expr: |
         (
           (time() - backend_resource_operation_start_time_seconds{
@@ -191,7 +134,7 @@ spec:
   - name: arohcp_access_cluster_saturation_alerts
     rules:
     # Queue depth: credential controller workqueue accumulating work
-    - alert: UJAccessClusterSaturationQueueDepth
+    - alert: userJourneyAccessClusterSaturationQueueDepth
       expr: |
         max by (name, cluster) (
           max without(prometheus_replica) (
@@ -206,7 +149,7 @@ spec:
         description: "Credential controller workqueue {{ $labels.name }} has had a depth > 10 for more than 5 minutes, indicating work is accumulating faster than it can be processed."
         runbook_url: "aka.ms/arohcp-runbook-access-cluster"
     # Retry hot loop: high retry ratio on credential workqueue
-    - alert: UJAccessClusterSaturationRetryHotLoop
+    - alert: userJourneyAccessClusterSaturationRetryHotLoop
       expr: |
         (
           sum by (name, cluster) (

--- a/observability/alerts/access-cluster-slo-prometheusRule_test.yaml
+++ b/observability/alerts/access-cluster-slo-prometheusRule_test.yaml
@@ -104,7 +104,7 @@ tests:
         short_window: 5m
       exp_annotations:
         summary: "mgmt-1: Credential operation error rate critically high (>72%)"
-        description: "More than 72% of credential operations (requestAdminCredential/revokeCredentials) are in failed state, indicating a fast error budget burn (14.4x) that would exhaust the 95% SLO budget in ~12 hours."
+        description: "More than 72% of credential operations (requestcredential/revokecredentials) are in failed state, indicating a fast error budget burn (14.4x) that would exhaust the 95% SLO budget in ~12 hours."
         runbook_url: "aka.ms/arohcp-runbook-access-cluster"
   # Degradation also fires (15% threshold met at 80%)
   - eval_time: 35m

--- a/observability/alerts/access-cluster-slo-prometheusRule_test.yaml
+++ b/observability/alerts/access-cluster-slo-prometheusRule_test.yaml
@@ -1,5 +1,6 @@
 rule_files:
 - access-cluster-slo-prometheusRule.yaml
+- access-cluster-slo-recordingRule.yaml
 evaluation_interval: 1m
 tests:
 # ========================================
@@ -49,18 +50,18 @@ tests:
       value: 0
   alert_rule_test:
   - eval_time: 10m
-    alertname: UJAccessClusterErrors1h5m
+    alertname: userJourneyAccessClusterErrors1h5m
   - eval_time: 10m
-    alertname: UJAccessClusterErrors6h30m
+    alertname: userJourneyAccessClusterErrors6h30m
   - eval_time: 10m
-    alertname: UJAccessClusterErrors3d
+    alertname: userJourneyAccessClusterErrors3d
   - eval_time: 10m
-    alertname: UJAccessClusterErrorsDegradation
+    alertname: userJourneyAccessClusterErrorsDegradation
 # ========================================
-# Test 2: Fast burn — 80% failure rate, UJAccessClusterErrors1h5m fires
+# Test 2: Fast burn — 80% failure rate, userJourneyAccessClusterErrors1h5m fires
 # ========================================
 # 2 succeeded, 8 failed → error rate = 80% > 72% threshold (14.4x burn)
-# Both UJAccessClusterErrors1h5m and UJAccessClusterErrorsDegradation should fire.
+# Both userJourneyAccessClusterErrors1h5m and userJourneyAccessClusterErrorsDegradation should fire.
 - interval: 1m
   input_series:
   # 2 succeeded
@@ -94,7 +95,7 @@ tests:
   alert_rule_test:
   # Fast burn fires after 5m 'for' duration
   - eval_time: 7m
-    alertname: UJAccessClusterErrors1h5m
+    alertname: userJourneyAccessClusterErrors1h5m
     exp_alerts:
     - exp_labels:
         cluster: "mgmt-1"
@@ -108,7 +109,7 @@ tests:
         runbook_url: "aka.ms/arohcp-runbook-access-cluster"
   # Degradation also fires (15% threshold met at 80%)
   - eval_time: 35m
-    alertname: UJAccessClusterErrorsDegradation
+    alertname: userJourneyAccessClusterErrorsDegradation
     exp_alerts:
     - exp_labels:
         cluster: "mgmt-1"
@@ -156,10 +157,10 @@ tests:
   alert_rule_test:
   # Fast burn should NOT fire (20% < 72%)
   - eval_time: 10m
-    alertname: UJAccessClusterErrors1h5m
+    alertname: userJourneyAccessClusterErrors1h5m
   # Degradation fires after 30m (20% > 15%)
   - eval_time: 35m
-    alertname: UJAccessClusterErrorsDegradation
+    alertname: userJourneyAccessClusterErrorsDegradation
     exp_alerts:
     - exp_labels:
         cluster: "mgmt-1"
@@ -184,7 +185,7 @@ tests:
   alert_rule_test:
   # At 90m (5400s), time() - 0 = 5400 > 3600, and for: 15m is satisfied
   - eval_time: 90m
-    alertname: UJAccessClusterStuckOperation
+    alertname: userJourneyAccessClusterStuckOperation
     exp_alerts:
     - exp_labels:
         resource_id: "/sub/3/cluster/stuck"
@@ -211,7 +212,7 @@ tests:
     values: "1+0x55"
   alert_rule_test:
   - eval_time: 50m
-    alertname: UJAccessClusterStuckOperation
+    alertname: userJourneyAccessClusterStuckOperation
 # ========================================
 # Test 6: Zero failure rate — all succeeded, no alerts
 # ========================================
@@ -231,11 +232,11 @@ tests:
     values: "1+0x15"
   alert_rule_test:
   - eval_time: 10m
-    alertname: UJAccessClusterErrors1h5m
+    alertname: userJourneyAccessClusterErrors1h5m
   - eval_time: 10m
-    alertname: UJAccessClusterErrors6h30m
+    alertname: userJourneyAccessClusterErrors6h30m
   - eval_time: 10m
-    alertname: UJAccessClusterErrorsDegradation
+    alertname: userJourneyAccessClusterErrorsDegradation
 # ========================================
 # Test 7: Queue depth — credential controller workqueue exceeds threshold
 # ========================================
@@ -245,7 +246,7 @@ tests:
     values: "15+0x10"
   alert_rule_test:
   - eval_time: 7m
-    alertname: UJAccessClusterSaturationQueueDepth
+    alertname: userJourneyAccessClusterSaturationQueueDepth
     exp_alerts:
     - exp_labels:
         name: "OperationRequestCredential"
@@ -264,7 +265,7 @@ tests:
     values: "5+0x10"
   alert_rule_test:
   - eval_time: 7m
-    alertname: UJAccessClusterSaturationQueueDepth
+    alertname: userJourneyAccessClusterSaturationQueueDepth
 # ========================================
 # Test 9: Retry hot loop — retry ratio > 50%
 # ========================================
@@ -276,7 +277,7 @@ tests:
     values: "0+100x25"
   alert_rule_test:
   - eval_time: 22m
-    alertname: UJAccessClusterSaturationRetryHotLoop
+    alertname: userJourneyAccessClusterSaturationRetryHotLoop
     exp_alerts:
     - exp_labels:
         name: "OperationRequestCredential"
@@ -297,7 +298,7 @@ tests:
     values: "0+100x25"
   alert_rule_test:
   - eval_time: 22m
-    alertname: UJAccessClusterSaturationRetryHotLoop
+    alertname: userJourneyAccessClusterSaturationRetryHotLoop
 # ========================================
 # Test 11: Mixed operation types — requestcredential and revokecredentials both tracked
 # ========================================
@@ -350,7 +351,7 @@ tests:
   alert_rule_test:
   # 50% > 30% → medium burn fires after 30m
   - eval_time: 35m
-    alertname: UJAccessClusterErrors6h30m
+    alertname: userJourneyAccessClusterErrors6h30m
     exp_alerts:
     - exp_labels:
         cluster: "mgmt-1"
@@ -364,7 +365,7 @@ tests:
         runbook_url: "aka.ms/arohcp-runbook-access-cluster"
   # 50% < 72% → fast burn should NOT fire
   - eval_time: 35m
-    alertname: UJAccessClusterErrors1h5m
+    alertname: userJourneyAccessClusterErrors1h5m
 # ========================================
 # Test 12: Stuck revokecredentials operation in "deleting" for > 1 hour
 # ========================================
@@ -377,7 +378,7 @@ tests:
     values: "1+0x95"
   alert_rule_test:
   - eval_time: 90m
-    alertname: UJAccessClusterStuckOperation
+    alertname: userJourneyAccessClusterStuckOperation
     exp_alerts:
     - exp_labels:
         resource_id: "/sub/7/cluster/stuck-revoke"

--- a/observability/alerts/access-cluster-slo-prometheusRule_test.yaml
+++ b/observability/alerts/access-cluster-slo-prometheusRule_test.yaml
@@ -1,0 +1,393 @@
+rule_files:
+- access-cluster-slo-prometheusRule.yaml
+evaluation_interval: 1m
+tests:
+# ========================================
+# Test 1: Normal operation — all operations succeeded, no alerts
+# ========================================
+# 10 credential operations in "succeeded" phase, 0 in "failed".
+# Error rate = 0%, well below 95% SLO. No alerts should fire.
+- interval: 1m
+  input_series:
+  # 5 succeeded requestcredential operations
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/a", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="requestcredential", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x70"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/b", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="requestcredential", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x70"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/c", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="requestcredential", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x70"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/d", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="requestcredential", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x70"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/e", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="requestcredential", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x70"
+  # 5 succeeded revokecredentials operations
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/f", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="revokecredentials", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x70"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/g", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="revokecredentials", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x70"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/h", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="revokecredentials", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x70"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/i", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="revokecredentials", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x70"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/j", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="revokecredentials", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x70"
+  promql_expr_test:
+  - expr: errors:backend_credential_operation:succeeded_total
+    eval_time: 10m
+    exp_samples:
+    - labels: 'errors:backend_credential_operation:succeeded_total{cluster="mgmt-1"}'
+      value: 10
+  - expr: errors:backend_credential_operation:terminal_total
+    eval_time: 10m
+    exp_samples:
+    - labels: 'errors:backend_credential_operation:terminal_total{cluster="mgmt-1"}'
+      value: 10
+  - expr: errors:backend_credential_operation:error_rate
+    eval_time: 10m
+    exp_samples:
+    - labels: 'errors:backend_credential_operation:error_rate{cluster="mgmt-1"}'
+      value: 0
+  alert_rule_test:
+  - eval_time: 10m
+    alertname: UJAccessClusterErrors1h5m
+  - eval_time: 10m
+    alertname: UJAccessClusterErrors6h30m
+  - eval_time: 10m
+    alertname: UJAccessClusterErrors3d
+  - eval_time: 10m
+    alertname: UJAccessClusterErrorsDegradation
+# ========================================
+# Test 2: Fast burn — 80% failure rate, UJAccessClusterErrors1h5m fires
+# ========================================
+# 2 succeeded, 8 failed → error rate = 80% > 72% threshold (14.4x burn)
+# Both UJAccessClusterErrors1h5m and UJAccessClusterErrorsDegradation should fire.
+- interval: 1m
+  input_series:
+  # 2 succeeded
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/a", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="requestcredential", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/b", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="revokecredentials", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x40"
+  # 8 failed
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/c", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="requestcredential", phase="failed", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/d", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="requestcredential", phase="failed", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/e", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="requestcredential", phase="failed", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/f", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="revokecredentials", phase="failed", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/g", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="requestcredential", phase="failed", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/h", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="requestcredential", phase="failed", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/i", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="requestcredential", phase="failed", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/j", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="requestcredential", phase="failed", cluster="mgmt-1"}'
+    values: "1+0x40"
+  promql_expr_test:
+  - expr: errors:backend_credential_operation:error_rate
+    eval_time: 10m
+    exp_samples:
+    - labels: 'errors:backend_credential_operation:error_rate{cluster="mgmt-1"}'
+      value: 0.8
+  alert_rule_test:
+  # Fast burn fires after 5m 'for' duration
+  - eval_time: 7m
+    alertname: UJAccessClusterErrors1h5m
+    exp_alerts:
+    - exp_labels:
+        cluster: "mgmt-1"
+        severity: info
+        slo: access-cluster-errors
+        long_window: 1h
+        short_window: 5m
+      exp_annotations:
+        summary: "mgmt-1: Credential operation error rate critically high (>72%)"
+        description: "More than 72% of credential operations (requestAdminCredential/revokeCredentials) are in failed state, indicating a fast error budget burn (14.4x) that would exhaust the 95% SLO budget in ~12 hours."
+        runbook_url: "aka.ms/arohcp-runbook-access-cluster"
+  # Degradation also fires (15% threshold met at 80%)
+  - eval_time: 35m
+    alertname: UJAccessClusterErrorsDegradation
+    exp_alerts:
+    - exp_labels:
+        cluster: "mgmt-1"
+        severity: info
+        slo: access-cluster-errors
+      exp_annotations:
+        summary: "mgmt-1: Credential operation failure rate exceeds 15% for 30 minutes"
+        description: "The credential operation failure rate has been above 15% for 30 minutes. This provides early warning of degradation before SLO-based burn rate alerts fire."
+        runbook_url: "aka.ms/arohcp-runbook-access-cluster"
+# ========================================
+# Test 3: Degradation — 20% failure rate, only degradation alert fires
+# ========================================
+# 8 succeeded, 2 failed → error rate = 20%
+# > 15% (degradation) but < 30% (medium burn) and < 72% (fast burn)
+- interval: 1m
+  input_series:
+  # 8 succeeded
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/2/cluster/a", subscription_id="sub-2", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="requestcredential", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/2/cluster/b", subscription_id="sub-2", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="requestcredential", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/2/cluster/c", subscription_id="sub-2", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="revokecredentials", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/2/cluster/d", subscription_id="sub-2", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="requestcredential", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/2/cluster/e", subscription_id="sub-2", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="requestcredential", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/2/cluster/f", subscription_id="sub-2", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="requestcredential", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/2/cluster/g", subscription_id="sub-2", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="revokecredentials", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/2/cluster/h", subscription_id="sub-2", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="requestcredential", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x40"
+  # 2 failed
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/2/cluster/i", subscription_id="sub-2", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="requestcredential", phase="failed", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/2/cluster/j", subscription_id="sub-2", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="revokecredentials", phase="failed", cluster="mgmt-1"}'
+    values: "1+0x40"
+  promql_expr_test:
+  - expr: errors:backend_credential_operation:error_rate
+    eval_time: 10m
+    exp_samples:
+    - labels: 'errors:backend_credential_operation:error_rate{cluster="mgmt-1"}'
+      value: 0.2
+  alert_rule_test:
+  # Fast burn should NOT fire (20% < 72%)
+  - eval_time: 10m
+    alertname: UJAccessClusterErrors1h5m
+  # Degradation fires after 30m (20% > 15%)
+  - eval_time: 35m
+    alertname: UJAccessClusterErrorsDegradation
+    exp_alerts:
+    - exp_labels:
+        cluster: "mgmt-1"
+        severity: info
+        slo: access-cluster-errors
+      exp_annotations:
+        summary: "mgmt-1: Credential operation failure rate exceeds 15% for 30 minutes"
+        description: "The credential operation failure rate has been above 15% for 30 minutes. This provides early warning of degradation before SLO-based burn rate alerts fire."
+        runbook_url: "aka.ms/arohcp-runbook-access-cluster"
+# ========================================
+# Test 4: Stuck operation — requestcredential in "accepted" for > 1 hour
+# ========================================
+# start_time is 0 (epoch). At eval_time=90m (5400s), delta = 5400 > 3600 threshold.
+# The alert has for: 15m, so it fires after the threshold is crossed for 15 minutes.
+# Threshold crossed at 60m, plus 15m for duration = 75m. Eval at 90m confirms firing.
+- interval: 1m
+  input_series:
+  - series: 'backend_resource_operation_start_time_seconds{resource_id="/sub/3/cluster/stuck", subscription_id="sub-3", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="requestcredential", phase="accepted", cluster="mgmt-1"}'
+    values: "0+0x95"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/3/cluster/stuck", subscription_id="sub-3", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="requestcredential", phase="accepted", cluster="mgmt-1"}'
+    values: "1+0x95"
+  alert_rule_test:
+  # At 90m (5400s), time() - 0 = 5400 > 3600, and for: 15m is satisfied
+  - eval_time: 90m
+    alertname: UJAccessClusterStuckOperation
+    exp_alerts:
+    - exp_labels:
+        resource_id: "/sub/3/cluster/stuck"
+        subscription_id: "sub-3"
+        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters"
+        operation_type: "requestcredential"
+        phase: "accepted"
+        cluster: "mgmt-1"
+        severity: info
+      exp_annotations:
+        summary: "mgmt-1: Credential operation stuck in accepted for over 1 hour"
+        description: "Credential operation for /sub/3/cluster/stuck has been in accepted phase for over 1 hour. Stuck operations are invisible to success/failure SLIs and require investigation."
+        runbook_url: "aka.ms/arohcp-runbook-access-cluster"
+# ========================================
+# Test 5: No stuck operation — requestcredential in "provisioning" for < 1 hour
+# ========================================
+# Operation started recently, should not trigger stuck alert.
+- interval: 1m
+  input_series:
+  # start_time=600 (recent). At eval_time=50m, time()=3000. delta=2400 < 3600.
+  - series: 'backend_resource_operation_start_time_seconds{resource_id="/sub/4/cluster/recent", subscription_id="sub-4", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="requestcredential", phase="provisioning", cluster="mgmt-1"}'
+    values: "600+0x55"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/4/cluster/recent", subscription_id="sub-4", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="requestcredential", phase="provisioning", cluster="mgmt-1"}'
+    values: "1+0x55"
+  alert_rule_test:
+  - eval_time: 50m
+    alertname: UJAccessClusterStuckOperation
+# ========================================
+# Test 6: Zero failure rate — all succeeded, no alerts
+# ========================================
+# 5 succeeded, 0 failed → error rate = 0%
+# No alerts should fire (well below all thresholds).
+- interval: 1m
+  input_series:
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/5/cluster/a", subscription_id="sub-5", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="requestcredential", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/5/cluster/b", subscription_id="sub-5", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="revokecredentials", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/5/cluster/c", subscription_id="sub-5", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="requestcredential", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/5/cluster/d", subscription_id="sub-5", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="requestcredential", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/5/cluster/e", subscription_id="sub-5", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="revokecredentials", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x15"
+  alert_rule_test:
+  - eval_time: 10m
+    alertname: UJAccessClusterErrors1h5m
+  - eval_time: 10m
+    alertname: UJAccessClusterErrors6h30m
+  - eval_time: 10m
+    alertname: UJAccessClusterErrorsDegradation
+# ========================================
+# Test 7: Queue depth — credential controller workqueue exceeds threshold
+# ========================================
+- interval: 1m
+  input_series:
+  - series: 'workqueue_depth{namespace="aro-hcp", name="OperationRequestCredential", cluster="mgmt-1"}'
+    values: "15+0x10"
+  alert_rule_test:
+  - eval_time: 7m
+    alertname: UJAccessClusterSaturationQueueDepth
+    exp_alerts:
+    - exp_labels:
+        name: "OperationRequestCredential"
+        cluster: "mgmt-1"
+        severity: info
+      exp_annotations:
+        summary: "mgmt-1: Credential controller workqueue OperationRequestCredential depth is high"
+        description: "Credential controller workqueue OperationRequestCredential has had a depth > 10 for more than 5 minutes, indicating work is accumulating faster than it can be processed."
+        runbook_url: "aka.ms/arohcp-runbook-access-cluster"
+# ========================================
+# Test 8: Queue depth normal — below threshold, no alert
+# ========================================
+- interval: 1m
+  input_series:
+  - series: 'workqueue_depth{namespace="aro-hcp", name="OperationRequestCredential", cluster="mgmt-1"}'
+    values: "5+0x10"
+  alert_rule_test:
+  - eval_time: 7m
+    alertname: UJAccessClusterSaturationQueueDepth
+# ========================================
+# Test 9: Retry hot loop — retry ratio > 50%
+# ========================================
+- interval: 1m
+  input_series:
+  - series: 'workqueue_retries_total{namespace="aro-hcp", name="OperationRequestCredential", cluster="mgmt-1"}'
+    values: "0+80x25"
+  - series: 'workqueue_adds_total{namespace="aro-hcp", name="OperationRequestCredential", cluster="mgmt-1"}'
+    values: "0+100x25"
+  alert_rule_test:
+  - eval_time: 22m
+    alertname: UJAccessClusterSaturationRetryHotLoop
+    exp_alerts:
+    - exp_labels:
+        name: "OperationRequestCredential"
+        cluster: "mgmt-1"
+        severity: info
+      exp_annotations:
+        summary: "mgmt-1: Credential controller workqueue OperationRequestCredential retry hot loop"
+        description: "Credential controller workqueue OperationRequestCredential has a retry ratio > 50% sustained over 10 minutes, indicating most queue activity is failed retries rather than fresh work."
+        runbook_url: "aka.ms/arohcp-runbook-access-cluster"
+# ========================================
+# Test 10: Retry hot loop — low retry ratio, no alert
+# ========================================
+- interval: 1m
+  input_series:
+  - series: 'workqueue_retries_total{namespace="aro-hcp", name="OperationRequestCredential", cluster="mgmt-1"}'
+    values: "0+10x25"
+  - series: 'workqueue_adds_total{namespace="aro-hcp", name="OperationRequestCredential", cluster="mgmt-1"}'
+    values: "0+100x25"
+  alert_rule_test:
+  - eval_time: 22m
+    alertname: UJAccessClusterSaturationRetryHotLoop
+# ========================================
+# Test 11: Mixed operation types — requestcredential and revokecredentials both tracked
+# ========================================
+# Verifies both operation types are captured by the regex filter.
+# 3 succeeded requestcredential, 2 succeeded revokecredentials,
+# 3 failed requestcredential, 2 failed revokecredentials
+# → error rate = 5/10 = 50%
+- interval: 1m
+  input_series:
+  # 3 succeeded requestcredential
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/6/cluster/a", subscription_id="sub-6", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="requestcredential", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/6/cluster/b", subscription_id="sub-6", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="requestcredential", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/6/cluster/c", subscription_id="sub-6", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="requestcredential", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x40"
+  # 2 succeeded revokecredentials
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/6/cluster/d", subscription_id="sub-6", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="revokecredentials", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/6/cluster/e", subscription_id="sub-6", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="revokecredentials", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x40"
+  # 3 failed requestcredential
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/6/cluster/f", subscription_id="sub-6", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="requestcredential", phase="failed", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/6/cluster/g", subscription_id="sub-6", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="requestcredential", phase="failed", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/6/cluster/h", subscription_id="sub-6", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="requestcredential", phase="failed", cluster="mgmt-1"}'
+    values: "1+0x40"
+  # 2 failed revokecredentials
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/6/cluster/i", subscription_id="sub-6", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="revokecredentials", phase="failed", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/6/cluster/j", subscription_id="sub-6", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="revokecredentials", phase="failed", cluster="mgmt-1"}'
+    values: "1+0x40"
+  promql_expr_test:
+  - expr: errors:backend_credential_operation:error_rate
+    eval_time: 10m
+    exp_samples:
+    - labels: 'errors:backend_credential_operation:error_rate{cluster="mgmt-1"}'
+      value: 0.5
+  - expr: errors:backend_credential_operation:succeeded_total
+    eval_time: 10m
+    exp_samples:
+    - labels: 'errors:backend_credential_operation:succeeded_total{cluster="mgmt-1"}'
+      value: 5
+  - expr: errors:backend_credential_operation:terminal_total
+    eval_time: 10m
+    exp_samples:
+    - labels: 'errors:backend_credential_operation:terminal_total{cluster="mgmt-1"}'
+      value: 10
+  alert_rule_test:
+  # 50% > 30% → medium burn fires after 30m
+  - eval_time: 35m
+    alertname: UJAccessClusterErrors6h30m
+    exp_alerts:
+    - exp_labels:
+        cluster: "mgmt-1"
+        severity: info
+        slo: access-cluster-errors
+        long_window: 6h
+        short_window: 30m
+      exp_annotations:
+        summary: "mgmt-1: Credential operation error rate elevated (>30%) for 30+ minutes"
+        description: "More than 30% of credential operations are in failed state sustained over 30 minutes, indicating a medium error budget burn (6x) that would exhaust the 95% SLO budget in ~28 hours."
+        runbook_url: "aka.ms/arohcp-runbook-access-cluster"
+  # 50% < 72% → fast burn should NOT fire
+  - eval_time: 35m
+    alertname: UJAccessClusterErrors1h5m
+# ========================================
+# Test 12: Stuck revokecredentials operation in "deleting" for > 1 hour
+# ========================================
+# Verifies that revokecredentials operations stuck in "deleting" also trigger the alert.
+- interval: 1m
+  input_series:
+  - series: 'backend_resource_operation_start_time_seconds{resource_id="/sub/7/cluster/stuck-revoke", subscription_id="sub-7", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="revokecredentials", phase="deleting", cluster="mgmt-1"}'
+    values: "0+0x95"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/7/cluster/stuck-revoke", subscription_id="sub-7", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="revokecredentials", phase="deleting", cluster="mgmt-1"}'
+    values: "1+0x95"
+  alert_rule_test:
+  - eval_time: 90m
+    alertname: UJAccessClusterStuckOperation
+    exp_alerts:
+    - exp_labels:
+        resource_id: "/sub/7/cluster/stuck-revoke"
+        subscription_id: "sub-7"
+        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters"
+        operation_type: "revokecredentials"
+        phase: "deleting"
+        cluster: "mgmt-1"
+        severity: info
+      exp_annotations:
+        summary: "mgmt-1: Credential operation stuck in deleting for over 1 hour"
+        description: "Credential operation for /sub/7/cluster/stuck-revoke has been in deleting phase for over 1 hour. Stuck operations are invisible to success/failure SLIs and require investigation."
+        runbook_url: "aka.ms/arohcp-runbook-access-cluster"

--- a/observability/recording-rules-services.yaml
+++ b/observability/recording-rules-services.yaml
@@ -1,4 +1,5 @@
 prometheusRules:
   rulesFolders: []
-  untestedRules: []
+  untestedRules:
+  - recording-rules/access-cluster-slo-recordingRule.yaml
   outputBicep: ../dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep

--- a/observability/recording-rules-services.yaml
+++ b/observability/recording-rules-services.yaml
@@ -1,5 +1,5 @@
 prometheusRules:
-  rulesFolders: []
-  untestedRules:
+  rulesFolders:
   - recording-rules/access-cluster-slo-recordingRule.yaml
+  untestedRules: []
   outputBicep: ../dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep

--- a/observability/recording-rules/access-cluster-slo-recordingRule.yaml
+++ b/observability/recording-rules/access-cluster-slo-recordingRule.yaml
@@ -1,0 +1,69 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app.kubernetes.io/name: kube-prometheus
+    app.kubernetes.io/part-of: kube-prometheus
+    prometheus: k8s
+    role: recording-rules
+  name: access-cluster-slo-recording-rules
+  namespace: monitoring
+spec:
+  groups:
+  # ========================================
+  # Access the Cluster SLO Recording Rules
+  # ========================================
+  # These rules track the Errors SLO for credential operations
+  # (operation_type: requestcredential, revokecredentials).
+  # SLO: 95% of credential operations should succeed (not reach "failed" terminal phase)
+  # Error Budget: 5% (1 - 0.95)
+  #
+  # Metrics are gauge-based (backend_resource_operation_phase_info) from Cosmos DB,
+  # so we use count() aggregations rather than rate() on counters.
+  #
+  # Scope: covers requestcredential and revokecredentials operations on
+  # hcpOpenShiftClusters (not nodepools).
+  - name: arohcp_access_cluster_slo_recording_rules
+    interval: 1m
+    rules:
+    # Instantaneous count of succeeded credential operations per cluster
+    - record: errors:backend_credential_operation:succeeded_total
+      expr: |
+        count by (cluster) (backend_resource_operation_phase_info{
+          resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
+          operation_type=~"requestcredential|revokecredentials",
+          phase="succeeded"
+        })
+    # Instantaneous count of all terminal credential operations per cluster
+    - record: errors:backend_credential_operation:terminal_total
+      expr: |
+        count by (cluster) (backend_resource_operation_phase_info{
+          resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
+          operation_type=~"requestcredential|revokecredentials",
+          phase=~"succeeded|failed|canceled"
+        })
+    # Instantaneous error rate per cluster: fraction of terminal operations that failed
+    - record: errors:backend_credential_operation:error_rate
+      expr: |
+        (
+          count by (cluster) (backend_resource_operation_phase_info{
+            resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
+            operation_type=~"requestcredential|revokecredentials",
+            phase="failed"
+          })
+          or
+          0 * count by (cluster) (backend_resource_operation_phase_info{
+            resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
+            operation_type=~"requestcredential|revokecredentials",
+            phase=~"succeeded|failed|canceled"
+          })
+        )
+        /
+        clamp_min(
+          count by (cluster) (backend_resource_operation_phase_info{
+            resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
+            operation_type=~"requestcredential|revokecredentials",
+            phase=~"succeeded|failed|canceled"
+          }),
+          1
+        )

--- a/observability/recording-rules/access-cluster-slo-recordingRule_test.yaml
+++ b/observability/recording-rules/access-cluster-slo-recordingRule_test.yaml
@@ -1,0 +1,44 @@
+rule_files:
+- access-cluster-slo-recordingRule.yaml
+evaluation_interval: 1m
+tests:
+# Verify recording rules produce expected output from input series
+- interval: 1m
+  input_series:
+  # 8 succeeded, 2 failed credential operations
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/a", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="requestcredential", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/b", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="requestcredential", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/c", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="requestcredential", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/d", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="requestcredential", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/e", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="revokecredentials", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/f", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="revokecredentials", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/g", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="revokecredentials", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/h", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="revokecredentials", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/i", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="requestcredential", phase="failed", cluster="mgmt-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/j", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="revokecredentials", phase="failed", cluster="mgmt-1"}'
+    values: "1+0x15"
+  promql_expr_test:
+  - expr: "errors:backend_credential_operation:succeeded_total"
+    eval_time: 5m
+    exp_samples:
+    - labels: 'errors:backend_credential_operation:succeeded_total{cluster="mgmt-1"}'
+      value: 8
+  - expr: "errors:backend_credential_operation:terminal_total"
+    eval_time: 5m
+    exp_samples:
+    - labels: 'errors:backend_credential_operation:terminal_total{cluster="mgmt-1"}'
+      value: 10
+  - expr: "errors:backend_credential_operation:error_rate"
+    eval_time: 5m
+    exp_samples:
+    - labels: 'errors:backend_credential_operation:error_rate{cluster="mgmt-1"}'
+      value: 0.2


### PR DESCRIPTION
## Summary

- Adds Prometheus recording rules and MWMBR alert rules for the **Access the Cluster** user journey (credential operations: `requestcredential`, `revokecredentials`)
- 3 recording rules: `errors:backend_credential_operation:{succeeded_total,terminal_total,error_rate}`
- 7 alert rules following ADR naming convention (`userJourney` prefix per #5765):
  - 4 error burn-rate alerts: `userJourneyAccessClusterErrors{1h5m,6h30m,3d}` + `userJourneyAccessClusterErrorsDegradation`
  - 1 stuck operation alert: `userJourneyAccessClusterStuckOperation` (>1h threshold — credential ops are faster than node pool ops, so 1h vs 2h)
  - 2 saturation alerts: `userJourneyAccessClusterSaturation{QueueDepth,RetryHotLoop}` for credential controllers
- 12 promtool tests covering normal operation, fast/medium burn, degradation, stuck ops (both requestcredential and revokecredentials), queue depth, retry ratio, mixed operation types
- Recording rules in separate file (`observability/recording-rules/access-cluster-slo-recordingRule.yaml`) with own test file
- Registered in `alerts-rp-services.yaml` (fleet-aggregate lane) and `recording-rules-services.yaml`
- Generated Bicep (`generatedRPPrometheusAlertingRules.bicep`, `generatedRecordingRules.bicep`) committed

## Metrics used

| Metric | Filters |
| --- | --- |
| `backend_resource_operation_phase_info` | `operation_type=requestcredential\|revokecredentials`, `resource_type=microsoft.redhatopenshift/hcpopenshiftclusters` |
| `backend_resource_operation_start_time_seconds` | same as above |
| `workqueue_depth` | `namespace=aro-hcp`, `name=~.*(RequestCredential\|RevokeCredentials).*` |
| `workqueue_retries_total` / `workqueue_adds_total` | same as above |

## SLO Design

- **SLO target**: 95% of credential operations succeed (5% error budget)
- **Burn rate tiers**: Fast (14.4x, >72%, 5m), Medium (6x, >30%, 30m), Slow (1x, >5%, 6h)
- **Stuck threshold**: 1 hour (vs 2h for node pools — credential ops don't involve VM provisioning)
- Follows [ARO HCP Alerting Recommendation ADR](https://github.com/openshift-online/architecture/pull/79)

## Jira

- [ARO-26192](https://redhat.atlassian.net/browse/ARO-26192) — Alerting
- Parent epic: [ARO-26180](https://redhat.atlassian.net/browse/ARO-26180) — Refactor UJ Runbook: Access the cluster

## Checklist

- [x] MWMBR alerts for Errors SLI (4 tiers)
- [x] Alert names follow `userJourney{Subject}{Metric}{BurnRateTier}` convention per #5765
- [x] promtool test file with 12 passing test cases
- [x] Each alert links to runbook via `runbook_url`
- [x] Recording rules in separate file with own tests
- [x] Registered in correct lane configs (`alerts-rp-services.yaml`, `recording-rules-services.yaml`)
- [x] Generated Bicep committed