### PR TITLE
fix: ToServiceProviderNodePoolResourceIDString embedded provider name…

### DIFF
--- a/internal/api/types_cosmosdata.go
+++ b/internal/api/types_cosmosdata.go
@@ -25,6 +25,13 @@ import (
 
 type CosmosMetadata = arm.CosmosMetadata
 
+// The ToXxxResourceIDString helpers form ARM resource ID strings by
+// delegating to the parent helper and appending the final segment. The
+// segment uses the leaf type name (Types[len-1]) for nested types so that
+// the provider namespace is added exactly once at the top of the chain.
+// Authoring each level via its parent makes it impossible to accidentally
+// produce a non-canonical key — which the cache uses to look up objects.
+
 func ToResourceGroupResourceIDString(subscriptionName, resourceGroupName string) string {
 	return strings.ToLower(path.Join("/subscriptions", subscriptionName, "resourceGroups", resourceGroupName))
 }
@@ -39,8 +46,7 @@ func ToClusterResourceID(subscriptionName, resourceGroupName, clusterName string
 
 func ToClusterResourceIDString(subscriptionName, resourceGroupName, clusterName string) string {
 	return strings.ToLower(path.Join(
-		"/subscriptions", subscriptionName,
-		"resourceGroups", resourceGroupName,
+		ToResourceGroupResourceIDString(subscriptionName, resourceGroupName),
 		"providers", ClusterResourceType.String(), clusterName,
 	))
 }
@@ -51,10 +57,8 @@ func ToNodePoolResourceID(subscriptionName, resourceGroupName, clusterName, node
 
 func ToNodePoolResourceIDString(subscriptionName, resourceGroupName, clusterName, nodePoolName string) string {
 	return strings.ToLower(path.Join(
-		"/subscriptions", subscriptionName,
-		"resourceGroups", resourceGroupName,
-		"providers", ClusterResourceType.String(), clusterName,
-		NodePoolResourceType.Types[len(NodePoolResourceType.Types)-1], nodePoolName,
+		ToClusterResourceIDString(subscriptionName, resourceGroupName, clusterName),
+		leafTypeName(NodePoolResourceType), nodePoolName,
 	))
 }
 
@@ -64,19 +68,15 @@ func ToExternalAuthResourceID(subscriptionName, resourceGroupName, clusterName, 
 
 func ToExternalAuthResourceIDString(subscriptionName, resourceGroupName, clusterName, externalAuthName string) string {
 	return strings.ToLower(path.Join(
-		"/subscriptions", subscriptionName,
-		"resourceGroups", resourceGroupName,
-		"providers", ClusterResourceType.String(), clusterName,
-		ExternalAuthResourceType.Types[len(ExternalAuthResourceType.Types)-1], externalAuthName,
+		ToClusterResourceIDString(subscriptionName, resourceGroupName, clusterName),
+		leafTypeName(ExternalAuthResourceType), externalAuthName,
 	))
 }
 
 func ToServiceProviderClusterResourceIDString(subscriptionName, resourceGroupName, clusterName string) string {
 	return strings.ToLower(path.Join(
-		"/subscriptions", subscriptionName,
-		"resourceGroups", resourceGroupName,
-		"providers", ClusterResourceType.String(), clusterName,
-		ServiceProviderClusterResourceType.Types[len(ServiceProviderClusterResourceType.Types)-1], ServiceProviderClusterResourceName,
+		ToClusterResourceIDString(subscriptionName, resourceGroupName, clusterName),
+		leafTypeName(ServiceProviderClusterResourceType), ServiceProviderClusterResourceName,
 	))
 }
 
@@ -89,19 +89,23 @@ func ToOperationResourceIDString(subscriptionName, operationName string) string 
 
 func ToManagementClusterContentResourceIDString(subscriptionName, resourceGroupName, clusterName, managementClusterContentName string) string {
 	return strings.ToLower(path.Join(
-		"/subscriptions", subscriptionName,
-		"resourceGroups", resourceGroupName,
-		"providers", ClusterResourceType.String(), clusterName,
+		ToClusterResourceIDString(subscriptionName, resourceGroupName, clusterName),
 		ManagementClusterContentResourceTypeName, managementClusterContentName,
 	))
 }
 
 func ToServiceProviderNodePoolResourceIDString(subscriptionName, resourceGroupName, clusterName, nodePoolName string) string {
 	return strings.ToLower(path.Join(
-		"/subscriptions", subscriptionName,
-		"resourceGroups", resourceGroupName,
-		"providers", ClusterResourceType.String(), clusterName,
-		NodePoolResourceType.String(), nodePoolName,
-		ServiceProviderNodePoolResourceType.Types[len(ServiceProviderNodePoolResourceType.Types)-1], ServiceProviderNodePoolResourceName,
+		ToNodePoolResourceIDString(subscriptionName, resourceGroupName, clusterName, nodePoolName),
+		leafTypeName(ServiceProviderNodePoolResourceType), ServiceProviderNodePoolResourceName,
 	))
+}
+
+// leafTypeName returns the trailing segment of an ARM ResourceType (the
+// part after the last slash). Using it in the per-level helpers prevents
+// callers from accidentally embedding the full `namespace/type/...` form
+// twice in the same ID — see the original ToServiceProviderNodePoolResourceIDString
+// bug.
+func leafTypeName(rt azcorearm.ResourceType) string {
+	return rt.Types[len(rt.Types)-1]
 }

--- a/internal/api/types_cosmosdata_test.go
+++ b/internal/api/types_cosmosdata_test.go
@@ -1,0 +1,80 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"strings"
+	"testing"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+)
+
+// TestToResourceIDStringsAreCanonical asserts that every ToXxxResourceIDString
+// helper produces an ARM resource ID that round-trips through the ARM parser
+// to the same lowercased string. Equivalently: the helper must produce the
+// same string the informer cache stores under (which is
+// strings.ToLower(resourceID.String()) for the canonical ResourceID).
+//
+// The ToServiceProviderNodePoolResourceIDString helper used to fail this test
+// because it embedded the provider namespace twice; this test now guards
+// against the same class of bug for every other helper.
+func TestToResourceIDStringsAreCanonical(t *testing.T) {
+	const (
+		sub     = "00000000-0000-0000-0000-000000000001"
+		rg      = "myrg"
+		cluster = "mycluster"
+		np      = "mynodepool"
+		ea      = "myextauth"
+		opName  = "myop"
+		mcc     = "mymcc"
+	)
+
+	tests := []struct {
+		name string
+		got  string
+	}{
+		{"ResourceGroup", ToResourceGroupResourceIDString(sub, rg)},
+		{"Cluster", ToClusterResourceIDString(sub, rg, cluster)},
+		{"NodePool", ToNodePoolResourceIDString(sub, rg, cluster, np)},
+		{"ExternalAuth", ToExternalAuthResourceIDString(sub, rg, cluster, ea)},
+		{"ServiceProviderCluster", ToServiceProviderClusterResourceIDString(sub, rg, cluster)},
+		{"Operation", ToOperationResourceIDString(sub, opName)},
+		{"ManagementClusterContent", ToManagementClusterContentResourceIDString(sub, rg, cluster, mcc)},
+		{"ServiceProviderNodePool", ToServiceProviderNodePoolResourceIDString(sub, rg, cluster, np)},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// ResourceGroup IDs aren't full ARM resource IDs (they have no
+			// /providers segment), but the rest must parse and round-trip.
+			if tc.name == "ResourceGroup" {
+				want := "/subscriptions/" + sub + "/resourcegroups/" + rg
+				if tc.got != want {
+					t.Fatalf("got %q\nwant %q", tc.got, want)
+				}
+				return
+			}
+
+			parsed, err := azcorearm.ParseResourceID(tc.got)
+			if err != nil {
+				t.Fatalf("helper produced an ID that does not parse: %v\ngot: %q", err, tc.got)
+			}
+			canonical := strings.ToLower(parsed.String())
+			if tc.got != canonical {
+				t.Fatalf("helper output is not canonical (informer cache lookups will miss):\nhelper:    %q\ncanonical: %q", tc.got, canonical)
+			}
+		})
+	}
+}

--- a/test-integration/frontend/informer_test.go
+++ b/test-integration/frontend/informer_test.go
@@ -29,6 +29,7 @@ import (
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
 	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/database"
@@ -672,4 +673,142 @@ func activeOperationInformerIntegrationTestCase() informerIntegrationTestCase {
 			}, 45*time.Second, 200*time.Millisecond, "expected add event for op-3")
 		},
 	}
+}
+
+// TestServiceProviderNodePoolLister verifies that after seeding a
+// ServiceProviderNodePool in cosmos and starting the SPNP informer with a
+// very short relist duration, the serviceProviderNodePoolLister built from
+// the informer's indexer eventually surfaces the SPNP via both List and Get.
+func TestServiceProviderNodePoolLister(t *testing.T) {
+	integrationutils.WithAndWithoutCosmos(t, testServiceProviderNodePoolLister)
+}
+
+func testServiceProviderNodePoolLister(t *testing.T, withMock bool) {
+	const (
+		subscriptionID    = "00000000-0000-0000-0000-000000000004"
+		resourceGroupName = "test-rg"
+		clusterName       = "spnp-cluster"
+		nodePoolName      = "spnp-np"
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	var storageInfo integrationutils.StorageIntegrationTestInfo
+	var err error
+	if withMock {
+		storageInfo, err = integrationutils.NewMockCosmosFromTestingEnv(ctx, t)
+	} else {
+		storageInfo, err = integrationutils.NewCosmosFromTestingEnv(ctx, t)
+	}
+	require.NoError(t, err)
+	defer storageInfo.Cleanup(context.Background())
+
+	resourcesDBClient := storageInfo.ResourcesDBClient()
+
+	// Seed the parent cluster, parent node pool, and the SPNP.
+	clusterResourceID := mustParseResourceID(t,
+		"/subscriptions/"+subscriptionID+
+			"/resourceGroups/"+resourceGroupName+
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/"+clusterName)
+	clusterInternalID, err := api.NewInternalID("/api/clusters_mgmt/v1/clusters/" + clusterName)
+	require.NoError(t, err)
+	cluster := &api.HCPOpenShiftCluster{
+		CosmosMetadata: arm.CosmosMetadata{
+			ResourceID:   clusterResourceID,
+			PartitionKey: strings.ToLower(clusterResourceID.SubscriptionID),
+		},
+		TrackedResource: arm.TrackedResource{
+			Resource: arm.Resource{
+				ID:   clusterResourceID,
+				Name: clusterName,
+				Type: api.ClusterResourceType.String(),
+			},
+			Location: "eastus",
+		},
+		ServiceProviderProperties: api.HCPOpenShiftClusterServiceProviderProperties{
+			ProvisioningState: arm.ProvisioningStateSucceeded,
+			ClusterServiceID:  &clusterInternalID,
+		},
+	}
+	_, err = resourcesDBClient.HCPClusters(subscriptionID, resourceGroupName).Create(ctx, cluster, nil)
+	require.NoError(t, err, "failed to seed parent cluster")
+
+	npResourceID := mustParseResourceID(t,
+		"/subscriptions/"+subscriptionID+
+			"/resourceGroups/"+resourceGroupName+
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/"+clusterName+
+			"/nodePools/"+nodePoolName)
+	npInternalID := api.Ptr(api.Must(api.NewInternalID("/api/aro_hcp/v1alpha1/clusters/" + clusterName + "/node_pools/" + nodePoolName)))
+	nodePool := &api.HCPOpenShiftClusterNodePool{
+		CosmosMetadata: arm.CosmosMetadata{
+			ResourceID:   npResourceID,
+			PartitionKey: strings.ToLower(npResourceID.SubscriptionID),
+		},
+		TrackedResource: arm.TrackedResource{
+			Resource: arm.Resource{
+				ID:   npResourceID,
+				Name: nodePoolName,
+				Type: api.NodePoolResourceType.String(),
+			},
+			Location: "eastus",
+		},
+		Properties: api.HCPOpenShiftClusterNodePoolProperties{
+			ProvisioningState: arm.ProvisioningStateSucceeded,
+			Replicas:          1,
+		},
+		ServiceProviderProperties: api.HCPOpenShiftClusterNodePoolServiceProviderProperties{
+			ClusterServiceID: npInternalID,
+		},
+	}
+	_, err = resourcesDBClient.HCPClusters(subscriptionID, resourceGroupName).NodePools(clusterName).Create(ctx, nodePool, nil)
+	require.NoError(t, err, "failed to seed parent node pool")
+
+	spnpResourceID := mustParseResourceID(t,
+		"/subscriptions/"+subscriptionID+
+			"/resourceGroups/"+resourceGroupName+
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/"+clusterName+
+			"/nodePools/"+nodePoolName+
+			"/serviceProviderNodePools/"+api.ServiceProviderNodePoolResourceName)
+	spnp := &api.ServiceProviderNodePool{
+		CosmosMetadata: arm.CosmosMetadata{
+			ResourceID:   spnpResourceID,
+			PartitionKey: strings.ToLower(spnpResourceID.SubscriptionID),
+		},
+	}
+	_, err = resourcesDBClient.ServiceProviderNodePools(subscriptionID, resourceGroupName, clusterName, nodePoolName).Create(ctx, spnp, nil)
+	require.NoError(t, err, "failed to seed service provider node pool")
+
+	// Start the SPNP informer with a very short relist duration so the cache
+	// observes the seeded object quickly.
+	informer := informers.NewServiceProviderNodePoolInformerWithRelistDuration(
+		resourcesDBClient.ResourcesGlobalListers().ServiceProviderNodePools(),
+		1*time.Second)
+	go informer.Run(ctx.Done())
+	require.True(t, cache.WaitForCacheSync(ctx.Done(), informer.HasSynced), "timed out waiting for service provider node pool informer cache sync")
+
+	lister := listers.NewServiceProviderNodePoolLister(informer.GetIndexer())
+
+	// Wait up to 30s for the SPNP to be visible via List.
+	require.Eventually(t, func() bool {
+		all, err := lister.List(ctx)
+		if err != nil {
+			return false
+		}
+		for _, item := range all {
+			if item.ResourceID != nil && strings.EqualFold(item.ResourceID.String(), spnpResourceID.String()) {
+				return true
+			}
+		}
+		return false
+	}, 30*time.Second, 200*time.Millisecond, "service provider node pool never appeared in lister.List output")
+
+	// Wait up to 30s for the SPNP to be visible via Get.
+	require.Eventually(t, func() bool {
+		got, err := lister.Get(ctx, subscriptionID, resourceGroupName, clusterName, nodePoolName)
+		if err != nil {
+			return false
+		}
+		return got != nil && got.ResourceID != nil && strings.EqualFold(got.ResourceID.String(), spnpResourceID.String())
+	}, 30*time.Second, 200*time.Millisecond, "service provider node pool never appeared in lister.Get output")
 }


### PR DESCRIPTION
…space twice

The helper concatenated NodePoolResourceType.String() (which already carries the Microsoft.RedHatOpenShift namespace prefix) into a path that already had the providers segment, producing keys like
.../providers/microsoft.redhatopenshift/hcpopenshiftclusters/<cluster>/microsoft.redhatopenshift/hcpopenshiftclusters/nodepools/<np>/...

The informer cache stores ServiceProviderNodePools under the canonical ARM resource ID, so serviceProviderNodePoolLister.Get always returned NotFound.

Switch to the same Types[-1] pattern the sibling helpers use, and add an integration test that seeds an SPNP, starts the informer with a short relist, and asserts the SPNP is observable via both lister.List and lister.Get within 30s. The test would have failed before this fix.
