### PR TITLE
fix(pipelines): declare shellIdentity on dev-ci ci-bot-secret Shell steps (AROSLSRE-1380)

### DIFF
--- a/dev-infrastructure/dev-ci/e2e-subscription-rbac/pipeline.yaml
+++ b/dev-infrastructure/dev-ci/e2e-subscription-rbac/pipeline.yaml
@@ -34,6 +34,12 @@ resourceGroups:
   resourceGroup: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
   steps:
+  - name: global-identity
+    action: ARM
+    template: ../../templates/output-opstool-global-identity.bicep
+    parameters: ../../configurations/output-opstool-global-identity.tmpl.bicepparam
+    deploymentLevel: ResourceGroup
+    outputOnly: true
   - name: ci-bot-identity
     action: ARM
     template: ../../templates/ci-bot-identity.bicep
@@ -43,6 +49,11 @@ resourceGroups:
     action: Shell
     command: ./ci-bot-ensure-secret.sh
     workingDir: ../../scripts
+    shellIdentity:
+      input:
+        resourceGroup: ci-bots
+        step: global-identity
+        name: globalMSIId
     variables:
     - name: APP_NAME
       configRef: ci.int.bot.applicationName
@@ -57,6 +68,11 @@ resourceGroups:
     action: Shell
     command: ./ci-bot-ensure-secret.sh
     workingDir: ../../scripts
+    shellIdentity:
+      input:
+        resourceGroup: ci-bots
+        step: global-identity
+        name: globalMSIId
     variables:
     - name: APP_NAME
       configRef: ci.stg.bot.applicationName
@@ -71,6 +87,11 @@ resourceGroups:
     action: Shell
     command: ./ci-bot-ensure-secret.sh
     workingDir: ../../scripts
+    shellIdentity:
+      input:
+        resourceGroup: ci-bots
+        step: global-identity
+        name: globalMSIId
     variables:
     - name: APP_NAME
       configRef: ci.prod.bot.applicationName


### PR DESCRIPTION
<!-- Link to Jira issue -->
[AROSLSRE-1380](https://redhat.atlassian.net/browse/AROSLSRE-1380)

### What

Declare `shellIdentity` on the dev-ci `Shell` steps that omit it:

- `ci-bot-secret-{int,stg,prod}` in `dev-infrastructure/dev-ci/e2e-subscription-rbac/pipeline.yaml` → reference a new `outputOnly` `global-identity` step (using the already-present `output-opstool-global-identity.bicep` + its bicepparam) to expose `globalMSIId`.

The `swift-vnet` and `mgmt-solo-pipeline.yaml` `fixes` Shell steps are handled in the reland PR [#5889](https://github.com/Azure/ARO-HCP/pull/5889) (which already edits both mgmt pipeline files). Together with this PR, every Shell step in the repo declares `shellIdentity`.

### Why

A `Shell` step's `shellIdentity` is effectively mandatory — sdp-pipelines EV2RA manifest generation validates it unconditionally:

```text
step ...: error validating step:
invalid shell identity: variable must specify config ref, value, or input chain
```

ARO-HCP CI never runs that generation, so a Shell step missing `shellIdentity` passes all checks and only breaks the bump after merge (as happened with [#5834](https://github.com/Azure/ARO-HCP/pull/5834), [ARO-28045](https://redhat.atlassian.net/browse/ARO-28045)). This PR makes the dev-ci pipeline compliant so [AROSLSRE-1380](https://redhat.atlassian.net/browse/AROSLSRE-1380) can make `shellIdentity` `required` in the ARO-Tools pipeline schema and catch this class of bug at PR time.

`shellIdentity` is consumed only by EV2; templatize's local executor ignores it, so dev/CI runtime behaviour is unchanged.

### Testing

- `yamllint -c .yamllint.yml` (clean).
- `templatize pipeline validate` against `topology-dev-ci.yaml` — passes, confirming the new `global-identity` output step and the `shellIdentity` input chains resolve.

### Special notes for your reviewer

`global-identity` is `outputOnly: true` — it deploys nothing, it only surfaces the existing global MSI's resource ID (via `existing` lookup) so the dev-ci Shell steps can reference it.

### PR Checklist

- [x] PR is scoped to a single task
- [x] Title follows Conventional Commits
- [x] Summary explains the "Why"
- [x] Linked to relevant ticket/issue
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Commit history is clean
- [x] Tricky code blocks are commented
