### PR TITLE
make leader lease for kube-applier low pressure, but still reasonably…

### DIFF
--- a/kube-applier/pkg/app/kube_applier.go
+++ b/kube-applier/pkg/app/kube_applier.go
@@ -157,7 +157,7 @@ func (o *Options) runControllersUnderLeaderElection(
 		return fmt.Errorf("read manager: %w", err)
 	}
 
-	le, err := leaderelection.NewLeaderElector(leaderelection.LeaderElectionConfig{
+	leaderElectionConfig := leaderelection.LeaderElectionConfig{
 		Lock:          o.LeaderElectionLock,
 		LeaseDuration: leaderElectionLeaseDuration,
 		RenewDeadline: leaderElectionRenewDeadline,
@@ -186,10 +186,25 @@ func (o *Options) runControllersUnderLeaderElection(
 		ReleaseOnCancel: true,
 		WatchDog:        electionChecker,
 		Name:            "kube-applier",
-	})
+	}
+
+	retryTimes := int(leaderElectionConfig.RenewDeadline / leaderElectionConfig.RetryPeriod)
+	logger.Info(
+		fmt.Sprintf(
+			"The leader election gives %v retries and allows for %v of clock skew. The kube-apiserver downtime tolerance is %vs. Worst non-graceful lease acquisition is %v. Worst graceful lease acquisition is %v.",
+			retryTimes,
+			leaderElectionConfig.LeaseDuration-leaderElectionConfig.RenewDeadline,
+			(retryTimes-1)*(int(leaderElectionConfig.RetryPeriod.Seconds())),
+			leaderElectionConfig.LeaseDuration+leaderElectionConfig.RetryPeriod,
+			leaderElectionConfig.RetryPeriod,
+		),
+	)
+
+	le, err := leaderelection.NewLeaderElector(leaderElectionConfig)
 	if err != nil {
 		return err
 	}
+
 	le.Run(ctx)
 	return nil
 }

--- a/kube-applier/pkg/app/leader_election_wiring.go
+++ b/kube-applier/pkg/app/leader_election_wiring.go
@@ -25,9 +25,18 @@ import (
 )
 
 const (
-	leaderElectionLeaseDuration = 15 * time.Second
-	leaderElectionRenewDeadline = 10 * time.Second
-	leaderElectionRetryPeriod   = 2 * time.Second
+	// We want to be able to tolerate 60s of kube-apiserver disruption without causing pod restarts.
+	// We want the graceful lease re-acquisition fairly quick to avoid waits on new deployments and other rollouts.
+	// We want a single set of guidance for nearly every lease in openshift.  If you're special, we'll let you know.
+	// 1. clock skew tolerance is leaseDuration-renewDeadline == 30s
+	// 2. kube-apiserver downtime tolerance is == 78s
+	//      lastRetry=floor(renewDeadline/retryPeriod)*retryPeriod == 104
+	//      downtimeTolerance = lastRetry-retryPeriod == 78s
+	// 3. worst non-graceful lease acquisition is leaseDuration+retryPeriod == 163s
+	// 4. worst graceful lease acquisition is retryPeriod == 26s
+	leaderElectionLeaseDuration = 137 * time.Second
+	leaderElectionRenewDeadline = 107 * time.Second
+	leaderElectionRetryPeriod   = 26 * time.Second
 )
 
 // NewLeaderElectionLock builds a Leases-backed lock in kubeNamespace named


### PR DESCRIPTION
… responsive based on OCP defaults
