### PR TITLE
fix(config): register Microsoft.ContainerInstance on mgmt subscriptions (ARO-28100)

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -601,6 +601,8 @@ defaults:
           features:
           - name: IstioNativeSidecarModePreview
             poll: true
+        'Microsoft.ContainerInstance':
+          poll: true
         'Microsoft.Quota':
           poll: true
     rg: "hcp-underlay-{{ .ctx.environment }}-{{ .ctx.region }}-mgmt-{{ .ctx.stamp }}"

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -703,6 +703,8 @@ mgmt:
         - name: EncryptionAtHost
           poll: true
         poll: true
+      Microsoft.ContainerInstance:
+        poll: true
       Microsoft.ContainerService:
         features:
         - name: IstioNativeSidecarModePreview

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -703,6 +703,8 @@ mgmt:
         - name: EncryptionAtHost
           poll: true
         poll: true
+      Microsoft.ContainerInstance:
+        poll: true
       Microsoft.ContainerService:
         features:
         - name: IstioNativeSidecarModePreview

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -701,6 +701,8 @@ mgmt:
         - name: EncryptionAtHost
           poll: true
         poll: true
+      Microsoft.ContainerInstance:
+        poll: true
       Microsoft.ContainerService:
         features:
         - name: IstioNativeSidecarModePreview

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -701,6 +701,8 @@ mgmt:
         - name: EncryptionAtHost
           poll: true
         poll: true
+      Microsoft.ContainerInstance:
+        poll: true
       Microsoft.ContainerService:
         features:
         - name: IstioNativeSidecarModePreview

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -701,6 +701,8 @@ mgmt:
         - name: EncryptionAtHost
           poll: true
         poll: true
+      Microsoft.ContainerInstance:
+        poll: true
       Microsoft.ContainerService:
         features:
         - name: IstioNativeSidecarModePreview

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -703,6 +703,8 @@ mgmt:
         - name: EncryptionAtHost
           poll: true
         poll: true
+      Microsoft.ContainerInstance:
+        poll: true
       Microsoft.ContainerService:
         features:
         - name: IstioNativeSidecarModePreview


### PR DESCRIPTION
<!-- Link to Jira issue -->
[ARO-28100](https://redhat.atlassian.net/browse/ARO-28100) (epic [ARO-28038](https://redhat.atlassian.net/browse/ARO-28038))

### What

Add `Microsoft.ContainerInstance` to the management subscription providers list (`mgmt.subscription.providers` in `config/config.yaml`) and regenerate the rendered dev configs (`make -C config/ materialize`).

```yaml
# config/config.yaml — mgmt.subscription.providers
'Microsoft.ContainerInstance':
  poll: true
```

### Why

The `swift-vnet` step ([#5834](https://github.com/Azure/ARO-HCP/pull/5834), relanded in [#5889](https://github.com/Azure/ARO-HCP/pull/5889)) creates an Azure Container Instance (`az container create`) in the **management subscription** to run the Swift VNet create/tag as the Swift-registered globalMSI. That subscription's registered providers did **not** include `Microsoft.ContainerInstance`, and `swift-vnet` is the first ACI user in the repo. On a brand-new management subscription with Swift enabled, `az container create` could fail with `MissingSubscriptionRegistration`.

Adding it to the providers list means the existing `rpRegistration` step registers it before `swift-vnet` runs, making fresh region buildouts deterministic. Existing int/stg/prod mgmt subscriptions already have it registered (#5834's e2e ran the container), so this is a fast-follow hardening — not a fix for the current reland.

Flagged by Copilot review on [#5889](https://github.com/Azure/ARO-HCP/pull/5889).

### Testing

- `make -C config/ materialize` — rendered dev configs regenerated; only `Microsoft.ContainerInstance` added.
- `verify-materialize` (`make -C config/ detect-change`) is clean after committing the rendered outputs.

### Special notes for your reviewer

`mgmt-solo-pipeline.yaml` is intentionally **not** touched: it is a manual/dev-only pipeline (not in any topology) with no `rpRegistration` step, and assumes a pre-registered subscription.

### PR Checklist

- [x] PR is scoped to a single task
- [x] Title follows Conventional Commits
- [x] Summary explains the "Why"
- [x] Linked to relevant ticket/issue
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Commit history is clean
- [x] Tricky code blocks are commented
