### PR TITLE
chore(observability): verify generated alert Bicep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ verify-kql:
 update: deepcopy json-format
 .PHONY: update
 
-verify: verify-deepcopy verify-json-format verify-generate verify-yamlfmt verify-materialize verify-gomega-assertions verify-schema
+verify: verify-deepcopy verify-json-format verify-generate verify-yamlfmt verify-materialize verify-alert-bicep verify-gomega-assertions verify-schema
 .PHONY: verify
 
 verify-schema:
@@ -381,6 +381,11 @@ test-helm-fixtures:
 verify-materialize:
 	$(MAKE) -C config/ detect-change
 .PHONY: verify-materialize
+
+verify-alert-bicep:
+	$(MAKE) -C observability/ alerts NPROC=1
+	./hack/verify.sh "-C observability alerts"
+.PHONY: verify-alert-bicep
 
 #
 # Generated SDKs


### PR DESCRIPTION
## Summary

Adds `verify-alert-bicep` to `make verify` so CI regenerates Prometheus alert Bicep and fails if the generated output is stale. This prevents alert YAML changes like #5652 from merging without the matching `dev-infrastructure/modules/metrics/rules/generated*.bicep` updates.

This PR intentionally does **not** include the currently missing generated orphaned MRG alert Bicep output, so the new check should fail and demonstrate the detection.

## Test plan

- [x] `make verify-alert-bicep` fails locally with uncommitted generated alert Bicep changes
- [x] Failure hint now points to `make -C observability alerts`
- [x] Verification path runs alert Bicep formatting with `NPROC=1` to avoid the Azure CLI/Bicep parallel formatter race seen in CI

## References

- Follow-up to https://github.com/Azure/ARO-HCP/pull/5652
- Replaces closed https://github.com/Azure/ARO-HCP/pull/5812

No separate Jira; this is CI enforcement for a regression found during PR review.