### PR TITLE
fix: increase MaestroServerNoReadyReplicas alert threshold to 10m

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
@@ -1071,14 +1071,14 @@ resource maestro 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
         }
         annotations: {
           correlationId: 'MaestroServerNoReadyReplicas/{{ $labels.cluster }}'
-          description: 'No maestro-server replicas have been Ready for 5 minutes. Readiness is gated on Postgres connectivity, so maestro is likely unable to reach its database; Clusters Service will get 503 and HCP cluster provisioning will stall.'
-          info: 'No maestro-server replicas have been Ready for 5 minutes. Readiness is gated on Postgres connectivity, so maestro is likely unable to reach its database; Clusters Service will get 503 and HCP cluster provisioning will stall.'
+          description: 'No maestro-server replicas have been Ready for 10 minutes. Readiness is gated on Postgres connectivity, so maestro is likely unable to reach its database; Clusters Service will get 503 and HCP cluster provisioning will stall.'
+          info: 'No maestro-server replicas have been Ready for 10 minutes. Readiness is gated on Postgres connectivity, so maestro is likely unable to reach its database; Clusters Service will get 503 and HCP cluster provisioning will stall.'
           runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/maestro/index.html'
           summary: 'No maestro-server replicas are Ready'
           title: 'No maestro-server replicas are Ready'
         }
         expression: 'kube_deployment_status_replicas_available{deployment="maestro",namespace="maestro"} == 0 and kube_deployment_spec_replicas{deployment="maestro",namespace="maestro"} > 0'
-        for: 'PT5M'
+        for: 'PT10M'
         severity: severityCeiling > 0 ? max(2, severityCeiling) : 2
       }
       {

--- a/maestro/alerts/maestro-prometheusRule.yaml
+++ b/maestro/alerts/maestro-prometheusRule.yaml
@@ -89,11 +89,11 @@ spec:
         kube_deployment_status_replicas_available{namespace="maestro", deployment="maestro"} == 0
         and
         kube_deployment_spec_replicas{namespace="maestro", deployment="maestro"} > 0
-      for: 5m
+      for: 10m
       labels:
         severity: critical
       annotations:
-        description: 'No maestro-server replicas have been Ready for 5 minutes. Readiness is gated on Postgres connectivity, so maestro is likely unable to reach its database; Clusters Service will get 503 and HCP cluster provisioning will stall.'
+        description: 'No maestro-server replicas have been Ready for 10 minutes. Readiness is gated on Postgres connectivity, so maestro is likely unable to reach its database; Clusters Service will get 503 and HCP cluster provisioning will stall.'
         runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/maestro/index.html'
         summary: 'No maestro-server replicas are Ready'
     - alert: MaestroServerReplicaNotReady

--- a/maestro/alerts/maestro-prometheusRule_test.yaml
+++ b/maestro/alerts/maestro-prometheusRule_test.yaml
@@ -110,15 +110,15 @@ tests:
   - eval_time: 15m
     alertname: MaestroSpecControllerReconcileErrors
     exp_alerts: []
-# Test: MaestroServerNoReadyReplicas fires when 0 replicas available for 5m
+# Test: MaestroServerNoReadyReplicas fires when 0 replicas available for 10m
 - interval: 1m
   input_series:
   - series: 'kube_deployment_status_replicas_available{namespace="maestro", deployment="maestro"}'
-    values: "0x10" # no Ready replicas
+    values: "0x15" # no Ready replicas
   - series: 'kube_deployment_spec_replicas{namespace="maestro", deployment="maestro"}'
-    values: "2x10" # 2 desired
+    values: "2x15" # 2 desired
   alert_rule_test:
-  - eval_time: 6m
+  - eval_time: 11m
     alertname: MaestroServerNoReadyReplicas
     exp_alerts:
     - exp_labels:
@@ -126,18 +126,18 @@ tests:
         namespace: maestro
         deployment: maestro
       exp_annotations:
-        description: 'No maestro-server replicas have been Ready for 5 minutes. Readiness is gated on Postgres connectivity, so maestro is likely unable to reach its database; Clusters Service will get 503 and HCP cluster provisioning will stall.'
+        description: 'No maestro-server replicas have been Ready for 10 minutes. Readiness is gated on Postgres connectivity, so maestro is likely unable to reach its database; Clusters Service will get 503 and HCP cluster provisioning will stall.'
         runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/maestro/index.html'
         summary: 'No maestro-server replicas are Ready'
 # Test: MaestroServerNoReadyReplicas does not fire when all replicas available
 - interval: 1m
   input_series:
   - series: 'kube_deployment_status_replicas_available{namespace="maestro", deployment="maestro"}'
-    values: "2x10"
+    values: "2x15"
   - series: 'kube_deployment_spec_replicas{namespace="maestro", deployment="maestro"}'
-    values: "2x10"
+    values: "2x15"
   alert_rule_test:
-  - eval_time: 6m
+  - eval_time: 11m
     alertname: MaestroServerNoReadyReplicas
     exp_alerts: []
 # Test: MaestroServerReplicaNotReady fires when available < desired (but > 0) for 15m


### PR DESCRIPTION
### What

On fresh cluster deployments, maestro cold-start routinely exceeds 5 minutes due to CSI volume mount delays (SecretProviderClass race with Deployment creation), init containers (wait-for-db, migration), and readiness probe initial delay. This causes the alert to fire and self-resolve during most provisioning cycle.

### Why

<!-- Briefly explain why this change is needed -->

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
