### PR TITLE
feat: add millions-unit config fields for AMW ingestion limits

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -7,7 +7,9 @@ clouds:
           # Monitoring - Int needs higher limits
           monitoring:
             maxActiveTimeSeries: 4000000
+            maxActiveTimeSeriesMillions: 4
             maxEventsPerMinute: 4000000
+            maxEventsPerMinuteMillions: 4
           # E2E
           e2e:
             regionTest:

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -2914,9 +2914,17 @@
           "type": "integer",
           "description": "Maximum active time series limit for Azure Monitor Workspace (2M initial, bump when hitting 50% utilization)"
         },
+        "maxActiveTimeSeriesMillions": {
+          "type": "integer",
+          "description": "Maximum active time series limit for Azure Monitor Workspace, expressed in millions (e.g. 2 = 2,000,000). Preferred over maxActiveTimeSeries to avoid scientific notation in Go rendering."
+        },
         "maxEventsPerMinute": {
           "type": "integer",
           "description": "Maximum events per minute limit for Azure Monitor Workspace (2M initial, bump when hitting 50% utilization)"
+        },
+        "maxEventsPerMinuteMillions": {
+          "type": "integer",
+          "description": "Maximum events per minute limit for Azure Monitor Workspace, expressed in millions (e.g. 2 = 2,000,000). Preferred over maxEventsPerMinute to avoid scientific notation in Go rendering."
         }
       },
       "additionalProperties": false,

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -380,7 +380,9 @@ defaults:
     # Azure Monitor Workspace ingestion limits
     # 2M initial limit, bump per env when hitting 50% utilization (Azure requires <200% increase)
     maxActiveTimeSeries: 2000000
+    maxActiveTimeSeriesMillions: 2
     maxEventsPerMinute: 2000000
+    maxEventsPerMinuteMillions: 2
     alertRuleOwningTeamTag: ""
     alertsEnabled: false
     alertSeverityCeiling: 0

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -800,7 +800,9 @@ monitoring:
       automitigationEnabled: ""
       routingId: ""
   maxActiveTimeSeries: 2000000
+  maxActiveTimeSeriesMillions: 2
   maxEventsPerMinute: 2000000
+  maxEventsPerMinuteMillions: 2
   svcWorkspaceName: services-j7654321
 msiCredentialsRefresher:
   certificate:

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -800,7 +800,9 @@ monitoring:
       automitigationEnabled: ""
       routingId: ""
   maxActiveTimeSeries: 2000000
+  maxActiveTimeSeriesMillions: 2
   maxEventsPerMinute: 2000000
+  maxEventsPerMinuteMillions: 2
   svcWorkspaceName: services-j7654321
 msiCredentialsRefresher:
   certificate:

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -798,7 +798,9 @@ monitoring:
       automitigationEnabled: ""
       routingId: ""
   maxActiveTimeSeries: 2000000
+  maxActiveTimeSeriesMillions: 2
   maxEventsPerMinute: 2000000
+  maxEventsPerMinuteMillions: 2
   svcWorkspaceName: services-cspr-usw3
 msiCredentialsRefresher:
   certificate:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -798,7 +798,9 @@ monitoring:
       automitigationEnabled: ""
       routingId: ""
   maxActiveTimeSeries: 2000000
+  maxActiveTimeSeriesMillions: 2
   maxEventsPerMinute: 2000000
+  maxEventsPerMinuteMillions: 2
   svcWorkspaceName: services-usw3
 msiCredentialsRefresher:
   certificate:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -798,7 +798,9 @@ monitoring:
       automitigationEnabled: ""
       routingId: ""
   maxActiveTimeSeries: 2000000
+  maxActiveTimeSeriesMillions: 2
   maxEventsPerMinute: 2000000
+  maxEventsPerMinuteMillions: 2
   svcWorkspaceName: services-usw3ptest
 msiCredentialsRefresher:
   certificate:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -800,7 +800,9 @@ monitoring:
       automitigationEnabled: ""
       routingId: ""
   maxActiveTimeSeries: 2000000
+  maxActiveTimeSeriesMillions: 2
   maxEventsPerMinute: 2000000
+  maxEventsPerMinuteMillions: 2
   svcWorkspaceName: services-usw3test
 msiCredentialsRefresher:
   certificate:


### PR DESCRIPTION
### What

Go's text/template renders float64 values above 1,000,000 in scientific notation (e.g. 2e+06), which breaks bicep parameter files that expect plain integers. Instead of working around the rendering, we introduce new config fields that express the same limits in millions (maxActiveTimeSeriesMillions, maxEventsPerMinuteMillions) so the raw config value stays small and renders cleanly.

This PR only adds the schema and default values — nothing consumes the new fields yet. This is intentional: it lets us land the corresponding overrides in sdp-pipelines first (for int/stg/prod environments), before a follow-up PR switches the bicep templates to read the new fields and multiply by 1,000,000 within bicep itself.

The old fields (maxActiveTimeSeries, maxEventsPerMinute) are kept unchanged and will be removed once the migration is complete.


### Why

<!-- Briefly explain why this change is needed -->

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
