### PR TITLE
fix: add known alerts for BackendControllerRetryHotLoop and PrometheusOperatorRejectedResources

### DIFF
--- a/test/cmd/aro-hcp-tests/gather-observability/knownIssues.yaml
+++ b/test/cmd/aro-hcp-tests/gather-observability/knownIssues.yaml
@@ -1,4 +1,16 @@
 knownIssues:
+- name: "BackendControllerRetryHotLoop"
+  labels:
+    name: "triggernodepoolupgrade"
+  reason: "being worked on in https://issues.redhat.com/browse/ARO-28029"
+- name: "BackendControllerRetryHotLoop"
+  labels:
+    name: "operationclustercreate"
+  reason: "fix in https://github.com/Azure/ARO-HCP/pull/5794"
+- name: "PrometheusOperatorRejectedResources"
+  labels:
+    resource: "servicemonitor"
+  reason: "https://issues.redhat.com/browse/ARO-28028"
 - name: "KubeVersionMismatch"
   labels:
     cluster: ".*-mgmt-.*"


### PR DESCRIPTION
### What

Adds known alert entries for:
- **BackendControllerRetryHotLoop** on `triggernodepoolupgrade` — controller repeatedly tries to create upgrade policies that Cluster Service rejects ([ARO-28029](https://redhat.atlassian.net/browse/ARO-28029))
- **BackendControllerRetryHotLoop** on `operationclustercreate` — fix in [#5794](https://github.com/Azure/ARO-HCP/pull/5794)
- **PrometheusOperatorRejectedResources** on `servicemonitor` — fires transiently on mgmt clusters because HyperShift creates ServiceMonitors before TLS configmaps/secrets exist during HCP bootstrap ([ARO-28028](https://redhat.atlassian.net/browse/ARO-28028))

### Why

Reduces CI noise from expected transient alert firings.