### PR TITLE
ControlPlaneDesiredVersion: skip recompute while cluster create is inflight

### DIFF
--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -556,6 +556,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		subscriptionLister,
 	)
 	triggerControlPlaneUpgradeController := upgradecontrollers.NewTriggerControlPlaneUpgradeController(
+		b.clock,
 		b.options.ResourcesDBClient,
 		b.options.ClustersServiceClient,
 		activeOperationLister,

--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -546,6 +546,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		unionReadDesireLister,
 	)
 	controlPlaneDesiredVersionController := upgradecontrollers.NewControlPlaneDesiredVersionController(
+		b.clock,
 		b.options.ResourcesDBClient,
 		b.options.ClustersServiceClient,
 		activeOperationLister,

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/blang/semver/v4"
@@ -26,6 +27,7 @@ import (
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/operation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilsclock "k8s.io/utils/clock"
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
@@ -47,6 +49,12 @@ import (
 	"github.com/Azure/ARO-HCP/internal/validation"
 )
 
+// clusterCreateGracePeriod is how long after a cluster's CreatedAt we
+// suppress automatic desired-version recomputation while an active Create
+// operation is still in flight. After this window the create is expected
+// to have finished, so resuming z-stream selection is safe.
+const clusterCreateGracePeriod = 2 * time.Hour
+
 // controlPlaneDesiredVersionControllerName is the Cosmos controller document ID for this syncer.
 const controlPlaneDesiredVersionControllerName = "ControlPlaneDesiredVersion"
 
@@ -54,11 +62,13 @@ const controlPlaneDesiredVersionControllerName = "ControlPlaneDesiredVersion"
 // It handles automated (managed) z-stream (patch) upgrades and assists with y-stream (minor)
 // version upgrades by selecting the appropriate z-stream within the user-desired minor version.
 type controlPlaneDesiredVersionSyncer struct {
-	cooldownChecker      controllerutil.CooldownChecker
-	readDesireLister     dblisters.ReadDesireLister
-	resourcesDBClient    database.ResourcesDBClient
-	clusterServiceClient ocm.ClusterServiceClientSpec
-	subscriptionLister   listers.SubscriptionLister
+	clock                 utilsclock.PassiveClock
+	cooldownChecker       controllerutil.CooldownChecker
+	readDesireLister      dblisters.ReadDesireLister
+	resourcesDBClient     database.ResourcesDBClient
+	clusterServiceClient  ocm.ClusterServiceClientSpec
+	subscriptionLister    listers.SubscriptionLister
+	activeOperationLister listers.ActiveOperationLister
 
 	cincinnatiClientCache cincinnati.ClientCache
 }
@@ -69,6 +79,7 @@ var _ controllerutils.ClusterSyncer = (*controlPlaneDesiredVersionSyncer)(nil)
 // control plane version. It periodically checks each cluster and sets the desired version
 // based on the OCPVersion logic documented in the ServiceProviderCluster type.
 func NewControlPlaneDesiredVersionController(
+	clock utilsclock.PassiveClock,
 	resourcesDBClient database.ResourcesDBClient,
 	clusterServiceClient ocm.ClusterServiceClientSpec,
 	activeOperationLister listers.ActiveOperationLister,
@@ -78,12 +89,14 @@ func NewControlPlaneDesiredVersionController(
 	subscriptionLister listers.SubscriptionLister,
 ) controllerutils.Controller {
 	syncer := &controlPlaneDesiredVersionSyncer{
+		clock:                 clock,
 		cooldownChecker:       controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
 		readDesireLister:      readDesireLister,
 		cincinnatiClientCache: cincinnati.NewClientCache(),
 		resourcesDBClient:     resourcesDBClient,
 		clusterServiceClient:  clusterServiceClient,
 		subscriptionLister:    subscriptionLister,
+		activeOperationLister: activeOperationLister,
 	}
 
 	controller := controllerutils.NewClusterWatchingController(
@@ -135,6 +148,17 @@ func (c *controlPlaneDesiredVersionSyncer) SyncOnce(ctx context.Context, key con
 	existingServiceProviderCluster, err := database.GetOrCreateServiceProviderCluster(ctx, c.resourcesDBClient, key.GetResourceID())
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to get or create ServiceProviderCluster: %w", err))
+	}
+
+	// here we check to see if we should be determining upgrade versions. We do this by
+	// 1. if existingServiceProviderCluster.Spec.ControlPlaneVersion.DesiredVersion is empty, then we must run so we can fill it in.
+	// 2. if the cluster was created more than two hours ago, then we can run
+	// 3. if there is no active operation that is a create, then we can run
+	shouldRun, err := c.shouldDetermineDesiredVersion(ctx, key, existingCluster, existingServiceProviderCluster)
+	if err != nil {
+		logger.Error(err, "error determining if desired version should be determined")
+	} else if !shouldRun {
+		return nil
 	}
 
 	// Resolve the cluster UUID from the cached HostedCluster so we can build the Cincinnati client.
@@ -556,4 +580,67 @@ func selectBestVersionFromCandidates(
 		return &candidates[0], nil
 	}
 	return nil, nil
+}
+
+// shouldDetermineDesiredVersion decides whether the syncer should compute a
+// desired control plane version on this pass. It returns true when ANY of:
+//
+//  1. ServiceProviderCluster.Spec.ControlPlaneVersion.DesiredVersion is unset
+//     — we have nothing seeded yet, so we must run to fill it in.
+//  2. The cluster's ARM CreatedAt is older than clusterCreateGracePeriod —
+//     past that window the create flow is expected to be done and resuming
+//     z-stream selection cannot race the initial DesiredVersion write.
+//  3. There is no active Create operation for the cluster itself — without a
+//     create in flight there is nothing to race with, so we can run.
+//
+// Otherwise (DesiredVersion already set, cluster still young, Create in
+// flight) we skip so a freshly created cluster doesn't have its initial
+// desired version overwritten while creation is still in progress.
+func (c *controlPlaneDesiredVersionSyncer) shouldDetermineDesiredVersion(ctx context.Context, key controllerutils.HCPClusterKey, cluster *api.HCPOpenShiftCluster, spc *api.ServiceProviderCluster) (bool, error) {
+	if spc.Spec.ControlPlaneVersion.DesiredVersion == nil {
+		return true, nil
+	}
+	if c.clusterOlderThanGracePeriod(cluster) {
+		return true, nil
+	}
+	hasCreate, err := c.hasActiveClusterCreateOperation(ctx, key)
+	if err != nil {
+		return true, err
+	}
+	return !hasCreate, nil
+}
+
+// clusterOlderThanGracePeriod returns true when the cluster's ARM CreatedAt
+// is more than clusterCreateGracePeriod in the past. A missing CreatedAt is
+// treated as "old enough" so a malformed document does not pin the controller
+// in skip-forever mode.
+func (c *controlPlaneDesiredVersionSyncer) clusterOlderThanGracePeriod(cluster *api.HCPOpenShiftCluster) bool {
+	if cluster.SystemData == nil || cluster.SystemData.CreatedAt == nil {
+		return true
+	}
+	return c.clock.Since(*cluster.SystemData.CreatedAt) > clusterCreateGracePeriod
+}
+
+// hasActiveClusterCreateOperation reports whether there is a non-terminal
+// Create operation whose ExternalID is the cluster itself. Operations on
+// child resources (node pools, external auths) under the cluster are
+// ignored on purpose: they don't gate control-plane upgrade selection.
+func (c *controlPlaneDesiredVersionSyncer) hasActiveClusterCreateOperation(ctx context.Context, key controllerutils.HCPClusterKey) (bool, error) {
+	ops, err := c.activeOperationLister.ListActiveOperationsForCluster(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if err != nil {
+		return false, fmt.Errorf("failed to list active operations for cluster: %w", err)
+	}
+	clusterRIDLower := api.ToClusterResourceIDString(key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	for _, op := range ops {
+		if op.Request != database.OperationRequestCreate {
+			continue
+		}
+		if op.ExternalID == nil {
+			continue
+		}
+		if strings.EqualFold(op.ExternalID.String(), clusterRIDLower) {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller_test.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller_test.go
@@ -16,8 +16,10 @@ package upgradecontrollers
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/blang/semver/v4"
 	"github.com/go-logr/logr"
@@ -27,6 +29,7 @@ import (
 
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clocktesting "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
@@ -35,10 +38,12 @@ import (
 	cvocincinnati "github.com/openshift/cluster-version-operator/pkg/cincinnati"
 
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
 	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/cincinnati"
+	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/databasetesting"
 	"github.com/Azure/ARO-HCP/internal/ocm"
 	"github.com/Azure/ARO-HCP/internal/utils"
@@ -1293,4 +1298,241 @@ func createServiceProviderClusterWithActiveAndDesiredVersion(t *testing.T, ctx c
 	serviceProviderCluster.SetPartitionKey(testSubscriptionID)
 	_, err := mockResourcesDBClient.ServiceProviderClusters(testSubscriptionID, testResourceGroupName, testClusterName).Create(ctx, serviceProviderCluster, nil)
 	require.NoError(t, err)
+}
+
+// boomActiveOperationLister is a test double that returns the configured
+// error from ListActiveOperationsForCluster. It exists so the gating helper
+// can exercise its error-propagation branch without a misbehaving mock DB.
+type boomActiveOperationLister struct {
+	listers.ActiveOperationLister
+	err error
+}
+
+func (b *boomActiveOperationLister) ListActiveOperationsForCluster(_ context.Context, _, _, _ string) ([]*api.Operation, error) {
+	return nil, b.err
+}
+
+// seedClusterCreateOperation seeds an active Create operation rooted at the
+// given ExternalID into the mock DB so the DB-backed active operation lister
+// can find it.
+func seedClusterCreateOperation(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient, externalID *azcorearm.ResourceID, opName string) {
+	t.Helper()
+	opResourceID := api.Must(azcorearm.ParseResourceID(api.ToOperationResourceIDString(externalID.SubscriptionID, opName)))
+	operationID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + externalID.SubscriptionID +
+			"/providers/Microsoft.RedHatOpenShift/locations/eastus/hcpOperationStatuses/" + opName,
+	))
+	op := &api.Operation{
+		CosmosMetadata: api.CosmosMetadata{
+			ResourceID:   opResourceID,
+			PartitionKey: strings.ToLower(externalID.SubscriptionID),
+		},
+		Status:      arm.ProvisioningStateAccepted,
+		Request:     database.OperationRequestCreate,
+		ExternalID:  externalID,
+		OperationID: operationID,
+	}
+	_, err := mockDB.Operations(externalID.SubscriptionID).Create(ctx, op, nil)
+	require.NoError(t, err)
+}
+
+func TestControlPlaneDesiredVersionSyncer_ShouldDetermineDesiredVersion(t *testing.T) {
+	clusterKey := controllerutils.HCPClusterKey{
+		SubscriptionID:    testSubscriptionID,
+		ResourceGroupName: testResourceGroupName,
+		HCPClusterName:    testClusterName,
+	}
+	clusterResourceID := api.Must(api.ToClusterResourceID(testSubscriptionID, testResourceGroupName, testClusterName))
+	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	listerBoom := errors.New("active operation lister exploded")
+
+	newCluster := func(createdAt *time.Time) *api.HCPOpenShiftCluster {
+		c := &api.HCPOpenShiftCluster{
+			TrackedResource: arm.TrackedResource{
+				Resource: arm.Resource{
+					ID:   clusterResourceID,
+					Name: testClusterName,
+					Type: api.ClusterResourceType.String(),
+				},
+			},
+		}
+		if createdAt != nil {
+			c.SystemData = &arm.SystemData{CreatedAt: createdAt}
+		}
+		return c
+	}
+	newSPC := func(desired *semver.Version) *api.ServiceProviderCluster {
+		return &api.ServiceProviderCluster{
+			Spec: api.ServiceProviderClusterSpec{
+				ControlPlaneVersion: api.ServiceProviderClusterSpecVersion{DesiredVersion: desired},
+			},
+		}
+	}
+
+	tests := []struct {
+		name           string
+		cluster        *api.HCPOpenShiftCluster
+		spc            *api.ServiceProviderCluster
+		seedOperation  bool
+		opLister       func(mockDB *databasetesting.MockResourcesDBClient) listers.ActiveOperationLister
+		wantShouldRun  bool
+		wantErrContain string
+	}{
+		{
+			name:          "empty DesiredVersion runs even when create is in flight (gate 1)",
+			cluster:       newCluster(ptr.To(now.Add(-5 * time.Minute))),
+			spc:           newSPC(nil),
+			seedOperation: true,
+			wantShouldRun: true,
+		},
+		{
+			name:          "cluster older than grace period runs even with active create (gate 2)",
+			cluster:       newCluster(ptr.To(now.Add(-3 * time.Hour))),
+			spc:           newSPC(ptr.To(semver.MustParse("4.19.15"))),
+			seedOperation: true,
+			wantShouldRun: true,
+		},
+		{
+			name:          "cluster with no SystemData.CreatedAt runs (treated as old enough)",
+			cluster:       newCluster(nil),
+			spc:           newSPC(ptr.To(semver.MustParse("4.19.15"))),
+			seedOperation: true,
+			wantShouldRun: true,
+		},
+		{
+			name:          "cluster younger than grace period with no active create runs (gate 3)",
+			cluster:       newCluster(ptr.To(now.Add(-5 * time.Minute))),
+			spc:           newSPC(ptr.To(semver.MustParse("4.19.15"))),
+			seedOperation: false,
+			wantShouldRun: true,
+		},
+		{
+			name:          "young cluster + DesiredVersion set + active create skips",
+			cluster:       newCluster(ptr.To(now.Add(-5 * time.Minute))),
+			spc:           newSPC(ptr.To(semver.MustParse("4.19.15"))),
+			seedOperation: true,
+			wantShouldRun: false,
+		},
+		{
+			name:    "cluster exactly at grace period boundary still skips (boundary is strict >)",
+			cluster: newCluster(ptr.To(now.Add(-clusterCreateGracePeriod))),
+			spc:     newSPC(ptr.To(semver.MustParse("4.19.15"))),
+			// active create present so without the boundary-is-strict gate, the
+			// cluster's age would have to push us through.
+			seedOperation: true,
+			wantShouldRun: false,
+		},
+		{
+			// Fail open: if we can't tell whether a Create is in flight we
+			// surface the error to the caller but still report shouldRun=true
+			// so a flaky lister doesn't pin the controller in skip-forever
+			// mode for the rest of the grace window.
+			name:          "active operation lister error is propagated and fails open to shouldRun=true",
+			cluster:       newCluster(ptr.To(now.Add(-5 * time.Minute))),
+			spc:           newSPC(ptr.To(semver.MustParse("4.19.15"))),
+			seedOperation: false,
+			opLister: func(_ *databasetesting.MockResourcesDBClient) listers.ActiveOperationLister {
+				return &boomActiveOperationLister{err: listerBoom}
+			},
+			wantShouldRun:  true,
+			wantErrContain: "failed to list active operations for cluster",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := utils.ContextWithLogger(context.Background(), logr.Discard())
+			mockDB := databasetesting.NewMockResourcesDBClient()
+			if tt.seedOperation {
+				seedClusterCreateOperation(t, ctx, mockDB, clusterResourceID, "op-create-1")
+			}
+			var opLister listers.ActiveOperationLister
+			if tt.opLister != nil {
+				opLister = tt.opLister(mockDB)
+			} else {
+				opLister = &listertesting.DBActiveOperationLister{ResourcesDBClient: mockDB}
+			}
+			syncer := &controlPlaneDesiredVersionSyncer{
+				clock:                 clocktesting.NewFakePassiveClock(now),
+				resourcesDBClient:     mockDB,
+				activeOperationLister: opLister,
+			}
+
+			gotShouldRun, err := syncer.shouldDetermineDesiredVersion(ctx, clusterKey, tt.cluster, tt.spc)
+			if tt.wantErrContain != "" {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tt.wantErrContain)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantShouldRun, gotShouldRun)
+		})
+	}
+}
+
+// TestControlPlaneDesiredVersionSyncer_SyncOnceSkipsWhenGated verifies the
+// end-to-end skip behaviour: when shouldDetermineDesiredVersion returns false
+// SyncOnce returns nil without touching the SPC DesiredVersion or writing a
+// controller doc, so the cluster create can finish without an upgrade
+// recomputation racing it.
+func TestControlPlaneDesiredVersionSyncer_SyncOnceSkipsWhenGated(t *testing.T) {
+	clusterKey := controllerutils.HCPClusterKey{
+		SubscriptionID:    testSubscriptionID,
+		ResourceGroupName: testResourceGroupName,
+		HCPClusterName:    testClusterName,
+	}
+	ctx := utils.ContextWithLogger(context.Background(), logr.Discard())
+	mockDB := databasetesting.NewMockResourcesDBClient()
+	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+
+	// Cluster is 5 minutes old.
+	createTestHCPClusterWithCustomerVersion(t, ctx, mockDB, "4.19", "stable")
+	clusterCRUD := mockDB.HCPClusters(testSubscriptionID, testResourceGroupName)
+	existing, err := clusterCRUD.Get(ctx, testClusterName)
+	require.NoError(t, err)
+	updated := existing.DeepCopy()
+	createdAt := now.Add(-5 * time.Minute)
+	updated.SystemData = &arm.SystemData{CreatedAt: &createdAt}
+	_, err = clusterCRUD.Replace(ctx, updated, nil)
+	require.NoError(t, err)
+
+	// SPC already has a desired version — gate 1 will not fire.
+	createServiceProviderClusterWithActiveAndDesiredVersion(t, ctx, mockDB, semver.MustParse("4.19.15"), ptr.To(semver.MustParse("4.19.22")))
+
+	// Active Create operation pinned to the cluster itself.
+	clusterResourceID := api.Must(api.ToClusterResourceID(testSubscriptionID, testResourceGroupName, testClusterName))
+	seedClusterCreateOperation(t, ctx, mockDB, clusterResourceID, "op-create-1")
+
+	ctrl := gomock.NewController(t)
+	mockClientCache := cincinnati.NewMockClientCache(ctrl)
+	// Cincinnati must not be consulted on the skip path.
+	mockClientCache.EXPECT().GetOrCreateClient(gomock.Any()).Times(0)
+
+	syncer := &controlPlaneDesiredVersionSyncer{
+		clock:                clocktesting.NewFakePassiveClock(now),
+		cooldownChecker:      &alwaysSyncCooldownChecker{},
+		readDesireLister:     newValidHostedClusterReadDesireLister(t),
+		resourcesDBClient:    mockDB,
+		clusterServiceClient: ocm.NewMockClusterServiceClientSpec(ctrl),
+		subscriptionLister: &listertesting.SliceSubscriptionLister{Subscriptions: []*arm.Subscription{{
+			ResourceID: api.Must(azcorearm.ParseResourceID("/subscriptions/" + testSubscriptionID)),
+			Properties: &arm.SubscriptionProperties{},
+		}}},
+		activeOperationLister: &listertesting.DBActiveOperationLister{ResourcesDBClient: mockDB},
+		cincinnatiClientCache: mockClientCache,
+	}
+
+	require.NoError(t, syncer.SyncOnce(ctx, clusterKey))
+
+	// DesiredVersion is untouched.
+	spc, err := mockDB.ServiceProviderClusters(testSubscriptionID, testResourceGroupName, testClusterName).Get(ctx, api.ServiceProviderClusterResourceName)
+	require.NoError(t, err)
+	require.NotNil(t, spc.Spec.ControlPlaneVersion.DesiredVersion)
+	assert.True(t, spc.Spec.ControlPlaneVersion.DesiredVersion.EQ(semver.MustParse("4.19.22")), "DesiredVersion must not change on the skip path")
+
+	// Controller doc was never written, since we returned before WriteController.
+	_, getControllerDocErr := mockDB.HCPClusters(testSubscriptionID, testResourceGroupName).
+		Controllers(testClusterName).Get(ctx, controlPlaneDesiredVersionControllerName)
+	assert.True(t, database.IsNotFoundError(getControllerDocErr), "controller doc must not be written on the skip path, got err=%v", getControllerDocErr)
 }

--- a/backend/pkg/controllers/upgradecontrollers/trigger_control_plane_upgrade_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/trigger_control_plane_upgrade_controller.go
@@ -17,9 +17,12 @@ package upgradecontrollers
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/blang/semver/v4"
+
+	utilsclock "k8s.io/utils/clock"
 
 	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
 
@@ -36,9 +39,11 @@ import (
 
 // triggerControlPlaneUpgradeSyncer is a Cluster syncer that triggers control plane upgrades
 type triggerControlPlaneUpgradeSyncer struct {
-	cooldownChecker      controllerutil.CooldownChecker
-	resourcesDBClient    database.ResourcesDBClient
-	clusterServiceClient ocm.ClusterServiceClientSpec
+	clock                 utilsclock.PassiveClock
+	cooldownChecker       controllerutil.CooldownChecker
+	resourcesDBClient     database.ResourcesDBClient
+	clusterServiceClient  ocm.ClusterServiceClientSpec
+	activeOperationLister listers.ActiveOperationLister
 }
 
 var _ controllerutils.ClusterSyncer = (*triggerControlPlaneUpgradeSyncer)(nil)
@@ -51,6 +56,7 @@ var _ controllerutils.ClusterSyncer = (*triggerControlPlaneUpgradeSyncer)(nil)
 //   - If desiredVersion == current cluster version: NOOP
 //   - Otherwise: Initiate the upgrade to desiredVersion
 func NewTriggerControlPlaneUpgradeController(
+	clock utilsclock.PassiveClock,
 	resourcesDBClient database.ResourcesDBClient,
 	clusterServiceClient ocm.ClusterServiceClientSpec,
 	activeOperationLister listers.ActiveOperationLister,
@@ -58,9 +64,11 @@ func NewTriggerControlPlaneUpgradeController(
 	kubeApplierInformers *unionkubeapplierinformers.UnionKubeApplierInformers,
 ) controllerutils.Controller {
 	syncer := &triggerControlPlaneUpgradeSyncer{
-		cooldownChecker:      controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
-		resourcesDBClient:    resourcesDBClient,
-		clusterServiceClient: clusterServiceClient,
+		clock:                 clock,
+		cooldownChecker:       controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		resourcesDBClient:     resourcesDBClient,
+		clusterServiceClient:  clusterServiceClient,
+		activeOperationLister: activeOperationLister,
 	}
 
 	controller := controllerutils.NewClusterWatchingController(
@@ -105,6 +113,17 @@ func (c *triggerControlPlaneUpgradeSyncer) SyncOnce(ctx context.Context, key con
 	existingServiceProviderCluster, err := database.GetOrCreateServiceProviderCluster(ctx, c.resourcesDBClient, key.GetResourceID())
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to get or create ServiceProviderCluster: %w", err))
+	}
+
+	// here we check to see if we should be triggering an upgrade. We do this by
+	// 1. if the cluster was created more than two hours ago, then we can run
+	// 2. if there is no active operation that is a create, then we can run
+	shouldRun, err := c.shouldTriggerUpgrade(ctx, key, existingCluster)
+	if err != nil {
+		logger := utils.LoggerFromContext(ctx)
+		logger.Error(err, "error determining if control plane upgrade should be triggered")
+	} else if !shouldRun {
+		return nil
 	}
 
 	desiredVersion := existingServiceProviderCluster.Spec.ControlPlaneVersion.DesiredVersion
@@ -167,4 +186,62 @@ func (c *triggerControlPlaneUpgradeSyncer) createUpgradePolicyIfNeeded(ctx conte
 	logger.Info("Successfully created control plane upgrade policy", "desiredVersion", desiredVersion)
 
 	return nil
+}
+
+// shouldTriggerUpgrade decides whether the syncer should trigger a control
+// plane upgrade on this pass. It returns true when ANY of:
+//
+//  1. The cluster's ARM CreatedAt is older than clusterCreateGracePeriod —
+//     past that window the create flow is expected to be done and triggering
+//     an upgrade cannot race the initial creation.
+//  2. There is no active Create operation for the cluster itself — without a
+//     create in flight there is nothing to race with, so we can run.
+//
+// Otherwise (cluster still young, Create in flight) we skip so a freshly
+// created cluster doesn't have a control plane upgrade policy posted while
+// creation is still in progress.
+func (c *triggerControlPlaneUpgradeSyncer) shouldTriggerUpgrade(ctx context.Context, key controllerutils.HCPClusterKey, cluster *api.HCPOpenShiftCluster) (bool, error) {
+	if c.clusterOlderThanGracePeriod(cluster) {
+		return true, nil
+	}
+	hasCreate, err := c.hasActiveClusterCreateOperation(ctx, key)
+	if err != nil {
+		return true, err
+	}
+	return !hasCreate, nil
+}
+
+// clusterOlderThanGracePeriod returns true when the cluster's ARM CreatedAt
+// is more than clusterCreateGracePeriod in the past. A missing CreatedAt is
+// treated as "old enough" so a malformed document does not pin the controller
+// in skip-forever mode.
+func (c *triggerControlPlaneUpgradeSyncer) clusterOlderThanGracePeriod(cluster *api.HCPOpenShiftCluster) bool {
+	if cluster.SystemData == nil || cluster.SystemData.CreatedAt == nil {
+		return true
+	}
+	return c.clock.Since(*cluster.SystemData.CreatedAt) > clusterCreateGracePeriod
+}
+
+// hasActiveClusterCreateOperation reports whether there is a non-terminal
+// Create operation whose ExternalID is the cluster itself. Operations on
+// child resources (node pools, external auths) under the cluster are
+// ignored on purpose: they don't gate control-plane upgrade triggering.
+func (c *triggerControlPlaneUpgradeSyncer) hasActiveClusterCreateOperation(ctx context.Context, key controllerutils.HCPClusterKey) (bool, error) {
+	ops, err := c.activeOperationLister.ListActiveOperationsForCluster(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if err != nil {
+		return false, fmt.Errorf("failed to list active operations for cluster: %w", err)
+	}
+	clusterRIDLower := api.ToClusterResourceIDString(key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	for _, op := range ops {
+		if op.Request != database.OperationRequestCreate {
+			continue
+		}
+		if op.ExternalID == nil {
+			continue
+		}
+		if strings.EqualFold(op.ExternalID.String(), clusterRIDLower) {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/backend/pkg/controllers/upgradecontrollers/trigger_control_plane_upgrade_controller_test.go
+++ b/backend/pkg/controllers/upgradecontrollers/trigger_control_plane_upgrade_controller_test.go
@@ -16,19 +16,30 @@ package upgradecontrollers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/blang/semver/v4"
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	clocktesting "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
 
 	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
 
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
 	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
 	"github.com/Azure/ARO-HCP/internal/ocm"
+	"github.com/Azure/ARO-HCP/internal/utils"
 )
 
 func TestTriggerControlPlaneUpgradeSyncer_CreateUpgradePolicyIfNeeded(t *testing.T) {
@@ -165,6 +176,118 @@ func TestTriggerControlPlaneUpgradeSyncer_CreateUpgradePolicyIfNeeded(t *testing
 			} else {
 				assert.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestTriggerControlPlaneUpgradeSyncer_ShouldTriggerUpgrade(t *testing.T) {
+	clusterKey := controllerutils.HCPClusterKey{
+		SubscriptionID:    testSubscriptionID,
+		ResourceGroupName: testResourceGroupName,
+		HCPClusterName:    testClusterName,
+	}
+	clusterResourceID := api.Must(api.ToClusterResourceID(testSubscriptionID, testResourceGroupName, testClusterName))
+	now := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
+	listerBoom := errors.New("active operation lister exploded")
+
+	newCluster := func(createdAt *time.Time) *api.HCPOpenShiftCluster {
+		c := &api.HCPOpenShiftCluster{
+			TrackedResource: arm.TrackedResource{
+				Resource: arm.Resource{
+					ID:   clusterResourceID,
+					Name: testClusterName,
+					Type: api.ClusterResourceType.String(),
+				},
+			},
+		}
+		if createdAt != nil {
+			c.SystemData = &arm.SystemData{CreatedAt: createdAt}
+		}
+		return c
+	}
+
+	tests := []struct {
+		name           string
+		cluster        *api.HCPOpenShiftCluster
+		seedOperation  bool
+		opLister       func(mockDB *databasetesting.MockResourcesDBClient) listers.ActiveOperationLister
+		wantShouldRun  bool
+		wantErrContain string
+	}{
+		{
+			name:          "cluster older than grace period runs even with active create (gate 1)",
+			cluster:       newCluster(ptr.To(now.Add(-3 * time.Hour))),
+			seedOperation: true,
+			wantShouldRun: true,
+		},
+		{
+			name:          "cluster with no SystemData.CreatedAt runs (treated as old enough)",
+			cluster:       newCluster(nil),
+			seedOperation: true,
+			wantShouldRun: true,
+		},
+		{
+			name:          "cluster younger than grace period with no active create runs (gate 2)",
+			cluster:       newCluster(ptr.To(now.Add(-5 * time.Minute))),
+			seedOperation: false,
+			wantShouldRun: true,
+		},
+		{
+			name:          "young cluster + active create skips",
+			cluster:       newCluster(ptr.To(now.Add(-5 * time.Minute))),
+			seedOperation: true,
+			wantShouldRun: false,
+		},
+		{
+			name:          "cluster exactly at grace period boundary still skips (boundary is strict >)",
+			cluster:       newCluster(ptr.To(now.Add(-clusterCreateGracePeriod))),
+			seedOperation: true,
+			wantShouldRun: false,
+		},
+		{
+			// Fail open: if we can't tell whether a Create is in flight we
+			// surface the error to the caller but still report shouldRun=true
+			// so a flaky lister doesn't pin the controller in skip-forever
+			// mode for the rest of the grace window.
+			name:          "active operation lister error is propagated and fails open to shouldRun=true",
+			cluster:       newCluster(ptr.To(now.Add(-5 * time.Minute))),
+			seedOperation: false,
+			opLister: func(_ *databasetesting.MockResourcesDBClient) listers.ActiveOperationLister {
+				return &boomActiveOperationLister{err: listerBoom}
+			},
+			wantShouldRun:  true,
+			wantErrContain: "failed to list active operations for cluster",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := utils.ContextWithLogger(context.Background(), logr.Discard())
+			mockDB := databasetesting.NewMockResourcesDBClient()
+			if tt.seedOperation {
+				seedClusterCreateOperation(t, ctx, mockDB, clusterResourceID, "op-create-1")
+			}
+			var opLister listers.ActiveOperationLister
+			if tt.opLister != nil {
+				opLister = tt.opLister(mockDB)
+			} else {
+				opLister = &listertesting.DBActiveOperationLister{ResourcesDBClient: mockDB}
+			}
+			syncer := &triggerControlPlaneUpgradeSyncer{
+				clock:                 clocktesting.NewFakePassiveClock(now),
+				resourcesDBClient:     mockDB,
+				activeOperationLister: opLister,
+			}
+
+			gotShouldRun, err := syncer.shouldTriggerUpgrade(ctx, clusterKey, tt.cluster)
+			if tt.wantErrContain != "" {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tt.wantErrContain)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantShouldRun, gotShouldRun)
 		})
 	}
 }


### PR DESCRIPTION
Until the initial cluster create finishes, the desired-version syncer should not race the create flow by recomputing a z-stream. Gate the computation on:

  1. SPC.Spec.ControlPlaneVersion.DesiredVersion is empty — must run to seed it.
  2. cluster.SystemData.CreatedAt older than 2h — past that window the create is expected to be done.
  3. no active Create operation whose ExternalID is the cluster itself — without a create in flight there is nothing to race with.

If the active-operation lister errors we fail open (shouldRun=true) and surface the error, so a flaky lister doesn't pin the controller in skip-forever mode.

NewControlPlaneDesiredVersionController now takes a PassiveClock and the syncer stores the ActiveOperationLister directly (the cooldown checker already wrapped it).
