### PR TITLE
refactor: always start cleanOrphanedClusterManagedResourceGroup controller

### DIFF
--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"os"
 	"time"
 
 	_ "k8s.io/component-base/metrics/prometheus/clientgo"
@@ -843,9 +842,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 				go createNodePoolScopedReadDesiresController.Run(ctx, 20)
 				go maestroDeleteOrphanedReadonlyBundlesController.Run(ctx, 20)
 				go cleanupLegacyMaestroReadonlyBundlesController.Run(ctx, 1)
-				if os.Getenv("CLEAN_ORPHANED_MANAGED_RESOURCE_GROUPS") == "enabled" {
-					go cleanOrphanedClusterManagedResourceGroupController.Run(ctx, 20)
-				}
+				go cleanOrphanedClusterManagedResourceGroupController.Run(ctx, 20)
 				go triggerNodePoolUpgradeController.Run(ctx, 20)
 				go nodePoolDeletionClusterServiceDeleteDispatchController.Run(ctx, 20)
 				go nodePoolClusterServiceIDClearerController.Run(ctx, 20)


### PR DESCRIPTION

<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

Remove the CLEAN_ORPHANED_MANAGED_RESOURCE_GROUPS environment variable check and always start the cleanOrphanedClusterManagedResourceGroup controller.

The controller's behavior (read-only vs read-write) is now controlled solely by the CLEAN_ORPHANED_MANAGED_RESOURCE_GROUPS_MODE environment variable:
- If not set or set to anything other than "readwrite", operates in read-only mode
- If set to "readwrite", performs actual deletions

This simplifies configuration by reducing from two environment variables to one, while maintaining safe-by-default behavior (read-only mode unless explicitly enabled).

### Why

<!-- Briefly explain why this change is needed -->

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
