### PR TITLE
fix(grafana): comment out grafana steps to unblock rollouts (ARO-28044)

### DIFF
--- a/dev-infrastructure/global-pipeline-stg.yaml
+++ b/dev-infrastructure/global-pipeline-stg.yaml
@@ -53,20 +53,21 @@ resourceGroups:
     dependsOn:
     - resourceGroup: singleton
       step: infra
-  - name: grafana-monitoring-reader
-    action: ARM
-    template: templates/grafana-monitoring-reader.bicep
-    parameters: configurations/grafana-monitoring-reader.tmpl.bicepparam
-    deploymentLevel: Subscription
-    variables:
-    - name: grafanaPrincipalId
-      input:
-        resourceGroup: singleton
-        step: output
-        name: grafanaPrincipalId
-    dependsOn:
-    - resourceGroup: singleton
-      step: output
+  # TODO(ARO-28044): re-enable after ARO-28040
+  # - name: grafana-monitoring-reader
+  #   action: ARM
+  #   template: templates/grafana-monitoring-reader.bicep
+  #   parameters: configurations/grafana-monitoring-reader.tmpl.bicepparam
+  #   deploymentLevel: Subscription
+  #   variables:
+  #   - name: grafanaPrincipalId
+  #     input:
+  #       resourceGroup: singleton
+  #       step: output
+  #       name: grafanaPrincipalId
+  #   dependsOn:
+  #   - resourceGroup: singleton
+  #     step: output
   - name: global-kv-private-issuer
     action: SetCertificateIssuer
     secretKeyVault:
@@ -135,19 +136,20 @@ resourceGroups:
     dependsOn:
     - resourceGroup: singleton
       step: infra
-  - name: grafana-dashboards
-    action: GrafanaDashboards
-    grafanaName: "{{ .stgGlobalV2.grafanaName }}"
-    observabilityConfig: ./../observability/observability.yaml
-    identityFrom:
-      resourceGroup: singleton
-      step: output
-      name: globalMSIId
-    dependsOn:
-    - resourceGroup: singleton
-      step: housekeeping
-    - resourceGroup: singleton
-      step: output
+  # TODO(ARO-28044): re-enable after ARO-28040
+  # - name: grafana-dashboards
+  #   action: GrafanaDashboards
+  #   grafanaName: "{{ .stgGlobalV2.grafanaName }}"
+  #   observabilityConfig: ./../observability/observability.yaml
+  #   identityFrom:
+  #     resourceGroup: singleton
+  #     step: output
+  #     name: globalMSIId
+  #   dependsOn:
+  #   - resourceGroup: singleton
+  #     step: housekeeping
+  #   - resourceGroup: singleton
+  #     step: output
   # creates DNS delegation for the ARO HCP global SVC zone
   - name: svcChildZone
     action: DelegateChildZone

--- a/dev-infrastructure/global-pipeline.yaml
+++ b/dev-infrastructure/global-pipeline.yaml
@@ -49,20 +49,21 @@ resourceGroups:
     dependsOn:
     - resourceGroup: singleton
       step: infra
-  - name: grafana-monitoring-reader
-    action: ARM
-    template: templates/grafana-monitoring-reader.bicep
-    parameters: configurations/grafana-monitoring-reader.tmpl.bicepparam
-    deploymentLevel: Subscription
-    variables:
-    - name: grafanaPrincipalId
-      input:
-        resourceGroup: singleton
-        step: output
-        name: grafanaPrincipalId
-    dependsOn:
-    - resourceGroup: singleton
-      step: output
+  # TODO(ARO-28044): re-enable after ARO-28040
+  # - name: grafana-monitoring-reader
+  #   action: ARM
+  #   template: templates/grafana-monitoring-reader.bicep
+  #   parameters: configurations/grafana-monitoring-reader.tmpl.bicepparam
+  #   deploymentLevel: Subscription
+  #   variables:
+  #   - name: grafanaPrincipalId
+  #     input:
+  #       resourceGroup: singleton
+  #       step: output
+  #       name: grafanaPrincipalId
+  #   dependsOn:
+  #   - resourceGroup: singleton
+  #     step: output
   - name: global-kv-private-issuer
     action: SetCertificateIssuer
     secretKeyVault:
@@ -131,19 +132,20 @@ resourceGroups:
     dependsOn:
     - resourceGroup: singleton
       step: infra
-  - name: grafana-dashboards
-    action: GrafanaDashboards
-    grafanaName: "{{ .monitoring.grafanaName }}"
-    observabilityConfig: ./../observability/observability.yaml
-    identityFrom:
-      resourceGroup: singleton
-      step: output
-      name: globalMSIId
-    dependsOn:
-    - resourceGroup: singleton
-      step: housekeeping
-    - resourceGroup: singleton
-      step: output
+  # TODO(ARO-28044): re-enable after ARO-28040
+  # - name: grafana-dashboards
+  #   action: GrafanaDashboards
+  #   grafanaName: "{{ .monitoring.grafanaName }}"
+  #   observabilityConfig: ./../observability/observability.yaml
+  #   identityFrom:
+  #     resourceGroup: singleton
+  #     step: output
+  #     name: globalMSIId
+  #   dependsOn:
+  #   - resourceGroup: singleton
+  #     step: housekeeping
+  #   - resourceGroup: singleton
+  #     step: output
   # creates DNS delegation for the ARO HCP global SVC zone
   - name: svcChildZone
     action: DelegateChildZone

--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -69,17 +69,18 @@ resourceGroups:
   resourceGroup: '{{ .mgmt.rg }}'
   subscription: '{{ .mgmt.subscription.key }}'
   steps:
-  - name: grafana-monitoring-reader
-    action: ARM
-    template: templates/grafana-monitoring-reader.bicep
-    parameters: configurations/grafana-monitoring-reader.tmpl.bicepparam
-    deploymentLevel: Subscription
-    variables:
-    - name: grafanaPrincipalId
-      input:
-        resourceGroup: global
-        step: output
-        name: grafanaPrincipalId
+  # TODO(ARO-28044): re-enable after ARO-28040
+  # - name: grafana-monitoring-reader
+  #   action: ARM
+  #   template: templates/grafana-monitoring-reader.bicep
+  #   parameters: configurations/grafana-monitoring-reader.tmpl.bicepparam
+  #   deploymentLevel: Subscription
+  #   variables:
+  #   - name: grafanaPrincipalId
+  #     input:
+  #       resourceGroup: global
+  #       step: output
+  #       name: grafanaPrincipalId
   - name: subscription-output
     action: ARM
     template: templates/subscription-lookup.bicep

--- a/dev-infrastructure/modules/metrics/monitor.bicep
+++ b/dev-infrastructure/modules/metrics/monitor.bicep
@@ -10,6 +10,7 @@ param purpose string
 import * as res from '../resource.bicep'
 
 var grafanaRef = res.grafanaRefFromId(grafanaResourceId)
+var hasGrafanaResourceId = !empty(grafanaResourceId)
 
 resource monitor 'microsoft.monitor/accounts@2021-06-03-preview' = {
   name: monitorName
@@ -22,16 +23,16 @@ resource monitor 'microsoft.monitor/accounts@2021-06-03-preview' = {
 // Assign the Monitoring Data Reader role to the Azure Managed Grafana system-assigned managed identity at the workspace scope
 var dataReader = 'b0d8363b-8ddd-447d-831f-62ca05bff136'
 
-resource grafana 'Microsoft.Dashboard/grafana@2023-09-01' existing = {
+resource grafana 'Microsoft.Dashboard/grafana@2023-09-01' existing = if (hasGrafanaResourceId) {
   name: grafanaRef.name
   scope: resourceGroup(grafanaRef.resourceGroup.subscriptionId, grafanaRef.resourceGroup.name)
 }
 
-resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(monitor.id, grafana.id, dataReader)
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (hasGrafanaResourceId) {
+  name: guid(monitor.id, grafana!.id, dataReader)
   scope: monitor
   properties: {
-    principalId: grafana.identity.principalId
+    principalId: grafana!.identity.principalId
     principalType: 'ServicePrincipal'
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', dataReader)
   }

--- a/dev-infrastructure/region-pipeline.yaml
+++ b/dev-infrastructure/region-pipeline.yaml
@@ -51,23 +51,23 @@ resourceGroups:
         resourceGroup: global
         step: output
         name: globalMSIId
-  # TODO(ARO-28044): re-enable after ARO-28040
-  # - name: add-grafana-datasource
-  #   action: GrafanaDatasources
-  #   omitFromServiceGroupCompletion: true
-  #   automatedRetry:
-  #     errorContainsAny:
-  #     - "UpdateConflict"
-  #     maximumRetryCount: 3
-  #     durationBetweenRetries: 1m
-  #   grafanaName: "{{ .monitoring.grafanaName }}"
-  #   identityFrom:
-  #     resourceGroup: global
-  #     step: output
-  #     name: globalMSIId
-  #   dependsOn:
-  #   - resourceGroup: regional
-  #     step: output
+        # TODO(ARO-28044): re-enable after ARO-28040
+        # - name: add-grafana-datasource
+        #   action: GrafanaDatasources
+        #   omitFromServiceGroupCompletion: true
+        #   automatedRetry:
+        #     errorContainsAny:
+        #     - "UpdateConflict"
+        #     maximumRetryCount: 3
+        #     durationBetweenRetries: 1m
+        #   grafanaName: "{{ .monitoring.grafanaName }}"
+        #   identityFrom:
+        #     resourceGroup: global
+        #     step: output
+        #     name: globalMSIId
+        #   dependsOn:
+        #   - resourceGroup: regional
+        #     step: output
 - name: kusto
   resourceGroup: '{{ .kusto.rg }}'
   subscription: '{{ .global.subscription.key }}'

--- a/dev-infrastructure/region-pipeline.yaml
+++ b/dev-infrastructure/region-pipeline.yaml
@@ -51,22 +51,23 @@ resourceGroups:
         resourceGroup: global
         step: output
         name: globalMSIId
-  - name: add-grafana-datasource
-    action: GrafanaDatasources
-    omitFromServiceGroupCompletion: true
-    automatedRetry:
-      errorContainsAny:
-      - "UpdateConflict"
-      maximumRetryCount: 3
-      durationBetweenRetries: 1m
-    grafanaName: "{{ .monitoring.grafanaName }}"
-    identityFrom:
-      resourceGroup: global
-      step: output
-      name: globalMSIId
-    dependsOn:
-    - resourceGroup: regional
-      step: output
+  # TODO(ARO-28044): re-enable after ARO-28040
+  # - name: add-grafana-datasource
+  #   action: GrafanaDatasources
+  #   omitFromServiceGroupCompletion: true
+  #   automatedRetry:
+  #     errorContainsAny:
+  #     - "UpdateConflict"
+  #     maximumRetryCount: 3
+  #     durationBetweenRetries: 1m
+  #   grafanaName: "{{ .monitoring.grafanaName }}"
+  #   identityFrom:
+  #     resourceGroup: global
+  #     step: output
+  #     name: globalMSIId
+  #   dependsOn:
+  #   - resourceGroup: regional
+  #     step: output
 - name: kusto
   resourceGroup: '{{ .kusto.rg }}'
   subscription: '{{ .global.subscription.key }}'

--- a/dev-infrastructure/region-pipeline.yaml
+++ b/dev-infrastructure/region-pipeline.yaml
@@ -51,23 +51,6 @@ resourceGroups:
         resourceGroup: global
         step: output
         name: globalMSIId
-        # TODO(ARO-28044): re-enable after ARO-28040
-        # - name: add-grafana-datasource
-        #   action: GrafanaDatasources
-        #   omitFromServiceGroupCompletion: true
-        #   automatedRetry:
-        #     errorContainsAny:
-        #     - "UpdateConflict"
-        #     maximumRetryCount: 3
-        #     durationBetweenRetries: 1m
-        #   grafanaName: "{{ .monitoring.grafanaName }}"
-        #   identityFrom:
-        #     resourceGroup: global
-        #     step: output
-        #     name: globalMSIId
-        #   dependsOn:
-        #   - resourceGroup: regional
-        #     step: output
 - name: kusto
   resourceGroup: '{{ .kusto.rg }}'
   subscription: '{{ .global.subscription.key }}'

--- a/dev-infrastructure/svc-pipeline.yaml
+++ b/dev-infrastructure/svc-pipeline.yaml
@@ -84,17 +84,18 @@ resourceGroups:
   resourceGroup: '{{ .svc.rg }}'
   subscription: '{{ .svc.subscription.key }}'
   steps:
-  - name: grafana-monitoring-reader
-    action: ARM
-    template: templates/grafana-monitoring-reader.bicep
-    parameters: configurations/grafana-monitoring-reader.tmpl.bicepparam
-    deploymentLevel: Subscription
-    variables:
-    - name: grafanaPrincipalId
-      input:
-        resourceGroup: global
-        step: output
-        name: grafanaPrincipalId
+  # TODO(ARO-28044): re-enable after ARO-28040
+  # - name: grafana-monitoring-reader
+  #   action: ARM
+  #   template: templates/grafana-monitoring-reader.bicep
+  #   parameters: configurations/grafana-monitoring-reader.tmpl.bicepparam
+  #   deploymentLevel: Subscription
+  #   variables:
+  #   - name: grafanaPrincipalId
+  #     input:
+  #       resourceGroup: global
+  #       step: output
+  #       name: grafanaPrincipalId
   # Create SVC KV
   - name: infra
     action: ARM

--- a/dev-infrastructure/templates/global-infra.bicep
+++ b/dev-infrastructure/templates/global-infra.bicep
@@ -322,28 +322,30 @@ resource svcParentZoneRoleAssignment 'Microsoft.Authorization/roleAssignments@20
 // we might want to have another source of truth for the integrations in the future, e.g.
 // some sort of inventory of the regions of ARO HCP
 
-module grafanaWorkspaceIdLookup '../modules/grafana/integration-lookup.bicep' = {
-  name: 'grafana-workspace-lookup'
-  params: {
-    location: location
-    grafanaName: grafanaName
-    deploymentScriptIdentityId: globalMSI.id
-  }
-}
+// TODO(ARO-28044): re-enable after ARO-28040
+// module grafanaWorkspaceIdLookup '../modules/grafana/integration-lookup.bicep' = {
+//   name: 'grafana-workspace-lookup'
+//   params: {
+//     location: location
+//     grafanaName: grafanaName
+//     deploymentScriptIdentityId: globalMSI.id
+//   }
+// }
 
-module grafana '../modules/grafana/instance.bicep' = {
-  name: 'grafana'
-  params: {
-    location: location
-    grafanaName: grafanaName
-    grafanaMajorVersion: grafanaMajorVersion
-    grafanaManagerPrincipalId: globalMSI.properties.principalId
-    grafanaRoles: grafanaRoles
-    zoneRedundancy: determineZoneRedundancy(locationAvailabilityZoneList, grafanaZoneRedundantMode)
-    azureMonitorWorkspaceIds: grafanaWorkspaceIdLookup.outputs.azureMonitorWorkspaceIds
-    crossTenantSecurityGroup: crossTenantSecurityGroup
-  }
-}
+// TODO(ARO-28044): re-enable after ARO-28040
+// module grafana '../modules/grafana/instance.bicep' = {
+//   name: 'grafana'
+//   params: {
+//     location: location
+//     grafanaName: grafanaName
+//     grafanaMajorVersion: grafanaMajorVersion
+//     grafanaManagerPrincipalId: globalMSI.properties.principalId
+//     grafanaRoles: grafanaRoles
+//     zoneRedundancy: determineZoneRedundancy(locationAvailabilityZoneList, grafanaZoneRedundantMode)
+//     azureMonitorWorkspaceIds: grafanaWorkspaceIdLookup.outputs.azureMonitorWorkspaceIds
+//     crossTenantSecurityGroup: crossTenantSecurityGroup
+//   }
+// }
 
 //
 //   N E T W O R K    S E C U R I T Y    P E R I M E T E R
@@ -397,13 +399,14 @@ module azureFrontDoor '../modules/oidc/global/main.bicep' = if (azureFrontDoorMa
   }
 }
 
-module grafanaAfdPermissions '../modules/grafana/observability-permissions.bicep' = if (azureFrontDoorManage) {
-  name: 'grafana-afd-permissions'
-  params: {
-    grafanaPrincipalId: grafana.outputs.grafanaPrincipalId
-    frontDoorProfileId: azureFrontDoor.outputs.frontDoorProfileId
-  }
-}
+// TODO(ARO-28044): re-enable after ARO-28040
+// module grafanaAfdPermissions '../modules/grafana/observability-permissions.bicep' = if (azureFrontDoorManage) {
+//   name: 'grafana-afd-permissions'
+//   params: {
+//     grafanaPrincipalId: grafana.outputs.grafanaPrincipalId
+//     frontDoorProfileId: azureFrontDoor.outputs.frontDoorProfileId
+//   }
+// }
 
 output globalKeyVaultUrl string = globalKV.outputs.kvUrl
 

--- a/dev-infrastructure/templates/output-global.bicep
+++ b/dev-infrastructure/templates/output-global.bicep
@@ -61,12 +61,11 @@ output svcParentZoneResourceId string = svcParentZone.id
 //   G R A F A N A
 //
 
-resource grafana 'Microsoft.Dashboard/grafana@2023-09-01' existing = {
-  name: grafanaName
-}
-
-output grafanaResourceId string = grafana.id
-output grafanaPrincipalId string = grafana.identity.principalId
+// TODO(ARO-28044): re-enable after ARO-28040.
+// Keep the outputs present for pipeline compatibility while Grafana reconciliation is paused.
+var grafanaOutputPaused = !empty(grafanaName)
+output grafanaResourceId string = grafanaOutputPaused ? '' : ''
+output grafanaPrincipalId string = grafanaOutputPaused ? '' : ''
 
 //
 //   A Z U R E   F R O N T   D O O R

--- a/dev-infrastructure/templates/output-global.bicep
+++ b/dev-infrastructure/templates/output-global.bicep
@@ -62,10 +62,9 @@ output svcParentZoneResourceId string = svcParentZone.id
 //
 
 // TODO(ARO-28044): re-enable after ARO-28040.
-// Keep the outputs present for pipeline compatibility while Grafana reconciliation is paused.
-var grafanaOutputPaused = !empty(grafanaName)
-output grafanaResourceId string = grafanaOutputPaused ? '' : ''
-output grafanaPrincipalId string = grafanaOutputPaused ? '' : ''
+// Grafana reconciliation is paused; emit empty outputs so dependent steps stay no-ops.
+output grafanaResourceId string = ''
+output grafanaPrincipalId string = ''
 
 //
 //   A Z U R E   F R O N T   D O O R


### PR DESCRIPTION
<!-- Link to Jira issue -->
[ARO-28044](https://redhat.atlassian.net/browse/ARO-28044)

### What

Comments out the Grafana rollout resources and steps that reconcile the shared Grafana instance and integrations:

- `grafanaWorkspaceIdLookup`, `grafana`, and Grafana AFD permissions in `global-infra.bicep`
- `grafana-monitoring-reader` and `grafana-dashboards` in the global pipelines
- `add-grafana-datasource` in the regional pipeline

### Why

Prod rollouts are currently blocked by the AME deployment-script storage policy used by the Grafana workspace lookup. This is a non-destructive mitigation: the existing Grafana instance and existing integrations remain in place, while EV2 stops reconciling Grafana until the proper reconcile fix lands in #5837 / [ARO-28040](https://redhat.atlassian.net/browse/ARO-28040).

### Testing

- `cd config && make materialize`
- `make validate-config-pipelines`
- `/home/rael/bin/bicep build dev-infrastructure/templates/global-infra.bicep` (passes with expected unused Grafana parameter/import warnings while Grafana is commented out)

No unit, integration, or E2E tests were added; this only disables EV2 Grafana rollout steps/resources.

### Special notes for your reviewer

@jboll this is intended as a temporary [ARO-28044](https://redhat.atlassian.net/browse/ARO-28044) mitigation only. Each commented block has a `TODO([ARO-28044](https://redhat.atlassian.net/browse/ARO-28044)): re-enable after [ARO-28040](https://redhat.atlassian.net/browse/ARO-28040)` marker.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
