### PR TITLE
feat: enable mise audit loging in msft environments

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -9,6 +9,7 @@ ignore:
 - 'frontend/deploy/templates/ext-authz.authorizationpolicy.yaml'
 - 'frontend/deploy/templates/allow-ingress.authorizationpolicy.yaml'
 - 'frontend/deploy/templates/frontend.deployment.yaml'
+- 'istio/deploy/charts/mise/templates/deployment.yaml'
 - 'istio/deploy/templates/istio-shared-configmap.yml'
 - 'cluster-service/helm-charts/cluster-service/templates/cs-keyvault.secret.yaml'
 - 'cluster-service/helm-charts/cluster-service/templates/deployment.yaml'

--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -18,6 +18,10 @@ clouds:
           frontend:
             audit:
               connectSocket: true
+          # MISE
+          mise:
+            audit:
+              connectSocket: true
       stg:
         # this is the MSFT STAGE environment
         defaults:
@@ -56,6 +60,10 @@ clouds:
           frontend:
             audit:
               connectSocket: true
+          # MISE
+          mise:
+            audit:
+              connectSocket: true
       prod:
         # this is the MSFT PRODUCTION environment
         defaults:
@@ -68,6 +76,10 @@ clouds:
             deployDebugJobs: true
           # RP Frontend
           frontend:
+            audit:
+              connectSocket: true
+          # MISE
+          mise:
             audit:
               connectSocket: true
         regions:

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -2188,6 +2188,17 @@
           ],
           "additionalProperties": false
         },
+        "audit": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "connectSocket": {
+              "type": "boolean",
+              "description": "Whether to connect to the mdsd audit socket for audit logging."
+            }
+          },
+          "required": ["connectSocket"]
+        },
         "image": {
           "$ref": "#/definitions/containerImage"
         },
@@ -2201,6 +2212,7 @@
       },
       "required": [
         "deploy",
+        "audit",
         "image",
         "imageV2",
         "arm",

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -854,6 +854,8 @@ defaults:
   # Mise
   mise:
     deploy: true
+    audit:
+      connectSocket: false
     applicationName: "arohcp-mise-{{ .ctx.environment }}"
     arm:
       policyLabel: "ARM Policy"

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -746,6 +746,8 @@ mise:
     authorityFQDN: login.microsoftonline.com
     policyLabel: ARM Policy
     tenantId: 33e01921-4d64-4f8c-a055-5bdaffd5e33d
+  audit:
+    connectSocket: false
   deploy: false
   genevaActions:
     audienceFQDN: management.azure.com

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -746,6 +746,8 @@ mise:
     authorityFQDN: login.microsoftonline.com
     policyLabel: ARM Policy
     tenantId: 33e01921-4d64-4f8c-a055-5bdaffd5e33d
+  audit:
+    connectSocket: false
   deploy: false
   genevaActions:
     audienceFQDN: management.azure.com

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -744,6 +744,8 @@ mise:
     authorityFQDN: login.microsoftonline.com
     policyLabel: ARM Policy
     tenantId: 33e01921-4d64-4f8c-a055-5bdaffd5e33d
+  audit:
+    connectSocket: false
   deploy: false
   genevaActions:
     audienceFQDN: management.azure.com

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -744,6 +744,8 @@ mise:
     authorityFQDN: login.microsoftonline.com
     policyLabel: ARM Policy
     tenantId: 33e01921-4d64-4f8c-a055-5bdaffd5e33d
+  audit:
+    connectSocket: false
   deploy: false
   genevaActions:
     audienceFQDN: management.azure.com

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -744,6 +744,8 @@ mise:
     authorityFQDN: login.microsoftonline.com
     policyLabel: ARM Policy
     tenantId: 33e01921-4d64-4f8c-a055-5bdaffd5e33d
+  audit:
+    connectSocket: false
   deploy: false
   genevaActions:
     audienceFQDN: management.azure.com

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -746,6 +746,8 @@ mise:
     authorityFQDN: login.microsoftonline.com
     policyLabel: ARM Policy
     tenantId: 33e01921-4d64-4f8c-a055-5bdaffd5e33d
+  audit:
+    connectSocket: false
   deploy: false
   genevaActions:
     audienceFQDN: management.azure.com

--- a/docs/mise.md
+++ b/docs/mise.md
@@ -42,3 +42,43 @@ See `istio/deploy/charts/mise/templates/configmap.yaml` for the full template.
 - Istio enforces the decision (forward or reject).
 Note: This retrofit ensures that Geneva Action traffic is consistently validated through the same MISE-based framework, providing a unified security model for both ARM and Geneva-originated requests.
 
+# Audit Logging
+
+MISE v2 (1.27.0+) automatically audits 100% of authentication requests. Audit records are written to the `AsmAuditCPRPMISE` Geneva table via the OpenTelemetry Geneva Log Exporter over a Unix domain socket provided by mdsd on the node.
+
+## How it works
+
+On Linux, MISE resolves the audit connection in this order:
+1. If `AzureAd:AuditOptions:CustomConnectionString` is set, use it.
+2. If `/var/run/mdsd/asa/default_fluent.socket` exists (AzSecPack/AutoConfig), use it.
+3. Otherwise fall back to `Endpoint=unix:/var/run/mdsd/default_fluent.socket`.
+
+ARO-HCP service cluster nodes run mdsd, exposing `/var/run/mdsd/` on the host. The MISE deployment mounts this directory into the pod via a `hostPath` volume when `audit.connectSocket` is enabled.
+
+## Configuration
+
+Audit logging is controlled by the `audit.connectSocket` toggle, following the same pattern as the RP frontend and Admin API:
+
+- **Default** (`config/config.yaml`): `mise.audit.connectSocket: false`
+- **Production overlay** (`config/config.msft.clouds-overlay.yaml`): set to `true` for int, stg, and prod environments
+
+When enabled, the MISE Helm chart:
+- Mounts `/var/run/mdsd` from the host into the pod
+- Adds `AuditOptions.CustomConnectionString` to `appsettings.json` pointing to `Endpoint=unix:/var/run/mdsd/default_fluent.socket`
+
+See `istio/deploy/charts/mise/templates/deployment.yaml` and `istio/deploy/charts/mise/templates/configmap.yaml` for the implementation.
+
+## Emergency disable
+
+In an emergency, audit logging can be disabled via the MISE config without removing the socket mount:
+
+```json
+{
+  "AzureAd": {
+    "AuditOptions": {
+      "EmergencyDisableAllAuditLogging": true
+    }
+  }
+}
+```
+

--- a/istio/deploy/charts/mise/templates/configmap.yaml
+++ b/istio/deploy/charts/mise/templates/configmap.yaml
@@ -15,6 +15,11 @@ data:
         "ClientId": "{{ .Values.miseAppId }}",
         "TenantId": "{{ .Values.audit.tenantId }}",
         "Audiences": ["api://{{ .Values.miseAppId }}"],
+        {{- if .Values.audit.connectSocket }}
+        "AuditOptions": {
+          "CustomConnectionString": "Endpoint=unix:/var/run/mdsd/default_fluent.socket"
+        },
+        {{- end }}
         "Logging": {
           "LogLevel": "Information"
         },

--- a/istio/deploy/charts/mise/templates/deployment.yaml
+++ b/istio/deploy/charts/mise/templates/deployment.yaml
@@ -46,6 +46,10 @@ spec:
           mountPath: /app/appsettings.json
           subPath: appsettings.json
           readOnly: true
+        {{- if .Values.audit.connectSocket }}
+        - name: mdsd-asa-run-vol
+          mountPath: /var/run/mdsd
+        {{- end }}
         env:
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: "{{ .Values.tracing.address }}"
@@ -55,3 +59,9 @@ spec:
       - name: mise-config
         configMap:
           name: mise-config
+      {{- if .Values.audit.connectSocket }}
+      - name: mdsd-asa-run-vol
+        hostPath:
+          path: /var/run/mdsd
+          type: Directory
+      {{- end }}

--- a/istio/deploy/charts/mise/values.yaml
+++ b/istio/deploy/charts/mise/values.yaml
@@ -11,6 +11,7 @@ miseAppId: ""
 audit:
   adInstance: ""
   tenantId: ""
+  connectSocket: false
 armPolicy:
   label: ""
   authority: ""

--- a/istio/values.yaml
+++ b/istio/values.yaml
@@ -19,6 +19,7 @@ mise:
   audit:
     adInstance: "https://{{ .mise.arm.authorityFQDN }}/"
     tenantId: "{{ .mise.arm.tenantId }}"
+    connectSocket: {{ .mise.audit.connectSocket }}
   miseAppId: "__miseAppId__"
   tracing:
     address: "{{ .mise.tracing.address }}"


### PR DESCRIPTION


fixes https://redhat.atlassian.net/browse/ARO-26485

### What

Configures mise v2 audit logging following the established frontend / admin api pattern.

### Why

For comprehensive audit logging of all requests through MISE.

### Testing
Testing mise audit logging is not possible in non-Microsoft environment.  Deployment / configuration is naturally validated through e2e environment provisioning.


### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
