### PR TITLE
Fix: Remove unneeded error message check

### DIFF
--- a/test/e2e/cluster_authorized_cidrs_connectivity.go
+++ b/test/e2e/cluster_authorized_cidrs_connectivity.go
@@ -187,7 +187,7 @@ var _ = Describe("Authorized CIDRs", func() {
 				// Try to connect from the test runner (which is not in authorized CIDRs)
 				err = testAPIConnectivity(apiURL, 5*time.Second)
 				Expect(err).To(HaveOccurred(), "Connection from unauthorized IP should be blocked")
-				GinkgoWriter.Printf("Unauthorized connection error: %v\n", err)
+				GinkgoWriter.Printf("Connection from unauthorized IP address failed as expected on error: %v\n", err)
 
 				By("verifying VM can access cluster API with credentials")
 				adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(

--- a/test/e2e/cluster_authorized_cidrs_connectivity.go
+++ b/test/e2e/cluster_authorized_cidrs_connectivity.go
@@ -187,7 +187,7 @@ var _ = Describe("Authorized CIDRs", func() {
 				// Try to connect from the test runner (which is not in authorized CIDRs)
 				err = testAPIConnectivity(apiURL, 5*time.Second)
 				Expect(err).To(HaveOccurred(), "Connection from unauthorized IP should be blocked")
-				// We only need to verify that the connection is blocked, not the specific error message
+				GinkgoWriter.Printf("Unauthorized connection error: %v\n", err)
 
 				By("verifying VM can access cluster API with credentials")
 				adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(

--- a/test/e2e/cluster_authorized_cidrs_connectivity.go
+++ b/test/e2e/cluster_authorized_cidrs_connectivity.go
@@ -187,8 +187,7 @@ var _ = Describe("Authorized CIDRs", func() {
 				// Try to connect from the test runner (which is not in authorized CIDRs)
 				err = testAPIConnectivity(apiURL, 5*time.Second)
 				Expect(err).To(HaveOccurred(), "Connection from unauthorized IP should be blocked")
-				// Verify it's a connection error (EOF indicates connection was closed by server/network)
-				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("Get \"%s/healthz\": EOF", apiURL)), "Should fail with EOF error indicating blocked connection")
+				// We only need to verify that the connection is blocked, not the specific error message
 
 				By("verifying VM can access cluster API with credentials")
 				adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-27850

### What

Fix test failure due to error message string mismatch by removing the error message content check.

### Why

The exact string check on the error message was causing false test failures and there isn't much value in knowing the exact error message, the test only needs to know that the connection failed.

### Testing

Pre-merge e2e is sufficient here.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes) (N/A)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md) N/A
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem. N/A
