### PR TITLE
fix(global): output step depends on acrs to avoid greenfield race (AROSLSRE-1388)

### DIFF
--- a/dev-infrastructure/global-pipeline-stg.yaml
+++ b/dev-infrastructure/global-pipeline-stg.yaml
@@ -53,6 +53,11 @@ resourceGroups:
     dependsOn:
     - resourceGroup: singleton
       step: infra
+    # output-global.bicep reads the SVC/OCP ACRs as `existing`; depend on acrs so a
+    # greenfield deploy (new subscription, no pre-existing ACRs) doesn't race and fail
+    # with ResourceNotFound before acrs creates them.
+    - resourceGroup: singleton
+      step: acrs
   # TODO(ARO-28044): re-enable after ARO-28040
   # - name: grafana-monitoring-reader
   #   action: ARM

--- a/dev-infrastructure/global-pipeline.yaml
+++ b/dev-infrastructure/global-pipeline.yaml
@@ -49,6 +49,11 @@ resourceGroups:
     dependsOn:
     - resourceGroup: singleton
       step: infra
+    # output-global.bicep reads the SVC/OCP ACRs as `existing`; depend on acrs so a
+    # greenfield deploy (new subscription, no pre-existing ACRs) doesn't race and fail
+    # with ResourceNotFound before acrs creates them.
+    - resourceGroup: singleton
+      step: acrs
   # TODO(ARO-28044): re-enable after ARO-28040
   # - name: grafana-monitoring-reader
   #   action: ARM


### PR DESCRIPTION
Fixes [AROSLSRE-1388](https://redhat.atlassian.net/browse/AROSLSRE-1388)

### What

Add `acrs` to the `output` step's `dependsOn` in `dev-infrastructure/global-pipeline.yaml` (and mirror it in the transient `global-pipeline-stg.yaml` V2 copy for diff consistency).

### Why

`output-global.bicep` reads the SVC/OCP ACRs as `existing` and emits their resource IDs / login servers, but the `output` step only declared `dependsOn: infra` — the same dependency as the `acrs` step (`global-acr.bicep`) that actually creates those registries. Both depending only on `infra` means they run in parallel.

On a greenfield global deploy (new subscription with no pre-existing ACRs) `output` races `acrs` and fails:

```
Code: ResourceNotFound
Message: The Resource 'Microsoft.ContainerRegistry/registries/arohcpocpstg2' under
resource group 'global-shared-resources' was not found.
```

It doesn't bite existing environments because their ACRs already exist, so `output`'s `existing` reference resolves regardless of ordering. The race only surfaces the first time the ACRs are created — proven real by the STG-global V2 greenfield deploy ([AROSLSRE-1200](https://redhat.atlassian.net/browse/AROSLSRE-1200)), where the `acrs` step succeeded (registries created) but `output` had already failed, confirming a pure ordering race rather than a name/config error.

No cycle risk: `acrs` consumes only `infra`'s MSI/KV, and `output` does not feed `acrs`.

### Testing

- `make validate-config-pipelines` passes (validates the pipeline graph against topology + config; the new `dependsOn` resolves with no cycle).
- No code/unit-test surface — this is a pipeline dependency ordering fix. The greenfield ordering will be exercised by the next STG-global V2 `output` rollout (re-run after the ACRs exist already passes; the fix prevents the first-run failure on future greenfield buildouts).

### Special notes for your reviewer

The durable fix is on the canonical `global-pipeline.yaml`; the same one-liner is mirrored into the transient `global-pipeline-stg.yaml` (deleted at STG-global decommission, [AROSLSRE-1202](https://redhat.atlassian.net/browse/AROSLSRE-1202)) purely to keep the two files in sync.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
