### PR TITLE
docs: ensure all Prometheus alerts have documentation

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
@@ -41,7 +41,7 @@ Check the status of the Prometheus pods, service endpoints, and network connecti
 This may indicate that the Prometheus server is down, unreachable due to network issues, or experiencing a crash loop.
 Check the status of the Prometheus pods, service endpoints, and network connectivity.
 '''
-          runbook_url: 'TBD'
+          runbook_url: 'https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md'
           summary: 'Prometheus is unreachable for 10 minutes.'
           title: 'Prometheus is unreachable for 10 minutes.'
         }
@@ -74,7 +74,7 @@ Please check the status of the Prometheus pods, service endpoints, and network c
 This may indicate that the Prometheus server is down, experiencing network issues, or stuck in a crash loop.
 Please check the status of the Prometheus pods, service endpoints, and network connectivity.
 '''
-          runbook_url: 'TBD'
+          runbook_url: 'https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md'
           summary: 'Prometheus is unreachable for 1 day.'
           title: 'Prometheus is unreachable for 1 day.'
         }
@@ -109,7 +109,7 @@ Unlike PrometheusUptime which averages existing samples, this alert treats data 
 Complete metric absence (no samples) will also trigger PrometheusMetricsAbsentPerCluster.
 Check the PrometheusAgent pod status, remote write pipeline, and PodMonitor configuration.
 '''
-          runbook_url: 'TBD'
+          runbook_url: 'https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md'
           summary: 'Prometheus sample count below 95% SLO threshold for 24 hours.'
           title: 'Prometheus sample count below 95% SLO threshold for 24 hours.'
         }
@@ -142,7 +142,7 @@ Check the PrometheusAgent pod status and remote write configuration on the affec
 This indicates the Prometheus agent on this specific cluster is dead or its remote write pipeline is broken.
 Check the PrometheusAgent pod status and remote write configuration on the affected cluster.
 '''
-          runbook_url: 'TBD'
+          runbook_url: 'https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md'
           summary: 'Prometheus metrics absent for cluster {{ $labels.cluster }}.'
           title: 'Prometheus metrics absent for cluster {{ $labels.cluster }}.'
         }
@@ -179,7 +179,7 @@ a bottleneck or issue with the remote write endpoint, network connectivity, or P
 If this condition persists, it could lead to increased memory usage and potential data loss if the buffer overflows.
 Investigate the health and performance of the remote storage endpoint, network latency, and Prometheus resource utilization.
 '''
-          runbook_url: 'TBD'
+          runbook_url: 'https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md'
           summary: 'Prometheus pending sample rate is above 40%.'
           title: 'Prometheus pending sample rate is above 40%.'
         }
@@ -216,7 +216,7 @@ issues with the remote write endpoint, network instability, or Prometheus resour
 Persistent failures may result in increased memory usage and potential data loss if the buffer overflows.
 Please check the health and performance of the remote storage endpoint, network connectivity, and Prometheus resource utilization.
 '''
-          runbook_url: 'TBD'
+          runbook_url: 'https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md'
           summary: 'Prometheus failed sample rate to remote storage is above 10%.'
           title: 'Prometheus failed sample rate to remote storage is above 10%.'
         }
@@ -337,7 +337,7 @@ resource prometheusRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
           correlationId: 'PrometheusScrapeSampleLimitHit/{{ $labels.cluster }}'
           description: 'Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed {{ printf "%.0f" $value }} scrapes in the last 5m because some targets exceeded the configured sample_limit.'
           info: 'Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed {{ printf "%.0f" $value }} scrapes in the last 5m because some targets exceeded the configured sample_limit.'
-          runbook_url: 'https://runbooks.prometheus-operator.dev/runbooks/prometheus/prometheusscrapesamplelimithit'
+          runbook_url: 'https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md'
           summary: 'Prometheus has failed scrapes that have exceeded the configured sample limit.'
           title: 'Prometheus has failed scrapes that have exceeded the configured sample limit.'
         }

--- a/docs/alerts/Prometheus.md
+++ b/docs/alerts/Prometheus.md
@@ -1,0 +1,144 @@
+# Prometheus alerts
+
+This page describes the Prometheus self-monitoring alerts in `observability/alerts/prometheus-prometheusRule.yaml`, including the alerts added by [Azure/ARO-HCP#5535](https://github.com/Azure/ARO-HCP/pull/5535).
+
+The timings below are approximate and exclude Azure Monitor evaluation jitter, IcM routing latency, and notification delivery latency. The alert generator maps `critical` to IcM Sev 2, `warning` to Sev 3, and `info` to Sev 4.
+
+## Alert coverage summary
+
+| Alert | `for:` | Severity | What it indicates |
+|---|---:|---|---|
+| `PrometheusJobUp` | 10m | critical | The cluster exists according to the external anchor, but `up{job="prometheus/prometheus", namespace="prometheus"} == 1` is not present. This catches Prometheus down, unreachable, or reporting `up=0`. |
+| `PrometheusMetricsAbsentPerCluster` | 10m | critical | No Prometheus self-`up` samples have arrived for a cluster that should be reporting. With `underlay_clusters`, this means a declared underlay cluster has no Prometheus self-metrics in the recent window. |
+| `PrometheusUptimeSampleCount` | 10m | warning | Fewer than 95% of expected Prometheus self-`up` samples arrived over 24h. This treats missing samples as downtime. |
+| `PrometheusUptime` | 10m | critical | More than 5% of present Prometheus self-`up` samples over 24h were `0`. This does not count missing samples as downtime. |
+| `PrometheusPendingRate` | 15m | critical | Prometheus remote-write queue pressure is high: too many samples are pending relative to in-flight samples. |
+| `PrometheusFailedRate` | 15m | critical | More than 10% of remote-write samples are failing over the short rate window. |
+| `PrometheusRemoteStorageFailures` | 15m | critical | Upstream Prometheus Operator alert: more than 1% of samples failed to send to remote storage. Metrics and alerts may be missing or inaccurate. |
+| `PrometheusNotIngestingSamples` | 10m | warning | Upstream Prometheus Operator alert: Prometheus is alive and has target metadata, but is not ingesting samples locally. |
+| `PrometheusBadConfig` | 10m | critical | Upstream Prometheus Operator alert: Prometheus could not reload its generated configuration and is running with the last known good config. |
+| `PrometheusScrapeSampleLimitHit` | 15m | warning | Upstream Prometheus Operator alert: at least one scrape exceeded the configured sample limit, so metrics from that target may be dropped. |
+| `PrometheusOperatorNotReady` | 5m | warning | Upstream Prometheus Operator alert: the operator is not ready and may not reconcile Prometheus resources. |
+| `PrometheusOperatorRejectedResources` | 20m | warning | Upstream Prometheus Operator alert: the operator rejected one or more managed resources, so their config was not propagated to Prometheus or Alertmanager. |
+
+## Time to page for Prometheus completely down
+
+This table assumes the worst useful "Prometheus is down" shape for each alert: Prometheus self-metrics stop reaching the Azure Monitor Workspace entirely. Alerts that require Prometheus to keep emitting internal metrics will not fire for this shape.
+
+| Alert | `for:` | Severity | Earliest firing for complete Prometheus silence | Why |
+|---|---:|---|---:|---|
+| `PrometheusJobUp` | 10m | critical | ~10-15m | It can fire as soon as the latest good `up == 1` sample is no longer selected, then the `for: 10m` timer completes. The upper bound accounts for PromQL lookback of the last good sample. |
+| `PrometheusMetricsAbsentPerCluster` | 10m | critical | ~20m | `count_over_time(...[10m])` remains non-empty until the last sample is older than 10m, then the `for: 10m` timer completes. |
+| `PrometheusUptimeSampleCount` | 10m | warning | ~82m | It fires once more than 5% of the expected 24h samples are missing: 72m of missing samples plus `for: 10m`. |
+| `PrometheusUptime` | 10m | critical | Never for pure absence; ~82m if `up=0` samples continue | `avg_over_time(up[1d])` averages only samples that exist. Missing samples do not lower the average. |
+| `PrometheusPendingRate` | 15m | critical | Never | Needs Prometheus to emit remote-write queue metrics. |
+| `PrometheusFailedRate` | 15m | critical | Never | Needs Prometheus to emit remote-write failure counters. |
+| `PrometheusRemoteStorageFailures` | 15m | critical | Never | Needs Prometheus to emit remote storage success/failure counters. |
+| `PrometheusNotIngestingSamples` | 10m | warning | Never | Needs Prometheus to emit ingestion and target metadata metrics. |
+| `PrometheusBadConfig` | 10m | critical | Never | Needs Prometheus to emit config reload status metrics. |
+| `PrometheusScrapeSampleLimitHit` | 15m | warning | Never | Needs Prometheus to emit scrape limit counters. |
+| `PrometheusOperatorNotReady` | 5m | warning | Never | Detects operator readiness, not Prometheus self-metric silence. |
+| `PrometheusOperatorRejectedResources` | 20m | warning | Never | Detects rejected operator resources, not Prometheus self-metric silence. |
+
+## Failure modes captured
+
+### Prometheus is completely dead or remote-write has stopped
+
+Primary alerts:
+
+| Alert | Signal |
+|---|---|
+| `PrometheusJobUp` | Fastest page. The declared/anchored cluster does not have a healthy Prometheus self-`up` series. |
+| `PrometheusMetricsAbsentPerCluster` | Confirms complete absence of Prometheus self-metrics for the cluster. |
+| `PrometheusUptimeSampleCount` | Later SLO-style signal that the 24h sample budget was missed. |
+
+This is the most important case for `PrometheusJobUp` and `PrometheusMetricsAbsentPerCluster`. Once `underlay_clusters` is the source of truth, these should be interpreted as "this declared underlay cluster is expected to report Prometheus self-metrics, but it is not doing so."
+
+### Prometheus is currently reporting `up=0`
+
+Primary alerts:
+
+| Alert | Signal |
+|---|---|
+| `PrometheusJobUp` | Fires after 10m because the expected healthy `up == 1` series is absent. |
+| `PrometheusUptime` | Fires after more than 5% of the 24h window contains present `up=0` samples, plus `for: 10m`. |
+
+`PrometheusUptimeSampleCount` does not detect this by itself because the samples are present. It only counts how many samples arrived, not whether they were `0` or `1`.
+
+### Prometheus self-metrics are gappy or intermittent
+
+Primary alert:
+
+| Alert | Signal |
+|---|---|
+| `PrometheusUptimeSampleCount` | Fires when the missing samples add up to more than 5% of the 24h expected count. |
+
+This is the main blind spot that `PrometheusUptimeSampleCount` covers. Repeated short outages can avoid `PrometheusJobUp` if each gap is too short to satisfy `for: 10m`, and they can avoid `PrometheusUptime` if the samples that do arrive are all `1`. The sample-count alert still catches the cumulative loss once the missing samples exceed the 5% budget.
+
+### Prometheus is alive, but remote write is failing
+
+Primary alerts:
+
+| Alert | Signal |
+|---|---|
+| `PrometheusRemoteStorageFailures` | More than 1% of samples failed to send to remote storage. |
+| `PrometheusFailedRate` | More than 10% of remote-write samples are failing. |
+| `PrometheusPendingRate` | Samples are backing up in the remote-write queue. |
+| `PrometheusUptimeSampleCount` | May later fire if the failure results in missing Prometheus self-`up` samples in AMW. |
+
+These alerts require Prometheus to remain alive enough to expose its remote-write metrics. If Prometheus dies completely, they do not fire.
+
+### Prometheus is alive, but not ingesting samples locally
+
+Primary alert:
+
+| Alert | Signal |
+|---|---|
+| `PrometheusNotIngestingSamples` | Prometheus has target metadata but appends no TSDB samples. |
+
+This means the local scrape/ingestion path is broken even though Prometheus itself is still exporting metrics. The upstream runbook describes the impact as missing metrics.
+
+### Prometheus configuration is bad or stale
+
+Primary alert:
+
+| Alert | Signal |
+|---|---|
+| `PrometheusBadConfig` | The last configuration reload failed. |
+
+According to the upstream runbook, Prometheus continues running with the last known good configuration. New or changed `Prometheus`, `Probe`, `PodMonitor`, or `ServiceMonitor` objects may not be picked up.
+
+### A target exceeds Prometheus scrape sample limits
+
+Primary alert:
+
+| Alert | Signal |
+|---|---|
+| `PrometheusScrapeSampleLimitHit` | A scrape exceeded the configured sample limit. |
+
+This usually means a target is exposing too many series or has a cardinality spike. Prometheus may drop metrics from that target, so downstream alerts and dashboards can become incomplete.
+
+### Prometheus Operator cannot reconcile correctly
+
+Primary alerts:
+
+| Alert | Signal |
+|---|---|
+| `PrometheusOperatorNotReady` | The operator is not ready and cannot reliably operate. |
+| `PrometheusOperatorRejectedResources` | The operator rejected one or more managed resources, so their configuration was not propagated. |
+
+These are not direct "Prometheus is down" alerts. They indicate that future Prometheus configuration, rules, scrape definitions, or related managed resources may not be reconciled correctly.
+
+## Upstream runbooks
+
+Several alerts come from the Prometheus Operator upstream runbooks:
+
+| Alert | Upstream runbook |
+|---|---|
+| `PrometheusRemoteStorageFailures` | <https://runbooks.prometheus-operator.dev/runbooks/prometheus/prometheusremotestoragefailures/> |
+| `PrometheusNotIngestingSamples` | <https://runbooks.prometheus-operator.dev/runbooks/prometheus/prometheusnotingestingsamples/> |
+| `PrometheusBadConfig` | <https://runbooks.prometheus-operator.dev/runbooks/prometheus/prometheusbadconfig/> |
+| `PrometheusOperatorNotReady` | <https://runbooks.prometheus-operator.dev/runbooks/prometheus-operator/prometheusoperatornotready/> |
+| `PrometheusOperatorRejectedResources` | <https://runbooks.prometheus-operator.dev/runbooks/prometheus-operator/prometheusoperatorrejectedresources/> |
+
+The checked-in `PrometheusScrapeSampleLimitHit` annotation points at `https://runbooks.prometheus-operator.dev/runbooks/prometheus/prometheusscrapesamplelimithit`, but that URL currently returns 404. The alert still means that a target exceeded its configured Prometheus scrape sample limit and some target metrics may be missing.

--- a/docs/alerts/Prometheus.md
+++ b/docs/alerts/Prometheus.md
@@ -141,4 +141,4 @@ Several alerts come from the Prometheus Operator upstream runbooks:
 | `PrometheusOperatorNotReady` | <https://runbooks.prometheus-operator.dev/runbooks/prometheus-operator/prometheusoperatornotready/> |
 | `PrometheusOperatorRejectedResources` | <https://runbooks.prometheus-operator.dev/runbooks/prometheus-operator/prometheusoperatorrejectedresources/> |
 
-The checked-in `PrometheusScrapeSampleLimitHit` annotation points at `https://runbooks.prometheus-operator.dev/runbooks/prometheus/prometheusscrapesamplelimithit`, but that URL currently returns 404. The alert still means that a target exceeded its configured Prometheus scrape sample limit and some target metrics may be missing.
+`PrometheusScrapeSampleLimitHit` points at this page instead of the upstream Prometheus Operator runbook because `https://runbooks.prometheus-operator.dev/runbooks/prometheus/prometheusscrapesamplelimithit` currently returns 404. The alert means that a target exceeded its configured Prometheus scrape sample limit and some target metrics may be missing.

--- a/observability/alerts/prometheus-prometheusRule.yaml
+++ b/observability/alerts/prometheus-prometheusRule.yaml
@@ -150,7 +150,7 @@ spec:
         severity: warning
       annotations:
         description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed {{ printf "%.0f" $value }} scrapes in the last 5m because some targets exceeded the configured sample_limit.
-        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/prometheus/prometheusscrapesamplelimithit
+        runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md
         summary: Prometheus has failed scrapes that have exceeded the configured sample limit.
   - name: prometheus-operator-rules
     rules:

--- a/observability/alerts/prometheus-prometheusRule.yaml
+++ b/observability/alerts/prometheus-prometheusRule.yaml
@@ -24,7 +24,7 @@ spec:
           Prometheus has not been reachable for the past 10 minutes.
           This may indicate that the Prometheus server is down, unreachable due to network issues, or experiencing a crash loop.
           Check the status of the Prometheus pods, service endpoints, and network connectivity.
-        runbook_url: TBD # https://runbooks.prometheus-operator.dev/runbooks/prometheus/prometheusdown
+        runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md
         summary: Prometheus is unreachable for 10 minutes.
     - alert: PrometheusUptime
       expr: avg by (job, namespace, cluster) (avg_over_time(up{job="prometheus/prometheus",namespace="prometheus"}[1d])) < 0.95
@@ -36,7 +36,7 @@ spec:
           Prometheus has been unreachable for more than 5% of the time over the past 24 hours.
           This may indicate that the Prometheus server is down, experiencing network issues, or stuck in a crash loop.
           Please check the status of the Prometheus pods, service endpoints, and network connectivity.
-        runbook_url: TBD # https://runbooks.prometheus-operator.dev/runbooks/prometheus/prometheusdown
+        runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md
         summary: Prometheus is unreachable for 1 day.
     - alert: PrometheusUptimeSampleCount
       # The divisor 30 matches spec.scrapeInterval (30s) in prometheus.yaml. Update both together if the interval changes.
@@ -59,7 +59,7 @@ spec:
           Unlike PrometheusUptime which averages existing samples, this alert treats data gaps as downtime.
           Complete metric absence (no samples) will also trigger PrometheusMetricsAbsentPerCluster.
           Check the PrometheusAgent pod status, remote write pipeline, and PodMonitor configuration.
-        runbook_url: TBD
+        runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md
         summary: Prometheus sample count below 95% SLO threshold for 24 hours.
     - alert: PrometheusMetricsAbsentPerCluster
       expr: count by (cluster) (count_over_time(up{job="prometheus/prometheus",namespace="prometheus"}[7d])) unless count by (cluster) (count_over_time(up{job="prometheus/prometheus",namespace="prometheus"}[10m]))
@@ -71,7 +71,7 @@ spec:
           Prometheus on cluster {{ $labels.cluster }} has not reported any up metrics in the last 10 minutes, but was reporting within the last 7 days.
           This indicates the Prometheus agent on this specific cluster is dead or its remote write pipeline is broken.
           Check the PrometheusAgent pod status and remote write configuration on the affected cluster.
-        runbook_url: TBD
+        runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md
         summary: Prometheus metrics absent for cluster {{ $labels.cluster }}.
     - alert: PrometheusPendingRate
       expr: |
@@ -90,7 +90,7 @@ spec:
           a bottleneck or issue with the remote write endpoint, network connectivity, or Prometheus performance.
           If this condition persists, it could lead to increased memory usage and potential data loss if the buffer overflows.
           Investigate the health and performance of the remote storage endpoint, network latency, and Prometheus resource utilization.
-        runbook_url: TBD
+        runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md
         summary: Prometheus pending sample rate is above 40%.
     - alert: PrometheusFailedRate
       expr: |
@@ -112,7 +112,7 @@ spec:
           issues with the remote write endpoint, network instability, or Prometheus resource constraints.
           Persistent failures may result in increased memory usage and potential data loss if the buffer overflows.
           Please check the health and performance of the remote storage endpoint, network connectivity, and Prometheus resource utilization.
-        runbook_url: TBD
+        runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md
         summary: Prometheus failed sample rate to remote storage is above 10%.
   - name: prometheus-rules
     rules:

--- a/observability/alerts/prometheus-prometheusRule_test.yaml
+++ b/observability/alerts/prometheus-prometheusRule_test.yaml
@@ -22,7 +22,7 @@ tests:
           Prometheus has not been reachable for the past 10 minutes.
           This may indicate that the Prometheus server is down, unreachable due to network issues, or experiencing a crash loop.
           Check the status of the Prometheus pods, service endpoints, and network connectivity.
-        runbook_url: TBD
+        runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md
 - interval: 1m
   input_series:
   - series: 'up{job="prometheus/prometheus",namespace="prometheus"}'
@@ -41,7 +41,7 @@ tests:
           Prometheus has been unreachable for more than 5% of the time over the past 24 hours.
           This may indicate that the Prometheus server is down, experiencing network issues, or stuck in a crash loop.
           Please check the status of the Prometheus pods, service endpoints, and network connectivity.
-        runbook_url: TBD
+        runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md
 - interval: 1m
   input_series:
   - series: 'prometheus_remote_storage_samples_pending{cluster="test"}'
@@ -77,7 +77,7 @@ tests:
           issues with the remote write endpoint, network instability, or Prometheus resource constraints.
           Persistent failures may result in increased memory usage and potential data loss if the buffer overflows.
           Please check the health and performance of the remote storage endpoint, network connectivity, and Prometheus resource utilization.
-        runbook_url: TBD
+        runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md
 # prometheus-rules group tests
 - interval: 1m
   input_series:
@@ -207,7 +207,7 @@ tests:
           Prometheus has not been reachable for the past 10 minutes.
           This may indicate that the Prometheus server is down, unreachable due to network issues, or experiencing a crash loop.
           Check the status of the Prometheus pods, service endpoints, and network connectivity.
-        runbook_url: TBD
+        runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md
 # Test no alert scenario for PrometheusJobUp
 - interval: 1m
   input_series:
@@ -261,7 +261,7 @@ tests:
           a bottleneck or issue with the remote write endpoint, network connectivity, or Prometheus performance.
           If this condition persists, it could lead to increased memory usage and potential data loss if the buffer overflows.
           Investigate the health and performance of the remote storage endpoint, network latency, and Prometheus resource utilization.
-        runbook_url: TBD
+        runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md
 # Test multiple remote storage endpoints for PrometheusRemoteStorageFailures
 - interval: 1m
   input_series:
@@ -436,7 +436,7 @@ tests:
           Prometheus has not been reachable for the past 10 minutes.
           This may indicate that the Prometheus server is down, unreachable due to network issues, or experiencing a crash loop.
           Check the status of the Prometheus pods, service endpoints, and network connectivity.
-        runbook_url: TBD
+        runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md
 # Test PrometheusUptime with gradual degradation
 - interval: 1m
   input_series:
@@ -456,7 +456,7 @@ tests:
           Prometheus has been unreachable for more than 5% of the time over the past 24 hours.
           This may indicate that the Prometheus server is down, experiencing network issues, or stuck in a crash loop.
           Please check the status of the Prometheus pods, service endpoints, and network connectivity.
-        runbook_url: TBD
+        runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md
 # Test PrometheusPendingRate with low pending rate
 - interval: 1m
   input_series:
@@ -505,7 +505,7 @@ tests:
           issues with the remote write endpoint, network instability, or Prometheus resource constraints.
           Persistent failures may result in increased memory usage and potential data loss if the buffer overflows.
           Please check the health and performance of the remote storage endpoint, network connectivity, and Prometheus resource utilization.
-        runbook_url: TBD
+        runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md
 # Test PrometheusFailedRate with no samples
 - interval: 1m
   input_series:
@@ -611,7 +611,7 @@ tests:
       exp_annotations:
         summary: Prometheus has failed scrapes that have exceeded the configured sample limit.
         description: Prometheus prometheus/ has failed 5 scrapes in the last 5m because some targets exceeded the configured sample_limit.
-        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/prometheus/prometheusscrapesamplelimithit
+        runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md
     - exp_labels:
         severity: warning
         job: prometheus/prometheus
@@ -620,7 +620,7 @@ tests:
       exp_annotations:
         summary: Prometheus has failed scrapes that have exceeded the configured sample limit.
         description: Prometheus prometheus/ has failed 10 scrapes in the last 5m because some targets exceeded the configured sample_limit.
-        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/prometheus/prometheusscrapesamplelimithit
+        runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md
 # Test PrometheusOperatorNotReady recovery scenario
 - interval: 1m
   input_series:
@@ -692,7 +692,7 @@ tests:
           Prometheus has not been reachable for the past 10 minutes.
           This may indicate that the Prometheus server is down, unreachable due to network issues, or experiencing a crash loop.
           Check the status of the Prometheus pods, service endpoints, and network connectivity.
-        runbook_url: TBD
+        runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md
 # Test PrometheusFailedRate with very high failure rate
 - interval: 1m
   input_series:
@@ -719,7 +719,7 @@ tests:
           issues with the remote write endpoint, network instability, or Prometheus resource constraints.
           Persistent failures may result in increased memory usage and potential data loss if the buffer overflows.
           Please check the health and performance of the remote storage endpoint, network connectivity, and Prometheus resource utilization.
-        runbook_url: TBD
+        runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md
 # Test negative scenarios - metrics not present
 - interval: 1m
   input_series: [] # No metrics present
@@ -783,7 +783,7 @@ tests:
           Prometheus has not been reachable for the past 10 minutes.
           This may indicate that the Prometheus server is down, unreachable due to network issues, or experiencing a crash loop.
           Check the status of the Prometheus pods, service endpoints, and network connectivity.
-        runbook_url: TBD
+        runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md
   - eval_time: 20m
     alertname: PrometheusJobUp
     exp_alerts: []
@@ -821,7 +821,7 @@ tests:
           Unlike PrometheusUptime which averages existing samples, this alert treats data gaps as downtime.
           Complete metric absence (no samples) will also trigger PrometheusMetricsAbsentPerCluster.
           Check the PrometheusAgent pod status, remote write pipeline, and PodMonitor configuration.
-        runbook_url: TBD
+        runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md
 # Test PrometheusUptimeSampleCount - healthy (full 24h of samples)
 # 2880 samples at 30s = 24h of data (t=0 to ~t=1440m).
 # At eval_time 1450m, [1d] window covers (10m, 1450m] → ~2859 effective samples.
@@ -865,7 +865,7 @@ tests:
           Prometheus on cluster dead-cluster has not reported any up metrics in the last 10 minutes, but was reporting within the last 7 days.
           This indicates the Prometheus agent on this specific cluster is dead or its remote write pipeline is broken.
           Check the PrometheusAgent pod status and remote write configuration on the affected cluster.
-        runbook_url: TBD
+        runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md
 # Test PrometheusMetricsAbsentPerCluster - healthy cluster (continuous data)
 - interval: 1m
   input_series:
@@ -896,7 +896,7 @@ tests:
           Prometheus on cluster dead has not reported any up metrics in the last 10 minutes, but was reporting within the last 7 days.
           This indicates the Prometheus agent on this specific cluster is dead or its remote write pipeline is broken.
           Check the PrometheusAgent pod status and remote write configuration on the affected cluster.
-        runbook_url: TBD
+        runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md
 # Test multiple namespaces and jobs
 - interval: 1m
   input_series:
@@ -987,7 +987,7 @@ tests:
           a bottleneck or issue with the remote write endpoint, network connectivity, or Prometheus performance.
           If this condition persists, it could lead to increased memory usage and potential data loss if the buffer overflows.
           Investigate the health and performance of the remote storage endpoint, network latency, and Prometheus resource utilization.
-        runbook_url: TBD
+        runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md
 # Test PrometheusOperatorNotReady with different controller types
 - interval: 1m
   input_series:

--- a/observability/alerts/prometheus-prometheusRule_test.yaml
+++ b/observability/alerts/prometheus-prometheusRule_test.yaml
@@ -148,7 +148,7 @@ tests:
       exp_annotations:
         summary: Prometheus has failed scrapes that have exceeded the configured sample limit.
         description: Prometheus prometheus/ has failed 10 scrapes in the last 5m because some targets exceeded the configured sample_limit.
-        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/prometheus/prometheusscrapesamplelimithit
+        runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md
 # prometheus-operator-rules group tests
 - interval: 1m
   input_series:


### PR DESCRIPTION
## Why

Prometheus self-monitoring now has several overlapping alerts, including alerts for complete silence, gappy self-metrics, remote-write failures, ingestion failures, config failures, scrape-limit hits, and Prometheus Operator reconciliation problems. Responders need one ARO-HCP-owned reference that explains what each alert means and all alert rules should link to working documentation.

## What

- Add `docs/alerts/Prometheus.md` with Prometheus alert coverage, failure modes, and timing tables.
- Point ARO-HCP Prometheus alerts with `TBD` runbooks at the new documentation.
- Replace the broken upstream `PrometheusScrapeSampleLimitHit` runbook URL with the new documentation.
- Regenerate alert Bicep outputs.

## Screenshots

N/A - documentation and alert metadata only.

## Testing

- `make -C observability alerts`

Related: https://github.com/Azure/ARO-HCP/pull/5535