### PR TITLE
fix(stg-global): create V2 Grafana on supported major version via stgGlobalV2.grafanaMajorVersion (AROSLSRE-1362)

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -48,6 +48,10 @@ clouds:
             # New Grafana workspace (live stg is arohcp-stg; this is the V2 one).
             # Globally unique — must differ from the live name to avoid NameNotUnique.
             grafanaName: "arohcp-{{ .ctx.environment }}2"
+            # New workspace must be created on v13: Azure retired v11 for new
+            # creation on 2026-06-15, so only major versions 12/13 are accepted.
+            # The live grandfathered workspace stays on 11 (shared monitoring value).
+            grafanaMajorVersion: "13"
           # E2E
           e2e:
             regionTest:

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -3342,6 +3342,9 @@
         },
         "grafanaName": {
           "type": "string"
+        },
+        "grafanaMajorVersion": {
+          "type": "string"
         }
       },
       "additionalProperties": false,
@@ -3356,7 +3359,8 @@
         "svcParentZoneName",
         "cxParentZoneName",
         "kustoName",
-        "grafanaName"
+        "grafanaName",
+        "grafanaMajorVersion"
       ]
     },
     "releaseApprover": {

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -119,6 +119,7 @@ defaults:
     cxParentZoneName: "empty-sentinel"
     kustoName: "empty-sentinel"
     grafanaName: "empty-sentinel"
+    grafanaMajorVersion: "empty-sentinel"
   # Image Registry Policy
   imageRegistryPolicy:
     extraAllowedRegistries: ""

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -914,6 +914,7 @@ stgGlobalV2:
   frontDoorName: empty-sentinel
   genevaKeyVaultName: empty-sentinel
   globalKeyVaultName: empty-sentinel
+  grafanaMajorVersion: empty-sentinel
   grafanaName: empty-sentinel
   kustoName: empty-sentinel
   oidcStorageAccountName: empty-sentinel

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -914,6 +914,7 @@ stgGlobalV2:
   frontDoorName: empty-sentinel
   genevaKeyVaultName: empty-sentinel
   globalKeyVaultName: empty-sentinel
+  grafanaMajorVersion: empty-sentinel
   grafanaName: empty-sentinel
   kustoName: empty-sentinel
   oidcStorageAccountName: empty-sentinel

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -912,6 +912,7 @@ stgGlobalV2:
   frontDoorName: empty-sentinel
   genevaKeyVaultName: empty-sentinel
   globalKeyVaultName: empty-sentinel
+  grafanaMajorVersion: empty-sentinel
   grafanaName: empty-sentinel
   kustoName: empty-sentinel
   oidcStorageAccountName: empty-sentinel

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -912,6 +912,7 @@ stgGlobalV2:
   frontDoorName: empty-sentinel
   genevaKeyVaultName: empty-sentinel
   globalKeyVaultName: empty-sentinel
+  grafanaMajorVersion: empty-sentinel
   grafanaName: empty-sentinel
   kustoName: empty-sentinel
   oidcStorageAccountName: empty-sentinel

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -912,6 +912,7 @@ stgGlobalV2:
   frontDoorName: empty-sentinel
   genevaKeyVaultName: empty-sentinel
   globalKeyVaultName: empty-sentinel
+  grafanaMajorVersion: empty-sentinel
   grafanaName: empty-sentinel
   kustoName: empty-sentinel
   oidcStorageAccountName: empty-sentinel

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -914,6 +914,7 @@ stgGlobalV2:
   frontDoorName: empty-sentinel
   genevaKeyVaultName: empty-sentinel
   globalKeyVaultName: empty-sentinel
+  grafanaMajorVersion: empty-sentinel
   grafanaName: empty-sentinel
   kustoName: empty-sentinel
   oidcStorageAccountName: empty-sentinel

--- a/dev-infrastructure/configurations/global-infra-stg.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/global-infra-stg.tmpl.bicepparam
@@ -21,7 +21,9 @@ param keyVaultEncryptionKeyName = '{{ .global.keyVault.encryptionKeyName }}'
 // V2 grafana name from stgGlobalV2 (not monitoring.grafanaName) so the parallel
 // STG-global stack does not collide with the live arohcp-stg Grafana workspace.
 param grafanaName = '{{ .stgGlobalV2.grafanaName }}'
-param grafanaMajorVersion = '{{ .monitoring.grafanaMajorVersion }}'
+// V2 grafana major version from stgGlobalV2: the new workspace must be created on
+// v13 (Azure retired v11 for new creation 2026-06-15); the live fleet stays on 11.
+param grafanaMajorVersion = '{{ .stgGlobalV2.grafanaMajorVersion }}'
 param grafanaZoneRedundantMode = '{{ .monitoring.grafanaZoneRedundantMode }}'
 param grafanaRoles = '{{ .monitoring.grafanaRoles }}'
 param crossTenantSecurityGroup = '{{ .monitoring.crossTenantSecurityGroup }}'


### PR DESCRIPTION
## What

Adds a transient, V2-only `stgGlobalV2.grafanaMajorVersion` config value (empty-sentinel default; `13` for stg in the MSFT overlay) and points the parallel **STG-global "V2"** Grafana deployment at it, instead of the shared `monitoring.grafanaMajorVersion`.

- `config/config.schema.json` — new `grafanaMajorVersion` property + `required` entry on the `stgGlobalV2` object.
- `config/config.yaml` — `grafanaMajorVersion: "empty-sentinel"` default (so every cloud/env resolves under `missingkey=error`).
- `config/config.msft.clouds-overlay.yaml` — real value `grafanaMajorVersion: "13"` for stg.
- `dev-infrastructure/configurations/global-infra-stg.tmpl.bicepparam` — rewires `param grafanaMajorVersion` from `{{ .monitoring.grafanaMajorVersion }}` → `{{ .stgGlobalV2.grafanaMajorVersion }}`.
- `config/rendered/**` — regenerated via `make -C config/ materialize`.

This mirrors the existing `stgGlobalV2.grafanaName` pattern (added in #5813) one-for-one.

## Why

Azure Managed Grafana **retired Grafana 11 for new workspace creation on 2026-06-15** — new workspaces on the Standard SKU now only accept major version **12** or **13**. The STG-global V2 migration creates a **brand-new** Grafana workspace in a dedicated subscription, so it hit:

```
GrafanaMajorVersionNotSupported: major version '11' not valid for sku Standard. Valid: 12, 13
```

The shared `monitoring.grafanaMajorVersion` is still `"11"`, which is correct for the **existing, grandfathered** live fleet (Azure auto-upgrades those 11 → 12 in place). We must **not** bump the shared value just to unblock the new V2 workspace — that would force an irreversible, breaking 11 → 12 upgrade on the live fleet.

A V2-only override keeps the two concerns separate:
- **Live fleet** stays on the shared `monitoring.grafanaMajorVersion` (`11`, grandfathered).
- **New V2 workspace** is born on `13` via `stgGlobalV2.grafanaMajorVersion`.

(The broader "keep the shared value on a supported release" hygiene is tracked separately in AROSLSRE-1364.)

## Testing

- **Direct Azure validation** — created a throwaway workspace on the exact SKU the bicep hardcodes (`Standard`) at major version 13; provisioning succeeded:
  ```
  az grafana create -n arohcp-g13-test -g hbhushan-test -l uksouth \
    --grafana-major-version 13 --sku Standard
  # -> provisioningState: Succeeded, grafanaVersion: 13.0.2, sku: Standard
  ```
  Confirms a fresh STG-global V2 workspace can be created on 13. (11 → 13 in-place upgrade is not a documented path, but fresh **creation** on 13 is — which is what V2 does.)
- **`make -C config/ materialize`** passes; schema is valid JSON.
- **Render check** — `stgGlobalV2.grafanaMajorVersion` resolves to `empty-sentinel` in all dev renders (dev gets no stg overlay); the real `13` is supplied by the MSFT overlay and surfaces in the downstream (sdp-pipelines) stg render, exactly like `stgGlobalV2.grafanaName`.
- All `stgGlobalV2.*` values remain consumed only by the stg/uksouth-only V2 pipelines; empty-sentinel is never deployed.

## Notes / follow-up

- **Transient:** the entire `stgGlobalV2` block (including this field) is removed at migration decommission.
- **Sequencing with grafanactl (#5837):** this rewires the bicepparam path. When #5837 moves Grafana creation to the `grafanactl reconcile` shell step, the new `GRAFANA_MAJOR_VERSION` configRef must be re-pointed from `monitoring.grafanaMajorVersion` → `stgGlobalV2.grafanaMajorVersion` as well. The config field added here stays valid across that change; only the wiring relocates.

Refs: [AROSLSRE-1362](https://redhat.atlassian.net/browse/AROSLSRE-1362). Follows #5813 (`stgGlobalV2.grafanaName`).
