### PR TITLE
fix: bump max throughput RU/s for manifests and resources cosmos containers

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -209,7 +209,7 @@ defaults:
       digest: sha256:bf05fa14daa56bd1275fd28da3c9348fdaa232b7f1f7cfe7e9cfa83072c63894 # f55beeb (2026-05-29 19:42)
     cosmosContainerName: "Manifests-MC-{{ .ctx.stamp }}"
     partitionKey: "/providers/microsoft.redhatopenshift/stamps/{{ .ctx.stamp }}/managementclusters/default"
-    cosmosContainerMaxScale: 4000
+    cosmosContainerMaxScale: 8000
     managedIdentityName: kube-applier
     k8s:
       replicas: 1
@@ -811,7 +811,7 @@ defaults:
       name: "arohcp{{ .ctx.environment }}-rp-{{ .ctx.regionShort }}" # [globally-unique]
       private: true
       zoneRedundantMode: 'Auto'
-      resourceContainerMaxScale: 4000
+      resourceContainerMaxScale: 8000
       billingContainerMaxScale: 4000
       locksContainerMaxScale: 4000
       fleetContainerMaxScale: 4000

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -286,7 +286,7 @@ frontend:
     locksContainerMaxScale: 4000
     name: arohcpci00-rp-j7654321
     private: false
-    resourceContainerMaxScale: 4000
+    resourceContainerMaxScale: 8000
     zoneRedundantMode: Disabled
   exitOnPanic: true
   image:
@@ -461,7 +461,7 @@ imageSync:
   outboundServiceTags: ""
 keyVaultDNSSuffix: vault.azure.net
 kubeApplier:
-  cosmosContainerMaxScale: 4000
+  cosmosContainerMaxScale: 8000
   cosmosContainerName: Manifests-MC-1
   image:
     digest: sha256:bf05fa14daa56bd1275fd28da3c9348fdaa232b7f1f7cfe7e9cfa83072c63894

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -286,7 +286,7 @@ frontend:
     locksContainerMaxScale: 4000
     name: arohcpci01-rp-j7654321
     private: false
-    resourceContainerMaxScale: 4000
+    resourceContainerMaxScale: 8000
     zoneRedundantMode: Disabled
   exitOnPanic: true
   image:
@@ -461,7 +461,7 @@ imageSync:
   outboundServiceTags: ""
 keyVaultDNSSuffix: vault.azure.net
 kubeApplier:
-  cosmosContainerMaxScale: 4000
+  cosmosContainerMaxScale: 8000
   cosmosContainerName: Manifests-MC-1
   image:
     digest: sha256:bf05fa14daa56bd1275fd28da3c9348fdaa232b7f1f7cfe7e9cfa83072c63894

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -286,7 +286,7 @@ frontend:
     locksContainerMaxScale: 4000
     name: arohcpcspr-rp-usw3
     private: false
-    resourceContainerMaxScale: 4000
+    resourceContainerMaxScale: 8000
     zoneRedundantMode: Disabled
   exitOnPanic: true
   image:
@@ -461,7 +461,7 @@ imageSync:
   outboundServiceTags: ""
 keyVaultDNSSuffix: vault.azure.net
 kubeApplier:
-  cosmosContainerMaxScale: 4000
+  cosmosContainerMaxScale: 8000
   cosmosContainerName: Manifests-MC-1
   image:
     digest: sha256:bf05fa14daa56bd1275fd28da3c9348fdaa232b7f1f7cfe7e9cfa83072c63894

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -286,7 +286,7 @@ frontend:
     locksContainerMaxScale: 4000
     name: arohcpdev-rp-usw3
     private: false
-    resourceContainerMaxScale: 4000
+    resourceContainerMaxScale: 8000
     zoneRedundantMode: Disabled
   exitOnPanic: true
   image:
@@ -461,7 +461,7 @@ imageSync:
   outboundServiceTags: ""
 keyVaultDNSSuffix: vault.azure.net
 kubeApplier:
-  cosmosContainerMaxScale: 4000
+  cosmosContainerMaxScale: 8000
   cosmosContainerName: Manifests-MC-1
   image:
     digest: sha256:bf05fa14daa56bd1275fd28da3c9348fdaa232b7f1f7cfe7e9cfa83072c63894

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -286,7 +286,7 @@ frontend:
     locksContainerMaxScale: 4000
     name: arohcpperf-rp-usw3ptest
     private: true
-    resourceContainerMaxScale: 4000
+    resourceContainerMaxScale: 8000
     zoneRedundantMode: Auto
   exitOnPanic: true
   image:
@@ -461,7 +461,7 @@ imageSync:
   outboundServiceTags: ""
 keyVaultDNSSuffix: vault.azure.net
 kubeApplier:
-  cosmosContainerMaxScale: 4000
+  cosmosContainerMaxScale: 8000
   cosmosContainerName: Manifests-MC-1
   image:
     digest: sha256:bf05fa14daa56bd1275fd28da3c9348fdaa232b7f1f7cfe7e9cfa83072c63894

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -286,7 +286,7 @@ frontend:
     locksContainerMaxScale: 4000
     name: arohcppers-rp-usw3test
     private: false
-    resourceContainerMaxScale: 4000
+    resourceContainerMaxScale: 8000
     zoneRedundantMode: Disabled
   exitOnPanic: true
   image:
@@ -461,7 +461,7 @@ imageSync:
   outboundServiceTags: ""
 keyVaultDNSSuffix: vault.azure.net
 kubeApplier:
-  cosmosContainerMaxScale: 4000
+  cosmosContainerMaxScale: 8000
   cosmosContainerName: Manifests-MC-1
   image:
     digest: sha256:bf05fa14daa56bd1275fd28da3c9348fdaa232b7f1f7cfe7e9cfa83072c63894


### PR DESCRIPTION

### What

We're 2x our comsosdb container max throughput limits on our resources and manifests containers respectively to thwart throttling we're seeing when e2e runs.  

### Why

We see sustained throughput of 50% normalized RU consumption during e2e tests running.  We expect to see some similar throughput in int/stg/prod when changes land here with the addition of customers being there.  

### Testing

An alert to follow based on normalized RU consumption not exceeding 80% in all regions over a sustained period as an indicator for scaling. 


### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
