### PR TITLE
fix(network): retry Swift VNet creation on RBAC propagation race (AROSLSRE-1346)

### DIFF
--- a/dev-infrastructure/modules/network/vnet.bicep
+++ b/dev-infrastructure/modules/network/vnet.bicep
@@ -90,7 +90,7 @@ resource vnetWithSwiftDeployment 'Microsoft.Resources/deploymentScripts@2020-10-
   properties: {
     azCliVersion: '2.53.1'
     scriptContent: '''
-      set -uo pipefail
+      set -euo pipefail
       az account set --subscription "${VNET_SUBSCRIPTION_ID}"
 
       # The deployment MSI's Network/Tag Contributor role assignments are created in
@@ -102,15 +102,14 @@ resource vnetWithSwiftDeployment 'Microsoft.Resources/deploymentScripts@2020-10-
       POLL_INTERVAL=5
 
       retry() {
-        local elapsed=0
+        local start=${SECONDS}
         until "$@"; do
-          if [ "${elapsed}" -ge "${MAX_WAIT}" ]; then
-            echo "✗ '$*' still failing after ${elapsed}s" >&2
+          if [ $((SECONDS - start)) -ge "${MAX_WAIT}" ]; then
+            echo "✗ '$*' still failing after $((SECONDS - start))s" >&2
             return 1
           fi
           echo "Command failed (likely RBAC propagation); retrying in ${POLL_INTERVAL}s..." >&2
           sleep "${POLL_INTERVAL}"
-          elapsed=$((elapsed + POLL_INTERVAL))
         done
       }
 

--- a/dev-infrastructure/modules/network/vnet.bicep
+++ b/dev-infrastructure/modules/network/vnet.bicep
@@ -90,31 +90,51 @@ resource vnetWithSwiftDeployment 'Microsoft.Resources/deploymentScripts@2020-10-
   properties: {
     azCliVersion: '2.53.1'
     scriptContent: '''
+      set -uo pipefail
       az account set --subscription "${VNET_SUBSCRIPTION_ID}"
 
-      az network vnet show \
+      # The deployment MSI's Network/Tag Contributor role assignments are created in
+      # this same deployment. Azure RBAC is eventually consistent, so the first write
+      # can fail with AuthorizationFailed ("if access was recently granted, please
+      # refresh your credentials") before the assignment propagates to the data plane.
+      # Retry the write to absorb that lag, mirroring scripts/validate-mi-aad-propagation.sh.
+      MAX_WAIT=120
+      POLL_INTERVAL=5
+
+      retry() {
+        local elapsed=0
+        until "$@"; do
+          if [ "${elapsed}" -ge "${MAX_WAIT}" ]; then
+            echo "✗ '$*' still failing after ${elapsed}s" >&2
+            return 1
+          fi
+          echo "Command failed (likely RBAC propagation); retrying in ${POLL_INTERVAL}s..." >&2
+          sleep "${POLL_INTERVAL}"
+          elapsed=$((elapsed + POLL_INTERVAL))
+        done
+      }
+
+      if az network vnet show \
         --resource-group "${VNET_RG}" \
         --name "${VNET_NAME}" \
-        --output none 2>/dev/null
-
-      if [ $? -ne 0 ]; then
-        echo "VNet does not exist. Creating..."
-        az network vnet create \
-          --resource-group "${VNET_RG}" \
-          --name "${VNET_NAME}" \
-          --address-prefixes "${VNET_ADDRESS_PREFIX}" \
-          --tags stampcreatorserviceinfo=true
-      else
+        --output none 2>/dev/null; then
         echo "VNet exists. Updating tags..."
-        az resource tag \
+        retry az resource tag \
           --tags stampcreatorserviceinfo=true \
           --resource-group "${VNET_RG}" \
           --name "${VNET_NAME}" \
           --resource-type Microsoft.Network/virtualnetworks \
           --api-version 2024-05-01
+      else
+        echo "VNet does not exist or not yet authorized. Creating..."
+        retry az network vnet create \
+          --resource-group "${VNET_RG}" \
+          --name "${VNET_NAME}" \
+          --address-prefixes "${VNET_ADDRESS_PREFIX}" \
+          --tags stampcreatorserviceinfo=true
       fi
     '''
-    timeout: 'PT5M'
+    timeout: 'PT10M'
     cleanupPreference: 'OnSuccess'
     retentionInterval: 'P1D'
     environmentVariables: [


### PR DESCRIPTION
Jira: https://redhat.atlassian.net/browse/AROSLSRE-1346

### What

Wrap the write in the Swift VNet creation deployment script (`vnet-<name>`, i.e. `aks-net`) in a bounded retry, and raise the script `timeout` from `PT5M` to `PT10M`.

In `dev-infrastructure/modules/network/vnet.bicep`, the `enableSwift` path creates the deployment MSI's Network Contributor + Tag Contributor role assignments and then immediately runs `az network vnet create` / `az resource tag`. The retry (`MAX_WAIT=120`, `POLL_INTERVAL=5`) re-attempts the write until the role assignment propagates.

### Why

`dependsOn` only orders resource creation; it does not wait for Azure RBAC to propagate to the data plane. When the first write lands before propagation, the script fails with:

```
AuthorizationFailed ... does not have authorization to perform action
'Microsoft.Network/virtualNetworks/write' over scope '.../virtualNetworks/aks-net'
... If access was recently granted, please refresh your credentials.
```

This was reported (by deads2k) as driving a ~3% e2e error rate over the past couple of days. `vnet.bicep` itself has not changed recently, so this is Azure-side RBAC latency, and the script simply had no retry. The repo already handles the same class of race in `scripts/validate-mi-aad-propagation.sh` (run as a deploymentScript in `svc-cluster.bicep`); this change applies the same idiom to the VNet write. `az network vnet create` / `az resource tag` are idempotent PUTs, so retrying is safe.

### Testing

- `bicep build dev-infrastructure/modules/network/vnet.bicep` is clean.
- Shell logic of the `retry()` helper validated locally (`bash -n` plus a functional test confirming it returns success after transient failures and bubbles failure after `MAX_WAIT`).
- No unit/integration/E2E code paths exercise this deploymentScript directly; effectiveness is observable via the e2e AuthorizationFailed-on-`aks-net` rate trending to ~0 (the search.dptools query from the report).

### Special notes for your reviewer

- Behavioral change is retry-only; the create/tag branches are unchanged in intent. The `az network vnet show` existence check now also routes an AuthorizationFailed-on-show into the create branch, which is retried and idempotent.
- `azCliVersion` kept at `2.53.1` to match the sibling propagation-wait script.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
