### PR TITLE
feat(e2e): add make target to apply slot-managed identity pool

### DIFF
--- a/docs/ci/identity-leasing.md
+++ b/docs/ci/identity-leasing.md
@@ -214,7 +214,9 @@ For the live DEV slot-managed path:
 
 - update `test/e2e-config/e2e-slots.yaml`
 - sync or validate the release-side Boskos inventory with `./test/aro-hcp-tests slot-manager sync-boskos-config` and `./test/aro-hcp-tests slot-manager validate-boskos-config`
-- apply the identity pool with `./test/aro-hcp-tests slot-manager apply-identity-pool --environment dev`
+- apply the identity pool with `make -C test apply-identity-pool ENVIRONMENT=dev`
+
+  Always apply through this Make target rather than `go run` or a hand-built binary. The target rebuilds `aro-hcp-tests` and, as part of that, regenerates the Bicep-derived ARM artifacts (e.g. `msi-pools.json`) from the source-of-truth Bicep in `test/e2e-setup/bicep/`. The generated artifacts under `test/e2e/test-artifacts/generated-test-artifacts/` are git-ignored build outputs, so bypassing the Make build can embed and apply a stale template — which manifests as resource groups being deleted and recreated instead of updated in place.
 - follow [DEV E2E Subscription Onboarding](dev-e2e-subscription-onboarding.md) for the full operator runbook when adding another customer subscription
 
 For higher environments, the identity-container acquisition path is still the older ci-operator `leases:` model. Those jobs are not yet wired to slot-manager acquire or release, so changes there still have to respect the existing `openshift/release` Boskos inventory and job configuration.

--- a/test/Makefile
+++ b/test/Makefile
@@ -40,6 +40,16 @@ $(PROW_JOB_EXECUTOR): $(PROW_JOB_EXECUTOR_SOURCES) $(MAKEFILE_LIST) $(TEST_DIR)/
 build: $(PROW_JOB_EXECUTOR) $(ARO_HCP_TESTS)
 .PHONY: build
 
+# Apply the slot-managed identity pool ARM deployment stack for a given environment.
+# Depends on $(ARO_HCP_TESTS), whose own prerequisites regenerate the Bicep-derived
+# ARM artifacts (e.g. msi-pools.json) from the source-of-truth Bicep before the binary
+# is (re)built and embeds them. Always run through this target instead of `go run`/
+# `go build`, otherwise a stale, git-ignored artifact may be embedded and applied.
+apply-identity-pool: $(ARO_HCP_TESTS)
+	$(ARO_HCP_TESTS) slot-manager apply-identity-pool \
+		--environment "$${ENVIRONMENT:?ENVIRONMENT must be set (e.g. dev, int, stg, prod)}"
+.PHONY: apply-identity-pool
+
 int-e2e:
 	PROW_JOB_NAME="$$(yq .clouds.public.environments.int.defaults.e2e.regionTest.prowJobName < ../config/config.msft.clouds-overlay.yaml)" \
 	REGION="uksouth" \


### PR DESCRIPTION
Add a `apply-identity-pool` target to test/Makefile that builds the aro-hcp-tests binary first, which regenerates the Bicep-derived ARM artifacts (e.g. msi-pools.json) from the source-of-truth Bicep before they are embedded. Running the CLI via `go run` or a hand-built binary could embed a stale, git-ignored artifact, causing resource groups to be deleted and recreated instead of updated in place.

Update the identity-leasing CI docs to point at the new target and explain why the raw binary invocation is unsafe.

Related to https://redhat.atlassian.net/browse/ARO-27549
