### PR TITLE
fix: skip nodepool upgrade trigger if no active versions exist yet

### DIFF
--- a/backend/pkg/controllers/upgradecontrollers/trigger_node_pool_upgrade_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/trigger_node_pool_upgrade_controller.go
@@ -79,8 +79,9 @@ func (c *triggerNodePoolUpgradeSyncer) CooldownChecker() controllerutil.Cooldown
 //
 // High-level flow:
 //  1. Fetch the node pool and service provider node pool state
-//  2. Check if desiredVersion differs from latest actual version
-//  3. If different, create a NodePoolUpgradePolicy to trigger upgrade
+//  2. Skips upgrade trigger if no active versions exist yet (during installation)
+//  3. Check if desiredVersion differs from latest actual version
+//  4. If different, create a NodePoolUpgradePolicy to trigger upgrade
 func (c *triggerNodePoolUpgradeSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPNodePoolKey) error {
 	existingNodePool, err := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).
 		NodePools(key.HCPClusterName).Get(ctx, key.HCPNodePoolName)
@@ -108,11 +109,13 @@ func (c *triggerNodePoolUpgradeSyncer) SyncOnce(ctx context.Context, key control
 		return nil // No desired version set
 	}
 
-	// Get latest actual version from active versions
-	var actualLatestVersion *semver.Version
-	if len(existingServiceProviderNodePool.Status.NodePoolVersion.ActiveVersions) > 0 {
-		actualLatestVersion = existingServiceProviderNodePool.Status.NodePoolVersion.ActiveVersions[0].Version
+	// No active version yet (installation ongoing); skip upgrade trigger.
+	if len(existingServiceProviderNodePool.Status.NodePoolVersion.ActiveVersions) == 0 {
+		return nil
 	}
+
+	// Get latest actual version from active versions
+	actualLatestVersion := existingServiceProviderNodePool.Status.NodePoolVersion.ActiveVersions[0].Version
 
 	// If desired version matches latest actual version, nothing to do
 	if actualLatestVersion != nil && desiredVersion.EQ(*actualLatestVersion) {

--- a/backend/pkg/controllers/upgradecontrollers/trigger_node_pool_upgrade_controller_test.go
+++ b/backend/pkg/controllers/upgradecontrollers/trigger_node_pool_upgrade_controller_test.go
@@ -17,19 +17,140 @@ package upgradecontrollers
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/blang/semver/v4"
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
 	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
 
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
 	"github.com/Azure/ARO-HCP/internal/ocm"
+	"github.com/Azure/ARO-HCP/internal/utils"
 )
+
+func TestTriggerNodePoolUpgradeSyncer_SyncOnce(t *testing.T) {
+	tests := []struct {
+		name   string
+		seedDB func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient)
+	}{
+		{
+			name: "node pool not found in cosmos returns nil",
+			seedDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+			},
+		},
+		{
+			name: "node pool with deletion timestamp returns nil",
+			seedDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+				createTestNodePoolWithVersion(t, ctx, mockDB, "4.21.0")
+
+				nodePool, err := mockDB.HCPClusters(testSubscriptionID, testResourceGroupName).
+					NodePools(testClusterName).Get(ctx, testNodePoolName)
+				require.NoError(t, err)
+				nodePool.ServiceProviderProperties.DeletionTimestamp = ptr.To(metav1.Now())
+
+				_, err = mockDB.HCPClusters(testSubscriptionID, testResourceGroupName).
+					NodePools(testClusterName).Replace(ctx, nodePool, nil)
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "missing NodePool ClusterServiceID returns nil",
+			seedDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+
+				nodePoolResourceID := api.Must(azcorearm.ParseResourceID("/subscriptions/" + testSubscriptionID +
+					"/resourceGroups/" + testResourceGroupName +
+					"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+					"/nodePools/" + testNodePoolName))
+				nodePool := &api.HCPOpenShiftClusterNodePool{
+					CosmosMetadata: arm.CosmosMetadata{
+						ResourceID:   nodePoolResourceID,
+						PartitionKey: strings.ToLower(nodePoolResourceID.SubscriptionID),
+					},
+					TrackedResource: arm.TrackedResource{
+						Resource: arm.Resource{
+							ID:   nodePoolResourceID,
+							Name: testNodePoolName,
+							Type: api.NodePoolResourceType.String(),
+						},
+						Location: "eastus",
+					},
+					ServiceProviderProperties: api.HCPOpenShiftClusterNodePoolServiceProviderProperties{},
+				}
+
+				_, err := mockDB.HCPClusters(testSubscriptionID, testResourceGroupName).
+					NodePools(testClusterName).Create(ctx, nodePool, nil)
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "no desired version on ServiceProviderNodePool returns nil",
+			seedDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+				createTestNodePoolWithVersion(t, ctx, mockDB, "4.21.0")
+				createServiceProviderNodePoolWithVersion(t, ctx, mockDB, "4.21.0")
+			},
+		},
+		{
+			name: "no active versions during installation returns nil",
+			seedDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+				createTestNodePoolWithVersion(t, ctx, mockDB, "4.21.0")
+				createServiceProviderNodePoolWithActiveAndDesiredVersion(
+					t, ctx, mockDB, ptr.To(semver.MustParse("4.21.0")),
+				)
+			},
+		},
+		{
+			name: "desired version matches latest actual version returns nil",
+			seedDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+				createTestNodePoolWithVersion(t, ctx, mockDB, "4.21.0")
+				createServiceProviderNodePoolWithActiveAndDesiredVersion(
+					t, ctx, mockDB, ptr.To(semver.MustParse("4.21.0")),
+					"4.21.0", "4.20.15",
+				)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			runCtx := utils.ContextWithLogger(context.Background(), logr.Discard())
+			mockDB := databasetesting.NewMockResourcesDBClient()
+			tt.seedDB(t, runCtx, mockDB)
+
+			syncer := &triggerNodePoolUpgradeSyncer{
+				resourcesDBClient: mockDB,
+			}
+
+			err := syncer.SyncOnce(runCtx, controllerutils.HCPNodePoolKey{
+				SubscriptionID:    testSubscriptionID,
+				ResourceGroupName: testResourceGroupName,
+				HCPClusterName:    testClusterName,
+				HCPNodePoolName:   testNodePoolName,
+			})
+			assertSyncResult(t, err, false, "")
+		})
+	}
+}
 
 func TestTriggerNodePoolUpgradeSyncer_CreateUpgradePolicyIfNeeded(t *testing.T) {
 	testNodePoolServiceID, _ := api.NewInternalID("/api/aro_hcp/v1alpha1/clusters/test-cluster-id/node_pools/test-nodepool-id")
@@ -167,4 +288,48 @@ func TestTriggerNodePoolUpgradeSyncer_CreateUpgradePolicyIfNeeded(t *testing.T) 
 			}
 		})
 	}
+}
+
+// createServiceProviderNodePoolWithActiveAndDesiredVersion seeds a
+// ServiceProviderNodePool with the given desired version and zero or more
+// active versions (newest first).
+func createServiceProviderNodePoolWithActiveAndDesiredVersion(
+	t *testing.T,
+	ctx context.Context,
+	mockResourcesDBClient *databasetesting.MockResourcesDBClient,
+	desiredVersion *semver.Version,
+	activeVersions ...string,
+) {
+	t.Helper()
+
+	nodePoolResourceID := "/subscriptions/" + testSubscriptionID +
+		"/resourceGroups/" + testResourceGroupName +
+		"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+		"/nodePools/" + testNodePoolName
+	spNodePoolResourceID := nodePoolResourceID + "/" + api.ServiceProviderNodePoolResourceTypeName + "/" + api.ServiceProviderNodePoolResourceName
+
+	var activeVersionEntries []api.HCPNodePoolActiveVersion
+	for _, activeVersion := range activeVersions {
+		version := semver.MustParse(activeVersion)
+		activeVersionEntries = append(activeVersionEntries, api.HCPNodePoolActiveVersion{Version: &version})
+	}
+
+	spNodePool := &api.ServiceProviderNodePool{
+		CosmosMetadata: api.CosmosMetadata{
+			ResourceID:   api.Must(azcorearm.ParseResourceID(spNodePoolResourceID)),
+			PartitionKey: strings.ToLower(testSubscriptionID),
+		},
+		Spec: api.ServiceProviderNodePoolSpec{
+			NodePoolVersion: api.ServiceProviderNodePoolSpecVersion{
+				DesiredVersion: desiredVersion,
+			},
+		},
+		Status: api.ServiceProviderNodePoolStatus{
+			NodePoolVersion: api.ServiceProviderNodePoolStatusVersion{
+				ActiveVersions: activeVersionEntries,
+			},
+		},
+	}
+	_, err := mockResourcesDBClient.ServiceProviderNodePools(testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName).Create(ctx, spNodePool, nil)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
### What

Skip creating an upgrade policy for a node pool if there are no active versions present. 

JIRA: [ARO-28029](https://redhat.atlassian.net/browse/ARO-28029)

### Why
With the move to reading the active versions from maestor/management cluster, there may be a chance that the active versions may not yet be present when a node pool is still being installed.

Previously, as soon as the desired version exist, the trigger would immediately attempt to create an upgrade policy since the actual version would be empty. This was causing the following errors and triggering unwanted alerts: 
```
(wrapped at trigger_node_pool_upgrade_controller.go:155) failed to create node pool upgrade policy: (wrapped at client.go:764) status is 400, identifier is '400', code is 'CLUSTERS-MGMT-400', at '2026-06-22T04:00:37Z' and operation identifier is 'xxx': Node pool new version '4.21.0' must be different from the old version
```

This change ensures that this controller doesn't trigger the upgrade in this case. 

### Testing
Unit tests added for the SyncOnce() to ensure the guards before creating the upgrade policy behave as expected. The full SyncOnce() path, including the creation of the upgrade policy, wasn't tested as there were already a separate test for this in the same file.

### Special notes for your reviewer
Required for https://github.com/Azure/ARO-HCP/pull/5805

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] ~~Screenshots included (if graph/UI/metrics changes)~~
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] ~~Draft PR used for WIP (if applicable)~~
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [x] All comment threads resolved before merge

If E2E tests are included:

- [ ] ~~E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)~~
- [ ] ~~If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.~~
