### PR TITLE
observability: increase KubeNodeNotReady alert threshold to 30m

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedHCPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedHCPPrometheusAlertingRules.bicep
@@ -1221,14 +1221,14 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
         }
         annotations: {
           correlationId: 'KubeNodeNotReady/{{ $labels.cluster }}'
-          description: '{{ $labels.node }} has been unready for more than 15 minutes.'
-          info: '{{ $labels.node }} has been unready for more than 15 minutes.'
+          description: '{{ $labels.node }} has been unready for more than 30 minutes.'
+          info: '{{ $labels.node }} has been unready for more than 30 minutes.'
           runbook_url: 'https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubenodenotready'
           summary: 'Node is not ready.'
           title: 'Node is not ready.'
         }
         expression: 'kube_node_status_condition{job="kube-state-metrics",condition="Ready",status="true"} == 0'
-        for: 'PT15M'
+        for: 'PT30M'
         severity: 3
       }
       {

--- a/dev-infrastructure/modules/metrics/rules/generatedMsftPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedMsftPrometheusAlertingRules.bicep
@@ -588,14 +588,14 @@ resource msftKubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleG
         }
         annotations: {
           correlationId: 'KubeNodeNotReady/{{ $labels.cluster }}/{{ $labels.node }}'
-          description: '{{ $labels.node }} has been unready for more than 15 minutes.'
-          info: '{{ $labels.node }} has been unready for more than 15 minutes.'
+          description: '{{ $labels.node }} has been unready for more than 30 minutes.'
+          info: '{{ $labels.node }} has been unready for more than 30 minutes.'
           runbook_url: 'https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubenodenotready'
           summary: 'Node is not ready.'
           title: 'Node is not ready. node:{{ $labels.node }}'
         }
         expression: 'kube_node_status_condition{job="kube-state-metrics",condition="Ready",status="true"} == 0'
-        for: 'PT15M'
+        for: 'PT30M'
         severity: 3
       }
       {

--- a/observability/alerts/kubernetesControlPlane-prometheusRule.yaml
+++ b/observability/alerts/kubernetesControlPlane-prometheusRule.yaml
@@ -602,12 +602,12 @@ spec:
     rules:
     - alert: KubeNodeNotReady
       annotations:
-        description: '{{ $labels.node }} has been unready for more than 15 minutes.'
+        description: '{{ $labels.node }} has been unready for more than 30 minutes.'
         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubenodenotready
         summary: Node is not ready.
       expr: |
         kube_node_status_condition{job="kube-state-metrics",condition="Ready",status="true"} == 0
-      for: 15m
+      for: 30m
       labels:
         severity: warning
     - alert: KubeNodeUnreachable


### PR DESCRIPTION
The AKS node auto-repair process can take up to 30 minutes to fully fix or replace a node, so alerting before that time will just lead to spurious issues.
