### PR TITLE
fix(swift-vnet): reland #5834 with shellIdentity on mgmt Shell steps (ARO-28045)

### DIFF
--- a/dev-infrastructure/configurations/swift-vnet-permissions.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/swift-vnet-permissions.tmpl.bicepparam
@@ -1,0 +1,4 @@
+using '../templates/swift-vnet-permissions.bicep'
+
+param deploymentMsiId = '__deploymentMsiId__'
+param enableSwift = {{ .mgmt.aks.enableSwiftV2Vnet }}

--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -222,6 +222,11 @@ resourceGroups:
     action: Shell
     command: ./swift-vnet.sh
     workingDir: ./scripts
+    shellIdentity:
+      input:
+        resourceGroup: global
+        step: output
+        name: globalMSIId
     variables:
     - name: ENABLE_SWIFT
       configRef: mgmt.aks.enableSwiftV2Vnet

--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -194,6 +194,56 @@ resourceGroups:
     issuer:
       value: OneCertV2-PublicCA
   # Build the MC
+  # The swift-vnet-permissions step runs unconditionally so the EV2 step graph is
+  # stable, but the Swift VNet RBAC grant inside it is gated at the Bicep layer via
+  # the enableSwift bicepparam (mgmt.aks.enableSwiftV2Vnet). A pipeline-level Go
+  # template guard would not work here: EV2 manifest generation renders pipeline
+  # config values as placeholders, so the guard would always evaluate truthy.
+  - name: swift-vnet-permissions
+    action: ARM
+    template: templates/swift-vnet-permissions.bicep
+    parameters: configurations/swift-vnet-permissions.tmpl.bicepparam
+    deploymentLevel: ResourceGroup
+    variables:
+    - name: deploymentMsiId
+      input:
+        resourceGroup: global
+        step: output
+        name: globalMSIId
+    dependsOn:
+    - resourceGroup: management
+      step: subscription-output
+  # Create/tag the Swift VNet. The tag stampcreatorserviceinfo=true must be written by the
+  # Swift-registered globalMSI, so this step launches a container group assigned globalMSI and
+  # runs the create/tag AS globalMSI from inside it (scripts/swift-vnet.sh). Create, wait, log
+  # and cleanup all happen in this single Shell step, so there is no cross-step async race. The
+  # script is a no-op when ENABLE_SWIFT is false, keeping the EV2 step graph stable.
+  - name: swift-vnet
+    action: Shell
+    command: ./swift-vnet.sh
+    workingDir: ./scripts
+    variables:
+    - name: ENABLE_SWIFT
+      configRef: mgmt.aks.enableSwiftV2Vnet
+    - name: VNET_NAME
+      value: aks-net
+    - name: VNET_ADDRESS_PREFIX
+      configRef: mgmt.aks.vnetAddressPrefix
+    - name: RESOURCE_GROUP
+      configRef: mgmt.rg
+    - name: SUBSCRIPTION_ID
+      input:
+        resourceGroup: management
+        step: subscription-output
+        name: subscriptionId
+    - name: DEPLOYMENT_MSI_ID
+      input:
+        resourceGroup: global
+        step: output
+        name: globalMSIId
+    dependsOn:
+    - resourceGroup: management
+      step: swift-vnet-permissions
   - name: cluster
     action: ARM
     template: templates/mgmt-cluster.bicep
@@ -247,6 +297,8 @@ resourceGroups:
       step: oncert-private-kv-issuer
     - resourceGroup: management
       step: oncert-public-kv-issuer
+    - resourceGroup: management
+      step: swift-vnet
     automatedRetry:
       errorContainsAny:
       - "DeploymentScriptACIProvisioningTimeout"

--- a/dev-infrastructure/mgmt-solo-pipeline.yaml
+++ b/dev-infrastructure/mgmt-solo-pipeline.yaml
@@ -36,6 +36,12 @@ resourceGroups:
   resourceGroup: '{{ .mgmt.rg }}'
   subscription: '{{ .mgmt.subscription.key }}'
   steps:
+  - name: subscription-output
+    action: ARM
+    template: templates/subscription-lookup.bicep
+    parameters: configurations/subscription-lookup.tmpl.bicepparam
+    deploymentLevel: ResourceGroup
+    outputOnly: true
   - name: infra
     action: ARM
     template: templates/mgmt-infra.bicep
@@ -46,6 +52,54 @@ resourceGroups:
       # we don't need to grant KV permissions to CS as there is no CS in the MC solo deployment
       value: "-"
   # Build the MC
+  # The swift-vnet-permissions and swift-vnet steps run unconditionally so the step graph is
+  # static (EV2 does not support Go-template {{ if }} guards - they render at generation time
+  # and would always evaluate truthy). Swift is gated instead at the Bicep layer (enableSwift
+  # param) and at the script layer (ENABLE_SWIFT), which both resolve to the real per-env value.
+  - name: swift-vnet-permissions
+    action: ARM
+    template: templates/swift-vnet-permissions.bicep
+    parameters: configurations/swift-vnet-permissions.tmpl.bicepparam
+    deploymentLevel: ResourceGroup
+    variables:
+    - name: deploymentMsiId
+      input:
+        resourceGroup: global
+        step: output
+        name: globalMSIId
+    dependsOn:
+    - resourceGroup: management
+      step: subscription-output
+  # Create/tag the Swift VNet via a container group assigned globalMSI (scripts/swift-vnet.sh).
+  # Create, wait, log and cleanup happen in this single Shell step, so there is no cross-step
+  # async race; the VNet write itself is performed by globalMSI from inside the container. The
+  # script is a no-op when ENABLE_SWIFT is false, keeping the step graph stable.
+  - name: swift-vnet
+    action: Shell
+    command: ./swift-vnet.sh
+    workingDir: ./scripts
+    variables:
+    - name: ENABLE_SWIFT
+      configRef: mgmt.aks.enableSwiftV2Vnet
+    - name: VNET_NAME
+      value: aks-net
+    - name: VNET_ADDRESS_PREFIX
+      configRef: mgmt.aks.vnetAddressPrefix
+    - name: RESOURCE_GROUP
+      configRef: mgmt.rg
+    - name: SUBSCRIPTION_ID
+      input:
+        resourceGroup: management
+        step: subscription-output
+        name: subscriptionId
+    - name: DEPLOYMENT_MSI_ID
+      input:
+        resourceGroup: global
+        step: output
+        name: globalMSIId
+    dependsOn:
+    - resourceGroup: management
+      step: swift-vnet-permissions
   - name: cluster
     action: ARM
     template: templates/mgmt-cluster.bicep
@@ -62,6 +116,11 @@ resourceGroups:
         resourceGroup: global
         step: output
         name: svcAcrResourceId
+    - name: globalMSIId
+      input:
+        resourceGroup: global
+        step: output
+        name: globalMSIId
     - name: azureMonitoringWorkspaceId
       input:
         resourceGroup: regional
@@ -75,6 +134,8 @@ resourceGroups:
     dependsOn:
     - resourceGroup: management
       step: infra
+    - resourceGroup: management
+      step: swift-vnet
   # Install ACRpull
   - name: acrpull
     aksCluster: '{{ .mgmt.aks.name }}'

--- a/dev-infrastructure/mgmt-solo-pipeline.yaml
+++ b/dev-infrastructure/mgmt-solo-pipeline.yaml
@@ -78,6 +78,11 @@ resourceGroups:
     action: Shell
     command: ./swift-vnet.sh
     workingDir: ./scripts
+    shellIdentity:
+      input:
+        resourceGroup: global
+        step: output
+        name: globalMSIId
     variables:
     - name: ENABLE_SWIFT
       configRef: mgmt.aks.enableSwiftV2Vnet
@@ -168,6 +173,11 @@ resourceGroups:
     aksCluster: '{{ .mgmt.aks.name }}'
     action: Shell
     command: make -C ../mgmt-fixes deploy
+    shellIdentity:
+      input:
+        resourceGroup: global
+        step: output
+        name: globalMSIId
     variables:
     - name: APPLY_KUBELET_FIXES
       configRef: mgmt.applyKubeletFixes

--- a/dev-infrastructure/modules/network/vnet-rbac.bicep
+++ b/dev-infrastructure/modules/network/vnet-rbac.bicep
@@ -1,0 +1,36 @@
+@description('The resource ID of the user-assigned managed identity that manages the VNet')
+param deploymentMsiId string
+
+// Network Contributor Role
+// https://www.azadvertizer.net/azrolesadvertizer/4d97b98b-1d4f-4787-a291-c67834d212e7.html
+var networkContributorRoleId = subscriptionResourceId(
+  'Microsoft.Authorization/roleDefinitions/',
+  '4d97b98b-1d4f-4787-a291-c67834d212e7'
+)
+
+// Tag Contributor Role
+// https://www.azadvertizer.net/azrolesadvertizer/4a9ae827-6dc8-4573-8ac7-8239d42aa03f.html
+var tagContributorRoleId = subscriptionResourceId(
+  'Microsoft.Authorization/roleDefinitions/',
+  '4a9ae827-6dc8-4573-8ac7-8239d42aa03f'
+)
+
+resource deploymentMsiNetworkContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  scope: resourceGroup()
+  name: guid(deploymentMsiId, networkContributorRoleId, resourceGroup().id)
+  properties: {
+    roleDefinitionId: networkContributorRoleId
+    principalId: reference(deploymentMsiId, '2023-01-31').principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource deploymentMsiTagContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  scope: resourceGroup()
+  name: guid(deploymentMsiId, tagContributorRoleId, resourceGroup().id)
+  properties: {
+    roleDefinitionId: tagContributorRoleId
+    principalId: reference(deploymentMsiId, '2023-01-31').principalId
+    principalType: 'ServicePrincipal'
+  }
+}

--- a/dev-infrastructure/modules/network/vnet.bicep
+++ b/dev-infrastructure/modules/network/vnet.bicep
@@ -9,29 +9,6 @@ param enableSwift bool
 @description('The address space for the VNET')
 param vnetAddressPrefix string
 
-@description('The resource ID of the user-assigned managed identity that will be used to execute the script')
-param deploymentMsiId string
-
-// Network Contributor Role
-// https://www.azadvertizer.net/azrolesadvertizer/4d97b98b-1d4f-4787-a291-c67834d212e7.html
-var networkContributorRoleId = subscriptionResourceId(
-  'Microsoft.Authorization/roleDefinitions/',
-  '4d97b98b-1d4f-4787-a291-c67834d212e7'
-)
-
-// Tag Contributor Role
-// https://www.azadvertizer.net/azrolesadvertizer/4a9ae827-6dc8-4573-8ac7-8239d42aa03f.html
-var tagContributorRoleId = subscriptionResourceId(
-  'Microsoft.Authorization/roleDefinitions/',
-  '4a9ae827-6dc8-4573-8ac7-8239d42aa03f'
-)
-
-// Enabling a VNET for Swift is a matter of placing the stampcreatorserviceinfo=true tag on it.
-// The tagging itself needs to be done by an identity that is registered with the Network/Swift RP.
-// All bicep code deployed via EV2 is executed by an EV2 identity that is not and cannot be registered
-// for Swift usage. Hence we use a deployment script for the tagging where we are in control of the
-// identity used to execute the script and tag the VNET.
-
 //
 //  D E P L O Y   V N E T   W I T H O U T   S W I F T
 //
@@ -53,119 +30,15 @@ resource vnet 'Microsoft.Network/virtualNetworks@2024-05-01' = if (!enableSwift)
 //  D E P L O Y   V N E T   W I T H   S W I F T
 //
 
-// for swift deployments we use a deployment script to create the VNET or just
-// tag it when it already exists. The identity used for this needs to be registered
-// for swift usage with the network RP.
-
-resource deploymentMsiNetworkContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  scope: resourceGroup()
-  name: guid(deploymentMsiId, networkContributorRoleId, resourceGroup().id)
-  properties: {
-    roleDefinitionId: networkContributorRoleId
-    principalId: reference(deploymentMsiId, '2023-01-31').principalId
-    principalType: 'ServicePrincipal'
-  }
-}
-
-resource deploymentMsiTagContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  scope: resourceGroup()
-  name: guid(deploymentMsiId, tagContributorRoleId, resourceGroup().id)
-  properties: {
-    roleDefinitionId: tagContributorRoleId
-    principalId: reference(deploymentMsiId, '2023-01-31').principalId
-    principalType: 'ServicePrincipal'
-  }
-}
-
-resource vnetWithSwiftDeployment 'Microsoft.Resources/deploymentScripts@2020-10-01' = if (enableSwift) {
-  name: 'vnet-${vnetName}'
-  location: location
-  identity: {
-    type: 'UserAssigned'
-    userAssignedIdentities: {
-      '${deploymentMsiId}': {}
-    }
-  }
-  kind: 'AzureCLI'
-  properties: {
-    azCliVersion: '2.53.1'
-    scriptContent: '''
-      set -euo pipefail
-      az account set --subscription "${VNET_SUBSCRIPTION_ID}"
-
-      # The deployment MSI's Network/Tag Contributor role assignments are created in
-      # this same deployment. Azure RBAC is eventually consistent, so the first write
-      # can fail with AuthorizationFailed ("if access was recently granted, please
-      # refresh your credentials") before the assignment propagates to the data plane.
-      # Retry the write to absorb that lag during RBAC propagation.
-      MAX_WAIT=120
-      POLL_INTERVAL=5
-
-      retry() {
-        local start=${SECONDS}
-        until "$@"; do
-          if [ $((SECONDS - start)) -ge "${MAX_WAIT}" ]; then
-            echo "✗ '$*' still failing after $((SECONDS - start))s" >&2
-            return 1
-          fi
-          echo "Command failed (likely RBAC propagation); retrying in ${POLL_INTERVAL}s..." >&2
-          sleep "${POLL_INTERVAL}"
-        done
-      }
-
-      if az network vnet show \
-        --resource-group "${VNET_RG}" \
-        --name "${VNET_NAME}" \
-        --output none 2>/dev/null; then
-        echo "VNet exists. Updating tags..."
-        retry az resource tag \
-          --tags stampcreatorserviceinfo=true \
-          --resource-group "${VNET_RG}" \
-          --name "${VNET_NAME}" \
-          --resource-type Microsoft.Network/virtualnetworks \
-          --api-version 2024-05-01
-      else
-        echo "VNet does not exist or not yet authorized. Creating..."
-        retry az network vnet create \
-          --resource-group "${VNET_RG}" \
-          --name "${VNET_NAME}" \
-          --address-prefixes "${VNET_ADDRESS_PREFIX}" \
-          --tags stampcreatorserviceinfo=true
-      fi
-    '''
-    timeout: 'PT10M'
-    cleanupPreference: 'OnSuccess'
-    retentionInterval: 'P1D'
-    environmentVariables: [
-      {
-        name: 'VNET_NAME'
-        value: vnetName
-      }
-      {
-        name: 'VNET_RG'
-        value: resourceGroup().name
-      }
-      {
-        name: 'VNET_SUBSCRIPTION_ID'
-        value: subscription().subscriptionId
-      }
-      {
-        name: 'VNET_ADDRESS_PREFIX'
-        value: vnetAddressPrefix
-      }
-    ]
-  }
-  dependsOn: [
-    deploymentMsiNetworkContributorRoleAssignment
-    deploymentMsiTagContributorRoleAssignment
-  ]
-}
+// For Swift, the VNet is created and tagged (stampcreatorserviceinfo=true) by a managed-identity
+// container group (launched by scripts/swift-vnet.sh) that runs AS the Swift-registered identity,
+// since that write must come from an identity registered for Swift usage with the network RP. The
+// RBAC that identity needs is granted by the dedicated swift-vnet-permissions pipeline step (see
+// templates/swift-vnet-permissions.bicep), which completes before the container runs. This module
+// only declares the VNet as existing because the container (not this module) creates it.
 
 resource provisionedSwiftVnet 'Microsoft.Network/virtualNetworks@2024-05-01' existing = if (enableSwift) {
   name: vnetName
-  dependsOn: [
-    vnetWithSwiftDeployment
-  ]
 }
 
 output vnetId string = enableSwift ? provisionedSwiftVnet.id : vnet.id

--- a/dev-infrastructure/scripts/swift-vnet.sh
+++ b/dev-infrastructure/scripts/swift-vnet.sh
@@ -1,0 +1,202 @@
+#!/bin/bash
+set -euo pipefail
+
+# Creates and/or tags the Swift management VNet so that it carries
+# stampcreatorserviceinfo=true. That tag only triggers Swift stamp registration when it is
+# written by an identity registered for Swift usage with the network RP (globalMSI).
+#
+# ARM deployment scripts used to provide that identity elevation, but they auto-create a
+# shared-key storage account that Azure Policy now blocks (SFI-ID4.2.1). A plain Shell step
+# cannot be used directly either: templatize ignores shellIdentity, so the write would run as
+# the ambient (non-Swift-registered) identity and the stamp would never register.
+#
+# Instead this step launches a single container group that is assigned globalMSI and performs
+# the create/tag AS globalMSI. Everything (create, wait, log, cleanup) happens in this one
+# Shell step so there is no cross-step ordering/async race: we start the container group
+# asynchronously (az container create --no-wait) and then poll it to completion. The ambient
+# identity only launches the container; the VNet write itself is performed by globalMSI from
+# inside it.
+#
+# Inputs via environment variables:
+#   ENABLE_SWIFT          - Whether Swift VNet creation/tagging should run ("true"/"false")
+#   VNET_NAME             - Name of the Swift VNet to create/tag
+#   VNET_ADDRESS_PREFIX   - Address space used when the VNet must be created
+#   RESOURCE_GROUP        - Resource group that holds the VNet and the container group
+#   SUBSCRIPTION_ID       - Subscription that holds the resource group
+#   DEPLOYMENT_MSI_ID     - Resource ID of the Swift-registered managed identity (globalMSI)
+
+if [ "${ENABLE_SWIFT:-false}" != "true" ]; then
+  echo "Swift VNet is disabled; skipping."
+  exit 0
+fi
+
+CONTAINER_IMAGE="mcr.microsoft.com/azure-cli:2.53.1"
+CONTAINER_GROUP_NAME="swift-vnet-${VNET_NAME}"
+TIMEOUT=600
+POLL_INTERVAL=10
+
+az account set --subscription "${SUBSCRIPTION_ID}"
+
+# Remove any leftover container group from a previous (failed) attempt so the create below is
+# deterministic and the name does not collide.
+az container delete \
+  --resource-group "${RESOURCE_GROUP}" \
+  --name "${CONTAINER_GROUP_NAME}" \
+  --yes >/dev/null 2>&1 || true
+
+# Script executed inside the container, AS globalMSI. Values are baked in here (none are
+# secret) and the whole script is base64-encoded below so container command-line quoting
+# cannot mangle it. The managed identity's Network/Tag Contributor role assignments are
+# created by the preceding swift-vnet-permissions step; Azure RBAC is eventually consistent,
+# so the first write can fail with AuthorizationFailed until the assignment propagates - the
+# retry helper absorbs that lag.
+read -r -d '' CONTAINER_SCRIPT <<EOF || true
+set -euo pipefail
+
+echo "Logging in with the Swift-registered managed identity..."
+az login --identity --username "${DEPLOYMENT_MSI_ID}" --output none
+az account set --subscription "${SUBSCRIPTION_ID}"
+
+MAX_WAIT=180
+POLL_INTERVAL=5
+
+retry() {
+  local start=\${SECONDS}
+  until "\$@"; do
+    if [ \$((SECONDS - start)) -ge "\${MAX_WAIT}" ]; then
+      echo "'\$*' still failing after \$((SECONDS - start))s" >&2
+      return 1
+    fi
+    echo "Command failed (likely RBAC propagation); retrying in \${POLL_INTERVAL}s..." >&2
+    sleep "\${POLL_INTERVAL}"
+  done
+}
+
+# Wait until the managed identity can actually read the resource group before deciding whether
+# the VNet exists. The Network/Tag Contributor assignments are created in a preceding step and
+# Azure RBAC is eventually consistent, so without this gate a transient auth failure on the
+# existence check could misroute a re-run (existing VNet) into the create path.
+retry az group show --name "${RESOURCE_GROUP}" --output none
+
+# Decide whether the VNet already exists, distinguishing a genuine NotFound (create path) from
+# a transient/AuthorizationFailed error (retry the read). The az group show gate above already
+# waits for RBAC to propagate, but we still never want a transient read failure to misroute an
+# existing VNet into the create path - only a real NotFound should reach create.
+vnet_exists=""
+show_start=\${SECONDS}
+while true; do
+  if show_err=\$(az network vnet show --resource-group "${RESOURCE_GROUP}" --name "${VNET_NAME}" --output none 2>&1); then
+    vnet_exists="yes"
+    break
+  fi
+  if printf '%s' "\${show_err}" | grep -qiE "ResourceNotFound|was not found|could not be found"; then
+    vnet_exists="no"
+    break
+  fi
+  if [ \$((SECONDS - show_start)) -ge "\${MAX_WAIT}" ]; then
+    echo "VNet existence check still failing after \$((SECONDS - show_start))s: \${show_err}" >&2
+    exit 1
+  fi
+  echo "VNet show failed (non-NotFound, likely transient/RBAC propagation); retrying in \${POLL_INTERVAL}s..." >&2
+  sleep "\${POLL_INTERVAL}"
+done
+
+if [ "\${vnet_exists}" = "yes" ]; then
+  echo "VNet ${VNET_NAME} exists. Updating Swift tag..."
+  retry az resource tag \
+    --is-incremental \
+    --tags stampcreatorserviceinfo=true \
+    --resource-group "${RESOURCE_GROUP}" \
+    --name "${VNET_NAME}" \
+    --resource-type Microsoft.Network/virtualNetworks \
+    --api-version 2024-05-01
+else
+  echo "VNet ${VNET_NAME} does not exist. Creating..."
+  retry az network vnet create \
+    --resource-group "${RESOURCE_GROUP}" \
+    --name "${VNET_NAME}" \
+    --address-prefixes "${VNET_ADDRESS_PREFIX}" \
+    --tags stampcreatorserviceinfo=true
+fi
+
+echo "Swift VNet ${VNET_NAME} is ready and tagged."
+EOF
+
+CONTAINER_SCRIPT_B64=$(printf '%s' "${CONTAINER_SCRIPT}" | base64 | tr -d '\n')
+
+echo "Launching container group ${CONTAINER_GROUP_NAME} as globalMSI..."
+az container create \
+  --resource-group "${RESOURCE_GROUP}" \
+  --name "${CONTAINER_GROUP_NAME}" \
+  --image "${CONTAINER_IMAGE}" \
+  --os-type Linux \
+  --restart-policy Never \
+  --cpu 1 \
+  --memory 1.5 \
+  --assign-identity "${DEPLOYMENT_MSI_ID}" \
+  --command-line "/bin/bash -c 'echo ${CONTAINER_SCRIPT_B64} | base64 -d | bash'" \
+  --no-wait
+
+container_state() {
+  az container show \
+    --resource-group "${RESOURCE_GROUP}" \
+    --name "${CONTAINER_GROUP_NAME}" \
+    --query "containers[0].instanceView.currentState.state" \
+    --output tsv 2>/dev/null || echo ""
+}
+
+group_provisioning_state() {
+  az container show \
+    --resource-group "${RESOURCE_GROUP}" \
+    --name "${CONTAINER_GROUP_NAME}" \
+    --query "provisioningState" \
+    --output tsv 2>/dev/null || echo ""
+}
+
+start=${SECONDS}
+while true; do
+  state=$(container_state)
+  if [ "${state}" = "Terminated" ]; then
+    break
+  fi
+  # Fail fast if the container group itself fails to provision: the container may never
+  # reach a Terminated state, so without this check we would wait the full TIMEOUT.
+  if [ "$(group_provisioning_state)" = "Failed" ]; then
+    echo "✗ Container group ${CONTAINER_GROUP_NAME} failed to provision" >&2
+    az container show --resource-group "${RESOURCE_GROUP}" --name "${CONTAINER_GROUP_NAME}" \
+      --query "containers[0].instanceView.events" --output json 2>/dev/null || true
+    az container logs --resource-group "${RESOURCE_GROUP}" --name "${CONTAINER_GROUP_NAME}" || true
+    az container delete --resource-group "${RESOURCE_GROUP}" --name "${CONTAINER_GROUP_NAME}" --yes >/dev/null 2>&1 || true
+    exit 1
+  fi
+  if [ $((SECONDS - start)) -ge "${TIMEOUT}" ]; then
+    echo "✗ Timed out after $((SECONDS - start))s waiting for ${CONTAINER_GROUP_NAME} (last state: ${state:-unknown})" >&2
+    az container logs --resource-group "${RESOURCE_GROUP}" --name "${CONTAINER_GROUP_NAME}" || true
+    az container delete --resource-group "${RESOURCE_GROUP}" --name "${CONTAINER_GROUP_NAME}" --yes >/dev/null 2>&1 || true
+    exit 1
+  fi
+  echo "Waiting for ${CONTAINER_GROUP_NAME} to finish (state: ${state:-pending})..."
+  sleep "${POLL_INTERVAL}"
+done
+
+echo "=== ${CONTAINER_GROUP_NAME} logs ==="
+az container logs --resource-group "${RESOURCE_GROUP}" --name "${CONTAINER_GROUP_NAME}" || true
+
+exit_code=$(az container show \
+  --resource-group "${RESOURCE_GROUP}" \
+  --name "${CONTAINER_GROUP_NAME}" \
+  --query "containers[0].instanceView.currentState.exitCode" \
+  --output tsv 2>/dev/null || echo "")
+
+echo "Cleaning up ${CONTAINER_GROUP_NAME}..."
+az container delete \
+  --resource-group "${RESOURCE_GROUP}" \
+  --name "${CONTAINER_GROUP_NAME}" \
+  --yes >/dev/null 2>&1 || true
+
+if [ "${exit_code}" != "0" ]; then
+  echo "✗ ${CONTAINER_GROUP_NAME} exited with code ${exit_code:-unknown}" >&2
+  exit 1
+fi
+
+echo "Swift VNet ${VNET_NAME} created/tagged successfully."

--- a/dev-infrastructure/templates/mgmt-cluster.bicep
+++ b/dev-infrastructure/templates/mgmt-cluster.bicep
@@ -345,7 +345,6 @@ module vnetCreation '../modules/network/vnet.bicep' = {
     vnetName: vnetName
     vnetAddressPrefix: vnetAddressPrefix
     enableSwift: aksEnableSwiftVnet
-    deploymentMsiId: globalMSIId
   }
 }
 

--- a/dev-infrastructure/templates/opstool-cluster.bicep
+++ b/dev-infrastructure/templates/opstool-cluster.bicep
@@ -196,7 +196,6 @@ module vnetCreation '../modules/network/vnet.bicep' = {
     vnetName: vnetName
     vnetAddressPrefix: vnetAddressPrefix
     enableSwift: false
-    deploymentMsiId: opstoolMI.id
   }
 }
 

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -631,7 +631,6 @@ module vnetCreation '../modules/network/vnet.bicep' = {
     vnetName: vnetName
     vnetAddressPrefix: vnetAddressPrefix
     enableSwift: false
-    deploymentMsiId: globalMSIId
   }
 }
 

--- a/dev-infrastructure/templates/swift-vnet-permissions.bicep
+++ b/dev-infrastructure/templates/swift-vnet-permissions.bicep
@@ -1,0 +1,12 @@
+@description('The resource ID of the user-assigned managed identity that manages the Swift VNet')
+param deploymentMsiId string
+
+@description('Whether Swift VNet is enabled. Gates the Swift VNet RBAC role assignments so they are only created when Swift is in use.')
+param enableSwift bool
+
+module swiftVnetRbac '../modules/network/vnet-rbac.bicep' = if (enableSwift) {
+  name: 'swift-vnet-rbac'
+  params: {
+    deploymentMsiId: deploymentMsiId
+  }
+}


### PR DESCRIPTION
<!-- Link to Jira issue -->
[ARO-28045](https://redhat.atlassian.net/browse/ARO-28045) (epic [ARO-28038](https://redhat.atlassian.net/browse/ARO-28038); follow-ups [ARO-28066](https://redhat.atlassian.net/browse/ARO-28066), [ARO-28082](https://redhat.atlassian.net/browse/ARO-28082))

Relands [#5834](https://github.com/Azure/ARO-HCP/pull/5834) (reverted in [#5888](https://github.com/Azure/ARO-HCP/pull/5888)) with the EV2 fix. Rebased onto `main` — now a single clean commit.

### What

Re-applies #5834 (Swift mgmt-VNet create/tag via a managed-identity ACI launched from a single synchronous `swift-vnet` Shell step, replacing the Azure-Policy-banned `deploymentScripts`) and adds the missing `shellIdentity` on the Shell steps in both `mgmt-pipeline.yaml` and `mgmt-solo-pipeline.yaml`:

```yaml
    shellIdentity:
      input:
        resourceGroup: global
        step: output
        name: globalMSIId
```

- `swift-vnet` in both mgmt pipelines (the step reverted from #5834).
- `fixes` in `mgmt-solo-pipeline.yaml`, which had the same omission — folded in here so all `shellIdentity` changes to that file live in a single PR (the dev-ci offenders are handled separately in [#5890](https://github.com/Azure/ARO-HCP/pull/5890)).

### Why

#5834 was reverted (#5888) because its `swift-vnet` Shell step omitted `shellIdentity`, which sdp-pipelines EV2RA manifest generation validates unconditionally. The bump failed at manifest resolution:

```text
step Management.Infra.management.swift-vnet: error validating step:
invalid shell identity: variable must specify config ref, value, or input chain
```

ARO-HCP CI does not exercise EV2RA generation, so it slipped through. Declaring `shellIdentity: globalMSIId` (same pattern as `upgrade-aks-cluster` / `cleanup-prometheus-pvc`, and matching the step's own `DEPLOYMENT_MSI_ID` input) satisfies the validator. In EV2 the outer shell runs as globalMSI (harmless — the container still performs the create/tag); templatize's local executor ignores `shellIdentity`, so e2e behaviour is identical to the proven #5834 run.

### Testing

- `yamllint -c .yamllint.yml` on both pipelines (clean).
- #5834's e2e already proved the swift networking path (container ran as globalMSI, VNet created + tagged, swift clusters reached ready).

### Special notes for your reviewer

Now rebased onto `main` after the revert (#5888) merged — the diff is exactly the #5834 reintroduction plus the `shellIdentity` additions, in one commit. The schema change that makes `shellIdentity` required lives in [Azure/ARO-Tools#262](https://github.com/Azure/ARO-Tools/pull/262) ([AROSLSRE-1380](https://redhat.atlassian.net/browse/AROSLSRE-1380)), held until this and #5890 merge.

### PR Checklist

- [x] PR is scoped to a single task
- [x] Title follows Conventional Commits
- [x] Summary explains the "Why"
- [x] Linked to relevant ticket/issue
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Commit history is clean
- [x] Tricky code blocks are commented
