### PR TITLE
feat : ARO-24013 | Remove direct autoscaler patch call from RP and pass autoscaler via patch cluster

### DIFF
--- a/backend/pkg/controllers/clustercreation/cluster_cluster_service_create_controller.go
+++ b/backend/pkg/controllers/clustercreation/cluster_cluster_service_create_controller.go
@@ -235,13 +235,13 @@ func (c *clusterClusterServiceCreateSyncer) csClustersMatchingClusterByAzureInfo
 func (c *clusterClusterServiceCreateSyncer) createClusterServiceCluster(ctx context.Context, cluster *api.HCPOpenShiftCluster, serviceProviderCluster *api.ServiceProviderCluster, tenantID string) (*arohcpv1alpha1.Cluster, error) {
 	logger := utils.LoggerFromContext(ctx)
 
-	csClusterBuilder, csAutoscalerBuilder, err := ocm.BuildCSCluster(cluster.ID, tenantID, cluster, nil, nil, serviceProviderCluster)
+	csClusterBuilder, err := ocm.BuildCSCluster(cluster.ID, tenantID, cluster, nil, nil, serviceProviderCluster)
 	if err != nil {
 		return nil, utils.TrackError(fmt.Errorf("failed to build CS cluster: %w", err))
 	}
 
 	logger.Info("Creating cluster in Cluster Service", "version", serviceProviderCluster.Spec.ControlPlaneVersion.DesiredVersion.String())
-	result, err := c.clustersServiceClient.PostCluster(ctx, csClusterBuilder, csAutoscalerBuilder)
+	result, err := c.clustersServiceClient.PostCluster(ctx, csClusterBuilder)
 	if err != nil {
 		return nil, utils.TrackError(fmt.Errorf("PostCluster failed: %w", err))
 	}

--- a/backend/pkg/controllers/clustercreation/cluster_cluster_service_create_controller_test.go
+++ b/backend/pkg/controllers/clustercreation/cluster_cluster_service_create_controller_test.go
@@ -146,7 +146,7 @@ func TestClusterClusterServiceCreate_SyncOnce(t *testing.T) {
 					Build()
 				require.NoError(t, err)
 				mockCS.EXPECT().
-					PostCluster(gomock.Any(), gomock.Any(), gomock.Any()).
+					PostCluster(gomock.Any(), gomock.Any()).
 					Return(csCluster, nil)
 				return mockCS
 			},

--- a/backend/pkg/controllers/clusterupdate/cluster_cluster_service_update_dispatch_controller.go
+++ b/backend/pkg/controllers/clusterupdate/cluster_cluster_service_update_dispatch_controller.go
@@ -44,7 +44,7 @@ import (
 //
 // On each reconcile, the Cluster's state and the live Cluster Service cluster state
 // are projected into ocm.clusterUpdateDispatchConfig. When the projections from both sides
-// differ, it PATCHes Cluster Service (autoscaler first, then cluster).
+// differ, it PATCHes Cluster Service
 //
 // Dispatch is paired with operation state calculation in operationcontrollers
 // (operation_cluster_update_state_calculation.go): dispatch sends updates, operation state
@@ -212,47 +212,10 @@ func (c *clusterClusterServiceUpdateDispatchSyncer) SyncOnce(ctx context.Context
 		"configDiff", configDiff,
 	)
 
-	csClusterBuilder, csAutoscalerBuilder, err := ocm.BuildCSCluster(cluster.ID, *subscription.Properties.TenantId, cluster, nil, clusterServiceCluster, serviceProviderCluster)
+	csClusterBuilder, err := ocm.BuildCSCluster(cluster.ID, *subscription.Properties.TenantId, cluster, nil, clusterServiceCluster, serviceProviderCluster)
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to build CS cluster: %w", err))
 	}
-
-	// We marshal the autoscaler CS builder config we are going to submit for cs cluster autoscaler update for logging purposes
-	clusterAutoscalerPayload, err := c.marshalClusterServiceClusterAutoscalerUpdatePayload(csAutoscalerBuilder)
-	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to marshal Cluster Service autoscaler update payload: %w", err))
-	}
-
-	logger.Info("dispatching cluster autoscaler update to Cluster Service",
-		"clusterServiceID", clusterCSID.String(),
-		"clusterServiceClusterAutoscalerPayload", clusterAutoscalerPayload,
-	)
-
-	_, err = c.clusterServiceClient.UpdateClusterAutoscaler(ctx, *clusterCSID, csAutoscalerBuilder)
-	if err != nil {
-		var ocmError *ocmerrors.Error
-		// XXX Matching an error message is brittle, but Clusters Service
-		//     returns 400 Bad Request for a wide range of errors and there
-		//     is no other information in the response to distinguish them.
-		//
-		//     If the error is indicating that a the cluster autoscaler is not in
-		//     an updatable state, we return without error and retry again on the
-		//     next sync. This can happen for example when the CS cluster is still in
-		//     the initial creation process.
-		if errors.As(err, &ocmError) && ocmError.Status() == http.StatusBadRequest &&
-			strings.Contains(ocmError.Reason(), "Cluster") &&
-			strings.Contains(ocmError.Reason(), "is in state") &&
-			strings.Contains(ocmError.Reason(), "can't update") {
-			logger.Info("Cluster Service rejected cluster autoscaler update because the cluster is not updatable. Retrying on next sync.",
-				"clusterServiceID", clusterCSID.String(),
-				"error", err.Error(),
-			)
-			return nil
-		}
-		return utils.TrackError(fmt.Errorf("failed to update cluster-service ClusterAutoscaler: %w", err))
-	}
-
-	logger.Info("dispatched cluster autoscaler update to Cluster Service", "clusterServiceID", clusterCSID.String())
 
 	// We marshal the cluster CS builder config we are going to submit for cs cluster update for logging purposes
 	clusterPayload, err := c.marshalClusterServiceClusterUpdatePayload(csClusterBuilder)
@@ -272,7 +235,7 @@ func (c *clusterClusterServiceUpdateDispatchSyncer) SyncOnce(ctx context.Context
 		//     returns 400 Bad Request for a wide range of errors and there
 		//     is no other information in the response to distinguish them.
 		//
-		//     If the error is indicating that a the cluster autoscaler is not in
+		//     If the error is indicating that the cluster is not in
 		//     an updatable state, we return without error and retry again on the
 		//     next sync. This can happen for example when the CS cluster is still in
 		//     the initial creation process.
@@ -306,19 +269,4 @@ func (c *clusterClusterServiceUpdateDispatchSyncer) marshalClusterServiceCluster
 	}
 
 	return clusterBuffer.String(), nil
-}
-
-// marshalClusterServiceClusterAutoscalerUpdatePayload serializes the autoscaler PATCH body for logging.
-func (c *clusterClusterServiceUpdateDispatchSyncer) marshalClusterServiceClusterAutoscalerUpdatePayload(autoscalerBuilder *arohcpv1alpha1.ClusterAutoscalerBuilder) (string, error) {
-	autoscaler, err := autoscalerBuilder.Build()
-	if err != nil {
-		return "", err
-	}
-
-	var autoscalerBuffer bytes.Buffer
-	if err := arohcpv1alpha1.MarshalClusterAutoscaler(autoscaler, &autoscalerBuffer); err != nil {
-		return "", err
-	}
-
-	return autoscalerBuffer.String(), nil
 }

--- a/backend/pkg/controllers/clusterupdate/cluster_cluster_service_update_dispatch_controller_test.go
+++ b/backend/pkg/controllers/clusterupdate/cluster_cluster_service_update_dispatch_controller_test.go
@@ -109,9 +109,6 @@ func TestClusterUpdateDispatchSyncer_SyncOnce(t *testing.T) {
 					GetCluster(gomock.Any(), csID).
 					Return(defaultExistingCSCluster, nil)
 				mock.EXPECT().
-					UpdateClusterAutoscaler(gomock.Any(), csID, gomock.Any()).
-					Return(nil, nil)
-				mock.EXPECT().
 					UpdateCluster(gomock.Any(), csID, gomock.Any()).
 					Return(nil, nil)
 			},
@@ -137,22 +134,6 @@ func TestClusterUpdateDispatchSyncer_SyncOnce(t *testing.T) {
 			minimumReconcileTimeCooldownChecker: &alwaysSyncCooldownChecker{},
 		},
 		{
-			name:                           "when CS autoscaler update returns cluster not updatable no error is returned and cluster update is not called",
-			existingCluster:                newClusterWithConfigDiff(),
-			existingSubscription:           newTestSubscription(),
-			existingServiceProviderCluster: newTestServiceProviderCluster(testClusterName),
-			existingCSCluster:              defaultExistingCSCluster,
-			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
-				mock.EXPECT().
-					GetCluster(gomock.Any(), csID).
-					Return(defaultExistingCSCluster, nil)
-				mock.EXPECT().
-					UpdateClusterAutoscaler(gomock.Any(), csID, gomock.Any()).
-					Return(nil, newFakeOCMClusterNotUpdatableError())
-			},
-			minimumReconcileTimeCooldownChecker: &alwaysSyncCooldownChecker{},
-		},
-		{
 			name:                           "when CS cluster update returns cluster not updatable no error is returned",
 			existingCluster:                newClusterWithConfigDiff(),
 			existingSubscription:           newTestSubscription(),
@@ -163,30 +144,9 @@ func TestClusterUpdateDispatchSyncer_SyncOnce(t *testing.T) {
 					GetCluster(gomock.Any(), csID).
 					Return(defaultExistingCSCluster, nil)
 				mock.EXPECT().
-					UpdateClusterAutoscaler(gomock.Any(), csID, gomock.Any()).
-					Return(nil, nil)
-				mock.EXPECT().
 					UpdateCluster(gomock.Any(), csID, gomock.Any()).
 					Return(nil, newFakeOCMClusterNotUpdatableError())
 			},
-			minimumReconcileTimeCooldownChecker: &alwaysSyncCooldownChecker{},
-		},
-		{
-			name:                           "when CS autoscaler update returns unhandled error error is propagated",
-			existingCluster:                newClusterWithConfigDiff(),
-			existingSubscription:           newTestSubscription(),
-			existingServiceProviderCluster: newTestServiceProviderCluster(testClusterName),
-			existingCSCluster:              defaultExistingCSCluster,
-			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
-				mock.EXPECT().
-					GetCluster(gomock.Any(), csID).
-					Return(defaultExistingCSCluster, nil)
-				mock.EXPECT().
-					UpdateClusterAutoscaler(gomock.Any(), csID, gomock.Any()).
-					Return(nil, errors.New("boom"))
-			},
-			wantErr:                             true,
-			wantErrContain:                      "failed to update cluster-service ClusterAutoscaler",
 			minimumReconcileTimeCooldownChecker: &alwaysSyncCooldownChecker{},
 		},
 		{
@@ -200,9 +160,6 @@ func TestClusterUpdateDispatchSyncer_SyncOnce(t *testing.T) {
 					GetCluster(gomock.Any(), csID).
 					Return(defaultExistingCSCluster, nil)
 				mock.EXPECT().
-					UpdateClusterAutoscaler(gomock.Any(), csID, gomock.Any()).
-					Return(nil, nil)
-				mock.EXPECT().
 					UpdateCluster(gomock.Any(), csID, gomock.Any()).
 					Return(nil, errors.New("boom"))
 			},
@@ -211,7 +168,7 @@ func TestClusterUpdateDispatchSyncer_SyncOnce(t *testing.T) {
 			minimumReconcileTimeCooldownChecker: &alwaysSyncCooldownChecker{},
 		},
 		{
-			name:                           "when CS autoscaler update returns unrelated bad request error error is propagated",
+			name:                           "when CS cluster update returns unrelated bad request error error is propagated",
 			existingCluster:                newClusterWithConfigDiff(),
 			existingSubscription:           newTestSubscription(),
 			existingServiceProviderCluster: newTestServiceProviderCluster(testClusterName),
@@ -221,11 +178,11 @@ func TestClusterUpdateDispatchSyncer_SyncOnce(t *testing.T) {
 					GetCluster(gomock.Any(), csID).
 					Return(defaultExistingCSCluster, nil)
 				mock.EXPECT().
-					UpdateClusterAutoscaler(gomock.Any(), csID, gomock.Any()).
+					UpdateCluster(gomock.Any(), csID, gomock.Any()).
 					Return(nil, newFakeOCMUnrelatedBadRequestError())
 			},
 			wantErr:                             true,
-			wantErrContain:                      "failed to update cluster-service ClusterAutoscaler",
+			wantErrContain:                      "failed to update cluster-service Cluster",
 			minimumReconcileTimeCooldownChecker: &alwaysSyncCooldownChecker{},
 		},
 		{
@@ -379,10 +336,10 @@ func mustBuildCSClusterFromRP(t *testing.T, hcpCluster *api.HCPOpenShiftCluster)
 	oldClusterServiceCluster, err := arohcpv1alpha1.NewCluster().Build()
 	require.NoError(t, err)
 
-	clusterBuilder, autoscalerBuilder, err := ocm.BuildCSCluster(hcpCluster.ID, "", hcpCluster, nil, oldClusterServiceCluster, &api.ServiceProviderCluster{})
+	clusterBuilder, err := ocm.BuildCSCluster(hcpCluster.ID, "", hcpCluster, nil, oldClusterServiceCluster, &api.ServiceProviderCluster{})
 	require.NoError(t, err)
 
-	csCluster, err := clusterBuilder.Autoscaler(autoscalerBuilder).Build()
+	csCluster, err := clusterBuilder.Build()
 	require.NoError(t, err)
 	return csCluster
 }

--- a/internal/ocm/client.go
+++ b/internal/ocm/client.go
@@ -59,13 +59,10 @@ type ClusterServiceClientSpec interface {
 	GetClusterHypershiftDetails(ctx context.Context, internalID InternalID) (*cmv1.HypershiftConfig, error)
 
 	// PostCluster sends a POST request to create a cluster in Cluster Service.
-	PostCluster(ctx context.Context, clusterBuilder *arohcpv1alpha1.ClusterBuilder, autoscalerBuilder *arohcpv1alpha1.ClusterAutoscalerBuilder) (*arohcpv1alpha1.Cluster, error)
+	PostCluster(ctx context.Context, clusterBuilder *arohcpv1alpha1.ClusterBuilder) (*arohcpv1alpha1.Cluster, error)
 
 	// UpdateCluster sends a PATCH request to update a cluster in Cluster Service.
 	UpdateCluster(ctx context.Context, internalID InternalID, builder *arohcpv1alpha1.ClusterBuilder) (*arohcpv1alpha1.Cluster, error)
-
-	// UpdateClusterAutoscaler sends a PATCH request to update cluster autoscaling values in Cluster Service.
-	UpdateClusterAutoscaler(ctx context.Context, internalID InternalID, builder *arohcpv1alpha1.ClusterAutoscalerBuilder) (*arohcpv1alpha1.ClusterAutoscaler, error)
 
 	// DeleteCluster sends a DELETE request to delete a cluster from Cluster Service.
 	DeleteCluster(ctx context.Context, internalID InternalID) error
@@ -376,10 +373,7 @@ func (csc *clusterServiceClient) GetClusterHypershiftDetails(ctx context.Context
 	return hypershiftConfig, nil
 }
 
-func (csc *clusterServiceClient) PostCluster(ctx context.Context, clusterBuilder *arohcpv1alpha1.ClusterBuilder, autoscalerBuilder *arohcpv1alpha1.ClusterAutoscalerBuilder) (*arohcpv1alpha1.Cluster, error) {
-	if autoscalerBuilder != nil {
-		clusterBuilder.Autoscaler(autoscalerBuilder)
-	}
+func (csc *clusterServiceClient) PostCluster(ctx context.Context, clusterBuilder *arohcpv1alpha1.ClusterBuilder) (*arohcpv1alpha1.Cluster, error) {
 	cluster, err := clusterBuilder.Build()
 	if err != nil {
 		return nil, utils.TrackError(err)
@@ -413,26 +407,6 @@ func (csc *clusterServiceClient) UpdateCluster(ctx context.Context, internalID I
 		return nil, fmt.Errorf("empty response body")
 	}
 	return resolveClusterLinks(ctx, csc.conn, cluster)
-}
-
-func (csc *clusterServiceClient) UpdateClusterAutoscaler(ctx context.Context, internalID InternalID, builder *arohcpv1alpha1.ClusterAutoscalerBuilder) (*arohcpv1alpha1.ClusterAutoscaler, error) {
-	autoscaler, err := builder.Build()
-	if err != nil {
-		return nil, utils.TrackError(err)
-	}
-	client, ok := getAroHCPClusterClient(internalID, csc.conn)
-	if !ok {
-		return nil, fmt.Errorf("OCM path is not a cluster: %s", internalID)
-	}
-	autoscalerUpdateResponse, err := client.Autoscaler().Update().Body(autoscaler).SendContext(ctx)
-	if err != nil {
-		return nil, utils.TrackError(err)
-	}
-	autoscaler, ok = autoscalerUpdateResponse.GetBody()
-	if !ok {
-		return nil, fmt.Errorf("empty response body")
-	}
-	return autoscaler, nil
 }
 
 func (csc *clusterServiceClient) DeleteCluster(ctx context.Context, internalID InternalID) error {

--- a/internal/ocm/cluster_update_dispatch_config.go
+++ b/internal/ocm/cluster_update_dispatch_config.go
@@ -75,7 +75,7 @@ import (
 //     Do not embed internal/api struct types.
 //   - Populate it in clusterUpdateDispatchConfigFromRP. This ensures RP projection works correctly
 //   - Populate it in clusterUpdateDispatchConfigFromCS. This ensures CS projection works correctly
-//   - Apply it in applyToCSBuilders and/or autoscalerBuilder. This ensures the CS builders work correctly.
+//   - Apply it in applyToCSBuilders. This ensures the CS builders work correctly.
 //
 // 2. Operation state wiring (backend/pkg/controllers/operationcontrollers/operation_cluster_update.go)
 //
@@ -577,14 +577,14 @@ func (c *clusterUpdateDispatchConfig) applyToCSBuilders(clusterBuilder *arohcpv1
 		clusterBuilder.Azure(azureBuilder)
 	}
 
-	return nil
-}
+	// The autoscaler is nested on the cluster builder.
+	autoscalerBuilder, err := convertRpAutoscalarToCSBuilder(ptr.To(clusterUpdateDispatchConfigAutoscalingToRP(c.Autoscaling)))
+	if err != nil {
+		return err
+	}
+	clusterBuilder.Autoscaler(autoscalerBuilder)
 
-// autoscalerBuilder builds the Cluster Service autoscaler update payload from the dispatch
-// config autoscaling fields.
-func (c *clusterUpdateDispatchConfig) autoscalerBuilder() (*arohcpv1alpha1.ClusterAutoscalerBuilder, error) {
-	profile := clusterUpdateDispatchConfigAutoscalingToRP(c.Autoscaling)
-	return convertRpAutoscalarToCSBuilder(&profile)
+	return nil
 }
 
 // clusterUpdateDispatchConfigImageDigestMirrorsToRP converts dispatch image mirrors into

--- a/internal/ocm/cluster_update_dispatch_config_test.go
+++ b/internal/ocm/cluster_update_dispatch_config_test.go
@@ -325,10 +325,10 @@ func TestClusterUpdateDispatchConfigFromCSRoundTrip(t *testing.T) {
 	}
 	spc := &api.ServiceProviderCluster{}
 
-	clusterBuilder, autoscalerBuilder, err := BuildCSCluster(resourceID, api.TestTenantID, hcpCluster, nil, oldClusterServiceCluster, spc)
+	clusterBuilder, err := BuildCSCluster(resourceID, api.TestTenantID, hcpCluster, nil, oldClusterServiceCluster, spc)
 	require.NoError(t, err)
 
-	csCluster, err := clusterBuilder.Autoscaler(autoscalerBuilder).Build()
+	csCluster, err := clusterBuilder.Build()
 	require.NoError(t, err)
 
 	actualConfig, err := clusterUpdateDispatchConfigFromCS(csCluster)
@@ -360,10 +360,10 @@ func TestClusterUpdateDispatchConfigFromCSRoundTripServiceProviderClusterSize(t 
 		},
 	}
 
-	clusterBuilder, autoscalerBuilder, err := BuildCSCluster(nil, "11111111-1111-1111-1111-111111111111", hcpCluster, nil, oldClusterServiceCluster, spc)
+	clusterBuilder, err := BuildCSCluster(nil, "11111111-1111-1111-1111-111111111111", hcpCluster, nil, oldClusterServiceCluster, spc)
 	require.NoError(t, err)
 
-	csCluster, err := clusterBuilder.Autoscaler(autoscalerBuilder).Build()
+	csCluster, err := clusterBuilder.Build()
 	require.NoError(t, err)
 
 	actualConfig, err := clusterUpdateDispatchConfigFromCS(csCluster)
@@ -583,10 +583,11 @@ func TestClusterUpdateDispatchConfigJSONFromRPAndCS(t *testing.T) {
 	oldClusterServiceCluster, err := arohcpv1alpha1.NewCluster().Build()
 	require.NoError(t, err)
 
-	clusterBuilder, autoscalerBuilder, err := BuildCSCluster(nil, "11111111-1111-1111-1111-111111111111", hcpCluster, nil, oldClusterServiceCluster, spc)
+	clusterBuilder, err := BuildCSCluster(nil, "11111111-1111-1111-1111-111111111111", hcpCluster, nil, oldClusterServiceCluster, spc)
 
 	require.NoError(t, err)
-	csCluster, err := clusterBuilder.Autoscaler(autoscalerBuilder).Build()
+
+	csCluster, err := clusterBuilder.Build()
 	require.NoError(t, err)
 
 	desiredJSON, err := ClusterUpdateDispatchConfigJSONFromRP(hcpCluster, spc)
@@ -966,6 +967,20 @@ func TestClusterUpdateDispatchConfigAutoscalingFromCS(t *testing.T) {
 			},
 		},
 		{
+			name: "non-minute-aligned max node provision time uses integer seconds",
+			autoscaler: func(t *testing.T) *arohcpv1alpha1.ClusterAutoscaler {
+				t.Helper()
+				autoscaler, err := arohcpv1alpha1.NewClusterAutoscaler().
+					MaxNodeProvisionTime("15m50s").
+					Build()
+				require.NoError(t, err)
+				return autoscaler
+			},
+			want: clusterUpdateDispatchConfigAutoscaling{
+				MaxNodeProvisionTimeSeconds: 950,
+			},
+		},
+		{
 			name: "invalid max node provision time returns error",
 			autoscaler: func(t *testing.T) *arohcpv1alpha1.ClusterAutoscaler {
 				t.Helper()
@@ -1062,7 +1077,9 @@ func TestClusterUpdateDispatchConfigImageDigestMirrorsFromCS(t *testing.T) {
 	}
 }
 
-func TestClusterUpdateDispatchConfigAutoscalerBuilder(t *testing.T) {
+func TestClusterUpdateDispatchConfigApplyToCSBuildersAutoscaling(t *testing.T) {
+	clusterBuilder := arohcpv1alpha1.NewCluster()
+	clusterAPIBuilder := arohcpv1alpha1.NewClusterAPI()
 	config := clusterUpdateDispatchConfig{
 		Autoscaling: clusterUpdateDispatchConfigAutoscaling{
 			MaxNodesTotal:               12,
@@ -1072,13 +1089,13 @@ func TestClusterUpdateDispatchConfigAutoscalerBuilder(t *testing.T) {
 		},
 	}
 
-	builder, err := config.autoscalerBuilder()
+	err := config.applyToCSBuilders(clusterBuilder, clusterAPIBuilder, nil, nil, map[string]string{})
 	require.NoError(t, err)
 
-	autoscaler, err := builder.Build()
+	csCluster, err := clusterBuilder.Build()
 	require.NoError(t, err)
 
-	got, err := clusterUpdateDispatchConfigAutoscalingFromCS(autoscaler)
+	got, err := clusterUpdateDispatchConfigAutoscalingFromCS(csCluster.Autoscaler())
 	require.NoError(t, err)
 	assert.Equal(t, config.Autoscaling, got)
 }
@@ -1282,7 +1299,7 @@ func TestClusterUpdateDispatchConfigFromCSRoundTripWithKMS(t *testing.T) {
 	// a PATCH payload — it only contains mutable fields. Simulate what CS returns
 	// after applying the PATCH by building a full cluster with immutable fields
 	// from the old cluster plus the updated key version.
-	_, _, err = BuildCSCluster(nil, "11111111-1111-1111-1111-111111111111", hcpCluster, nil, oldClusterServiceCluster, spc)
+	_, err = BuildCSCluster(nil, "11111111-1111-1111-1111-111111111111", hcpCluster, nil, oldClusterServiceCluster, spc)
 	require.NoError(t, err)
 
 	fullCSCluster, err := arohcpv1alpha1.NewCluster().

--- a/internal/ocm/convert.go
+++ b/internal/ocm/convert.go
@@ -359,7 +359,6 @@ func GetClusterServiceUserAssignedIdentities(clusterServiceCluster *arohcpv1alph
 }
 
 func convertRpAutoscalarToCSBuilder(in *api.ClusterAutoscalingProfile) (*arohcpv1alpha1.ClusterAutoscalerBuilder, error) {
-
 	// MaxNodeProvisionTime (string) - minutes e.g - “15m”
 	// https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/blob/master/pkg/api/autoscaler.go?ref_type=heads#L30-42
 	maxNodeProvisionDuration, err := time.ParseDuration(fmt.Sprint(in.MaxNodeProvisionTimeSeconds, "s"))
@@ -397,7 +396,7 @@ func convertImageDigestMirrorsToCSBuilder(in []api.ImageDigestMirror) []*arohcpv
 // requiredProperties are caller-specified properties (e.g. provision shard, noop flags).
 // oldClusterServiceCluster, if non-nil, indicates an update and its existing properties
 // are preserved as a base layer.
-func BuildCSCluster(resourceID *azcorearm.ResourceID, tenantID string, hcpCluster *api.HCPOpenShiftCluster, requiredProperties map[string]string, oldClusterServiceCluster *arohcpv1alpha1.Cluster, serviceProviderCluster *api.ServiceProviderCluster) (*arohcpv1alpha1.ClusterBuilder, *arohcpv1alpha1.ClusterAutoscalerBuilder, error) {
+func BuildCSCluster(resourceID *azcorearm.ResourceID, tenantID string, hcpCluster *api.HCPOpenShiftCluster, requiredProperties map[string]string, oldClusterServiceCluster *arohcpv1alpha1.Cluster, serviceProviderCluster *api.ServiceProviderCluster) (*arohcpv1alpha1.ClusterBuilder, error) {
 	var err error
 
 	clusterBuilder := arohcpv1alpha1.NewCluster()
@@ -410,7 +409,7 @@ func BuildCSCluster(resourceID *azcorearm.ResourceID, tenantID string, hcpCluste
 	if oldClusterServiceCluster == nil {
 		csVersionID, err := clusterCSVersionID(serviceProviderCluster, hcpCluster)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 		clusterBuilder, azureBuilder, err = withImmutableAttributes(clusterBuilder, hcpCluster,
 			resourceID.SubscriptionID,
@@ -420,17 +419,17 @@ func BuildCSCluster(resourceID *azcorearm.ResourceID, tenantID string, hcpCluste
 			csVersionID,
 		)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 		apiListening, err := convertVisibilityToListening(hcpCluster.CustomerProperties.API.Visibility)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 		clusterAPIBuilder.Listening(apiListening)
 
 		ingressListening, err := convertIngressTypeToListening(hcpCluster.CustomerProperties.Ingress.Type)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 		clusterBuilder.Ingresses(arohcpv1alpha1.NewIngressList().Items(
 			arohcpv1alpha1.NewIngress().Default(true).Listening(ingressListening),
@@ -438,7 +437,7 @@ func BuildCSCluster(resourceID *azcorearm.ResourceID, tenantID string, hcpCluste
 
 		etcdEncryption, err := convertEtcdRPToCS(hcpCluster.CustomerProperties.Etcd, clusterKMSActiveKeyBuilder)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 		azureBuilder.EtcdEncryption(etcdEncryption)
 		clusterBuilder.Azure(azureBuilder)
@@ -461,15 +460,10 @@ func BuildCSCluster(resourceID *azcorearm.ResourceID, tenantID string, hcpCluste
 	clusterUpdateDispatchConfig := clusterUpdateDispatchConfigFromRP(hcpCluster, serviceProviderCluster)
 	err = clusterUpdateDispatchConfig.applyToCSBuilders(clusterBuilder, clusterAPIBuilder, azureBuilder, clusterKMSActiveKeyBuilder, properties)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	clusterAutoscalerBuilder, err := clusterUpdateDispatchConfig.autoscalerBuilder()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return clusterBuilder, clusterAutoscalerBuilder, nil
+	return clusterBuilder, nil
 }
 
 // clusterCSVersionID returns the OpenShift version ID for a new Cluster Service cluster

--- a/internal/ocm/convert_test.go
+++ b/internal/ocm/convert_test.go
@@ -1293,7 +1293,7 @@ func TestBuildCSCluster(t *testing.T) {
 			}
 
 			// Build actual CS cluster
-			actualClusterBuilder, actualAutoscalerBuilder, err := BuildCSCluster(resourceID, api.TestTenantID, hcpCluster, tc.requiredProperties, tc.oldClusterServiceCluster, serviceProviderCluster)
+			actualClusterBuilder, err := BuildCSCluster(resourceID, api.TestTenantID, hcpCluster, tc.requiredProperties, tc.oldClusterServiceCluster, serviceProviderCluster)
 
 			if tc.expectedError != "" {
 				require.Error(t, err)
@@ -1307,7 +1307,7 @@ func TestBuildCSCluster(t *testing.T) {
 			expected, err := tc.expectedCSCluster.Build()
 			require.NoError(t, err)
 
-			actual, err := actualClusterBuilder.Autoscaler(actualAutoscalerBuilder).Build()
+			actual, err := actualClusterBuilder.Build()
 			require.NoError(t, err)
 
 			// Compare

--- a/internal/ocm/mock_client.go
+++ b/internal/ocm/mock_client.go
@@ -1005,18 +1005,18 @@ func (c *MockClusterServiceClientSpecPostBreakGlassCredentialCall) DoAndReturn(f
 }
 
 // PostCluster mocks base method.
-func (m *MockClusterServiceClientSpec) PostCluster(ctx context.Context, clusterBuilder *v1alpha1.ClusterBuilder, autoscalerBuilder *v1alpha1.ClusterAutoscalerBuilder) (*v1alpha1.Cluster, error) {
+func (m *MockClusterServiceClientSpec) PostCluster(ctx context.Context, clusterBuilder *v1alpha1.ClusterBuilder) (*v1alpha1.Cluster, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PostCluster", ctx, clusterBuilder, autoscalerBuilder)
+	ret := m.ctrl.Call(m, "PostCluster", ctx, clusterBuilder)
 	ret0, _ := ret[0].(*v1alpha1.Cluster)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // PostCluster indicates an expected call of PostCluster.
-func (mr *MockClusterServiceClientSpecMockRecorder) PostCluster(ctx, clusterBuilder, autoscalerBuilder any) *MockClusterServiceClientSpecPostClusterCall {
+func (mr *MockClusterServiceClientSpecMockRecorder) PostCluster(ctx, clusterBuilder any) *MockClusterServiceClientSpecPostClusterCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostCluster", reflect.TypeOf((*MockClusterServiceClientSpec)(nil).PostCluster), ctx, clusterBuilder, autoscalerBuilder)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostCluster", reflect.TypeOf((*MockClusterServiceClientSpec)(nil).PostCluster), ctx, clusterBuilder)
 	return &MockClusterServiceClientSpecPostClusterCall{Call: call}
 }
 
@@ -1032,13 +1032,13 @@ func (c *MockClusterServiceClientSpecPostClusterCall) Return(arg0 *v1alpha1.Clus
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockClusterServiceClientSpecPostClusterCall) Do(f func(context.Context, *v1alpha1.ClusterBuilder, *v1alpha1.ClusterAutoscalerBuilder) (*v1alpha1.Cluster, error)) *MockClusterServiceClientSpecPostClusterCall {
+func (c *MockClusterServiceClientSpecPostClusterCall) Do(f func(context.Context, *v1alpha1.ClusterBuilder) (*v1alpha1.Cluster, error)) *MockClusterServiceClientSpecPostClusterCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockClusterServiceClientSpecPostClusterCall) DoAndReturn(f func(context.Context, *v1alpha1.ClusterBuilder, *v1alpha1.ClusterAutoscalerBuilder) (*v1alpha1.Cluster, error)) *MockClusterServiceClientSpecPostClusterCall {
+func (c *MockClusterServiceClientSpecPostClusterCall) DoAndReturn(f func(context.Context, *v1alpha1.ClusterBuilder) (*v1alpha1.Cluster, error)) *MockClusterServiceClientSpecPostClusterCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1273,45 +1273,6 @@ func (c *MockClusterServiceClientSpecUpdateClusterCall) Do(f func(context.Contex
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockClusterServiceClientSpecUpdateClusterCall) DoAndReturn(f func(context.Context, InternalID, *v1alpha1.ClusterBuilder) (*v1alpha1.Cluster, error)) *MockClusterServiceClientSpecUpdateClusterCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// UpdateClusterAutoscaler mocks base method.
-func (m *MockClusterServiceClientSpec) UpdateClusterAutoscaler(ctx context.Context, internalID InternalID, builder *v1alpha1.ClusterAutoscalerBuilder) (*v1alpha1.ClusterAutoscaler, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateClusterAutoscaler", ctx, internalID, builder)
-	ret0, _ := ret[0].(*v1alpha1.ClusterAutoscaler)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// UpdateClusterAutoscaler indicates an expected call of UpdateClusterAutoscaler.
-func (mr *MockClusterServiceClientSpecMockRecorder) UpdateClusterAutoscaler(ctx, internalID, builder any) *MockClusterServiceClientSpecUpdateClusterAutoscalerCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateClusterAutoscaler", reflect.TypeOf((*MockClusterServiceClientSpec)(nil).UpdateClusterAutoscaler), ctx, internalID, builder)
-	return &MockClusterServiceClientSpecUpdateClusterAutoscalerCall{Call: call}
-}
-
-// MockClusterServiceClientSpecUpdateClusterAutoscalerCall wrap *gomock.Call
-type MockClusterServiceClientSpecUpdateClusterAutoscalerCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockClusterServiceClientSpecUpdateClusterAutoscalerCall) Return(arg0 *v1alpha1.ClusterAutoscaler, arg1 error) *MockClusterServiceClientSpecUpdateClusterAutoscalerCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockClusterServiceClientSpecUpdateClusterAutoscalerCall) Do(f func(context.Context, InternalID, *v1alpha1.ClusterAutoscalerBuilder) (*v1alpha1.ClusterAutoscaler, error)) *MockClusterServiceClientSpecUpdateClusterAutoscalerCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockClusterServiceClientSpecUpdateClusterAutoscalerCall) DoAndReturn(f func(context.Context, InternalID, *v1alpha1.ClusterAutoscalerBuilder) (*v1alpha1.ClusterAutoscaler, error)) *MockClusterServiceClientSpecUpdateClusterAutoscalerCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/ocm/tracing.go
+++ b/internal/ocm/tracing.go
@@ -97,11 +97,11 @@ func (csc *clusterServiceClientWithTracing) GetClusterProvisionShard(ctx context
 	return csc.csc.GetClusterProvisionShard(ctx, internalID)
 }
 
-func (csc *clusterServiceClientWithTracing) PostCluster(ctx context.Context, clusterBuilder *arohcpv1alpha1.ClusterBuilder, autoscalerBuilder *arohcpv1alpha1.ClusterAutoscalerBuilder) (*arohcpv1alpha1.Cluster, error) {
+func (csc *clusterServiceClientWithTracing) PostCluster(ctx context.Context, clusterBuilder *arohcpv1alpha1.ClusterBuilder) (*arohcpv1alpha1.Cluster, error) {
 	ctx, span := csc.startChildSpan(ctx, "ClusterServiceClient.PostCluster")
 	defer span.End()
 
-	cluster, err := csc.csc.PostCluster(ctx, clusterBuilder, autoscalerBuilder)
+	cluster, err := csc.csc.PostCluster(ctx, clusterBuilder)
 	if err != nil {
 		span.RecordError(err)
 	} else {
@@ -123,21 +123,6 @@ func (csc *clusterServiceClientWithTracing) UpdateCluster(ctx context.Context, i
 	}
 
 	return cluster, err
-}
-
-func (csc *clusterServiceClientWithTracing) UpdateClusterAutoscaler(ctx context.Context, internalID InternalID, builder *arohcpv1alpha1.ClusterAutoscalerBuilder) (*arohcpv1alpha1.ClusterAutoscaler, error) {
-	ctx, span := csc.startChildSpan(ctx, "ClusterServiceClient.UpdateClusterAutoscaler")
-	defer span.End()
-
-	autoscaler, err := csc.csc.UpdateClusterAutoscaler(ctx, internalID, builder)
-	if err != nil {
-		span.RecordError(err)
-	}
-
-	// FIXME Can't call tracing.SetClusterAttributes to identify the cluster.
-	//       Do we need a tracing function that picks apart an InternalID?
-
-	return autoscaler, err
 }
 
 func (csc *clusterServiceClientWithTracing) DeleteCluster(ctx context.Context, internalID InternalID) error {

--- a/test-integration/utils/integrationutils/cluster_service_mock.go
+++ b/test-integration/utils/integrationutils/cluster_service_mock.go
@@ -66,22 +66,12 @@ func (s *ClusterServiceMock) setupMockClusterService(t *testing.T) {
 	internalIDToCluster := s.GetOrCreateMockData(t.Name() + "_clusters")
 	internalIDToExternalAuth := s.GetOrCreateMockData(t.Name() + "_externalAuths")
 	internalIDToNodePool := s.GetOrCreateMockData(t.Name() + "_nodePools")
-	internalIDToAutoscaler := s.GetOrCreateMockData(t.Name() + "_autoscalers")
 	internalIDToProvisionShard := s.GetOrCreateMockData(t.Name() + "_provisionShards")
 	internalIDToHypershiftDetails := s.GetOrCreateMockData(t.Name() + "_hypershiftDetails")
 
-	s.MockClusterServiceClient.EXPECT().PostCluster(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, clusterBuilder *arohcpv1alpha1.ClusterBuilder, autoscalerBuilder *arohcpv1alpha1.ClusterAutoscalerBuilder) (*arohcpv1alpha1.Cluster, error) {
+	s.MockClusterServiceClient.EXPECT().PostCluster(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, clusterBuilder *arohcpv1alpha1.ClusterBuilder) (*arohcpv1alpha1.Cluster, error) {
 		justID := rand.String(10)
 		internalID := "/api/clusters_mgmt/v1/clusters/" + justID
-
-		if autoscalerBuilder != nil {
-			autoscaler, err := autoscalerBuilder.HREF(internalID).Build()
-			if err != nil {
-				return nil, err
-			}
-
-			internalIDToAutoscaler[internalID] = append(internalIDToAutoscaler[internalID], autoscaler)
-		}
 
 		ret, err := clusterBuilder.ID(justID).HREF(internalID).Build()
 		if err != nil {
@@ -112,21 +102,11 @@ func (s *ClusterServiceMock) setupMockClusterService(t *testing.T) {
 			return fmt.Errorf("cluster %q does not exist", id.String())
 		}
 		delete(internalIDToCluster, id.String())
-		delete(internalIDToAutoscaler, id.String())
 
 		return nil
 	}).AnyTimes()
-	s.MockClusterServiceClient.EXPECT().UpdateClusterAutoscaler(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, internalID ocm.InternalID, builder *arohcpv1alpha1.ClusterAutoscalerBuilder) (*arohcpv1alpha1.ClusterAutoscaler, error) {
-		ret, err := builder.HREF(internalID.String()).Build()
-		if err != nil {
-			return nil, err
-		}
-
-		internalIDToAutoscaler[internalID.String()] = append(internalIDToAutoscaler[internalID.String()], ret)
-		return ret, nil
-	}).AnyTimes()
 	s.MockClusterServiceClient.EXPECT().GetCluster(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, id ocm.InternalID) (*csarhcpv1alpha1.Cluster, error) {
-		ret, err := mergeClusterServiceClusterAndAutoscaler(internalIDToCluster[id.String()], internalIDToAutoscaler[id.String()])
+		ret, err := mergeClusterServiceInstance[csarhcpv1alpha1.Cluster](internalIDToCluster[id.String()])
 		if err != nil {
 			return nil, fmt.Errorf("failed to merge cluster id %q: %w", id.String(), err)
 		}
@@ -136,7 +116,7 @@ func (s *ClusterServiceMock) setupMockClusterService(t *testing.T) {
 	s.MockClusterServiceClient.EXPECT().ListClusters(gomock.Any()).DoAndReturn(func(s string) ocm.ClusterListIterator {
 		allObjs := []*csarhcpv1alpha1.Cluster{}
 		for _, key := range sets.StringKeySet(internalIDToCluster).List() {
-			obj, err := mergeClusterServiceClusterAndAutoscaler(internalIDToCluster[key], internalIDToAutoscaler[key])
+			obj, err := mergeClusterServiceInstance[csarhcpv1alpha1.Cluster](internalIDToCluster[key])
 			if err != nil {
 				panic(fmt.Errorf("failed to merge cluster id %q: %w", key, err))
 			}
@@ -291,7 +271,6 @@ func (s *ClusterServiceMock) AddContent(t *testing.T, initialDataDir fs.FS) erro
 	internalIDToCluster := s.GetOrCreateMockData(t.Name() + "_clusters")
 	internalIDToExternalAuth := s.GetOrCreateMockData(t.Name() + "_externalAuths")
 	internalIDToNodePool := s.GetOrCreateMockData(t.Name() + "_nodePools")
-	internalIDToAutoscaler := s.GetOrCreateMockData(t.Name() + "_autoscalers")
 	internalIDToProvisionShard := s.GetOrCreateMockData(t.Name() + "_provisionShards")
 	internalIDToHypershiftDetails := s.GetOrCreateMockData(t.Name() + "_hypershiftDetails")
 
@@ -299,6 +278,9 @@ func (s *ClusterServiceMock) AddContent(t *testing.T, initialDataDir fs.FS) erro
 	if err != nil {
 		return fmt.Errorf("failed to read dir: %w", err)
 	}
+
+	var pendingAutoscalers []*arohcpv1alpha1.ClusterAutoscaler
+	internalIDToAutoscaler := make(map[string][]*arohcpv1alpha1.ClusterAutoscaler)
 
 	for _, dirEntry := range dirContent {
 		if dirEntry.IsDir() {
@@ -347,12 +329,13 @@ func (s *ClusterServiceMock) AddContent(t *testing.T, initialDataDir fs.FS) erro
 		case strings.HasSuffix(dirEntry.Name(), "-autoscaler.json"):
 			obj, err := arohcpv1alpha1.UnmarshalClusterAutoscaler(fileContent)
 			if err != nil {
-				return fmt.Errorf("failed to unmarshal cluster: %w", err)
+				return fmt.Errorf("failed to unmarshal autoscaler: %w", err)
 			}
 			if _, exists := internalIDToAutoscaler[obj.HREF()]; exists {
 				return fmt.Errorf("duplicate autoscaler: %s", obj.HREF())
 			}
-			internalIDToAutoscaler[obj.HREF()] = []any{obj}
+			internalIDToAutoscaler[obj.HREF()] = []*arohcpv1alpha1.ClusterAutoscaler{obj}
+			pendingAutoscalers = append(pendingAutoscalers, obj)
 
 		case strings.HasSuffix(dirEntry.Name(), "-provisionshard.json"):
 			href, err := clusterHrefFromClusterServiceSubResource(fileContent)
@@ -385,6 +368,19 @@ func (s *ClusterServiceMock) AddContent(t *testing.T, initialDataDir fs.FS) erro
 		default:
 			return fmt.Errorf("unknown file %s", dirEntry.Name())
 		}
+	}
+
+	for _, autoscaler := range pendingAutoscalers {
+		clusterHref := autoscaler.HREF()
+		clusterHistory, exists := internalIDToCluster[clusterHref]
+		if !exists {
+			return fmt.Errorf("autoscaler fixture references cluster %q but no matching -cluster.json was loaded", clusterHref)
+		}
+		updatedHistory, err := embedAutoscalerInClusterHistory(clusterHistory, autoscaler)
+		if err != nil {
+			return fmt.Errorf("failed to embed autoscaler into cluster %q: %w", clusterHref, err)
+		}
+		internalIDToCluster[clusterHref] = updatedHistory
 	}
 
 	return nil
@@ -564,24 +560,34 @@ func mergeClusterServiceInstance[T any](history []any) (*T, error) {
 	return unmarshalClusterServiceAny[T](mergedJSON)
 }
 
-func mergeClusterServiceClusterAndAutoscaler(clusterHistory []any, autoscalerHistory []any) (*arohcpv1alpha1.Cluster, error) {
-	cluster, err := mergeClusterServiceInstance[csarhcpv1alpha1.Cluster](clusterHistory)
+func embedAutoscalerInClusterHistory(clusterHistory []any, autoscaler *arohcpv1alpha1.ClusterAutoscaler) ([]any, error) {
+	if len(clusterHistory) == 0 {
+		return nil, fmt.Errorf("cluster history is empty")
+	}
+
+	if autoscaler == nil {
+		return nil, fmt.Errorf("autoscaler is nil")
+	}
+
+	mergedJSON, err := mergeClusterServiceReturn(clusterHistory)
 	if err != nil {
 		return nil, err
 	}
 
-	clusterBuilder := csarhcpv1alpha1.NewCluster().Copy(cluster)
-
-	if len(autoscalerHistory) > 0 {
-		autoscaler, err := mergeClusterServiceInstance[csarhcpv1alpha1.ClusterAutoscaler](autoscalerHistory)
-		if err != nil {
-			return nil, err
-		}
-
-		clusterBuilder.Autoscaler(csarhcpv1alpha1.NewClusterAutoscaler().Copy(autoscaler))
+	cluster, err := arohcpv1alpha1.UnmarshalCluster(mergedJSON)
+	if err != nil {
+		return nil, err
 	}
 
-	return clusterBuilder.Build()
+	embedded, err := arohcpv1alpha1.NewCluster().Copy(cluster).
+		Autoscaler(arohcpv1alpha1.NewClusterAutoscaler().Copy(autoscaler)).
+		Build()
+	if err != nil {
+		return nil, err
+	}
+	result := append([]any(nil), clusterHistory[:len(clusterHistory)-1]...)
+	result = append(result, embedded)
+	return result, nil
 }
 
 func unmarshalClusterServiceAny[T any](mergedJSON []byte) (*T, error) {


### PR DESCRIPTION

### Jira Issue
 [ Remove direct autoscaler patch call from RP and pass autoscaler via patch cluster](https://redhat.atlassian.net/browse/ARO-24013)

### What

- Removed the explicit API call to patch autoscaler from RP and instead pass autoscaler data as part of the Patch Cluster request. 
- Nest autoscaler into the cluster builder in dispatch config / BuildCSCluster, and simplify create/update paths (PostCluster, frontend, create/dispatch controllers) to a single cluster payload.
- Remove the unused autoscaler client API and update related mocks/tests accordingly.

### Why

- To align RP behavior with async autoscaler update model.

<!-- Briefly explain why this change is needed -->

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
 (internal/ocm/convert_test.go) - Already test autoscaler builder construction  
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
Updated mock properly extracts autoscaler history for verification  
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

No New Tests Required:                                                                                                                                                                                                                                                                                                                                                                                                      This is a refactoring change that doesn't alter external behavior - the ARM API contract remains unchanged. Existing tests validate the consolidated approach.   

## Manual Testing

1. patch autoscaler call was present in patch cluster RP call. After changes it is removed and confirmed using logs
Before changes patch cluster and patch autoscaler call is present in logs-
￼￼
<img width="2994" height="364" alt="image" src="https://github.com/user-attachments/assets/2b3bfd37-8c70-426f-a64e-6fae8142bf0d" />

After changes only patch cluster call is present in logs -
<img width="1498" height="217" alt="image" src="https://github.com/user-attachments/assets/475993d0-5e83-4630-aeec-16f8768e4028" />

2.  Patch Cluster with autoscaler payload. Check the autoscaler is updated.
￼￼￼
Autoscaler values before patch
<img width="2994" height="398" alt="image" src="https://github.com/user-attachments/assets/26c92869-4912-48c9-9d7b-217897041c0f" />


Patch cluster payload - 

```
{
  "properties": {
    "autoscaling": {
      "maxNodesTotal": 5,
      "maxPodGracePeriodSeconds": 1200,
      "podPriorityThreshold": -10
    }
  }
}
```
Success -
<img width="2994" height="1752" alt="image" src="https://github.com/user-attachments/assets/14bba6aa-aa24-4ac6-a5a7-0083d5551476" />


Get Autoscaler changes to check the updation -
<img width="2950" height="436" alt="image" src="https://github.com/user-attachments/assets/03621c5d-d566-4799-a09e-b78738469ed8" />



### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

E2E test will be covered in https://github.com/Azure/ARO-HCP/pull/5932 this PR.