### PR TITLE
fix: re-land CPO registryOverride for FSI compliance (AROSLSRE-1363)

### DIFF
--- a/hypershiftoperator/testdata/zz_fixture_TestHelmTemplate_hypershift_performance_metrics.yaml
+++ b/hypershiftoperator/testdata/zz_fixture_TestHelmTemplate_hypershift_performance_metrics.yaml
@@ -754,7 +754,7 @@ spec:
             --enable-conversion-webhook=false \
             --managed-service ARO-HCP \
             --aro-hcp-key-vault-users-client-id __csiSecretStoreClientId__ \
-            --registry-overrides "quay.io/openshift-release-dev/ocp-v4.0-art-dev=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-v4.0-art-dev,quay.io/openshift-release-dev/ocp-v5.0-art-dev=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-v5.0-art-dev,quay.io/openshift-release-dev/ocp-release=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-release,quay.io/openshift-release-dev/ocp-release-nightly=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-release-nightly,registry.redhat.io/redhat=arohcpocpdev.azurecr.io/redhat" \
+            --registry-overrides "quay.io/openshift-release-dev/ocp-v4.0-art-dev=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-v4.0-art-dev,quay.io/openshift-release-dev/ocp-v5.0-art-dev=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-v5.0-art-dev,quay.io/openshift-release-dev/ocp-release=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-release,quay.io/openshift-release-dev/ocp-release-nightly=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-release-nightly,registry.redhat.io/redhat=arohcpocpdev.azurecr.io/redhat,quay.io/redhat-user-workloads/crt-redhat-acm-tenant=arohcpocpdev.azurecr.io/quay-cache/redhat-user-workloads/crt-redhat-acm-tenant" \
             --hypershift-image arohcpsvcdev.azurecr.io/redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator@sha256:1234567890 \
             --platform-monitoring=None \
             --metrics-set=SRE \

--- a/hypershiftoperator/values.yaml
+++ b/hypershiftoperator/values.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to manage Hypershift Operator and dependencies for ARO
 name: aro-hcp-hypershift-operator
 image: "{{ .acr.svc.name }}.{{ .acrDNSSuffix }}/{{ .hypershift.image.repository }}"
 imageDigest: "{{ .hypershift.image.digest }}"
-registryOverrides: "quay.io/openshift-release-dev/ocp-v4.0-art-dev={{ .acr.ocp.name }}.{{ .acrDNSSuffix }}/openshift-release-dev/ocp-v4.0-art-dev,quay.io/openshift-release-dev/ocp-v5.0-art-dev={{ .acr.ocp.name }}.{{ .acrDNSSuffix }}/openshift-release-dev/ocp-v5.0-art-dev,quay.io/openshift-release-dev/ocp-release={{ .acr.ocp.name }}.{{ .acrDNSSuffix }}/openshift-release-dev/ocp-release,quay.io/openshift-release-dev/ocp-release-nightly={{ .acr.ocp.name }}.{{ .acrDNSSuffix }}/openshift-release-dev/ocp-release-nightly,registry.redhat.io/redhat={{ .acr.ocp.name }}.{{ .acrDNSSuffix }}/redhat"
+registryOverrides: "quay.io/openshift-release-dev/ocp-v4.0-art-dev={{ .acr.ocp.name }}.{{ .acrDNSSuffix }}/openshift-release-dev/ocp-v4.0-art-dev,quay.io/openshift-release-dev/ocp-v5.0-art-dev={{ .acr.ocp.name }}.{{ .acrDNSSuffix }}/openshift-release-dev/ocp-v5.0-art-dev,quay.io/openshift-release-dev/ocp-release={{ .acr.ocp.name }}.{{ .acrDNSSuffix }}/openshift-release-dev/ocp-release,quay.io/openshift-release-dev/ocp-release-nightly={{ .acr.ocp.name }}.{{ .acrDNSSuffix }}/openshift-release-dev/ocp-release-nightly,registry.redhat.io/redhat={{ .acr.ocp.name }}.{{ .acrDNSSuffix }}/redhat,quay.io/redhat-user-workloads/crt-redhat-acm-tenant={{ .acr.ocp.name }}.{{ .acrDNSSuffix }}/quay-cache/redhat-user-workloads/crt-redhat-acm-tenant"
 azureKeyVaultClientId: "__csiSecretStoreClientId__"
 additionalArgs: "{{ .hypershift.additionalInstallArg }}"
 operatorEnvVars:

--- a/hypershiftoperator/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_hypershift.yaml
+++ b/hypershiftoperator/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_hypershift.yaml
@@ -720,7 +720,7 @@ spec:
             --enable-conversion-webhook=false \
             --managed-service ARO-HCP \
             --aro-hcp-key-vault-users-client-id __csiSecretStoreClientId__ \
-            --registry-overrides "quay.io/openshift-release-dev/ocp-v4.0-art-dev=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-v4.0-art-dev,quay.io/openshift-release-dev/ocp-v5.0-art-dev=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-v5.0-art-dev,quay.io/openshift-release-dev/ocp-release=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-release,quay.io/openshift-release-dev/ocp-release-nightly=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-release-nightly,registry.redhat.io/redhat=arohcpocpdev.azurecr.io/redhat" \
+            --registry-overrides "quay.io/openshift-release-dev/ocp-v4.0-art-dev=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-v4.0-art-dev,quay.io/openshift-release-dev/ocp-v5.0-art-dev=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-v5.0-art-dev,quay.io/openshift-release-dev/ocp-release=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-release,quay.io/openshift-release-dev/ocp-release-nightly=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-release-nightly,registry.redhat.io/redhat=arohcpocpdev.azurecr.io/redhat,quay.io/redhat-user-workloads/crt-redhat-acm-tenant=arohcpocpdev.azurecr.io/quay-cache/redhat-user-workloads/crt-redhat-acm-tenant" \
             --hypershift-image arohcpsvcdev.azurecr.io/redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator@sha256:1234567890 \
             --platform-monitoring=None \
             --metrics-set=SRE \

--- a/hypershiftoperator/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_hypershift.yaml
+++ b/hypershiftoperator/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_hypershift.yaml
@@ -775,7 +775,7 @@ spec:
             --enable-conversion-webhook=false \
             --managed-service ARO-HCP \
             --aro-hcp-key-vault-users-client-id __csiSecretStoreClientId__ \
-            --registry-overrides "quay.io/openshift-release-dev/ocp-v4.0-art-dev=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-v4.0-art-dev,quay.io/openshift-release-dev/ocp-v5.0-art-dev=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-v5.0-art-dev,quay.io/openshift-release-dev/ocp-release=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-release,quay.io/openshift-release-dev/ocp-release-nightly=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-release-nightly,registry.redhat.io/redhat=arohcpocpdev.azurecr.io/redhat" \
+            --registry-overrides "quay.io/openshift-release-dev/ocp-v4.0-art-dev=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-v4.0-art-dev,quay.io/openshift-release-dev/ocp-v5.0-art-dev=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-v5.0-art-dev,quay.io/openshift-release-dev/ocp-release=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-release,quay.io/openshift-release-dev/ocp-release-nightly=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-release-nightly,registry.redhat.io/redhat=arohcpocpdev.azurecr.io/redhat,quay.io/redhat-user-workloads/crt-redhat-acm-tenant=arohcpocpdev.azurecr.io/quay-cache/redhat-user-workloads/crt-redhat-acm-tenant" \
             --hypershift-image arohcpsvcdev.azurecr.io/redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator@sha256:1234567890 \
             --platform-monitoring=None \
             --metrics-set=SRE \

--- a/hypershiftoperator/zz_fixture_TestNodeRolloutConfig_dev_westus3_mgmt_1_hypershift.yaml
+++ b/hypershiftoperator/zz_fixture_TestNodeRolloutConfig_dev_westus3_mgmt_1_hypershift.yaml
@@ -14,5 +14,6 @@ registryOverrides:
 - quay.io/openshift-release-dev/ocp-release=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-release
 - quay.io/openshift-release-dev/ocp-v4.0-art-dev=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-v4.0-art-dev
 - quay.io/openshift-release-dev/ocp-v5.0-art-dev=arohcpocpdev.azurecr.io/openshift-release-dev/ocp-v5.0-art-dev
+- quay.io/redhat-user-workloads/crt-redhat-acm-tenant=arohcpocpdev.azurecr.io/quay-cache/redhat-user-workloads/crt-redhat-acm-tenant
 - registry.redhat.io/redhat=arohcpocpdev.azurecr.io/redhat
 sharedIngressHAProxyImage: arohcpocpdev.azurecr.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main@sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678


### PR DESCRIPTION
## Why

The Control Plane Operator (CPO) images are pulled from `quay.io/redhat-user-workloads/crt-redhat-acm-tenant/...`, which is not on the FSI image registry allowlist. When the ValidatingAdmissionPolicy (VAP) is switched from Audit to Deny mode, HCP cluster creation hangs because CPO's init containers (e.g. `availability-prober`) are blocked.

This PR re-adds the `--registry-overrides` mapping that remaps the CPO image source to ACR, so the VAP will allow these images. This mapping was originally landed in #5162 but reverted in #5189 due to an incident where it triggered unexpected customer node pool re-rolls (ITN-2026-00126).

## What unblocked re-landing

Two upstream HyperShift fixes have merged that resolve the root cause:

- [openshift/hypershift#8509](https://github.com/openshift/hypershift/pull/8509) — Propagates `--registry-overrides` to CPO init containers (merged Jun 22)
- [openshift/hypershift#8824](https://github.com/openshift/hypershift/pull/8824) — Fixes `registryoverride.Replace` to handle `@sha256:` digest and `:tag` separators (merged Jun 25)

With these fixes, when we provide the registry override mapping, the CPO will correctly rewrite all image references (including init containers) from quay.io to ACR.

## What changed since the original #5162

The Helm values template syntax was updated after the original PR to use `{{ .acrDNSSuffix }}` instead of hardcoded `azurecr.io`. This PR uses the updated template syntax.

## Node pool re-roll impact

⚠️ Adding this `registryOverrides` entry changes the HyperShift operator deployment spec → HO pod rolls → ignition configs re-rendered → NodePool config hash changes → CAPI MachineSet replacements across all customer clusters. This is the same mechanism that caused the Apr 28 incident.

Deployment must be coordinated with SRE. The node-rollout-detection e2e test is tracked in ARO-27491.

## Follow-up

- **AROSLSRE-861**: Remove the hardcoded CPO exception from the VAP CEL expression (depends on this change being deployed and verified in int/stg first)
- Switch VAP from `Audit` to `Deny` mode in production

## Tracking

- Jira: [AROSLSRE-1363](https://issues.redhat.com/browse/AROSLSRE-1363)
- Epic: [ARO-22152](https://issues.redhat.com/browse/ARO-22152) (Ensure All Deployed Images Come from MCR or ACR for MSFT FSI Compliance)