### PR TITLE
fix(grafana): pin STG-global V2 Grafana major version to 13 (AROSLSRE-1362)

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -48,6 +48,11 @@ clouds:
             # New Grafana workspace (live stg is arohcp-stg; this is the V2 one).
             # Globally unique — must differ from the live name to avoid NameNotUnique.
             grafanaName: "arohcp-{{ .ctx.environment }}2"
+            # V2-only Grafana major version. Azure Managed Grafana retired v11 for
+            # new Standard-SKU workspace creation on 2026-06-15 (valid: 12, 13), so
+            # the brand-new V2 workspace must be born on 13. Kept separate from the
+            # shared monitoring config so the live fleet stays grandfathered.
+            grafanaMajorVersion: "13"
           # E2E
           e2e:
             regionTest:

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -3342,6 +3342,9 @@
         },
         "grafanaName": {
           "type": "string"
+        },
+        "grafanaMajorVersion": {
+          "type": "string"
         }
       },
       "additionalProperties": false,
@@ -3356,7 +3359,8 @@
         "svcParentZoneName",
         "cxParentZoneName",
         "kustoName",
-        "grafanaName"
+        "grafanaName",
+        "grafanaMajorVersion"
       ]
     },
     "releaseApprover": {

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -119,6 +119,7 @@ defaults:
     cxParentZoneName: "empty-sentinel"
     kustoName: "empty-sentinel"
     grafanaName: "empty-sentinel"
+    grafanaMajorVersion: "empty-sentinel"
   # Image Registry Policy
   imageRegistryPolicy:
     extraAllowedRegistries: ""

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -914,6 +914,7 @@ stgGlobalV2:
   frontDoorName: empty-sentinel
   genevaKeyVaultName: empty-sentinel
   globalKeyVaultName: empty-sentinel
+  grafanaMajorVersion: empty-sentinel
   grafanaName: empty-sentinel
   kustoName: empty-sentinel
   oidcStorageAccountName: empty-sentinel

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -914,6 +914,7 @@ stgGlobalV2:
   frontDoorName: empty-sentinel
   genevaKeyVaultName: empty-sentinel
   globalKeyVaultName: empty-sentinel
+  grafanaMajorVersion: empty-sentinel
   grafanaName: empty-sentinel
   kustoName: empty-sentinel
   oidcStorageAccountName: empty-sentinel

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -912,6 +912,7 @@ stgGlobalV2:
   frontDoorName: empty-sentinel
   genevaKeyVaultName: empty-sentinel
   globalKeyVaultName: empty-sentinel
+  grafanaMajorVersion: empty-sentinel
   grafanaName: empty-sentinel
   kustoName: empty-sentinel
   oidcStorageAccountName: empty-sentinel

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -912,6 +912,7 @@ stgGlobalV2:
   frontDoorName: empty-sentinel
   genevaKeyVaultName: empty-sentinel
   globalKeyVaultName: empty-sentinel
+  grafanaMajorVersion: empty-sentinel
   grafanaName: empty-sentinel
   kustoName: empty-sentinel
   oidcStorageAccountName: empty-sentinel

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -912,6 +912,7 @@ stgGlobalV2:
   frontDoorName: empty-sentinel
   genevaKeyVaultName: empty-sentinel
   globalKeyVaultName: empty-sentinel
+  grafanaMajorVersion: empty-sentinel
   grafanaName: empty-sentinel
   kustoName: empty-sentinel
   oidcStorageAccountName: empty-sentinel

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -914,6 +914,7 @@ stgGlobalV2:
   frontDoorName: empty-sentinel
   genevaKeyVaultName: empty-sentinel
   globalKeyVaultName: empty-sentinel
+  grafanaMajorVersion: empty-sentinel
   grafanaName: empty-sentinel
   kustoName: empty-sentinel
   oidcStorageAccountName: empty-sentinel

--- a/dev-infrastructure/configurations/global-infra-stg.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/global-infra-stg.tmpl.bicepparam
@@ -18,10 +18,13 @@ param keyVaultTagKey = '{{ .global.keyVault.tagKey }}'
 param keyVaultTagValue = '{{ .global.keyVault.tagValue }}'
 param keyVaultEncryptionKeyName = '{{ .global.keyVault.encryptionKeyName }}'
 
-// V2 grafana name from stgGlobalV2 (not monitoring.grafanaName) so the parallel
-// STG-global stack does not collide with the live arohcp-stg Grafana workspace.
+// V2 grafana name and major version from stgGlobalV2 (not monitoring.*) so the
+// parallel STG-global stack does not collide with the live arohcp-stg Grafana
+// workspace, and so the brand-new V2 workspace is created on a Grafana major
+// version Azure still accepts for new Standard-SKU workspaces (v11 retired
+// 2026-06-15; valid: 12, 13). The live fleet stays grandfathered on monitoring.*.
 param grafanaName = '{{ .stgGlobalV2.grafanaName }}'
-param grafanaMajorVersion = '{{ .monitoring.grafanaMajorVersion }}'
+param grafanaMajorVersion = '{{ .stgGlobalV2.grafanaMajorVersion }}'
 param grafanaZoneRedundantMode = '{{ .monitoring.grafanaZoneRedundantMode }}'
 param grafanaRoles = '{{ .monitoring.grafanaRoles }}'
 param crossTenantSecurityGroup = '{{ .monitoring.crossTenantSecurityGroup }}'


### PR DESCRIPTION
<!-- https://issues.redhat.com/browse/AROSLSRE-1362 -->

### What

Pin the STG-global **V2** Grafana workspace to major version **13**, decoupled from the shared `monitoring.grafanaMajorVersion`.

- New transient `stgGlobalV2.grafanaMajorVersion` config field: `empty-sentinel` default in `config.yaml`, `13` in the stg overlay, added to the schema (properties + required).
- `global-infra-stg.tmpl.bicepparam` now sources `grafanaMajorVersion` from `stgGlobalV2.grafanaMajorVersion` instead of `monitoring.grafanaMajorVersion`.
- Re-materialized rendered configs.

### Why

Azure Managed Grafana retired Grafana **11** for new Standard-SKU workspace creation on **2026-06-15** (valid: 12, 13). The STG-global V2 workspace is created fresh in the dedicated subscription, so it must be born on a supported version, otherwise:

```
GrafanaMajorVersionNotSupported: major version '11' not valid for sku Standard. Valid: 12, 13
```

Keeping this as a V2-only override (mirroring the existing `stgGlobalV2.grafanaName` pattern) leaves the live fleet grandfathered on `monitoring.*` and untouched.

### Testing

- `cd config && make materialize` — rendered configs updated, no unexpected drift.
- `make validate` and `make validate-config-pipelines` — pass.
- `make yamlfmt` — no changes.
- Rendered stg config resolves `stgGlobalV2.grafanaMajorVersion: "13"`; dev clouds resolve the `empty-sentinel` default (never consumed; V2 pipelines are stg/uksouth-only).

### Special notes for your reviewer

- Scope is intentionally **V2-only**. The canonical `global-infra.tmpl.bicepparam` (int/stg/prod) still sources `grafanaMajorVersion` from `monitoring.grafanaMajorVersion`, which is currently undefined for public envs — a separate pre-existing gap to address when Grafana creation is re-enabled (it is presently commented out in `global-infra.bicep`).
- `empty-sentinel` follows the established `stgGlobalV2.*` convention; the value is only consumed for stg/uksouth.

### PR Checklist

- [x] Documented in commit/PR description
- [x] Rendered configs regenerated and committed
- [x] Schema updated for the new config field
