### PR TITLE
chore(config): bump hypershift operator digest (bisect e2e #5789)

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -341,7 +341,7 @@ defaults:
     image:
       registry: quay.io
       repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
-      digest: sha256:9775a90c9bf7affe17341f04769b4817b8835c2a83c923019b169c33d23b070e # 9acec4759a16c86f0f87792c18a1d738b3b85129 (2026-06-25 05:28)
+      digest: sha256:c22bdb0f0f1c8388fe5169c2fc3a38480c9b9720fe91217b92e948a5ae46cbb0 # 9aeb1f3b64b5dbdd060374a396764545e0935b48 (2026-07-02 13:17)
     namespace: hypershift
     additionalInstallArg: '--enable-cpo-overrides'
     # By default we set it to empty as this tag is only required for msft environments. We override

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -437,7 +437,7 @@ hcpRecovery:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides
   image:
-    digest: sha256:9775a90c9bf7affe17341f04769b4817b8835c2a83c923019b169c33d23b070e
+    digest: sha256:c22bdb0f0f1c8388fe5169c2fc3a38480c9b9720fe91217b92e948a5ae46cbb0
     registry: quay.io
     repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
   limitClusterSizes: true

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -437,7 +437,7 @@ hcpRecovery:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides
   image:
-    digest: sha256:9775a90c9bf7affe17341f04769b4817b8835c2a83c923019b169c33d23b070e
+    digest: sha256:c22bdb0f0f1c8388fe5169c2fc3a38480c9b9720fe91217b92e948a5ae46cbb0
     registry: quay.io
     repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
   limitClusterSizes: true

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -437,7 +437,7 @@ hcpRecovery:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides
   image:
-    digest: sha256:9775a90c9bf7affe17341f04769b4817b8835c2a83c923019b169c33d23b070e
+    digest: sha256:c22bdb0f0f1c8388fe5169c2fc3a38480c9b9720fe91217b92e948a5ae46cbb0
     registry: quay.io
     repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
   limitClusterSizes: true

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -437,7 +437,7 @@ hcpRecovery:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides
   image:
-    digest: sha256:9775a90c9bf7affe17341f04769b4817b8835c2a83c923019b169c33d23b070e
+    digest: sha256:c22bdb0f0f1c8388fe5169c2fc3a38480c9b9720fe91217b92e948a5ae46cbb0
     registry: quay.io
     repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
   limitClusterSizes: true

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -437,7 +437,7 @@ hcpRecovery:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides
   image:
-    digest: sha256:9775a90c9bf7affe17341f04769b4817b8835c2a83c923019b169c33d23b070e
+    digest: sha256:c22bdb0f0f1c8388fe5169c2fc3a38480c9b9720fe91217b92e948a5ae46cbb0
     registry: quay.io
     repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
   limitClusterSizes: true

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -437,7 +437,7 @@ hcpRecovery:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides
   image:
-    digest: sha256:9775a90c9bf7affe17341f04769b4817b8835c2a83c923019b169c33d23b070e
+    digest: sha256:c22bdb0f0f1c8388fe5169c2fc3a38480c9b9720fe91217b92e948a5ae46cbb0
     registry: quay.io
     repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
   limitClusterSizes: true


### PR DESCRIPTION
Bisecting the e2e-parallel regression on the automated image-digest PR [#5789](https://github.com/Azure/ARO-HCP/pull/5789), which flipped from green to red at commit `128feb1`.

### What

Bumps **only** the `hypershift` operator image digest to the latest value from #5789, on top of current `main`. All other components (including ACM/MCE and everything else) stay at their `main` digests.

```
hypershift/hypershift-operator
  sha256:9775a90c…  (main)
  sha256:c22bdb0f…  (#5789 latest)
```

### Why

At the pass→fail boundary (`7294d8c` → `128feb1`) of #5789, only 6 digests changed: hypershift, ACM operator bundle, MCE bundle, OADP velero azure/hypershift plugins, and oc-mirror. `clusters-service` did **not** change. The failure signature is `CreateHCPCluster` timing out (clusters never provision) across ~16 tests, which points at hypershift/ACM. This PR isolates hypershift so e2e-parallel tells us whether the hypershift bump alone breaks provisioning.

### Testing

Relies on `ci/prow/e2e-parallel`. `make -C config/ detect-change` is clean (materialize idempotent). This is a diagnostic bisect PR — not intended to merge as-is.

### Special notes for your reviewer

Do not merge. Diagnostic bisect of #5789. Companion PRs isolate ACM and the remaining components.
