### PR TITLE
fix(cleanup-sweeper): delete managed RGs before their parents

### DIFF
--- a/tooling/cleanup-sweeper/cmd/workflow/resourcegroup/discovery.go
+++ b/tooling/cleanup-sweeper/cmd/workflow/resourcegroup/discovery.go
@@ -17,12 +17,14 @@ package resourcegroup
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/go-logr/logr"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 )
 
@@ -37,12 +39,15 @@ func discoverCandidates(ctx context.Context, opts RunOptions) ([]string, error) 
 		candidateSources[resourceGroup] = "provided via CLI args"
 	}
 
-	discoveredCandidates, err := discoverPolicyCandidates(ctx, opts, candidateSources)
+	discoveredCandidates, allResourceGroups, err := discoverPolicyCandidates(ctx, opts, candidateSources)
 	if err != nil {
 		return nil, fmt.Errorf("failed to discover resource groups: %w", err)
 	}
 
-	finalCandidates := sets.List(opts.ResourceGroups.Union(discoveredCandidates))
+	deletionTargets := opts.ResourceGroups.Union(discoveredCandidates)
+	excluded := sets.New(opts.Policy.ExcludedResourceGroups...)
+	finalCandidates := sortDeletionTargets(logger, deletionTargets, allResourceGroups, excluded, candidateSources)
+
 	for _, resourceGroup := range finalCandidates {
 		source := candidateSources[resourceGroup]
 		if strings.TrimSpace(source) == "" {
@@ -69,7 +74,7 @@ func discoverPolicyCandidates(
 	ctx context.Context,
 	opts RunOptions,
 	candidateSources map[string]string,
-) (sets.Set[string], error) {
+) (sets.Set[string], []*armresources.ResourceGroup, error) {
 	logger, err := logr.FromContext(ctx)
 	if err != nil {
 		panic(err)
@@ -77,15 +82,15 @@ func discoverPolicyCandidates(
 
 	discoveredResourceGroups := sets.New[string]()
 	if len(opts.Policy.Discovery.Rules) == 0 {
-		return discoveredResourceGroups, nil
+		return discoveredResourceGroups, nil, nil
 	}
 	if opts.ReferenceTime.IsZero() {
-		return nil, fmt.Errorf("reference time is required for resource group discovery")
+		return nil, nil, fmt.Errorf("reference time is required for resource group discovery")
 	}
 
 	rgClient, err := armresources.NewResourceGroupsClient(opts.SubscriptionID, opts.AzureCredential, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create resource groups client: %w", err)
+		return nil, nil, fmt.Errorf("failed to create resource groups client: %w", err)
 	}
 
 	resourceGroups, err := listResourceGroups(ctx, rgClient)
@@ -94,7 +99,7 @@ func discoverPolicyCandidates(
 			"Best-effort mode: failed to list resource groups; continuing with explicit targets only",
 			"error", err,
 		)
-		return discoveredResourceGroups, nil
+		return discoveredResourceGroups, nil, nil
 	}
 
 	excludedResourceGroups := sets.New(opts.Policy.ExcludedResourceGroups...)
@@ -116,8 +121,64 @@ func discoverPolicyCandidates(
 		logger.Info("Discovered RG candidate from policy", "resourceGroup", *rg.Name, "reason", reason.String())
 	}
 
-	return discoveredResourceGroups, nil
+	return discoveredResourceGroups, resourceGroups, nil
 }
+
+// sortDeletionTargets ensures managed (child) RGs are deleted before their
+// parents. If a parent RG is a deletion target, its managed children are
+// added to the target set and placed first in the returned list, unblocking
+// the parent's VNet/NSG deletion.
+func sortDeletionTargets(
+	logger logr.Logger,
+	deletionTargets sets.Set[string],
+	allResourceGroups []*armresources.ResourceGroup,
+	excludedResourceGroups sets.Set[string],
+	candidateSources map[string]string,
+) []string {
+	imminentOrphans := sets.New[string]()
+	deletionTargetsLower := sets.New[string]()
+	for t := range deletionTargets {
+		deletionTargetsLower.Insert(strings.ToLower(t))
+	}
+
+	for _, rg := range allResourceGroups {
+		if rg.Name == nil || rg.ManagedBy == nil {
+			continue
+		}
+		name := *rg.Name
+		if excludedResourceGroups.Has(strings.ToLower(name)) {
+			continue
+		}
+		parsed, err := azcorearm.ParseResourceID(*rg.ManagedBy)
+		if err != nil {
+			slog.Warn("failed to parse managedBy resource ID", "managedBy", *rg.ManagedBy, "error", err)
+			continue
+		}
+		if !deletionTargetsLower.Has(strings.ToLower(parsed.ResourceGroupName)) {
+			continue
+		}
+		imminentOrphans.Insert(name)
+		if deletionTargets.Has(name) {
+			continue
+		}
+		deletionTargets.Insert(name)
+		candidateSources[name] = fmt.Sprintf("managed child of deletion target %q", parsed.ResourceGroupName)
+		logger.Info("Adding managed RG to deletion targets (parent scheduled for deletion)",
+			"resourceGroup", name,
+			"parentResourceGroup", parsed.ResourceGroupName,
+		)
+	}
+
+	sorted := make([]string, 0, deletionTargets.Len())
+	sorted = append(sorted, sets.List(imminentOrphans)...)
+	for _, t := range sets.List(deletionTargets) {
+		if !imminentOrphans.Has(t) {
+			sorted = append(sorted, t)
+		}
+	}
+	return sorted
+}
+
 func listResourceGroups(
 	ctx context.Context,
 	rgClient *armresources.ResourceGroupsClient,

--- a/tooling/cleanup-sweeper/cmd/workflow/resourcegroup/discovery.go
+++ b/tooling/cleanup-sweeper/cmd/workflow/resourcegroup/discovery.go
@@ -17,7 +17,6 @@ package resourcegroup
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -149,7 +148,7 @@ func promoteAndSortDeletionTargets(
 		}
 		parsed, err := azcorearm.ParseResourceID(*rg.ManagedBy)
 		if err != nil {
-			slog.Warn("failed to parse managedBy resource ID", "resourceGroup", name, "managedBy", *rg.ManagedBy, "error", err)
+			logger.Info("failed to parse managedBy resource ID, skipping", "resourceGroup", name, "managedBy", *rg.ManagedBy, "error", err)
 			continue
 		}
 		if !deletionTargetsLower.Has(strings.ToLower(parsed.ResourceGroupName)) {

--- a/tooling/cleanup-sweeper/cmd/workflow/resourcegroup/discovery.go
+++ b/tooling/cleanup-sweeper/cmd/workflow/resourcegroup/discovery.go
@@ -46,7 +46,7 @@ func discoverCandidates(ctx context.Context, opts RunOptions) ([]string, error) 
 
 	deletionTargets := opts.ResourceGroups.Union(discoveredCandidates)
 	excluded := sets.New(opts.Policy.ExcludedResourceGroups...)
-	finalCandidates := sortDeletionTargets(logger, deletionTargets, allResourceGroups, excluded, candidateSources)
+	finalCandidates := promoteAndSortDeletionTargets(logger, deletionTargets, allResourceGroups, excluded, candidateSources)
 
 	for _, resourceGroup := range finalCandidates {
 		source := candidateSources[resourceGroup]
@@ -124,11 +124,8 @@ func discoverPolicyCandidates(
 	return discoveredResourceGroups, resourceGroups, nil
 }
 
-// sortDeletionTargets ensures managed (child) RGs are deleted before their
-// parents. If a parent RG is a deletion target, its managed children are
-// added to the target set and placed first in the returned list, unblocking
-// the parent's VNet/NSG deletion.
-func sortDeletionTargets(
+// promoteAndSortDeletionTargets ensures that for each deletion target, all managed children are also targets (promoting if necessary) and that children are deleted first.
+func promoteAndSortDeletionTargets(
 	logger logr.Logger,
 	deletionTargets sets.Set[string],
 	allResourceGroups []*armresources.ResourceGroup,

--- a/tooling/cleanup-sweeper/cmd/workflow/resourcegroup/discovery.go
+++ b/tooling/cleanup-sweeper/cmd/workflow/resourcegroup/discovery.go
@@ -149,7 +149,7 @@ func promoteAndSortDeletionTargets(
 		}
 		parsed, err := azcorearm.ParseResourceID(*rg.ManagedBy)
 		if err != nil {
-			slog.Warn("failed to parse managedBy resource ID", "managedBy", *rg.ManagedBy, "error", err)
+			slog.Warn("failed to parse managedBy resource ID", "resourceGroup", name, "managedBy", *rg.ManagedBy, "error", err)
 			continue
 		}
 		if !deletionTargetsLower.Has(strings.ToLower(parsed.ResourceGroupName)) {

--- a/tooling/cleanup-sweeper/cmd/workflow/resourcegroup/discovery.go
+++ b/tooling/cleanup-sweeper/cmd/workflow/resourcegroup/discovery.go
@@ -80,10 +80,9 @@ func discoverPolicyCandidates(
 	}
 
 	discoveredResourceGroups := sets.New[string]()
-	if len(opts.Policy.Discovery.Rules) == 0 {
-		return discoveredResourceGroups, nil, nil
-	}
-	if opts.ReferenceTime.IsZero() {
+	hasRules := len(opts.Policy.Discovery.Rules) > 0
+
+	if hasRules && opts.ReferenceTime.IsZero() {
 		return nil, nil, fmt.Errorf("reference time is required for resource group discovery")
 	}
 
@@ -99,6 +98,10 @@ func discoverPolicyCandidates(
 			"error", err,
 		)
 		return discoveredResourceGroups, nil, nil
+	}
+
+	if !hasRules {
+		return discoveredResourceGroups, resourceGroups, nil
 	}
 
 	excludedResourceGroups := sets.New(opts.Policy.ExcludedResourceGroups...)

--- a/tooling/cleanup-sweeper/cmd/workflow/resourcegroup/discovery.go
+++ b/tooling/cleanup-sweeper/cmd/workflow/resourcegroup/discovery.go
@@ -146,7 +146,8 @@ func sortDeletionTargets(
 			continue
 		}
 		name := *rg.Name
-		if excludedResourceGroups.Has(strings.ToLower(name)) {
+		nameLower := strings.ToLower(name)
+		if excludedResourceGroups.Has(nameLower) {
 			continue
 		}
 		parsed, err := azcorearm.ParseResourceID(*rg.ManagedBy)
@@ -158,11 +159,11 @@ func sortDeletionTargets(
 			continue
 		}
 		imminentOrphans.Insert(name)
-		if deletionTargets.Has(name) {
+		if deletionTargetsLower.Has(nameLower) {
 			continue
 		}
 		deletionTargets.Insert(name)
-		deletionTargetsLower.Insert(strings.ToLower(name))
+		deletionTargetsLower.Insert(nameLower)
 		candidateSources[name] = fmt.Sprintf("managed child of deletion target %q", parsed.ResourceGroupName)
 		logger.Info("Adding managed RG to deletion targets (parent scheduled for deletion)",
 			"resourceGroup", name,

--- a/tooling/cleanup-sweeper/cmd/workflow/resourcegroup/discovery.go
+++ b/tooling/cleanup-sweeper/cmd/workflow/resourcegroup/discovery.go
@@ -162,6 +162,7 @@ func sortDeletionTargets(
 			continue
 		}
 		deletionTargets.Insert(name)
+		deletionTargetsLower.Insert(strings.ToLower(name))
 		candidateSources[name] = fmt.Sprintf("managed child of deletion target %q", parsed.ResourceGroupName)
 		logger.Info("Adding managed RG to deletion targets (parent scheduled for deletion)",
 			"resourceGroup", name,

--- a/tooling/cleanup-sweeper/cmd/workflow/resourcegroup/discovery_test.go
+++ b/tooling/cleanup-sweeper/cmd/workflow/resourcegroup/discovery_test.go
@@ -193,7 +193,7 @@ func TestSortDeletionTargets(t *testing.T) {
 			excluded := sets.New(tc.excludedRGs...)
 			candidateSources := map[string]string{}
 
-			got := sortDeletionTargets(logger, tc.deletionTargets, tc.allResourceGroups, excluded, candidateSources)
+			got := promoteAndSortDeletionTargets(logger, tc.deletionTargets, tc.allResourceGroups, excluded, candidateSources)
 
 			if len(got) != len(tc.want) {
 				t.Fatalf("expected %v, got %v", tc.want, got)

--- a/tooling/cleanup-sweeper/cmd/workflow/resourcegroup/discovery_test.go
+++ b/tooling/cleanup-sweeper/cmd/workflow/resourcegroup/discovery_test.go
@@ -108,12 +108,12 @@ func TestSortDeletionTargets(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		name             string
-		deletionTargets  sets.Set[string]
+		name              string
+		deletionTargets   sets.Set[string]
 		allResourceGroups []*armresources.ResourceGroup
-		excludedRGs      []string
-		want             []string
-		wantTargetsAdded []string
+		excludedRGs       []string
+		want              []string
+		wantTargetsAdded  []string
 	}{
 		{
 			name:            "managed child of target is added and sorted first",

--- a/tooling/cleanup-sweeper/cmd/workflow/resourcegroup/discovery_test.go
+++ b/tooling/cleanup-sweeper/cmd/workflow/resourcegroup/discovery_test.go
@@ -104,7 +104,7 @@ func TestDiscoverCandidates(t *testing.T) {
 
 func ptr(s string) *string { return &s }
 
-func TestSortDeletionTargets(t *testing.T) {
+func TestPromoteAndSortDeletionTargets(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {

--- a/tooling/cleanup-sweeper/cmd/workflow/resourcegroup/discovery_test.go
+++ b/tooling/cleanup-sweeper/cmd/workflow/resourcegroup/discovery_test.go
@@ -24,6 +24,8 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+
 	"github.com/Azure/ARO-HCP/tooling/cleanup-sweeper/pkg/policy"
 )
 
@@ -94,6 +96,116 @@ func TestDiscoverCandidates(t *testing.T) {
 			for idx := range tc.want {
 				if got[idx] != tc.want[idx] {
 					t.Fatalf("expected sorted resource groups %v, got %v", tc.want, got)
+				}
+			}
+		})
+	}
+}
+
+func ptr(s string) *string { return &s }
+
+func TestSortDeletionTargets(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name             string
+		deletionTargets  sets.Set[string]
+		allResourceGroups []*armresources.ResourceGroup
+		excludedRGs      []string
+		want             []string
+		wantTargetsAdded []string
+	}{
+		{
+			name:            "managed child of target is added and sorted first",
+			deletionTargets: sets.New("parent-rg"),
+			allResourceGroups: []*armresources.ResourceGroup{
+				{Name: ptr("parent-rg")},
+				{Name: ptr("child-rg"), ManagedBy: ptr("/subscriptions/sub/resourceGroups/parent-rg/providers/Microsoft.RedHatOpenshift/hcpOpenShiftClusters/cluster")},
+			},
+			want:             []string{"child-rg", "parent-rg"},
+			wantTargetsAdded: []string{"child-rg"},
+		},
+		{
+			name:            "multiple children before parent",
+			deletionTargets: sets.New("parent-rg"),
+			allResourceGroups: []*armresources.ResourceGroup{
+				{Name: ptr("parent-rg")},
+				{Name: ptr("child-b"), ManagedBy: ptr("/subscriptions/sub/resourceGroups/parent-rg/providers/Microsoft.RedHatOpenshift/hcpOpenShiftClusters/b")},
+				{Name: ptr("child-a"), ManagedBy: ptr("/subscriptions/sub/resourceGroups/parent-rg/providers/Microsoft.RedHatOpenshift/hcpOpenShiftClusters/a")},
+			},
+			want:             []string{"child-a", "child-b", "parent-rg"},
+			wantTargetsAdded: []string{"child-a", "child-b"},
+		},
+		{
+			name:            "child already a target is sorted first without duplication",
+			deletionTargets: sets.New("parent-rg", "z-child-rg"),
+			allResourceGroups: []*armresources.ResourceGroup{
+				{Name: ptr("parent-rg")},
+				{Name: ptr("z-child-rg"), ManagedBy: ptr("/subscriptions/sub/resourceGroups/parent-rg/providers/Microsoft.RedHatOpenshift/hcpOpenShiftClusters/cluster")},
+			},
+			want: []string{"z-child-rg", "parent-rg"},
+		},
+		{
+			name:            "excluded child is not added",
+			deletionTargets: sets.New("parent-rg"),
+			excludedRGs:     []string{"child-rg"},
+			allResourceGroups: []*armresources.ResourceGroup{
+				{Name: ptr("parent-rg")},
+				{Name: ptr("child-rg"), ManagedBy: ptr("/subscriptions/sub/resourceGroups/parent-rg/providers/Microsoft.RedHatOpenshift/hcpOpenShiftClusters/cluster")},
+			},
+			want: []string{"parent-rg"},
+		},
+		{
+			name:            "managed RG whose parent is not a target is ignored",
+			deletionTargets: sets.New("other-rg"),
+			allResourceGroups: []*armresources.ResourceGroup{
+				{Name: ptr("other-rg")},
+				{Name: ptr("child-rg"), ManagedBy: ptr("/subscriptions/sub/resourceGroups/not-a-target/providers/Microsoft.RedHatOpenshift/hcpOpenShiftClusters/cluster")},
+			},
+			want: []string{"other-rg"},
+		},
+		{
+			name:            "unparsable managedBy is skipped",
+			deletionTargets: sets.New("parent-rg"),
+			allResourceGroups: []*armresources.ResourceGroup{
+				{Name: ptr("parent-rg")},
+				{Name: ptr("child-rg"), ManagedBy: ptr("not-a-valid-resource-id")},
+			},
+			want: []string{"parent-rg"},
+		},
+		{
+			name:            "case-insensitive parent matching",
+			deletionTargets: sets.New("Parent-RG"),
+			allResourceGroups: []*armresources.ResourceGroup{
+				{Name: ptr("Parent-RG")},
+				{Name: ptr("child-rg"), ManagedBy: ptr("/subscriptions/sub/resourceGroups/parent-rg/providers/Microsoft.RedHatOpenshift/hcpOpenShiftClusters/cluster")},
+			},
+			want:             []string{"child-rg", "Parent-RG"},
+			wantTargetsAdded: []string{"child-rg"},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			logger := logr.Discard()
+			excluded := sets.New(tc.excludedRGs...)
+			candidateSources := map[string]string{}
+
+			got := sortDeletionTargets(logger, tc.deletionTargets, tc.allResourceGroups, excluded, candidateSources)
+
+			if len(got) != len(tc.want) {
+				t.Fatalf("expected %v, got %v", tc.want, got)
+			}
+			for idx := range tc.want {
+				if got[idx] != tc.want[idx] {
+					t.Fatalf("expected %v, got %v", tc.want, got)
+				}
+			}
+			for _, added := range tc.wantTargetsAdded {
+				if !tc.deletionTargets.Has(added) {
+					t.Errorf("expected %q to be added to deletion targets", added)
 				}
 			}
 		})


### PR DESCRIPTION
[AROSLSRE-1245](https://redhat.atlassian.net/browse/AROSLSRE-1245)

### What

Delete managed (child) RGs before their parents during sweeper cleanup.

### Why

Parent RG deletion fails with `InUseSubnetCannotBeDeleted` when a managed child holds a load balancer referencing the parent's VNet subnet.

### Testing

- Unit tests for `sortDeletionTargets` (7 cases)

<details>
<summary>Currently deadlocked RGs this unblocks</summary>

| Parent (deletion target) | Managed child (deleted first) |
|---|---|
| `autoscaling-cluster-jgwrn6` | `autoscaling-cluster-jgwrn6--managed` |
| `jamesh-swift-dev-2` | `managed-test-jamesh-swift-dev-2` |
| `jbtest-net-rg-03` | `jbtest-rg-03` |
| `marc-customer-rg` | `marc-hcp-mrg-1`, `marc-hcp-mrg-5` |
| `test-zgalor` | `managed-test-test-zgalor` |
| `zg-private` | `managed-zg-public-baseline` |
| `zg-public` | `managed-zg-priv-ingress-1` |

3 additional RGs (`mmazur-net-rg-03`, `mmazur2-net-rg-03`, `suraj-supa-external-RG`) are blocked by stale `serviceAssociationLinks/RedHatOpenShift` and won't be fixed by this change.

</details>

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [x] All comment threads resolved before merge