### PR TITLE
docs(ci): add upgrade-path presubmit documentation (ARO-27255)

### DIFF
--- a/docs/ci/README.md
+++ b/docs/ci/README.md
@@ -144,6 +144,16 @@ ARO HCP CI is split across this repository and the OpenShift CI configuration in
 - [Test Suites And Labels](e2e-testing.md#test-suites-and-labels)
 - [Periodic Tests](e2e-testing.md#periodic-tests)
 
+### [Upgrade-Path Presubmit](upgrade-path-presubmit.md)
+
+- [When To Use It](upgrade-path-presubmit.md#when-to-use-it)
+- [How It Works](upgrade-path-presubmit.md#how-it-works)
+- [Image Resolution](upgrade-path-presubmit.md#image-resolution)
+- [Interpreting Failures](upgrade-path-presubmit.md#interpreting-failures)
+- [Rehearsal Expectations](upgrade-path-presubmit.md#rehearsal-expectations)
+- [Relationship To `e2e-parallel`](upgrade-path-presubmit.md#relationship-to-e2e-parallel)
+- [Known Limitations](upgrade-path-presubmit.md#known-limitations)
+
 ### [CI Operations](operations.md)
 
 - [Inspecting Runs](operations.md#inspecting-runs)
@@ -183,6 +193,7 @@ ARO HCP CI is split across this repository and the OpenShift CI configuration in
 - [CI EV2 Integration](ev2-integration.md) explains how EV2 selects Prow jobs, authenticates to Gangway, and pins runs to the exact rollout commit.
 - [CI Cleanup](cleanup.md) explains why cleanup is intentionally split across strict per-test teardown, targeted environment teardown, and background hygiene.
 - [E2E Testing In CI](e2e-testing.md) explains how to trigger E2E jobs from PRs and how to narrow test selection safely.
+- [Upgrade-Path Presubmit](upgrade-path-presubmit.md) explains the optional `upgrade-e2e-parallel` job that validates main-to-PR infrastructure upgrades, including how to trigger it, interpret failures, and understand its image resolution strategy.
 - [CI Operations](operations.md) explains how to trigger, inspect, troubleshoot, and change the CI system itself.
 
 ## Source Of Truth

--- a/docs/ci/upgrade-path-presubmit.md
+++ b/docs/ci/upgrade-path-presubmit.md
@@ -1,0 +1,48 @@
+# Upgrade-Path Presubmit (`upgrade-e2e-parallel`)
+
+An optional presubmit job that validates infrastructure upgrades from `main` to the PR branch. Unlike the standard `e2e-parallel` job which provisions a fresh environment, this job catches regressions that only appear when upgrading existing infrastructure (e.g., breaking Bicep parameter changes, missing migration steps, incompatible config transitions).
+
+## When to use it
+
+- Manually via `/test upgrade-e2e-parallel` on any PR
+- Use it when your PR modifies infrastructure definitions and you want to verify the change is safe to apply on top of what's currently deployed from `main`
+
+## How it works
+
+The job uses the `aro-hcp-upgrade-e2e` workflow with these phases:
+
+1. **`aro-hcp-provision-from-main`** - Checks out the base branch commit (`PULL_BASE_SHA`) that the PR targets, resolves service image digests from ACR for that commit (falling back through recent history if images aren't published yet), and provisions a baseline environment using the base commit's Bicep templates, Helm charts, config, and ACR-resolved image overrides. For rehearsal runs on `openshift/release` PRs, it fetches `main` from the ARO-HCP repo instead.
+2. **`aro-hcp-upgrade-environment`** - Runs in a fresh container with the PR source (each step gets its own container), applies CI-built image overrides, and re-runs `make entrypoint/Region` against the already-provisioned environment (ARM idempotent upgrade)
+3. **`aro-hcp-test-local`** - Runs the full e2e test suite against the upgraded environment
+4. **Post steps** - Gathers artifacts and deprovisions the environment
+
+### Image resolution
+
+Both phases resolve service images to pin exact digests rather than using mutable tags:
+
+- **Baseline (from-main)**: Queries the SVC ACR for images tagged with main's 7-character commit SHA. If the latest commit's images aren't available (e.g., the postsubmit images-push job is still running), it polls for up to 15 minutes, then walks back through the last 20 commits to find the most recent one with published images.
+- **Upgrade (PR)**: Uses CI-built images from the PR's `pipeline:*` image stream, overriding the image registry/repository/digest via the config overlay.
+
+## Interpreting failures
+
+| Failed step | Meaning | Action |
+|---|---|---|
+| `aro-hcp-provision-from-main` | The `main` branch itself is broken - the baseline provision failed before the PR was applied | Check if `main`'s CI is green; this is not a PR issue |
+| `aro-hcp-upgrade-environment` | **The PR introduces an upgrade-path regression** - the environment provisioned from `main` could not be upgraded to the PR's state | This is the signal this job is designed to catch. Investigate the Bicep/Helm/config diff between `main` and your PR |
+| `aro-hcp-test-local` | The upgraded environment has a functional regression - e2e tests failed after the upgrade | Could be upgrade-related or a general bug in the PR's service code |
+
+## Rehearsal expectations
+
+When this job is rehearsed via Prow's `pj-rehearse` plugin on an `openshift/release` PR, it will attempt to run the full provision -> upgrade -> test -> deprovision cycle. Expect:
+- Longer runtime than `e2e-parallel` due to the dual provision cycle, though the upgrade phase is faster than fresh provision since ARM skips unchanged resources
+- Requires a Boskos lease from `aro-hcp-msi-mock-cs-sp-dev`
+- Uses the same `ci01` environment and Azure subscriptions as the standard `e2e-parallel` job
+
+## Relationship to `e2e-parallel`
+
+`upgrade-e2e-parallel` is on-demand only - it runs when manually triggered via `/test upgrade-e2e-parallel`. `e2e-parallel` validates fresh provisioning while `upgrade-e2e-parallel` validates upgrading existing infrastructure. Both jobs acquire leases from the same Boskos pool (`aro-hcp-msi-mock-cs-sp-dev`) and the `aro-hcp-lease-acquire` step assigns each job a distinct environment slot, so they can run concurrently if pool capacity allows.
+
+## Known limitations
+
+- The `aro-hcp-provision-from-main` step uses the PR's pre-built `templatize` binary (baked into the container image) with `main`'s config/Bicep/Helm files. In rare cases where a PR changes `templatize` in a way incompatible with `main`'s pipeline definitions, the baseline provision may fail spuriously.
+- ACR image resolution requires that the `images-push-postsubmit` job has run for a recent main commit. If ACR has no images for any of the last 20 commits, the baseline provision will fail.


### PR DESCRIPTION
[ARO-27255](https://issues.redhat.com/browse/ARO-27255)

### What

Adds documentation for the new `upgrade-e2e-parallel` optional presubmit job, defined in the companion [openshift/release PR](<!-- link to openshift-release PR -->).

### Why

The upgrade-path presubmit is a new CI workflow that validates `main` -> PR infrastructure upgrades. This doc explains when to use the job, how it works, how to interpret failures, and known limitations — reducing debugging time for developers whose PRs touch infrastructure definitions.

### Testing

Documentation-only change. The companion openshift/release PR defines the actual CI job; this PR should be merged first so the cross-repo README link resolves correctly.

### Special notes for your reviewer

- Companion PR in openshift/release adds the `aro-hcp-provision-from-main` step, `aro-hcp-upgrade-e2e` workflow, and `upgrade-e2e-parallel` presubmit job definition
- This PR should merge **before** the openshift/release PR, which links to this doc from its README

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes) — N/A
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented — N/A
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge