### PR TITLE
feat: switch AMW ingestion limits bicep to millions config params

### DIFF
--- a/dev-infrastructure/configurations/region.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/region.tmpl.bicepparam
@@ -24,5 +24,5 @@ param globalMSIId = '__globalMSIId__'
 param svcMonitorName = '{{ .monitoring.svcWorkspaceName }}'
 param hcpMonitorName = '{{ .monitoring.hcpWorkspaceName }}'
 param grafanaResourceId = '__grafanaResourceId__'
-param amwMaxActiveTimeSeries = {{ if eq (printf "%T" .monitoring.maxActiveTimeSeries) "float64" }}{{ printf "%.0f" .monitoring.maxActiveTimeSeries }}{{ else }}{{ .monitoring.maxActiveTimeSeries }}{{ end }}
-param amwMaxEventsPerMinute = {{ if eq (printf "%T" .monitoring.maxEventsPerMinute) "float64" }}{{ printf "%.0f" .monitoring.maxEventsPerMinute }}{{ else }}{{ .monitoring.maxEventsPerMinute }}{{ end }}
+param amwMaxActiveTimeSeriesMillions = {{ .monitoring.maxActiveTimeSeriesMillions }}
+param amwMaxEventsPerMinuteMillions = {{ .monitoring.maxEventsPerMinuteMillions }}

--- a/dev-infrastructure/modules/metrics/amw-ingestion-limits.bicep
+++ b/dev-infrastructure/modules/metrics/amw-ingestion-limits.bicep
@@ -4,11 +4,11 @@ param azureMonitorWorkspaceName string
 @description('Location of the Azure Monitor Workspace')
 param location string
 
-@description('Maximum active time series limit (2M initial, bump when hitting 50% utilization)')
-param maxActiveTimeSeries int = 2000000
+@description('Maximum active time series limit in millions (2M initial, bump when hitting 50% utilization)')
+param maxActiveTimeSeriesMillions int = 2
 
-@description('Maximum events per minute limit (2M initial, bump when hitting 50% utilization)')
-param maxEventsPerMinute int = 2000000
+@description('Maximum events per minute limit in millions (2M initial, bump when hitting 50% utilization)')
+param maxEventsPerMinuteMillions int = 2
 
 // Existing Azure Monitor Workspace (parent resource for metrics container)
 resource azureMonitorWorkspace 'Microsoft.Monitor/accounts@2023-04-03' existing = {
@@ -27,11 +27,8 @@ resource metricsContainer 'Microsoft.Monitor/accounts/metricsContainers@2025-10-
   location: location
   properties: {
     limits: {
-      maxActiveTimeSeries: maxActiveTimeSeries
-      maxEventsPerMinute: maxEventsPerMinute
+      maxActiveTimeSeries: maxActiveTimeSeriesMillions * 1000000
+      maxEventsPerMinute: maxEventsPerMinuteMillions * 1000000
     }
   }
 }
-
-output maxActiveTimeSeries int = maxActiveTimeSeries
-output maxEventsPerMinute int = maxEventsPerMinute

--- a/dev-infrastructure/templates/opstool-cluster.bicep
+++ b/dev-infrastructure/templates/opstool-cluster.bicep
@@ -103,11 +103,11 @@ param aksClusterOutboundIPAddressIPTags string = ''
 @description('Azure Monitor Workspace name for Prometheus remote write')
 param azureMonitorWorkspaceName string
 
-@description('Maximum active time series limit for Azure Monitor Workspace (2M initial, bump when hitting 50% utilization)')
-param amwMaxActiveTimeSeries int = 2000000
+@description('Maximum active time series limit for Azure Monitor Workspace in millions (2M initial, bump when hitting 50% utilization)')
+param amwMaxActiveTimeSeriesMillions int = 2
 
-@description('Maximum events per minute limit for Azure Monitor Workspace (2M initial, bump when hitting 50% utilization)')
-param amwMaxEventsPerMinute int = 2000000
+@description('Maximum events per minute limit for Azure Monitor Workspace in millions (2M initial, bump when hitting 50% utilization)')
+param amwMaxEventsPerMinuteMillions int = 2
 
 @description('Owning team tag value')
 param owningTeamTagValue string = 'ARO-HCP-SRE'
@@ -295,8 +295,8 @@ module amwIngestionLimits '../modules/metrics/amw-ingestion-limits.bicep' = {
   params: {
     azureMonitorWorkspaceName: azureMonitorWorkspaceName
     location: location
-    maxActiveTimeSeries: amwMaxActiveTimeSeries
-    maxEventsPerMinute: amwMaxEventsPerMinute
+    maxActiveTimeSeriesMillions: amwMaxActiveTimeSeriesMillions
+    maxEventsPerMinuteMillions: amwMaxEventsPerMinuteMillions
   }
   dependsOn: [
     azureMonitorWorkspace

--- a/dev-infrastructure/templates/region.bicep
+++ b/dev-infrastructure/templates/region.bicep
@@ -51,11 +51,11 @@ param svcMonitorName string
 @description('Name of the Azure Monitor Workspace for hosted control planes')
 param hcpMonitorName string
 
-@description('Maximum active time series limit for Azure Monitor Workspaces (2M initial, bump when hitting 50% utilization)')
-param amwMaxActiveTimeSeries int = 2000000
+@description('Maximum active time series limit for Azure Monitor Workspaces in millions (2M initial, bump when hitting 50% utilization)')
+param amwMaxActiveTimeSeriesMillions int = 2
 
-@description('Maximum events per minute limit for Azure Monitor Workspaces (2M initial, bump when hitting 50% utilization)')
-param amwMaxEventsPerMinute int = 2000000
+@description('Maximum events per minute limit for Azure Monitor Workspaces in millions (2M initial, bump when hitting 50% utilization)')
+param amwMaxEventsPerMinuteMillions int = 2
 
 import { determineZoneRedundancyForRegion } from '../modules/common.bicep'
 import * as res from '../modules/resource.bicep'
@@ -179,8 +179,8 @@ module svcMonitorIngestionLimits '../modules/metrics/amw-ingestion-limits.bicep'
   params: {
     azureMonitorWorkspaceName: svcMonitorName
     location: location
-    maxActiveTimeSeries: amwMaxActiveTimeSeries
-    maxEventsPerMinute: amwMaxEventsPerMinute
+    maxActiveTimeSeriesMillions: amwMaxActiveTimeSeriesMillions
+    maxEventsPerMinuteMillions: amwMaxEventsPerMinuteMillions
   }
   dependsOn: [svcMonitor]
 }
@@ -190,8 +190,8 @@ module hcpMonitorIngestionLimits '../modules/metrics/amw-ingestion-limits.bicep'
   params: {
     azureMonitorWorkspaceName: hcpMonitorName
     location: location
-    maxActiveTimeSeries: amwMaxActiveTimeSeries
-    maxEventsPerMinute: amwMaxEventsPerMinute
+    maxActiveTimeSeriesMillions: amwMaxActiveTimeSeriesMillions
+    maxEventsPerMinuteMillions: amwMaxEventsPerMinuteMillions
   }
   dependsOn: [hcpMonitor]
 }


### PR DESCRIPTION
### What

Cut over bicep templates and the amw-ingestion-limits module to use the new maxActiveTimeSeriesMillions / maxEventsPerMinuteMillions config parameters introduced in a previous PR. The module now receives the value in millions and multiplies by 1,000,000 internally.

This also removes the conditional float64 formatting workaround from region.tmpl.bicepparam, since the millions values are small integers that don't require special type handling.

The sdp-pipelines counterpart is already prepared for this change.

A follow-up PR will remove the old raw-number config params (maxActiveTimeSeries, maxEventsPerMinute) once both sides have landed.

### Why

<!-- Briefly explain why this change is needed -->

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
