### PR TITLE
feat: introduce asynchronous externalauth creation in backend in a disabled state

### DIFF
--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -42,6 +42,7 @@ import (
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/clusterpropertiescontroller"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/datadumpcontrollers"
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/externalauthcreationcontrollers"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/externalauthdeletion"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/managementclustercontrollers"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/metricscontrollers"
@@ -492,6 +493,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		b.options.ClustersServiceClient,
 		http.DefaultClient,
 		activeOperationInformer,
+		backendInformers,
 	)
 	operationExternalAuthUpdateController := operationcontrollers.NewOperationExternalAuthUpdateController(
 		b.clock,
@@ -709,6 +711,13 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		unionKubeApplierInformers,
 	)
 
+	externalAuthClusterServiceCreateController := externalauthcreationcontrollers.NewExternalAuthClusterServiceCreateController(
+		b.options.ResourcesDBClient,
+		b.options.ClustersServiceClient,
+		activeOperationLister,
+		backendInformers,
+	)
+
 	nodePoolDeletionClusterServiceDeleteDispatchController := nodepooldeletion.NewNodePoolClusterServiceDeleteDispatchController(
 		utilsclock.RealClock{},
 		b.options.ResourcesDBClient,
@@ -821,6 +830,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 				go dispatchRequestCredentialController.Run(ctx, 20)
 				go dispatchRevokeCredentialsController.Run(ctx, 20)
 				go nodePoolClusterServiceCreateController.Run(ctx, 20)
+				go externalAuthClusterServiceCreateController.Run(ctx, 20)
 				go operationClusterCreateController.Run(ctx, 20)
 				go operationClusterUpdateController.Run(ctx, 20)
 				go operationClusterDeleteController.Run(ctx, 20)

--- a/backend/pkg/controllers/externalauthcreationcontrollers/external_auth_cluster_service_create_controller.go
+++ b/backend/pkg/controllers/externalauthcreationcontrollers/external_auth_cluster_service_create_controller.go
@@ -1,0 +1,183 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package externalauthcreationcontrollers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/internal/api"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+const ExternalAuthClusterServiceCreateControllerName = "ExternalAuthClusterServiceCreate"
+
+type externalAuthClusterServiceCreateSyncer struct {
+	cooldownChecker       controllerutil.CooldownChecker
+	resourcesDBClient     database.ResourcesDBClient
+	externalAuthLister    listers.ExternalAuthLister
+	clusterLister         listers.ClusterLister
+	clustersServiceClient ocm.ClusterServiceClientSpec
+}
+
+func NewExternalAuthClusterServiceCreateController(
+	resourcesDBClient database.ResourcesDBClient,
+	clustersServiceClient ocm.ClusterServiceClientSpec,
+	activeOperationLister listers.ActiveOperationLister,
+	informers informers.BackendInformers,
+) controllerutils.Controller {
+	_, externalAuthLister := informers.ExternalAuths()
+	_, clusterLister := informers.Clusters()
+	syncer := &externalAuthClusterServiceCreateSyncer{
+		cooldownChecker:       controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		resourcesDBClient:     resourcesDBClient,
+		externalAuthLister:    externalAuthLister,
+		clusterLister:         clusterLister,
+		clustersServiceClient: clustersServiceClient,
+	}
+
+	return controllerutils.NewExternalAuthWatchingController(
+		ExternalAuthClusterServiceCreateControllerName,
+		resourcesDBClient,
+		informers,
+		time.Minute,
+		syncer,
+	)
+}
+
+func (c *externalAuthClusterServiceCreateSyncer) needsWork(externalAuth *api.HCPOpenShiftClusterExternalAuth) bool {
+	return externalAuth.ServiceProviderProperties.DeletionTimestamp == nil &&
+		(externalAuth.ServiceProviderProperties.ClusterServiceID == nil || len(externalAuth.ServiceProviderProperties.ClusterServiceID.String()) == 0)
+}
+
+func (c *externalAuthClusterServiceCreateSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPExternalAuthKey) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	externalAuth, err := c.externalAuthLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPExternalAuthName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(err)
+	}
+
+	if !c.needsWork(externalAuth) {
+		return nil
+	}
+
+	// For the ExternalAuth, we retrieve from the actual database because we are about to use its data to interact with cluster-service.
+	externalAuth, err = c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).ExternalAuth(key.HCPClusterName).Get(ctx, key.HCPExternalAuthName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(err)
+	}
+
+	if !c.needsWork(externalAuth) {
+		return nil
+	}
+
+	// For the Cluster, we retrieve from the cache because we are not about to use its data to interact with cluster-service. At
+	// the moment we only use the ClusterServiceID to interact with cluster-service, which shouldn't change over time once set.
+	// If at some point this controller evolves to use other Cluster properties that will be sent to cluster-service and that
+	// can change over time, we will need to retrieve from the database instead.
+	cluster, err := c.clusterLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if err != nil {
+		return utils.TrackError(err)
+	}
+	if cluster.ServiceProviderProperties.ClusterServiceID == nil || len(cluster.ServiceProviderProperties.ClusterServiceID.String()) == 0 {
+		return utils.TrackError(fmt.Errorf("cluster %s has no ClusterServiceID", key.HCPClusterName))
+	}
+	clusterCSInternalID := *cluster.ServiceProviderProperties.ClusterServiceID
+
+	// GET must target the same href POST would use: {clusterHref}/external_auth_config/external_auths/{id} where id is
+	// lowercased ARM name (see ocm.BuildCSExternalAuth). We reconstruct it here:
+	csExternalAuthHREF := ocm.GenerateAROHCPExternalAuthHREF(clusterCSInternalID.ID(), strings.ToLower(key.HCPExternalAuthName))
+	externalAuthCSInternalID, err := api.NewInternalID(csExternalAuthHREF)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("build external auth internal ID for adoption lookup: %w", err))
+	}
+
+	existing, err := c.findCSExternalAuth(ctx, externalAuthCSInternalID)
+	if err != nil {
+		return utils.TrackError(err)
+	}
+
+	if existing == nil {
+		csExternalAuthBuilder, err := ocm.BuildCSExternalAuth(ctx, externalAuth, false)
+		if err != nil {
+			return utils.TrackError(err)
+		}
+		logger.Info("performing POST external auth to Cluster Service", "cs_external_auth_href", csExternalAuthHREF, "external_auth_resource_id", externalAuth.ID.String())
+		_, err = c.clustersServiceClient.PostExternalAuth(ctx, clusterCSInternalID, csExternalAuthBuilder)
+		if c.isOCMErrorBadRequest(err) {
+			logger.Error(err, "CS external auth POST returned OCM error with HTTP 400 status code", "cs_external_auth_href", csExternalAuthHREF, "external_auth_resource_id", externalAuth.ID.String())
+		}
+		if err != nil {
+			return utils.TrackError(err)
+		}
+	}
+
+	logger.Info("setting external auth cluster service ID in external auth cosmos document", "external_auth_cluster_service_id", externalAuthCSInternalID.String())
+	replacement := externalAuth.DeepCopy()
+	replacement.ServiceProviderProperties.ClusterServiceID = externalAuthCSInternalID.DeepCopy() // DeepCopy() to avoid referencing the original pointer
+	_, err = c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).ExternalAuth(key.HCPClusterName).Replace(ctx, replacement, nil)
+	if database.IsPreconditionFailedError(err) {
+		// if we have a conflict error, then we're guaranteed that our informer will eventually see an update and trigger us again.
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(err)
+	}
+
+	return nil
+}
+
+// findCSExternalAuth performs GetExternalAuth for the given Cluster Service external auth InternalID.
+// It returns (nil, nil) when CS responds with 404.
+func (c *externalAuthClusterServiceCreateSyncer) findCSExternalAuth(ctx context.Context, externalAuthInternalID api.InternalID) (*arohcpv1alpha1.ExternalAuth, error) {
+	ea, err := c.clustersServiceClient.GetExternalAuth(ctx, externalAuthInternalID)
+	if err != nil {
+		var ocmErr *ocmerrors.Error
+		if errors.As(err, &ocmErr) && ocmErr.Status() == http.StatusNotFound {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return ea, nil
+}
+
+func (c *externalAuthClusterServiceCreateSyncer) CooldownChecker() controllerutil.CooldownChecker {
+	return c.cooldownChecker
+}
+
+func (c *externalAuthClusterServiceCreateSyncer) isOCMErrorBadRequest(err error) bool {
+	var ocmErr *ocmerrors.Error
+	return err != nil && errors.As(err, &ocmErr) && ocmErr.Status() == http.StatusBadRequest
+}

--- a/backend/pkg/controllers/externalauthcreationcontrollers/external_auth_cluster_service_create_controller_test.go
+++ b/backend/pkg/controllers/externalauthcreationcontrollers/external_auth_cluster_service_create_controller_test.go
@@ -1,0 +1,357 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package externalauthcreationcontrollers
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+const (
+	testSubscriptionID      = "00000000-0000-0000-0000-000000000000"
+	testResourceGroupName   = "test-rg"
+	testClusterName         = "test-cluster"
+	testExternalAuthName    = "test-external-auth"
+	testClusterServiceIDStr = "/api/aro_hcp/v1alpha1/clusters/abc123"
+	testExternalAuthCSIDStr = testClusterServiceIDStr + "/external_auth_config/external_auths/" + testExternalAuthName
+)
+
+type alwaysSyncCooldownChecker struct{}
+
+func (c *alwaysSyncCooldownChecker) CanSync(ctx context.Context, key any) bool {
+	return true
+}
+
+func TestExternalAuthClusterServiceCreateSyncer_SyncOnce(t *testing.T) {
+	testKey := controllerutils.HCPExternalAuthKey{
+		SubscriptionID:      testSubscriptionID,
+		ResourceGroupName:   testResourceGroupName,
+		HCPClusterName:      testClusterName,
+		HCPExternalAuthName: testExternalAuthName,
+	}
+
+	clusterCSInternalID := api.Must(api.NewInternalID(testClusterServiceIDStr))
+	externalAuthCSInternalID := api.Must(api.NewInternalID(testExternalAuthCSIDStr))
+
+	verifyClusterServiceIDIsNil := func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+		t.Helper()
+		stored, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).
+			ExternalAuth(testClusterName).Get(ctx, testExternalAuthName)
+		require.NoError(t, err)
+		assert.Nil(t, stored.ServiceProviderProperties.ClusterServiceID)
+	}
+
+	verifyClusterServiceIDIsSet := func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+		t.Helper()
+		stored, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).
+			ExternalAuth(testClusterName).Get(ctx, testExternalAuthName)
+		require.NoError(t, err)
+		require.NotNil(t, stored.ServiceProviderProperties.ClusterServiceID, "expected ClusterServiceID to be set")
+		assert.Equal(t, testExternalAuthCSIDStr, stored.ServiceProviderProperties.ClusterServiceID.String())
+	}
+
+	testCases := []struct {
+		name                 string
+		listerCluster        *api.HCPOpenShiftCluster
+		existingExternalAuth *api.HCPOpenShiftClusterExternalAuth
+		listerExternalAuth   *api.HCPOpenShiftClusterExternalAuth
+		setupMockCSClient    func(mock *ocm.MockClusterServiceClientSpec)
+		wantErr              bool
+		wantErrContain       string
+		verifyDB             func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient)
+	}{
+		{
+			name:          "when ClusterServiceID is already set no-op is performed",
+			listerCluster: newTestCluster(t, nil),
+			existingExternalAuth: newTestExternalAuthForCreate(t, func(ea *api.HCPOpenShiftClusterExternalAuth) {
+				ea.ServiceProviderProperties.ClusterServiceID = api.Ptr(api.Must(api.NewInternalID(testExternalAuthCSIDStr)))
+			}),
+			verifyDB: verifyClusterServiceIDIsSet,
+		},
+		{
+			name:          "when DeletionTimestamp is set no-op is performed",
+			listerCluster: newTestCluster(t, nil),
+			existingExternalAuth: newTestExternalAuthForCreate(t, func(ea *api.HCPOpenShiftClusterExternalAuth) {
+				ea.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: metav1.Now().Time}
+			}),
+			verifyDB: verifyClusterServiceIDIsNil,
+		},
+		{
+			name: "external auth not found in lister no-op is performed",
+		},
+		{
+			name:          "when lister is stale but DB already has ClusterServiceID no-op is performed",
+			listerCluster: newTestCluster(t, nil),
+			existingExternalAuth: newTestExternalAuthForCreate(t, func(ea *api.HCPOpenShiftClusterExternalAuth) {
+				ea.ServiceProviderProperties.ClusterServiceID = api.Ptr(api.Must(api.NewInternalID(testExternalAuthCSIDStr)))
+			}),
+			listerExternalAuth: newTestExternalAuthForCreate(t, nil),
+			verifyDB:           verifyClusterServiceIDIsSet,
+		},
+		{
+			name:                 "when cluster has no ClusterServiceID error is returned",
+			listerCluster:        newTestCluster(t, func(c *api.HCPOpenShiftCluster) { c.ServiceProviderProperties.ClusterServiceID = nil }),
+			existingExternalAuth: newTestExternalAuthForCreate(t, nil),
+			wantErr:              true,
+			wantErrContain:       "cluster test-cluster has no ClusterServiceID",
+		},
+		{
+			name:                 "when CS external auth does not exist POST is issued and ClusterServiceID is set",
+			listerCluster:        newTestCluster(t, nil),
+			existingExternalAuth: newTestExternalAuthForCreate(t, nil),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetExternalAuth(gomock.Any(), externalAuthCSInternalID).
+					Return(nil, fakeOCMNotFoundError())
+				csExternalAuth, err := arohcpv1alpha1.NewExternalAuth().
+					ID(testExternalAuthName).
+					HREF(testExternalAuthCSIDStr).
+					Build()
+				require.NoError(t, err)
+				mock.EXPECT().
+					PostExternalAuth(gomock.Any(), clusterCSInternalID, gomock.Any()).
+					Return(csExternalAuth, nil)
+			},
+			verifyDB: verifyClusterServiceIDIsSet,
+		},
+		{
+			name:                 "when CS external auth already exists POST is skipped and ClusterServiceID is set",
+			listerCluster:        newTestCluster(t, nil),
+			existingExternalAuth: newTestExternalAuthForCreate(t, nil),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				existing, err := arohcpv1alpha1.NewExternalAuth().
+					ID(testExternalAuthName).
+					HREF(testExternalAuthCSIDStr).
+					Build()
+				require.NoError(t, err)
+				mock.EXPECT().
+					GetExternalAuth(gomock.Any(), externalAuthCSInternalID).
+					Return(existing, nil)
+			},
+			verifyDB: verifyClusterServiceIDIsSet,
+		},
+		{
+			name:                 "when CS external auth lookup returns a non-404 error it is propagated",
+			listerCluster:        newTestCluster(t, nil),
+			existingExternalAuth: newTestExternalAuthForCreate(t, nil),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetExternalAuth(gomock.Any(), externalAuthCSInternalID).
+					Return(nil, errors.New("boom"))
+			},
+			wantErr:        true,
+			wantErrContain: "boom",
+		},
+		{
+			name:                 "when CS external auth POST fails error is propagated",
+			listerCluster:        newTestCluster(t, nil),
+			existingExternalAuth: newTestExternalAuthForCreate(t, nil),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetExternalAuth(gomock.Any(), externalAuthCSInternalID).
+					Return(nil, fakeOCMNotFoundError())
+				mock.EXPECT().
+					PostExternalAuth(gomock.Any(), clusterCSInternalID, gomock.Any()).
+					Return(nil, errors.New("post failed"))
+			},
+			wantErr:        true,
+			wantErrContain: "post failed",
+		},
+		{
+			name:                 "when PostExternalAuth returns 400 OCM error reconciler returns error",
+			listerCluster:        newTestCluster(t, nil),
+			existingExternalAuth: newTestExternalAuthForCreate(t, nil),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetExternalAuth(gomock.Any(), externalAuthCSInternalID).
+					Return(nil, fakeOCMNotFoundError())
+				mock.EXPECT().
+					PostExternalAuth(gomock.Any(), clusterCSInternalID, gomock.Any()).
+					Return(nil, fakeOCMError(http.StatusBadRequest, "invalid external auth"))
+			},
+			wantErr:        true,
+			wantErrContain: "invalid external auth",
+			verifyDB:       verifyClusterServiceIDIsNil,
+		},
+		{
+			name:                 "when PostExternalAuth returns 403 OCM error reconciler returns error",
+			listerCluster:        newTestCluster(t, nil),
+			existingExternalAuth: newTestExternalAuthForCreate(t, nil),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetExternalAuth(gomock.Any(), externalAuthCSInternalID).
+					Return(nil, fakeOCMNotFoundError())
+				mock.EXPECT().
+					PostExternalAuth(gomock.Any(), clusterCSInternalID, gomock.Any()).
+					Return(nil, fakeOCMError(http.StatusForbidden, "forbidden"))
+			},
+			wantErr:        true,
+			wantErrContain: "forbidden",
+			verifyDB:       verifyClusterServiceIDIsNil,
+		},
+		{
+			name:                 "when PostExternalAuth returns 500 OCM error it is propagated for retry",
+			listerCluster:        newTestCluster(t, nil),
+			existingExternalAuth: newTestExternalAuthForCreate(t, nil),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetExternalAuth(gomock.Any(), externalAuthCSInternalID).
+					Return(nil, fakeOCMNotFoundError())
+				mock.EXPECT().
+					PostExternalAuth(gomock.Any(), clusterCSInternalID, gomock.Any()).
+					Return(nil, fakeOCMInternalServerError("internal error"))
+			},
+			wantErr:        true,
+			wantErrContain: "internal error",
+			verifyDB:       verifyClusterServiceIDIsNil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+			ctrl := gomock.NewController(t)
+
+			resources := []any{}
+			if tc.existingExternalAuth != nil {
+				resources = append(resources, tc.existingExternalAuth)
+			}
+			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, resources)
+			require.NoError(t, err)
+
+			mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
+			if tc.setupMockCSClient != nil {
+				tc.setupMockCSClient(mockCSClient)
+			}
+
+			clustersForLister := []*api.HCPOpenShiftCluster{}
+			if tc.listerCluster != nil {
+				clustersForLister = append(clustersForLister, tc.listerCluster)
+			}
+
+			externalAuthsForLister := []*api.HCPOpenShiftClusterExternalAuth{}
+			listerExternalAuth := tc.listerExternalAuth
+			if listerExternalAuth == nil {
+				listerExternalAuth = tc.existingExternalAuth
+			}
+			if listerExternalAuth != nil {
+				externalAuthsForLister = append(externalAuthsForLister, listerExternalAuth)
+			}
+
+			syncer := &externalAuthClusterServiceCreateSyncer{
+				cooldownChecker:       &alwaysSyncCooldownChecker{},
+				externalAuthLister:    &listertesting.SliceExternalAuthLister{ExternalAuths: externalAuthsForLister},
+				clusterLister:         &listertesting.SliceClusterLister{Clusters: clustersForLister},
+				resourcesDBClient:     mockResourcesDBClient,
+				clustersServiceClient: mockCSClient,
+			}
+
+			err = syncer.SyncOnce(ctx, testKey)
+			if tc.wantErr {
+				require.Error(t, err)
+				if len(tc.wantErrContain) > 0 {
+					require.ErrorContains(t, err, tc.wantErrContain)
+				}
+				return
+			}
+			require.NoError(t, err)
+
+			if tc.verifyDB != nil {
+				tc.verifyDB(t, ctx, mockResourcesDBClient)
+			}
+		})
+	}
+}
+
+func fakeOCMNotFoundError() error {
+	e, _ := ocmerrors.NewError().Status(http.StatusNotFound).Reason("not found").Build()
+	return e
+}
+
+func fakeOCMError(status int, msg string) error {
+	e, _ := ocmerrors.NewError().Status(status).Reason(msg).Build()
+	return e
+}
+
+func fakeOCMInternalServerError(msg string) error {
+	e, _ := ocmerrors.NewError().Status(http.StatusInternalServerError).Reason(msg).Build()
+	return e
+}
+
+func newTestCluster(t *testing.T, opts func(*api.HCPOpenShiftCluster)) *api.HCPOpenShiftCluster {
+	t.Helper()
+	resourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName))
+	clusterInternalID := api.Ptr(api.Must(api.NewInternalID(testClusterServiceIDStr)))
+	cluster := &api.HCPOpenShiftCluster{
+		TrackedResource: arm.TrackedResource{
+			Resource: arm.Resource{
+				ID:   resourceID,
+				Name: testClusterName,
+				Type: api.ClusterResourceType.String(),
+			},
+			Location: "eastus",
+		},
+		CosmosMetadata: arm.CosmosMetadata{ResourceID: resourceID, PartitionKey: strings.ToLower(resourceID.SubscriptionID)},
+		ServiceProviderProperties: api.HCPOpenShiftClusterServiceProviderProperties{
+			ClusterServiceID: clusterInternalID,
+		},
+	}
+	if opts != nil {
+		opts(cluster)
+	}
+	return cluster
+}
+
+func newTestExternalAuthForCreate(t *testing.T, opts func(*api.HCPOpenShiftClusterExternalAuth)) *api.HCPOpenShiftClusterExternalAuth {
+	t.Helper()
+	resourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+			"/externalAuths/" + testExternalAuthName))
+	ea := api.NewDefaultHCPOpenShiftClusterExternalAuth(resourceID)
+	ea.CosmosMetadata = arm.CosmosMetadata{ResourceID: resourceID, PartitionKey: strings.ToLower(resourceID.SubscriptionID)}
+	ea.ServiceProviderProperties.ClusterServiceID = nil
+	if opts != nil {
+		opts(ea)
+	}
+	return ea
+}

--- a/backend/pkg/controllers/operationcontrollers/operation_external_auth_create.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_external_auth_create.go
@@ -16,8 +16,10 @@ package operationcontrollers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -25,17 +27,22 @@ import (
 	utilsclock "k8s.io/utils/clock"
 
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
 	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/ocm"
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
 
 type operationExternalAuthCreate struct {
-	clock                utilsclock.PassiveClock
-	resourcesDBClient    database.ResourcesDBClient
-	clusterServiceClient ocm.ClusterServiceClientSpec
-	notificationClient   *http.Client
+	clock                  utilsclock.PassiveClock
+	resourcesDBClient      database.ResourcesDBClient
+	activeOperationsLister listers.ActiveOperationLister
+	externalAuthLister     listers.ExternalAuthLister
+	clusterServiceClient   ocm.ClusterServiceClientSpec
+	notificationClient     *http.Client
 }
 
 // NewOperationExternalAuthCreateController returns a new Controller instance that
@@ -58,12 +65,18 @@ func NewOperationExternalAuthCreateController(
 	clusterServiceClient ocm.ClusterServiceClientSpec,
 	notificationClient *http.Client,
 	activeOperationInformer cache.SharedIndexInformer,
+	backendInformers informers.BackendInformers,
 ) controllerutils.Controller {
+	_, externalAuthLister := backendInformers.ExternalAuths()
+	_, activeOperationsLister := backendInformers.ActiveOperations()
+
 	syncer := &operationExternalAuthCreate{
-		clock:                clock,
-		resourcesDBClient:    resourcesDBClient,
-		clusterServiceClient: clusterServiceClient,
-		notificationClient:   notificationClient,
+		clock:                  clock,
+		resourcesDBClient:      resourcesDBClient,
+		externalAuthLister:     externalAuthLister,
+		activeOperationsLister: activeOperationsLister,
+		clusterServiceClient:   clusterServiceClient,
+		notificationClient:     notificationClient,
 	}
 
 	controller := NewGenericOperationController(
@@ -94,7 +107,7 @@ func (c *operationExternalAuthCreate) SynchronizeOperation(ctx context.Context, 
 	logger := utils.LoggerFromContext(ctx)
 	logger.Info("checking operation")
 
-	operation, err := c.resourcesDBClient.Operations(key.SubscriptionID).Get(ctx, key.OperationName)
+	operation, err := c.activeOperationsLister.Get(ctx, key.SubscriptionID, key.OperationName)
 	if database.IsNotFoundError(err) {
 		return nil // no work to do
 	}
@@ -105,5 +118,95 @@ func (c *operationExternalAuthCreate) SynchronizeOperation(ctx context.Context, 
 		return nil // no work to do
 	}
 
-	return pollExternalAuthStatus(ctx, c.clock, c.resourcesDBClient, c.clusterServiceClient, operation, c.notificationClient)
+	externalAuth, err := c.externalAuthLister.Get(ctx, operation.ExternalID.SubscriptionID, operation.ExternalID.ResourceGroupName, operation.ExternalID.Parent.Name, operation.ExternalID.Name)
+	if database.IsNotFoundError(err) {
+		logger.Info("external auth not found in cache, waiting")
+		return nil // no work to do
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get external auth: %w", err)
+	}
+
+	if operation.ResourceID.Name != externalAuth.ServiceProviderProperties.ActiveOperationID {
+		logger.Info("external auth active operation id mismatch, returning early", "synchronizedActiveOperationID", operation.ResourceID.Name, "externalAuthActiveOperationID", externalAuth.ServiceProviderProperties.ActiveOperationID)
+		return nil
+	}
+
+	if !c.shouldReconcileOperationAndResourceStatus(externalAuth) {
+		return nil
+	}
+
+	operationalState, err := c.determineOperationState(ctx, externalAuth)
+	if err != nil {
+		return utils.TrackError(err)
+	}
+
+	var persistErr *arm.CloudErrorBody
+	if operationalState.provisioningState == arm.ProvisioningStateFailed {
+		persistErr = &arm.CloudErrorBody{
+			// TODO for now we always set the error code to InternalServerError, but we should improve to be able
+			// to be more specific than that when we calculate operationalState. When work is done to improve on this, we
+			// should design it in a way where no internal details are exposed to the operation's error.
+			Code:    arm.CloudErrorCodeInternalServerError,
+			Message: operationalState.message,
+		}
+	}
+
+	logger.Info("updating status")
+	err = UpdateOperationStatus(ctx, c.clock, c.resourcesDBClient, operation, operationalState.provisioningState, persistErr, postAsyncNotificationFn(c.notificationClient))
+	if database.IsPreconditionFailedError(err) {
+		// if we have a conflict error, then we're guaranteed that our informer will eventually see an update and trigger us again.
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(err)
+	}
+
+	return nil
+}
+
+func (c *operationExternalAuthCreate) shouldReconcileOperationAndResourceStatus(externalAuth *api.HCPOpenShiftClusterExternalAuth) bool {
+	return externalAuth.ServiceProviderProperties.DeletionTimestamp == nil && externalAuth.ServiceProviderProperties.ClusterServiceID != nil
+}
+
+func (c *operationExternalAuthCreate) determineOperationState(ctx context.Context, externalAuth *api.HCPOpenShiftClusterExternalAuth) (*operationState, error) {
+	logger := utils.LoggerFromContext(ctx)
+
+	var errs []error
+	var operationStates []*operationState
+
+	if state, err := c.externalAuthClusterServiceCreateOperationState(ctx, externalAuth); err != nil {
+		errs = append(errs, utils.TrackError(err))
+	} else {
+		operationStates = append(operationStates, state)
+	}
+
+	if err := errors.Join(errs...); err != nil {
+		return nil, err
+	}
+	if len(operationStates) == 0 {
+		return nil, errors.New("no operation states")
+	}
+	slices.SortStableFunc(operationStates, compareOperationState)
+	if operationStates[0] == nil {
+		return nil, errors.New("nil operation state")
+	}
+	logger.Info("determined external auth create operation status", "operationStates", operationStates)
+	picked, err := pickWorstOperationState(operationStates)
+	if err != nil {
+		return nil, utils.TrackError(err)
+	}
+	logger.Info("picked external auth create operation status", "provisioningState", picked.provisioningState, "message", picked.message)
+	return picked, nil
+}
+
+func (c *operationExternalAuthCreate) externalAuthClusterServiceCreateOperationState(ctx context.Context, externalAuth *api.HCPOpenShiftClusterExternalAuth) (*operationState, error) {
+	logger := utils.LoggerFromContext(ctx)
+	_, err := c.clusterServiceClient.GetExternalAuth(ctx, *externalAuth.ServiceProviderProperties.ClusterServiceID)
+	if err != nil {
+		return nil, utils.TrackError(err)
+	}
+
+	logger.Info("new status via cluster-service", "newStatus", arm.ProvisioningStateSucceeded)
+	return newOperationState(arm.ProvisioningStateSucceeded, ""), nil
 }

--- a/backend/pkg/controllers/operationcontrollers/operation_external_auth_create_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_external_auth_create_test.go
@@ -18,16 +18,20 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr/testr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilsclock "k8s.io/utils/clock"
 
 	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
 
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
+	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/databasetesting"
@@ -36,15 +40,45 @@ import (
 )
 
 func TestOperationExternalAuthCreate_SynchronizeOperation(t *testing.T) {
+	defaultExternalAuth := func(fixture *externalAuthTestFixture) *api.HCPOpenShiftClusterExternalAuth {
+		return fixture.newExternalAuth()
+	}
+
+	externalAuthWithoutCSID := func(fixture *externalAuthTestFixture) *api.HCPOpenShiftClusterExternalAuth {
+		ea := fixture.newExternalAuth()
+		ea.ServiceProviderProperties.ClusterServiceID = nil
+		return ea
+	}
+
+	externalAuthWithDeletionTimestamp := func(fixture *externalAuthTestFixture) *api.HCPOpenShiftClusterExternalAuth {
+		ea := fixture.newExternalAuth()
+		ea.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+		return ea
+	}
+
+	externalAuthWithMismatchedActiveOperationID := func(fixture *externalAuthTestFixture) *api.HCPOpenShiftClusterExternalAuth {
+		ea := fixture.newExternalAuth()
+		ea.ServiceProviderProperties.ActiveOperationID = "other-operation"
+		return ea
+	}
+
+	externalAuthWithEmptyActiveOperationID := func(fixture *externalAuthTestFixture) *api.HCPOpenShiftClusterExternalAuth {
+		ea := fixture.newExternalAuth()
+		ea.ServiceProviderProperties.ActiveOperationID = ""
+		return ea
+	}
+
 	tests := []struct {
-		name        string
-		setupMock   func(ctrl *gomock.Controller, fixture *externalAuthTestFixture) ocm.ClusterServiceClientSpec
-		expectError bool
-		verify      func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *externalAuthTestFixture)
+		name         string
+		externalAuth func(fixture *externalAuthTestFixture) *api.HCPOpenShiftClusterExternalAuth
+		setupCSMock  func(ctrl *gomock.Controller, fixture *externalAuthTestFixture) ocm.ClusterServiceClientSpec
+		expectError  bool
+		verify       func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *externalAuthTestFixture)
 	}{
 		{
-			name: "external auth exists transitions to succeeded",
-			setupMock: func(ctrl *gomock.Controller, fixture *externalAuthTestFixture) ocm.ClusterServiceClientSpec {
+			name:         "external auth exists transitions to succeeded",
+			externalAuth: defaultExternalAuth,
+			setupCSMock: func(ctrl *gomock.Controller, fixture *externalAuthTestFixture) ocm.ClusterServiceClientSpec {
 				mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
 				externalAuth, _ := arohcpv1alpha1.NewExternalAuth().
 					ID(testExternalAuthIDStr).
@@ -60,7 +94,6 @@ func TestOperationExternalAuthCreate_SynchronizeOperation(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateSucceeded, op.Status)
 
-				// Verify external auth provisioning state was also updated
 				externalAuth, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).ExternalAuth(testClusterName).Get(ctx, testExternalAuthName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateSucceeded, externalAuth.Properties.ProvisioningState)
@@ -68,8 +101,9 @@ func TestOperationExternalAuthCreate_SynchronizeOperation(t *testing.T) {
 			},
 		},
 		{
-			name: "external auth get error returns error",
-			setupMock: func(ctrl *gomock.Controller, fixture *externalAuthTestFixture) ocm.ClusterServiceClientSpec {
+			name:         "external auth get error returns error",
+			externalAuth: defaultExternalAuth,
+			setupCSMock: func(ctrl *gomock.Controller, fixture *externalAuthTestFixture) ocm.ClusterServiceClientSpec {
 				mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
 				mockCSClient.EXPECT().
 					GetExternalAuth(gomock.Any(), fixture.externalAuthInternalID).
@@ -78,6 +112,42 @@ func TestOperationExternalAuthCreate_SynchronizeOperation(t *testing.T) {
 			},
 			expectError: true,
 			verify:      nil,
+		},
+		{
+			name:         "ClusterServiceID nil skips reconciliation",
+			externalAuth: externalAuthWithoutCSID,
+			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *externalAuthTestFixture) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+			},
+		},
+		{
+			name:         "ActiveOperationID mismatch skips reconciliation",
+			externalAuth: externalAuthWithMismatchedActiveOperationID,
+			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *externalAuthTestFixture) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+			},
+		},
+		{
+			name:         "empty ActiveOperationID skips reconciliation",
+			externalAuth: externalAuthWithEmptyActiveOperationID,
+			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *externalAuthTestFixture) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+			},
+		},
+		{
+			name:         "DeletionTimestamp set skips reconciliation",
+			externalAuth: externalAuthWithDeletionTimestamp,
+			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *externalAuthTestFixture) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+			},
 		},
 	}
 
@@ -90,28 +160,36 @@ func TestOperationExternalAuthCreate_SynchronizeOperation(t *testing.T) {
 
 			fixture := newExternalAuthTestFixture()
 			cluster := fixture.newCluster()
-			externalAuth := fixture.newExternalAuth()
+			externalAuth := tt.externalAuth(fixture)
 			operation := fixture.newOperation(database.OperationRequestCreate)
 
-			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, []any{cluster, externalAuth, operation})
+			resources := []any{cluster, externalAuth, operation}
+
+			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, resources)
 			require.NoError(t, err)
 
-			mockCSClient := tt.setupMock(ctrl, fixture)
+			var mockCSClient ocm.ClusterServiceClientSpec
+			if tt.setupCSMock != nil {
+				mockCSClient = tt.setupCSMock(ctrl, fixture)
+			} else {
+				mockCSClient = ocm.NewMockClusterServiceClientSpec(ctrl)
+			}
 
 			controller := &operationExternalAuthCreate{
-				clock:                utilsclock.RealClock{},
-				resourcesDBClient:    mockResourcesDBClient,
-				clusterServiceClient: mockCSClient,
-				notificationClient:   nil,
+				clock:                  utilsclock.RealClock{},
+				resourcesDBClient:      mockResourcesDBClient,
+				activeOperationsLister: &listertesting.DBActiveOperationLister{ResourcesDBClient: mockResourcesDBClient},
+				externalAuthLister:     &listertesting.DBExternalAuthLister{ResourcesDBClient: mockResourcesDBClient},
+				clusterServiceClient:   mockCSClient,
+				notificationClient:     nil,
 			}
 
 			err = controller.SynchronizeOperation(ctx, fixture.operationKey())
-
 			if tt.expectError {
 				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
+				return
 			}
+			require.NoError(t, err)
 
 			if tt.verify != nil {
 				tt.verify(t, ctx, mockResourcesDBClient, fixture)


### PR DESCRIPTION
 The backend logic to perform asynchronous externalauth creation is disabled for now: the added controller is only executed when ClusterServiceID is not set. For now in frontend we always store the ClusterServiceID so it is guaranteed to not be executed.

Additionally, the externalauth create operation has been updated to retrieve the ClusterServiceID from the ExternalAuth cosmos resource instead of the operation. This allows us to stop relying on it for when we stop setting it in frontend.
