### PR TITLE
fix(config): set grafanaZoneRedundantMode for public clouds (AROSLSRE-1379)

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -368,6 +368,10 @@ defaults:
   # Monitoring
   monitoring:
     grafanaName: "arohcp-{{ .ctx.environment }}"
+    # Zone redundancy for the managed Grafana instance. Consumed by the
+    # GrafanaManage pipeline step, whose schema only accepts Enabled/Disabled.
+    # Default matches Azure's default and the existing instances; dev overrides it.
+    grafanaZoneRedundantMode: Disabled
     # Format:
     #   Multiline string using '>-' YAML block scalar
     #   One item per line, formatted as: UUID/PrincipalType/RoleName


### PR DESCRIPTION
[AROSLSRE-1379](https://redhat.atlassian.net/browse/AROSLSRE-1379)

### What

Adds `grafanaZoneRedundantMode: Disabled` to the base `defaults.monitoring` block in `config/config.yaml`, alongside the existing `grafanaName`.

### Why

The `GrafanaManage` step in `dev-infrastructure/global-pipeline.yaml` renders `zoneRedundancy: "{{ .monitoring.grafanaZoneRedundantMode }}"`. `monitoring.grafanaZoneRedundantMode` is a **required** config field, but only the dev-cloud block defined it — the base defaults never did. For public clouds (int/stg/prod) the value was absent, rendered to an empty string, and failed EV2 pipeline-schema validation downstream in sdp-pipelines:

```text
at '/resourceGroups/0/steps/1/zoneRedundancy': value must be one of 'Enabled', 'Disabled'
```

This surfaced in sdp-pipelines build 170669006. The step was re-enabled in `448930dc8` ("Re-enable grafana with refactoring"); while grafana pipeline steps were disabled the missing base value was dormant. ARO-HCP CI only validates dev/pers rendered configs (which have the value via the dev override), so the gap only appears in the public int/stg/prod EV2 generation.

`Disabled` matches the dev override, Azure Managed Grafana's default, and the existing grandfathered instances. Zone redundancy is immutable at creation, so a mismatched value would risk a reconcile conflict.

### Testing

Config-only change; validated by rendering and materialization:

- Rendered the msft `int` config locally (`templatize configuration render ... --cloud public --environment int`) and confirmed `monitoring.grafanaZoneRedundantMode: Disabled` now resolves (was previously absent).
- `make -C config materialize` produces no change to dev/pers rendered outputs (dev already overrides to `Disabled`), confirming the base default is consistent.
- Confirmed the failing pipeline step (`global-pipeline.yaml` line 48) now resolves `zoneRedundancy: Disabled` instead of an empty string.

### Special notes for your reviewer

- `monitoring.grafanaMajorVersion` is also empty for public clouds but is **optional** in the schema, so it does not block validation and is out of scope here.
- No zone-redundancy policy change (e.g. HA `Enabled` for prod) is made — that can be a follow-up if desired.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
