### PR TITLE
fix(observability): move bicep alert check to alerts target

### DIFF
--- a/observability/Makefile
+++ b/observability/Makefile
@@ -8,7 +8,7 @@ sync-upstream:
 	https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/$${PROMETHEUS_OPERATOR_REF}/manifests/kubernetesControlPlane-prometheusRule.yaml
 .PHONY: sync-upstream
 
-alerts:
+alerts: verify-no-prom-alerts-in-bicep
 	EXTRA_FLAGS=$(GENERATOR_FLAGS) make -C ../tooling/prometheus-rules alerts
 .PHONY: alerts
 
@@ -16,7 +16,7 @@ recording-rules:
 	EXTRA_FLAGS=$(GENERATOR_FLAGS) make -C ../tooling/prometheus-rules recording-rules
 .PHONY: recording-rules
 
-verify: verify-no-prom-alerts-in-bicep
+verify:
 	go run ../tooling/grafanactl/main.go verify dashboards --config-file observability.yaml
 .PHONY: verify
 


### PR DESCRIPTION
## Summary

The `verify-no-prom-alerts-in-bicep` check (from #5774) guards against hand-written
prometheus alert resources in bicep files under `dev-infrastructure/`. However, it was
wired as a dependency of the `verify` make target, which is run by the `observability-verify`
CI job — triggered only by `^observability/` changes.

This means if someone adds a `Microsoft.AlertsManagement/prometheusRuleGroups` resource
directly in a bicep file under `dev-infrastructure/`, the check never runs.

This PR moves the check from the `verify` target to the `alerts` target instead. The
`alerts` target is run by the `observability-prometheus` CI job, which (after
openshift/release#81214) triggers on `dev-infrastructure/` changes too — making the
check actually effective.

Depends on: openshift/release#81214

🤖 Generated with [Claude Code](https://claude.com/claude-code)