### PR TITLE
fix: deduplicate overlapping alert firing durations in JUnit reports

### DIFF
--- a/test/cmd/aro-hcp-tests/gather-observability/junit.go
+++ b/test/cmd/aro-hcp-tests/gather-observability/junit.go
@@ -142,8 +142,33 @@ func workspaceDataToJUnit(logger logr.Logger, ws *workspaceData, timeWindow timi
 	}
 }
 
+type timeInterval struct {
+	start, end time.Time
+}
+
+func mergeIntervals(intervals []timeInterval) []timeInterval {
+	if len(intervals) == 0 {
+		return nil
+	}
+	slices.SortFunc(intervals, func(a, b timeInterval) int {
+		return a.start.Compare(b.start)
+	})
+	merged := []timeInterval{intervals[0]}
+	for _, next := range intervals[1:] {
+		last := &merged[len(merged)-1]
+		if next.start.After(last.end) {
+			merged = append(merged, next)
+			continue
+		}
+		if next.end.After(last.end) {
+			last.end = next.end
+		}
+	}
+	return merged
+}
+
 func computeGroupDuration(firings []alert, tw timing.TimeWindow) float64 {
-	var total float64
+	var intervals []timeInterval
 	for _, f := range firings {
 		if f.Alert.StartsAt == nil {
 			continue
@@ -152,10 +177,13 @@ func computeGroupDuration(firings []alert, tw timing.TimeWindow) float64 {
 		if f.Alert.EndsAt != nil {
 			end = *f.Alert.EndsAt
 		}
-		d := end.Sub(*f.Alert.StartsAt).Seconds()
-		if d > 0 {
-			total += d
+		if end.After(*f.Alert.StartsAt) {
+			intervals = append(intervals, timeInterval{start: *f.Alert.StartsAt, end: end})
 		}
+	}
+	var total float64
+	for _, interval := range mergeIntervals(intervals) {
+		total += interval.end.Sub(interval.start).Seconds()
 	}
 	return total
 }

--- a/test/cmd/aro-hcp-tests/gather-observability/junit_test.go
+++ b/test/cmd/aro-hcp-tests/gather-observability/junit_test.go
@@ -72,6 +72,83 @@ func TestBuildTestName(t *testing.T) {
 	}
 }
 
+func TestMergeIntervals(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		intervals []timeInterval
+		want      []timeInterval
+	}{
+		{
+			name:      "empty",
+			intervals: nil,
+			want:      nil,
+		},
+		{
+			name:      "single",
+			intervals: []timeInterval{{start: *mustTime("2026-04-13T06:00:00Z"), end: *mustTime("2026-04-13T06:10:00Z")}},
+			want:      []timeInterval{{start: *mustTime("2026-04-13T06:00:00Z"), end: *mustTime("2026-04-13T06:10:00Z")}},
+		},
+		{
+			name: "unsorted_overlapping",
+			intervals: []timeInterval{
+				{start: *mustTime("2026-04-13T06:15:00Z"), end: *mustTime("2026-04-13T06:35:00Z")},
+				{start: *mustTime("2026-04-13T06:10:00Z"), end: *mustTime("2026-04-13T06:30:00Z")},
+			},
+			want: []timeInterval{
+				{start: *mustTime("2026-04-13T06:10:00Z"), end: *mustTime("2026-04-13T06:35:00Z")},
+			},
+		},
+		{
+			name: "full_containment",
+			intervals: []timeInterval{
+				{start: *mustTime("2026-04-13T06:00:00Z"), end: *mustTime("2026-04-13T07:00:00Z")},
+				{start: *mustTime("2026-04-13T06:10:00Z"), end: *mustTime("2026-04-13T06:20:00Z")},
+			},
+			want: []timeInterval{
+				{start: *mustTime("2026-04-13T06:00:00Z"), end: *mustTime("2026-04-13T07:00:00Z")},
+			},
+		},
+		{
+			name: "touching_boundaries",
+			intervals: []timeInterval{
+				{start: *mustTime("2026-04-13T06:00:00Z"), end: *mustTime("2026-04-13T06:10:00Z")},
+				{start: *mustTime("2026-04-13T06:10:00Z"), end: *mustTime("2026-04-13T06:20:00Z")},
+			},
+			want: []timeInterval{
+				{start: *mustTime("2026-04-13T06:00:00Z"), end: *mustTime("2026-04-13T06:20:00Z")},
+			},
+		},
+		{
+			name: "disjoint",
+			intervals: []timeInterval{
+				{start: *mustTime("2026-04-13T06:00:00Z"), end: *mustTime("2026-04-13T06:10:00Z")},
+				{start: *mustTime("2026-04-13T07:00:00Z"), end: *mustTime("2026-04-13T07:10:00Z")},
+			},
+			want: []timeInterval{
+				{start: *mustTime("2026-04-13T06:00:00Z"), end: *mustTime("2026-04-13T06:10:00Z")},
+				{start: *mustTime("2026-04-13T07:00:00Z"), end: *mustTime("2026-04-13T07:10:00Z")},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := mergeIntervals(tt.intervals)
+			if len(got) != len(tt.want) {
+				t.Fatalf("mergeIntervals() returned %d intervals, want %d", len(got), len(tt.want))
+			}
+			for i := range got {
+				if !got[i].start.Equal(tt.want[i].start) || !got[i].end.Equal(tt.want[i].end) {
+					t.Errorf("interval[%d] = {%v, %v}, want {%v, %v}",
+						i, got[i].start, got[i].end, tt.want[i].start, tt.want[i].end)
+				}
+			}
+		})
+	}
+}
+
 func TestComputeGroupDuration(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -98,6 +175,66 @@ func TestComputeGroupDuration(t *testing.T) {
 				StartsAt: mustTime("2026-04-13T07:00:00Z"),
 			}}},
 			want: 3600,
+		},
+		{
+			name: "overlapping_firings",
+			firings: []alert{
+				{Alert: alertData{
+					StartsAt: mustTime("2026-04-13T06:10:00Z"),
+					EndsAt:   mustTime("2026-04-13T06:30:00Z"),
+				}},
+				{Alert: alertData{
+					StartsAt: mustTime("2026-04-13T06:15:00Z"),
+					EndsAt:   mustTime("2026-04-13T06:35:00Z"),
+				}},
+			},
+			want: 1500, // merged 06:10–06:35 = 25min, not 20+20=40min
+		},
+		{
+			name: "concurrent_firings",
+			firings: []alert{
+				{Alert: alertData{
+					StartsAt: mustTime("2026-04-13T06:00:00Z"),
+					EndsAt:   mustTime("2026-04-13T06:20:00Z"),
+				}},
+				{Alert: alertData{
+					StartsAt: mustTime("2026-04-13T06:00:00Z"),
+					EndsAt:   mustTime("2026-04-13T06:22:00Z"),
+				}},
+				{Alert: alertData{
+					StartsAt: mustTime("2026-04-13T06:01:00Z"),
+					EndsAt:   mustTime("2026-04-13T06:21:00Z"),
+				}},
+			},
+			want: 1320, // merged 06:00–06:22 = 22min, not 20+22+20=62min
+		},
+		{
+			name: "touching_firings",
+			firings: []alert{
+				{Alert: alertData{
+					StartsAt: mustTime("2026-04-13T06:00:00Z"),
+					EndsAt:   mustTime("2026-04-13T06:10:00Z"),
+				}},
+				{Alert: alertData{
+					StartsAt: mustTime("2026-04-13T06:10:00Z"),
+					EndsAt:   mustTime("2026-04-13T06:20:00Z"),
+				}},
+			},
+			want: 1200, // merged 06:00–06:20 = 20min (touching boundary merges)
+		},
+		{
+			name: "non_overlapping_firings",
+			firings: []alert{
+				{Alert: alertData{
+					StartsAt: mustTime("2026-04-13T06:00:00Z"),
+					EndsAt:   mustTime("2026-04-13T06:10:00Z"),
+				}},
+				{Alert: alertData{
+					StartsAt: mustTime("2026-04-13T07:00:00Z"),
+					EndsAt:   mustTime("2026-04-13T07:10:00Z"),
+				}},
+			},
+			want: 1200, // 10min + 10min = 20min (no overlap)
 		},
 		{
 			name:    "empty_firings",


### PR DESCRIPTION
### What

When multiple firings of the same alert rule overlap in time, computeGroupDuration was summing each firing's duration independently, inflating the reported duration. 

Collect firing intervals and merge overlapping ranges before summing, so each second of alert-active time is counted exactly once.

### Why

<!-- Briefly explain why this change is needed -->

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
