### PR TITLE
feat(templatize): enforce simple field access in bicepparam templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -353,6 +353,9 @@ rebase:
 validate-config-pipelines: $(YQ) $(TEMPLATIZE)
 	$(TEMPLATIZE) pipeline validate --topology-config-file topology.yaml --service-config-file "$(CONFIG_FILE)" --dev-mode --dev-region $(shell $(YQ) '.environments[] | select(.name == "dev") | .defaults.region' <tooling/templatize/settings.yaml) $(ONLY_CHANGED)
 
+validate-config-pipelines-dev-ci: $(YQ) $(TEMPLATIZE)
+	$(TEMPLATIZE) pipeline validate --topology-config-file topology-dev-ci.yaml --service-config-file config/config-dev-ci.yaml --dev-mode --dev-region $(shell $(YQ) '.environments[] | select(.name == "dev-ci") | .defaults.region' <tooling/templatize/settings.yaml)
+
 validate-changed-config-pipelines:
 	$(MAKE) validate-config-pipelines DEV_MODE="--dev-mode --dev-region uksouth" ONLY_CHANGED="--only-changed"
 
@@ -485,11 +488,11 @@ endif
 # Dev CI topology local run
 #
 dev-ci-local-run:
-	$(MAKE) local-run DEPLOY_ENV=dev-ci CONFIG_FILE=config/config-dev-ci.yaml TOPOLOGY_FILE=topology-dev-ci.yaml WHAT="--entrypoint Microsoft.Azure.ARO.HCP.DevCI.Infra" STEP_CACHE_DIR=""
+	$(MAKE) local-run DEPLOY_ENV=dev-ci CONFIG_FILE=config/config-dev-ci.yaml TOPOLOGY_FILE=topology-dev-ci.yaml WHAT="--entrypoint Microsoft.Azure.ARO.HCP.DevCI.Infra" STEP_CACHE_DIR="" EXTRA_ARGS="--skip-bicepparam-validation"
 .PHONY: dev-ci-local-run
 
 dev-ci-e2e-subscription-rbac-local-run:
-	$(MAKE) local-run DEPLOY_ENV=dev-ci CONFIG_FILE=config/config-dev-ci.yaml TOPOLOGY_FILE=topology-dev-ci.yaml WHAT="--service-group Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBAC" STEP_CACHE_DIR=""
+	$(MAKE) local-run DEPLOY_ENV=dev-ci CONFIG_FILE=config/config-dev-ci.yaml TOPOLOGY_FILE=topology-dev-ci.yaml WHAT="--service-group Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBAC" STEP_CACHE_DIR="" EXTRA_ARGS="--skip-bicepparam-validation"
 .PHONY: dev-ci-e2e-subscription-rbac-local-run
 
 #

--- a/tooling/templatize/cmd/entrypoint/run/options.go
+++ b/tooling/templatize/cmd/entrypoint/run/options.go
@@ -51,6 +51,7 @@ func BindOptions(opts *RawOptions, cmd *cobra.Command) error {
 	cmd.Flags().BoolVar(&opts.Persist, "persist-tag", opts.Persist, "toggle if persist tag should be set")
 	cmd.Flags().IntVar(&opts.DeploymentTimeoutSeconds, "deployment-timeout-seconds", opts.DeploymentTimeoutSeconds, "Timeout in Seconds to wait for previous deployments of the pipeline to finish")
 	cmd.Flags().BoolVar(&opts.AbortIfRegionalExist, "abort-if-regional-exist", opts.AbortIfRegionalExist, "Abort deployment if regional resource groups already exist (concurrent execution prevention)")
+	cmd.Flags().BoolVar(&opts.SkipBicepparamValidation, "skip-bicepparam-validation", opts.SkipBicepparamValidation, "Skip validation of bicepparam templates for simple field access.")
 
 	return nil
 }
@@ -61,6 +62,7 @@ type RawOptions struct {
 	Persist                  bool
 	DeploymentTimeoutSeconds int
 	AbortIfRegionalExist     bool
+	SkipBicepparamValidation bool
 
 	TimingOutputFile string
 	JUnitOutputFile  string
@@ -85,6 +87,7 @@ type completedOptions struct {
 	NoPersist                bool
 	DeploymentTimeoutSeconds int
 	AbortIfRegionalExist     bool
+	SkipBicepparamValidation bool
 
 	TimingOutputFile string
 	JUnitOutputFile  string
@@ -123,6 +126,7 @@ func (o *ValidatedOptions) Complete(ctx context.Context) (*Options, error) {
 			NoPersist:                !o.Persist,
 			DeploymentTimeoutSeconds: o.DeploymentTimeoutSeconds,
 			AbortIfRegionalExist:     o.AbortIfRegionalExist,
+			SkipBicepparamValidation: o.SkipBicepparamValidation,
 
 			TimingOutputFile: o.TimingOutputFile,
 			JUnitOutputFile:  o.JUnitOutputFile,
@@ -172,6 +176,7 @@ func (o *Options) Run(ctx context.Context) error {
 			DeploymentTimeoutSeconds:             o.DeploymentTimeoutSeconds,
 			StepCacheDir:                         o.StepCacheDir,
 			BicepClient:                          o.BicepClient,
+			SkipBicepparamValidation:             o.SkipBicepparamValidation,
 			SubscriptionIdToAzureConfigDirectory: subscriptionIdToAzureConfigDirectory,
 		},
 		TopoDirLookupFunc:     o.Topo.GetTopologyDirForServiceGroup,

--- a/tooling/templatize/cmd/pipeline/run/options.go
+++ b/tooling/templatize/cmd/pipeline/run/options.go
@@ -38,6 +38,7 @@ func BindOptions(opts *RawRunOptions, cmd *cobra.Command) error {
 	}
 	cmd.Flags().BoolVar(&opts.NoPersist, "no-persist-tag", opts.NoPersist, "toggle if persist tag should not be set")
 	cmd.Flags().IntVar(&opts.DeploymentTimeoutSeconds, "deployment-timeout-seconds", pipeline.DefaultDeploymentTimeoutSeconds, "Timeout in Seconds to wait for previous deployments of the pipeline to finish")
+	cmd.Flags().BoolVar(&opts.SkipBicepparamValidation, "skip-bicepparam-validation", opts.SkipBicepparamValidation, "Skip validation of bicepparam templates for simple field access.")
 	return nil
 }
 
@@ -45,6 +46,7 @@ type RawRunOptions struct {
 	PipelineOptions          *options.RawPipelineOptions
 	NoPersist                bool
 	DeploymentTimeoutSeconds int
+	SkipBicepparamValidation bool
 }
 
 // validatedRunOptions is a private wrapper that enforces a call of Validate() before Complete() can be invoked.
@@ -63,6 +65,7 @@ type completedRunOptions struct {
 	PipelineOptions          *options.PipelineOptions
 	NoPersist                bool
 	DeploymentTimeoutSeconds int
+	SkipBicepparamValidation bool
 }
 
 type RunOptions struct {
@@ -95,6 +98,7 @@ func (o *ValidatedRunOptions) Complete(ctx context.Context) (*RunOptions, error)
 			PipelineOptions:          completed,
 			NoPersist:                o.NoPersist,
 			DeploymentTimeoutSeconds: o.DeploymentTimeoutSeconds,
+			SkipBicepparamValidation: o.SkipBicepparamValidation,
 		},
 	}, nil
 }
@@ -122,6 +126,7 @@ func (o *RunOptions) RunPipeline(ctx context.Context) error {
 			NoPersist:                            o.NoPersist,
 			DeploymentTimeoutSeconds:             o.DeploymentTimeoutSeconds,
 			BicepClient:                          o.PipelineOptions.RolloutOptions.BicepClient,
+			SkipBicepparamValidation:             o.SkipBicepparamValidation,
 			SubscriptionIdToAzureConfigDirectory: subscriptionIdToAzureConfigDirectory,
 		},
 		Region:                o.PipelineOptions.RolloutOptions.Region,

--- a/tooling/templatize/cmd/pipeline/validate/bicepparam.go
+++ b/tooling/templatize/cmd/pipeline/validate/bicepparam.go
@@ -1,0 +1,117 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validate
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/go-logr/logr"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/Azure/ARO-Tools/config"
+	"github.com/Azure/ARO-Tools/pipelines/topology"
+	pipelinetypes "github.com/Azure/ARO-Tools/pipelines/types"
+)
+
+type rawPipelineParams struct {
+	ResourceGroups []struct {
+		Steps []struct {
+			Action     string `json:"action"`
+			Parameters string `json:"parameters,omitempty"`
+		} `json:"steps"`
+	} `json:"resourceGroups"`
+}
+
+func (opts *ValidationOptions) ValidateBicepparamTemplates(ctx context.Context) error {
+	logger, err := logr.FromContext(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get logger from context: %w", err)
+	}
+
+	bicepparamFiles := sets.New[string]()
+	for _, service := range opts.Topology.Services {
+		if err := collectBicepparamFiles(opts.Topology, service, bicepparamFiles); err != nil {
+			return err
+		}
+	}
+
+	sortedFiles := bicepparamFiles.UnsortedList()
+	slices.Sort(sortedFiles)
+	var errors []string
+	for _, file := range sortedFiles {
+		content, err := os.ReadFile(file)
+		if err != nil {
+			return fmt.Errorf("failed to read bicepparam file %s: %w", file, err)
+		}
+		if err := config.ValidateSimpleFieldAccess(content); err != nil {
+			errors = append(errors, fmt.Sprintf("%s: %v", file, err))
+		}
+	}
+
+	if len(errors) > 0 {
+		return fmt.Errorf("bicepparam template validation failed:\n%s", strings.Join(errors, "\n"))
+	}
+
+	logger.V(3).Info("All bicepparam templates passed validation.", "count", len(bicepparamFiles))
+	return nil
+}
+
+func collectBicepparamFiles(t *topology.CombinedTopology, service topology.Service, files sets.Set[string]) error {
+	if len(service.PipelinePath) > 0 {
+		baseDir, err := t.GetTopologyDirForServiceGroup(service.ServiceGroup)
+		if err != nil {
+			return fmt.Errorf("%s: failed to get topology dir: %w", service.ServiceGroup, err)
+		}
+
+		pipelineFile := filepath.Join(baseDir, service.PipelinePath)
+		raw, err := os.ReadFile(pipelineFile)
+		if err != nil {
+			return fmt.Errorf("%s: failed to read pipeline %s: %w", service.ServiceGroup, pipelineFile, err)
+		}
+
+		var pipeline rawPipelineParams
+		if err := yaml.Unmarshal(raw, &pipeline); err != nil {
+			return fmt.Errorf("%s: failed to parse pipeline %s: %w", service.ServiceGroup, pipelineFile, err)
+		}
+
+		pipelineDir := filepath.Dir(pipelineFile)
+		for _, rg := range pipeline.ResourceGroups {
+			for _, step := range rg.Steps {
+				if step.Action != pipelinetypes.StepActionARM && step.Action != pipelinetypes.StepActionARMStack {
+					continue
+				}
+				if len(step.Parameters) == 0 {
+					continue
+				}
+				files.Insert(filepath.Join(pipelineDir, step.Parameters))
+			}
+		}
+	}
+
+	for _, child := range service.Children {
+		if err := collectBicepparamFiles(t, child, files); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/tooling/templatize/cmd/pipeline/validate/bicepparam_test.go
+++ b/tooling/templatize/cmd/pipeline/validate/bicepparam_test.go
@@ -1,0 +1,111 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validate
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/Azure/ARO-Tools/pipelines/topology"
+)
+
+func TestCollectBicepparamFiles(t *testing.T) {
+	topo, err := topology.LoadCombined([]string{"testdata/topology.yaml"})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		service  topology.Service
+		expected []string
+	}{
+		{
+			name:    "ARM step collects bicepparam file",
+			service: topo.Services[0], // TestSvcA
+			expected: []string{
+				filepath.Join("testdata", "svc-a", "network.tmpl.bicepparam"),
+				filepath.Join("testdata", "svc-b", "cluster.tmpl.bicepparam"),
+			},
+		},
+		{
+			name:     "Shell-only service collects nothing",
+			service:  topo.Services[1], // TestSvcC
+			expected: []string{},
+		},
+		{
+			name:     "empty pipeline path collects nothing",
+			service:  topology.Service{ServiceGroup: "NoPipeline"},
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			files := sets.New[string]()
+			err := collectBicepparamFiles(topo, tt.service, files)
+			require.NoError(t, err)
+			assert.ElementsMatch(t, tt.expected, files.UnsortedList())
+		})
+	}
+}
+
+func TestValidateBicepparamTemplates(t *testing.T) {
+	tests := []struct {
+		name         string
+		topoFile     string
+		expectError  bool
+		errorContain string
+	}{
+		{
+			name:        "valid templates pass",
+			topoFile:    "testdata/topology.yaml",
+			expectError: false,
+		},
+		{
+			name:         "invalid templates fail",
+			topoFile:     "testdata/topology-invalid.yaml",
+			expectError:  true,
+			errorContain: "bicepparam template validation failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			topo, err := topology.LoadCombined([]string{tt.topoFile})
+			require.NoError(t, err)
+
+			opts := &ValidationOptions{
+				completedValidationOptions: &completedValidationOptions{
+					Topology: topo,
+				},
+			}
+
+			ctx := logr.NewContext(context.Background(), logr.Discard())
+			err = opts.ValidateBicepparamTemplates(ctx)
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorContain)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/tooling/templatize/cmd/pipeline/validate/cmd.go
+++ b/tooling/templatize/cmd/pipeline/validate/cmd.go
@@ -59,5 +59,8 @@ func runValidate(ctx context.Context, opts *RawValidationOptions) error {
 	if err != nil {
 		return err
 	}
+	if err := completed.ValidateBicepparamTemplates(ctx); err != nil {
+		return err
+	}
 	return completed.ValidatePipelineConfigReferences(ctx)
 }

--- a/tooling/templatize/cmd/pipeline/validate/testdata/svc-a/network.tmpl.bicepparam
+++ b/tooling/templatize/cmd/pipeline/validate/testdata/svc-a/network.tmpl.bicepparam
@@ -1,0 +1,4 @@
+using 'network.bicep'
+
+param vnetName = '{{ .network.vnetName }}'
+param subnetPrefix = '{{ .network.subnetPrefix }}'

--- a/tooling/templatize/cmd/pipeline/validate/testdata/svc-a/pipeline.yaml
+++ b/tooling/templatize/cmd/pipeline/validate/testdata/svc-a/pipeline.yaml
@@ -1,0 +1,11 @@
+resourceGroups:
+- name: rg1
+  subscription: sub1
+  steps:
+  - name: deploy-network
+    action: ARM
+    template: network.bicep
+    parameters: network.tmpl.bicepparam
+  - name: run-script
+    action: Shell
+    command: echo hello

--- a/tooling/templatize/cmd/pipeline/validate/testdata/svc-b/cluster.tmpl.bicepparam
+++ b/tooling/templatize/cmd/pipeline/validate/testdata/svc-b/cluster.tmpl.bicepparam
@@ -1,0 +1,3 @@
+using 'cluster.bicep'
+
+param clusterName = '{{ .cluster.name }}'

--- a/tooling/templatize/cmd/pipeline/validate/testdata/svc-b/pipeline.yaml
+++ b/tooling/templatize/cmd/pipeline/validate/testdata/svc-b/pipeline.yaml
@@ -1,0 +1,8 @@
+resourceGroups:
+- name: rg2
+  subscription: sub1
+  steps:
+  - name: deploy-cluster
+    action: ARMStack
+    template: cluster.bicep
+    parameters: cluster.tmpl.bicepparam

--- a/tooling/templatize/cmd/pipeline/validate/testdata/svc-c/pipeline.yaml
+++ b/tooling/templatize/cmd/pipeline/validate/testdata/svc-c/pipeline.yaml
@@ -1,0 +1,7 @@
+resourceGroups:
+- name: rg3
+  subscription: sub1
+  steps:
+  - name: run-script
+    action: Shell
+    command: echo hello

--- a/tooling/templatize/cmd/pipeline/validate/testdata/svc-invalid/invalid.tmpl.bicepparam
+++ b/tooling/templatize/cmd/pipeline/validate/testdata/svc-invalid/invalid.tmpl.bicepparam
@@ -1,0 +1,5 @@
+using 'template.bicep'
+
+param items = [{{ range .items }}
+  '{{ . }}'
+{{ end }}]

--- a/tooling/templatize/cmd/pipeline/validate/testdata/svc-invalid/pipeline.yaml
+++ b/tooling/templatize/cmd/pipeline/validate/testdata/svc-invalid/pipeline.yaml
@@ -1,0 +1,8 @@
+resourceGroups:
+- name: rg1
+  subscription: sub1
+  steps:
+  - name: deploy-with-loop
+    action: ARM
+    template: template.bicep
+    parameters: invalid.tmpl.bicepparam

--- a/tooling/templatize/cmd/pipeline/validate/testdata/topology-invalid.yaml
+++ b/tooling/templatize/cmd/pipeline/validate/testdata/topology-invalid.yaml
@@ -1,0 +1,4 @@
+services:
+- serviceGroup: TestSvcInvalid
+  pipelinePath: svc-invalid/pipeline.yaml
+  purpose: Test service with invalid bicepparam templates

--- a/tooling/templatize/cmd/pipeline/validate/testdata/topology.yaml
+++ b/tooling/templatize/cmd/pipeline/validate/testdata/topology.yaml
@@ -1,0 +1,11 @@
+services:
+- serviceGroup: TestSvcA
+  pipelinePath: svc-a/pipeline.yaml
+  purpose: Test service A with ARM steps
+  children:
+  - serviceGroup: TestSvcB
+    pipelinePath: svc-b/pipeline.yaml
+    purpose: Test service B (child) with ARM step
+- serviceGroup: TestSvcC
+  pipelinePath: svc-c/pipeline.yaml
+  purpose: Test service C with no ARM steps

--- a/tooling/templatize/pkg/pipeline/arm.go
+++ b/tooling/templatize/pkg/pipeline/arm.go
@@ -91,7 +91,7 @@ func (a *armClient) runArmStep(ctx context.Context, options *StepRunOptions, rgN
 		return nil, nil, fmt.Errorf("failed to ensure resource group exists: %w", err)
 	}
 
-	return doWaitForDeployment(ctx, a.bicepClient, a.deploymentClient, a.getOperationsClient, a.subscriptionID, id.ServiceGroup, id.Stamp, rgName, step, options.PipelineDirectory, options.StepCacheDir, options.Configuration, options.DeploymentTimeoutSeconds, options.RetryAttempt, state)
+	return doWaitForDeployment(ctx, a.bicepClient, a.deploymentClient, a.getOperationsClient, a.subscriptionID, id.ServiceGroup, id.Stamp, rgName, step, options.PipelineDirectory, options.StepCacheDir, options.Configuration, options.DeploymentTimeoutSeconds, options.RetryAttempt, options.SkipBicepparamValidation, state)
 }
 
 func createError(errors armresources.ErrorResponse) error {
@@ -145,7 +145,7 @@ func armOutputFromOutputs(outputs any) ArmOutput {
 	return nil
 }
 
-func doWaitForDeployment(ctx context.Context, bicepClient *bicep.LSPClient, client *armresources.DeploymentsClient, getOperationsClient OperationsClientGetter, subscriptionID, serviceGroup string, stamp graph.Stamp, rgName string, step *types.ARMStep, pipelineWorkingDir, stepCacheDir string, cfg configtypes.Configuration, timeoutSeconds int, retryAttempt int, state *ExecutionState) (Output, DetailsProducer, error) {
+func doWaitForDeployment(ctx context.Context, bicepClient *bicep.LSPClient, client *armresources.DeploymentsClient, getOperationsClient OperationsClientGetter, subscriptionID, serviceGroup string, stamp graph.Stamp, rgName string, step *types.ARMStep, pipelineWorkingDir, stepCacheDir string, cfg configtypes.Configuration, timeoutSeconds int, retryAttempt int, skipBicepparamValidation bool, state *ExecutionState) (Output, DetailsProducer, error) {
 	logger := logr.FromContextOrDiscard(ctx)
 
 	state.RLock()
@@ -155,7 +155,7 @@ func doWaitForDeployment(ctx context.Context, bicepClient *bicep.LSPClient, clie
 		return nil, nil, fmt.Errorf("failed to get input values: %w", err)
 	}
 	// Transform Bicep to ARM
-	deploymentProperties, err := transformBicepToARMDeployment(ctx, bicepClient, step.Parameters, step.DeploymentMode, pipelineWorkingDir, cfg, inputValues)
+	deploymentProperties, err := transformBicepToARMDeployment(ctx, bicepClient, step.Parameters, step.DeploymentMode, pipelineWorkingDir, cfg, inputValues, skipBicepparamValidation)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to transform Bicep to ARM: %w", err)
 	}

--- a/tooling/templatize/pkg/pipeline/arm_stack.go
+++ b/tooling/templatize/pkg/pipeline/arm_stack.go
@@ -110,7 +110,7 @@ func runArmStackStep(
 		return nil, nil, fmt.Errorf("failed to get input values: %w", err)
 	}
 
-	template, params, err := transformParameters(ctx, options.BicepClient, options.Configuration, inputValues, step.Parameters, options.PipelineDirectory)
+	template, params, err := transformParameters(ctx, options.BicepClient, options.Configuration, inputValues, step.Parameters, options.PipelineDirectory, options.SkipBicepparamValidation)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/tooling/templatize/pkg/pipeline/bicep.go
+++ b/tooling/templatize/pkg/pipeline/bicep.go
@@ -38,8 +38,8 @@ func modeFromString(mode string) armresources.DeploymentMode {
 	}
 }
 
-func transformBicepToARMDeployment(ctx context.Context, bicepClient *bicep.LSPClient, bicepParameterTemplateFile, deploymentMode, pipelineWorkingDir string, cfg types.Configuration, inputs map[string]any) (*armresources.DeploymentProperties, error) {
-	template, params, err := transformParameters(ctx, bicepClient, cfg, inputs, bicepParameterTemplateFile, pipelineWorkingDir)
+func transformBicepToARMDeployment(ctx context.Context, bicepClient *bicep.LSPClient, bicepParameterTemplateFile, deploymentMode, pipelineWorkingDir string, cfg types.Configuration, inputs map[string]any, skipBicepparamValidation bool) (*armresources.DeploymentProperties, error) {
+	template, params, err := transformParameters(ctx, bicepClient, cfg, inputs, bicepParameterTemplateFile, pipelineWorkingDir, skipBicepparamValidation)
 	if err != nil {
 		return nil, err
 	}
@@ -50,8 +50,17 @@ func transformBicepToARMDeployment(ctx context.Context, bicepClient *bicep.LSPCl
 	}, nil
 }
 
-func transformParameters(ctx context.Context, bicepClient *bicep.LSPClient, cfg types.Configuration, inputs map[string]any, bicepParameterTemplateFile, pipelineWorkingDir string) (map[string]interface{}, map[string]interface{}, error) {
+func transformParameters(ctx context.Context, bicepClient *bicep.LSPClient, cfg types.Configuration, inputs map[string]any, bicepParameterTemplateFile, pipelineWorkingDir string, skipBicepparamValidation bool) (map[string]interface{}, map[string]interface{}, error) {
 	bicepParameterFile := filepath.Join(pipelineWorkingDir, bicepParameterTemplateFile)
+	if !skipBicepparamValidation {
+		rawContent, err := os.ReadFile(bicepParameterFile)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to read bicepparam template %s: %w", bicepParameterFile, err)
+		}
+		if err := config.ValidateSimpleFieldAccess(rawContent); err != nil {
+			return nil, nil, fmt.Errorf("invalid bicepparam template %s: %w", bicepParameterFile, err)
+		}
+	}
 	bicepParamContent, err := config.PreprocessFile(bicepParameterFile, cfg)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to preprocess file: %w", err)

--- a/tooling/templatize/pkg/pipeline/run.go
+++ b/tooling/templatize/pkg/pipeline/run.go
@@ -86,6 +86,8 @@ type BaseRunOptions struct {
 	StepCacheDir             string
 	BicepClient              *bicep.LSPClient
 
+	SkipBicepparamValidation bool
+
 	SubscriptionIdToAzureConfigDirectory map[string]string
 }
 


### PR DESCRIPTION
### What

Bicepparam files are Go templates preprocessed before being fed to the Bicep LSP. Unrestricted template constructs (range, if, variables, function calls) make these files fragile and hard to reason about — the intent is that all logic lives in the config layer, not in the template.

Add ValidateSimpleFieldAccess at two levels:

1. Runtime guard in transformParameters — rejects invalid templates before preprocessing, giving a clear error instead of a silent misbuild.

2. Static validation in `templatize pipeline validate` — walks topology → pipeline → ARM/ARMStack steps, collects referenced bicepparam files, and validates each once. Runs before config reference validation (no config resolution needed since parameter paths are always literal). Reachable via `make validate-config-pipelines`.

### Why

Bicepparam templates with complex Go template constructs (conditionals, loops, function calls) bypass the config layer's role as the single source of logic. This makes templates fragile, hard to review, and prone to silent misbuilds. Enforcing simple field access ensures all logic stays in config where it belongs, and template files remain straightforward value substitutions.

### Testing

- `ValidateSimpleFieldAccess` is tested in the ARO-Tools dependency where it is defined.
- `make validate-config-pipelines` runs the new validation against all existing bicepparam templates in the repo and passes (no existing templates use complex constructs).

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.