### PR TITLE
Add billing repository value to config

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -2343,12 +2343,16 @@
             },
             "digest": {
               "type": "string"
+            },
+            "repository": {
+              "type": "string"
             }
           },
           "required": [
             "subscriptionKey",
             "rg",
-            "digest"
+            "digest",
+            "repository"
           ]
         },
         "subscription": {

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -69,6 +69,7 @@ defaults:
     billing:
       rg: "placeholder"
       digest: "placeholder"
+      repository: billing
       subscriptionKey: "hcp-billng-{{ .ctx.environment }}"
     globalMSIName: global-ev2-identity
     nsp:

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -376,6 +376,7 @@ geneva:
 global:
   billing:
     digest: placeholder
+    repository: billing
     rg: placeholder
     subscriptionKey: hcp-billng-ci00
   globalMSIName: global-rollout-identity

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -376,6 +376,7 @@ geneva:
 global:
   billing:
     digest: placeholder
+    repository: billing
     rg: placeholder
     subscriptionKey: hcp-billng-ci01
   globalMSIName: global-rollout-identity

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -376,6 +376,7 @@ geneva:
 global:
   billing:
     digest: placeholder
+    repository: billing
     rg: placeholder
     subscriptionKey: hcp-billng-cspr
   globalMSIName: global-rollout-identity

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -376,6 +376,7 @@ geneva:
 global:
   billing:
     digest: placeholder
+    repository: billing
     rg: placeholder
     subscriptionKey: hcp-billng-dev
   globalMSIName: global-rollout-identity

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -376,6 +376,7 @@ geneva:
 global:
   billing:
     digest: placeholder
+    repository: billing
     rg: placeholder
     subscriptionKey: hcp-billng-perf
   globalMSIName: global-rollout-identity

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -376,6 +376,7 @@ geneva:
 global:
   billing:
     digest: placeholder
+    repository: billing
     rg: placeholder
     subscriptionKey: hcp-billng-pers
   globalMSIName: global-rollout-identity


### PR DESCRIPTION
The release dashboard image.versions controller needs to see `repository` as a field on billing in order to discover its deployed image when scanning config.