### PR TITLE
fix: create/tag Swift VNet via a managed-identity container (ARO-28045)

### DIFF
--- a/dev-infrastructure/configurations/swift-vnet-permissions.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/swift-vnet-permissions.tmpl.bicepparam
@@ -1,0 +1,4 @@
+using '../templates/swift-vnet-permissions.bicep'
+
+param deploymentMsiId = '__deploymentMsiId__'
+param enableSwift = {{ .mgmt.aks.enableSwiftV2Vnet }}

--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -194,6 +194,56 @@ resourceGroups:
     issuer:
       value: OneCertV2-PublicCA
   # Build the MC
+  # The swift-vnet-permissions step runs unconditionally so the EV2 step graph is
+  # stable, but the Swift VNet RBAC grant inside it is gated at the Bicep layer via
+  # the enableSwift bicepparam (mgmt.aks.enableSwiftV2Vnet). A pipeline-level Go
+  # template guard would not work here: EV2 manifest generation renders pipeline
+  # config values as placeholders, so the guard would always evaluate truthy.
+  - name: swift-vnet-permissions
+    action: ARM
+    template: templates/swift-vnet-permissions.bicep
+    parameters: configurations/swift-vnet-permissions.tmpl.bicepparam
+    deploymentLevel: ResourceGroup
+    variables:
+    - name: deploymentMsiId
+      input:
+        resourceGroup: global
+        step: output
+        name: globalMSIId
+    dependsOn:
+    - resourceGroup: management
+      step: subscription-output
+  # Create/tag the Swift VNet. The tag stampcreatorserviceinfo=true must be written by the
+  # Swift-registered globalMSI, so this step launches a container group assigned globalMSI and
+  # runs the create/tag AS globalMSI from inside it (scripts/swift-vnet.sh). Create, wait, log
+  # and cleanup all happen in this single Shell step, so there is no cross-step async race. The
+  # script is a no-op when ENABLE_SWIFT is false, keeping the EV2 step graph stable.
+  - name: swift-vnet
+    action: Shell
+    command: ./swift-vnet.sh
+    workingDir: ./scripts
+    variables:
+    - name: ENABLE_SWIFT
+      configRef: mgmt.aks.enableSwiftV2Vnet
+    - name: VNET_NAME
+      value: aks-net
+    - name: VNET_ADDRESS_PREFIX
+      configRef: mgmt.aks.vnetAddressPrefix
+    - name: RESOURCE_GROUP
+      configRef: mgmt.rg
+    - name: SUBSCRIPTION_ID
+      input:
+        resourceGroup: management
+        step: subscription-output
+        name: subscriptionId
+    - name: DEPLOYMENT_MSI_ID
+      input:
+        resourceGroup: global
+        step: output
+        name: globalMSIId
+    dependsOn:
+    - resourceGroup: management
+      step: swift-vnet-permissions
   - name: cluster
     action: ARM
     template: templates/mgmt-cluster.bicep
@@ -247,6 +297,8 @@ resourceGroups:
       step: oncert-private-kv-issuer
     - resourceGroup: management
       step: oncert-public-kv-issuer
+    - resourceGroup: management
+      step: swift-vnet
     automatedRetry:
       errorContainsAny:
       - "DeploymentScriptACIProvisioningTimeout"

--- a/dev-infrastructure/mgmt-solo-pipeline.yaml
+++ b/dev-infrastructure/mgmt-solo-pipeline.yaml
@@ -36,6 +36,12 @@ resourceGroups:
   resourceGroup: '{{ .mgmt.rg }}'
   subscription: '{{ .mgmt.subscription.key }}'
   steps:
+  - name: subscription-output
+    action: ARM
+    template: templates/subscription-lookup.bicep
+    parameters: configurations/subscription-lookup.tmpl.bicepparam
+    deploymentLevel: ResourceGroup
+    outputOnly: true
   - name: infra
     action: ARM
     template: templates/mgmt-infra.bicep
@@ -46,6 +52,54 @@ resourceGroups:
       # we don't need to grant KV permissions to CS as there is no CS in the MC solo deployment
       value: "-"
   # Build the MC
+  # The swift-vnet-permissions and swift-vnet steps run unconditionally so the step graph is
+  # static (EV2 does not support Go-template {{ if }} guards - they render at generation time
+  # and would always evaluate truthy). Swift is gated instead at the Bicep layer (enableSwift
+  # param) and at the script layer (ENABLE_SWIFT), which both resolve to the real per-env value.
+  - name: swift-vnet-permissions
+    action: ARM
+    template: templates/swift-vnet-permissions.bicep
+    parameters: configurations/swift-vnet-permissions.tmpl.bicepparam
+    deploymentLevel: ResourceGroup
+    variables:
+    - name: deploymentMsiId
+      input:
+        resourceGroup: global
+        step: output
+        name: globalMSIId
+    dependsOn:
+    - resourceGroup: management
+      step: subscription-output
+  # Create/tag the Swift VNet via a container group assigned globalMSI (scripts/swift-vnet.sh).
+  # Create, wait, log and cleanup happen in this single Shell step, so there is no cross-step
+  # async race; the VNet write itself is performed by globalMSI from inside the container. The
+  # script is a no-op when ENABLE_SWIFT is false, keeping the step graph stable.
+  - name: swift-vnet
+    action: Shell
+    command: ./swift-vnet.sh
+    workingDir: ./scripts
+    variables:
+    - name: ENABLE_SWIFT
+      configRef: mgmt.aks.enableSwiftV2Vnet
+    - name: VNET_NAME
+      value: aks-net
+    - name: VNET_ADDRESS_PREFIX
+      configRef: mgmt.aks.vnetAddressPrefix
+    - name: RESOURCE_GROUP
+      configRef: mgmt.rg
+    - name: SUBSCRIPTION_ID
+      input:
+        resourceGroup: management
+        step: subscription-output
+        name: subscriptionId
+    - name: DEPLOYMENT_MSI_ID
+      input:
+        resourceGroup: global
+        step: output
+        name: globalMSIId
+    dependsOn:
+    - resourceGroup: management
+      step: swift-vnet-permissions
   - name: cluster
     action: ARM
     template: templates/mgmt-cluster.bicep
@@ -62,6 +116,11 @@ resourceGroups:
         resourceGroup: global
         step: output
         name: svcAcrResourceId
+    - name: globalMSIId
+      input:
+        resourceGroup: global
+        step: output
+        name: globalMSIId
     - name: azureMonitoringWorkspaceId
       input:
         resourceGroup: regional
@@ -75,6 +134,8 @@ resourceGroups:
     dependsOn:
     - resourceGroup: management
       step: infra
+    - resourceGroup: management
+      step: swift-vnet
   # Install ACRpull
   - name: acrpull
     aksCluster: '{{ .mgmt.aks.name }}'

--- a/dev-infrastructure/modules/network/vnet-rbac.bicep
+++ b/dev-infrastructure/modules/network/vnet-rbac.bicep
@@ -1,0 +1,36 @@
+@description('The resource ID of the user-assigned managed identity that manages the VNet')
+param deploymentMsiId string
+
+// Network Contributor Role
+// https://www.azadvertizer.net/azrolesadvertizer/4d97b98b-1d4f-4787-a291-c67834d212e7.html
+var networkContributorRoleId = subscriptionResourceId(
+  'Microsoft.Authorization/roleDefinitions/',
+  '4d97b98b-1d4f-4787-a291-c67834d212e7'
+)
+
+// Tag Contributor Role
+// https://www.azadvertizer.net/azrolesadvertizer/4a9ae827-6dc8-4573-8ac7-8239d42aa03f.html
+var tagContributorRoleId = subscriptionResourceId(
+  'Microsoft.Authorization/roleDefinitions/',
+  '4a9ae827-6dc8-4573-8ac7-8239d42aa03f'
+)
+
+resource deploymentMsiNetworkContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  scope: resourceGroup()
+  name: guid(deploymentMsiId, networkContributorRoleId, resourceGroup().id)
+  properties: {
+    roleDefinitionId: networkContributorRoleId
+    principalId: reference(deploymentMsiId, '2023-01-31').principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource deploymentMsiTagContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  scope: resourceGroup()
+  name: guid(deploymentMsiId, tagContributorRoleId, resourceGroup().id)
+  properties: {
+    roleDefinitionId: tagContributorRoleId
+    principalId: reference(deploymentMsiId, '2023-01-31').principalId
+    principalType: 'ServicePrincipal'
+  }
+}

--- a/dev-infrastructure/modules/network/vnet.bicep
+++ b/dev-infrastructure/modules/network/vnet.bicep
@@ -9,28 +9,8 @@ param enableSwift bool
 @description('The address space for the VNET')
 param vnetAddressPrefix string
 
-@description('The resource ID of the user-assigned managed identity that will be used to execute the script')
+@description('The resource ID of the Swift-registered user-assigned managed identity granted RBAC here and assigned to the container group (scripts/swift-vnet.sh) that creates/tags the VNet')
 param deploymentMsiId string
-
-// Network Contributor Role
-// https://www.azadvertizer.net/azrolesadvertizer/4d97b98b-1d4f-4787-a291-c67834d212e7.html
-var networkContributorRoleId = subscriptionResourceId(
-  'Microsoft.Authorization/roleDefinitions/',
-  '4d97b98b-1d4f-4787-a291-c67834d212e7'
-)
-
-// Tag Contributor Role
-// https://www.azadvertizer.net/azrolesadvertizer/4a9ae827-6dc8-4573-8ac7-8239d42aa03f.html
-var tagContributorRoleId = subscriptionResourceId(
-  'Microsoft.Authorization/roleDefinitions/',
-  '4a9ae827-6dc8-4573-8ac7-8239d42aa03f'
-)
-
-// Enabling a VNET for Swift is a matter of placing the stampcreatorserviceinfo=true tag on it.
-// The tagging itself needs to be done by an identity that is registered with the Network/Swift RP.
-// All bicep code deployed via EV2 is executed by an EV2 identity that is not and cannot be registered
-// for Swift usage. Hence we use a deployment script for the tagging where we are in control of the
-// identity used to execute the script and tag the VNET.
 
 //
 //  D E P L O Y   V N E T   W I T H O U T   S W I F T
@@ -53,119 +33,23 @@ resource vnet 'Microsoft.Network/virtualNetworks@2024-05-01' = if (!enableSwift)
 //  D E P L O Y   V N E T   W I T H   S W I F T
 //
 
-// for swift deployments we use a deployment script to create the VNET or just
-// tag it when it already exists. The identity used for this needs to be registered
-// for swift usage with the network RP.
+// For Swift, the VNet is created and tagged (stampcreatorserviceinfo=true) by a managed-identity
+// container group (launched by scripts/swift-vnet.sh) that runs AS the Swift-registered identity,
+// since that write must come from an identity registered for Swift usage with the network RP. The
+// management pipeline provisions this RBAC and runs that container before the cluster is built;
+// this module keeps the same assignments idempotent for direct ARM deployments and declares the
+// VNet as existing because the container (not this module) creates it.
 
-resource deploymentMsiNetworkContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  scope: resourceGroup()
-  name: guid(deploymentMsiId, networkContributorRoleId, resourceGroup().id)
-  properties: {
-    roleDefinitionId: networkContributorRoleId
-    principalId: reference(deploymentMsiId, '2023-01-31').principalId
-    principalType: 'ServicePrincipal'
+module vnetRbac 'vnet-rbac.bicep' = if (enableSwift) {
+  name: 'vnet-rbac'
+  params: {
+    deploymentMsiId: deploymentMsiId
   }
-}
-
-resource deploymentMsiTagContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  scope: resourceGroup()
-  name: guid(deploymentMsiId, tagContributorRoleId, resourceGroup().id)
-  properties: {
-    roleDefinitionId: tagContributorRoleId
-    principalId: reference(deploymentMsiId, '2023-01-31').principalId
-    principalType: 'ServicePrincipal'
-  }
-}
-
-resource vnetWithSwiftDeployment 'Microsoft.Resources/deploymentScripts@2020-10-01' = if (enableSwift) {
-  name: 'vnet-${vnetName}'
-  location: location
-  identity: {
-    type: 'UserAssigned'
-    userAssignedIdentities: {
-      '${deploymentMsiId}': {}
-    }
-  }
-  kind: 'AzureCLI'
-  properties: {
-    azCliVersion: '2.53.1'
-    scriptContent: '''
-      set -euo pipefail
-      az account set --subscription "${VNET_SUBSCRIPTION_ID}"
-
-      # The deployment MSI's Network/Tag Contributor role assignments are created in
-      # this same deployment. Azure RBAC is eventually consistent, so the first write
-      # can fail with AuthorizationFailed ("if access was recently granted, please
-      # refresh your credentials") before the assignment propagates to the data plane.
-      # Retry the write to absorb that lag during RBAC propagation.
-      MAX_WAIT=120
-      POLL_INTERVAL=5
-
-      retry() {
-        local start=${SECONDS}
-        until "$@"; do
-          if [ $((SECONDS - start)) -ge "${MAX_WAIT}" ]; then
-            echo "✗ '$*' still failing after $((SECONDS - start))s" >&2
-            return 1
-          fi
-          echo "Command failed (likely RBAC propagation); retrying in ${POLL_INTERVAL}s..." >&2
-          sleep "${POLL_INTERVAL}"
-        done
-      }
-
-      if az network vnet show \
-        --resource-group "${VNET_RG}" \
-        --name "${VNET_NAME}" \
-        --output none 2>/dev/null; then
-        echo "VNet exists. Updating tags..."
-        retry az resource tag \
-          --tags stampcreatorserviceinfo=true \
-          --resource-group "${VNET_RG}" \
-          --name "${VNET_NAME}" \
-          --resource-type Microsoft.Network/virtualnetworks \
-          --api-version 2024-05-01
-      else
-        echo "VNet does not exist or not yet authorized. Creating..."
-        retry az network vnet create \
-          --resource-group "${VNET_RG}" \
-          --name "${VNET_NAME}" \
-          --address-prefixes "${VNET_ADDRESS_PREFIX}" \
-          --tags stampcreatorserviceinfo=true
-      fi
-    '''
-    timeout: 'PT10M'
-    cleanupPreference: 'OnSuccess'
-    retentionInterval: 'P1D'
-    environmentVariables: [
-      {
-        name: 'VNET_NAME'
-        value: vnetName
-      }
-      {
-        name: 'VNET_RG'
-        value: resourceGroup().name
-      }
-      {
-        name: 'VNET_SUBSCRIPTION_ID'
-        value: subscription().subscriptionId
-      }
-      {
-        name: 'VNET_ADDRESS_PREFIX'
-        value: vnetAddressPrefix
-      }
-    ]
-  }
-  dependsOn: [
-    deploymentMsiNetworkContributorRoleAssignment
-    deploymentMsiTagContributorRoleAssignment
-  ]
 }
 
 resource provisionedSwiftVnet 'Microsoft.Network/virtualNetworks@2024-05-01' existing = if (enableSwift) {
+  // The container group creates this VNet after RBAC is ready; this module only declares it existing.
   name: vnetName
-  dependsOn: [
-    vnetWithSwiftDeployment
-  ]
 }
 
 output vnetId string = enableSwift ? provisionedSwiftVnet.id : vnet.id

--- a/dev-infrastructure/modules/network/vnet.bicep
+++ b/dev-infrastructure/modules/network/vnet.bicep
@@ -9,9 +9,6 @@ param enableSwift bool
 @description('The address space for the VNET')
 param vnetAddressPrefix string
 
-@description('The resource ID of the Swift-registered user-assigned managed identity granted RBAC here and assigned to the container group (scripts/swift-vnet.sh) that creates/tags the VNet')
-param deploymentMsiId string
-
 //
 //  D E P L O Y   V N E T   W I T H O U T   S W I F T
 //
@@ -36,19 +33,11 @@ resource vnet 'Microsoft.Network/virtualNetworks@2024-05-01' = if (!enableSwift)
 // For Swift, the VNet is created and tagged (stampcreatorserviceinfo=true) by a managed-identity
 // container group (launched by scripts/swift-vnet.sh) that runs AS the Swift-registered identity,
 // since that write must come from an identity registered for Swift usage with the network RP. The
-// management pipeline provisions this RBAC and runs that container before the cluster is built;
-// this module keeps the same assignments idempotent for direct ARM deployments and declares the
-// VNet as existing because the container (not this module) creates it.
-
-module vnetRbac 'vnet-rbac.bicep' = if (enableSwift) {
-  name: 'vnet-rbac'
-  params: {
-    deploymentMsiId: deploymentMsiId
-  }
-}
+// RBAC that identity needs is granted by the dedicated swift-vnet-permissions pipeline step (see
+// templates/swift-vnet-permissions.bicep), which completes before the container runs. This module
+// only declares the VNet as existing because the container (not this module) creates it.
 
 resource provisionedSwiftVnet 'Microsoft.Network/virtualNetworks@2024-05-01' existing = if (enableSwift) {
-  // The container group creates this VNet after RBAC is ready; this module only declares it existing.
   name: vnetName
 }
 

--- a/dev-infrastructure/scripts/swift-vnet.sh
+++ b/dev-infrastructure/scripts/swift-vnet.sh
@@ -1,0 +1,202 @@
+#!/bin/bash
+set -euo pipefail
+
+# Creates and/or tags the Swift management VNet so that it carries
+# stampcreatorserviceinfo=true. That tag only triggers Swift stamp registration when it is
+# written by an identity registered for Swift usage with the network RP (globalMSI).
+#
+# ARM deployment scripts used to provide that identity elevation, but they auto-create a
+# shared-key storage account that Azure Policy now blocks (SFI-ID4.2.1). A plain Shell step
+# cannot be used directly either: templatize ignores shellIdentity, so the write would run as
+# the ambient (non-Swift-registered) identity and the stamp would never register.
+#
+# Instead this step launches a single container group that is assigned globalMSI and performs
+# the create/tag AS globalMSI. Everything (create, wait, log, cleanup) happens in this one
+# Shell step so there is no cross-step ordering/async race: we start the container group
+# asynchronously (az container create --no-wait) and then poll it to completion. The ambient
+# identity only launches the container; the VNet write itself is performed by globalMSI from
+# inside it.
+#
+# Inputs via environment variables:
+#   ENABLE_SWIFT          - Whether Swift VNet creation/tagging should run ("true"/"false")
+#   VNET_NAME             - Name of the Swift VNet to create/tag
+#   VNET_ADDRESS_PREFIX   - Address space used when the VNet must be created
+#   RESOURCE_GROUP        - Resource group that holds the VNet and the container group
+#   SUBSCRIPTION_ID       - Subscription that holds the resource group
+#   DEPLOYMENT_MSI_ID     - Resource ID of the Swift-registered managed identity (globalMSI)
+
+if [ "${ENABLE_SWIFT:-false}" != "true" ]; then
+  echo "Swift VNet is disabled; skipping."
+  exit 0
+fi
+
+CONTAINER_IMAGE="mcr.microsoft.com/azure-cli:2.53.1"
+CONTAINER_GROUP_NAME="swift-vnet-${VNET_NAME}"
+TIMEOUT=600
+POLL_INTERVAL=10
+
+az account set --subscription "${SUBSCRIPTION_ID}"
+
+# Remove any leftover container group from a previous (failed) attempt so the create below is
+# deterministic and the name does not collide.
+az container delete \
+  --resource-group "${RESOURCE_GROUP}" \
+  --name "${CONTAINER_GROUP_NAME}" \
+  --yes >/dev/null 2>&1 || true
+
+# Script executed inside the container, AS globalMSI. Values are baked in here (none are
+# secret) and the whole script is base64-encoded below so container command-line quoting
+# cannot mangle it. The managed identity's Network/Tag Contributor role assignments are
+# created by the preceding swift-vnet-permissions step; Azure RBAC is eventually consistent,
+# so the first write can fail with AuthorizationFailed until the assignment propagates - the
+# retry helper absorbs that lag.
+read -r -d '' CONTAINER_SCRIPT <<EOF || true
+set -euo pipefail
+
+echo "Logging in with the Swift-registered managed identity..."
+az login --identity --username "${DEPLOYMENT_MSI_ID}" --output none
+az account set --subscription "${SUBSCRIPTION_ID}"
+
+MAX_WAIT=180
+POLL_INTERVAL=5
+
+retry() {
+  local start=\${SECONDS}
+  until "\$@"; do
+    if [ \$((SECONDS - start)) -ge "\${MAX_WAIT}" ]; then
+      echo "'\$*' still failing after \$((SECONDS - start))s" >&2
+      return 1
+    fi
+    echo "Command failed (likely RBAC propagation); retrying in \${POLL_INTERVAL}s..." >&2
+    sleep "\${POLL_INTERVAL}"
+  done
+}
+
+# Wait until the managed identity can actually read the resource group before deciding whether
+# the VNet exists. The Network/Tag Contributor assignments are created in a preceding step and
+# Azure RBAC is eventually consistent, so without this gate a transient auth failure on the
+# existence check could misroute a re-run (existing VNet) into the create path.
+retry az group show --name "${RESOURCE_GROUP}" --output none
+
+# Decide whether the VNet already exists, distinguishing a genuine NotFound (create path) from
+# a transient/AuthorizationFailed error (retry the read). The az group show gate above already
+# waits for RBAC to propagate, but we still never want a transient read failure to misroute an
+# existing VNet into the create path - only a real NotFound should reach create.
+vnet_exists=""
+show_start=\${SECONDS}
+while true; do
+  if show_err=\$(az network vnet show --resource-group "${RESOURCE_GROUP}" --name "${VNET_NAME}" --output none 2>&1); then
+    vnet_exists="yes"
+    break
+  fi
+  if printf '%s' "\${show_err}" | grep -qiE "ResourceNotFound|was not found|could not be found"; then
+    vnet_exists="no"
+    break
+  fi
+  if [ \$((SECONDS - show_start)) -ge "\${MAX_WAIT}" ]; then
+    echo "VNet existence check still failing after \$((SECONDS - show_start))s: \${show_err}" >&2
+    exit 1
+  fi
+  echo "VNet show failed (non-NotFound, likely transient/RBAC propagation); retrying in \${POLL_INTERVAL}s..." >&2
+  sleep "\${POLL_INTERVAL}"
+done
+
+if [ "\${vnet_exists}" = "yes" ]; then
+  echo "VNet ${VNET_NAME} exists. Updating Swift tag..."
+  retry az resource tag \
+    --is-incremental \
+    --tags stampcreatorserviceinfo=true \
+    --resource-group "${RESOURCE_GROUP}" \
+    --name "${VNET_NAME}" \
+    --resource-type Microsoft.Network/virtualNetworks \
+    --api-version 2024-05-01
+else
+  echo "VNet ${VNET_NAME} does not exist. Creating..."
+  retry az network vnet create \
+    --resource-group "${RESOURCE_GROUP}" \
+    --name "${VNET_NAME}" \
+    --address-prefixes "${VNET_ADDRESS_PREFIX}" \
+    --tags stampcreatorserviceinfo=true
+fi
+
+echo "Swift VNet ${VNET_NAME} is ready and tagged."
+EOF
+
+CONTAINER_SCRIPT_B64=$(printf '%s' "${CONTAINER_SCRIPT}" | base64 | tr -d '\n')
+
+echo "Launching container group ${CONTAINER_GROUP_NAME} as globalMSI..."
+az container create \
+  --resource-group "${RESOURCE_GROUP}" \
+  --name "${CONTAINER_GROUP_NAME}" \
+  --image "${CONTAINER_IMAGE}" \
+  --os-type Linux \
+  --restart-policy Never \
+  --cpu 1 \
+  --memory 1.5 \
+  --assign-identity "${DEPLOYMENT_MSI_ID}" \
+  --command-line "/bin/bash -c 'echo ${CONTAINER_SCRIPT_B64} | base64 -d | bash'" \
+  --no-wait
+
+container_state() {
+  az container show \
+    --resource-group "${RESOURCE_GROUP}" \
+    --name "${CONTAINER_GROUP_NAME}" \
+    --query "containers[0].instanceView.currentState.state" \
+    --output tsv 2>/dev/null || echo ""
+}
+
+group_provisioning_state() {
+  az container show \
+    --resource-group "${RESOURCE_GROUP}" \
+    --name "${CONTAINER_GROUP_NAME}" \
+    --query "provisioningState" \
+    --output tsv 2>/dev/null || echo ""
+}
+
+start=${SECONDS}
+while true; do
+  state=$(container_state)
+  if [ "${state}" = "Terminated" ]; then
+    break
+  fi
+  # Fail fast if the container group itself fails to provision: the container may never
+  # reach a Terminated state, so without this check we would wait the full TIMEOUT.
+  if [ "$(group_provisioning_state)" = "Failed" ]; then
+    echo "✗ Container group ${CONTAINER_GROUP_NAME} failed to provision" >&2
+    az container show --resource-group "${RESOURCE_GROUP}" --name "${CONTAINER_GROUP_NAME}" \
+      --query "containers[0].instanceView.events" --output json 2>/dev/null || true
+    az container logs --resource-group "${RESOURCE_GROUP}" --name "${CONTAINER_GROUP_NAME}" || true
+    az container delete --resource-group "${RESOURCE_GROUP}" --name "${CONTAINER_GROUP_NAME}" --yes >/dev/null 2>&1 || true
+    exit 1
+  fi
+  if [ $((SECONDS - start)) -ge "${TIMEOUT}" ]; then
+    echo "✗ Timed out after $((SECONDS - start))s waiting for ${CONTAINER_GROUP_NAME} (last state: ${state:-unknown})" >&2
+    az container logs --resource-group "${RESOURCE_GROUP}" --name "${CONTAINER_GROUP_NAME}" || true
+    az container delete --resource-group "${RESOURCE_GROUP}" --name "${CONTAINER_GROUP_NAME}" --yes >/dev/null 2>&1 || true
+    exit 1
+  fi
+  echo "Waiting for ${CONTAINER_GROUP_NAME} to finish (state: ${state:-pending})..."
+  sleep "${POLL_INTERVAL}"
+done
+
+echo "=== ${CONTAINER_GROUP_NAME} logs ==="
+az container logs --resource-group "${RESOURCE_GROUP}" --name "${CONTAINER_GROUP_NAME}" || true
+
+exit_code=$(az container show \
+  --resource-group "${RESOURCE_GROUP}" \
+  --name "${CONTAINER_GROUP_NAME}" \
+  --query "containers[0].instanceView.currentState.exitCode" \
+  --output tsv 2>/dev/null || echo "")
+
+echo "Cleaning up ${CONTAINER_GROUP_NAME}..."
+az container delete \
+  --resource-group "${RESOURCE_GROUP}" \
+  --name "${CONTAINER_GROUP_NAME}" \
+  --yes >/dev/null 2>&1 || true
+
+if [ "${exit_code}" != "0" ]; then
+  echo "✗ ${CONTAINER_GROUP_NAME} exited with code ${exit_code:-unknown}" >&2
+  exit 1
+fi
+
+echo "Swift VNet ${VNET_NAME} created/tagged successfully."

--- a/dev-infrastructure/templates/mgmt-cluster.bicep
+++ b/dev-infrastructure/templates/mgmt-cluster.bicep
@@ -345,7 +345,6 @@ module vnetCreation '../modules/network/vnet.bicep' = {
     vnetName: vnetName
     vnetAddressPrefix: vnetAddressPrefix
     enableSwift: aksEnableSwiftVnet
-    deploymentMsiId: globalMSIId
   }
 }
 

--- a/dev-infrastructure/templates/opstool-cluster.bicep
+++ b/dev-infrastructure/templates/opstool-cluster.bicep
@@ -196,7 +196,6 @@ module vnetCreation '../modules/network/vnet.bicep' = {
     vnetName: vnetName
     vnetAddressPrefix: vnetAddressPrefix
     enableSwift: false
-    deploymentMsiId: opstoolMI.id
   }
 }
 

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -631,7 +631,6 @@ module vnetCreation '../modules/network/vnet.bicep' = {
     vnetName: vnetName
     vnetAddressPrefix: vnetAddressPrefix
     enableSwift: false
-    deploymentMsiId: globalMSIId
   }
 }
 

--- a/dev-infrastructure/templates/swift-vnet-permissions.bicep
+++ b/dev-infrastructure/templates/swift-vnet-permissions.bicep
@@ -1,0 +1,12 @@
+@description('The resource ID of the user-assigned managed identity that manages the Swift VNet')
+param deploymentMsiId string
+
+@description('Whether Swift VNet is enabled. Gates the Swift VNet RBAC role assignments so they are only created when Swift is in use.')
+param enableSwift bool
+
+module swiftVnetRbac '../modules/network/vnet-rbac.bicep' = if (enableSwift) {
+  name: 'swift-vnet-rbac'
+  params: {
+    deploymentMsiId: deploymentMsiId
+  }
+}


### PR DESCRIPTION
<!-- Link to Jira issue -->
[ARO-28045](https://redhat.atlassian.net/browse/ARO-28045) (epic [ARO-28038](https://redhat.atlassian.net/browse/ARO-28038))

Follow-ups: [ARO-28082](https://redhat.atlassian.net/browse/ARO-28082) (make Swift mandatory for mgmt, drop the non-Swift path) · [ARO-28066](https://redhat.atlassian.net/browse/ARO-28066) (collapse back to a plain Shell step once the CI runner can run as `globalMSI`)

### What

Replace the Azure Policy-banned ARM `deploymentScript` that created/tagged the Swift management VNet with a single **Shell** step (`scripts/swift-vnet.sh`) that launches a container group assigned the Swift-registered `globalMSI` and performs the create/tag **as `globalMSI`** from inside it.

- `swift-vnet` (Shell): `az container create` assigning `globalMSI`, poll to termination, dump logs, assert exit 0, delete — all in one step (no cross-step async/ordering race). The container runs `az login --identity --username {globalMSI-resource-id}` then the create-or-tag logic with RBAC-propagation retry. No-op when `ENABLE_SWIFT` is false.
- `swift-vnet-permissions` (ARM, `templates/swift-vnet-permissions.bicep` + `modules/network/vnet-rbac.bicep`): grants `globalMSI` Network + Tag Contributor. Runs unconditionally; the RBAC grant is gated at the Bicep layer (`enableSwift` ← `mgmt.aks.enableSwiftV2Vnet`).
- Applied identically in `mgmt-pipeline.yaml` and `mgmt-solo-pipeline.yaml`; both lint cleanly under the existing `.yamllint.yml` (no ignore entry needed).
- **RBAC consolidation:** the Swift VNet role assignments (Network + Tag Contributor for `globalMSI`) live solely in the `swift-vnet-permissions` step (`modules/network/vnet-rbac.bicep`). The redundant inline `vnetRbac` module in `modules/network/vnet.bicep` — which re-declared the same idempotent assignments from the later `cluster` step — and its now-unused `deploymentMsiId` param were removed (along with the parameter passed from the svc/opstool/mgmt `vnetCreation` callers). Making Swift mandatory for mgmt and dropping the remaining non-Swift toggle is tracked as a follow-up in [ARO-28082](https://redhat.atlassian.net/browse/ARO-28082).

### Why

`deploymentScript` auto-provisions a shared-key storage account, which Azure Policy now blocks (**SFI-ID4.2.1**). The tag `stampcreatorserviceinfo=true` only triggers Swift stamp registration when written by a Swift-registered identity (`globalMSI`); written by any other identity the stamp never registers (→ `SubnetNotDelegated`, 0/N Swift clusters).

A plain Shell step with `shellIdentity: globalMSI` would solve this **in EV2** (int/stg/prod) — that is how `upgrade-aks-cluster` already runs as `globalMSI`. But this step must behave identically across **three executors**: EV2, the dev Prow-based CI, and personal-dev. The CI and personal-dev environments run the pipeline through templatize's **local executor** (`tooling/templatize/pkg/pipeline/shell.go: runShellStep`), which **does not apply `shellIdentity`** — it runs the command under the ambient login — and Swift is enabled in those contexts (`pers` sets `enableSwiftV2Vnet: true`). There the write would run as the ambient (non-registered) identity and the stamp would never register.

Assigning `globalMSI` to a **container** performs the identity elevation **in-band, inside the script**, independent of which executor runs it — so it works uniformly across EV2, CI, and personal dev, and preserves the exact identity elevation the `deploymentScript` provided, with **no shared-key storage**.

### How it works

**Before (banned) vs. after (this PR):**

```mermaid
flowchart LR
    subgraph OLD["OLD — ARM deploymentScripts (banned)"]
        direction TB
        A1["bicep: Microsoft.Resources/deploymentScripts"]
        A2["auto-creates storage account<br/>SHARED KEY&nbsp;&nbsp;❌ SFI-ID4.2.1"]
        A3["auto-creates ACI, runs az as globalMSI"]
        A4["writes stampcreatorserviceinfo=true"]
        A1 --> A2 --> A3 --> A4
    end
    subgraph NEW["NEW — single Shell step (this PR)"]
        direction TB
        B1["Shell step: scripts/swift-vnet.sh<br/>runs as AMBIENT identity"]
        B2["az container create<br/>--assign-identity globalMSI<br/>NO storage, NO shared key ✅"]
        B3["container runs AS globalMSI"]
        B4["writes stampcreatorserviceinfo=true"]
        B1 --> B2 --> B3 --> B4
    end
    OLD -. "replaced by" .-> NEW
```

**Pipeline step graph (gated by `enableSwift` / `ENABLE_SWIFT`):**

```mermaid
flowchart LR
    P["swift-vnet-permissions<br/>(ARM)<br/>grant globalMSI:<br/>Network + Tag Contributor"]
    S["swift-vnet<br/>(Shell) scripts/swift-vnet.sh<br/>create/tag VNet AS globalMSI"]
    C["cluster<br/>(ARM)"]
    P --> S --> C
```

**Runtime identity flow — why the tag registers the Swift stamp:**

```mermaid
sequenceDiagram
    autonumber
    participant Amb as Ambient pipeline identity
    participant ACI as Container (ACI)
    participant MSI as globalMSI (Swift-registered)
    participant VNet as Swift VNet
    participant RP as Network RP

    Amb->>ACI: az container create --assign-identity globalMSI
    Note over ACI,MSI: globalMSI attached to the container
    ACI->>MSI: az login --identity --username {globalMSI-resource-id}
    MSI-->>ACI: token issued FOR globalMSI
    ACI->>ACI: retry az group show (wait for RBAC to propagate)
    ACI->>VNet: az network vnet show?
    alt exists
        ACI->>VNet: az resource tag --is-incremental stampcreatorserviceinfo=true
    else NotFound
        ACI->>VNet: az network vnet create (+ tag)
    else transient / AuthorizationFailed
        ACI->>VNet: retry the show (never misroute to create)
    end
    VNet-->>RP: tag written BY a Swift-registered identity
    RP-->>RP: registers the Swift stamp ✅
```

**Correctness safeguards (hardened across review):**

| Concern | Safeguard |
| --- | --- |
| Cross-step async race | Everything in one Shell step: create → poll → cleanup inline |
| RBAC is eventually consistent | `retry az group show` gate before any write |
| Transient/auth error on existence check | Distinguish real `NotFound` (→ create) from transient (→ retry the show) |
| Tag write clobbering other tags | `az resource tag --is-incremental` (merge, don't replace) |
| Container-group provisioning failure | Poll checks `provisioningState`; fail-fast + dump `events` |
| Leaked container on failure/timeout | Container group deleted on every exit path |
| Non-Swift environments | Gated at Bicep (`if(enableSwift)`) and script (`ENABLE_SWIFT`) layers |


### Testing

No unit/E2E tests apply (infra pipeline + Bicep change). Validated via:

- `bash -n scripts/swift-vnet.sh` and base64 round-trip of the container-embedded script.
- `make validate-config-pipelines` (exit 0).
- YAML step-graph integrity: no dangling deps, `cluster` depends on `swift-vnet`.
- `bicep build` + `bicep format` on `vnet.bicep`, `vnet-rbac.bicep`, `swift-vnet-permissions.bicep`, and the svc/opstool/mgmt cluster templates (clean, no new lint warnings).
- `yamllint -c .yamllint.yml` on `mgmt-pipeline.yaml` and `mgmt-solo-pipeline.yaml` (clean); `shellcheck` on `scripts/swift-vnet.sh` (clean).

### Special notes for your reviewer

Two deliberate constraints drive the shape of this change:

1. **Identity must be elevated in-band (container), not via `shellIdentity`.** `shellIdentity` is honored only by EV2; the templatize local executor used in Prow CI and personal-dev ignores it, and Swift is enabled there. The container is the only mechanism that yields `globalMSI` in all three contexts. The longer-term simplification is tracked in [ARO-28066](https://redhat.atlassian.net/browse/ARO-28066) (federate `globalMSI` for the CI runner, or teach templatize's local executor to honor `shellIdentity`, so the step can collapse back to a plain Shell step).
2. **Gating is script-level (`ENABLE_SWIFT`) + Bicep-level, not pipeline-level.** EV2 does not support Go-template `{{ if }}` guards: manifest generation renders pipeline config values as placeholders, so a guard would always evaluate truthy. Keeping both steps unconditional keeps the EV2 step graph static across environments.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented



