### PR TITLE
fix(cleanup-sweeper): stop skipping orphaned managed RGs

### DIFF
--- a/tooling/cleanup-sweeper/cmd/workflow/resourcegroup/discovery.go
+++ b/tooling/cleanup-sweeper/cmd/workflow/resourcegroup/discovery.go
@@ -98,9 +98,14 @@ func discoverPolicyCandidates(
 	}
 
 	excludedResourceGroups := sets.New(opts.Policy.ExcludedResourceGroups...)
-
+	knownResourceGroups := make(sets.Set[string], len(resourceGroups))
 	for _, rg := range resourceGroups {
-		include, reason := opts.Policy.Discovery.SelectsResourceGroup(rg, excludedResourceGroups, opts.ReferenceTime)
+		if rg.Name != nil {
+			knownResourceGroups.Insert(strings.ToLower(*rg.Name))
+		}
+	}
+	for _, rg := range resourceGroups {
+		include, reason := opts.Policy.Discovery.SelectsResourceGroup(rg, excludedResourceGroups, knownResourceGroups, opts.ReferenceTime)
 		if !include {
 			continue
 		}

--- a/tooling/cleanup-sweeper/pkg/policy/discovery.go
+++ b/tooling/cleanup-sweeper/pkg/policy/discovery.go
@@ -16,6 +16,7 @@ package policy
 
 import (
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -170,6 +171,9 @@ func (c RGDiscoveryConditions) MatchesResourceGroup(rg *armresources.ResourceGro
 			return false
 		}
 		parsed, err := azcorearm.ParseResourceID(*rg.ManagedBy)
+		if err != nil {
+			slog.Warn("failed to parse managedBy resource ID, treating as alive", "managedBy", *rg.ManagedBy, "error", err)
+		}
 		alive := err != nil || knownResourceGroups.Has(strings.ToLower(parsed.ResourceGroupName))
 		if alive != *c.ManagedByAlive {
 			return false

--- a/tooling/cleanup-sweeper/pkg/policy/discovery.go
+++ b/tooling/cleanup-sweeper/pkg/policy/discovery.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 )
 
@@ -91,9 +92,12 @@ func newRGSelectionRuleReason(ruleIndex int, rule RGDiscoveryRule, ruleResult st
 }
 
 // SelectsResourceGroup evaluates discovery rules for a resource group.
+// knownResourceGroups is the set of all RG names in the subscription
+// used by the managedByAlive condition to detect orphaned managed RGs.
 func (p *RGDiscoveryPolicy) SelectsResourceGroup(
 	rg *armresources.ResourceGroup,
 	excludedResourceGroups sets.Set[string],
+	knownResourceGroups sets.Set[string],
 	now time.Time,
 ) (bool, RGSelectionReason) {
 	if p == nil {
@@ -118,7 +122,7 @@ func (p *RGDiscoveryPolicy) SelectsResourceGroup(
 		if !rule.Match.MatchesResourceGroup(rgName) {
 			continue
 		}
-		if !rule.Conditions.MatchesResourceGroup(rg) {
+		if !rule.Conditions.MatchesResourceGroup(rg, knownResourceGroups) {
 			continue
 		}
 
@@ -156,14 +160,18 @@ func (m RGDiscoveryMatch) MatchesResourceGroup(resourceGroupName string) bool {
 }
 
 // MatchesResourceGroup evaluates additional condition predicates.
-func (c RGDiscoveryConditions) MatchesResourceGroup(rg *armresources.ResourceGroup) bool {
+func (c RGDiscoveryConditions) MatchesResourceGroup(rg *armresources.ResourceGroup, knownResourceGroups sets.Set[string]) bool {
 	if rg == nil {
 		return false
 	}
 
-	if c.ManagedBySet != nil {
-		managedBySet := rg.ManagedBy != nil
-		if managedBySet != *c.ManagedBySet {
+	if c.ManagedByAlive != nil {
+		if rg.ManagedBy == nil {
+			return false
+		}
+		parsed, err := azcorearm.ParseResourceID(*rg.ManagedBy)
+		alive := err != nil || knownResourceGroups.Has(strings.ToLower(parsed.ResourceGroupName))
+		if alive != *c.ManagedByAlive {
 			return false
 		}
 	}

--- a/tooling/cleanup-sweeper/pkg/policy/discovery_test.go
+++ b/tooling/cleanup-sweeper/pkg/policy/discovery_test.go
@@ -28,6 +28,7 @@ func TestSelectsResourceGroup_IntendedLegacyPolicyBehavior(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, time.March, 16, 15, 0, 0, 0, time.UTC)
+
 	pol := &RGDiscoveryPolicy{
 		Rules: []RGDiscoveryRule{
 			{
@@ -35,7 +36,7 @@ func TestSelectsResourceGroup_IntendedLegacyPolicyBehavior(t *testing.T) {
 				Action: RGDiscoveryActionSkip,
 				Match:  RGDiscoveryMatch{Any: true},
 				Conditions: RGDiscoveryConditions{
-					ManagedBySet: boolPtr(true),
+					ManagedByAlive: boolPtr(true),
 				},
 			},
 			{
@@ -77,18 +78,27 @@ func TestSelectsResourceGroup_IntendedLegacyPolicyBehavior(t *testing.T) {
 		name           string
 		rg             *armresources.ResourceGroup
 		excluded       sets.Set[string]
+		knownRGs       sets.Set[string]
 		expectSelected bool
 	}{
 		{
-			name: "managed RG is always skipped",
+			name: "managed RG with alive target is always skipped",
+			rg: newResourceGroupWithManagedBy(
+				"hcp-underlay-pers-usw3rvaz",
+				"/subscriptions/sub/resourceGroups/hcp-underlay-pers-usw3parent/providers/Microsoft.ContainerService/managedClusters/aks1",
+			),
+			knownRGs:       sets.New("hcp-underlay-pers-usw3parent"),
+			expectSelected: false,
+		},
+		{
+			name: "orphaned managed RG falls through to delete rules",
 			rg: newResourceGroup(
 				"hcp-underlay-pers-usw3rvaz",
-				timePtr(now.Add(-20*24*time.Hour)),
-				map[string]string{"persist": "false"},
+				timePtr(now.Add(-72*time.Hour)),
+				nil,
 				true,
 			),
-			excluded:       sets.New[string](),
-			expectSelected: false,
+			expectSelected: true,
 		},
 		{
 			name: "pers persist true older than 15 days is selected",
@@ -172,7 +182,7 @@ func TestSelectsResourceGroup_IntendedLegacyPolicyBehavior(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			selected, _ := pol.SelectsResourceGroup(tc.rg, tc.excluded, now)
+			selected, _ := pol.SelectsResourceGroup(tc.rg, tc.excluded, tc.knownRGs, now)
 			if selected != tc.expectSelected {
 				t.Fatalf("expected selected=%t, got selected=%t", tc.expectSelected, selected)
 			}
@@ -214,7 +224,7 @@ func TestSelectsResourceGroup_ReturnsStructuredRuleReason(t *testing.T) {
 	}
 	rg := newResourceGroup("example-rg", timePtr(now.Add(-72*time.Hour)), nil, false)
 
-	selected, reason := pol.SelectsResourceGroup(rg, sets.New[string](), now)
+	selected, reason := pol.SelectsResourceGroup(rg, sets.New[string](), sets.New[string](), now)
 	if !selected {
 		t.Fatalf("expected resource group to be selected")
 	}
@@ -353,7 +363,7 @@ func TestSelectsResourceGroup_PersistTrueDeleteAfter15d(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			selected, _ := pol.SelectsResourceGroup(tc.rg, excluded, now)
+			selected, _ := pol.SelectsResourceGroup(tc.rg, excluded, sets.New[string](), now)
 			if selected != tc.expectSelected {
 				t.Fatalf("expected selected=%t, got selected=%t", tc.expectSelected, selected)
 			}
@@ -378,6 +388,13 @@ func TestSelectionReasonSourceDescription_WithAndWithoutRule(t *testing.T) {
 	withoutRule := RGSelectionReason{Code: "excluded"}
 	if got, want := withoutRule.SourceDescription(), "matched policy (excluded)"; got != want {
 		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func newResourceGroupWithManagedBy(name, managedBy string) *armresources.ResourceGroup {
+	return &armresources.ResourceGroup{
+		Name:      strPtr(name),
+		ManagedBy: strPtr(managedBy),
 	}
 }
 

--- a/tooling/cleanup-sweeper/pkg/policy/policy.go
+++ b/tooling/cleanup-sweeper/pkg/policy/policy.go
@@ -66,9 +66,9 @@ type RGDiscoveryMatch struct {
 
 // RGDiscoveryConditions defines additional rule predicates.
 type RGDiscoveryConditions struct {
-	ManagedBySet *bool             `json:"managedBySet,omitempty" yaml:"managedBySet,omitempty"`
-	TagsEq       map[string]string `json:"tagsEq,omitempty" yaml:"tagsEq,omitempty"`
-	TagsNotEq    map[string]string `json:"tagsNotEq,omitempty" yaml:"tagsNotEq,omitempty"`
+	ManagedByAlive *bool             `json:"managedByAlive,omitempty" yaml:"managedByAlive,omitempty"`
+	TagsEq         map[string]string `json:"tagsEq,omitempty" yaml:"tagsEq,omitempty"`
+	TagsNotEq      map[string]string `json:"tagsNotEq,omitempty" yaml:"tagsNotEq,omitempty"`
 }
 
 type rgDiscoveryRuleWireFormat struct {

--- a/tooling/cleanup-sweeper/resourcegroups.policy.yaml
+++ b/tooling/cleanup-sweeper/resourcegroups.policy.yaml
@@ -1,6 +1,6 @@
 # cleanup-sweeper rg-ordered discovery policy (first matching rule wins).
 # - excludedResourceGroups: never candidates (see list below).
-# - Skip managed RGs (managedBy set).
+# - Skip managed RGs (managedBy alive).
 # - Skip *-shared-resources RGs.
 # - hcp-underlay-pers-*: delete after 15d if persist=true; after 2d if persist is absent or not "true".
 # - hcp-underlay-prow-*: delete after 6h (transitional, remove after rename rollout).
@@ -29,7 +29,7 @@ rgOrdered:
       match:
         any: true
       conditions:
-        managedBySet: true
+        managedByAlive: true
     - name: skip-shared-resources
       action: skip
       match:


### PR DESCRIPTION
## Summary

- Replaces `managedBySet` condition with `managedByAlive` in cleanup-sweeper policy — instead of skipping all managed RGs, only skips those whose `managedBy` target RG still exists in the subscription
- Orphaned managed RGs (parent RG deleted) now fall through to existing time-based delete rules
- Resolves `managedBy` against the already-fetched RG list — zero extra API calls
- Unparsable `managedBy` values are treated as alive (safe side for a deletion tool)
- Uses `azcorearm.ParseResourceID` (already used in `dns_step.go`) instead of a custom helper

Jira: [AROSLSRE-1245](https://redhat.atlassian.net/browse/AROSLSRE-1245)

## Changes

- **`policy.go`**: `ManagedBySet` field → `ManagedByAlive`
- **`discovery.go`**: new `knownResourceGroups` param on `SelectsResourceGroup`/`MatchesResourceGroup`; `managedByAlive` condition resolves target RG via `azcorearm.ParseResourceID`
- **`discovery.go` (cmd)**: builds `knownResourceGroups` set from already-fetched RG list, passes to `SelectsResourceGroup`
- **`resourcegroups.policy.yaml`**: `managedBySet: true` → `managedByAlive: true`
- **`discovery_test.go`**: updated legacy test with `managedByAlive`, added orphan fallthrough case, added `knownRGs` per-case field, added `newResourceGroupWithManagedBy` helper

## Dry-run results

Ran against `ARO Hosted Control Planes (EA Subscription 1)` (`1d3378d3`). 48 deletion candidates discovered (previously orphaned managed RGs were blanket-skipped).

<details>
<summary>Full deletion candidate list (48 RGs)</summary>

```
MA_hcps-j2992384_westus3_managed (rule[6]-expired)
MA_hcps-j4468864_westus3_managed (rule[6]-expired)
MA_hcps-j4984576_westus3_managed (rule[6]-expired)
MA_hcps-j7045504_westus3_managed (rule[6]-expired)
MA_hcps-j8424832_westus3_managed (rule[6]-expired)
MA_hcps-usw3j480_westus3_managed (rule[6]-expired)
MA_services-j0647808_westus3_managed (rule[6]-expired)
MA_services-j2169088_westus3_managed (rule[6]-expired)
MA_services-j2318464_westus3_managed (rule[6]-expired)
MA_services-j5762816_westus3_managed (rule[6]-expired)
MA_services-j6151424_westus3_managed (rule[6]-expired)
MA_services-j9202176_westus3_managed (rule[6]-expired)
MA_services-usw3j480_westus3_managed (rule[6]-expired)
abc-rg-03 (rule[6]-expired)
abc-ves-rg-03 (rule[6]-expired)
bberg-min-res-2-rg-03 (rule[6]-expired)
bbergen-pers-pers-bbergen-pers-01 (rule[6]-expired)
bbergen-pers-pers-bbergen-pers-02 (rule[6]-expired)
bragazzi-rg-03 (rule[6]-expired)
customer-rg-rjg9d7--managed-2 (rule[6]-expired)
dav-rg-03 (rule[6]-expired)
ea-list-8cxb6j-managed (rule[6]-expired)
haowang-e2e (rule[6]-expired)
haowang-fail (rule[6]-expired)
haowang-test-02 (rule[6]-expired)
hcp-underlay-prow-j4940544-mgmt-1 (rule[3]-expired)
imani-rg-03 (rule[6]-expired)
jdgray-rg-03 (rule[6]-expired)
kshimpi-rg-03 (rule[6]-expired)
lszaszki-rg-03 (rule[6]-expired)
mvacula-rg-03 (rule[6]-expired)
nshneor-rg-03 (rule[6]-expired)
oadler-rg-03 (rule[6]-expired)
pr-check-e2e-tests-resource-group-fgb5z (rule[6]-expired)
pr-check-e2e-tests-resource-group-lk82w (rule[6]-expired)
pr-check-e2e-tests-resource-group-scpm4 (rule[6]-expired)
pr-check-e2e-tests-resource-group-wjvsp (rule[6]-expired)
pr-check-e2e-tests-resource-group-xtcfp (rule[6]-expired)
rg-cluster-nsg-subnet-reuse-2x99np--managed-1 (rule[6]-expired)
rg-cp-ystream-upgrade-4-21-hdxpph-cp-ystream-n65dqd--managed (rule[6]-expired)
rg-cp-ystream-upgrade-4-22-2fjwr2-cp-ystream-ssxppw--managed (rule[6]-expired)
rg-zstream-upgrade-4-19-mfc4jv-zstream-nv5skz--managed (rule[6]-expired)
rg-zstream-upgrade-4-20-55jx7v-zstream-lfvl6x--managed (rule[6]-expired)
rg-zstream-upgrade-4-21-tgljdm-zstream-m7whzm--managed (rule[6]-expired)
rg-zstream-upgrade-4-22-hjnmfd-zstream-th4x6j--managed (rule[6]-expired)
sjante-us-mrg (rule[6]-expired)
ves-rg-03(rule[6]-expired)
yog404-pdb-test-managed-rg (rule[6]-expired)
```

</details>

## Test plan

- [x] `go test ./...` in `tooling/cleanup-sweeper/` passes
- [x] Dry-run against dev subscription confirms orphaned managed RGs are no longer skipped
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)