### PR TITLE
feat: reintroduce MR 5790 and do not error on DB precondition failed in operation node pool create

### DIFF
--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -46,6 +46,7 @@ import (
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/managementclustercontrollers"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/metricscontrollers"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/mismatchcontrollers"
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/nodepoolcreationcontrollers"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/nodepooldeletion"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/operationcontrollers"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/statuscontrollers"
@@ -438,6 +439,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		b.options.ClustersServiceClient,
 		activeOperationInformer,
 	)
+
 	operationClusterCreateController := operationcontrollers.NewOperationClusterCreateController(
 		b.clock,
 		b.options.ResourcesDBClient,
@@ -468,6 +470,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		b.options.ClustersServiceClient,
 		http.DefaultClient,
 		activeOperationInformer,
+		backendInformers,
 	)
 	operationNodePoolUpdateController := operationcontrollers.NewOperationNodePoolUpdateController(
 		b.clock,
@@ -698,6 +701,14 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		unionKubeApplierInformers,
 	)
 
+	nodePoolClusterServiceCreateController := nodepoolcreationcontrollers.NewNodePoolClusterServiceCreateController(
+		b.options.ResourcesDBClient,
+		b.options.ClustersServiceClient,
+		activeOperationLister,
+		backendInformers,
+		unionKubeApplierInformers,
+	)
+
 	nodePoolDeletionClusterServiceDeleteDispatchController := nodepooldeletion.NewNodePoolClusterServiceDeleteDispatchController(
 		utilsclock.RealClock{},
 		b.options.ResourcesDBClient,
@@ -809,6 +820,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 				go doNothingController.Run(ctx, 20)
 				go dispatchRequestCredentialController.Run(ctx, 20)
 				go dispatchRevokeCredentialsController.Run(ctx, 20)
+				go nodePoolClusterServiceCreateController.Run(ctx, 20)
 				go operationClusterCreateController.Run(ctx, 20)
 				go operationClusterUpdateController.Run(ctx, 20)
 				go operationClusterDeleteController.Run(ctx, 20)

--- a/backend/pkg/controllers/nodepoolcreationcontrollers/node_pool_cluster_service_create_controller.go
+++ b/backend/pkg/controllers/nodepoolcreationcontrollers/node_pool_cluster_service_create_controller.go
@@ -1,0 +1,186 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodepoolcreationcontrollers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/internal/api"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/database"
+	unionkubeapplierinformers "github.com/Azure/ARO-HCP/internal/database/unioninformers/kubeapplier"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+const NodePoolClusterServiceCreateControllerName = "NodePoolClusterServiceCreate"
+
+type nodePoolClusterServiceCreateSyncer struct {
+	cooldownChecker       controllerutil.CooldownChecker
+	resourcesDBClient     database.ResourcesDBClient
+	nodePoolLister        listers.NodePoolLister
+	clusterLister         listers.ClusterLister
+	clustersServiceClient ocm.ClusterServiceClientSpec
+}
+
+func NewNodePoolClusterServiceCreateController(
+	resourcesDBClient database.ResourcesDBClient,
+	clustersServiceClient ocm.ClusterServiceClientSpec,
+	activeOperationLister listers.ActiveOperationLister,
+	informers informers.BackendInformers,
+	kubeApplierInformers *unionkubeapplierinformers.UnionKubeApplierInformers,
+) controllerutils.Controller {
+	_, nodePoolLister := informers.NodePools()
+	_, clusterLister := informers.Clusters()
+	syncer := &nodePoolClusterServiceCreateSyncer{
+		cooldownChecker:       controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		resourcesDBClient:     resourcesDBClient,
+		nodePoolLister:        nodePoolLister,
+		clusterLister:         clusterLister,
+		clustersServiceClient: clustersServiceClient,
+	}
+
+	return controllerutils.NewNodePoolWatchingController(
+		NodePoolClusterServiceCreateControllerName,
+		resourcesDBClient,
+		informers,
+		kubeApplierInformers,
+		time.Minute,
+		syncer,
+	)
+}
+
+func (c *nodePoolClusterServiceCreateSyncer) needsWork(nodePool *api.HCPOpenShiftClusterNodePool) bool {
+	return nodePool.ServiceProviderProperties.DeletionTimestamp == nil &&
+		(nodePool.ServiceProviderProperties.ClusterServiceID == nil || len(nodePool.ServiceProviderProperties.ClusterServiceID.String()) == 0)
+}
+
+func (c *nodePoolClusterServiceCreateSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPNodePoolKey) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	nodePool, err := c.nodePoolLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(err)
+	}
+
+	if !c.needsWork(nodePool) {
+		return nil
+	}
+
+	// For the NodePool, we retrieve from the actual database because we are about to use its data to interact with cluster-service.
+	nodePool, err = c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).NodePools(key.HCPClusterName).Get(ctx, key.HCPNodePoolName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(err)
+	}
+
+	if !c.needsWork(nodePool) {
+		return nil
+	}
+
+	// For the Cluster, we retrieve from the cache because we are not about to use its data to interact with cluster-service. At
+	// the moment we only use the ClusterServiceID to interact with cluster-service, which shouldn't change over time once set.
+	// If at some point this controller evolves to use other Cluster properties that will be sent to cluster-service and that
+	// can change over time, we will need to retrieve from the database instead.
+	cluster, err := c.clusterLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if err != nil {
+		return utils.TrackError(err)
+	}
+	if cluster.ServiceProviderProperties.ClusterServiceID == nil || len(cluster.ServiceProviderProperties.ClusterServiceID.String()) == 0 {
+		return utils.TrackError(fmt.Errorf("cluster %s has no ClusterServiceID", key.HCPClusterName))
+	}
+	clusterCSInternalID := *cluster.ServiceProviderProperties.ClusterServiceID
+
+	// GET must target the same href POST would use: {clusterHref}/node_pools/{id} where id is
+	// lowercased ARM name (see ocm.BuildCSNodePool). We reconstruct it here:
+	csNodePoolHREF := ocm.GenerateAROHCPNodePoolHREF(clusterCSInternalID.ID(), strings.ToLower(key.HCPNodePoolName))
+	nodePoolCSInternalID, err := api.NewInternalID(csNodePoolHREF)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("build node pool internal ID for adoption lookup: %w", err))
+	}
+
+	existing, err := c.findCSNodePool(ctx, nodePoolCSInternalID)
+	if err != nil {
+		return utils.TrackError(err)
+	}
+
+	if existing == nil {
+		csNodePoolBuilder, err := ocm.BuildCSNodePool(ctx, nodePool, false)
+		if err != nil {
+			return utils.TrackError(err)
+		}
+		logger.Info("performing POST node pool to Cluster Service", "cs_node_pool_href", csNodePoolHREF, "node_pool_resource_id", nodePool.ID.String())
+		_, err = c.clustersServiceClient.PostNodePool(ctx, clusterCSInternalID, csNodePoolBuilder)
+		if c.isOCMErrorBadRequest(err) {
+			logger.Error(err, "CS node pool POST returned OCM error with HTTP 400 status code", "cs_node_pool_href", csNodePoolHREF, "node_pool_resource_id", nodePool.ID.String())
+		}
+		if err != nil {
+			return utils.TrackError(err)
+		}
+	}
+
+	logger.Info("setting node pool cluster service ID in node pool cosmos document", "node_pool_cluster_service_id", nodePoolCSInternalID.String())
+	replacement := nodePool.DeepCopy()
+	replacement.ServiceProviderProperties.ClusterServiceID = nodePoolCSInternalID.DeepCopy() // DeepCopy() to avoid referencing the original pointer
+	_, err = c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).NodePools(key.HCPClusterName).Replace(ctx, replacement, nil)
+	if database.IsPreconditionFailedError(err) {
+		// if we have a conflict error, then we're guaranteed that our informer will eventually see an update and trigger us again.
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(err)
+	}
+
+	return nil
+}
+
+// findCSNodePool performs GetNodePool for the given Cluster Service node pool InternalID.
+// It returns (nil, nil) when CS responds with 404.
+func (c *nodePoolClusterServiceCreateSyncer) findCSNodePool(ctx context.Context, nodePoolInternalID api.InternalID) (*arohcpv1alpha1.NodePool, error) {
+	np, err := c.clustersServiceClient.GetNodePool(ctx, nodePoolInternalID)
+	if err != nil {
+		var ocmErr *ocmerrors.Error
+		if errors.As(err, &ocmErr) && ocmErr.Status() == http.StatusNotFound {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return np, nil
+}
+
+func (c *nodePoolClusterServiceCreateSyncer) CooldownChecker() controllerutil.CooldownChecker {
+	return c.cooldownChecker
+}
+
+func (c *nodePoolClusterServiceCreateSyncer) isOCMErrorBadRequest(err error) bool {
+	var ocmErr *ocmerrors.Error
+	return err != nil && errors.As(err, &ocmErr) && ocmErr.Status() == http.StatusBadRequest
+}

--- a/backend/pkg/controllers/nodepoolcreationcontrollers/node_pool_cluster_service_create_controller_test.go
+++ b/backend/pkg/controllers/nodepoolcreationcontrollers/node_pool_cluster_service_create_controller_test.go
@@ -1,0 +1,368 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodepoolcreationcontrollers
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+const (
+	testSubscriptionID      = "00000000-0000-0000-0000-000000000000"
+	testResourceGroupName   = "test-rg"
+	testClusterName         = "test-cluster"
+	testNodePoolName        = "test-nodepool"
+	testClusterServiceIDStr = "/api/aro_hcp/v1alpha1/clusters/abc123"
+	testNodePoolCSIDStr     = testClusterServiceIDStr + "/node_pools/" + testNodePoolName
+)
+
+type alwaysSyncCooldownChecker struct{}
+
+func (c *alwaysSyncCooldownChecker) CanSync(ctx context.Context, key any) bool {
+	return true
+}
+
+func TestNodePoolClusterServiceCreateSyncer_SyncOnce(t *testing.T) {
+	testKey := controllerutils.HCPNodePoolKey{
+		SubscriptionID:    testSubscriptionID,
+		ResourceGroupName: testResourceGroupName,
+		HCPClusterName:    testClusterName,
+		HCPNodePoolName:   testNodePoolName,
+	}
+
+	clusterCSInternalID := api.Must(api.NewInternalID(testClusterServiceIDStr))
+	nodePoolCSInternalID := api.Must(api.NewInternalID(testNodePoolCSIDStr))
+
+	verifyClusterServiceIDIsNil := func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+		t.Helper()
+		stored, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).
+			NodePools(testClusterName).Get(ctx, testNodePoolName)
+		require.NoError(t, err)
+		assert.Nil(t, stored.ServiceProviderProperties.ClusterServiceID)
+	}
+
+	verifyClusterServiceIDIsSet := func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+		t.Helper()
+		stored, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).
+			NodePools(testClusterName).Get(ctx, testNodePoolName)
+		require.NoError(t, err)
+		require.NotNil(t, stored.ServiceProviderProperties.ClusterServiceID, "expected ClusterServiceID to be set")
+		assert.Equal(t, testNodePoolCSIDStr, stored.ServiceProviderProperties.ClusterServiceID.String())
+	}
+
+	testCases := []struct {
+		name              string
+		listerCluster     *api.HCPOpenShiftCluster
+		existingNodePool  *api.HCPOpenShiftClusterNodePool
+		listerNodePool    *api.HCPOpenShiftClusterNodePool // Optional. If not provided, existingNodePool is used as the listerNodePool
+		setupMockCSClient func(mock *ocm.MockClusterServiceClientSpec)
+		wantErr           bool
+		wantErrContain    string
+		verifyDB          func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient)
+	}{
+		{
+			name:          "when ClusterServiceID is already set no-op is performed",
+			listerCluster: newTestCluster(t, nil),
+			existingNodePool: newTestNodePoolForCreate(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				np.ServiceProviderProperties.ClusterServiceID = api.Ptr(api.Must(api.NewInternalID(testNodePoolCSIDStr)))
+			}),
+			verifyDB: verifyClusterServiceIDIsSet,
+		},
+		{
+			name:          "when DeletionTimestamp is set no-op is performed",
+			listerCluster: newTestCluster(t, nil),
+			existingNodePool: newTestNodePoolForCreate(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: metav1.Now().Time}
+			}),
+			verifyDB: verifyClusterServiceIDIsNil,
+		},
+		{
+			name: "node pool not found in lister no-op is performed",
+		},
+		{
+			name:          "when lister is stale but DB already has ClusterServiceID no-op is performed",
+			listerCluster: newTestCluster(t, nil),
+			existingNodePool: newTestNodePoolForCreate(t, func(np *api.HCPOpenShiftClusterNodePool) {
+				np.ServiceProviderProperties.ClusterServiceID = api.Ptr(api.Must(api.NewInternalID(testNodePoolCSIDStr)))
+			}),
+			listerNodePool: newTestNodePoolForCreate(t, nil),
+			verifyDB:       verifyClusterServiceIDIsSet,
+		},
+		{
+			name:             "when cluster has no ClusterServiceID error is returned",
+			listerCluster:    newTestCluster(t, func(c *api.HCPOpenShiftCluster) { c.ServiceProviderProperties.ClusterServiceID = nil }),
+			existingNodePool: newTestNodePoolForCreate(t, nil),
+			wantErr:          true,
+			wantErrContain:   "cluster test-cluster has no ClusterServiceID",
+		},
+		{
+			name:             "when CS node pool does not exist POST is issued and ClusterServiceID is set",
+			listerCluster:    newTestCluster(t, nil),
+			existingNodePool: newTestNodePoolForCreate(t, nil),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetNodePool(gomock.Any(), nodePoolCSInternalID).
+					Return(nil, fakeOCMNotFoundError())
+				csNodePool, err := arohcpv1alpha1.NewNodePool().
+					ID(testNodePoolName).
+					HREF(testNodePoolCSIDStr).
+					Build()
+				require.NoError(t, err)
+				mock.EXPECT().
+					PostNodePool(gomock.Any(), clusterCSInternalID, gomock.Any()).
+					Return(csNodePool, nil)
+			},
+			verifyDB: verifyClusterServiceIDIsSet,
+		},
+		{
+			name:             "when CS node pool already exists POST is skipped and ClusterServiceID is set",
+			listerCluster:    newTestCluster(t, nil),
+			existingNodePool: newTestNodePoolForCreate(t, nil),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				existing, err := arohcpv1alpha1.NewNodePool().
+					ID(testNodePoolName).
+					HREF(testNodePoolCSIDStr).
+					Build()
+				require.NoError(t, err)
+				mock.EXPECT().
+					GetNodePool(gomock.Any(), nodePoolCSInternalID).
+					Return(existing, nil)
+			},
+			verifyDB: verifyClusterServiceIDIsSet,
+		},
+		{
+			name:             "when CS node pool lookup returns a non-404 error it is propagated",
+			listerCluster:    newTestCluster(t, nil),
+			existingNodePool: newTestNodePoolForCreate(t, nil),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetNodePool(gomock.Any(), nodePoolCSInternalID).
+					Return(nil, errors.New("boom"))
+			},
+			wantErr:        true,
+			wantErrContain: "boom",
+		},
+		{
+			name:             "when CS node pool POST fails error is propagated",
+			listerCluster:    newTestCluster(t, nil),
+			existingNodePool: newTestNodePoolForCreate(t, nil),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetNodePool(gomock.Any(), nodePoolCSInternalID).
+					Return(nil, fakeOCMNotFoundError())
+				mock.EXPECT().
+					PostNodePool(gomock.Any(), clusterCSInternalID, gomock.Any()).
+					Return(nil, errors.New("post failed"))
+			},
+			wantErr:        true,
+			wantErrContain: "post failed",
+		},
+		{
+			name:             "when PostNodePool returns 400 OCM error reconciler returns error",
+			listerCluster:    newTestCluster(t, nil),
+			existingNodePool: newTestNodePoolForCreate(t, nil),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetNodePool(gomock.Any(), nodePoolCSInternalID).
+					Return(nil, fakeOCMNotFoundError())
+				mock.EXPECT().
+					PostNodePool(gomock.Any(), clusterCSInternalID, gomock.Any()).
+					Return(nil, fakeOCMError(http.StatusBadRequest, "Machine type not supported"))
+			},
+			wantErr:        true,
+			wantErrContain: "Machine type not supported",
+			verifyDB:       verifyClusterServiceIDIsNil,
+		},
+		{
+			name:             "when PostNodePool returns 500 OCM error it is propagated for retry",
+			listerCluster:    newTestCluster(t, nil),
+			existingNodePool: newTestNodePoolForCreate(t, nil),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetNodePool(gomock.Any(), nodePoolCSInternalID).
+					Return(nil, fakeOCMNotFoundError())
+				mock.EXPECT().
+					PostNodePool(gomock.Any(), clusterCSInternalID, gomock.Any()).
+					Return(nil, fakeOCMInternalServerError("internal error"))
+			},
+			wantErr:        true,
+			wantErrContain: "internal error",
+			verifyDB:       verifyClusterServiceIDIsNil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+			ctrl := gomock.NewController(t)
+
+			resources := []any{}
+			if tc.existingNodePool != nil {
+				resources = append(resources, tc.existingNodePool)
+			}
+			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, resources)
+			require.NoError(t, err)
+
+			mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
+			if tc.setupMockCSClient != nil {
+				tc.setupMockCSClient(mockCSClient)
+			}
+
+			clustersForLister := []*api.HCPOpenShiftCluster{}
+			if tc.listerCluster != nil {
+				clustersForLister = append(clustersForLister, tc.listerCluster)
+			}
+
+			nodePoolsForLister := []*api.HCPOpenShiftClusterNodePool{}
+			listerNodePool := tc.listerNodePool
+			if listerNodePool == nil {
+				listerNodePool = tc.existingNodePool
+			}
+			if listerNodePool != nil {
+				nodePoolsForLister = append(nodePoolsForLister, listerNodePool)
+			}
+
+			syncer := &nodePoolClusterServiceCreateSyncer{
+				cooldownChecker:       &alwaysSyncCooldownChecker{},
+				nodePoolLister:        &listertesting.SliceNodePoolLister{NodePools: nodePoolsForLister},
+				clusterLister:         &listertesting.SliceClusterLister{Clusters: clustersForLister},
+				resourcesDBClient:     mockResourcesDBClient,
+				clustersServiceClient: mockCSClient,
+			}
+
+			err = syncer.SyncOnce(ctx, testKey)
+			if tc.wantErr {
+				require.Error(t, err)
+				if len(tc.wantErrContain) > 0 {
+					require.ErrorContains(t, err, tc.wantErrContain)
+				}
+				return
+			}
+			require.NoError(t, err)
+
+			if tc.verifyDB != nil {
+				tc.verifyDB(t, ctx, mockResourcesDBClient)
+			}
+		})
+	}
+}
+
+func fakeOCMNotFoundError() error {
+	e, _ := ocmerrors.NewError().Status(http.StatusNotFound).Reason("not found").Build()
+	return e
+}
+
+func fakeOCMError(status int, msg string) error {
+	e, _ := ocmerrors.NewError().Status(status).Reason(msg).Build()
+	return e
+}
+
+func fakeOCMInternalServerError(msg string) error {
+	e, _ := ocmerrors.NewError().Status(http.StatusInternalServerError).Reason(msg).Build()
+	return e
+}
+
+func newTestCluster(t *testing.T, opts func(*api.HCPOpenShiftCluster)) *api.HCPOpenShiftCluster {
+	t.Helper()
+	resourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName))
+	clusterInternalID := api.Ptr(api.Must(api.NewInternalID(testClusterServiceIDStr)))
+	cluster := &api.HCPOpenShiftCluster{
+		TrackedResource: arm.TrackedResource{
+			Resource: arm.Resource{
+				ID:   resourceID,
+				Name: testClusterName,
+				Type: api.ClusterResourceType.String(),
+			},
+			Location: "eastus",
+		},
+		CosmosMetadata: arm.CosmosMetadata{ResourceID: resourceID, PartitionKey: strings.ToLower(resourceID.SubscriptionID)},
+		ServiceProviderProperties: api.HCPOpenShiftClusterServiceProviderProperties{
+			ClusterServiceID: clusterInternalID,
+		},
+	}
+	if opts != nil {
+		opts(cluster)
+	}
+	return cluster
+}
+
+func newTestNodePoolForCreate(t *testing.T, opts func(*api.HCPOpenShiftClusterNodePool)) *api.HCPOpenShiftClusterNodePool {
+	t.Helper()
+	resourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+			"/nodePools/" + testNodePoolName))
+	np := &api.HCPOpenShiftClusterNodePool{
+		TrackedResource: arm.TrackedResource{
+			Resource: arm.Resource{
+				ID:   resourceID,
+				Name: testNodePoolName,
+				Type: api.NodePoolResourceType.String(),
+			},
+			Location: "eastus",
+		},
+		CosmosMetadata: arm.CosmosMetadata{ResourceID: resourceID, PartitionKey: strings.ToLower(resourceID.SubscriptionID)},
+		Properties: api.HCPOpenShiftClusterNodePoolProperties{
+			Version: api.NodePoolVersionProfile{
+				ID:           "4.20.8",
+				ChannelGroup: "stable",
+			},
+			Replicas: 2,
+			Platform: api.NodePoolPlatformProfile{
+				VMSize: "Standard_D4s_v3",
+				OSDisk: api.OSDiskProfile{
+					SizeGiB:                ptr.To(int32(128)),
+					DiskType:               api.OsDiskTypeManaged,
+					DiskStorageAccountType: api.DiskStorageAccountTypePremium_LRS,
+				},
+			},
+		},
+		ServiceProviderProperties: api.HCPOpenShiftClusterNodePoolServiceProviderProperties{
+			ClusterServiceID: nil,
+		},
+	}
+	if opts != nil {
+		opts(np)
+	}
+	return np
+}

--- a/backend/pkg/controllers/operationcontrollers/operation_node_pool_create.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_node_pool_create.go
@@ -16,8 +16,10 @@ package operationcontrollers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -25,17 +27,22 @@ import (
 	utilsclock "k8s.io/utils/clock"
 
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
 	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/ocm"
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
 
 type operationNodePoolCreate struct {
-	clock                utilsclock.PassiveClock
-	resourcesDBClient    database.ResourcesDBClient
-	clusterServiceClient ocm.ClusterServiceClientSpec
-	notificationClient   *http.Client
+	clock                  utilsclock.PassiveClock
+	resourcesDBClient      database.ResourcesDBClient
+	activeOperationsLister listers.ActiveOperationLister
+	nodePoolLister         listers.NodePoolLister
+	clusterServiceClient   ocm.ClusterServiceClientSpec
+	notificationClient     *http.Client
 }
 
 // NewOperationNodePoolCreateController returns a new Controller instance that
@@ -58,12 +65,18 @@ func NewOperationNodePoolCreateController(
 	clusterServiceClient ocm.ClusterServiceClientSpec,
 	notificationClient *http.Client,
 	activeOperationInformer cache.SharedIndexInformer,
+	backendInformers informers.BackendInformers,
 ) controllerutils.Controller {
+	_, nodePoolLister := backendInformers.NodePools()
+	_, activeOperationsLister := backendInformers.ActiveOperations()
+
 	syncer := &operationNodePoolCreate{
-		clock:                clock,
-		resourcesDBClient:    resourcesDBClient,
-		clusterServiceClient: clusterServiceClient,
-		notificationClient:   notificationClient,
+		clock:                  clock,
+		resourcesDBClient:      resourcesDBClient,
+		nodePoolLister:         nodePoolLister,
+		activeOperationsLister: activeOperationsLister,
+		clusterServiceClient:   clusterServiceClient,
+		notificationClient:     notificationClient,
 	}
 
 	controller := NewGenericOperationController(
@@ -87,6 +100,7 @@ func (c *operationNodePoolCreate) ShouldProcess(ctx context.Context, operation *
 	if operation.ExternalID == nil || !strings.EqualFold(operation.ExternalID.ResourceType.String(), api.NodePoolResourceType.String()) {
 		return false
 	}
+
 	return true
 }
 
@@ -94,16 +108,111 @@ func (c *operationNodePoolCreate) SynchronizeOperation(ctx context.Context, key 
 	logger := utils.LoggerFromContext(ctx)
 	logger.Info("checking operation")
 
-	operation, err := c.resourcesDBClient.Operations(key.SubscriptionID).Get(ctx, key.OperationName)
+	operation, err := c.activeOperationsLister.Get(ctx, key.SubscriptionID, key.OperationName)
 	if database.IsNotFoundError(err) {
 		return nil // no work to do
 	}
 	if err != nil {
 		return fmt.Errorf("failed to get active operation: %w", err)
 	}
+
 	if !c.ShouldProcess(ctx, operation) {
 		return nil // no work to do
 	}
 
-	return pollNodePoolStatus(ctx, c.clock, c.resourcesDBClient, c.clusterServiceClient, operation, c.notificationClient)
+	nodePool, err := c.nodePoolLister.Get(ctx, operation.ExternalID.SubscriptionID, operation.ExternalID.ResourceGroupName, operation.ExternalID.Parent.Name, operation.ExternalID.Name)
+	if database.IsNotFoundError(err) {
+		logger.Info("node pool not found in cache, waiting")
+		return nil // no work to do
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get node pool: %w", err)
+	}
+
+	if operation.ResourceID.Name != nodePool.ServiceProviderProperties.ActiveOperationID {
+		logger.Info("node pool active operation id mismatch, returning early", "synchronizedActiveOperationID", operation.ResourceID.Name, "nodePoolActiveOperationID", nodePool.ServiceProviderProperties.ActiveOperationID)
+		return nil
+	}
+
+	if !c.shouldReconcileOperationAndResourceStatus(nodePool) {
+		return nil
+	}
+
+	operationalState, err := c.determineOperationState(ctx, operation, nodePool)
+	if err != nil {
+		return utils.TrackError(err)
+	}
+
+	var persistErr *arm.CloudErrorBody
+	if operationalState.provisioningState == arm.ProvisioningStateFailed {
+		persistErr = &arm.CloudErrorBody{
+			// TODO for now we always set the error code to InternalServerError, but we should improve to be able
+			// to be more specific than that when we calculate operationalState. When work is done to improve on this, we
+			// should design it in a way where no internal details are exposed to the operation's error.
+			Code:    arm.CloudErrorCodeInternalServerError,
+			Message: operationalState.message,
+		}
+	}
+
+	logger.Info("updating status")
+	err = UpdateOperationStatus(ctx, c.clock, c.resourcesDBClient, operation, operationalState.provisioningState, persistErr, postAsyncNotificationFn(c.notificationClient))
+	if err != nil {
+		return utils.TrackError(err)
+	}
+
+	return nil
+}
+
+func (c *operationNodePoolCreate) shouldReconcileOperationAndResourceStatus(nodePool *api.HCPOpenShiftClusterNodePool) bool {
+	return nodePool.ServiceProviderProperties.DeletionTimestamp == nil && nodePool.ServiceProviderProperties.ClusterServiceID != nil
+}
+
+func (c *operationNodePoolCreate) determineOperationState(ctx context.Context, operation *api.Operation, nodePool *api.HCPOpenShiftClusterNodePool) (*operationState, error) {
+	logger := utils.LoggerFromContext(ctx)
+
+	var errs []error
+	var operationStates []*operationState
+
+	if state, err := c.nodePoolServiceCreateOperationState(ctx, operation, nodePool); err != nil {
+		errs = append(errs, utils.TrackError(err))
+	} else {
+		operationStates = append(operationStates, state)
+	}
+
+	if err := errors.Join(errs...); err != nil {
+		return nil, err
+	}
+	if len(operationStates) == 0 {
+		return nil, errors.New("no operation states")
+	}
+	slices.SortStableFunc(operationStates, compareOperationState)
+	if operationStates[0] == nil {
+		return nil, errors.New("nil operation state")
+	}
+	logger.Info("determined node pool create operation status", "operationStates", operationStates)
+	picked, err := pickWorstOperationState(operationStates)
+	if err != nil {
+		return nil, utils.TrackError(err)
+	}
+	logger.Info("picked node pool create operation status", "provisioningState", picked.provisioningState, "message", picked.message)
+	return picked, nil
+}
+
+func (c *operationNodePoolCreate) nodePoolServiceCreateOperationState(ctx context.Context, operation *api.Operation, nodePool *api.HCPOpenShiftClusterNodePool) (*operationState, error) {
+	logger := utils.LoggerFromContext(ctx)
+	csNodePoolStatus, err := c.clusterServiceClient.GetNodePoolStatus(ctx, *nodePool.ServiceProviderProperties.ClusterServiceID)
+	if err != nil {
+		return nil, utils.TrackError(err)
+	}
+
+	newOperationStatus, newOperationError, err := convertNodePoolStatus(operation, csNodePoolStatus)
+	if err != nil {
+		return nil, utils.TrackError(err)
+	}
+	logger.Info("new status via cluster-service", "newStatus", newOperationStatus, "newOperationError", newOperationError)
+	msg := ""
+	if newOperationError != nil {
+		msg = newOperationError.Message
+	}
+	return newOperationState(newOperationStatus, msg), nil
 }

--- a/backend/pkg/controllers/operationcontrollers/operation_node_pool_create.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_node_pool_create.go
@@ -156,6 +156,10 @@ func (c *operationNodePoolCreate) SynchronizeOperation(ctx context.Context, key 
 
 	logger.Info("updating status")
 	err = UpdateOperationStatus(ctx, c.clock, c.resourcesDBClient, operation, operationalState.provisioningState, persistErr, postAsyncNotificationFn(c.notificationClient))
+	if database.IsPreconditionFailedError(err) {
+		// if we have a conflict error, then we're guaranteed that our informer will eventually see an update and trigger us again.
+		return nil
+	}
 	if err != nil {
 		return utils.TrackError(err)
 	}

--- a/backend/pkg/controllers/operationcontrollers/operation_node_pool_create_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_node_pool_create_test.go
@@ -17,16 +17,20 @@ package operationcontrollers
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr/testr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilsclock "k8s.io/utils/clock"
 
 	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
 
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
+	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/databasetesting"
@@ -35,23 +39,66 @@ import (
 )
 
 func TestOperationNodePoolCreate_SynchronizeOperation(t *testing.T) {
+	defaultNodePool := func(fixture *nodePoolTestFixture) *api.HCPOpenShiftClusterNodePool {
+		return fixture.newNodePool()
+	}
+
+	nodePoolWithoutCSID := func(fixture *nodePoolTestFixture) *api.HCPOpenShiftClusterNodePool {
+		np := fixture.newNodePool()
+		np.ServiceProviderProperties.ClusterServiceID = nil
+		return np
+	}
+
+	nodePoolWithDeletionTimestamp := func(fixture *nodePoolTestFixture) *api.HCPOpenShiftClusterNodePool {
+		np := fixture.newNodePool()
+		np.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+		return np
+	}
+
+	nodePoolWithMismatchedActiveOperationID := func(fixture *nodePoolTestFixture) *api.HCPOpenShiftClusterNodePool {
+		np := fixture.newNodePool()
+		np.ServiceProviderProperties.ActiveOperationID = "other-operation"
+		return np
+	}
+
+	nodePoolWithEmptyActiveOperationID := func(fixture *nodePoolTestFixture) *api.HCPOpenShiftClusterNodePool {
+		np := fixture.newNodePool()
+		np.ServiceProviderProperties.ActiveOperationID = ""
+		return np
+	}
+
+	setupCSNodePoolStatus := func(t *testing.T, mock *ocm.MockClusterServiceClientSpec, fixture *nodePoolTestFixture, state, msg string) {
+		t.Helper()
+		nodePoolStatusBuilder := arohcpv1alpha1.NewNodePoolStatus().
+			State(arohcpv1alpha1.NewNodePoolState().NodePoolStateValue(state))
+		if msg != "" {
+			nodePoolStatusBuilder = nodePoolStatusBuilder.Message(msg)
+		}
+		nodePoolStatus, err := nodePoolStatusBuilder.Build()
+		require.NoError(t, err)
+		mock.EXPECT().
+			GetNodePoolStatus(gomock.Any(), fixture.nodePoolInternalID).
+			Return(nodePoolStatus, nil)
+	}
+
 	tests := []struct {
-		name          string
-		nodePoolState string
-		nodePoolMsg   string
-		expectError   bool
-		verify        func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture)
+		name        string
+		nodePool    func(fixture *nodePoolTestFixture) *api.HCPOpenShiftClusterNodePool
+		setupCSMock func(t *testing.T, mock *ocm.MockClusterServiceClientSpec, fixture *nodePoolTestFixture)
+		expectError bool
+		verifyDB    func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient)
 	}{
 		{
-			name:          "node pool ready transitions to succeeded",
-			nodePoolState: string(NodePoolStateReady),
-			expectError:   false,
-			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
+			name:     "node pool ready transitions to succeeded",
+			nodePool: defaultNodePool,
+			setupCSMock: func(t *testing.T, mock *ocm.MockClusterServiceClientSpec, fixture *nodePoolTestFixture) {
+				setupCSNodePoolStatus(t, mock, fixture, string(NodePoolStateReady), "")
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateSucceeded, op.Status)
 
-				// Verify node pool provisioning state was also updated
 				nodePool, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).NodePools(testClusterName).Get(ctx, testNodePoolName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateSucceeded, nodePool.Properties.ProvisioningState)
@@ -59,15 +106,16 @@ func TestOperationNodePoolCreate_SynchronizeOperation(t *testing.T) {
 			},
 		},
 		{
-			name:          "node pool installing transitions to provisioning",
-			nodePoolState: string(NodePoolStateInstalling),
-			expectError:   false,
-			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
+			name:     "node pool installing transitions to provisioning",
+			nodePool: defaultNodePool,
+			setupCSMock: func(t *testing.T, mock *ocm.MockClusterServiceClientSpec, fixture *nodePoolTestFixture) {
+				setupCSNodePoolStatus(t, mock, fixture, string(NodePoolStateInstalling), "")
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateProvisioning, op.Status)
 
-				// Verify node pool still has active operation
 				nodePool, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).NodePools(testClusterName).Get(ctx, testNodePoolName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateProvisioning, nodePool.Properties.ProvisioningState)
@@ -75,18 +123,18 @@ func TestOperationNodePoolCreate_SynchronizeOperation(t *testing.T) {
 			},
 		},
 		{
-			name:          "node pool error transitions to failed",
-			nodePoolState: string(NodePoolStateError),
-			nodePoolMsg:   "node pool creation failed",
-			expectError:   false,
-			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
+			name:     "node pool error transitions to failed",
+			nodePool: defaultNodePool,
+			setupCSMock: func(t *testing.T, mock *ocm.MockClusterServiceClientSpec, fixture *nodePoolTestFixture) {
+				setupCSNodePoolStatus(t, mock, fixture, string(NodePoolStateError), "node pool creation failed")
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateFailed, op.Status)
 				assert.NotNil(t, op.Error)
 				assert.Equal(t, "node pool creation failed", op.Error.Message)
 
-				// Verify node pool shows failed
 				nodePool, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).NodePools(testClusterName).Get(ctx, testNodePoolName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateFailed, nodePool.Properties.ProvisioningState)
@@ -94,20 +142,60 @@ func TestOperationNodePoolCreate_SynchronizeOperation(t *testing.T) {
 			},
 		},
 		{
-			name:          "node pool pending stays accepted",
-			nodePoolState: string(NodePoolStatePending),
-			expectError:   false,
-			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
+			name:     "node pool pending stays accepted",
+			nodePool: defaultNodePool,
+			setupCSMock: func(t *testing.T, mock *ocm.MockClusterServiceClientSpec, fixture *nodePoolTestFixture) {
+				setupCSNodePoolStatus(t, mock, fixture, string(NodePoolStatePending), "")
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
 			},
 		},
 		{
-			name:          "node pool validating stays accepted",
-			nodePoolState: string(NodePoolStateValidating),
-			expectError:   false,
-			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
+			name:     "node pool validating stays accepted",
+			nodePool: defaultNodePool,
+			setupCSMock: func(t *testing.T, mock *ocm.MockClusterServiceClientSpec, fixture *nodePoolTestFixture) {
+				setupCSNodePoolStatus(t, mock, fixture, string(NodePoolStateValidating), "")
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+			},
+		},
+		{
+			name:     "ClusterServiceID nil skips reconciliation",
+			nodePool: nodePoolWithoutCSID,
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+			},
+		},
+		{
+			name:     "ActiveOperationID mismatch skips reconciliation",
+			nodePool: nodePoolWithMismatchedActiveOperationID,
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+			},
+		},
+		{
+			name:     "empty ActiveOperationID skips reconciliation",
+			nodePool: nodePoolWithEmptyActiveOperationID,
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+			},
+		},
+		{
+			name:     "DeletionTimestamp set skips reconciliation",
+			nodePool: nodePoolWithDeletionTimestamp,
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
@@ -124,42 +212,37 @@ func TestOperationNodePoolCreate_SynchronizeOperation(t *testing.T) {
 
 			fixture := newNodePoolTestFixture()
 			cluster := fixture.newCluster()
-			nodePool := fixture.newNodePool()
+			nodePool := tt.nodePool(fixture)
 			operation := fixture.newOperation(database.OperationRequestCreate)
 
-			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, []any{cluster, nodePool, operation})
+			resources := []any{cluster, nodePool, operation}
+
+			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, resources)
 			require.NoError(t, err)
 
 			mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
-			nodePoolStatusBuilder := arohcpv1alpha1.NewNodePoolStatus().
-				State(arohcpv1alpha1.NewNodePoolState().NodePoolStateValue(tt.nodePoolState))
-			if tt.nodePoolMsg != "" {
-				nodePoolStatusBuilder = nodePoolStatusBuilder.Message(tt.nodePoolMsg)
+			if tt.setupCSMock != nil {
+				tt.setupCSMock(t, mockCSClient, fixture)
 			}
-			nodePoolStatus, err := nodePoolStatusBuilder.Build()
-			require.NoError(t, err)
-
-			mockCSClient.EXPECT().
-				GetNodePoolStatus(gomock.Any(), fixture.nodePoolInternalID).
-				Return(nodePoolStatus, nil)
 
 			controller := &operationNodePoolCreate{
-				clock:                utilsclock.RealClock{},
-				resourcesDBClient:    mockResourcesDBClient,
-				clusterServiceClient: mockCSClient,
-				notificationClient:   nil,
+				clock:                  utilsclock.RealClock{},
+				resourcesDBClient:      mockResourcesDBClient,
+				activeOperationsLister: &listertesting.DBActiveOperationLister{ResourcesDBClient: mockResourcesDBClient},
+				nodePoolLister:         &listertesting.DBNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
+				clusterServiceClient:   mockCSClient,
+				notificationClient:     nil,
 			}
 
 			err = controller.SynchronizeOperation(ctx, fixture.operationKey())
-
 			if tt.expectError {
 				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
+				return
 			}
+			require.NoError(t, err)
 
-			if tt.verify != nil {
-				tt.verify(t, ctx, mockResourcesDBClient, fixture)
+			if tt.verifyDB != nil {
+				tt.verifyDB(t, ctx, mockResourcesDBClient)
 			}
 		})
 	}

--- a/backend/pkg/controllers/operationcontrollers/test_helpers_test.go
+++ b/backend/pkg/controllers/operationcontrollers/test_helpers_test.go
@@ -47,7 +47,7 @@ const (
 	testNodePoolName              = "test-nodepool"
 	testExternalAuthName          = "test-external-auth"
 	testClusterServiceIDStr       = "/api/clusters_mgmt/v1/clusters/abc123"
-	testNodePoolIDStr             = "/api/clusters_mgmt/v1/clusters/abc123/node_pools/np123"
+	testNodePoolIDStr             = "/api/aro_hcp/v1alpha1/clusters/abc123/node_pools/test-nodepool"
 	testExternalAuthIDStr         = "/api/clusters_mgmt/v1/clusters/abc123/external_auth_config/external_auths/ea123"
 	testBreakGlassCredentialIDStr = "/api/clusters_mgmt/v1/clusters/abc123/break_glass_credentials/bgc123"
 	testOperationName             = "test-operation-id"

--- a/backend/pkg/controllers/operationcontrollers/utils.go
+++ b/backend/pkg/controllers/operationcontrollers/utils.go
@@ -487,43 +487,6 @@ func convertClusterStatus(ctx context.Context, clusterServiceClient ocm.ClusterS
 	return newOperationStatus, opError, err
 }
 
-// pollNodePoolStatus converts a node pool status from Cluster
-// Service to info for an Azure async operation status endpoint.
-func pollNodePoolStatus(
-	ctx context.Context,
-	clock utilsclock.PassiveClock,
-	resourcesDBClient database.ResourcesDBClient,
-	clusterServiceClient ocm.ClusterServiceClientSpec,
-	operation *api.Operation,
-	notificationClient *http.Client) error {
-	// XXX This is currently called by the operationNodePoolCreate and
-	//     operationNodePoolUpdate controllers because the logic flows
-	//     are identical. If the logic flows ever diverge, then this
-	//     function should be split up and the pieces moved back to
-	//     their respective controllers.
-
-	logger := utils.LoggerFromContext(ctx)
-
-	nodePoolStatus, err := clusterServiceClient.GetNodePoolStatus(ctx, operation.InternalID)
-	if err != nil {
-		return utils.TrackError(err)
-	}
-
-	newOperationStatus, newOperationError, err := convertNodePoolStatus(operation, nodePoolStatus)
-	if err != nil {
-		return utils.TrackError(err)
-	}
-	logger.Info("new status", "newStatus", newOperationStatus)
-
-	logger.Info("updating status")
-	err = UpdateOperationStatus(ctx, clock, resourcesDBClient, operation, newOperationStatus, newOperationError, postAsyncNotificationFn(notificationClient))
-	if err != nil {
-		return utils.TrackError(err)
-	}
-
-	return nil
-}
-
 // convertNodePoolStatus attempts to translate a NodePoolStatus object
 // from Cluster Service into an ARM provisioning state and, if necessary,
 // a structured OData error.


### PR DESCRIPTION
Reintroduces https://github.com/Azure/ARO-HCP/pull/5790 by reverting the revert MR https://github.com/Azure/ARO-HCP/pull/5856.

Additionally, it also ensures that when UpdateOperationStatus fails with DB precondition error we do not return an error and we return early instead. This ensures it does not count as part of the controller error rates metrics, which triggered CI blockages.