### PR TITLE
fix: tolerating tenths place in credential refresher alerts and fixing dashboard

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedMsftPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedMsftPrometheusAlertingRules.bicep
@@ -765,7 +765,7 @@ resource msftMsiCredentialRefresher 'Microsoft.AlertsManagement/prometheusRuleGr
           summary: 'Customer cluster credential expiring in less than 30 days'
           title: 'Customer cluster credential expiring in less than 30 days'
         }
-        expression: 'sum by (cluster) (increase(credential_refresher_days_until_msi_credential_expiration_bucket{le="30"}[30m])) - sum by (cluster) (increase(credential_refresher_days_until_msi_credential_expiration_bucket{le="0"}[30m])) > 0'
+        expression: 'sum by (cluster) (increase(credential_refresher_days_until_msi_credential_expiration_bucket{le=~"^30([.]0)?$"}[30m])) - sum by (cluster) (increase(credential_refresher_days_until_msi_credential_expiration_bucket{le=~"^0([.]0)?$"}[30m])) > 0'
         for: 'PT5M'
         severity: severityCeiling > 0 ? max(2, severityCeiling) : 2
       }
@@ -792,7 +792,7 @@ resource msftMsiCredentialRefresher 'Microsoft.AlertsManagement/prometheusRuleGr
           summary: 'Customer cluster credential expired'
           title: 'Customer cluster credential expired'
         }
-        expression: 'sum by (cluster) (increase(credential_refresher_days_until_msi_credential_expiration_bucket{le="0"}[30m])) - sum by (cluster) (increase(credential_refresher_days_until_msi_credential_expiration_bucket{le="-90"}[30m])) > 0'
+        expression: 'sum by (cluster) (increase(credential_refresher_days_until_msi_credential_expiration_bucket{le=~"^0([.]0)?$"}[30m])) - sum by (cluster) (increase(credential_refresher_days_until_msi_credential_expiration_bucket{le=~"^-90([.]0)?$"}[30m])) > 0'
         for: 'PT5M'
         severity: severityCeiling > 0 ? max(2, severityCeiling) : 2
       }
@@ -819,7 +819,7 @@ resource msftMsiCredentialRefresher 'Microsoft.AlertsManagement/prometheusRuleGr
           summary: 'Customer cluster credential is no longer renewable'
           title: 'Customer cluster credential is no longer renewable'
         }
-        expression: 'sum by (cluster) (increase(credential_refresher_days_until_msi_credential_expiration_bucket{le="-90"}[30m])) > 0'
+        expression: 'sum by (cluster) (increase(credential_refresher_days_until_msi_credential_expiration_bucket{le=~"^-90([.]0)?$"}[30m])) > 0'
         for: 'PT5M'
         severity: severityCeiling > 0 ? max(2, severityCeiling) : 2
       }

--- a/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
@@ -1077,7 +1077,7 @@ resource maestro 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
           summary: 'No maestro-server replicas are Ready'
           title: 'No maestro-server replicas are Ready'
         }
-        expression: 'kube_deployment_status_replicas_available{namespace="maestro", deployment="maestro"} == 0 and kube_deployment_spec_replicas{namespace="maestro", deployment="maestro"} > 0'
+        expression: 'kube_deployment_status_replicas_available{deployment="maestro",namespace="maestro"} == 0 and kube_deployment_spec_replicas{deployment="maestro",namespace="maestro"} > 0'
         for: 'PT5M'
         severity: severityCeiling > 0 ? max(2, severityCeiling) : 2
       }
@@ -1104,7 +1104,7 @@ resource maestro 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
           summary: 'A maestro-server replica is not Ready'
           title: 'A maestro-server replica is not Ready'
         }
-        expression: 'kube_deployment_status_replicas_available{namespace="maestro", deployment="maestro"} > 0 and kube_deployment_status_replicas_available{namespace="maestro", deployment="maestro"} < kube_deployment_spec_replicas{namespace="maestro", deployment="maestro"}'
+        expression: 'kube_deployment_status_replicas_available{deployment="maestro",namespace="maestro"} > 0 and kube_deployment_status_replicas_available{deployment="maestro",namespace="maestro"} < kube_deployment_spec_replicas{deployment="maestro",namespace="maestro"}'
         for: 'PT15M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }

--- a/observability/alerts/msi-credential-refresher-prometheusRule.yaml
+++ b/observability/alerts/msi-credential-refresher-prometheusRule.yaml
@@ -9,7 +9,7 @@ spec:
     interval: 1m
     rules:
     - alert: ClusterCredentialExpiringSoon
-      expr: sum by (cluster) (increase(credential_refresher_days_until_msi_credential_expiration_bucket{le="30"}[30m])) - sum by (cluster) (increase(credential_refresher_days_until_msi_credential_expiration_bucket{le="0"}[30m])) > 0
+      expr: sum by (cluster) (increase(credential_refresher_days_until_msi_credential_expiration_bucket{le=~"^30([.]0)?$"}[30m])) - sum by (cluster) (increase(credential_refresher_days_until_msi_credential_expiration_bucket{le=~"^0([.]0)?$"}[30m])) > 0
       for: 5m
       labels:
         severity: critical
@@ -19,7 +19,7 @@ spec:
         runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/troubleshooting/tsgs/credential-refresher-expiring-cert'
         correlationId: 'ClusterCredentialExpiringSoon/{{ $labels.cluster }}'
     - alert: ClusterCredentialExpired
-      expr: sum by (cluster) (increase(credential_refresher_days_until_msi_credential_expiration_bucket{le="0"}[30m])) - sum by (cluster) (increase(credential_refresher_days_until_msi_credential_expiration_bucket{le="-90"}[30m])) > 0
+      expr: sum by (cluster) (increase(credential_refresher_days_until_msi_credential_expiration_bucket{le=~"^0([.]0)?$"}[30m])) - sum by (cluster) (increase(credential_refresher_days_until_msi_credential_expiration_bucket{le=~"^-90([.]0)?$"}[30m])) > 0
       for: 5m
       labels:
         severity: critical
@@ -29,7 +29,7 @@ spec:
         runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/troubleshooting/tsgs/credential-refresher-expiring-cert'
         correlationId: 'ClusterCredentialExpired/{{ $labels.cluster }}'
     - alert: ClusterCredentialNotRenewable
-      expr: sum by (cluster) (increase(credential_refresher_days_until_msi_credential_expiration_bucket{le="-90"}[30m])) > 0
+      expr: sum by (cluster) (increase(credential_refresher_days_until_msi_credential_expiration_bucket{le=~"^-90([.]0)?$"}[30m])) > 0
       for: 5m
       labels:
         severity: critical

--- a/observability/alerts/msi-credential-refresher-prometheusRule_test.yaml
+++ b/observability/alerts/msi-credential-refresher-prometheusRule_test.yaml
@@ -102,3 +102,60 @@ tests:
   - eval_time: 35m
     alertname: ClusterCredentialExpired
     exp_alerts: []
+- interval: 1m
+  input_series:
+  - series: 'credential_refresher_days_until_msi_credential_expiration_bucket{cluster="test-cluster",le="30.0"}'
+    # Tenths-place form should also be accepted for the 30-day bucket
+    values: '0+1x35'
+  - series: 'credential_refresher_days_until_msi_credential_expiration_bucket{cluster="test-cluster",le="0.0"}'
+    # Tenths-place form should also be accepted for the 0-day bucket
+    values: '0x35'
+  alert_rule_test:
+  - eval_time: 35m
+    alertname: ClusterCredentialExpiringSoon
+    exp_alerts:
+    - exp_labels:
+        severity: critical
+        cluster: test-cluster
+      exp_annotations:
+        description: 'Credential(s) for customer cluster monitored by test-cluster are expiring in less than 30 days.'
+        summary: 'Customer cluster credential expiring in less than 30 days'
+        runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/troubleshooting/tsgs/credential-refresher-expiring-cert'
+        correlationId: 'ClusterCredentialExpiringSoon/test-cluster'
+- interval: 1m
+  input_series:
+  - series: 'credential_refresher_days_until_msi_credential_expiration_bucket{cluster="test-cluster",le="-90.0"}'
+    # Tenths-place form should also be accepted for the non-renewable bucket
+    values: '0+1x35'
+  alert_rule_test:
+  - eval_time: 35m
+    alertname: ClusterCredentialNotRenewable
+    exp_alerts:
+    - exp_labels:
+        severity: critical
+        cluster: test-cluster
+      exp_annotations:
+        description: 'Credential(s) for customer cluster monitored by test-cluster are no longer renewable.'
+        summary: 'Customer cluster credential is no longer renewable'
+        runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/troubleshooting/tsgs/credential-refresher-expiring-cert'
+        correlationId: 'ClusterCredentialNotRenewable/test-cluster'
+- interval: 1m
+  input_series:
+  - series: 'credential_refresher_days_until_msi_credential_expiration_bucket{cluster="test-cluster",le="0.0"}'
+    # Tenths-place form should also be accepted for the expired bucket
+    values: '0+1x35'
+  - series: 'credential_refresher_days_until_msi_credential_expiration_bucket{cluster="test-cluster",le="-90.0"}'
+    # Tenths-place form should also be accepted for the non-renewable bucket
+    values: '0x35'
+  alert_rule_test:
+  - eval_time: 35m
+    alertname: ClusterCredentialExpired
+    exp_alerts:
+    - exp_labels:
+        severity: critical
+        cluster: test-cluster
+      exp_annotations:
+        description: 'Credential(s) for customer cluster monitored by test-cluster expired.'
+        summary: 'Customer cluster credential expired'
+        runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/troubleshooting/tsgs/credential-refresher-expiring-cert'
+        correlationId: 'ClusterCredentialExpired/test-cluster'

--- a/observability/grafana-dashboards/msi-credential-refresher/msi-credential-refresher.json
+++ b/observability/grafana-dashboards/msi-credential-refresher/msi-credential-refresher.json
@@ -93,7 +93,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (le) (rate(credential_refresher_days_until_msi_credential_expiration_bucket[60m])) * 600",
+          "expr": "label_replace(vector(scalar(sum(rate(credential_refresher_days_until_msi_credential_expiration_bucket{le=~\"^-90([.]0)?$\"}[60m])) * 600)), \"le\", \"-90\", \"__name__\", \".*\") or label_replace(vector(scalar((sum(rate(credential_refresher_days_until_msi_credential_expiration_bucket{le=~\"^0([.]0)?$\"}[60m])) - sum(rate(credential_refresher_days_until_msi_credential_expiration_bucket{le=~\"^-90([.]0)?$\"}[60m]))) * 600)), \"le\", \"0\", \"__name__\", \".*\") or label_replace(vector(scalar((sum(rate(credential_refresher_days_until_msi_credential_expiration_bucket{le=~\"^3([.]0)?$\"}[60m])) - sum(rate(credential_refresher_days_until_msi_credential_expiration_bucket{le=~\"^0([.]0)?$\"}[60m]))) * 600)), \"le\", \"3\", \"__name__\", \".*\") or label_replace(vector(scalar((sum(rate(credential_refresher_days_until_msi_credential_expiration_bucket{le=~\"^7([.]0)?$\"}[60m])) - sum(rate(credential_refresher_days_until_msi_credential_expiration_bucket{le=~\"^3([.]0)?$\"}[60m]))) * 600)), \"le\", \"7\", \"__name__\", \".*\") or label_replace(vector(scalar((sum(rate(credential_refresher_days_until_msi_credential_expiration_bucket{le=~\"^14([.]0)?$\"}[60m])) - sum(rate(credential_refresher_days_until_msi_credential_expiration_bucket{le=~\"^7([.]0)?$\"}[60m]))) * 600)), \"le\", \"14\", \"__name__\", \".*\") or label_replace(vector(scalar((sum(rate(credential_refresher_days_until_msi_credential_expiration_bucket{le=~\"^30([.]0)?$\"}[60m])) - sum(rate(credential_refresher_days_until_msi_credential_expiration_bucket{le=~\"^14([.]0)?$\"}[60m]))) * 600)), \"le\", \"30\", \"__name__\", \".*\") or label_replace(vector(scalar((sum(rate(credential_refresher_days_until_msi_credential_expiration_bucket{le=~\"^60([.]0)?$\"}[60m])) - sum(rate(credential_refresher_days_until_msi_credential_expiration_bucket{le=~\"^30([.]0)?$\"}[60m]))) * 600)), \"le\", \"60\", \"__name__\", \".*\") or label_replace(vector(scalar((sum(rate(credential_refresher_days_until_msi_credential_expiration_bucket{le=\"+Inf\"}[60m])) - sum(rate(credential_refresher_days_until_msi_credential_expiration_bucket{le=~\"^60([.]0)?$\"}[60m]))) * 600)), \"le\", \"Infinity\", \"__name__\", \".*\")",
           "format": "table",
           "instant": true,
           "refId": "A"
@@ -135,21 +135,6 @@
                 "desc": false
               }
             ]
-          }
-        },
-        {
-          "id": "calculateField",
-          "options": {
-            "alias": "Count",
-            "mode": "window",
-            "replaceFields": true,
-            "window": {
-              "field": "Count",
-              "size": 1,
-              "sizeMode": "window",
-              "windowAlignment": "trailing",
-              "function": "delta"
-            }
           }
         }
       ],


### PR DESCRIPTION
[ARO-28061](https://redhat.atlassian.net/browse/ARO-28061)
### What

Tolerates tenths place in credential refresher alerts. Also, explicitly calculating the diff between different buckets in the dashboard.

### Why

The buckets used to be whole numbers (-90, 0, 3, etc...), but now they have a tenths place (-90.0, 0.0, 3.0, etc...). This broke the alerts. For the dashboard, I thought the delta calculation was working, but lower buckets were still being included in the columns of higher buckets. I tried for a while to fix this in a way that's better to read and more flexible, but ultimately settled on this. Open to suggestions here.

### Testing

Updated the alerts tests to have both formats and tested the queries/dashboard update manually in the int grafana.

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [x] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [x] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
