### PR TITLE
feat: add peak threshold slider to metrics panel for series filtering

### DIFF
--- a/test/cmd/aro-hcp-tests/gather-observability/artifacts/metricspanel.html.tmpl
+++ b/test/cmd/aro-hcp-tests/gather-observability/artifacts/metricspanel.html.tmpl
@@ -31,7 +31,7 @@
 </head>
 <body>
 {{range .Charts}}
-    <div class="chart-section">
+    <div class="chart-section" data-min-peak-threshold="{{.MinPeakThreshold}}">
     {{if .HasData}}
         {{.ChartHTML}}
     {{else}}
@@ -58,5 +58,162 @@
 {{end}}
     <!-- workaround for spyglass cutting off page bottoms -->
     <div style="height: 30px;"></div>
+<script>
+(function() {
+    var items = document.querySelectorAll('.item');
+    for (var i = 0; i < items.length; i++) {
+        var inst = echarts.getInstanceByDom(items[i]);
+        if (!inst) continue;
+        var section = items[i].closest('.chart-section');
+        var initialThreshold = section ? parseFloat(section.getAttribute('data-min-peak-threshold')) || 0 : 0;
+        initSlider(inst, items[i], initialThreshold);
+    }
+
+    function initSlider(chart, chartDom, initialThreshold) {
+        var option = chart.getOption();
+        if (!option.series || option.series.length < 2) return;
+
+        var seriesPeaks = computePeaks(option.series);
+        var globalMax = Math.max.apply(null, seriesPeaks.map(function(s) { return s.peak; }));
+        if (globalMax <= 0) return;
+
+        var gridRect = chart.getModel().getComponent('grid', 0).coordinateSystem.getRect();
+        var yExtent = chart.getModel().getComponent('yAxis', 0).axis.scale.getExtent();
+        var yRange = yExtent[1] - yExtent[0];
+        if (!isFinite(yRange) || yRange <= 0) return;
+
+        // Pin Y axis and grid dimensions so resizing the container doesn't rescale the plot
+        chart.setOption({
+            yAxis: {min: yExtent[0], max: yExtent[1]},
+            grid: {top: gridRect.y, height: gridRect.height}
+        });
+
+        chartDom.style.position = 'relative';
+
+        // Vertical slider aligned with Y axis
+        var slider = document.createElement('input');
+        slider.type = 'range';
+        slider.min = String(yExtent[0]);
+        slider.max = String(yExtent[1]);
+        slider.value = String(yExtent[0]);
+        slider.step = String(yRange / 200);
+        slider.style.cssText =
+            'position:absolute;' +
+            'writing-mode:vertical-lr;direction:rtl;' +
+            'left:' + (gridRect.x - 50) + 'px;' +
+            'top:' + gridRect.y + 'px;' +
+            'height:' + gridRect.height + 'px;' +
+            'width:20px;margin:0;padding:0;' +
+            'cursor:ns-resize;accent-color:#F44336;opacity:0.5;z-index:10;';
+        slider.title = 'Filter series by minimum peak value';
+        chartDom.appendChild(slider);
+
+        slider.addEventListener('mouseenter', function() { this.style.opacity = '0.9'; });
+        slider.addEventListener('mouseleave', function() { this.style.opacity = '0.5'; });
+
+        // Info display above slider
+        var info = document.createElement('div');
+        info.style.cssText =
+            'position:absolute;' +
+            'left:0;top:' + (gridRect.y - 16) + 'px;' +
+            'width:' + gridRect.x + 'px;' +
+            'font-size:10px;color:#666;text-align:center;' +
+            'white-space:nowrap;z-index:10;';
+        info.textContent = seriesPeaks.length + '/' + seriesPeaks.length;
+        chartDom.appendChild(info);
+
+        var allNames = seriesPeaks.map(function(s) { return s.name; });
+
+        function legendHeight(names) {
+            if (names.length === 0) return 40;
+            var rows = 1, rowWidth = 0;
+            for (var i = 0; i < names.length; i++) {
+                var w = names[i].length * 7 + 40;
+                if (rowWidth + w > 1200 && rowWidth > 0) { rows++; rowWidth = w; }
+                else { rowWidth += w; }
+            }
+            return Math.max(40, rows * 22);
+        }
+
+        function applyThreshold() {
+            var threshold = parseFloat(slider.value);
+            var visibleNames = [];
+            var selected = {};
+            seriesPeaks.forEach(function(s) {
+                var show = s.peak >= threshold;
+                selected[s.name] = show;
+                if (show) visibleNames.push(s.name);
+            });
+
+            info.textContent = visibleNames.length + '/' + seriesPeaks.length +
+                (threshold > yExtent[0] ? ' ≥' + formatVal(threshold) : '');
+
+            chart.setOption({
+                legend: {data: visibleNames, selected: selected}
+            });
+
+            // Move legend up below the grid and shrink the container to eliminate the gap
+            var newLH = legendHeight(visibleNames);
+            var legendTop = gridRect.y + gridRect.height + 30;
+            chart.setOption({legend: {bottom: null, top: legendTop}});
+            var newHeight = legendTop + newLH + 10;
+            chartDom.style.height = newHeight + 'px';
+            chart.resize({height: newHeight});
+
+            var py = chart.convertToPixel({gridIndex: 0}, [0, threshold]);
+            chart.setOption({
+                graphic: {elements: [{
+                    id: 'thresh',
+                    type: 'line',
+                    silent: true,
+                    shape: {x1: gridRect.x, y1: py[1], x2: gridRect.x + gridRect.width, y2: py[1]},
+                    style: {
+                        stroke: '#F44336', lineDash: [4, 4], lineWidth: 1,
+                        opacity: threshold > yExtent[0] ? 0.6 : 0
+                    },
+                    z: 100
+                }]}
+            });
+        }
+
+        slider.addEventListener('input', applyThreshold);
+
+        if (initialThreshold > 0 && initialThreshold <= yExtent[1]) {
+            slider.value = String(initialThreshold);
+            applyThreshold();
+        }
+    }
+
+    function computePeaks(series) {
+        return series.map(function(s) {
+            var peak = 0;
+            if (s.data) {
+                s.data.forEach(function(d) {
+                    var val = null;
+                    if (Array.isArray(d)) {
+                        val = d.length >= 2 ? d[1] : null;
+                    } else if (d && typeof d === 'object' && d.value) {
+                        val = Array.isArray(d.value) && d.value.length >= 2 ? d.value[1] : d.value;
+                    }
+                    if (typeof val === 'number' && val > peak) {
+                        peak = val;
+                    }
+                });
+            }
+            return {name: s.name, peak: peak};
+        });
+    }
+
+    function formatVal(v) {
+        if (v >= 1e9) return (v/1e9).toFixed(1) + 'G';
+        if (v >= 1e6) return (v/1e6).toFixed(1) + 'M';
+        if (v >= 1e3) return (v/1e3).toFixed(1) + 'k';
+        if (v >= 1) return v.toFixed(2);
+        if (v >= 0.01) return v.toFixed(3);
+        if (v === 0) return '0';
+        return v.toExponential(1);
+    }
+})();
+</script>
 </body>
 </html>

--- a/test/cmd/aro-hcp-tests/gather-observability/chart.go
+++ b/test/cmd/aro-hcp-tests/gather-observability/chart.go
@@ -84,12 +84,13 @@ type panelPageData struct {
 // chartData holds the rendered chart HTML and metadata for a single query
 // within a panel.
 type chartData struct {
-	Title       string
-	Description string
-	Query       string
-	HasData     bool
-	Error       string
-	ChartHTML   template.HTML // raw HTML from go-echarts, not escaped
+	Title            string
+	Description      string
+	Query            string
+	HasData          bool
+	Error            string
+	ChartHTML        template.HTML // raw HTML from go-echarts, not escaped
+	MinPeakThreshold float64
 }
 
 // renderPanel assembles multiple charts into a single HTML page.
@@ -132,7 +133,7 @@ func estimateLegendHeight(series []parsedSeries, chartWidth int) int {
 // buildChartData builds the chart HTML for a single PromQL query result.
 // Each PrometheusResult becomes a separate series, labeled by its metric
 // labels.
-func buildChartData(title, description, query, unit, queryErr string, results []PrometheusResult, tw timing.TimeWindow) chartData {
+func buildChartData(title, description, query, unit, queryErr string, results []PrometheusResult, tw timing.TimeWindow, minPeakThreshold float64) chartData {
 	var series []parsedSeries
 	for _, result := range results {
 		if len(result.Values) == 0 {
@@ -166,7 +167,7 @@ func buildChartData(title, description, query, unit, queryErr string, results []
 	}
 
 	if len(series) == 0 {
-		return chartData{Title: title, Description: description, Query: query, Error: queryErr}
+		return chartData{Title: title, Description: description, Query: query, Error: queryErr, MinPeakThreshold: minPeakThreshold}
 	}
 
 	// Sort by peak value descending for consistent legend ordering
@@ -239,11 +240,12 @@ func buildChartData(title, description, query, unit, queryErr string, results []
 	html := extractChartBody(rendered)
 
 	return chartData{
-		Title:       title,
-		Description: description,
-		Query:       query,
-		HasData:     true,
-		ChartHTML:   template.HTML(html), //nolint:gosec // trusted go-echarts output
+		Title:            title,
+		Description:      description,
+		Query:            query,
+		HasData:          true,
+		ChartHTML:        template.HTML(html), //nolint:gosec // trusted go-echarts output
+		MinPeakThreshold: minPeakThreshold,
 	}
 }
 

--- a/test/cmd/aro-hcp-tests/gather-observability/chart_test.go
+++ b/test/cmd/aro-hcp-tests/gather-observability/chart_test.go
@@ -479,6 +479,37 @@ func TestLoadQueriesConfig(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "minPeakThreshold is parsed when provided",
+			yaml: `panels:
+  - title: "Panel"
+    queries:
+    - title: "Retry Ratio"
+      query: "rate(retries[5m])"
+      workspace: svc
+      minPeakThreshold: 0.5
+`,
+			check: func(t *testing.T, cfg *QueriesConfig) {
+				if cfg.Panels[0].Queries[0].MinPeakThreshold != 0.5 {
+					t.Errorf("MinPeakThreshold = %v, want %v", cfg.Panels[0].Queries[0].MinPeakThreshold, 0.5)
+				}
+			},
+		},
+		{
+			name: "minPeakThreshold defaults to zero when omitted",
+			yaml: `panels:
+  - title: "Panel"
+    queries:
+    - title: "CPU Usage"
+      query: "rate(cpu_seconds_total[5m])"
+      workspace: svc
+`,
+			check: func(t *testing.T, cfg *QueriesConfig) {
+				if cfg.Panels[0].Queries[0].MinPeakThreshold != 0 {
+					t.Errorf("MinPeakThreshold = %v, want %v", cfg.Panels[0].Queries[0].MinPeakThreshold, 0.0)
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/test/cmd/aro-hcp-tests/gather-observability/options.go
+++ b/test/cmd/aro-hcp-tests/gather-observability/options.go
@@ -312,7 +312,7 @@ func (o Options) runQueries(ctx context.Context, workspaces map[string]*workspac
 				results = resp.Data.Result
 			}
 
-			panelCharts = append(panelCharts, buildChartData(q.Title, q.Description, q.Query, q.Unit, queryErr, results, o.TimeWindow))
+			panelCharts = append(panelCharts, buildChartData(q.Title, q.Description, q.Query, q.Unit, queryErr, results, o.TimeWindow, q.MinPeakThreshold))
 		}
 
 		// filename must match the Spyglass HTML lens regex .*-summary.*\.html

--- a/test/cmd/aro-hcp-tests/gather-observability/promql.go
+++ b/test/cmd/aro-hcp-tests/gather-observability/promql.go
@@ -51,12 +51,13 @@ type PanelSpec struct {
 
 // QuerySpec describes a single PromQL query to execute and chart.
 type QuerySpec struct {
-	Title       string `json:"title" yaml:"title"`
-	Description string `json:"description,omitempty" yaml:"description,omitempty"`
-	Query       string `json:"query" yaml:"query"`
-	Unit        string `json:"unit,omitempty" yaml:"unit,omitempty"`
-	Workspace   string `json:"workspace" yaml:"workspace"` // "svc" or "hcp"
-	Step        string `json:"step,omitempty" yaml:"step,omitempty"`
+	Title            string  `json:"title" yaml:"title"`
+	Description      string  `json:"description,omitempty" yaml:"description,omitempty"`
+	Query            string  `json:"query" yaml:"query"`
+	Unit             string  `json:"unit,omitempty" yaml:"unit,omitempty"`
+	Workspace        string  `json:"workspace" yaml:"workspace"` // "svc" or "hcp"
+	Step             string  `json:"step,omitempty" yaml:"step,omitempty"`
+	MinPeakThreshold float64 `json:"minPeakThreshold,omitempty" yaml:"minPeakThreshold,omitempty"`
 }
 
 // PrometheusResponse is the top-level Prometheus HTTP API response.

--- a/test/cmd/aro-hcp-tests/gather-observability/queries.yaml
+++ b/test/cmd/aro-hcp-tests/gather-observability/queries.yaml
@@ -12,6 +12,7 @@ panels:
     unit: seconds
     workspace: svc
     step: "60s"
+    minPeakThreshold: 2.5
 - title: "Backend Metrics"
   queries:
   - title: "Controller Workqueue Retry Ratio"
@@ -33,6 +34,7 @@ panels:
     unit: ratio
     workspace: svc
     step: "60s"
+    minPeakThreshold: 0.5
   - title: "Controller Workqueue Depth"
     description: "Number of items waiting to be processed in each controller workqueue. Sustained depth indicates the controller cannot keep up with incoming work items."
     query: |
@@ -44,6 +46,7 @@ panels:
     unit: items
     workspace: svc
     step: "60s"
+    minPeakThreshold: 10
   - title: "Controller Panic Rate"
     description: "Rate of panics caught by the runtime panic handler, per controller. Any non-zero rate indicates a controller is actively crashing and recovering via the panic handler."
     query: |
@@ -74,6 +77,7 @@ panels:
     unit: ratio
     workspace: svc
     step: "60s"
+    minPeakThreshold: 0.5
   - title: "Controller Workqueue Depth"
     description: "Number of items waiting to be processed in each fleet controller workqueue. Sustained depth indicates the controller cannot keep up with incoming work items."
     query: |
@@ -85,6 +89,7 @@ panels:
     unit: items
     workspace: svc
     step: "60s"
+    minPeakThreshold: 10
   - title: "Controller Reconcile Rate"
     description: "Rate of reconciliations per fleet controller. Shows how much work each controller is processing."
     query: |


### PR DESCRIPTION
### What

Adds a vertical threshold slider to metrics panel charts. The slider sits alongside the Y axis and filters both visible series and legend entries to only those whose peak value exceeds the threshold. A dashed red line marks the threshold on the chart. The initial threshold can be configured per-query via `minPeakThreshold` in `queries.yaml`.

### Why

Metrics panels can have dozens of timeseries where only a few are interesting. The slider lets reviewers quickly isolate the series that actually spiked without manually toggling legend entries.

### Screenshot

Before

<img width="1595" height="1001" alt="image" src="https://github.com/user-attachments/assets/6712c153-10b2-4d21-9a20-c2cd6db46688" />

After

<img width="1400" height="900" alt="slider-demo" src="https://github.com/user-attachments/assets/daa39453-d5eb-4245-8706-8b4df22aeeb8" />