### PR TITLE
alerts: separate prometheusrule alert generation from promtool test runs

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep
@@ -100,27 +100,27 @@ resource arohcpFrontendSloRecordingRules 'Microsoft.AlertsManagement/prometheusR
     rules: [
       {
         record: 'sli:frontend_http:availability:rate5m'
-        expression: '((sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{code!~"5..",route!~".*hcpoperation(results|statuses).*"}[5m]))) or 0 * sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!~".*hcpoperation(results|statuses).*"}[5m])))) / sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!~".*hcpoperation(results|statuses).*"}[5m])))) and on (cluster) (sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!~".*hcpoperation(results|statuses).*"}[5m]))) > 0)'
+        expression: '((sum by (cluster, region) (max without (prometheus_replica) (rate(frontend_http_requests_total{code!~"5..",route!~".*hcpoperation(results|statuses).*"}[5m]))) or 0 * sum by (cluster, region) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!~".*hcpoperation(results|statuses).*"}[5m])))) / sum by (cluster, region) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!~".*hcpoperation(results|statuses).*"}[5m])))) and on (cluster) (sum by (cluster, region) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!~".*hcpoperation(results|statuses).*"}[5m]))) > 0)'
       }
       {
         record: 'sli:frontend_http:good:rate5m'
-        expression: '(sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{code!~"5..",route!~".*hcpoperation(results|statuses).*"}[5m]))) or 0 * sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!~".*hcpoperation(results|statuses).*"}[5m]))))'
+        expression: '(sum by (cluster, region) (max without (prometheus_replica) (rate(frontend_http_requests_total{code!~"5..",route!~".*hcpoperation(results|statuses).*"}[5m]))) or 0 * sum by (cluster, region) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!~".*hcpoperation(results|statuses).*"}[5m]))))'
       }
       {
         record: 'errors:frontend_http:error_rate:rate5m'
-        expression: '((sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{code=~"5..",route!~".*hcpoperation(results|statuses).*"}[5m]))) or 0 * sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!~".*hcpoperation(results|statuses).*"}[5m])))) / sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!~".*hcpoperation(results|statuses).*"}[5m])))) and on (cluster) (sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!~".*hcpoperation(results|statuses).*"}[5m]))) > 0)'
+        expression: '((sum by (cluster, region) (max without (prometheus_replica) (rate(frontend_http_requests_total{code=~"5..",route!~".*hcpoperation(results|statuses).*"}[5m]))) or 0 * sum by (cluster, region) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!~".*hcpoperation(results|statuses).*"}[5m])))) / sum by (cluster, region) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!~".*hcpoperation(results|statuses).*"}[5m])))) and on (cluster) (sum by (cluster, region) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!~".*hcpoperation(results|statuses).*"}[5m]))) > 0)'
       }
       {
         record: 'sli:frontend_http:latency_p99:rate5m'
-        expression: 'histogram_quantile(0.99, sum by (cluster, le) (max without (prometheus_replica) (rate(frontend_http_requests_duration_seconds_bucket{route!~".*hcpoperation(results|statuses).*"}[5m])))) and on (cluster) (sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_duration_seconds_count{route!~".*hcpoperation(results|statuses).*"}[5m]))) > 0)'
+        expression: 'histogram_quantile(0.99, sum by (cluster, le, region) (max without (prometheus_replica) (rate(frontend_http_requests_duration_seconds_bucket{route!~".*hcpoperation(results|statuses).*"}[5m])))) and on (cluster) (sum by (cluster, region) (max without (prometheus_replica) (rate(frontend_http_requests_duration_seconds_count{route!~".*hcpoperation(results|statuses).*"}[5m]))) > 0)'
       }
       {
         record: 'sli:frontend_http:latency_p95:rate5m'
-        expression: 'histogram_quantile(0.95, sum by (cluster, le) (max without (prometheus_replica) (rate(frontend_http_requests_duration_seconds_bucket{route!~".*hcpoperation(results|statuses).*"}[5m])))) and on (cluster) (sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_duration_seconds_count{route!~".*hcpoperation(results|statuses).*"}[5m]))) > 0)'
+        expression: 'histogram_quantile(0.95, sum by (cluster, le, region) (max without (prometheus_replica) (rate(frontend_http_requests_duration_seconds_bucket{route!~".*hcpoperation(results|statuses).*"}[5m])))) and on (cluster) (sum by (cluster, region) (max without (prometheus_replica) (rate(frontend_http_requests_duration_seconds_count{route!~".*hcpoperation(results|statuses).*"}[5m]))) > 0)'
       }
       {
         record: 'traffic:frontend_http:request_rate:rate5m'
-        expression: 'sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!~".*hcpoperation(results|statuses).*"}[5m])))'
+        expression: 'sum by (cluster, region) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!~".*hcpoperation(results|statuses).*"}[5m])))'
       }
       {
         record: 'sli:frontend_http:availability:rate_avg_30d'
@@ -128,15 +128,15 @@ resource arohcpFrontendSloRecordingRules 'Microsoft.AlertsManagement/prometheusR
       }
       {
         record: 'sli:frontend:ready:ratio5m'
-        expression: '(sum by (cluster) (max without (prometheus_replica) (kube_deployment_status_replicas_available{deployment="aro-hcp-frontend",namespace="aro-hcp"})) / sum by (cluster) (max without (prometheus_replica) (kube_deployment_spec_replicas{deployment="aro-hcp-frontend",namespace="aro-hcp"}))) and on (cluster) (sum by (cluster) (max without (prometheus_replica) (kube_deployment_spec_replicas{deployment="aro-hcp-frontend",namespace="aro-hcp"})) > 0)'
+        expression: '(sum by (cluster, region) (max without (prometheus_replica) (kube_deployment_status_replicas_available{deployment="aro-hcp-frontend",namespace="aro-hcp"})) / sum by (cluster, region) (max without (prometheus_replica) (kube_deployment_spec_replicas{deployment="aro-hcp-frontend",namespace="aro-hcp"}))) and on (cluster) (sum by (cluster, region) (max without (prometheus_replica) (kube_deployment_spec_replicas{deployment="aro-hcp-frontend",namespace="aro-hcp"})) > 0)'
       }
       {
         record: 'sli:frontend:saturation_cpu:ratio5m'
-        expression: '(sum by (cluster) (max without (prometheus_replica) (rate(container_cpu_usage_seconds_total{container="aro-hcp-frontend",namespace="aro-hcp"}[5m]))) / sum by (cluster) (max by (cluster, namespace, pod, container) (kube_pod_container_resource_requests{container="aro-hcp-frontend",job="kube-state-metrics",namespace="aro-hcp",resource="cpu"}))) and on (cluster) (sum by (cluster) (max by (cluster, namespace, pod, container) (kube_pod_container_resource_requests{container="aro-hcp-frontend",job="kube-state-metrics",namespace="aro-hcp",resource="cpu"})) > 0)'
+        expression: '(sum by (cluster, region) (max without (prometheus_replica) (rate(container_cpu_usage_seconds_total{container="aro-hcp-frontend",namespace="aro-hcp"}[5m]))) / sum by (cluster, region) (max by (cluster, namespace, pod, container, region) (kube_pod_container_resource_requests{container="aro-hcp-frontend",job="kube-state-metrics",namespace="aro-hcp",resource="cpu"}))) and on (cluster) (sum by (cluster, region) (max by (cluster, namespace, pod, container, region) (kube_pod_container_resource_requests{container="aro-hcp-frontend",job="kube-state-metrics",namespace="aro-hcp",resource="cpu"})) > 0)'
       }
       {
         record: 'sli:frontend:saturation_memory:ratio5m'
-        expression: '(sum by (cluster) (max without (prometheus_replica) (container_memory_working_set_bytes{container="aro-hcp-frontend",namespace="aro-hcp"})) / sum by (cluster) (max by (cluster, namespace, pod, container) (kube_pod_container_resource_limits{container="aro-hcp-frontend",job="kube-state-metrics",namespace="aro-hcp",resource="memory"}))) and on (cluster) (sum by (cluster) (max by (cluster, namespace, pod, container) (kube_pod_container_resource_limits{container="aro-hcp-frontend",job="kube-state-metrics",namespace="aro-hcp",resource="memory"})) > 0)'
+        expression: '(sum by (cluster, region) (max without (prometheus_replica) (container_memory_working_set_bytes{container="aro-hcp-frontend",namespace="aro-hcp"})) / sum by (cluster, region) (max by (cluster, namespace, pod, container, region) (kube_pod_container_resource_limits{container="aro-hcp-frontend",job="kube-state-metrics",namespace="aro-hcp",resource="memory"}))) and on (cluster) (sum by (cluster, region) (max by (cluster, namespace, pod, container, region) (kube_pod_container_resource_limits{container="aro-hcp-frontend",job="kube-state-metrics",namespace="aro-hcp",resource="memory"})) > 0)'
       }
     ]
   }

--- a/observability/Makefile
+++ b/observability/Makefile
@@ -45,6 +45,10 @@ alerts: verify-no-prom-alerts-in-bicep
 	EXTRA_FLAGS=$(GENERATOR_FLAGS) make -C ../tooling/prometheus-rules alerts
 .PHONY: alerts
 
+alerts-and-test: verify-no-prom-alerts-in-bicep
+	EXTRA_FLAGS=$(GENERATOR_FLAGS) make -C ../tooling/prometheus-rules alerts-and-test
+.PHONY: alerts-and-test
+
 correlation-map:
 	@make -C ../tooling/prometheus-rules correlation-map OUTPUT=$(OUTPUT)
 .PHONY: correlation-map

--- a/observability/Makefile
+++ b/observability/Makefile
@@ -12,6 +12,10 @@ alerts: verify-no-prom-alerts-in-bicep
 	EXTRA_FLAGS=$(GENERATOR_FLAGS) make -C ../tooling/prometheus-rules alerts
 .PHONY: alerts
 
+alerts-and-test: verify-no-prom-alerts-in-bicep
+	EXTRA_FLAGS=$(GENERATOR_FLAGS) make -C ../tooling/prometheus-rules alerts-and-test
+.PHONY: alerts-and-test
+
 correlation-map:
 	@make -C ../tooling/prometheus-rules correlation-map OUTPUT=$(OUTPUT)
 .PHONY: correlation-map

--- a/observability/Makefile
+++ b/observability/Makefile
@@ -49,6 +49,9 @@ alerts-and-test: verify-no-prom-alerts-in-bicep
 	EXTRA_FLAGS=$(GENERATOR_FLAGS) make -C ../tooling/prometheus-rules alerts-and-test
 .PHONY: alerts-and-test
 
+test-alerts: alerts-and-test
+.PHONY: test-alerts
+
 correlation-map:
 	@make -C ../tooling/prometheus-rules correlation-map OUTPUT=$(OUTPUT)
 .PHONY: correlation-map

--- a/tooling/prometheus-rules/Makefile
+++ b/tooling/prometheus-rules/Makefile
@@ -20,67 +20,43 @@ fmt-devinfra:
 	$(MAKE) -C ../../dev-infrastructure fmt
 .PHONY: fmt-devinfra
 
-run: alerts recording-rules
-.PHONY: run
+ALERT_CONFIGS = alerts-sl-services alerts-sl-hcps alerts-sre-hcps alerts-sre-services alerts-rp-services alerts-msft-services alerts-kusto-services alerts-kusto-hcps
+RECORDING_CONFIGS = recording-rules-services recording-rules-hcps
+CONFIGS = $(ALERT_CONFIGS) $(RECORDING_CONFIGS)
 
-alerts: run-sl-services run-sl-hcps run-sre-hcps run-sre-services run-rp-services run-msft-services run-kusto-services run-kusto-hcps
+alerts: $(BINARY)
+	@set -e; for cfg in $(ALERT_CONFIGS); do \
+		./$(BINARY) --skip-tests --config-file ../../observability/$${cfg}.yaml $(EXTRA_FLAGS); \
+	done
 	$(MAKE) fmt-devinfra
 .PHONY: alerts
 
-recording-rules: run-recording-rules-services run-recording-rules-hcps
+alerts-and-test: $(BINARY)
+	@set -e; for cfg in $(CONFIGS); do \
+		./$(BINARY) --config-file ../../observability/$${cfg}.yaml $(EXTRA_FLAGS); \
+	done
+	$(MAKE) fmt-devinfra
+.PHONY: alerts-and-test
+
+run: alerts
+.PHONY: run
+
+RUN_TARGETS = $(addprefix run-,$(CONFIGS))
+
+$(RUN_TARGETS): run-%: $(BINARY)
+	./$(BINARY) --config-file ../../observability/$*.yaml $(EXTRA_FLAGS)
+
+.PHONY: $(RUN_TARGETS)
+
+recording-rules: $(BINARY)
+	@set -e; for cfg in $(RECORDING_CONFIGS); do \
+		./$(BINARY) --skip-tests --config-file ../../observability/$${cfg}.yaml $(EXTRA_FLAGS); \
+	done
 	$(MAKE) fmt-devinfra
 .PHONY: recording-rules
 
-run-sl-services:
-	go run ./...  --config-file ../../observability/alerts-sl-services.yaml $(EXTRA_FLAGS)
-.PHONY: run-sl-services
+CORRELATION_MAP_FILES = $(addprefix ../../observability/,$(addsuffix .yaml,$(ALERT_CONFIGS)))
 
-run-sl-hcps:
-	go run ./...  --config-file ../../observability/alerts-sl-hcps.yaml $(EXTRA_FLAGS)
-.PHONY: run-sl-hcps
-
-run-sre-hcps:
-	go run ./...  --config-file ../../observability/alerts-sre-hcps.yaml $(EXTRA_FLAGS)
-.PHONY: run-sre-hcps
-
-run-sre-services:
-	go run ./...  --config-file ../../observability/alerts-sre-services.yaml $(EXTRA_FLAGS)
-.PHONY: run-sre-services
-
-run-rp-services:
-	go run ./...  --config-file ../../observability/alerts-rp-services.yaml $(EXTRA_FLAGS)
-.PHONY: run-rp-services
-
-run-msft-services:
-	go run ./...  --config-file ../../observability/alerts-msft-services.yaml $(EXTRA_FLAGS)
-.PHONY: run-msft-services
-
-run-kusto-services:
-	go run ./...  --config-file ../../observability/alerts-kusto-services.yaml $(EXTRA_FLAGS)
-.PHONY: run-kusto-services
-
-run-kusto-hcps:
-	go run ./...  --config-file ../../observability/alerts-kusto-hcps.yaml $(EXTRA_FLAGS)
-.PHONY: run-kusto-hcps
-
-run-recording-rules-services:
-	go run ./...  --config-file ../../observability/recording-rules-services.yaml $(EXTRA_FLAGS)
-.PHONY: run-recording-rules-services
-
-run-recording-rules-hcps:
-	go run ./...  --config-file ../../observability/recording-rules-hcps.yaml $(EXTRA_FLAGS)
-.PHONY: run-recording-rules-hcps
-
-ALERT_CONFIGS = \
-	../../observability/alerts-sl-services.yaml \
-	../../observability/alerts-sl-hcps.yaml \
-	../../observability/alerts-sre-hcps.yaml \
-	../../observability/alerts-sre-services.yaml \
-	../../observability/alerts-rp-services.yaml \
-	../../observability/alerts-msft-services.yaml \
-	../../observability/alerts-kusto-services.yaml \
-	../../observability/alerts-kusto-hcps.yaml
-
-correlation-map:
-	go run ./... --correlation-map $(ALERT_CONFIGS) > $(OUTPUT)
+correlation-map: $(BINARY)
+	./$(BINARY) --correlation-map $(CORRELATION_MAP_FILES) > $(OUTPUT)
 .PHONY: correlation-map

--- a/tooling/prometheus-rules/Makefile
+++ b/tooling/prometheus-rules/Makefile
@@ -20,82 +20,45 @@ fmt-devinfra:
 	$(MAKE) -C ../../dev-infrastructure fmt
 .PHONY: fmt-devinfra
 
-run: alerts recording-rules
-.PHONY: run
+ALERT_CONFIGS = alerts-sl-services alerts-sl-hcps alerts-sre-hcps alerts-sre-services alerts-rp-services alerts-rp-hcps alerts-msft-services alerts-kusto-services alerts-kusto-hcps alerts-dev-services alerts-dev-hcps
+RECORDING_CONFIGS = recording-rules-services recording-rules-hcps
+CONFIGS = $(ALERT_CONFIGS) $(RECORDING_CONFIGS)
 
-alerts: run-sl-services run-sl-hcps run-sre-hcps run-sre-services run-rp-services run-rp-hcps run-msft-services run-kusto-services run-kusto-hcps run-dev-services run-dev-hcps
+alerts: $(BINARY)
+	@set -e; for cfg in $(ALERT_CONFIGS); do \
+		./$(BINARY) --skip-tests --config-file ../../observability/$${cfg}.yaml $(EXTRA_FLAGS); \
+	done
 	$(MAKE) fmt-devinfra
 .PHONY: alerts
 
-recording-rules: run-recording-rules-services run-recording-rules-hcps
+alerts-and-test: $(BINARY)
+	@set -e; for cfg in $(CONFIGS); do \
+		./$(BINARY) --config-file ../../observability/$${cfg}.yaml $(EXTRA_FLAGS); \
+	done
+	$(MAKE) fmt-devinfra
+.PHONY: alerts-and-test
+
+# Compatibility entrypoint: historically `run` generated both alerts and
+# recording rules with promtool tests, so keep it pointed at the tested path.
+run: alerts-and-test
+.PHONY: run
+
+RUN_TARGETS = $(addprefix run-,$(CONFIGS))
+
+$(RUN_TARGETS): run-%: $(BINARY)
+	./$(BINARY) --config-file ../../observability/$*.yaml $(EXTRA_FLAGS)
+
+.PHONY: $(RUN_TARGETS)
+
+recording-rules: $(BINARY)
+	@set -e; for cfg in $(RECORDING_CONFIGS); do \
+		./$(BINARY) --skip-tests --config-file ../../observability/$${cfg}.yaml $(EXTRA_FLAGS); \
+	done
 	$(MAKE) fmt-devinfra
 .PHONY: recording-rules
 
-run-sl-services:
-	go run ./...  --config-file ../../observability/alerts-sl-services.yaml $(EXTRA_FLAGS)
-.PHONY: run-sl-services
+CORRELATION_MAP_FILES = $(addprefix ../../observability/,$(addsuffix .yaml,$(ALERT_CONFIGS)))
 
-run-sl-hcps:
-	go run ./...  --config-file ../../observability/alerts-sl-hcps.yaml $(EXTRA_FLAGS)
-.PHONY: run-sl-hcps
-
-run-sre-hcps:
-	go run ./...  --config-file ../../observability/alerts-sre-hcps.yaml $(EXTRA_FLAGS)
-.PHONY: run-sre-hcps
-
-run-sre-services:
-	go run ./...  --config-file ../../observability/alerts-sre-services.yaml $(EXTRA_FLAGS)
-.PHONY: run-sre-services
-
-run-rp-services:
-	go run ./...  --config-file ../../observability/alerts-rp-services.yaml $(EXTRA_FLAGS)
-.PHONY: run-rp-services
-
-run-rp-hcps:
-	go run ./...  --config-file ../../observability/alerts-rp-hcps.yaml $(EXTRA_FLAGS)
-.PHONY: run-rp-hcps
-
-run-msft-services:
-	go run ./...  --config-file ../../observability/alerts-msft-services.yaml $(EXTRA_FLAGS)
-.PHONY: run-msft-services
-
-run-kusto-services:
-	go run ./...  --config-file ../../observability/alerts-kusto-services.yaml $(EXTRA_FLAGS)
-.PHONY: run-kusto-services
-
-run-kusto-hcps:
-	go run ./...  --config-file ../../observability/alerts-kusto-hcps.yaml $(EXTRA_FLAGS)
-.PHONY: run-kusto-hcps
-
-run-dev-services:
-	go run ./...  --config-file ../../observability/alerts-dev-services.yaml $(EXTRA_FLAGS)
-.PHONY: run-dev-services
-
-run-dev-hcps:
-	go run ./...  --config-file ../../observability/alerts-dev-hcps.yaml $(EXTRA_FLAGS)
-.PHONY: run-dev-hcps
-
-run-recording-rules-services:
-	go run ./...  --config-file ../../observability/recording-rules-services.yaml $(EXTRA_FLAGS)
-.PHONY: run-recording-rules-services
-
-run-recording-rules-hcps:
-	go run ./...  --config-file ../../observability/recording-rules-hcps.yaml $(EXTRA_FLAGS)
-.PHONY: run-recording-rules-hcps
-
-ALERT_CONFIGS = \
-	../../observability/alerts-sl-services.yaml \
-	../../observability/alerts-sl-hcps.yaml \
-	../../observability/alerts-sre-hcps.yaml \
-	../../observability/alerts-sre-services.yaml \
-	../../observability/alerts-rp-services.yaml \
-	../../observability/alerts-rp-hcps.yaml \
-	../../observability/alerts-msft-services.yaml \
-	../../observability/alerts-kusto-services.yaml \
-	../../observability/alerts-kusto-hcps.yaml \
-	../../observability/alerts-dev-services.yaml \
-	../../observability/alerts-dev-hcps.yaml
-
-correlation-map:
-	go run ./... --correlation-map $(ALERT_CONFIGS) > $(OUTPUT)
+correlation-map: $(BINARY)
+	./$(BINARY) --correlation-map $(CORRELATION_MAP_FILES) > $(OUTPUT)
 .PHONY: correlation-map

--- a/tooling/prometheus-rules/README.md
+++ b/tooling/prometheus-rules/README.md
@@ -57,7 +57,9 @@ Note: `run`, `alerts`, and `recording-rules` automatically run `fmt-devinfra` af
 ### Command-line Options
 
 - `--config-file` (required): Path to configuration YAML file
-- `--force-info-severity`: Override all alert severities to "info" level (useful for testing)
+- `--promtool-path`: Path to promtool binary (default: `promtool`)
+- `--skip-tests`: Skip promtool test execution (generate Bicep only)
+- `--correlation-map`: Output a YAML correlation map instead of generating Bicep
 
 ## Configuration
 

--- a/tooling/prometheus-rules/README.md
+++ b/tooling/prometheus-rules/README.md
@@ -58,7 +58,9 @@ Note: `run`, `alerts`, and `recording-rules` automatically run `fmt-devinfra` af
 ### Command-line Options
 
 - `--config-file` (required): Path to configuration YAML file
-- `--force-info-severity`: Override all alert severities to "info" level (useful for testing)
+- `--promtool-path`: Path to promtool binary (default: `promtool`)
+- `--skip-tests`: Skip promtool test execution (generate Bicep only)
+- `--correlation-map`: Output a YAML correlation map instead of generating Bicep
 
 ## Configuration
 

--- a/tooling/prometheus-rules/README.md
+++ b/tooling/prometheus-rules/README.md
@@ -33,34 +33,50 @@ make
 ### Run
 
 ```bash
-# Generate everything (alerts + recording rules)
+# Generate alerts only, skipping promtool tests for speed
+make alerts
+
+# Generate alerts *and* recording rules, running promtool tests for each
+make alerts-and-test
+
+# Alias for alerts-and-test, kept for callers that predate the split
 make run
 
-# Generate all alerts or all recording rules
-make alerts          # All 4 alert configs
-make recording-rules # Both recording-rules configs
+# Generate recording rules only, skipping promtool tests
+make recording-rules
 
-# Generate individually
-make run-sl-services              # Alerting rules: SL queue, services datasource
-make run-sre-hcps                 # Alerting rules: SRE queue, HCPs datasource
-make run-rp-services              # Alerting rules: RP queue, services datasource
-make run-rp-hcps                  # Alerting rules: RP queue, HCPs datasource
-make run-msft-services            # Alerting rules: MSFT queue, services datasource
-make run-recording-rules-services # Recording rules: services datasource
-make run-recording-rules-hcps    # Recording rules: HCPs datasource
+# Generate individually (runs promtool tests)
+make run-alerts-sl-services              # Alerting rules: SL queue, services datasource
+make run-alerts-sl-hcps                  # Alerting rules: SL queue, HCPs datasource
+make run-alerts-sre-hcps                 # Alerting rules: SRE queue, HCPs datasource
+make run-alerts-sre-services             # Alerting rules: SRE queue, services datasource
+make run-alerts-rp-services              # Alerting rules: RP queue, services datasource
+make run-alerts-rp-hcps                  # Alerting rules: RP queue, HCPs datasource
+make run-alerts-msft-services            # Alerting rules: MSFT queue, services datasource
+make run-alerts-kusto-services           # Alerting rules: Kusto, services datasource
+make run-alerts-kusto-hcps               # Alerting rules: Kusto, HCPs datasource
+make run-alerts-dev-services             # Alerting rules: DEV queue, services datasource
+make run-alerts-dev-hcps                 # Alerting rules: DEV queue, HCPs datasource
+make run-recording-rules-services        # Recording rules: services datasource
+make run-recording-rules-hcps            # Recording rules: HCPs datasource
+
+# Generate a correlation map (YAML to stdout)
+make correlation-map OUTPUT=path/to/output.yaml
 
 # Custom configuration
-go run . --config-file path/to/config.yaml
+./prometheus-rules --config-file path/to/config.yaml
 ```
 
-Note: `run`, `alerts`, and `recording-rules` automatically run `fmt-devinfra` after generation. Individual `run-*` targets do not.
+Note: `alerts`, `alerts-and-test`, and `recording-rules` automatically run `fmt-devinfra` after generation. Individual `run-*` targets do not.
 
 ### Command-line Options
 
-- `--config-file` (required): Path to configuration YAML file
+- `--config-file`: Path to configuration YAML file. Required for Bicep generation; optional
+  with `--correlation-map`, where config paths may also be given as positional arguments
 - `--promtool-path`: Path to promtool binary (default: `promtool`)
 - `--skip-tests`: Skip promtool test execution (generate Bicep only)
 - `--correlation-map`: Output a YAML correlation map instead of generating Bicep
+- `--preserve-aggregation-labels`: Comma-separated labels that must survive every aggregation in a rule's PromQL (default: `region`)
 
 ## Configuration
 
@@ -154,13 +170,16 @@ go test -cover ./...
 
 ```
 .
-├── main.go              # CLI entry point
-├── main_test.go         # CLI tests
+├── main.go                          # CLI entry point
+├── main_test.go                     # CLI tests
 ├── internal/
-│   ├── generator.go     # Core rule generation logic
+│   ├── generator.go                 # Core rule generation logic
 │   ├── generator_test.go
-│   ├── writer.go        # Expression replacement utilities
+│   ├── writer.go                    # Expression replacement utilities
 │   └── writer_test.go
+├── pkg/prometheusrules/
+│   ├── prometheusrules.go           # Options, validation, and public API
+│   └── prometheusrules_test.go
 └── README.md
 ```
 

--- a/tooling/prometheus-rules/go.mod
+++ b/tooling/prometheus-rules/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/prometheus/common v0.67.5
 	github.com/prometheus/prometheus v0.312.0
 	github.com/sirupsen/logrus v1.9.4
+	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	k8s.io/apimachinery v0.35.3
 	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5
@@ -25,6 +26,7 @@ require (
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/grafana/regexp v0.0.0-20250905093917-f7b3be9d1853 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
@@ -33,6 +35,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
+	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect

--- a/tooling/prometheus-rules/go.sum
+++ b/tooling/prometheus-rules/go.sum
@@ -52,6 +52,7 @@ github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1x
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -83,6 +84,8 @@ github.com/googleapis/gax-go/v2 v2.22.0 h1:PjIWBpgGIVKGoCXuiCoP64altEJCj3/Ei+kSU
 github.com/googleapis/gax-go/v2 v2.22.0/go.mod h1:irWBbALSr0Sk3qlqb9SyJ1h68WjgeFuiOzI4Rqw5+aY=
 github.com/grafana/regexp v0.0.0-20250905093917-f7b3be9d1853 h1:cLN4IBkmkYZNnk7EAJ0BHIethd+J6LqxFNw5mSiI2bM=
 github.com/grafana/regexp v0.0.0-20250905093917-f7b3be9d1853/go.mod h1:+JKpmjMGhpgPL+rXZ5nsZieVzvarn86asRlBg4uNGnk=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -132,8 +135,12 @@ github.com/prometheus/sigv4 v0.4.1 h1:EIc3j+8NBea9u1iV6O5ZAN8uvPq2xOIUPcqCTivHuX
 github.com/prometheus/sigv4 v0.4.1/go.mod h1:eu+ZbRvsc5TPiHwqh77OWuCnWK73IdkETYY46P4dXOU=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
+github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
+github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/tooling/prometheus-rules/internal/generator.go
+++ b/tooling/prometheus-rules/internal/generator.go
@@ -113,9 +113,6 @@ func readRulesFile(filename string) (*monitoringv1.PrometheusRule, error) {
 }
 
 func (o *Options) Complete(configFilePath string, promtoolPath string) error {
-	if promtoolPath == "" {
-		return fmt.Errorf("promtoolPath cannot be an empty string")
-	}
 	o.promtoolPath = promtoolPath
 
 	o.ruleFiles = make([]alertingRuleFile, 0)

--- a/tooling/prometheus-rules/internal/generator.go
+++ b/tooling/prometheus-rules/internal/generator.go
@@ -152,9 +152,6 @@ func readRulesFile(filename string) (*monitoringv1.PrometheusRule, error) {
 }
 
 func (o *Options) Complete(configFilePath string, promtoolPath string) error {
-	if promtoolPath == "" {
-		return fmt.Errorf("promtoolPath cannot be an empty string")
-	}
 	o.promtoolPath = promtoolPath
 
 	o.ruleFiles = make([]alertingRuleFile, 0)
@@ -268,7 +265,9 @@ func (o *Options) Complete(configFilePath string, promtoolPath string) error {
 			}
 
 			if d.Type().IsRegular() {
-				if strings.Contains(path, "_test") {
+				// Match on the filename only: a parent directory containing
+				// "_test" must not cause every rule under it to be skipped.
+				if strings.Contains(filepath.Base(path), "_test") {
 					return nil
 				}
 

--- a/tooling/prometheus-rules/main.go
+++ b/tooling/prometheus-rules/main.go
@@ -15,10 +15,11 @@
 package main
 
 import (
-	"flag"
+	"fmt"
 	"os"
 
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/yaml"
 
@@ -29,40 +30,67 @@ func main() {
 	if os.Getenv("DEBUG") == "true" {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
-	var configFilePath string
-	var promtoolPath string
-	var correlationMap bool
 
-	flag.CommandLine.StringVar(&configFilePath, "config-file", "", "Path to configuration")
-	flag.CommandLine.StringVar(&promtoolPath, "promtool-path", "promtool", "Path to promtool binary ")
-	flag.CommandLine.BoolVar(&correlationMap, "correlation-map", false, "Output a YAML correlation map instead of generating Bicep")
-	flag.Parse()
-
-	if correlationMap {
-		configs := flag.Args()
-		if configFilePath != "" {
-			configs = append([]string{configFilePath}, configs...)
-		}
-		if len(configs) == 0 {
-			logrus.Fatal("at least one config file must be provided via --config-file or as arguments")
-		}
-		entries, err := prometheusrules.GenerateCorrelationMap(configs)
-		if err != nil {
-			logrus.WithError(err).Fatal("error generating correlation map")
-		}
-		out, err := yaml.Marshal(entries)
-		if err != nil {
-			logrus.WithError(err).Fatal("error marshaling correlation map")
-		}
-		os.Stdout.Write(out)
-		return
+	cmd, err := newCommand()
+	if err != nil {
+		logrus.WithError(err).Fatal("failed to create command")
 	}
 
-	if err := prometheusrules.Validate(flag.Args(), configFilePath, promtoolPath); err != nil {
-		logrus.WithError(err).Fatal("invalid options")
-	}
-
-	if err := prometheusrules.GenerateFromConfig(configFilePath, false, promtoolPath); err != nil {
+	if err := cmd.Execute(); err != nil {
 		logrus.WithError(err).Fatal("error running generator")
 	}
+}
+
+func newCommand() (*cobra.Command, error) {
+	opts := prometheusrules.DefaultOptions()
+	cmd := &cobra.Command{
+		Use:           "prometheus-rules",
+		Short:         "Generate Azure Bicep templates from Prometheus rules",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.CorrelationMap {
+				configs := args
+				if opts.ConfigFile != "" {
+					configs = append([]string{opts.ConfigFile}, configs...)
+				}
+				if len(configs) == 0 {
+					return fmt.Errorf("at least one config file must be provided via --config-file or as arguments")
+				}
+				entries, err := prometheusrules.GenerateCorrelationMap(configs)
+				if err != nil {
+					return fmt.Errorf("error generating correlation map: %w", err)
+				}
+				out, err := yaml.Marshal(entries)
+				if err != nil {
+					return fmt.Errorf("error marshaling correlation map: %w", err)
+				}
+				if _, err := os.Stdout.Write(out); err != nil {
+					return fmt.Errorf("error writing correlation map: %w", err)
+				}
+				return nil
+			}
+
+			if len(args) > 0 {
+				return fmt.Errorf("unexpected positional arguments: %v", args)
+			}
+			return run(opts)
+		},
+	}
+	if err := prometheusrules.BindOptions(opts, cmd); err != nil {
+		return nil, err
+	}
+	return cmd, nil
+}
+
+func run(opts *prometheusrules.RawOptions) error {
+	validated, err := opts.Validate()
+	if err != nil {
+		return err
+	}
+	completed, err := validated.Complete()
+	if err != nil {
+		return err
+	}
+	return completed.Run()
 }

--- a/tooling/prometheus-rules/main.go
+++ b/tooling/prometheus-rules/main.go
@@ -15,11 +15,11 @@
 package main
 
 import (
-	"flag"
+	"fmt"
 	"os"
-	"strings"
 
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 
 	"sigs.k8s.io/yaml"
 
@@ -30,53 +30,67 @@ func main() {
 	if os.Getenv("DEBUG") == "true" {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
-	var configFilePath string
-	var promtoolPath string
-	var correlationMap bool
-	var preserveAggregationLabels string
 
-	flag.CommandLine.StringVar(&configFilePath, "config-file", "", "Path to configuration")
-	flag.CommandLine.StringVar(&promtoolPath, "promtool-path", "promtool", "Path to promtool binary ")
-	flag.CommandLine.BoolVar(&correlationMap, "correlation-map", false, "Output a YAML correlation map instead of generating Bicep")
-	flag.CommandLine.StringVar(&preserveAggregationLabels, "preserve-aggregation-labels", "region", "Comma-separated labels that must survive every aggregation in a rule's PromQL")
-	flag.Parse()
-
-	if correlationMap {
-		configs := flag.Args()
-		if configFilePath != "" {
-			configs = append([]string{configFilePath}, configs...)
-		}
-		if len(configs) == 0 {
-			logrus.Fatal("at least one config file must be provided via --config-file or as arguments")
-		}
-		entries, err := prometheusrules.GenerateCorrelationMap(configs)
-		if err != nil {
-			logrus.WithError(err).Fatal("error generating correlation map")
-		}
-		out, err := yaml.Marshal(entries)
-		if err != nil {
-			logrus.WithError(err).Fatal("error marshaling correlation map")
-		}
-		os.Stdout.Write(out)
-		return
+	cmd, err := newCommand()
+	if err != nil {
+		logrus.WithError(err).Fatal("failed to create command")
 	}
 
-	if err := prometheusrules.Validate(flag.Args(), configFilePath, promtoolPath); err != nil {
-		logrus.WithError(err).Fatal("invalid options")
-	}
-
-	if err := prometheusrules.GenerateFromConfig(configFilePath, false, promtoolPath, splitAndTrim(preserveAggregationLabels)); err != nil {
+	if err := cmd.Execute(); err != nil {
 		logrus.WithError(err).Fatal("error running generator")
 	}
 }
 
-// splitAndTrim splits a comma-separated list, trimming whitespace and dropping empties.
-func splitAndTrim(csv string) []string {
-	var out []string
-	for _, part := range strings.Split(csv, ",") {
-		if trimmed := strings.TrimSpace(part); trimmed != "" {
-			out = append(out, trimmed)
-		}
+func newCommand() (*cobra.Command, error) {
+	opts := prometheusrules.DefaultOptions()
+	cmd := &cobra.Command{
+		Use:           "prometheus-rules",
+		Short:         "Generate Azure Bicep templates from Prometheus rules",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.CorrelationMap {
+				configs := args
+				if opts.ConfigFile != "" {
+					configs = append([]string{opts.ConfigFile}, configs...)
+				}
+				if len(configs) == 0 {
+					return fmt.Errorf("at least one config file must be provided via --config-file or as arguments")
+				}
+				entries, err := prometheusrules.GenerateCorrelationMap(configs)
+				if err != nil {
+					return fmt.Errorf("error generating correlation map: %w", err)
+				}
+				out, err := yaml.Marshal(entries)
+				if err != nil {
+					return fmt.Errorf("error marshaling correlation map: %w", err)
+				}
+				if _, err := cmd.OutOrStdout().Write(out); err != nil {
+					return fmt.Errorf("error writing correlation map: %w", err)
+				}
+				return nil
+			}
+
+			if len(args) > 0 {
+				return fmt.Errorf("unexpected positional arguments: %v", args)
+			}
+			return run(opts)
+		},
 	}
-	return out
+	if err := prometheusrules.BindOptions(opts, cmd); err != nil {
+		return nil, err
+	}
+	return cmd, nil
+}
+
+func run(opts *prometheusrules.RawOptions) error {
+	validated, err := opts.Validate()
+	if err != nil {
+		return err
+	}
+	completed, err := validated.Complete()
+	if err != nil {
+		return err
+	}
+	return completed.Run()
 }

--- a/tooling/prometheus-rules/main_test.go
+++ b/tooling/prometheus-rules/main_test.go
@@ -50,6 +50,23 @@ func copyFile(fileToCopy, targetDir string) error {
 	return os.WriteFile(filepath.Join(targetDir, filepath.Base(fileToCopy)), input, 0644)
 }
 
+func runGenerator(configFile, promtoolPath string, skipTests bool) error {
+	opts := &prometheusrules.RawOptions{
+		ConfigFile:   configFile,
+		PromtoolPath: promtoolPath,
+		SkipTests:    skipTests,
+	}
+	validated, err := opts.Validate()
+	if err != nil {
+		return err
+	}
+	completed, err := validated.Complete()
+	if err != nil {
+		return err
+	}
+	return completed.Run()
+}
+
 func TestPrometheusRules(t *testing.T) {
 
 	testCases := []struct {
@@ -72,7 +89,7 @@ func TestPrometheusRules(t *testing.T) {
 			} {
 				require.NoError(t, copyFile(testfile, filepath.Join(tmpDir, "alerts")))
 			}
-			err := prometheusrules.GenerateFromConfig(filepath.Join(tmpDir, "config.yaml"), false, "promtool")
+			err := runGenerator(filepath.Join(tmpDir, "config.yaml"), "promtool", false)
 			require.NoError(t, err)
 
 			generatedFile, err := os.ReadFile(filepath.Join(tmpDir, "zzz_generated_AlertingRules.bicep"))
@@ -100,7 +117,7 @@ func TestPrometheusRulesMissingTest(t *testing.T) {
 	} {
 		require.NoError(t, copyFile(testfile, filepath.Join(tmpDir, "alerts")))
 	}
-	err := prometheusrules.GenerateFromConfig(filepath.Join(tmpDir, "config.yaml"), false, "promtool")
+	err := runGenerator(filepath.Join(tmpDir, "config.yaml"), "promtool", false)
 	require.ErrorContains(t, err, "missing testfile")
 }
 
@@ -108,7 +125,6 @@ func TestPrometheusRulesMixedRulesNotAllowed(t *testing.T) {
 	tmpDir := t.TempDir()
 	require.NoError(t, setupTestFiles(tmpDir, ""))
 
-	// Create a rule file with mixed alert and recording rules in the same group
 	mixedRulesContent := `apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -125,7 +141,6 @@ spec:
       expr: rate(test_metric[5m])
 `
 
-	// Create a corresponding test file (required by the generator)
 	testFileContent := `rule_files:
 - mixed-prometheusRule.yaml
 tests: []
@@ -137,17 +152,12 @@ tests: []
 	err = os.WriteFile(filepath.Join(tmpDir, "alerts", "mixed-prometheusRule_test.yaml"), []byte(testFileContent), 0644)
 	require.NoError(t, err)
 
-	// Run the generator - it should handle mixed rules based on file type
-	// Since we're using AlertingRules filename, it should process only alerts
-	err = prometheusrules.GenerateFromConfig(filepath.Join(tmpDir, "config.yaml"), false, "promtool")
+	err = runGenerator(filepath.Join(tmpDir, "config.yaml"), "promtool", false)
 	require.NoError(t, err)
 
-	// Verify the generated file exists and contains only alert rules
 	generatedFile, err := os.ReadFile(filepath.Join(tmpDir, "zzz_generated_AlertingRules.bicep"))
 	require.NoError(t, err)
 
-	// The generated content should contain alert-related configuration
 	require.Contains(t, string(generatedFile), "alert: 'TestAlert'")
-	// Recording rules should be ignored when generating AlertingRules file
 	require.NotContains(t, string(generatedFile), "record: 'test:metric:rate5m'")
 }

--- a/tooling/prometheus-rules/main_test.go
+++ b/tooling/prometheus-rules/main_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -50,6 +51,24 @@ func copyFile(fileToCopy, targetDir string) error {
 	return os.WriteFile(filepath.Join(targetDir, filepath.Base(fileToCopy)), input, 0644)
 }
 
+func runGenerator(configFile, promtoolPath string, skipTests bool) error {
+	opts := &prometheusrules.RawOptions{
+		ConfigFile:                configFile,
+		PromtoolPath:              promtoolPath,
+		SkipTests:                 skipTests,
+		PreserveAggregationLabels: "region",
+	}
+	validated, err := opts.Validate()
+	if err != nil {
+		return err
+	}
+	completed, err := validated.Complete()
+	if err != nil {
+		return err
+	}
+	return completed.Run()
+}
+
 func TestPrometheusRules(t *testing.T) {
 
 	testCases := []struct {
@@ -72,7 +91,7 @@ func TestPrometheusRules(t *testing.T) {
 			} {
 				require.NoError(t, copyFile(testfile, filepath.Join(tmpDir, "alerts")))
 			}
-			err := prometheusrules.GenerateFromConfig(filepath.Join(tmpDir, "config.yaml"), false, "promtool", []string{"region"})
+			err := runGenerator(filepath.Join(tmpDir, "config.yaml"), "promtool", false)
 			require.NoError(t, err)
 
 			generatedFile, err := os.ReadFile(filepath.Join(tmpDir, "zzz_generated_AlertingRules.bicep"))
@@ -100,7 +119,7 @@ func TestPrometheusRulesMissingTest(t *testing.T) {
 	} {
 		require.NoError(t, copyFile(testfile, filepath.Join(tmpDir, "alerts")))
 	}
-	err := prometheusrules.GenerateFromConfig(filepath.Join(tmpDir, "config.yaml"), false, "promtool", []string{"region"})
+	err := runGenerator(filepath.Join(tmpDir, "config.yaml"), "promtool", false)
 	require.ErrorContains(t, err, "missing testfile")
 }
 
@@ -108,7 +127,6 @@ func TestPrometheusRulesMixedRulesNotAllowed(t *testing.T) {
 	tmpDir := t.TempDir()
 	require.NoError(t, setupTestFiles(tmpDir, ""))
 
-	// Create a rule file with mixed alert and recording rules in the same group
 	mixedRulesContent := `apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -126,7 +144,6 @@ spec:
       expr: rate(test_metric[5m])
 `
 
-	// Create a corresponding test file (required by the generator)
 	testFileContent := `rule_files:
 - mixed-prometheusRule.yaml
 tests: []
@@ -138,17 +155,98 @@ tests: []
 	err = os.WriteFile(filepath.Join(tmpDir, "alerts", "mixed-prometheusRule_test.yaml"), []byte(testFileContent), 0644)
 	require.NoError(t, err)
 
-	// Run the generator - it should handle mixed rules based on file type
-	// Since we're using AlertingRules filename, it should process only alerts
-	err = prometheusrules.GenerateFromConfig(filepath.Join(tmpDir, "config.yaml"), false, "promtool", []string{"region"})
+	err = runGenerator(filepath.Join(tmpDir, "config.yaml"), "promtool", false)
 	require.NoError(t, err)
 
-	// Verify the generated file exists and contains only alert rules
 	generatedFile, err := os.ReadFile(filepath.Join(tmpDir, "zzz_generated_AlertingRules.bicep"))
 	require.NoError(t, err)
 
-	// The generated content should contain alert-related configuration
 	require.Contains(t, string(generatedFile), "alert: 'TestAlert'")
-	// Recording rules should be ignored when generating AlertingRules file
 	require.NotContains(t, string(generatedFile), "record: 'test:metric:rate5m'")
+}
+
+// executeCommand builds the real cobra command and runs it with the given
+// arguments, returning anything the command wrote to its output stream. This
+// exercises the flag binding and RunE dispatch that main() relies on, which
+// calling prometheusrules.RawOptions directly would bypass.
+func executeCommand(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+
+	cmd, err := newCommand()
+	require.NoError(t, err)
+
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(args)
+
+	execErr := cmd.Execute()
+	return out.String(), execErr
+}
+
+func TestCommandGenerates(t *testing.T) {
+	tmpDir := t.TempDir()
+	require.NoError(t, setupTestFiles(tmpDir, ""))
+
+	for _, testfile := range []string{
+		"./testdata/alerts/testing-prometheusRule_test.yaml",
+		"./testdata/alerts/testing-prometheusRule.yaml",
+	} {
+		require.NoError(t, copyFile(testfile, filepath.Join(tmpDir, "alerts")))
+	}
+
+	_, err := executeCommand(t, "--config-file", filepath.Join(tmpDir, "config.yaml"), "--skip-tests")
+	require.NoError(t, err)
+
+	generated, err := os.ReadFile(filepath.Join(tmpDir, "zzz_generated_AlertingRules.bicep"))
+	require.NoError(t, err)
+	require.Contains(t, string(generated), "alert:")
+}
+
+func TestCommandCorrelationMap(t *testing.T) {
+	tmpDir := t.TempDir()
+	require.NoError(t, setupTestFiles(tmpDir, ""))
+
+	for _, testfile := range []string{
+		"./testdata/alerts/testing-prometheusRule_test.yaml",
+		"./testdata/alerts/testing-prometheusRule.yaml",
+	} {
+		require.NoError(t, copyFile(testfile, filepath.Join(tmpDir, "alerts")))
+	}
+
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	// The Makefile drives correlation-map mode with positional args rather than
+	// --config-file, so both spellings need to keep working.
+	t.Run("positional config", func(t *testing.T) {
+		out, err := executeCommand(t, "--correlation-map", configPath)
+		require.NoError(t, err)
+		require.Contains(t, out, "alert: InstancesDownV1/")
+		require.Contains(t, out, "correlationId:")
+	})
+
+	t.Run("config-file flag", func(t *testing.T) {
+		out, err := executeCommand(t, "--correlation-map", "--config-file", configPath)
+		require.NoError(t, err)
+		require.Contains(t, out, "alert: InstancesDownV1/")
+		require.Contains(t, out, "correlationId:")
+	})
+
+	t.Run("no config at all", func(t *testing.T) {
+		_, err := executeCommand(t, "--correlation-map")
+		require.ErrorContains(t, err, "at least one config file must be provided")
+	})
+}
+
+func TestCommandRejectsUnexpectedArgs(t *testing.T) {
+	tmpDir := t.TempDir()
+	require.NoError(t, setupTestFiles(tmpDir, ""))
+
+	_, err := executeCommand(t, "--config-file", filepath.Join(tmpDir, "config.yaml"), "--skip-tests", "stray-arg")
+	require.ErrorContains(t, err, "unexpected positional arguments")
+}
+
+func TestCommandRequiresConfigFile(t *testing.T) {
+	_, err := executeCommand(t, "--skip-tests")
+	require.ErrorContains(t, err, "--config-file is required")
 }

--- a/tooling/prometheus-rules/pkg/prometheusrules/prometheusrules.go
+++ b/tooling/prometheus-rules/pkg/prometheusrules/prometheusrules.go
@@ -15,8 +15,10 @@
 package prometheusrules
 
 import (
-	"errors"
 	"fmt"
+	"os/exec"
+
+	"github.com/spf13/cobra"
 
 	"github.com/Azure/ARO-HCP/tooling/prometheus-rules/internal"
 )
@@ -27,35 +29,91 @@ type CorrelationMapEntry = internal.CorrelationMapEntry
 // CorrelationIDSegment re-exports the internal type for callers.
 type CorrelationIDSegment = internal.CorrelationIDSegment
 
-// Validate checks CLI arguments for rule generation.
-func Validate(args []string, configFilePath, promtoolPath string) error {
-	if len(args) != 0 {
-		return errors.New("no arguments are supported")
+func DefaultOptions() *RawOptions {
+	return &RawOptions{
+		PromtoolPath: "promtool",
 	}
-	if configFilePath == "" {
-		return errors.New("--config-file is required")
-	}
-	if promtoolPath == "" {
-		return errors.New("--promtool-path cannot be empty")
-	}
+}
+
+func BindOptions(opts *RawOptions, cmd *cobra.Command) error {
+	cmd.Flags().StringVar(&opts.ConfigFile, "config-file", opts.ConfigFile, "Path to configuration")
+	cmd.Flags().StringVar(&opts.PromtoolPath, "promtool-path", opts.PromtoolPath, "Path to promtool binary")
+	cmd.Flags().BoolVar(&opts.SkipTests, "skip-tests", opts.SkipTests, "Skip promtool test execution")
+	cmd.Flags().BoolVar(&opts.CorrelationMap, "correlation-map", opts.CorrelationMap, "Output a YAML correlation map instead of generating Bicep")
 	return nil
 }
 
-// GenerateFromConfig validates and renders rule files into Bicep output.
-// forceInfoSeverity is kept for compatibility with external callers and is ignored.
-func GenerateFromConfig(configFilePath string, _ bool, promtoolPath string) error {
-	o := internal.NewOptions()
+type RawOptions struct {
+	ConfigFile     string
+	PromtoolPath   string
+	SkipTests      bool
+	CorrelationMap bool
+}
 
-	if err := o.Complete(configFilePath, promtoolPath); err != nil {
-		return fmt.Errorf("could not complete options, %w", err)
+func (o *RawOptions) Validate() (*ValidatedOptions, error) {
+	if o.ConfigFile == "" {
+		return nil, fmt.Errorf("--config-file is required")
 	}
-	if err := o.RunTests(); err != nil {
-		return fmt.Errorf("testing rules failed %w", err)
+	if !o.SkipTests {
+		if o.PromtoolPath == "" {
+			return nil, fmt.Errorf("--promtool-path cannot be empty when tests are enabled")
+		}
 	}
-	if err := o.Generate(); err != nil {
-		return fmt.Errorf("failed to generate bicep %w", err)
+	return &ValidatedOptions{
+		validatedOptions: &validatedOptions{
+			RawOptions: o,
+		},
+	}, nil
+}
+
+type validatedOptions struct {
+	*RawOptions
+}
+
+type ValidatedOptions struct {
+	*validatedOptions
+}
+
+func (o *ValidatedOptions) Complete() (*Options, error) {
+	promtoolPath := o.PromtoolPath
+	if !o.SkipTests {
+		resolved, err := exec.LookPath(o.PromtoolPath)
+		if err != nil {
+			return nil, fmt.Errorf("promtool not found at %q: %w", o.PromtoolPath, err)
+		}
+		promtoolPath = resolved
 	}
 
+	gen := internal.NewOptions()
+	if err := gen.Complete(o.ConfigFile, promtoolPath); err != nil {
+		return nil, fmt.Errorf("could not complete options: %w", err)
+	}
+	return &Options{
+		completedOptions: &completedOptions{
+			generator: gen,
+			skipTests: o.SkipTests,
+		},
+	}, nil
+}
+
+type completedOptions struct {
+	generator *internal.Options
+	skipTests bool
+}
+
+type Options struct {
+	*completedOptions
+}
+
+func (o *Options) Run() error {
+	if !o.skipTests {
+		if err := o.generator.RunTests(); err != nil {
+			return fmt.Errorf("testing rules failed: %w", err)
+		}
+	}
+	if err := o.generator.Generate(); err != nil {
+		return fmt.Errorf("failed to generate bicep: %w", err)
+	}
 	return nil
 }
 
@@ -65,7 +123,7 @@ func GenerateCorrelationMap(configFilePaths []string) ([]CorrelationMapEntry, er
 	var all []CorrelationMapEntry
 	for _, configFilePath := range configFilePaths {
 		o := internal.NewOptions()
-		if err := o.Complete(configFilePath, "true"); err != nil {
+		if err := o.Complete(configFilePath, ""); err != nil {
 			return nil, fmt.Errorf("could not complete options for %s: %w", configFilePath, err)
 		}
 		entries, err := o.CorrelationMap()

--- a/tooling/prometheus-rules/pkg/prometheusrules/prometheusrules.go
+++ b/tooling/prometheus-rules/pkg/prometheusrules/prometheusrules.go
@@ -15,6 +15,7 @@
 package prometheusrules
 
 import (
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -93,18 +94,24 @@ type ValidatedOptions struct {
 }
 
 func (o *ValidatedOptions) Complete() (*Options, error) {
+	var validationErrors []error
+
 	promtoolPath := o.PromtoolPath
 	if !o.SkipTests {
 		resolved, err := exec.LookPath(o.PromtoolPath)
 		if err != nil {
-			return nil, fmt.Errorf("promtool not found at %q: %w", o.PromtoolPath, err)
+			validationErrors = append(validationErrors, fmt.Errorf("unable to find promtool binary: %w", err))
 		}
 		promtoolPath = resolved
 	}
 
 	gen := internal.NewOptions().WithPreserveAggregationLabels(splitAndTrim(o.PreserveAggregationLabels))
 	if err := gen.Complete(o.ConfigFile, promtoolPath); err != nil {
-		return nil, fmt.Errorf("could not complete options: %w", err)
+		validationErrors = append(validationErrors, fmt.Errorf("could not complete options: %w", err))
+	}
+
+	if len(validationErrors) > 0 {
+		return nil, errors.Join(validationErrors...)
 	}
 	return &Options{
 		completedOptions: &completedOptions{

--- a/tooling/prometheus-rules/pkg/prometheusrules/prometheusrules.go
+++ b/tooling/prometheus-rules/pkg/prometheusrules/prometheusrules.go
@@ -15,8 +15,11 @@
 package prometheusrules
 
 import (
-	"errors"
 	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/spf13/cobra"
 
 	"github.com/Azure/ARO-HCP/tooling/prometheus-rules/internal"
 )
@@ -27,37 +30,108 @@ type CorrelationMapEntry = internal.CorrelationMapEntry
 // CorrelationIDSegment re-exports the internal type for callers.
 type CorrelationIDSegment = internal.CorrelationIDSegment
 
-// Validate checks CLI arguments for rule generation.
-func Validate(args []string, configFilePath, promtoolPath string) error {
-	if len(args) != 0 {
-		return errors.New("no arguments are supported")
+func DefaultOptions() *RawOptions {
+	return &RawOptions{
+		PromtoolPath:              "promtool",
+		PreserveAggregationLabels: "region",
 	}
-	if configFilePath == "" {
-		return errors.New("--config-file is required")
-	}
-	if promtoolPath == "" {
-		return errors.New("--promtool-path cannot be empty")
-	}
+}
+
+func BindOptions(opts *RawOptions, cmd *cobra.Command) error {
+	cmd.Flags().StringVar(&opts.ConfigFile, "config-file", opts.ConfigFile, "Path to configuration")
+	cmd.Flags().StringVar(&opts.PromtoolPath, "promtool-path", opts.PromtoolPath, "Path to promtool binary")
+	cmd.Flags().BoolVar(&opts.SkipTests, "skip-tests", opts.SkipTests, "Skip promtool test execution")
+	cmd.Flags().BoolVar(&opts.CorrelationMap, "correlation-map", opts.CorrelationMap, "Output a YAML correlation map instead of generating Bicep")
+	cmd.Flags().StringVar(&opts.PreserveAggregationLabels, "preserve-aggregation-labels", opts.PreserveAggregationLabels, "Comma-separated labels that must survive every aggregation in a rule's PromQL")
 	return nil
 }
 
-// GenerateFromConfig validates and renders rule files into Bicep output.
-// forceInfoSeverity is kept for compatibility with external callers and is ignored.
-// preserveAggregationLabels lists labels that must survive every aggregation in a
-// rule's PromQL; each aggregation is rewritten so those labels remain on the output.
-func GenerateFromConfig(configFilePath string, _ bool, promtoolPath string, preserveAggregationLabels []string) error {
-	o := internal.NewOptions().WithPreserveAggregationLabels(preserveAggregationLabels)
+// splitAndTrim splits a comma-separated list, trimming whitespace and dropping empties.
+func splitAndTrim(csv string) []string {
+	var out []string
+	for _, part := range strings.Split(csv, ",") {
+		if trimmed := strings.TrimSpace(part); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}
 
-	if err := o.Complete(configFilePath, promtoolPath); err != nil {
-		return fmt.Errorf("could not complete options, %w", err)
+type RawOptions struct {
+	ConfigFile     string
+	PromtoolPath   string
+	SkipTests      bool
+	CorrelationMap bool
+	// PreserveAggregationLabels is a comma-separated list of labels that must
+	// survive every aggregation in a rule's PromQL; each aggregation is
+	// rewritten so those labels remain on the output.
+	PreserveAggregationLabels string
+}
+
+func (o *RawOptions) Validate() (*ValidatedOptions, error) {
+	if o.ConfigFile == "" {
+		return nil, fmt.Errorf("--config-file is required")
 	}
-	if err := o.RunTests(); err != nil {
-		return fmt.Errorf("testing rules failed %w", err)
+	if !o.SkipTests {
+		if o.PromtoolPath == "" {
+			return nil, fmt.Errorf("--promtool-path cannot be empty when tests are enabled")
+		}
 	}
-	if err := o.Generate(); err != nil {
-		return fmt.Errorf("failed to generate bicep %w", err)
+	return &ValidatedOptions{
+		validatedOptions: &validatedOptions{
+			RawOptions: o,
+		},
+	}, nil
+}
+
+type validatedOptions struct {
+	*RawOptions
+}
+
+type ValidatedOptions struct {
+	*validatedOptions
+}
+
+func (o *ValidatedOptions) Complete() (*Options, error) {
+	promtoolPath := o.PromtoolPath
+	if !o.SkipTests {
+		resolved, err := exec.LookPath(o.PromtoolPath)
+		if err != nil {
+			return nil, fmt.Errorf("promtool not found at %q: %w", o.PromtoolPath, err)
+		}
+		promtoolPath = resolved
 	}
 
+	gen := internal.NewOptions().WithPreserveAggregationLabels(splitAndTrim(o.PreserveAggregationLabels))
+	if err := gen.Complete(o.ConfigFile, promtoolPath); err != nil {
+		return nil, fmt.Errorf("could not complete options: %w", err)
+	}
+	return &Options{
+		completedOptions: &completedOptions{
+			generator: gen,
+			skipTests: o.SkipTests,
+		},
+	}, nil
+}
+
+type completedOptions struct {
+	generator *internal.Options
+	skipTests bool
+}
+
+type Options struct {
+	*completedOptions
+}
+
+func (o *Options) Run() error {
+	if !o.skipTests {
+		if err := o.generator.RunTests(); err != nil {
+			return fmt.Errorf("testing rules failed: %w", err)
+		}
+	}
+	if err := o.generator.Generate(); err != nil {
+		return fmt.Errorf("failed to generate bicep: %w", err)
+	}
 	return nil
 }
 
@@ -67,7 +141,7 @@ func GenerateCorrelationMap(configFilePaths []string) ([]CorrelationMapEntry, er
 	var all []CorrelationMapEntry
 	for _, configFilePath := range configFilePaths {
 		o := internal.NewOptions()
-		if err := o.Complete(configFilePath, "true"); err != nil {
+		if err := o.Complete(configFilePath, ""); err != nil {
 			return nil, fmt.Errorf("could not complete options for %s: %w", configFilePath, err)
 		}
 		entries, err := o.CorrelationMap()

--- a/tooling/prometheus-rules/pkg/prometheusrules/prometheusrules.go
+++ b/tooling/prometheus-rules/pkg/prometheusrules/prometheusrules.go
@@ -142,6 +142,42 @@ func (o *Options) Run() error {
 	return nil
 }
 
+// Validate checks CLI arguments for rule generation.
+//
+// Deprecated: use RawOptions.Validate instead. Retained so external callers of
+// this module keep compiling.
+func Validate(args []string, configFilePath, promtoolPath string) error {
+	if len(args) != 0 {
+		return errors.New("no arguments are supported")
+	}
+	opts := &RawOptions{ConfigFile: configFilePath, PromtoolPath: promtoolPath}
+	_, err := opts.Validate()
+	return err
+}
+
+// GenerateFromConfig validates and renders rule files into Bicep output,
+// running the promtool tests first.
+//
+// Deprecated: use RawOptions.Validate, ValidatedOptions.Complete and
+// Options.Run instead. Retained so external callers of this module keep
+// compiling. forceInfoSeverity is ignored.
+func GenerateFromConfig(configFilePath string, _ bool, promtoolPath string, preserveAggregationLabels []string) error {
+	opts := &RawOptions{
+		ConfigFile:                configFilePath,
+		PromtoolPath:              promtoolPath,
+		PreserveAggregationLabels: strings.Join(preserveAggregationLabels, ","),
+	}
+	validated, err := opts.Validate()
+	if err != nil {
+		return err
+	}
+	completed, err := validated.Complete()
+	if err != nil {
+		return err
+	}
+	return completed.Run()
+}
+
 // GenerateCorrelationMap loads rule configs and returns a structured mapping
 // from group/alert to parsed correlation ID segments.
 func GenerateCorrelationMap(configFilePaths []string) ([]CorrelationMapEntry, error) {

--- a/tooling/prometheus-rules/pkg/prometheusrules/prometheusrules_test.go
+++ b/tooling/prometheus-rules/pkg/prometheusrules/prometheusrules_test.go
@@ -1,0 +1,212 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheusrules
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultOptions(t *testing.T) {
+	opts := DefaultOptions()
+	assert.Equal(t, "promtool", opts.PromtoolPath)
+	assert.Equal(t, "", opts.ConfigFile)
+	assert.False(t, opts.SkipTests)
+}
+
+func TestBindOptions(t *testing.T) {
+	opts := DefaultOptions()
+	cmd := &cobra.Command{}
+	require.NoError(t, BindOptions(opts, cmd))
+
+	// config-file flag should exist (validated at runtime, not cobra-level required,
+	// because --correlation-map mode uses positional args instead)
+	flag := cmd.Flags().Lookup("config-file")
+	require.NotNil(t, flag)
+
+	// promtool-path should have a default
+	flag = cmd.Flags().Lookup("promtool-path")
+	require.NotNil(t, flag)
+	assert.Equal(t, "promtool", flag.DefValue)
+
+	// skip-tests should exist
+	flag = cmd.Flags().Lookup("skip-tests")
+	require.NotNil(t, flag)
+	assert.Equal(t, "false", flag.DefValue)
+}
+
+func TestValidate(t *testing.T) {
+	configFile := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(configFile, []byte(""), 0644))
+
+	promtoolFile := filepath.Join(t.TempDir(), "promtool")
+	require.NoError(t, os.WriteFile(promtoolFile, []byte(""), 0755))
+
+	tests := []struct {
+		name        string
+		opts        RawOptions
+		expectError string
+	}{
+		{
+			name: "valid with tests enabled and explicit promtool path",
+			opts: RawOptions{
+				ConfigFile:   configFile,
+				PromtoolPath: promtoolFile,
+			},
+		},
+		{
+			name: "valid with skip-tests and empty promtool path",
+			opts: RawOptions{
+				ConfigFile: configFile,
+				SkipTests:  true,
+			},
+		},
+		{
+			name: "empty config file",
+			opts: RawOptions{
+				PromtoolPath: promtoolFile,
+			},
+			expectError: "--config-file is required",
+		},
+		{
+			name: "empty promtool path with tests enabled",
+			opts: RawOptions{
+				ConfigFile:   configFile,
+				PromtoolPath: "",
+			},
+			expectError: "--promtool-path cannot be empty when tests are enabled",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			validated, err := tc.opts.Validate()
+			if tc.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectError)
+				assert.Nil(t, validated)
+			} else {
+				require.NoError(t, err)
+				assert.NotNil(t, validated)
+			}
+		})
+	}
+}
+
+func TestComplete(t *testing.T) {
+	configContent := `
+prometheusRules:
+  rulesFolders: []
+  untestedRules: []
+  outputBicep: zzz_generated_AlertingRules.bicep
+`
+	t.Run("valid config", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config.yaml")
+		require.NoError(t, os.WriteFile(configPath, []byte(configContent), 0644))
+
+		opts := &RawOptions{
+			ConfigFile: configPath,
+			SkipTests:  true,
+		}
+		validated, err := opts.Validate()
+		require.NoError(t, err)
+
+		completed, err := validated.Complete()
+		require.NoError(t, err)
+		assert.NotNil(t, completed)
+	})
+
+	t.Run("promtool binary not found", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config.yaml")
+		require.NoError(t, os.WriteFile(configPath, []byte(configContent), 0644))
+
+		opts := &RawOptions{
+			ConfigFile:   configPath,
+			PromtoolPath: "definitely-not-a-real-binary-abc123",
+		}
+		validated, err := opts.Validate()
+		require.NoError(t, err)
+
+		completed, err := validated.Complete()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "promtool not found at")
+		assert.Nil(t, completed)
+	})
+
+	t.Run("config file not found", func(t *testing.T) {
+		opts := &RawOptions{
+			ConfigFile: "/nonexistent/path/config.yaml",
+			SkipTests:  true,
+		}
+		validated, err := opts.Validate()
+		require.NoError(t, err)
+
+		completed, err := validated.Complete()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "configuration file")
+		assert.Nil(t, completed)
+	})
+
+	t.Run("invalid config content", func(t *testing.T) {
+		badConfig := filepath.Join(t.TempDir(), "bad.yaml")
+		require.NoError(t, os.WriteFile(badConfig, []byte("not: valid: yaml: ["), 0644))
+
+		opts := &RawOptions{
+			ConfigFile: badConfig,
+			SkipTests:  true,
+		}
+		validated, err := opts.Validate()
+		require.NoError(t, err)
+
+		completed, err := validated.Complete()
+		require.Error(t, err)
+		assert.Nil(t, completed)
+	})
+}
+
+func TestRun(t *testing.T) {
+	configContent := `
+prometheusRules:
+  rulesFolders: []
+  untestedRules: []
+  outputBicep: zzz_generated_AlertingRules.bicep
+`
+	t.Run("generate only with skip-tests", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config.yaml")
+		require.NoError(t, os.WriteFile(configPath, []byte(configContent), 0644))
+
+		opts := &RawOptions{
+			ConfigFile: configPath,
+			SkipTests:  true,
+		}
+		validated, err := opts.Validate()
+		require.NoError(t, err)
+		completed, err := validated.Complete()
+		require.NoError(t, err)
+
+		require.NoError(t, completed.Run())
+
+		_, err = os.Stat(filepath.Join(tmpDir, "zzz_generated_AlertingRules.bicep"))
+		assert.NoError(t, err)
+	})
+}

--- a/tooling/prometheus-rules/pkg/prometheusrules/prometheusrules_test.go
+++ b/tooling/prometheus-rules/pkg/prometheusrules/prometheusrules_test.go
@@ -364,3 +364,62 @@ func TestRunRuleFolderBelowTestNamedDirectory(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(generated), "alert: 'TestAlert'", "rule was dropped during discovery")
 }
+
+// The deprecated package-level helpers are the API this module exposed before
+// the options refactor. They are kept so out-of-repo callers keep compiling, so
+// exercise them here rather than letting them rot untested.
+func TestDeprecatedValidate(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		args         []string
+		configFile   string
+		promtoolPath string
+		expectedErr  string
+	}{
+		{
+			name:         "valid",
+			configFile:   "config.yaml",
+			promtoolPath: "promtool",
+		},
+		{
+			name:         "positional args rejected",
+			args:         []string{"stray"},
+			configFile:   "config.yaml",
+			promtoolPath: "promtool",
+			expectedErr:  "no arguments are supported",
+		},
+		{
+			name:         "config file required",
+			promtoolPath: "promtool",
+			expectedErr:  "--config-file is required",
+		},
+		{
+			name:        "promtool path required",
+			configFile:  "config.yaml",
+			expectedErr: "--promtool-path cannot be empty",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := Validate(tc.args, tc.configFile, tc.promtoolPath)
+			if tc.expectedErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tc.expectedErr)
+		})
+	}
+}
+
+func TestDeprecatedGenerateFromConfig(t *testing.T) {
+	tmpDir := writeRuleFixture(t)
+	promtool, marker := fakePromtool(t, 0)
+
+	require.NoError(t, GenerateFromConfig(filepath.Join(tmpDir, "config.yaml"), false, promtool, []string{"region"}))
+
+	_, err := os.Stat(marker)
+	require.NoError(t, err, "promtool was never invoked, but the deprecated helper always tests")
+
+	generated, err := os.ReadFile(filepath.Join(tmpDir, "zzz_generated_AlertingRules.bicep"))
+	require.NoError(t, err)
+	assert.Contains(t, string(generated), "alert: 'TestAlert'")
+}

--- a/tooling/prometheus-rules/pkg/prometheusrules/prometheusrules_test.go
+++ b/tooling/prometheus-rules/pkg/prometheusrules/prometheusrules_test.go
@@ -1,0 +1,366 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheusrules
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultOptions(t *testing.T) {
+	opts := DefaultOptions()
+	assert.Equal(t, "promtool", opts.PromtoolPath)
+	assert.Equal(t, "", opts.ConfigFile)
+	assert.False(t, opts.SkipTests)
+	assert.Equal(t, "region", opts.PreserveAggregationLabels)
+}
+
+func TestSplitAndTrim(t *testing.T) {
+	tests := []struct {
+		name     string
+		csv      string
+		expected []string
+	}{
+		{name: "empty", csv: "", expected: nil},
+		{name: "single", csv: "region", expected: []string{"region"}},
+		{name: "multiple with whitespace", csv: "region, cluster ,namespace", expected: []string{"region", "cluster", "namespace"}},
+		{name: "drops empties", csv: "region,,  ,cluster", expected: []string{"region", "cluster"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, splitAndTrim(tc.csv))
+		})
+	}
+}
+
+func TestBindOptions(t *testing.T) {
+	opts := DefaultOptions()
+	cmd := &cobra.Command{}
+	require.NoError(t, BindOptions(opts, cmd))
+
+	// config-file flag should exist (validated at runtime, not cobra-level required,
+	// because --correlation-map mode uses positional args instead)
+	flag := cmd.Flags().Lookup("config-file")
+	require.NotNil(t, flag)
+
+	// promtool-path should have a default
+	flag = cmd.Flags().Lookup("promtool-path")
+	require.NotNil(t, flag)
+	assert.Equal(t, "promtool", flag.DefValue)
+
+	// skip-tests should exist
+	flag = cmd.Flags().Lookup("skip-tests")
+	require.NotNil(t, flag)
+	assert.Equal(t, "false", flag.DefValue)
+
+	// preserve-aggregation-labels should keep the "region" default
+	flag = cmd.Flags().Lookup("preserve-aggregation-labels")
+	require.NotNil(t, flag)
+	assert.Equal(t, "region", flag.DefValue)
+}
+
+func TestValidate(t *testing.T) {
+	configFile := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(configFile, []byte(""), 0644))
+
+	promtoolFile := filepath.Join(t.TempDir(), "promtool")
+	require.NoError(t, os.WriteFile(promtoolFile, []byte(""), 0755))
+
+	tests := []struct {
+		name        string
+		opts        RawOptions
+		expectError string
+	}{
+		{
+			name: "valid with tests enabled and explicit promtool path",
+			opts: RawOptions{
+				ConfigFile:   configFile,
+				PromtoolPath: promtoolFile,
+			},
+		},
+		{
+			name: "valid with skip-tests and empty promtool path",
+			opts: RawOptions{
+				ConfigFile: configFile,
+				SkipTests:  true,
+			},
+		},
+		{
+			name: "empty config file",
+			opts: RawOptions{
+				PromtoolPath: promtoolFile,
+			},
+			expectError: "--config-file is required",
+		},
+		{
+			name: "empty promtool path with tests enabled",
+			opts: RawOptions{
+				ConfigFile:   configFile,
+				PromtoolPath: "",
+			},
+			expectError: "--promtool-path cannot be empty when tests are enabled",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			validated, err := tc.opts.Validate()
+			if tc.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectError)
+				assert.Nil(t, validated)
+			} else {
+				require.NoError(t, err)
+				assert.NotNil(t, validated)
+			}
+		})
+	}
+}
+
+func TestComplete(t *testing.T) {
+	configContent := `
+prometheusRules:
+  rulesFolders: []
+  untestedRules: []
+  outputBicep: zzz_generated_AlertingRules.bicep
+`
+	t.Run("valid config", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config.yaml")
+		require.NoError(t, os.WriteFile(configPath, []byte(configContent), 0644))
+
+		opts := &RawOptions{
+			ConfigFile: configPath,
+			SkipTests:  true,
+		}
+		validated, err := opts.Validate()
+		require.NoError(t, err)
+
+		completed, err := validated.Complete()
+		require.NoError(t, err)
+		assert.NotNil(t, completed)
+	})
+
+	t.Run("promtool binary not found", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configPath := filepath.Join(tmpDir, "config.yaml")
+		require.NoError(t, os.WriteFile(configPath, []byte(configContent), 0644))
+
+		opts := &RawOptions{
+			ConfigFile:   configPath,
+			PromtoolPath: "definitely-not-a-real-binary-abc123",
+		}
+		validated, err := opts.Validate()
+		require.NoError(t, err)
+
+		completed, err := validated.Complete()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "promtool not found at")
+		assert.Nil(t, completed)
+	})
+
+	t.Run("config file not found", func(t *testing.T) {
+		opts := &RawOptions{
+			ConfigFile: "/nonexistent/path/config.yaml",
+			SkipTests:  true,
+		}
+		validated, err := opts.Validate()
+		require.NoError(t, err)
+
+		completed, err := validated.Complete()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "configuration file")
+		assert.Nil(t, completed)
+	})
+
+	t.Run("invalid config content", func(t *testing.T) {
+		badConfig := filepath.Join(t.TempDir(), "bad.yaml")
+		require.NoError(t, os.WriteFile(badConfig, []byte("not: valid: yaml: ["), 0644))
+
+		opts := &RawOptions{
+			ConfigFile: badConfig,
+			SkipTests:  true,
+		}
+		validated, err := opts.Validate()
+		require.NoError(t, err)
+
+		completed, err := validated.Complete()
+		require.Error(t, err)
+		assert.Nil(t, completed)
+	})
+}
+
+// writeRuleFixture creates a config plus an alerts folder holding one alerting
+// rule and its promtool test file. A fixture with real rules is what gives
+// RunTests actual work to do; with an empty rulesFolders the generator never
+// shells out to promtool and skip-tests assertions pass vacuously.
+func writeRuleFixture(t *testing.T) string {
+	t.Helper()
+
+	return writeRuleFixtureIn(t, t.TempDir())
+}
+
+// writeRuleFixtureIn builds the fixture under an explicit base directory, so
+// tests can control the surrounding path.
+func writeRuleFixtureIn(t *testing.T, tmpDir string) string {
+	t.Helper()
+
+	require.NoError(t, os.Mkdir(filepath.Join(tmpDir, "alerts"), 0755))
+
+	config := `
+prometheusRules:
+  rulesFolders:
+  - ./alerts
+  untestedRules: []
+  outputBicep: zzz_generated_AlertingRules.bicep
+`
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "config.yaml"), []byte(config), 0644))
+
+	rule := `apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: testing
+spec:
+  groups:
+  - name: TestGroup
+    rules:
+    - alert: TestAlert
+      expr: up == 0
+      labels:
+        severity: critical
+        component: testing
+`
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "alerts", "testing-prometheusRule.yaml"), []byte(rule), 0644))
+
+	ruleTest := `rule_files:
+- testing-prometheusRule.yaml
+tests: []
+`
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "alerts", "testing-prometheusRule_test.yaml"), []byte(ruleTest), 0644))
+
+	return tmpDir
+}
+
+// fakePromtool writes an executable stub that appends its arguments to a marker
+// file and exits with exitCode, so tests can assert whether promtool ran at all
+// rather than relying on a real binary being present on PATH.
+func fakePromtool(t *testing.T, exitCode int) (binary string, marker string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	marker = filepath.Join(dir, "invocations")
+	binary = filepath.Join(dir, "promtool")
+
+	script := fmt.Sprintf("#!/bin/sh\necho \"$@\" >> %q\nexit %d\n", marker, exitCode)
+	require.NoError(t, os.WriteFile(binary, []byte(script), 0755))
+
+	return binary, marker
+}
+
+func completeOptions(t *testing.T, opts *RawOptions) *Options {
+	t.Helper()
+
+	validated, err := opts.Validate()
+	require.NoError(t, err)
+	completed, err := validated.Complete()
+	require.NoError(t, err)
+	return completed
+}
+
+func TestRun(t *testing.T) {
+	t.Run("skip-tests generates bicep without invoking promtool", func(t *testing.T) {
+		tmpDir := writeRuleFixture(t)
+		promtool, marker := fakePromtool(t, 0)
+
+		completed := completeOptions(t, &RawOptions{
+			ConfigFile:   filepath.Join(tmpDir, "config.yaml"),
+			PromtoolPath: promtool,
+			SkipTests:    true,
+		})
+		require.NoError(t, completed.Run())
+
+		_, err := os.Stat(marker)
+		assert.True(t, os.IsNotExist(err), "promtool was invoked even though --skip-tests was set")
+
+		_, err = os.Stat(filepath.Join(tmpDir, "zzz_generated_AlertingRules.bicep"))
+		assert.NoError(t, err, "bicep output should still be generated when tests are skipped")
+	})
+
+	t.Run("promtool runs when tests are not skipped", func(t *testing.T) {
+		tmpDir := writeRuleFixture(t)
+		promtool, marker := fakePromtool(t, 0)
+
+		completed := completeOptions(t, &RawOptions{
+			ConfigFile:   filepath.Join(tmpDir, "config.yaml"),
+			PromtoolPath: promtool,
+			SkipTests:    false,
+		})
+		require.NoError(t, completed.Run())
+
+		invocations, err := os.ReadFile(marker)
+		require.NoError(t, err, "promtool was never invoked")
+		assert.Contains(t, string(invocations), "test rules")
+
+		_, err = os.Stat(filepath.Join(tmpDir, "zzz_generated_AlertingRules.bicep"))
+		assert.NoError(t, err)
+	})
+
+	t.Run("failing promtool fails the run", func(t *testing.T) {
+		tmpDir := writeRuleFixture(t)
+		promtool, _ := fakePromtool(t, 1)
+
+		completed := completeOptions(t, &RawOptions{
+			ConfigFile:   filepath.Join(tmpDir, "config.yaml"),
+			PromtoolPath: promtool,
+			SkipTests:    false,
+		})
+		err := completed.Run()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "testing rules failed")
+	})
+}
+
+func TestRunRuleFolderBelowTestNamedDirectory(t *testing.T) {
+	// Rule discovery skips promtool test files by name. Matching that against
+	// the whole path would silently drop every rule in a checkout that happens
+	// to live under a directory such as "my_test_workspace", generating an
+	// empty bicep file and running no tests at all.
+	parent := filepath.Join(t.TempDir(), "my_test_workspace")
+	require.NoError(t, os.Mkdir(parent, 0755))
+
+	tmpDir := writeRuleFixtureIn(t, parent)
+	promtool, marker := fakePromtool(t, 0)
+
+	completed := completeOptions(t, &RawOptions{
+		ConfigFile:   filepath.Join(tmpDir, "config.yaml"),
+		PromtoolPath: promtool,
+		SkipTests:    false,
+	})
+	require.NoError(t, completed.Run())
+
+	_, err := os.Stat(marker)
+	require.NoError(t, err, "promtool was never invoked, so the rule file was skipped")
+
+	generated, err := os.ReadFile(filepath.Join(tmpDir, "zzz_generated_AlertingRules.bicep"))
+	require.NoError(t, err)
+	assert.Contains(t, string(generated), "alert: 'TestAlert'", "rule was dropped during discovery")
+}

--- a/tooling/prometheus-rules/pkg/prometheusrules/prometheusrules_test.go
+++ b/tooling/prometheus-rules/pkg/prometheusrules/prometheusrules_test.go
@@ -174,7 +174,7 @@ prometheusRules:
 
 		completed, err := validated.Complete()
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "promtool not found at")
+		assert.Contains(t, err.Error(), "unable to find promtool binary")
 		assert.Nil(t, completed)
 	})
 


### PR DESCRIPTION

### What

- splits generation of alerts and tests
- refactors the prometheusrules tooling to use cobra commands
- updates makefile targets

### Why

The generation of alerts takes upwards of 1 minute.  This is due to promtool testing having to generate large amounts of data based on the test rules, specifically `cluster-service-slo-rules_test.yaml` which generates 1 minute interval test data across 3 days for multiple tests.  


### Testing

Follow-up in openshift/release prowjob that executes a makefile target to run the `alerts-and-test` makefile target (which both generates and tests the alerts) as a part of this change.  

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
