### PR TITLE
infra: enable dyanamic scaling feature on cosmosdb instance

### DIFF
--- a/dev-infrastructure/modules/rp-cosmos-account.bicep
+++ b/dev-infrastructure/modules/rp-cosmos-account.bicep
@@ -5,7 +5,7 @@ param location string
 param zoneRedundant bool
 param private bool
 
-resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2023-11-15' = {
+resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2024-11-15' = {
   kind: 'GlobalDocumentDB'
   name: name
   location: location
@@ -45,6 +45,7 @@ resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2023-11-15' = {
     networkAclBypass: 'None'
     enablePartitionMerge: false
     enableBurstCapacity: false
+    enablePerRegionPerPartitionAutoscale: true
     minimalTlsVersion: 'Tls12'
   }
 }


### PR DESCRIPTION
no jira

### What

Enables dynamic scaling on our cosmosdb instance.

### Why

Our regions have this inconsistently applied.  This allows us to be more consistent between our environments.  Dynamic scaling allows per-region and per-partition autoscaling rather than setting the autoscaling at an individual collection/db level.  


> Dynamic scaling is enabled by default for all Azure Cosmos DB accounts created after September 25, 2024. Customers who want to enable this feature for their older accounts can do so programmatically through Azure PowerShell, CLI, REST API, or from the features pane of the Azure portal as shown:

https://learn.microsoft.com/en-us/azure/cosmos-db/provision-throughput-autoscale?context=/azure/cosmos-db/context/context#enabling-dynamic-scaling

### Testing

e2e should be sufficient.  



- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
