### PR TITLE
fix(maestro): wire liveness/readiness/startup probes on maestro-agent (AROSLSRE-1115)

### DIFF
--- a/maestro/agent/deploy/templates/maestro-agent.deployment.yaml
+++ b/maestro/agent/deploy/templates/maestro-agent.deployment.yaml
@@ -81,6 +81,30 @@ spec:
         - mountPath: /secrets/mqtt-creds
           name: mqtt-creds
           readOnly: true
+        # The agent is the OCM work spoke binary, which serves /healthz over HTTPS
+        # on port 8443 (library-go controllercmd serving). A stuck agent stops
+        # passing this check and is restarted instead of sitting silently broken.
+        startupProbe:
+          httpGet:
+            path: /healthz
+            scheme: HTTPS
+            port: 8443
+          periodSeconds: 10
+          failureThreshold: 30
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            scheme: HTTPS
+            port: 8443
+          initialDelaySeconds: 2
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            scheme: HTTPS
+            port: 8443
+          initialDelaySeconds: 2
+          periodSeconds: 10
       serviceAccountName: '{{ .Values.serviceAccountName }}'
       affinity:
         nodeAffinity:

--- a/maestro/agent/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_maestro_agent.yaml
+++ b/maestro/agent/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_maestro_agent.yaml
@@ -360,6 +360,30 @@ spec:
         - mountPath: /secrets/mqtt-creds
           name: mqtt-creds
           readOnly: true
+        # The agent is the OCM work spoke binary, which serves /healthz over HTTPS
+        # on port 8443 (library-go controllercmd serving). A stuck agent stops
+        # passing this check and is restarted instead of sitting silently broken.
+        startupProbe:
+          httpGet:
+            path: /healthz
+            scheme: HTTPS
+            port: 8443
+          periodSeconds: 10
+          failureThreshold: 30
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            scheme: HTTPS
+            port: 8443
+          initialDelaySeconds: 2
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            scheme: HTTPS
+            port: 8443
+          initialDelaySeconds: 2
+          periodSeconds: 10
       serviceAccountName: 'maestro'
       affinity:
         nodeAffinity:


### PR DESCRIPTION
<!-- [AROSLSRE-1115](https://redhat.atlassian.net/browse/AROSLSRE-1115) -->

### What

Adds `startupProbe`, `livenessProbe` and `readinessProbe` to the `maestro-agent` primary container. All three hit `/healthz` over HTTPS on port `8443`:

- `startupProbe`: `periodSeconds: 10`, `failureThreshold: 30` (tolerates up to ~5m of slow bring-up before liveness/readiness kick in).
- `livenessProbe` and `readinessProbe`: `initialDelaySeconds: 2`, `periodSeconds: 10`.

Regenerates the Helm golden fixture.

### Why

The `maestro-agent` container previously had **no probes at all** (`L=- R=- S=-`), so a stuck agent stayed `Running` but silently broken instead of being restarted or pulled from rotation ([AROSLSRE-1115](https://redhat.atlassian.net/browse/AROSLSRE-1115), under epic [AROSLSRE-1109](https://redhat.atlassian.net/browse/AROSLSRE-1109) "Ensure all ARO-HCP components expose health endpoints and wire probes").

The agent is the OCM work spoke binary (`maestro agent` -> `open-cluster-management.io/ocm/pkg/work/spoke`), which serves `/healthz` over HTTPS on `8443` via the library-go controllercmd serving. This is the exact endpoint the upstream OCM klusterlet work agent probes, so no code or new flag is required.

### Testing

- `make -C tooling/helmtest update && make -C tooling/helmtest test` -> green; the only fixture delta is the new probe block on `maestro-agent`.
- Endpoint/port confirmed against upstream `open-cluster-management-io/ocm` `manifests/klusterlet/management/klusterlet-work-deployment.yaml`, which probes `/healthz` HTTPS `8443` on the same binary.

### Special notes for your reviewer

Server-side hardening (maestro-server `/livez`, HA, PDB, alerts) landed separately in #5642 ([AROSLSRE-1170](https://redhat.atlassian.net/browse/AROSLSRE-1170)). This PR is the agent-side probes only. The `startupProbe` deliberately relies on `failureThreshold` rather than `initialDelaySeconds` to gate startup; once it succeeds, kubelet begins liveness/readiness.

### PR Checklist

- [x] Helm golden fixtures regenerated and passing
- [x] No config schema changes
- [x] Jira issue linked
