### PR TITLE
perf: speed up personal-dev-env by fixing bingo reinstall cycle and parallelizing ACR lookups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,6 @@ mocks: $(MOCKGEN) $(GOIMPORTS)
 .PHONY: mocks
 
 install-tools: $(BINGO) $(HELM_LINK) $(YQ_LINK) $(JQ) $(ORAS_LINK)
-	$(BINGO) get
 .PHONY: install-tools
 
 licenses: $(ADDLICENSE)

--- a/Makefile
+++ b/Makefile
@@ -449,13 +449,14 @@ record-services-override: $(YQ) $(ORAS)
 # Query ACR for the latest image digest of each service (no build/push)
 #
 latest-services-override: $(YQ)
-	$(MAKE) -C frontend record-latest-override OVERRIDE_CONFIG_FILE=/tmp/_frontend-override.yaml
-	$(MAKE) -C backend record-latest-override OVERRIDE_CONFIG_FILE=/tmp/_backend-override.yaml
-	$(MAKE) -C admin record-latest-override OVERRIDE_CONFIG_FILE=/tmp/_admin-override.yaml
-	$(MAKE) -C sessiongate record-latest-override OVERRIDE_CONFIG_FILE=/tmp/_sessiongate-override.yaml
-	$(MAKE) -C mgmt-agent record-latest-override OVERRIDE_CONFIG_FILE=/tmp/_mgmt-agent-override.yaml
-	$(MAKE) -C kube-applier record-latest-override OVERRIDE_CONFIG_FILE=/tmp/_kube-applier-override.yaml
-	$(MAKE) -C fleet record-latest-override OVERRIDE_CONFIG_FILE=/tmp/_fleet-override.yaml
+	$(MAKE) -C frontend record-latest-override OVERRIDE_CONFIG_FILE=/tmp/_frontend-override.yaml &
+	$(MAKE) -C backend record-latest-override OVERRIDE_CONFIG_FILE=/tmp/_backend-override.yaml &
+	$(MAKE) -C admin record-latest-override OVERRIDE_CONFIG_FILE=/tmp/_admin-override.yaml &
+	$(MAKE) -C sessiongate record-latest-override OVERRIDE_CONFIG_FILE=/tmp/_sessiongate-override.yaml &
+	$(MAKE) -C mgmt-agent record-latest-override OVERRIDE_CONFIG_FILE=/tmp/_mgmt-agent-override.yaml &
+	$(MAKE) -C kube-applier record-latest-override OVERRIDE_CONFIG_FILE=/tmp/_kube-applier-override.yaml &
+	$(MAKE) -C fleet record-latest-override OVERRIDE_CONFIG_FILE=/tmp/_fleet-override.yaml &
+	wait
 	$(YQ) eval-all '. as $$item ireduce ({}; . * $$item)' \
 	  /tmp/_frontend-override.yaml \
 	  /tmp/_backend-override.yaml \


### PR DESCRIPTION
## Summary

- **Remove redundant `bingo get` from `install-tools`**: The prerequisite list (`$(BINGO) $(HELM_LINK) $(YQ_LINK) $(JQ) $(ORAS_LINK)`) already triggers bingo's `Variables.mk` rules, which build each tool from its `.mod` file on demand. The additional `bingo get` call is redundant and causes a timestamp poisoning cycle — `bingo get` touches all `.mod` files after binaries are built, making them appear stale on the next `make` invocation, triggering a full rebuild of every tool (~2-3 min) on every run.
- **Parallelize ACR image lookups in `latest-services-override`**: Each service's `record-latest-override` queries ACR for the latest image digest and writes to its own temp file. These are independent network calls with no shared state — run all 7 in parallel with background processes and `wait` before merging results.

## Test plan

- [ ] Run `make personal-dev-env DEPLOY_ENV=pers USE_LATEST_IMAGES=1` — verify tools are not rebuilt on second run
- [ ] Run `make install-tools` twice — second run should be a no-op
- [ ] Verify `latest-services-override` produces correct merged override YAML