### PR TITLE
ci(provision): centralize shared provisioning logic for step-registry consumers

### DIFF
--- a/hack/ci/provision-environment.sh
+++ b/hack/ci/provision-environment.sh
@@ -123,6 +123,21 @@ else
   echo "No MSI mock SP lease provided, skipping mock SP overrides"
 fi
 
+# Temporary MGMT cluster sizing overrides for single-wave E2E parallelism.
+# These will be removed once the matching config.yaml defaults land in ARO-HCP.
+# Only apply when identity containers are leased (E2E runs); healthcheck
+# workflows provision without leases and should use the default sizing.
+if [[ -n "${LEASED_MSI_CONTAINERS:-}" ]]; then
+  yq -i "
+    .clouds.dev.environments.${DEPLOY_ENV}.defaults.mgmt.aks.userAgentPool.minCount = 7 |
+    .clouds.dev.environments.${DEPLOY_ENV}.defaults.mgmt.aks.infraAgentPool.vmSize = \"Standard_D8ds_v6\"
+  " "${OVERRIDE_CONFIG_FILE}"
+else
+  yq -i "
+    .clouds.dev.environments.${DEPLOY_ENV}.defaults.mgmt.aks.userAgentPool.minCount = 1
+  " "${OVERRIDE_CONFIG_FILE}"
+fi
+
 # Merge hypershift image overrides if present (written by aro-hcp-hypershift-images-push)
 HYPERSHIFT_OVERRIDES="${SHARED_DIR}/hypershift-image-overrides.yaml"
 if [[ -f "${HYPERSHIFT_OVERRIDES}" ]]; then
@@ -155,12 +170,21 @@ finalize() {
 trap finalize EXIT
 
 unset GOFLAGS
+
+EXTRA_ARGS="--region ${LOCATION}"
+if [[ "${ARO_HCP_PROVISION_ABORT_IF_EXISTS:-true}" == "true" ]]; then
+  EXTRA_ARGS+=" --abort-if-regional-exist"
+fi
+
+STEP_NAME="${PROVISION_STEP_NAME:-entrypoint}"
+# Sanitize to safe filename characters to prevent path traversal or word-splitting
+STEP_NAME="${STEP_NAME//[^a-zA-Z0-9_-]/}"
 make -o "tooling/templatize/templatize-$(uname -m)" entrypoint/Region \
   DEPLOY_ENV="${DEPLOY_ENV}" \
   OVERRIDE_CONFIG_FILE="${OVERRIDE_CONFIG_FILE}" \
-  EXTRA_ARGS="--region ${LOCATION} --abort-if-regional-exist" \
+  EXTRA_ARGS="${EXTRA_ARGS}" \
   TIMING_OUTPUT=${SHARED_DIR}/steps.yaml.gz \
-  ENTRYPOINT_JUNIT_OUTPUT=${ARTIFACT_DIR}/junit_entrypoint.xml \
+  ENTRYPOINT_JUNIT_OUTPUT=${ARTIFACT_DIR}/junit_${STEP_NAME}.xml \
   CONFIG_OUTPUT=${CONFIG_PROV}
 
 touch "${SHARED_DIR}/provision-complete"


### PR DESCRIPTION
[ARO-27255](https://redhat.atlassian.net/browse/ARO-27255)

### What

Updates `hack/ci/provision-environment.sh` so openshift/release step-registry scripts can source it directly instead of duplicating provisioning logic inline.

### Why

The step-registry provision scripts (`provision-environment`, `provision-from-main`) in openshift/release duplicate ~150 lines of shared provisioning logic (Azure login, MSI overrides, MGMT sizing, config output, make entrypoint call). This PR adds the missing features to the shared script so those step-registry scripts can become thin wrappers that `source hack/ci/provision-environment.sh`.

### Testing

- No standalone test - this script is exercised by CI provision workflows
- Companion openshift/release PR will migrate step-registry scripts to source this, validatable via pj-rehearse

### Special notes for your reviewer

- Adds MGMT cluster sizing overrides (carried from openshift/release PR #80714)
- Parameterizes `--abort-if-regional-exist` via `ARO_HCP_PROVISION_ABORT_IF_EXISTS` (default `true`)
- Adds `PROVISION_STEP_NAME` for configurable junit output filenames
- The companion openshift/release PR must merge **after** this one

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes) — N/A
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge