### PR TITLE
fix(observability): PrometheusAgent topology spread and remote-write batchSendDeadline

### DIFF
--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arohcp_monitor.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arohcp_monitor.yaml
@@ -68656,7 +68656,7 @@ spec:
       maxShards: 50
       minShards: 1
       maxSamplesPerSend: 10000
-      batchSendDeadline: 60s
+      batchSendDeadline: 30s
       minBackoff: 30ms
       maxBackoff: 256s
     metadataConfig:
@@ -68674,7 +68674,7 @@ spec:
       maxShards: 50
       minShards: 1
       maxSamplesPerSend: 10000
-      batchSendDeadline: 60s
+      batchSendDeadline: 30s
       minBackoff: 30ms
       maxBackoff: 256s
     metadataConfig:

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arohcp_monitor.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arohcp_monitor.yaml
@@ -68620,16 +68620,27 @@ spec:
   topologySpreadConstraints:
   - labelSelector:
       matchLabels:
-        app: prometheus
+        app.kubernetes.io/name: prometheus-agent
+        operator.prometheus.io/name: prometheus
     maxSkew: 1
     topologyKey: 'topology.kubernetes.io/zone'
     whenUnsatisfiable: ScheduleAnyway
   - labelSelector:
       matchLabels:
-        app: prometheus
+        app.kubernetes.io/name: prometheus-agent
+        operator.prometheus.io/name: prometheus
     maxSkew: 1
     topologyKey: kubernetes.io/hostname
     whenUnsatisfiable: ScheduleAnyway
+  - labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: prometheus-agent
+        operator.prometheus.io/name: prometheus
+    matchLabelKeys:
+    - operator.prometheus.io/shard
+    maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: DoNotSchedule
   walCompression: true
   externalLabels:
     cluster: 'dev-westus3-mgmt-1'

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_arohcp_monitor.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_arohcp_monitor.yaml
@@ -68501,16 +68501,27 @@ spec:
   topologySpreadConstraints:
   - labelSelector:
       matchLabels:
-        app: prometheus
+        app.kubernetes.io/name: prometheus-agent
+        operator.prometheus.io/name: prometheus
     maxSkew: 1
     topologyKey: 'topology.kubernetes.io/zone'
     whenUnsatisfiable: ScheduleAnyway
   - labelSelector:
       matchLabels:
-        app: prometheus
+        app.kubernetes.io/name: prometheus-agent
+        operator.prometheus.io/name: prometheus
     maxSkew: 1
     topologyKey: kubernetes.io/hostname
     whenUnsatisfiable: ScheduleAnyway
+  - labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: prometheus-agent
+        operator.prometheus.io/name: prometheus
+    matchLabelKeys:
+    - operator.prometheus.io/shard
+    maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: DoNotSchedule
   walCompression: true
   externalLabels:
     cluster: 'dev-westus3-svc-1'

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_arohcp_monitor.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_arohcp_monitor.yaml
@@ -68537,7 +68537,7 @@ spec:
       maxShards: 50
       minShards: 1
       maxSamplesPerSend: 10000
-      batchSendDeadline: 60s
+      batchSendDeadline: 30s
       minBackoff: 30ms
       maxBackoff: 256s
     metadataConfig:
@@ -68555,7 +68555,7 @@ spec:
       maxShards: 50
       minShards: 1
       maxSamplesPerSend: 10000
-      batchSendDeadline: 60s
+      batchSendDeadline: 30s
       minBackoff: 30ms
       maxBackoff: 256s
     metadataConfig:

--- a/observability/prometheus/deploy/templates/prometheus.yaml
+++ b/observability/prometheus/deploy/templates/prometheus.yaml
@@ -123,7 +123,7 @@ spec:
       maxShards: 50
       minShards: 1
       maxSamplesPerSend: 10000
-      batchSendDeadline: 60s
+      batchSendDeadline: 30s
       minBackoff: 30ms
       maxBackoff: 256s
     metadataConfig:
@@ -144,7 +144,7 @@ spec:
       maxShards: 50
       minShards: 1
       maxSamplesPerSend: 10000
-      batchSendDeadline: 60s
+      batchSendDeadline: 30s
       minBackoff: 30ms
       maxBackoff: 256s
     metadataConfig:

--- a/observability/prometheus/deploy/templates/prometheus.yaml
+++ b/observability/prometheus/deploy/templates/prometheus.yaml
@@ -87,16 +87,27 @@ spec:
   topologySpreadConstraints:
   - labelSelector:
       matchLabels:
-        app: prometheus
+        app.kubernetes.io/name: prometheus-agent
+        operator.prometheus.io/name: prometheus
     maxSkew: 1
     topologyKey: '{{ if eq (int .Values.prometheusSpec.zoneCount) 0 }}kubernetes.azure.com/agentpool{{ else }}topology.kubernetes.io/zone{{ end }}'
     whenUnsatisfiable: ScheduleAnyway
   - labelSelector:
       matchLabels:
-        app: prometheus
+        app.kubernetes.io/name: prometheus-agent
+        operator.prometheus.io/name: prometheus
     maxSkew: 1
     topologyKey: kubernetes.io/hostname
     whenUnsatisfiable: ScheduleAnyway
+  - labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: prometheus-agent
+        operator.prometheus.io/name: prometheus
+    matchLabelKeys:
+    - operator.prometheus.io/shard
+    maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: DoNotSchedule
   walCompression: true
   externalLabels:
     cluster: '{{ .Values.prometheusSpec.externalLabels.cluster }}'

--- a/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_mgmt_resources.yaml
+++ b/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_mgmt_resources.yaml
@@ -68662,7 +68662,7 @@ spec:
       maxShards: 50
       minShards: 1
       maxSamplesPerSend: 10000
-      batchSendDeadline: 60s
+      batchSendDeadline: 30s
       minBackoff: 30ms
       maxBackoff: 256s
     metadataConfig:
@@ -68680,7 +68680,7 @@ spec:
       maxShards: 50
       minShards: 1
       maxSamplesPerSend: 10000
-      batchSendDeadline: 60s
+      batchSendDeadline: 30s
       minBackoff: 30ms
       maxBackoff: 256s
     metadataConfig:

--- a/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_mgmt_resources.yaml
+++ b/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_mgmt_resources.yaml
@@ -68626,16 +68626,27 @@ spec:
   topologySpreadConstraints:
   - labelSelector:
       matchLabels:
-        app: prometheus
+        app.kubernetes.io/name: prometheus-agent
+        operator.prometheus.io/name: prometheus
     maxSkew: 1
     topologyKey: 'topology.kubernetes.io/zone'
     whenUnsatisfiable: ScheduleAnyway
   - labelSelector:
       matchLabels:
-        app: prometheus
+        app.kubernetes.io/name: prometheus-agent
+        operator.prometheus.io/name: prometheus
     maxSkew: 1
     topologyKey: kubernetes.io/hostname
     whenUnsatisfiable: ScheduleAnyway
+  - labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: prometheus-agent
+        operator.prometheus.io/name: prometheus
+    matchLabelKeys:
+    - operator.prometheus.io/shard
+    maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: DoNotSchedule
   walCompression: true
   externalLabels:
     cluster: 'dev-westus3-mgmt-1'

--- a/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_mgmt_resources_unset.yaml
+++ b/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_mgmt_resources_unset.yaml
@@ -68656,7 +68656,7 @@ spec:
       maxShards: 50
       minShards: 1
       maxSamplesPerSend: 10000
-      batchSendDeadline: 60s
+      batchSendDeadline: 30s
       minBackoff: 30ms
       maxBackoff: 256s
     metadataConfig:
@@ -68674,7 +68674,7 @@ spec:
       maxShards: 50
       minShards: 1
       maxSamplesPerSend: 10000
-      batchSendDeadline: 60s
+      batchSendDeadline: 30s
       minBackoff: 30ms
       maxBackoff: 256s
     metadataConfig:

--- a/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_mgmt_resources_unset.yaml
+++ b/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_mgmt_resources_unset.yaml
@@ -68620,16 +68620,27 @@ spec:
   topologySpreadConstraints:
   - labelSelector:
       matchLabels:
-        app: prometheus
+        app.kubernetes.io/name: prometheus-agent
+        operator.prometheus.io/name: prometheus
     maxSkew: 1
     topologyKey: 'topology.kubernetes.io/zone'
     whenUnsatisfiable: ScheduleAnyway
   - labelSelector:
       matchLabels:
-        app: prometheus
+        app.kubernetes.io/name: prometheus-agent
+        operator.prometheus.io/name: prometheus
     maxSkew: 1
     topologyKey: kubernetes.io/hostname
     whenUnsatisfiable: ScheduleAnyway
+  - labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: prometheus-agent
+        operator.prometheus.io/name: prometheus
+    matchLabelKeys:
+    - operator.prometheus.io/shard
+    maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: DoNotSchedule
   walCompression: true
   externalLabels:
     cluster: 'dev-westus3-mgmt-1'

--- a/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_svc_resources.yaml
+++ b/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_svc_resources.yaml
@@ -68543,7 +68543,7 @@ spec:
       maxShards: 50
       minShards: 1
       maxSamplesPerSend: 10000
-      batchSendDeadline: 60s
+      batchSendDeadline: 30s
       minBackoff: 30ms
       maxBackoff: 256s
     metadataConfig:
@@ -68561,7 +68561,7 @@ spec:
       maxShards: 50
       minShards: 1
       maxSamplesPerSend: 10000
-      batchSendDeadline: 60s
+      batchSendDeadline: 30s
       minBackoff: 30ms
       maxBackoff: 256s
     metadataConfig:

--- a/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_svc_resources.yaml
+++ b/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_svc_resources.yaml
@@ -68507,16 +68507,27 @@ spec:
   topologySpreadConstraints:
   - labelSelector:
       matchLabels:
-        app: prometheus
+        app.kubernetes.io/name: prometheus-agent
+        operator.prometheus.io/name: prometheus
     maxSkew: 1
     topologyKey: 'topology.kubernetes.io/zone'
     whenUnsatisfiable: ScheduleAnyway
   - labelSelector:
       matchLabels:
-        app: prometheus
+        app.kubernetes.io/name: prometheus-agent
+        operator.prometheus.io/name: prometheus
     maxSkew: 1
     topologyKey: kubernetes.io/hostname
     whenUnsatisfiable: ScheduleAnyway
+  - labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: prometheus-agent
+        operator.prometheus.io/name: prometheus
+    matchLabelKeys:
+    - operator.prometheus.io/shard
+    maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: DoNotSchedule
   walCompression: true
   externalLabels:
     cluster: 'dev-westus3-svc-1'

--- a/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_svc_resources_unset.yaml
+++ b/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_svc_resources_unset.yaml
@@ -68501,16 +68501,27 @@ spec:
   topologySpreadConstraints:
   - labelSelector:
       matchLabels:
-        app: prometheus
+        app.kubernetes.io/name: prometheus-agent
+        operator.prometheus.io/name: prometheus
     maxSkew: 1
     topologyKey: 'topology.kubernetes.io/zone'
     whenUnsatisfiable: ScheduleAnyway
   - labelSelector:
       matchLabels:
-        app: prometheus
+        app.kubernetes.io/name: prometheus-agent
+        operator.prometheus.io/name: prometheus
     maxSkew: 1
     topologyKey: kubernetes.io/hostname
     whenUnsatisfiable: ScheduleAnyway
+  - labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: prometheus-agent
+        operator.prometheus.io/name: prometheus
+    matchLabelKeys:
+    - operator.prometheus.io/shard
+    maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: DoNotSchedule
   walCompression: true
   externalLabels:
     cluster: 'dev-westus3-svc-1'

--- a/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_svc_resources_unset.yaml
+++ b/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_svc_resources_unset.yaml
@@ -68537,7 +68537,7 @@ spec:
       maxShards: 50
       minShards: 1
       maxSamplesPerSend: 10000
-      batchSendDeadline: 60s
+      batchSendDeadline: 30s
       minBackoff: 30ms
       maxBackoff: 256s
     metadataConfig:
@@ -68555,7 +68555,7 @@ spec:
       maxShards: 50
       minShards: 1
       maxSamplesPerSend: 10000
-      batchSendDeadline: 60s
+      batchSendDeadline: 30s
       minBackoff: 30ms
       maxBackoff: 256s
     metadataConfig:


### PR DESCRIPTION
Related to [AROSLSRE-948](https://redhat.atlassian.net/browse/AROSLSRE-948), [AROSLSRE-1242](https://redhat.atlassian.net/browse/AROSLSRE-1242).

Two independent tuning changes to `observability/prometheus/deploy/templates/prometheus.yaml`. Applies to all envs via the shared template.

## 1. Topology spread

The existing `topologySpreadConstraints` used `labelSelector: {app: prometheus}` — a label the prometheus-operator does not apply to `PrometheusAgent` pods. The constraint matched zero pods and was a silent no-op.

- Correct the `labelSelector` on the two existing constraints to `app.kubernetes.io/name: prometheus-agent` + `operator.prometheus.io/name: prometheus` (the labels the operator actually sets).
- Add a third constraint with `matchLabelKeys: [operator.prometheus.io/shard]` and `whenUnsatisfiable: DoNotSchedule` on `kubernetes.io/hostname`, so two replicas of the *same* shard can never share a node. Pods from *different* shards can still share a node when capacity is tight.

**Why**: without a working per-shard hostname constraint, a single node MemoryPressure/OOM can take out both replicas of one shard at once, defeating `replicas: 2`.

## 2. Lower remote-write `batchSendDeadline` (`f09cd31ea`)

In both remote-write blocks: `batchSendDeadline: 60s → 30s`.

All other queue knobs (`capacity: 50000`, `maxShards: 50`, `minShards: 1`, `maxSamplesPerSend: 10000`, backoffs) are unchanged.

**Why**: [Prometheus remote-write docs](https://prometheus.io/docs/practices/remote_write/) frame `batchSendDeadline` as a knob that *"can be increased for low volume systems that are not latency sensitive in order to increase request efficiency."* Our workload (70+ tenants scraped every 30s per shard) is not low-volume, so 60s was pessimistic for our throughput — a remote-write goroutine could sit idle up to a full minute waiting for its outgoing batch to fill.

30s is a middle-ground between the Prometheus default (5s) and the current 60s: still generous for request-efficiency benefits during low-activity windows, but bounds per-shard tail-flush delay.

`capacity` at 50000 (5x `maxSamplesPerSend`) is unchanged — it sits in the middle of the docs' recommended 3–10x range and matches jboll's [AROSLSRE-948](https://redhat.atlassian.net/browse/AROSLSRE-948) tuning. No observable change to samples delivered; sender-side latency tune only.

## Testing

Regenerated helm fixtures with `UPDATE=true go test -run TestHelmTemplate -count=1 ./tooling/helmtest/...`; diffs match the source template.