### PR TITLE
fix: disable local auth for backup storage accounts

### DIFF
--- a/dev-infrastructure/modules/hcp-backups/storage.bicep
+++ b/dev-infrastructure/modules/hcp-backups/storage.bicep
@@ -35,7 +35,7 @@ module hcpBackupsStorageAccount '../storage/storage.bicep' = {
     skuName: determineZoneRedundancy(locationAvailabilityZoneList, zoneRedundantMode) ? 'Standard_ZRS' : 'Standard_LRS'
     accessTier: 'Cool'
     allowBlobPublicAccess: public
-    allowSharedKeyAccess: true
+    allowSharedKeyAccess: false
     publicNetworkAccess: 'Enabled'
     configureNetworkAcls: true
     networkAclsBypass: 'AzureServices'


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-28019

### What

Disables "Allow Storage Account Key Access" for backup storage accounts (oadpxxxx).

### Why

Local auth is not used for our storage accounts and having it enabled is causing us to be noncompliant on a [KPI in Service 360.](https://vnext.s360.msftcloudes.com/blades/security?global=4:b8e9ef87-cd63-4085-ab14-1c637806568c&blade=KPI:c6876c6f-2376-49a6-bcbd-f15af106d1af~SLA:2~AssignedTo:All~Forums:All~Program:bbb5a659-c49e-420c-b1a2-84e0fa142951;68556099-a3e2-472e-8da0-e1d1b000eda4;65a010a5-1e3d-4777-bb89-f149470a507d~waves:All~Tab:Summary~_loc:Security&peopleBasedNodes=pradipak_team;stekuznetsov_team)

### Testing

Tested in personal dev, and e2e.

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
