### PR TITLE
chore: aling ci mgmt cluster sizing with provision script

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1662,12 +1662,12 @@ clouds:
                 vmSize: Standard_D4ds_v6
               userAgentPool:
                 maxCount: 14
-                minCount: 3
+                minCount: 5
                 osDiskSizeGB: 100
-                vmSize: Standard_D16ds_v6
+                vmSize: Standard_E16ds_v6
                 secondaryNicCount: 7
               infraAgentPool:
-                vmSize: Standard_D4ds_v6
+                vmSize: Standard_D8ds_v6
                 osDiskSizeGB: 64
               enableSwiftV2Nodepools: true
               enableSwiftV2Vnet: true
@@ -1761,12 +1761,12 @@ clouds:
                 vmSize: Standard_D4ds_v6
               userAgentPool:
                 maxCount: 14
-                minCount: 3
+                minCount: 5
                 osDiskSizeGB: 100
-                vmSize: Standard_D16ds_v6
+                vmSize: Standard_E16ds_v6
                 secondaryNicCount: 7
               infraAgentPool:
-                vmSize: Standard_D4ds_v6
+                vmSize: Standard_D8ds_v6
                 osDiskSizeGB: 64
               enableSwiftV2Nodepools: true
               enableSwiftV2Vnet: true

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -602,7 +602,7 @@ mgmt:
       name: infra
       osDiskSizeGB: 64
       poolCount: 2
-      vmSize: Standard_D4ds_v6
+      vmSize: Standard_D8ds_v6
       zoneRedundantMode: Auto
       zones: ""
     kubernetesVersion: "1.35"
@@ -622,12 +622,12 @@ mgmt:
       zones: ""
     userAgentPool:
       maxCount: 14
-      minCount: 3
+      minCount: 5
       name: userswft
       osDiskSizeGB: 100
       poolCount: 3
       secondaryNicCount: 7
-      vmSize: Standard_D16ds_v6
+      vmSize: Standard_E16ds_v6
       zoneRedundantMode: Auto
       zones: ""
     vnetAddressPrefix: 10.128.0.0/14

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -602,7 +602,7 @@ mgmt:
       name: infra
       osDiskSizeGB: 64
       poolCount: 2
-      vmSize: Standard_D4ds_v6
+      vmSize: Standard_D8ds_v6
       zoneRedundantMode: Auto
       zones: ""
     kubernetesVersion: "1.35"
@@ -622,12 +622,12 @@ mgmt:
       zones: ""
     userAgentPool:
       maxCount: 14
-      minCount: 3
+      minCount: 5
       name: userswft
       osDiskSizeGB: 100
       poolCount: 3
       secondaryNicCount: 7
-      vmSize: Standard_D16ds_v6
+      vmSize: Standard_E16ds_v6
       zoneRedundantMode: Auto
       zones: ""
     vnetAddressPrefix: 10.128.0.0/14


### PR DESCRIPTION
[This](https://github.com/openshift/release/blob/30ca9730b6f4e3b5f8b00ef16e31aa2772863f44/ci-operator/step-registry/aro-hcp/provision/environment/aro-hcp-provision-environment-commands.sh#L135-L137) override was set to reollout single-wave e2e. This PR sets those values in the config so the override can be removed.

https://redhat.atlassian.net/browse/ARO-27792
