### PR TITLE
test(e2e): resolve nodepool availability zone dynamically (AROSLSRE-1391)

### DIFF
--- a/test/e2e/nodepool_autoscaling.go
+++ b/test/e2e/nodepool_autoscaling.go
@@ -48,7 +48,6 @@ var _ = Describe("Customer", func() {
 				azNodePoolName         = "autoscale-az"
 				azAutoscalingMin int32 = 3
 				azAutoscalingMax int32 = 500
-				availabilityZone       = "1"
 
 				noAZNodePoolName         = "autoscale-noaz"
 				noAZAutoscalingMin int32 = 3
@@ -64,8 +63,13 @@ var _ = Describe("Customer", func() {
 			By("resolving the default worker VM size and checking if the region supports availability zones")
 			workerVMSize, err := tc.SelectVMSize(ctx, framework.DefaultWorkerVMSizeSelector())
 			Expect(err).NotTo(HaveOccurred(), "failed to resolve the default worker VM size")
-			hasAZ, err := tc.LocationHasAvailabilityZones(ctx, workerVMSize)
-			Expect(err).NotTo(HaveOccurred(), "failed to check availability zone support")
+			availableZones, err := tc.AvailableZones(ctx, workerVMSize)
+			Expect(err).NotTo(HaveOccurred(), "failed to resolve available availability zones for worker VM size %s", workerVMSize)
+			hasAZ := len(availableZones) > 0
+			var availabilityZone string
+			if hasAZ {
+				availabilityZone = availableZones[0]
+			}
 
 			By("creating a resource group")
 			resourceGroup, err := tc.NewResourceGroup(ctx, "np-autoscaling", tc.Location())
@@ -127,7 +131,7 @@ var _ = Describe("Customer", func() {
 			if !hasAZ {
 				By("skipping AZ nodepool creation: region does not support availability zones")
 			} else {
-				By("creating the AZ nodepool with 500 max replicas")
+				By("creating the AZ nodepool with 500 max replicas in availability zone " + availabilityZone)
 				azNodePoolParams := framework.NewDefaultNodePoolParams20240610()
 				azNodePoolParams.ClusterName = customerClusterName
 				azNodePoolParams.NodePoolName = azNodePoolName

--- a/test/e2e/nodepool_autoscaling.go
+++ b/test/e2e/nodepool_autoscaling.go
@@ -60,11 +60,11 @@ var _ = Describe("Customer", func() {
 				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
 			}
 
-			By("resolving the default worker VM size and checking if the region supports availability zones")
+			By("resolving the default worker VM size and its usable availability zones")
 			workerVMSize, err := tc.SelectVMSize(ctx, framework.DefaultWorkerVMSizeSelector())
 			Expect(err).NotTo(HaveOccurred(), "failed to resolve the default worker VM size")
 			availableZones, err := tc.AvailableZones(ctx, workerVMSize)
-			Expect(err).NotTo(HaveOccurred(), "failed to resolve available availability zones for worker VM size %s", workerVMSize)
+			Expect(err).NotTo(HaveOccurred(), "failed to resolve usable availability zones for worker VM size %s", workerVMSize)
 			hasAZ := len(availableZones) > 0
 			var availabilityZone string
 			if hasAZ {

--- a/test/e2e/nodepool_autoscaling.go
+++ b/test/e2e/nodepool_autoscaling.go
@@ -129,7 +129,8 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create Kubernetes client from admin REST config")
 
 			if !hasAZ {
-				By("skipping AZ nodepool creation: region does not support availability zones")
+				By("skipping AZ nodepool creation: no usable availability zones for worker VM size " +
+					workerVMSize + " in " + tc.Location())
 			} else {
 				By("creating the AZ nodepool with 500 max replicas in availability zone " + availabilityZone)
 				azNodePoolParams := framework.NewDefaultNodePoolParams20240610()

--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -1143,9 +1143,11 @@ func (tc *perItOrDescribeTestContext) PullSecretPath() string {
 // AvailableZones returns the sorted list of non-restricted availability zones
 // for the given VM SKU in the current test location, querying the Azure Resource
 // SKUs API. Zone-restricted zones (e.g. SkuNotAvailable for the subscription)
-// are subtracted from the advertised list, so every returned zone is guaranteed
-// to be usable for the SKU. An empty slice means the location/SKU combination
-// exposes no usable availability zones.
+// are subtracted from the advertised list, and a SKU that is entirely restricted
+// in the location (Location-type restriction) yields no zones, so every returned
+// zone is guaranteed to be usable for the SKU. An empty slice means the
+// location/SKU combination exposes no usable availability zones. An error is
+// returned if the SKU is not present in the location's Resource SKUs response.
 func (tc *perItOrDescribeTestContext) AvailableZones(ctx context.Context, vmSize string) ([]string, error) {
 	location := tc.Location()
 	skus, err := tc.listVirtualMachineResourceSKUs(ctx, location)
@@ -1156,9 +1158,12 @@ func (tc *perItOrDescribeTestContext) AvailableZones(ctx context.Context, vmSize
 		if sku.Name == nil || *sku.Name != vmSize {
 			continue
 		}
+		if skuRestrictedInLocation(sku, location) {
+			return nil, nil
+		}
 		return availableZones(sku, location), nil
 	}
-	return nil, nil
+	return nil, fmt.Errorf("VM size %q not found in Resource SKUs for location %q", vmSize, location)
 }
 
 func (tc *perItOrDescribeTestContext) SubscriptionID(ctx context.Context) (string, error) {

--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -1140,24 +1140,25 @@ func (tc *perItOrDescribeTestContext) PullSecretPath() string {
 	return tc.perBinaryInvocationTestContext.pullSecretPath
 }
 
-// LocationHasAvailabilityZones checks if the given VM SKU has at least one
-// non-restricted availability zone in the current test location by querying the
-// Azure Resource SKUs API.
-func (tc *perItOrDescribeTestContext) LocationHasAvailabilityZones(ctx context.Context, vmSize string) (bool, error) {
+// AvailableZones returns the sorted list of non-restricted availability zones
+// for the given VM SKU in the current test location, querying the Azure Resource
+// SKUs API. Zone-restricted zones (e.g. SkuNotAvailable for the subscription)
+// are subtracted from the advertised list, so every returned zone is guaranteed
+// to be usable for the SKU. An empty slice means the location/SKU combination
+// exposes no usable availability zones.
+func (tc *perItOrDescribeTestContext) AvailableZones(ctx context.Context, vmSize string) ([]string, error) {
 	location := tc.Location()
 	skus, err := tc.listVirtualMachineResourceSKUs(ctx, location)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
 	for _, sku := range skus {
 		if sku.Name == nil || *sku.Name != vmSize {
 			continue
 		}
-		if len(availableZones(sku, location)) > 0 {
-			return true, nil
-		}
+		return availableZones(sku, location), nil
 	}
-	return false, nil
+	return nil, nil
 }
 
 func (tc *perItOrDescribeTestContext) SubscriptionID(ctx context.Context) (string, error) {


### PR DESCRIPTION
[AROSLSRE-1391](https://redhat.atlassian.net/browse/AROSLSRE-1391)

### What

Replace the hardcoded `availabilityZone = "1"` in `test/e2e/nodepool_autoscaling.go` with a zone that is resolved dynamically from the SKU's actually available (non-restricted) zones in the target region.

- Adds framework helper `AvailableZones(ctx, vmSize) ([]string, error)` that returns the sorted list of usable zones for a VM SKU (zone-restricted zones are subtracted).
- `LocationHasAvailabilityZones` is superseded by `AvailableZones` (the test now derives `hasAZ` from `len(zones) > 0`).
- The AZ nodepool is pinned to the first available zone instead of a static `"1"`.

### Why

The test validates "autoscaling in a zone", not "autoscaling specifically in zone 1". When zone 1 is zone-restricted for the selected SKU (as seen in STG E2E), the hardcoded value produces `SkuNotAvailable` failures. Picking a zone from the real availability list keeps the test meaningful and portable across regions/subscriptions. Parent bug: [AROSLSRE-1389](https://redhat.atlassian.net/browse/AROSLSRE-1389).

### Testing

- `go build -tags E2Etests ./e2e/... ./util/framework/...` — passes.
- `golangci-lint run ./e2e/... ./util/framework/...` — no new findings from this change.

### Special notes for your reviewer

Starting with `/hold` so QE can confirm whether this change is needed before it merges.

### PR Checklist

- [x] Tests added/updated or not required
- [x] Documentation updated or not required
