### PR TITLE
refactor(dev-ci): self-contained RBAC for dev e2e subscriptions

### DIFF
--- a/dev-infrastructure/configurations/ci-bot-rbac-dev.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/ci-bot-rbac-dev.tmpl.bicepparam
@@ -1,0 +1,16 @@
+using '../templates/ci-bot-rbac.bicep'
+
+param botApplicationName = '{{ .ci.dev.bot.applicationName }}'
+
+param e2eSubscriptionIds = [
+{{ range .ci.dev.e2eSubscriptions }}  '{{ .id }}'
+{{ end }}]
+
+param infrastructureSubscriptions = [
+{{ range .ci.dev.infrastructureSubscriptions }}  {
+    id: '{{ .id }}'
+    isGlobalSubscription: {{ if index . "isGlobalSubscription" }}{{ .isGlobalSubscription }}{{ else }}false{{ end }}
+  }
+{{ end }}]
+
+param grantAksRbac = true

--- a/dev-infrastructure/configurations/e2e-subscription-rbac-assignments.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/e2e-subscription-rbac-assignments.tmpl.bicepparam
@@ -1,8 +1,6 @@
 using '../templates/e2e-subscription-rbac-assignments.bicep'
 
-param customerSubscriptionIds = empty('{{ range $index, $subscription := .ci.dev.e2eSubscriptions }}{{ if $index }},{{ end }}{{ $subscription.id }}{{ end }}') ? [] : split('{{ range $index, $subscription := .ci.dev.e2eSubscriptions }}{{ if $index }},{{ end }}{{ $subscription.id }}{{ end }}', ',')
-
-param homeSubscriptionId = '{{ .ci.dev.devMockIdentities.homeSubscriptionId }}'
+param customerSubscriptionIds = empty('{{ $sep := "" }}{{ range $subscription := .ci.dev.e2eSubscriptions }}{{ $sep }}{{ $subscription.id }}{{ $sep = "," }}{{ end }}') ? [] : split('{{ $sep := "" }}{{ range $subscription := .ci.dev.e2eSubscriptions }}{{ $sep }}{{ $subscription.id }}{{ $sep = "," }}{{ end }}', ',')
 
 param firstPartyPrincipalId = '{{ .ci.dev.devMockIdentities.sharedPrincipals.firstParty.principalId }}'
 

--- a/dev-infrastructure/dev-ci/e2e-subscription-rbac/pipeline.yaml
+++ b/dev-infrastructure/dev-ci/e2e-subscription-rbac/pipeline.yaml
@@ -2,20 +2,6 @@ $schema: "pipeline.schema.v1"
 serviceGroup: Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBAC
 rolloutName: Dev CI E2E Subscription RBAC Rollout
 resourceGroups:
-- name: home
-  resourceGroup: '{{ .global.rg }}'
-  subscription: '{{ .global.subscription.key }}'
-  steps:
-  - name: operator-roles
-    action: ARM
-    template: ../../templates/dev-operator-roles.bicep
-    parameters: ../../configurations/dev-operator-roles.tmpl.bicepparam
-    deploymentLevel: Subscription
-  - name: mock-identity-roles
-    action: ARM
-    template: ../../templates/mock-identity-roles.bicep
-    parameters: ../../configurations/mock-identity-roles.tmpl.bicepparam
-    deploymentLevel: Subscription
 - name: grants
   resourceGroup: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
@@ -25,11 +11,6 @@ resourceGroups:
     template: ../../templates/e2e-subscription-rbac-assignments.bicep
     parameters: ../../configurations/e2e-subscription-rbac-assignments.tmpl.bicepparam
     deploymentLevel: Subscription
-    dependsOn:
-    - resourceGroup: home
-      step: operator-roles
-    - resourceGroup: home
-      step: mock-identity-roles
 - name: ci-bots
   resourceGroup: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'

--- a/dev-infrastructure/dev-ci/e2e-subscription-rbac/pipeline.yaml
+++ b/dev-infrastructure/dev-ci/e2e-subscription-rbac/pipeline.yaml
@@ -83,6 +83,21 @@ resourceGroups:
     dependsOn:
     - resourceGroup: ci-bots
       step: ci-bot-identity
+  # The DEV Release Bot RBAC is still managed imperatively by the legacy
+  # grant-openshift-release-bot-dev.sh script, which created role assignments
+  # under random (non-deterministic) names. Enabling this step before those
+  # legacy assignments are removed fails with RoleAssignmentExists, because the
+  # deterministic guid()-named assignments this template creates collide with
+  # the pre-existing ones. Keep it commented until the DEV bot RBAC migration
+  # (delete legacy assignments, then enable this step) has been performed.
+  # - name: ci-bot-rbac-dev
+  #   action: ARM
+  #   template: ../../templates/ci-bot-rbac.bicep
+  #   parameters: ../../configurations/ci-bot-rbac-dev.tmpl.bicepparam
+  #   deploymentLevel: ResourceGroup
+  #   dependsOn:
+  #   - resourceGroup: ci-bots
+  #     step: ci-bot-identity
   - name: ci-bot-rbac-int
     action: ARM
     template: ../../templates/ci-bot-rbac.bicep

--- a/dev-infrastructure/templates/e2e-subscription-rbac-assignment-subscription.bicep
+++ b/dev-infrastructure/templates/e2e-subscription-rbac-assignment-subscription.bicep
@@ -1,8 +1,5 @@
 targetScope = 'subscription'
 
-@description('Subscription ID that owns the shared custom role definitions')
-param homeSubscriptionId string
-
 @description('Principal ID for aro-dev-first-party2')
 param firstPartyPrincipalId string
 
@@ -21,10 +18,6 @@ param firstPartyRoleName string = 'dev-first-party-mock'
 @description('Custom role name for the MSI mock principal')
 param msiMockRoleName string = 'dev-msi-mock'
 
-@description('Historical custom role name for the KMS plugin role')
-param kmsPluginRoleName string = 'Azure Red Hat OpenShift KMS Plugin - Dev'
-
-var homeSubscriptionScope = '/subscriptions/${homeSubscriptionId}'
 var contributorRoleDefinitionId = subscriptionResourceId(
   'Microsoft.Authorization/roleDefinitions',
   'b24988ac-6180-42a0-ab88-20f7382dd24c'
@@ -33,25 +26,100 @@ var rbacAdminRoleDefinitionId = subscriptionResourceId(
   'Microsoft.Authorization/roleDefinitions',
   'f58310d9-a9f6-439a-9e8d-f62e7b41a168'
 )
-var firstPartyRoleDefinitionId = subscriptionResourceId(
+// Built-in 'Key Vault Crypto User' role. In dev/int the single mock MSI service
+// principal backs every cluster operator identity (see the hardcoded MI dataplane
+// client), so when a cluster enables etcd encryption the KMS plugin authenticates
+// as this principal and needs Key Vault crypto access. This matches the role the
+// product assigns to the per-cluster KMS identity (cluster_scoped_identities_config.go).
+var kmsCryptoUserRoleDefinitionId = subscriptionResourceId(
   'Microsoft.Authorization/roleDefinitions',
-  guid(homeSubscriptionScope, firstPartyRoleName)
+  '12338af0-0e69-4776-bea7-57ae8d297424'
 )
-var msiMockRoleDefinitionId = subscriptionResourceId(
-  'Microsoft.Authorization/roleDefinitions',
-  guid(homeSubscriptionScope, msiMockRoleName)
-)
-var kmsPluginRoleDefinitionId = subscriptionResourceId(
-  'Microsoft.Authorization/roleDefinitions',
-  guid(kmsPluginRoleName)
-)
+
+// Custom role definitions — defined locally in the target subscription so there
+// is no cross-subscription dependency on assignableScopes. Azure enforces custom
+// role display-name (roleName) uniqueness per tenant, so each subscription's copy
+// suffixes the display name with the subscription id to avoid
+// RoleDefinitionWithSameNameExists. The role-definition resource id
+// (guid(subscription().id, roleName)) is already per-subscription unique.
+
+resource firstPartyRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
+  name: guid(subscription().id, firstPartyRoleName)
+  properties: {
+    roleName: '${firstPartyRoleName}-${subscription().subscriptionId}'
+    description: 'ARO HCP Dev Role for mock 1p service principal'
+    type: 'CustomRole'
+    permissions: [
+      {
+        actions: [
+          'Microsoft.Network/virtualNetworks/subnets/serviceAssociationLinks/delete'
+          'Microsoft.Network/virtualNetworks/subnets/serviceAssociationLinks/write'
+          'Microsoft.Network/virtualNetworks/subnets/serviceAssociationLinks/read'
+          'Microsoft.Network/virtualNetworks/subnets/serviceAssociationLinks/details/read'
+          'Microsoft.Network/virtualNetworks/subnets/serviceAssociationLinks/validate/action'
+          'Microsoft.Resources/subscriptions/resourceGroups/read'
+          'Microsoft.Resources/subscriptions/resourceGroups/write'
+        ]
+        notActions: []
+      }
+    ]
+    assignableScopes: [
+      subscription().id
+    ]
+  }
+}
+
+resource msiMockRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
+  name: guid(subscription().id, msiMockRoleName)
+  properties: {
+    roleName: '${msiMockRoleName}-${subscription().subscriptionId}'
+    description: 'ARO HCP Dev Role for MSI mock principal'
+    type: 'CustomRole'
+    permissions: [
+      {
+        actions: [
+          'Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials/delete'
+          'Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials/read'
+          'Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials/write'
+          'Microsoft.ManagedIdentity/userAssignedIdentities/read'
+          'Microsoft.Network/loadBalancers/backendAddressPools/read'
+          'Microsoft.Network/loadBalancers/backendAddressPools/write'
+          'Microsoft.Network/loadBalancers/read'
+          'Microsoft.Network/loadBalancers/write'
+          'Microsoft.Network/natGateways/join/action'
+          'Microsoft.Network/natGateways/read'
+          'Microsoft.Network/networkSecurityGroups/join/action'
+          'Microsoft.Network/networkSecurityGroups/read'
+          'Microsoft.Network/networkSecurityGroups/write'
+          'Microsoft.Network/privateDnsZones/virtualNetworkLinks/read'
+          'Microsoft.Network/privateDnsZones/virtualNetworkLinks/write'
+          'Microsoft.Network/routeTables/join/action'
+          'Microsoft.Network/routeTables/read'
+          'Microsoft.Network/virtualNetworks/join/action'
+          'Microsoft.Network/virtualNetworks/joinLoadBalancer/action'
+          'Microsoft.Network/virtualNetworks/read'
+          'Microsoft.Network/virtualNetworks/subnets/join/action'
+          'Microsoft.Network/virtualNetworks/subnets/read'
+          'Microsoft.Network/virtualNetworks/subnets/write'
+        ]
+        notActions: []
+      }
+    ]
+    assignableScopes: [
+      subscription().id
+    ]
+  }
+}
+
+// Role assignments
+
 resource firstPartyRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(subscription().id, firstPartyPrincipalId, firstPartyRoleDefinitionId)
+  name: guid(subscription().id, firstPartyPrincipalId, firstPartyRole.id)
   scope: subscription()
   properties: {
     principalId: firstPartyPrincipalId
     principalType: 'ServicePrincipal'
-    roleDefinitionId: firstPartyRoleDefinitionId
+    roleDefinitionId: firstPartyRole.id
   }
 }
 
@@ -76,45 +144,45 @@ resource armHelperRbacAdminRoleAssignment 'Microsoft.Authorization/roleAssignmen
 }
 
 resource miMockRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(subscription().id, miMockPrincipalId, msiMockRoleDefinitionId)
+  name: guid(subscription().id, miMockPrincipalId, msiMockRole.id)
   scope: subscription()
   properties: {
     principalId: miMockPrincipalId
     principalType: 'ServicePrincipal'
-    roleDefinitionId: msiMockRoleDefinitionId
+    roleDefinitionId: msiMockRole.id
   }
 }
 
 resource miMockKmsRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(subscription().id, miMockPrincipalId, kmsPluginRoleDefinitionId)
+  name: guid(subscription().id, miMockPrincipalId, kmsCryptoUserRoleDefinitionId)
   scope: subscription()
   properties: {
     principalId: miMockPrincipalId
     principalType: 'ServicePrincipal'
-    roleDefinitionId: kmsPluginRoleDefinitionId
+    roleDefinitionId: kmsCryptoUserRoleDefinitionId
   }
 }
 
 resource pooledMiMockRoleAssignments 'Microsoft.Authorization/roleAssignments@2022-04-01' = [
   for principal in msiMockPoolPrincipals: {
-    name: guid(subscription().id, principal.principalId, msiMockRoleDefinitionId)
+    name: guid(subscription().id, principal.principalId, msiMockRole.id)
     scope: subscription()
     properties: {
       principalId: principal.principalId
       principalType: 'ServicePrincipal'
-      roleDefinitionId: msiMockRoleDefinitionId
+      roleDefinitionId: msiMockRole.id
     }
   }
 ]
 
 resource pooledMiMockKmsRoleAssignments 'Microsoft.Authorization/roleAssignments@2022-04-01' = [
   for principal in msiMockPoolPrincipals: {
-    name: guid(subscription().id, principal.principalId, kmsPluginRoleDefinitionId)
+    name: guid(subscription().id, principal.principalId, kmsCryptoUserRoleDefinitionId)
     scope: subscription()
     properties: {
       principalId: principal.principalId
       principalType: 'ServicePrincipal'
-      roleDefinitionId: kmsPluginRoleDefinitionId
+      roleDefinitionId: kmsCryptoUserRoleDefinitionId
     }
   }
 ]

--- a/dev-infrastructure/templates/e2e-subscription-rbac-assignments.bicep
+++ b/dev-infrastructure/templates/e2e-subscription-rbac-assignments.bicep
@@ -3,9 +3,6 @@ targetScope = 'subscription'
 @description('Subscription IDs that should receive the shared E2E role assignments')
 param customerSubscriptionIds array = []
 
-@description('Subscription ID that owns the shared custom role definitions')
-param homeSubscriptionId string
-
 @description('Principal ID for aro-dev-first-party2')
 param firstPartyPrincipalId string
 
@@ -24,22 +21,17 @@ param firstPartyRoleName string = 'dev-first-party-mock'
 @description('Custom role name for the MSI mock principal')
 param msiMockRoleName string = 'dev-msi-mock'
 
-@description('Historical custom role name for the KMS plugin role')
-param kmsPluginRoleName string = 'Azure Red Hat OpenShift KMS Plugin - Dev'
-
 module customerSubscriptionAssignments './e2e-subscription-rbac-assignment-subscription.bicep' = [
   for (customerSubscriptionId, index) in customerSubscriptionIds: {
     name: 'cust-sub-rbac-${index}'
     scope: subscription(customerSubscriptionId)
     params: {
-      homeSubscriptionId: homeSubscriptionId
       firstPartyPrincipalId: firstPartyPrincipalId
       armHelperPrincipalId: armHelperPrincipalId
       miMockPrincipalId: miMockPrincipalId
       msiMockPoolPrincipals: msiMockPoolPrincipals
       firstPartyRoleName: firstPartyRoleName
       msiMockRoleName: msiMockRoleName
-      kmsPluginRoleName: kmsPluginRoleName
     }
   }
 ]

--- a/docs/.prow-docs-maintenance.md
+++ b/docs/.prow-docs-maintenance.md
@@ -9,7 +9,8 @@ The canonical CI docs now live in:
 - `docs/ci/README.md`
 - `docs/ci/execution.md`
 - `docs/ci/dev-ci-topology.md`
-- `docs/ci/dev-e2e-subscription-onboarding.md`
+- `docs/ci/e2e-subscription-onboarding.md`
+- `docs/ci/dev-mock-identities.md`
 - `docs/ci/image-lifecycle.md`
 - `docs/ci/identity-leasing.md`
 - `docs/ci/ev2-integration.md`
@@ -26,7 +27,8 @@ Keep the CI docs concept-first:
 - `README.md`: where to start and which doc answers which question
 - `execution.md`: how CI works and what each mode validates
 - `dev-ci-topology.md`: what the standalone `dev-ci` rollout owns and where it still hands off to runtime CI or mixed operator paths
-- `dev-e2e-subscription-onboarding.md`: the operator procedure for adding another DEV customer subscription to the slot-based E2E fleet
+- `e2e-subscription-onboarding.md`: the operator procedure for onboarding E2E customer subscriptions across all environments (DEV, INT, STG, PROD)
+- `dev-mock-identities.md`: what each DEV mock identity stands in for and why it needs each role it is granted
 - `image-lifecycle.md`: deep mechanics for the CI image graph, promotion, and ACR push boundary
 - `identity-leasing.md`: deep mechanics for managed identity and MSI mock SP leasing
 - `ev2-integration.md`: deep mechanics for EV2, Gangway, and pinned gating runs
@@ -97,12 +99,19 @@ Update `docs/ci/dev-ci-topology.md` when:
 - the supported local entry points for `dev-ci` rollouts change
 - the long-term direction for replacing the mixed model changes materially
 
-Update `docs/ci/dev-e2e-subscription-onboarding.md` when:
+Update `docs/ci/e2e-subscription-onboarding.md` when:
 
 - the slot-catalog contract or slot-manager onboarding flow changes
 - the release-side Boskos sync/validation workflow changes
 - the cluster-profile shard inventory contract changes
 - the `dev-ci` bootstrap RBAC onboarding path or its current limitations change
+
+Update `docs/ci/dev-mock-identities.md` when:
+
+- a mock identity is added, removed, or repurposed
+- the role definitions or role assignments granted to a mock identity change
+- the mock MSI data-plane behavior (one SP backing all operator identities) changes
+- a custom mock role is migrated to or from an Azure built-in role
 
 Update `docs/ci/image-lifecycle.md` when:
 
@@ -177,7 +186,7 @@ Before finalizing CI doc updates:
 - [ ] links point at `docs/ci/` targets, not the old top-level docs
 - [ ] `execution.md` still answers "how does CI work?"
 - [ ] `dev-ci-topology.md` still answers "what does standalone dev-ci own today?"
-- [ ] `dev-e2e-subscription-onboarding.md` still reflects the real onboarding path and any current fixed-width limitations
+- [ ] `e2e-subscription-onboarding.md` still reflects the real onboarding path and any current fixed-width limitations
 - [ ] `image-lifecycle.md` still carries the deep CI image graph instead of duplicating it across multiple docs
 - [ ] `identity-leasing.md` still carries the deep lease mechanics instead of duplicating them across multiple docs
 - [ ] `ev2-integration.md` still carries the deep EV2/Prow narrative instead of duplicating it across multiple docs

--- a/docs/README.md
+++ b/docs/README.md
@@ -97,8 +97,8 @@ Welcome to the **ARO HCP** documentation. This guide provides an overview of the
 - [Dev-CI Topology](ci/dev-ci-topology.md)
   - Standalone `dev-ci` rollout, persistent CI-supporting infrastructure, and service-group ownership
   - Current mixed-management boundary for the DEV MSI mock SP pool and the long-term declarative direction
-- [DEV E2E Subscription Onboarding](ci/dev-e2e-subscription-onboarding.md)
-  - Procedure for adding another DEV customer subscription to the slot-based E2E fleet
+- [E2E Subscription Onboarding](ci/e2e-subscription-onboarding.md)
+  - Procedure for onboarding E2E customer subscriptions across all environments (DEV, INT, STG, PROD)
   - Covers slot catalog, Boskos, cluster-profile inventory, and `dev-ci` bootstrap RBAC updates
 - [CI Image Lifecycle](ci/image-lifecycle.md)
   - Shared CI build root, job-local image graph, and local E2E image injection

--- a/docs/ci/README.md
+++ b/docs/ci/README.md
@@ -46,15 +46,20 @@ ARO HCP CI is split across this repository and the OpenShift CI configuration in
 - [Operator Entry Points](dev-ci-topology.md#operator-entry-points)
 - [Where To Look](dev-ci-topology.md#where-to-look)
 
-### [DEV E2E Subscription Onboarding](dev-e2e-subscription-onboarding.md)
+### [E2E Subscription Onboarding](e2e-subscription-onboarding.md)
 
-- [What This Onboarding Touches](dev-e2e-subscription-onboarding.md#what-this-onboarding-touches)
-- [Current Model](dev-e2e-subscription-onboarding.md#current-model)
-- [Existing-Assignment Caveat](dev-e2e-subscription-onboarding.md#existing-assignment-caveat)
-- [Shared Bootstrap Identities](dev-e2e-subscription-onboarding.md#shared-bootstrap-identities)
-- [Procedure](dev-e2e-subscription-onboarding.md#procedure)
-- [What Usually Does Not Change](dev-e2e-subscription-onboarding.md#what-usually-does-not-change)
-- [Where To Look](dev-e2e-subscription-onboarding.md#where-to-look)
+- [DEV E2E Subscription Onboarding](e2e-subscription-onboarding.md#dev-e2e-subscription-onboarding)
+- [INT/STG/PROD E2E Subscription Onboarding](e2e-subscription-onboarding.md#intstgprod-e2e-subscription-onboarding)
+
+### [DEV Mock Identities](dev-mock-identities.md)
+
+- [The Identities At A Glance](dev-mock-identities.md#the-identities-at-a-glance)
+- [First Party Mock](dev-mock-identities.md#first-party-mock--aro-dev-first-party2)
+- [ARM Helper](dev-mock-identities.md#arm-helper--aro-dev-arm-helper2-the-mockfpa)
+- [MSI Mock](dev-mock-identities.md#msi-mock--aro-dev-msi-mock2-and-the-pool)
+- [Why Some Roles Are Custom And Others Built-In](dev-mock-identities.md#why-some-roles-are-custom-and-others-built-in)
+- [How The Roles Are Assigned](dev-mock-identities.md#how-the-roles-are-assigned)
+- [Where To Look](dev-mock-identities.md#where-to-look)
 
 ### [CI Image Lifecycle](image-lifecycle.md)
 
@@ -170,7 +175,8 @@ ARO HCP CI is split across this repository and the OpenShift CI configuration in
 
 - [CI Execution](execution.md) explains how CI works, what each execution mode validates, and how requests flow across tenants and subscriptions.
 - [Dev-CI Topology](dev-ci-topology.md) explains what the standalone `dev-ci` rollout owns today, how it relates to on-demand DEV CI, and where the remaining mixed-management boundary still sits.
-- [DEV E2E Subscription Onboarding](dev-e2e-subscription-onboarding.md) documents the end-to-end procedure for adding another DEV customer subscription, including slot catalog, Boskos, cluster-profile inventory, and bootstrap RBAC updates.
+- [E2E Subscription Onboarding](e2e-subscription-onboarding.md) documents the end-to-end procedure for adding customer subscriptions across all environments (DEV, INT, STG, PROD), including slot catalog, Boskos, AFEC flags, and RBAC updates.
+- [DEV Mock Identities](dev-mock-identities.md) explains what each DEV mock identity (first-party, ARM helper, MSI mock and its pool) stands in for and why it needs each role it is granted, given the absence of a real FPA and Managed Identities Data Plane.
 - [CI Image Lifecycle](image-lifecycle.md) explains the shared CI build root, job-local image graph, local E2E image injection, and the difference between CI promotion and ACR mirroring.
 - [CI Identity Leasing](identity-leasing.md) explains the managed identity container pool, the MSI mock SP pool, and the current staged model: slot-manager for DEV `e2e-parallel`, legacy ci-operator identity-container leases elsewhere.
 - [CI Quota Monitoring](quota-monitoring.md) explains how Azure quotas that constrain CI are monitored and where to check current usage.

--- a/docs/ci/dev-ci-topology.md
+++ b/docs/ci/dev-ci-topology.md
@@ -97,6 +97,6 @@ When you need to change or debug the standalone `dev-ci` topology, start here:
 
 - [CI Overview](README.md)
 - [CI Execution](execution.md)
-- [DEV E2E Subscription Onboarding](dev-e2e-subscription-onboarding.md)
+- [E2E Subscription Onboarding](e2e-subscription-onboarding.md)
 - [CI Identity Leasing](identity-leasing.md)
 - [CI Operations](operations.md)

--- a/docs/ci/dev-mock-identities.md
+++ b/docs/ci/dev-mock-identities.md
@@ -1,0 +1,171 @@
+# DEV Mock Identities
+
+DEV (and the CSPR PR-check and MSIT INT environments) cannot use the real Azure
+control planes that the product relies on in production:
+
+- there is no Microsoft **First Party Application (FPA)** that the Resource Provider
+  and Clusters Service can act through, and
+- the **Managed Identities Data Plane** service — which hands out the runtime
+  credentials of a cluster's user-assigned managed identities — is only available in
+  tenants where that FPA integration exists.
+
+To run end to end without those, DEV substitutes a small set of **mock identities**:
+ordinary Entra service principals that impersonate the identities the product would
+otherwise use. This document explains what each mock identity stands in for, why it
+needs exactly the roles it is granted, and how those roles are assigned today.
+
+## The Identities At A Glance
+
+The DEV bootstrap layer manages four logical identities (principal IDs come from
+`config/config-dev-ci.yaml` under `.ci.dev.devMockIdentities`):
+
+| Identity | Mocks | Roles it receives |
+|---|---|---|
+| `aro-dev-first-party2` (firstParty) | The Microsoft First Party Application | `dev-first-party-mock` (custom) |
+| `aro-dev-arm-helper2` (armHelper) | The FPA's ARM/RBAC delegation ("MockFPA") | `Contributor` + `Role Based Access Control Administrator` (built-in) |
+| `aro-dev-msi-mock2` (miMock) | Every per-cluster operator managed identity | `dev-msi-mock` (custom) + `Key Vault Crypto User` (built-in) |
+| `aro-dev-msi-mock-pool-<i>` (pool) | Same as miMock, one per Boskos lease | Same as miMock |
+
+Clusters Service consumes them via its deployment arguments
+(`cluster-service/helm-charts/cluster-service/templates/deployment.yaml`):
+`azureFirstPartyApplicationClientId`, `azureArmHelperIdentityClientId` +
+`azureArmHelperMockFpaPrincipalId`, and `azureMiMockServicePrincipal*`.
+
+## First Party Mock — `aro-dev-first-party2`
+
+This principal stands in for the Microsoft First Party Application. In production the
+FPA performs the subnet-delegation handshake (service association links) when a
+customer virtual network is attached to a managed cluster, and reads/writes the
+managed resource group.
+
+Its custom role `dev-first-party-mock` therefore grants only:
+
+- `Microsoft.Network/virtualNetworks/subnets/serviceAssociationLinks/*` — create,
+  read, validate and delete the service association link that delegates a subnet.
+- `Microsoft.Resources/subscriptions/resourceGroups/read|write` — manage the
+  managed resource group.
+
+That narrow scope is deliberate: the first-party mock does **not** create the
+cluster's Azure resources or assign roles. Those are the ARM helper's job.
+
+## ARM Helper — `aro-dev-arm-helper2` (the "MockFPA")
+
+In production the FPA can act on behalf of the customer to create Azure resources and
+to **assign roles to the cluster's operator identities**. DEV has no FPA, so the ARM
+helper impersonates that capability — hence the config key
+`azureArmHelperMockFpaPrincipalId` ("Mock FPA principal id").
+
+It is granted two **built-in** roles at subscription scope:
+
+- **Contributor** (`b24988ac-…`) — create and manage the Azure resources a cluster
+  needs.
+- **Role Based Access Control Administrator** (`f58310d9-…`) — create the role
+  assignments that bind each cluster operator identity to its operator role.
+
+Note that Azure does **not** require the granting principal to hold the permissions
+it hands out; *Role Based Access Control Administrator* can assign `Key Vault Crypto
+User` (and the operator roles) without holding them itself. This is why the ARM
+helper, not the MSI mock, is the identity that performs operator-role assignments.
+
+## MSI Mock — `aro-dev-msi-mock2` and the pool
+
+This is the most important — and most easily misunderstood — identity.
+
+Because the Managed Identities Data Plane is unavailable, the backend/CS uses a mock
+client (`backend/pkg/azure/client/hardcoded_identity_mi_dataplane_client.go`) whose
+own documentation states it plainly: *"all requests made with it return a single
+Azure Service Principal identity, disguised as a Managed Identity."* In other words,
+**every per-cluster operator identity — Cloud Controller Manager, Ingress, the
+network operator, the KMS plugin, and so on — authenticates at runtime as the single
+MSI mock service principal.**
+
+That is why its custom role `dev-msi-mock` is the **union** of what those operators
+actually do at runtime:
+
+- `Microsoft.ManagedIdentity/userAssignedIdentities/read` and
+  `…/federatedIdentityCredentials/*` — workload-identity federation for the
+  operators.
+- A broad set of `Microsoft.Network/*` actions on load balancers, subnets, NSGs,
+  route tables, NAT gateways, private DNS zone links and virtual networks — the
+  operations the cloud-controller-manager, ingress and network operators perform.
+
+For the same reason it also needs Key Vault crypto access: when a cluster enables
+etcd data encryption, the **KMS plugin authenticates as the MSI mock** and calls
+Key Vault key operations. This path is exercised by DEV E2E
+(`test/e2e/cluster_create_private_kv.go`,
+`test/e2e/cluster_create_complex_cilium_kv.go`,
+`test/e2e/cluster_version_backlevel.go`). The MSI mock is therefore granted the
+**built-in `Key Vault Crypto User`** role (`12338af0-0e69-4776-bea7-57ae8d297424`) —
+the same role the product assigns to the per-cluster KMS identity for both Dev and
+Public (`internal/azure/cluster_scoped_identities_config.go`).
+
+The pooled `aro-dev-msi-mock-pool-<i>` principals are functionally identical clones
+of the MSI mock. They exist so concurrent presubmit jobs can each lease a distinct
+principal via Boskos, spreading subscription-level ARM throttling. They receive the
+exact same roles. See [CI Identity Leasing](identity-leasing.md) for the lease model.
+
+## Why Some Roles Are Custom And Others Built-In
+
+Historically the operator-equivalent permissions were packaged as **custom** roles
+(`dev-operator-roles`, and a custom `Azure Red Hat OpenShift KMS Plugin - Dev` role)
+because the corresponding Azure **built-in** roles were not yet approved or available
+across the tenants. As the built-ins became available, the setup migrates to them:
+
+- ARM helper already uses built-in `Contributor` + `Role Based Access Control
+  Administrator`.
+- The MSI mock's KMS grant now uses the built-in `Key Vault Crypto User` instead of
+  the retired custom KMS role — matching INT and the product.
+
+The two remaining custom roles, `dev-first-party-mock` and `dev-msi-mock`, persist
+because they bundle a bespoke set of actions with no single built-in equivalent.
+
+## How The Roles Are Assigned
+
+Role definitions and assignments are reconciled by the `dev-ci` rollout's
+`Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBAC` service group
+(`dev-infrastructure/dev-ci/e2e-subscription-rbac/pipeline.yaml`):
+
+- `templates/e2e-subscription-rbac-assignments.bicep` fans out over the onboarded
+  E2E customer subscriptions (the DEV home subscription is intentionally excluded —
+  its mock roles are still managed by the legacy Makefile targets) and deploys
+  `e2e-subscription-rbac-assignment-subscription.bicep` into each.
+- `templates/e2e-subscription-rbac-assignment-subscription.bicep` is **self-contained
+  per subscription**: it defines the custom roles (`dev-first-party-mock`,
+  `dev-msi-mock`) inline in the target subscription and creates all the role
+  assignments. Defining the roles locally avoids any cross-subscription
+  `assignableScopes` dependency, so the pipeline can onboard subscriptions it does
+  not own. Because each subscription gets its own copy and Azure enforces custom-role
+  display-name uniqueness **per tenant**, the display name is suffixed with the
+  subscription id (e.g. `dev-msi-mock-<subscriptionId>`) to avoid
+  `RoleDefinitionWithSameNameExists`.
+
+Principal IDs and the subscription list are supplied by
+`configurations/e2e-subscription-rbac-assignments.tmpl.bicepparam` from
+`config/config-dev-ci.yaml`.
+
+> The separate `templates/mock-identity-roles.bicep` provisions the custom role
+> *definitions* in the DEV home subscription only, and is **not** deployed by this
+> pipeline — the home-subscription mock roles are still managed by the legacy
+> `dev-infrastructure/Makefile` targets (`create-mock-identities`). The E2E customer
+> subscriptions do not use it — they define their roles inline as described above.
+
+## Where To Look
+
+- `config/config-dev-ci.yaml` — `.ci.dev.devMockIdentities` principal IDs and pool
+- `dev-infrastructure/templates/e2e-subscription-rbac-assignments.bicep`
+- `dev-infrastructure/templates/e2e-subscription-rbac-assignment-subscription.bicep`
+  — inline custom role definitions + all assignments
+- `dev-infrastructure/templates/mock-identity-roles.bicep` — home-subscription role
+  definitions (legacy; deployed by the `dev-infrastructure/Makefile`, not this pipeline)
+- `dev-infrastructure/dev-ci/e2e-subscription-rbac/pipeline.yaml`
+- `backend/pkg/azure/client/hardcoded_identity_mi_dataplane_client.go` — the mock MSI
+- `internal/azure/cluster_scoped_identities_config.go` — product operator-role mapping
+- `cluster-service/helm-charts/cluster-service/templates/deployment.yaml` — how CS
+  consumes the mock identities
+
+## See Also
+
+- [CI Overview](README.md)
+- [Dev-CI Topology](dev-ci-topology.md)
+- [E2E Subscription Onboarding](e2e-subscription-onboarding.md)
+- [CI Identity Leasing](identity-leasing.md)

--- a/docs/ci/e2e-subscription-onboarding.md
+++ b/docs/ci/e2e-subscription-onboarding.md
@@ -1,10 +1,19 @@
-# DEV E2E Subscription Onboarding
+# E2E Subscription Onboarding
 
-This document covers the current procedure for adding another customer subscription to the DEV E2E slot fleet.
+This document covers the procedure for onboarding new customer subscriptions for E2E testing across all environments.
 
-Today the canonical DEV slot inventory lives in `test/e2e-config/e2e-slots.yaml`, where the `dev` slot environment is consumed by the `prow` and `ci01` deploy environments. This onboarding flow is DEV-specific; INT, STG, and PROD use different access models.
+- [DEV](#dev-e2e-subscription-onboarding) — no ARM integration; onboarding is CI-infrastructure-only
+- [INT / STG / PROD](#intstgprod-e2e-subscription-onboarding) — ARM-integrated environments; requires AFEC flag registration plus CI infrastructure changes
 
-## What This Onboarding Touches
+---
+
+## DEV E2E Subscription Onboarding
+
+This section covers the procedure for adding another customer subscription to the DEV E2E slot fleet.
+
+Today the canonical DEV slot inventory lives in `test/e2e-config/e2e-slots.yaml`, where the `dev` slot environment is consumed by the `prow` and `ci01` deploy environments.
+
+### What This Onboarding Touches
 
 Adding a new DEV customer subscription spans four different inventories:
 
@@ -15,7 +24,7 @@ Adding a new DEV customer subscription spans four different inventories:
 
 It is not just a slot-catalog change.
 
-## Current Model
+### Current Model
 
 The current implementation is split across two layers:
 
@@ -99,7 +108,7 @@ az provider show --namespace Microsoft.Compute \
    - Verify that the deployment stacks and identity-container resource groups are created in the new subscription.
 
 6. Extend the DEV bootstrap RBAC and quota-monitoring inventory.
-   - Add the subscription name and ID to `config/config-dev-ci.yaml` under `devCi.e2eSubscriptionRbac.customerSubscriptions`.
+   - Add the subscription name and ID to `config/config-dev-ci.yaml` under `ci.dev.e2eSubscriptions`.
    - That list now feeds the `dev-ci` RBAC parameter templates directly, so a brand-new subscription does not require extra per-index template edits.
    - In the same `config/config-dev-ci.yaml`, also add the subscription to the `opstool.tenantQuota` tenant's `subscriptions` list so the `tenant-quota-collector` tracks it. Set `roleAssignmentLimit: 8000` and list the same `regions` the pool runs in, matching the Role Assignment quota requested in step 2.
    - In a normal onboarding flow, `homeSubscription`, `sharedPrincipals`, and `msiMockPool.principals` should not need to change.
@@ -112,7 +121,7 @@ az provider show --namespace Microsoft.Compute \
    - Verify customer-resource creation in the new subscription succeeds without Azure `AuthorizationFailed` errors.
    - Verify release and cleanup still return the leased slot correctly.
 
-## What Usually Does Not Change
+### What Usually Does Not Change
 
 Adding a new DEV customer subscription normally does not require:
 
@@ -122,7 +131,7 @@ Adding a new DEV customer subscription normally does not require:
 
 Those steps only become necessary if the shared identities or the Boskos-backed MSI mock pool itself changes.
 
-## Where To Look
+### Where To Look
 
 - `test/e2e-config/e2e-slots.yaml`
 - `test/cmd/aro-hcp-tests/slot-manager/DESIGN.md`
@@ -130,11 +139,94 @@ Those steps only become necessary if the shared identities or the Boskos-backed 
 - `test/cmd/aro-hcp-tests/slot-manager/identity-pool/`
 - `config/config-dev-ci.yaml`
 - `dev-infrastructure/dev-ci/e2e-subscription-rbac/pipeline.yaml`
-- `dev-infrastructure/configurations/dev-operator-roles.tmpl.bicepparam`
-- `dev-infrastructure/configurations/mock-identity-roles.tmpl.bicepparam`
 - `dev-infrastructure/configurations/e2e-subscription-rbac-assignments.tmpl.bicepparam`
 - [Dev-CI Topology](dev-ci-topology.md)
 - [CI Identity Leasing](identity-leasing.md)
+
+### External (Unmanaged) Subscriptions
+
+For subscriptions owned by a different team where our pipeline identity does **not** have access, use the external onboarding model instead. External subscriptions are **not listed** in `config/config-dev-ci.yaml` and are marked with `identity_provisioning: unmanaged` in the slot catalog.
+
+The external team runs the RBAC setup and identity-pool provisioning themselves using our Bicep modules. See [External Subscription Onboarding](external-subscription-onboarding.md) for the full procedure and grant contract.
+
+---
+
+## INT/STG/PROD E2E Subscription Onboarding
+
+INT, STG, and PROD are ARM-integrated environments. Each runs its own RP instance, and ARM routes `Microsoft.RedHatOpenShift` API calls to the correct RP based on AFEC (Azure Feature Exposure Control) flags registered on the customer subscription. Without the correct flags, API calls from a subscription will not reach the intended RP.
+
+Onboarding a new E2E testing subscription requires two steps: registering the AFEC flags so ARM routes traffic to the correct RP, and setting up the CI infrastructure (service principal, Boskos slots, cleanup jobs).
+
+### ARM Routing Flags
+
+| AFEC Flag | Routes to |
+| :-------- | :-------- |
+| `HcpPrivatePreview` | Prod RP in GA regions (uksouth, switzerlandnorth, canadacentral, etc.) |
+| `STAGING-APPROVED` | STG RP (uksouthstaging) |
+| `INT-APPROVED` | INT RP (uksouth azure-test.net) |
+| `InProgress` | EUAP/canary regions (centraluseuap, eastus2euap) + disabled future regions (westus, westus2) |
+
+### Required AFEC Flags per Environment
+
+| Environment | Required AFEC Flags |
+| :---------- | :------------------ |
+| INT         | `Microsoft.RedHatOpenShift/INT-APPROVED`, `Microsoft.RedHatOpenShift/ExperimentalReleaseFeatures` |
+| STG         | `Microsoft.RedHatOpenShift/STAGING-APPROVED`, `Microsoft.RedHatOpenShift/ExperimentalReleaseFeatures` |
+| PROD        | `Microsoft.RedHatOpenShift/HcpPrivatePreview`, `Microsoft.RedHatOpenShift/InProgress`, `Microsoft.RedHatOpenShift/ExperimentalReleaseFeatures` |
+
+The routing flag controls which RP instance ARM sends requests to. `ExperimentalReleaseFeatures` gates experimental features used by E2E tests (non-stable channel groups, single-replica control planes, etc.). PROD additionally requires `InProgress` to enable EUAP/canary region access.
+
+### Step 1: Register AFEC Flags
+
+AFEC registration is a two-step process: first initiate the registration from the customer subscription, then approve it via a Geneva Action.
+
+1. **Initiate registration** from the subscription's tenant. Run `az feature register` for each required flag:
+   ```bash
+   az feature register --namespace Microsoft.RedHatOpenShift --name <flag-name> \
+     --subscription <subscription-id>
+   ```
+   For example, for STG:
+   ```bash
+   az feature register --namespace Microsoft.RedHatOpenShift --name STAGING-APPROVED \
+     --subscription <subscription-id>
+   az feature register --namespace Microsoft.RedHatOpenShift --name ExperimentalReleaseFeatures \
+     --subscription <subscription-id>
+   ```
+   This puts the features into `Registering` state.
+
+2. **Request JIT access** (in Teams):
+   - Resource type: `acis`
+   - ARO → `PlatformServiceAdministrator`
+
+3. **Approve the registration** via Geneva Actions:
+   - Azure Resource Manager → Feature Management → Approve Feature Registration
+   - Namespace: `Microsoft.RedHatOpenShift`
+   - Feature Names: all flags initiated in step 1 that are in "Pending" status
+   - Subscription: the subscription ID to onboard
+
+4. **Verify** (from the subscription's tenant):
+   ```bash
+   az feature list --namespace Microsoft.RedHatOpenShift -o table \
+     --subscription <subscription-id>
+   ```
+   All flags should show `Registered`.
+
+> [!NOTE]
+> Step 1 can be performed by anyone with write access to the subscription. Steps 2-3 require Microsoft PlatformServiceAdministrator access.
+
+### Step 2: CI Infrastructure Setup
+
+1. Add the subscription to `config/config-dev-ci.yaml` under the appropriate `ci.<env>.e2eSubscriptions` section.
+
+2. Run the `Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBAC` pipeline to grant the environment's CI bot (e.g. `OpenShift Release Bot - STG`) the required RBAC on the new subscription.
+
+3. Add the pool to `test/e2e-config/e2e-slots.yaml` under the environment's `pools` list.
+
+4. Sync the Boskos inventory and update CI job configs in `openshift/release` (slot catalog, cleanup jobs, `make update`).
+
+5. Update the Vault cluster profile secret (e.g. `kv/selfservice/hcm-aro/aro-hcp-<env>-rh`) with the new subscription's `customer-shard0-subscription-name` and `customer-shard0-subscription-id`.
+
+6. Validate by running a rehearsal E2E job against the new subscription.
 
 ## See Also
 
@@ -142,3 +234,4 @@ Those steps only become necessary if the shared identities or the Boskos-backed 
 - [Dev-CI Topology](dev-ci-topology.md)
 - [CI Identity Leasing](identity-leasing.md)
 - [CI Operations](operations.md)
+- [Environments](../environments.md)

--- a/docs/ci/external-subscription-onboarding.md
+++ b/docs/ci/external-subscription-onboarding.md
@@ -1,0 +1,177 @@
+# External Subscription Onboarding
+
+## DEV E2E Subscription Onboarding
+
+This section covers the procedure for onboarding a DEV E2E customer subscription that is **not managed by the ARO-HCP pipeline identity** — i.e. a subscription owned by a different team within the same Entra tenant.
+
+For subscriptions where the ARO-HCP team has Owner access, see the standard [E2E Subscription Onboarding](e2e-subscription-onboarding.md) procedure.
+
+## Background: Identity Model
+
+E2E tests involve two distinct classes of service principals acting on the customer subscription. Understanding this split is key to the onboarding steps below.
+
+### CI Bot (test runner)
+
+The **OpenShift Release Bot** is the identity under which the Prow CI system executes test code. It creates resource groups, deploys ARM templates, provisions AKS clusters, and assigns roles to per-cluster managed identities during each test run. It needs broad access (Contributor + RBAC Administrator + AKS RBAC Cluster Admin) because it orchestrates the entire test lifecycle — from infrastructure provisioning through teardown.
+
+### DEV RP identities (request handlers)
+
+In production, the ARO-HCP Resource Provider processes customer requests using Azure First Party Application identities. In DEV, these are emulated by shared service principals:
+
+- **`aro-dev-first-party2`** — Simulates the first-party application that manages subnet service association links and resource groups in the customer subscription.
+- **`aro-dev-arm-helper2`** — Simulates the ARM helper that performs Contributor-level and RBAC-level operations on behalf of the RP.
+- **`aro-dev-msi-mock2`** and the **pooled MSI mock principals** — Simulate the managed-identity operations the RP performs (federated credential management, network configuration, Key Vault access for KMS encryption).
+
+These RP identities are **not** used by the test code directly — they are used by the DEV RP instance to handle the API requests that the test code generates. Each needs custom role assignments on the customer subscription so the RP can fulfill those requests.
+
+The pooled MSI mock principals exist so that parallel presubmit jobs each get their own identity, distributing the ARM throttling budget across different principals.
+
+### Identity containers
+
+Each E2E test slot gets a set of pre-provisioned resource groups containing managed identities. These are deployed via ARM deployment stacks and sized according to the slot catalog. The number of identity containers limits the number of concurrent HCPs the E2E job can create within the slot.
+
+### Cleanup jobs
+
+Resource groups left behind by failed or timed-out tests are garbage-collected by periodic Prow jobs that delete expired groups.
+
+## How It Differs From Internal Onboarding
+
+In a standard DEV subscription onboarding, the ARO-HCP pipeline identity (`aro-hcp-owners` group) has Owner access and can deploy RBAC, custom role assignments, and identity containers directly.
+
+For an **external** subscription:
+
+- The subscription is **not listed** in `config/config-dev-ci.yaml` — the ARO-HCP pipeline does not interact with it at all
+- The `apply-identity-pool` command **skips** it by default (controlled by `identity_provisioning: unmanaged` in the slot catalog)
+- The subscription-owning team is responsible for running the RBAC setup and identity-pool provisioning themselves, using the ARO-HCP Bicep modules and tooling
+
+## Responsibility Split
+
+| Step | Responsible Team | Description |
+| :--- | :--------------- | :---------- |
+| Slot catalog entry | ARO-HCP (approves PR) | Add the pool to `test/e2e-config/e2e-slots.yaml` with `identity_provisioning: unmanaged` |
+| Boskos sync | ARO-HCP (approves PR) | Run `slot-manager sync-boskos-config` and merge the `openshift/release` PR |
+| Vault secret | ARO-HCP (manual) | Add `customer-<shard>-subscription-id` and `customer-<shard>-subscription-name` to the cluster profile secret |
+| CI Bot grants | Subscription owner | Grant the CI bot (test runner) the required roles on the subscription (Step 1 below) |
+| RP identity RBAC | Subscription owner | Deploy the Bicep module that grants the DEV RP identities access (Step 2 below) |
+| Identity containers | Subscription owner | Run `make -C test apply-identity-pool ENVIRONMENT=dev SUBSCRIPTION=<name>` (Step 3 below) |
+| Cleanup job | Subscription owner | Add a periodic cleanup job in `openshift/release` (Step 4 below) |
+
+## Subscription Owner Steps
+
+### Prerequisites
+
+Register the Azure resource providers required for E2E test operations:
+
+```sh
+for ns in Microsoft.Compute Microsoft.Network Microsoft.ManagedIdentity; do
+  az provider register --namespace "$ns" --subscription <subscription-id>
+done
+```
+
+These are needed so the CI bot and RP identities can create/manage compute resources, networking, and managed identities within the subscription.
+
+### Step 1: Grant the CI Bot (Test Runner)
+
+The CI bot (`OpenShift Release Bot`, appId `38335e22-716a-4a21-bf20-15ab141823f0`, objectId `c209f8df-52ae-48fb-98ea-380f58b04652`) is the identity that **executes the test code** — it provisions infrastructure, deploys the RP, runs assertions, and tears everything down. It needs the following roles at **subscription scope**:
+
+| Role | Condition | Purpose |
+| :--- | :-------- | :------ |
+| Contributor | None | Create/manage resource groups, ARM deployments, and Azure resources during tests |
+| Role Based Access Control Administrator | ABAC condition preventing assignment of Owner, UAA, and RBAC Administrator roles | Assign roles to per-cluster managed identities created during test runs |
+| Azure Kubernetes Service RBAC Cluster Admin | None | Required for AKS infrastructure provisioning (service cluster creation), not for the tests themselves |
+
+Deploy using the same Bicep module that manages CI bot RBAC for all environments:
+
+```sh
+SUBSCRIPTION_ID="<target-subscription-id>"
+BOT_PRINCIPAL_ID="c209f8df-52ae-48fb-98ea-380f58b04652"
+
+az deployment sub create \
+  --subscription "${SUBSCRIPTION_ID}" \
+  --location westus3 \
+  --template-file dev-infrastructure/templates/ci-bot-rbac-subscription.bicep \
+  --parameters \
+    botPrincipalId="${BOT_PRINCIPAL_ID}" \
+    isGlobalSubscription=false \
+    grantAksRbac=true
+```
+
+> **Note:** Set `grantAksRbac=true` only if the subscription will also host AKS service and management clusters (the DEV RP). If the subscription is used solely for customer resources (HCPs), set it to `false`.
+
+This deploys Contributor, RBAC Administrator (with ABAC condition), and optionally AKS RBAC Cluster Admin — identical to what the pipeline deploys for internally-managed subscriptions.
+
+### Step 2: Grant the DEV RP Identities (Request Handlers)
+
+The shared DEV RP identities are service principals that the **DEV Resource Provider uses to handle API requests** generated by the test code. They are not invoked by the test runner itself — they act on behalf of the RP when it processes cluster creation, deletion, and management operations in the customer subscription.
+
+The Bicep module defines the custom roles (`dev-first-party-mock`, `dev-msi-mock`) locally in the target subscription and assigns them to these RP identities, together with the built-in `Key Vault Crypto User` role (for KMS/etcd encryption) for the MSI mocks and the built-in `Contributor` + `Role Based Access Control Administrator` roles for the ARM helper.
+
+```sh
+SUBSCRIPTION_ID="<your-subscription-id>"
+
+az deployment sub create \
+  --subscription "${SUBSCRIPTION_ID}" \
+  --location westus3 \
+  --template-file dev-infrastructure/templates/e2e-subscription-rbac-assignment-subscription.bicep \
+  --parameters \
+    firstPartyPrincipalId="47f69502-0065-4d9a-b19b-d403e183d2f4" \
+    armHelperPrincipalId="ddeffa11-e3d9-487d-8fc9-9a9e26f64975" \
+    miMockPrincipalId="d6b62dfa-87f5-49b3-bbcb-4a687c4faa96" \
+    msiMockPoolPrincipals='[{"name":"aro-hcp-msi-mock-cs-sp-dev-0","principalId":"db27175c-5bd0-48b4-929a-41de9a53ffbf"},{"name":"aro-hcp-msi-mock-cs-sp-dev-1","principalId":"cd39c606-1f6a-4062-a5b9-497cd04c39fc"},{"name":"aro-hcp-msi-mock-cs-sp-dev-2","principalId":"3871b527-fb1e-4123-b38b-3cb2445a9fc8"},{"name":"aro-hcp-msi-mock-cs-sp-dev-3","principalId":"e92b9f76-b040-4cf6-a4dd-5c8bdc759e69"},{"name":"aro-hcp-msi-mock-cs-sp-dev-4","principalId":"3d8c36e1-ae7a-42ef-b7d1-ea4667708d30"},{"name":"aro-hcp-msi-mock-cs-sp-dev-5","principalId":"3015be55-a361-4a86-8439-0abc7860a4ef"},{"name":"aro-hcp-msi-mock-cs-sp-dev-6","principalId":"f8be0ede-39df-41cf-aed7-7f3626f23a5a"},{"name":"aro-hcp-msi-mock-cs-sp-dev-7","principalId":"07aa0e83-353e-444c-9f1d-d023ac3c5396"},{"name":"aro-hcp-msi-mock-cs-sp-dev-8","principalId":"0d25d885-2cd8-4972-b610-4d85881c1ec4"},{"name":"aro-hcp-msi-mock-cs-sp-dev-9","principalId":"5157a63c-87dc-4680-8f46-954b46399bdc"},{"name":"aro-hcp-msi-mock-cs-sp-dev-10","principalId":"5a34d2fd-f7db-460a-a272-334006a8a3b8"},{"name":"aro-hcp-msi-mock-cs-sp-dev-11","principalId":"fd35ac5f-6493-40cb-9131-d669a70114c3"},{"name":"aro-hcp-msi-mock-cs-sp-dev-12","principalId":"a76148d4-cb11-4b93-9363-54ba8239b0b1"},{"name":"aro-hcp-msi-mock-cs-sp-dev-13","principalId":"b117cf0f-0276-4486-9691-4f00f5a90e1b"},{"name":"aro-hcp-msi-mock-cs-sp-dev-14","principalId":"8d1ff6d0-aadd-4331-9171-9443ac5f4337"},{"name":"aro-hcp-msi-mock-cs-sp-dev-15","principalId":"3e3ad333-db6b-46df-b57d-6f0989dda8b2"},{"name":"aro-hcp-msi-mock-cs-sp-dev-16","principalId":"b26c2343-0863-4a55-bb7e-dfb2544999c1"},{"name":"aro-hcp-msi-mock-cs-sp-dev-17","principalId":"39eefc4f-5e24-491d-9f09-bcc0ad573bcf"},{"name":"aro-hcp-msi-mock-cs-sp-dev-18","principalId":"ccbf438f-08ec-4e2b-ae4e-219ce7dc3762"},{"name":"aro-hcp-msi-mock-cs-sp-dev-19","principalId":"12eafc4e-f869-4b62-8198-816b7d6d0876"}]'
+```
+
+### Step 3: Provision Identity Containers
+
+Use the `apply-identity-pool` Make target with the `SUBSCRIPTION` variable to target only the relevant pool:
+
+```sh
+make -C test apply-identity-pool ENVIRONMENT=dev SUBSCRIPTION="Hypershift Managed Azure"
+```
+
+Always run through this Make target rather than `go run` or a hand-built binary. The target rebuilds `aro-hcp-tests` and, as part of that, regenerates the Bicep-derived ARM artifacts (e.g. `msi-pools.json`) from the source-of-truth Bicep in `test/e2e-setup/bicep/`. The generated artifacts under `test/e2e/test-artifacts/generated-test-artifacts/` are git-ignored build outputs, so bypassing the Make build can embed and apply a stale template — which manifests as resource groups being deleted and recreated instead of updated in place.
+
+This deploys the MSI container deployment stacks into the target subscription based on the slot catalog configuration.
+
+### Step 4: Add a Cleanup Job
+
+Open a PR to `openshift/release` adding a periodic cleanup job for the subscription:
+
+```yaml
+- as: delete-expired-dev-ci-hypershift-resource-groups
+  cron: 35 * * * *
+  steps:
+    env:
+      CLEANUP_MODE: no-rp
+      CUSTOMER_SUBSCRIPTION: Hypershift Managed Azure
+    test:
+    - ref: aro-hcp-deprovision-expired-resource-groups
+```
+
+## Maintenance
+
+If the Bicep module `e2e-subscription-rbac-assignment-subscription.bicep` is updated (new RP principals, new roles, permission changes), the subscription-owning team must re-run the deployment in Step 2.
+
+Changes to the pooled MSI mock principal list (additions or removals in `config/config-dev-ci.yaml` → `msiMockPool.principals`) require re-running Step 2 with the updated `msiMockPoolPrincipals` parameter.
+
+## Reference: Shared Principal IDs
+
+### CI Bot (test runner)
+
+| Identity | Principal ID | Purpose |
+| :------- | :----------- | :------ |
+| OpenShift Release Bot | `c209f8df-52ae-48fb-98ea-380f58b04652` | Executes test code, provisions infrastructure (app: `38335e22-716a-4a21-bf20-15ab141823f0`) |
+
+### DEV RP identities (request handlers)
+
+| Identity | Principal ID | Purpose |
+| :------- | :----------- | :------ |
+| `aro-dev-first-party2` | `47f69502-0065-4d9a-b19b-d403e183d2f4` | First-party application mock — manages subnet links and resource groups |
+| `aro-dev-arm-helper2` | `ddeffa11-e3d9-487d-8fc9-9a9e26f64975` | ARM helper — Contributor + RBAC Admin operations on behalf of the RP |
+| `aro-dev-msi-mock2` | `d6b62dfa-87f5-49b3-bbcb-4a687c4faa96` | MSI mock — federated credentials, networking, Key Vault access |
+| `aro-hcp-msi-mock-cs-sp-dev-{0..19}` | *(see Step 2 command)* | Pooled MSI mocks for parallel presubmit job isolation |
+
+## See Also
+
+- [E2E Subscription Onboarding](e2e-subscription-onboarding.md) — internal subscription procedure
+- [Dev-CI Topology](dev-ci-topology.md)
+- [CI Identity Leasing](identity-leasing.md)

--- a/docs/ci/identity-leasing.md
+++ b/docs/ci/identity-leasing.md
@@ -304,7 +304,7 @@ Jobs only consume the Boskos key and the static `msi-mock-pool.yaml` catalog at 
 When you need to change or debug identity leasing, start here:
 
 - [CI Execution](execution.md)
-- [DEV E2E Subscription Onboarding](dev-e2e-subscription-onboarding.md)
+- [E2E Subscription Onboarding](e2e-subscription-onboarding.md)
 - [slot-manager design](../../test/cmd/aro-hcp-tests/slot-manager/DESIGN.md)
 - ARO HCP test framework: `test/util/framework/identities_helper.go`
 - slot-managed identity-pool code: `test/cmd/aro-hcp-tests/slot-manager/identity-pool/`
@@ -325,7 +325,7 @@ When you need to change or debug identity leasing, start here:
 
 - [CI Overview](README.md)
 - [CI Execution](execution.md)
-- [DEV E2E Subscription Onboarding](dev-e2e-subscription-onboarding.md)
+- [E2E Subscription Onboarding](e2e-subscription-onboarding.md)
 - [CI Quota Monitoring](quota-monitoring.md)
 - [CI Operations](operations.md)
 - [CI EV2 Integration](ev2-integration.md)

--- a/test/Makefile
+++ b/test/Makefile
@@ -47,8 +47,8 @@ build: $(PROW_JOB_EXECUTOR) $(ARO_HCP_TESTS)
 # `go build`, otherwise a stale, git-ignored artifact may be embedded and applied.
 #
 # Set the optional SUBSCRIPTION variable to limit provisioning to the named
-# subscription(s); this is required to provision externally-managed pools
-# (identity_provisioning: external), which are skipped otherwise. Example:
+# subscription(s); this is required to provision unmanaged pools
+# (identity_provisioning: unmanaged), which are skipped otherwise. Example:
 #   make -C test apply-identity-pool ENVIRONMENT=dev SUBSCRIPTION="Hypershift Managed Azure"
 apply-identity-pool: $(ARO_HCP_TESTS)
 	$(ARO_HCP_TESTS) slot-manager apply-identity-pool \

--- a/test/Makefile
+++ b/test/Makefile
@@ -45,9 +45,15 @@ build: $(PROW_JOB_EXECUTOR) $(ARO_HCP_TESTS)
 # ARM artifacts (e.g. msi-pools.json) from the source-of-truth Bicep before the binary
 # is (re)built and embeds them. Always run through this target instead of `go run`/
 # `go build`, otherwise a stale, git-ignored artifact may be embedded and applied.
+#
+# Set the optional SUBSCRIPTION variable to limit provisioning to the named
+# subscription(s); this is required to provision externally-managed pools
+# (identity_provisioning: external), which are skipped otherwise. Example:
+#   make -C test apply-identity-pool ENVIRONMENT=dev SUBSCRIPTION="Hypershift Managed Azure"
 apply-identity-pool: $(ARO_HCP_TESTS)
 	$(ARO_HCP_TESTS) slot-manager apply-identity-pool \
-		--environment "$${ENVIRONMENT:?ENVIRONMENT must be set (e.g. dev, int, stg, prod)}"
+		--environment "$${ENVIRONMENT:?ENVIRONMENT must be set (e.g. dev, int, stg, prod)}" \
+		$(if $(SUBSCRIPTION),--subscription "$(SUBSCRIPTION)")
 .PHONY: apply-identity-pool
 
 int-e2e:

--- a/test/cmd/aro-hcp-tests/slot-manager/identity-pool/options.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/identity-pool/options.go
@@ -44,6 +44,7 @@ func DefaultApplyOptions() *RawApplyOptions {
 func BindApplyOptions(opts *RawApplyOptions, cmd *cobra.Command) error {
 	cmd.Flags().StringVar(&opts.Environment, "environment", opts.Environment, "Environment short name. One of: int, stg, dev, prod")
 	cmd.Flags().StringVar(&opts.SlotCatalog, "slot-catalog", opts.SlotCatalog, "Path to the canonical E2E slot catalog")
+	cmd.Flags().StringSliceVar(&opts.Subscriptions, "subscription", nil, "Limit provisioning to the named subscription(s). When set, unmanaged pools matching the filter are included.")
 	if err := cmd.MarkFlagRequired("environment"); err != nil {
 		return fmt.Errorf("failed to mark flag %q as required: %w", "environment", err)
 	}
@@ -51,8 +52,9 @@ func BindApplyOptions(opts *RawApplyOptions, cmd *cobra.Command) error {
 }
 
 type RawApplyOptions struct {
-	Environment string
-	SlotCatalog string
+	Environment   string
+	SlotCatalog   string
+	Subscriptions []string
 }
 
 type validatedApplyOptions struct {
@@ -98,7 +100,7 @@ func (o *ValidatedApplyOptions) Complete(ctx context.Context) (*ApplyOptions, er
 	}
 	subscriptionClient := subscriptionClientFactory.NewClient()
 
-	pools, err := loadIdentityPools(ctx, o.SlotCatalog, o.Environment, func(ctx context.Context, name string) (string, error) {
+	pools, err := loadIdentityPools(ctx, o.SlotCatalog, o.Environment, o.Subscriptions, func(ctx context.Context, name string) (string, error) {
 		return framework.GetSubscriptionID(ctx, subscriptionClient, name)
 	})
 	if err != nil {

--- a/test/cmd/aro-hcp-tests/slot-manager/identity-pool/options.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/identity-pool/options.go
@@ -44,7 +44,7 @@ func DefaultApplyOptions() *RawApplyOptions {
 func BindApplyOptions(opts *RawApplyOptions, cmd *cobra.Command) error {
 	cmd.Flags().StringVar(&opts.Environment, "environment", opts.Environment, "Environment short name. One of: int, stg, dev, prod")
 	cmd.Flags().StringVar(&opts.SlotCatalog, "slot-catalog", opts.SlotCatalog, "Path to the canonical E2E slot catalog")
-	cmd.Flags().StringSliceVar(&opts.Subscriptions, "subscription", nil, "Limit provisioning to the named subscription(s). When set, unmanaged pools matching the filter are included.")
+	cmd.Flags().StringSliceVar(&opts.Subscriptions, "subscription", opts.Subscriptions, "Limit provisioning to the named subscription(s). When set, unmanaged pools matching the filter are included.")
 	if err := cmd.MarkFlagRequired("environment"); err != nil {
 		return fmt.Errorf("failed to mark flag %q as required: %w", "environment", err)
 	}

--- a/test/cmd/aro-hcp-tests/slot-manager/identity-pool/pools.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/identity-pool/pools.go
@@ -35,7 +35,12 @@ type identityPool struct {
 	Slots              []slots.ExpandedSlot
 }
 
-func loadIdentityPools(ctx context.Context, catalogPath, environment string, resolveSubscriptionID subscriptionIDResolverFunc) ([]identityPool, error) {
+// loadIdentityPools loads pools for the given environment. When
+// subscriptionFilter is non-empty, only pools whose subscription_name matches
+// one of the filter values are included (regardless of identity_provisioning).
+// When subscriptionFilter is empty, pools with identity_provisioning: unmanaged
+// are skipped.
+func loadIdentityPools(ctx context.Context, catalogPath, environment string, subscriptionFilter []string, resolveSubscriptionID subscriptionIDResolverFunc) ([]identityPool, error) {
 	catalog, err := slots.LoadCatalog(catalogPath)
 	if err != nil {
 		return nil, err
@@ -46,9 +51,22 @@ func loadIdentityPools(ctx context.Context, catalogPath, environment string, res
 		return nil, fmt.Errorf("unknown environment %q", environment)
 	}
 
+	filterSet := make(map[string]struct{}, len(subscriptionFilter))
+	for _, name := range subscriptionFilter {
+		filterSet[name] = struct{}{}
+	}
+
 	resolvedIDs := map[string]string{}
 	pools := make([]identityPool, 0, len(environmentConfig.Pools))
 	for _, pool := range environmentConfig.Pools {
+		if len(filterSet) > 0 {
+			if _, match := filterSet[pool.SubscriptionName]; !match {
+				continue
+			}
+		} else if pool.IsUnmanaged() {
+			continue
+		}
+
 		subscriptionID, found := resolvedIDs[pool.SubscriptionName]
 		if !found {
 			subscriptionID, err = resolveSubscriptionID(ctx, pool.SubscriptionName)

--- a/test/cmd/aro-hcp-tests/slot-manager/identity-pool/pools.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/identity-pool/pools.go
@@ -17,6 +17,7 @@ package identitypool
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/Azure/ARO-HCP/test/cmd/aro-hcp-tests/slot-manager/slots"
 )
@@ -53,6 +54,13 @@ func loadIdentityPools(ctx context.Context, catalogPath, environment string, sub
 
 	filterSet := make(map[string]struct{}, len(subscriptionFilter))
 	for _, name := range subscriptionFilter {
+		// Ignore empty/whitespace-only entries so that a wrapper passing an
+		// empty --subscription value (e.g. an unset env var) does not produce
+		// a non-empty filter that silently skips every pool.
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
 		filterSet[name] = struct{}{}
 	}
 

--- a/test/cmd/aro-hcp-tests/slot-manager/identity-pool/pools_test.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/identity-pool/pools_test.go
@@ -68,7 +68,7 @@ environments:
 		"dev-sub-2": "00000000-0000-0000-0000-000000000002",
 	})
 
-	pools, err := loadIdentityPools(context.Background(), catalogPath, "dev", resolver)
+	pools, err := loadIdentityPools(context.Background(), catalogPath, "dev", nil, resolver)
 	if err != nil {
 		t.Fatalf("expected identity pools to load: %v", err)
 	}
@@ -122,7 +122,7 @@ environments:
 
 	resolver := fakeResolver(map[string]string{})
 
-	_, err := loadIdentityPools(context.Background(), catalogPath, "dev", resolver)
+	_, err := loadIdentityPools(context.Background(), catalogPath, "dev", nil, resolver)
 	if err == nil {
 		t.Fatal("expected error when subscription resolution fails")
 	}
@@ -167,7 +167,7 @@ environments:
 		return "", fmt.Errorf("unknown subscription %q", name)
 	}
 
-	pools, err := loadIdentityPools(context.Background(), catalogPath, "dev", resolver)
+	pools, err := loadIdentityPools(context.Background(), catalogPath, "dev", nil, resolver)
 	if err != nil {
 		t.Fatalf("expected identity pools to load: %v", err)
 	}

--- a/test/cmd/aro-hcp-tests/slot-manager/identity-pool/pools_test.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/identity-pool/pools_test.go
@@ -193,6 +193,57 @@ environments:
 	}
 }
 
+func TestLoadIdentityPoolsIgnoresEmptyFilterEntries(t *testing.T) {
+	t.Parallel()
+
+	catalogDir := t.TempDir()
+	catalogPath := filepath.Join(catalogDir, "e2e-slots.yaml")
+	catalog := `version: 1
+environments:
+  dev:
+    deploy_envs:
+      - ci00
+    pools:
+      - subscription_name: managed-sub
+        region: westus3
+        region_mode: fixed
+        resource_type: aro-hcp-dev-westus3-slot
+        slot_count: 1
+        identity_container_prefix: aro-hcp-msi-container-dev-a
+        identity_container_count: 1
+      - subscription_name: unmanaged-sub
+        region: eastus2
+        region_mode: fixed
+        identity_provisioning: unmanaged
+        resource_type: aro-hcp-dev-eastus2-slot
+        slot_count: 1
+        identity_container_prefix: aro-hcp-msi-container-dev-b
+        identity_container_count: 1
+`
+	if err := os.WriteFile(catalogPath, []byte(catalog), 0o644); err != nil {
+		t.Fatalf("expected catalog write to succeed: %v", err)
+	}
+
+	resolver := fakeResolver(map[string]string{
+		"managed-sub":   "00000000-0000-0000-0000-000000000001",
+		"unmanaged-sub": "00000000-0000-0000-0000-000000000002",
+	})
+
+	// A wrapper passing an unset env var can yield an empty (or whitespace-only)
+	// filter entry. Those must be ignored so the call behaves like an empty
+	// filter (unmanaged pools skipped) instead of silently matching nothing.
+	pools, err := loadIdentityPools(context.Background(), catalogPath, "dev", []string{"", "   "}, resolver)
+	if err != nil {
+		t.Fatalf("expected identity pools to load: %v", err)
+	}
+	if len(pools) != 1 {
+		t.Fatalf("expected 1 pool (empty filter ignored, unmanaged skipped), got %d", len(pools))
+	}
+	if pools[0].SubscriptionName != "managed-sub" {
+		t.Fatalf("expected only the managed pool, got %q", pools[0].SubscriptionName)
+	}
+}
+
 func TestLoadIdentityPoolsResolutionFailure(t *testing.T) {
 	t.Parallel()
 

--- a/test/cmd/aro-hcp-tests/slot-manager/identity-pool/pools_test.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/identity-pool/pools_test.go
@@ -97,6 +97,102 @@ environments:
 	}
 }
 
+func TestLoadIdentityPoolsSkipsUnmanagedByDefault(t *testing.T) {
+	t.Parallel()
+
+	catalogDir := t.TempDir()
+	catalogPath := filepath.Join(catalogDir, "e2e-slots.yaml")
+	catalog := `version: 1
+environments:
+  dev:
+    deploy_envs:
+      - ci00
+    pools:
+      - subscription_name: managed-sub
+        region: westus3
+        region_mode: fixed
+        resource_type: aro-hcp-dev-westus3-slot
+        slot_count: 1
+        identity_container_prefix: aro-hcp-msi-container-dev-a
+        identity_container_count: 1
+      - subscription_name: unmanaged-sub
+        region: eastus2
+        region_mode: fixed
+        identity_provisioning: unmanaged
+        resource_type: aro-hcp-dev-eastus2-slot
+        slot_count: 1
+        identity_container_prefix: aro-hcp-msi-container-dev-b
+        identity_container_count: 1
+`
+	if err := os.WriteFile(catalogPath, []byte(catalog), 0o644); err != nil {
+		t.Fatalf("expected catalog write to succeed: %v", err)
+	}
+
+	resolver := fakeResolver(map[string]string{
+		"managed-sub":   "00000000-0000-0000-0000-000000000001",
+		"unmanaged-sub": "00000000-0000-0000-0000-000000000002",
+	})
+
+	pools, err := loadIdentityPools(context.Background(), catalogPath, "dev", nil, resolver)
+	if err != nil {
+		t.Fatalf("expected identity pools to load: %v", err)
+	}
+	if len(pools) != 1 {
+		t.Fatalf("expected 1 pool (unmanaged skipped), got %d", len(pools))
+	}
+	if pools[0].SubscriptionName != "managed-sub" {
+		t.Fatalf("expected only the managed pool, got %q", pools[0].SubscriptionName)
+	}
+}
+
+func TestLoadIdentityPoolsIncludesUnmanagedWhenFiltered(t *testing.T) {
+	t.Parallel()
+
+	catalogDir := t.TempDir()
+	catalogPath := filepath.Join(catalogDir, "e2e-slots.yaml")
+	catalog := `version: 1
+environments:
+  dev:
+    deploy_envs:
+      - ci00
+    pools:
+      - subscription_name: managed-sub
+        region: westus3
+        region_mode: fixed
+        resource_type: aro-hcp-dev-westus3-slot
+        slot_count: 1
+        identity_container_prefix: aro-hcp-msi-container-dev-a
+        identity_container_count: 1
+      - subscription_name: unmanaged-sub
+        region: eastus2
+        region_mode: fixed
+        identity_provisioning: unmanaged
+        resource_type: aro-hcp-dev-eastus2-slot
+        slot_count: 1
+        identity_container_prefix: aro-hcp-msi-container-dev-b
+        identity_container_count: 1
+`
+	if err := os.WriteFile(catalogPath, []byte(catalog), 0o644); err != nil {
+		t.Fatalf("expected catalog write to succeed: %v", err)
+	}
+
+	resolver := fakeResolver(map[string]string{
+		"managed-sub":   "00000000-0000-0000-0000-000000000001",
+		"unmanaged-sub": "00000000-0000-0000-0000-000000000002",
+	})
+
+	pools, err := loadIdentityPools(context.Background(), catalogPath, "dev", []string{"unmanaged-sub"}, resolver)
+	if err != nil {
+		t.Fatalf("expected identity pools to load: %v", err)
+	}
+	if len(pools) != 1 {
+		t.Fatalf("expected 1 pool matching the filter, got %d", len(pools))
+	}
+	if pools[0].SubscriptionName != "unmanaged-sub" {
+		t.Fatalf("expected the unmanaged pool to be included via filter, got %q", pools[0].SubscriptionName)
+	}
+}
+
 func TestLoadIdentityPoolsResolutionFailure(t *testing.T) {
 	t.Parallel()
 

--- a/test/cmd/aro-hcp-tests/slot-manager/slots/catalog.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/slots/catalog.go
@@ -54,11 +54,16 @@ type Pool struct {
 	Region                     string `yaml:"region"`
 	RegionMode                 string `yaml:"region_mode,omitempty"`
 	IdentityProvisioningRegion string `yaml:"identity_provisioning_region,omitempty"`
+	IdentityProvisioning       string `yaml:"identity_provisioning,omitempty"`
 	ResourceType               string `yaml:"resource_type"`
 	SlotCount                  int    `yaml:"slot_count"`
 	IdentityContainerPrefix    string `yaml:"identity_container_prefix"`
 	IdentityContainerCount     int    `yaml:"identity_container_count"`
 }
+
+const (
+	IdentityProvisioningUnmanaged = "unmanaged"
+)
 
 type ExpandedSlot struct {
 	Environment             string `yaml:"environment"`
@@ -377,6 +382,10 @@ func (c *Catalog) FindSlotByResourceName(resourceName string) (*ExpandedSlot, er
 	}
 
 	return nil, fmt.Errorf("failed to find slot for leased resource %q", resourceName)
+}
+
+func (p Pool) IsUnmanaged() bool {
+	return p.IdentityProvisioning == IdentityProvisioningUnmanaged
 }
 
 func (p Pool) EffectiveRegionMode() string {

--- a/test/cmd/aro-hcp-tests/slot-manager/slots/catalog.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/slots/catalog.go
@@ -168,10 +168,13 @@ func (c *Catalog) Validate() error {
 			pool.IdentityProvisioningRegion = strings.TrimSpace(pool.IdentityProvisioningRegion)
 			pool.ResourceType = strings.TrimSpace(pool.ResourceType)
 			pool.IdentityContainerPrefix = strings.TrimSpace(pool.IdentityContainerPrefix)
+			pool.IdentityProvisioning = strings.TrimSpace(pool.IdentityProvisioning)
 
 			switch {
 			case pool.SubscriptionName == "":
 				return fmt.Errorf("environment %q has a pool with empty subscription_name", environmentName)
+			case pool.IdentityProvisioning != "" && pool.IdentityProvisioning != IdentityProvisioningUnmanaged:
+				return fmt.Errorf("environment %q pool %s has invalid identity_provisioning %q (must be empty or %q)", environmentName, describePool(*pool), pool.IdentityProvisioning, IdentityProvisioningUnmanaged)
 			case pool.Region == "":
 				return fmt.Errorf("environment %q has a pool with empty region", environmentName)
 			case pool.RegionMode != RegionModeFixed && pool.RegionMode != RegionModeRuntimeSelected:

--- a/test/cmd/aro-hcp-tests/slot-manager/slots/catalog_test.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/slots/catalog_test.go
@@ -240,6 +240,34 @@ environments:
 	}
 }
 
+func TestLoadCatalogRejectsInvalidIdentityProvisioning(t *testing.T) {
+	t.Parallel()
+
+	invalidCatalog := `version: 1
+environments:
+  dev:
+    deploy_envs: [ci00]
+    pools:
+      - subscription_name: dev-sub-1
+        region: westus3
+        region_mode: fixed
+        identity_provisioning: unmanged
+        resource_type: aro-hcp-dev-westus3-slot
+        slot_count: 1
+        identity_container_prefix: aro-hcp-msi-container-dev-a
+        identity_container_count: 1
+`
+
+	catalogPath := filepath.Join(t.TempDir(), "e2e-slots.yaml")
+	if err := os.WriteFile(catalogPath, []byte(invalidCatalog), 0o644); err != nil {
+		t.Fatalf("expected invalid catalog write to succeed: %v", err)
+	}
+
+	if _, err := LoadCatalog(catalogPath); err == nil {
+		t.Fatal("expected catalog with a typo in identity_provisioning to fail validation")
+	}
+}
+
 func TestLoadCatalogRejectsDuplicateRuntimeSelectedSubscriptionPools(t *testing.T) {
 	t.Parallel()
 

--- a/test/e2e-config/e2e-slots.yaml
+++ b/test/e2e-config/e2e-slots.yaml
@@ -42,6 +42,7 @@ environments:
       slot_count: 1
       identity_container_prefix: aro-hcp-msi-container-dev
       identity_container_count: 20
+      identity_provisioning: unmanaged
   int:
     deploy_envs:
     - int


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-28002

## Why

The dev e2e CI runs against dedicated Azure subscriptions whose "mock identity" RBAC (first-party mock, MSI mock, ARM-helper, and KMS key access) was managed by a mix of imperative shell scripts and a shared home-subscription role-definition module. That coupled every e2e subscription to one shared set of role definitions and was hard to reason about. We also want other teams (e.g. Hypershift Managed Azure) to back e2e slots with subscriptions we don't manage.

This PR makes the dev e2e subscription RBAC **self-contained per subscription**, moves the KMS grant onto the built-in Azure role, brings the DEV CI bot RBAC under the same declarative pipeline as INT/STG/PROD, and teaches the slot-manager about **unmanaged** identity pools.

## What changed (four reviewable commits)

1. **docs(ci): document e2e subscription onboarding and dev mock identities** — managed e2e onboarding (incl. AFEC flag registration), a new procedure for **unmanaged** subscriptions, and a `dev-mock-identities.md` reference.
2. **refactor(dev-ci): self-contained per-subscription RBAC for dev e2e subs** — the per-sub module now inlines its own custom role definitions with **subscription-suffixed** names and issues the grants directly; the KMS grant switches from the custom `Azure Red Hat OpenShift KMS Plugin - Dev` role to the built-in **Key Vault Crypto User** role; slot-manager gains **unmanaged** pool support. Because the grants are now self-contained, the pipeline no longer manages any home-subscription role definitions: the `home` resource group (and the grants step's dependency on it) is dropped.
3. **feat(dev-ci): add DEV CI bot RBAC step (disabled pending migration)** — adds the `ci-bot-rbac-dev` step + bicepparam, **committed commented out** because the DEV bot still has script-era random-named assignments that collide (`RoleAssignmentExists`) until cleaned up.
4. **refactor(dev-ci): validate identity_provisioning and cover unmanaged pool filtering** — fail-fast validation of the slot catalog's `identity_provisioning` value, a correct `--subscription` flag default, and unit tests covering unmanaged-pool filtering.

## Scope note: home-subscription role definitions

This PR intentionally leaves the DEV **home-subscription** mock role *definitions* alone. They stay managed by the legacy `dev-infrastructure/Makefile` (`create-mock-identities`) for now. A follow-up PR will migrate home-subscription management into the pipeline and drop the Makefile ownership.

## Migration / rollout notes

- New additive grants (suffixed role defs + Key Vault Crypto User) were rolled out to all four dev e2e subscriptions, validated on a canary sub with a full e2e run, then the old shared-home-def grants were removed. The pipeline now owns the complete per-subscription grant set.
- Enabling the DEV CI bot RBAC step (commit 3) is deferred to a follow-up after its legacy assignments are cleaned up.