### PR TITLE
feat: option to use latest ACR images for personal-dev-env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -447,10 +447,36 @@ record-services-override: $(YQ) $(ORAS)
 .PHONY: record-services-override
 
 #
+# Query ACR for the latest image digest of each service (no build/push)
+#
+latest-services-override: $(YQ)
+	$(MAKE) -C frontend record-latest-override OVERRIDE_CONFIG_FILE=/tmp/_frontend-override.yaml
+	$(MAKE) -C backend record-latest-override OVERRIDE_CONFIG_FILE=/tmp/_backend-override.yaml
+	$(MAKE) -C admin record-latest-override OVERRIDE_CONFIG_FILE=/tmp/_admin-override.yaml
+	$(MAKE) -C sessiongate record-latest-override OVERRIDE_CONFIG_FILE=/tmp/_sessiongate-override.yaml
+	$(MAKE) -C mgmt-agent record-latest-override OVERRIDE_CONFIG_FILE=/tmp/_mgmt-agent-override.yaml
+	$(MAKE) -C kube-applier record-latest-override OVERRIDE_CONFIG_FILE=/tmp/_kube-applier-override.yaml
+	$(MAKE) -C fleet record-latest-override OVERRIDE_CONFIG_FILE=/tmp/_fleet-override.yaml
+	$(YQ) eval-all '. as $$item ireduce ({}; . * $$item)' \
+	  /tmp/_frontend-override.yaml \
+	  /tmp/_backend-override.yaml \
+	  /tmp/_admin-override.yaml \
+	  /tmp/_sessiongate-override.yaml \
+	  /tmp/_mgmt-agent-override.yaml \
+	  /tmp/_kube-applier-override.yaml \
+	  /tmp/_fleet-override.yaml \
+	  > $(PERS_OVERRIDE_FILE)
+.PHONY: latest-services-override
+
+#
 # One-Step Personal Dev Environment
 #
 ifeq ($(DEPLOY_ENV),$(filter $(DEPLOY_ENV),pers swft))
+ifdef USE_LATEST_IMAGES
+personal-dev-env: latest-services-override install-tools
+else
 personal-dev-env: build-services record-services-override install-tools
+endif
 	$(MAKE) entrypoint/Region OVERRIDE_CONFIG_FILE=$(PERS_OVERRIDE_FILE)
 	$(MAKE) infra.svc.aks.kubeconfig infra.mgmt.aks.kubeconfig infra.tracing infra.cosmos.access
 else

--- a/admin/Makefile
+++ b/admin/Makefile
@@ -100,6 +100,13 @@ record-override: $(YQ) $(ORAS)
 	" > $(OVERRIDE_CONFIG_FILE)
 .PHONY: record-override
 
+record-latest-override: $(YQ)
+	@../hack/record-latest-image-override.sh \
+		"$(ARO_HCP_IMAGE_ACR)" "$(ARO_HCP_IMAGE_REGISTRY)" \
+		"$(ADMIN_API_GENERATED_IMAGE_REPOSITORY)" "$(DEPLOY_ENV)" \
+		"adminApi" "$(OVERRIDE_CONFIG_FILE)" "$(YQ)"
+.PHONY: record-latest-override
+
 deploy: build-and-push record-override
 	make -C .. pipeline/AdminAPI OVERRIDE_CONFIG_FILE=$(OVERRIDE_CONFIG_FILE)
 .PHONY: deploy

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -82,6 +82,13 @@ record-override: $(YQ) $(ORAS)
 	" > $(OVERRIDE_CONFIG_FILE)
 .PHONY: record-override
 
+record-latest-override: $(YQ)
+	@../hack/record-latest-image-override.sh \
+		"$(ARO_HCP_IMAGE_ACR)" "$(ARO_HCP_IMAGE_REGISTRY)" \
+		"$(BACKEND_GENERATED_IMAGE_REPOSITORY)" "$(DEPLOY_ENV)" \
+		"backend" "$(OVERRIDE_CONFIG_FILE)" "$(YQ)"
+.PHONY: record-latest-override
+
 deploy: build-and-push record-override
 	make -C .. pipeline/RP.Backend OVERRIDE_CONFIG_FILE=$(OVERRIDE_CONFIG_FILE)
 .PHONY: deploy

--- a/fleet/Makefile
+++ b/fleet/Makefile
@@ -64,3 +64,10 @@ record-override: $(YQ) $(ORAS)
 		.clouds.dev.environments.$(DEPLOY_ENV).defaults.fleet.image.digest = \"$$DIGEST\" \
 	" > $(OVERRIDE_CONFIG_FILE)
 .PHONY: record-override
+
+record-latest-override: $(YQ)
+	@../hack/record-latest-image-override.sh \
+		"$(ARO_HCP_IMAGE_ACR)" "$(ARO_HCP_IMAGE_REGISTRY)" \
+		"$(FLEET_GENERATED_IMAGE_REPOSITORY)" "$(DEPLOY_ENV)" \
+		"fleet" "$(OVERRIDE_CONFIG_FILE)" "$(YQ)"
+.PHONY: record-latest-override

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -82,6 +82,13 @@ record-override: $(YQ) $(ORAS)
 	" > $(OVERRIDE_CONFIG_FILE)
 .PHONY: record-override
 
+record-latest-override: $(YQ)
+	@../hack/record-latest-image-override.sh \
+		"$(ARO_HCP_IMAGE_ACR)" "$(ARO_HCP_IMAGE_REGISTRY)" \
+		"$(FRONTEND_GENERATED_IMAGE_REPOSITORY)" "$(DEPLOY_ENV)" \
+		"frontend" "$(OVERRIDE_CONFIG_FILE)" "$(YQ)"
+.PHONY: record-latest-override
+
 deploy: build-and-push record-override
 	make -C .. pipeline/RP.Frontend OVERRIDE_CONFIG_FILE=$(OVERRIDE_CONFIG_FILE)
 .PHONY: deploy

--- a/hack/record-latest-image-override.sh
+++ b/hack/record-latest-image-override.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# Queries ACR for the latest image digest in a repository and writes
+# a config override YAML file suitable for personal-dev-env deployments.
+#
+# Usage: record-latest-image-override.sh \
+#          <acr-name> <registry> <repository> <deploy-env> <config-key> <output-file> <yq>
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [[ $# -ne 7 ]]; then
+    echo "Usage: $0 <acr-name> <registry> <repository> <deploy-env> <config-key> <output-file> <yq>" >&2
+    exit 1
+fi
+
+ACR_NAME=$1
+REGISTRY=$2
+REPOSITORY=$3
+DEPLOY_ENV=$4
+CONFIG_KEY=$5
+OUTPUT_FILE=$6
+YQ=$7
+
+DIGEST=$(az acr manifest list-metadata \
+    --registry "$ACR_NAME" \
+    --name "$REPOSITORY" \
+    --orderby time_desc --top 1 \
+    --query '[0].digest' -o tsv)
+
+if [[ -z "$DIGEST" ]]; then
+    echo "Error: no images found for ${REPOSITORY} in ${ACR_NAME}" >&2
+    exit 1
+fi
+
+$YQ eval -n "
+    .clouds.dev.environments.${DEPLOY_ENV}.defaults.${CONFIG_KEY}.image.registry = \"${REGISTRY}\" |
+    .clouds.dev.environments.${DEPLOY_ENV}.defaults.${CONFIG_KEY}.image.repository = \"${REPOSITORY}\" |
+    .clouds.dev.environments.${DEPLOY_ENV}.defaults.${CONFIG_KEY}.image.digest = \"${DIGEST}\"
+" > "$OUTPUT_FILE"
+
+echo "Using latest image for ${CONFIG_KEY}: ${REGISTRY}/${REPOSITORY}@${DIGEST}"

--- a/kube-applier/Makefile
+++ b/kube-applier/Makefile
@@ -72,6 +72,13 @@ record-override: $(YQ) $(ORAS)
 	" > $(OVERRIDE_CONFIG_FILE)
 .PHONY: record-override
 
+record-latest-override: $(YQ)
+	@../hack/record-latest-image-override.sh \
+		"$(ARO_HCP_IMAGE_ACR)" "$(ARO_HCP_IMAGE_REGISTRY)" \
+		"$(KUBE_APPLIER_GENERATED_IMAGE_REPOSITORY)" "$(DEPLOY_ENV)" \
+		"kubeApplier" "$(OVERRIDE_CONFIG_FILE)" "$(YQ)"
+.PHONY: record-latest-override
+
 deploy: build-and-push record-override
 	make -C .. pipeline/KubeApplier OVERRIDE_CONFIG_FILE=$(OVERRIDE_CONFIG_FILE)
 .PHONY: deploy

--- a/mgmt-agent/Makefile
+++ b/mgmt-agent/Makefile
@@ -73,6 +73,13 @@ record-override: $(YQ) $(ORAS)
 
 # Dev work
 
+record-latest-override: $(YQ)
+	@../hack/record-latest-image-override.sh \
+		"$(ARO_HCP_IMAGE_ACR)" "$(ARO_HCP_IMAGE_REGISTRY)" \
+		"$(MGMT_AGENT_GENERATED_IMAGE_REPOSITORY)" "$(DEPLOY_ENV)" \
+		"mgmtAgent" "$(OVERRIDE_CONFIG_FILE)" "$(YQ)"
+.PHONY: record-latest-override
+
 deploy: build-and-push record-override
 	make -C .. pipeline/Microsoft.Azure.ARO.HCP.MgmtAgent OVERRIDE_CONFIG_FILE=$(OVERRIDE_CONFIG_FILE)
 .PHONY: deploy

--- a/sessiongate/Makefile
+++ b/sessiongate/Makefile
@@ -85,6 +85,13 @@ record-override: $(YQ) $(ORAS)
 
 # Dev work
 
+record-latest-override: $(YQ)
+	@../hack/record-latest-image-override.sh \
+		"$(ARO_HCP_IMAGE_ACR)" "$(ARO_HCP_IMAGE_REGISTRY)" \
+		"$(SESSION_GATE_GENERATED_IMAGE_REPOSITORY)" "$(DEPLOY_ENV)" \
+		"sessiongate" "$(OVERRIDE_CONFIG_FILE)" "$(YQ)"
+.PHONY: record-latest-override
+
 deploy: build-and-push record-override
 	make -C .. pipeline/SessionGate OVERRIDE_CONFIG_FILE=$(OVERRIDE_CONFIG_FILE)
 .PHONY: deploy


### PR DESCRIPTION
Adds USE_LATEST_IMAGES flag to skip building and pushing service images during personal-dev-env deployment. Instead, each service queries ACR for the latest digest found in its image repository and uses that for the deployment.

Usage:

  USE_LATEST_IMAGES=1 DEPLOY_ENV=pers make personal-dev-env

⚠️  The latest image in ACR may be newer than the currently checked out infrastructure and Helm chart code, which can cause deployment mismatches. This is best suited for quick infrastructure testing where the actual service components are not the focus and failures are acceptable.

<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

### Why

<!-- Briefly explain why this change is needed -->

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
