### PR TITLE
fix: drop high-cardinality HCP metrics to reduce Prometheus load (Tier 1)

### DIFF
--- a/hypershiftoperator/deploy/templates/sre-metrics-set.configmap.yaml
+++ b/hypershiftoperator/deploy/templates/sre-metrics-set.configmap.yaml
@@ -6,10 +6,25 @@ metadata:
 data:
   config: |
     etcd:
+      - action:       "drop"
+        regex:        "etcd_debugging_.*"
+        sourceLabels: ["__name__"]
+      - action:       "drop"
+        regex:        "etcd_(disk_backend_(defrag|snapshot)|disk_wal_write|mvcc_hash|mvcc_hash_rev|server_apply|snap_db_fsync|snap_db_save_total|snap_fsync)_duration_seconds_(bucket|count|sum)"
+        sourceLabels: ["__name__"]
+      - action:       "drop"
+        regex:        "grpc_(client|server)_(handled|started|msg_received|msg_sent)_total"
+        sourceLabels: ["__name__"]
       - action:       "keep"
         regex:        ".*"
         sourceLabels: ["__name__"]
     kubeAPIServer:
+      - action:       "drop"
+        regex:        "apiserver_request_duration_seconds_.*|apiserver_request_slo_duration_seconds_.*|apiserver_response_sizes_.*|apiserver_request_body_size_bytes_.*|apiserver_admission_(controller|step)_admission_duration_seconds_.*"
+        sourceLabels: ["__name__"]
+      - action:       "drop"
+        regex:        "grpc_(client|server)_(handled|started|msg_received|msg_sent)_total"
+        sourceLabels: ["__name__"]
       - action:       "keep"
         regex:        ".*"
         sourceLabels: ["__name__"]
@@ -18,6 +33,12 @@ data:
         regex:        ".*"
         sourceLabels: ["__name__"]
     openshiftAPIServer:
+      - action:       "drop"
+        regex:        "apiserver_request_duration_seconds_.*|apiserver_request_slo_duration_seconds_.*|apiserver_response_sizes_.*|apiserver_request_body_size_bytes_.*|apiserver_admission_(controller|step)_admission_duration_seconds_.*"
+        sourceLabels: ["__name__"]
+      - action:       "drop"
+        regex:        "grpc_(client|server)_(handled|started|msg_received|msg_sent)_total"
+        sourceLabels: ["__name__"]
       - action:       "keep"
         regex:        ".*"
         sourceLabels: ["__name__"]

--- a/hypershiftoperator/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_hypershift.yaml
+++ b/hypershiftoperator/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_hypershift.yaml
@@ -653,10 +653,25 @@ metadata:
 data:
   config: |
     etcd:
+      - action:       "drop"
+        regex:        "etcd_debugging_.*"
+        sourceLabels: ["__name__"]
+      - action:       "drop"
+        regex:        "etcd_(disk_backend_(defrag|snapshot)|disk_wal_write|mvcc_hash|mvcc_hash_rev|server_apply|snap_db_fsync|snap_db_save_total|snap_fsync)_duration_seconds_(bucket|count|sum)"
+        sourceLabels: ["__name__"]
+      - action:       "drop"
+        regex:        "grpc_(client|server)_(handled|started|msg_received|msg_sent)_total"
+        sourceLabels: ["__name__"]
       - action:       "keep"
         regex:        ".*"
         sourceLabels: ["__name__"]
     kubeAPIServer:
+      - action:       "drop"
+        regex:        "apiserver_request_duration_seconds_.*|apiserver_request_slo_duration_seconds_.*|apiserver_response_sizes_.*|apiserver_request_body_size_bytes_.*|apiserver_admission_(controller|step)_admission_duration_seconds_.*"
+        sourceLabels: ["__name__"]
+      - action:       "drop"
+        regex:        "grpc_(client|server)_(handled|started|msg_received|msg_sent)_total"
+        sourceLabels: ["__name__"]
       - action:       "keep"
         regex:        ".*"
         sourceLabels: ["__name__"]
@@ -665,6 +680,12 @@ data:
         regex:        ".*"
         sourceLabels: ["__name__"]
     openshiftAPIServer:
+      - action:       "drop"
+        regex:        "apiserver_request_duration_seconds_.*|apiserver_request_slo_duration_seconds_.*|apiserver_response_sizes_.*|apiserver_request_body_size_bytes_.*|apiserver_admission_(controller|step)_admission_duration_seconds_.*"
+        sourceLabels: ["__name__"]
+      - action:       "drop"
+        regex:        "grpc_(client|server)_(handled|started|msg_received|msg_sent)_total"
+        sourceLabels: ["__name__"]
       - action:       "keep"
         regex:        ".*"
         sourceLabels: ["__name__"]


### PR DESCRIPTION
## Summary

- Add `metric_relabel_configs` drop rules to the `sre-metric-set` ConfigMap, which currently keeps **all** metrics (`regex: ".*"`) for every HCP component. With hundreds of HCPs per management cluster, the resulting cardinality overwhelms Prometheus and inflates AMW ingestion costs.
- Targets the three highest-cardinality groups: **apiserver histograms** (kubeAPIServer/openshiftAPIServer), **etcd debugging + histograms** (etcd), and **gRPC metrics** (all three).
- Preserves `apiserver_request_sli_duration_seconds` (feeds SLI recording rules), `etcd_disk_backend_commit`, `etcd_disk_wal_fsync`, `etcd_network_peer_round_trip_time` (SRE oncall dashboards), and `etcd_request_duration_seconds` (KAS Golden Signals).

### What's dropped (~104 metric names, estimated 1,000–6,000 series per HCP pod)

| Category | Metrics Dropped | Dashboard Impact |
|---|---|---|
| `apiserver_request_duration_seconds` | 3 (bucket/count/sum) | api-performance (perfscale) — 3 panels |
| `apiserver_request_slo_duration_seconds` | 3 | None |
| `apiserver_response_sizes` | 3 | api-performance — 1 panel |
| `apiserver_request_body_size_bytes` | 3 | None |
| `apiserver_admission_{controller,step}_admission_duration_seconds` | 9 | kas_golden_signals — 1 panel |
| `etcd_debugging_*` | ~40 | etcd-performance (perfscale) — 3 panels |
| Unused etcd histograms (9 families) | 27 | None |
| gRPC client/server metrics | 8 | etcd-performance — 1 panel |

### What's preserved (deviations from raw Tier 1 plan)

| Metric | Reason |
|---|---|
| `apiserver_request_sli_duration_seconds` | Feeds `kas:apiserver_request_latency:sli_ratio:rate5m` recording rule → SLO monitoring |
| `etcd_disk_backend_commit_duration_seconds` | Used by 3 SRE oncall dashboards |
| `etcd_disk_wal_fsync_duration_seconds` | Used by 4 SRE oncall dashboards |
| `etcd_network_peer_round_trip_time_seconds` | Used by 3 SRE oncall dashboards |
| `etcd_request_duration_seconds` | Used by KAS Golden Signals |

### Trade-offs

All broken dashboard panels are in **perfscale** or non-critical operational dashboards. No SLI recording rules, SLO alerts, or SRE oncall triage dashboards are affected. Broken panels need follow-up removal.

Ref: [AROSLSRE-1387](https://redhat.atlassian.net/browse/AROSLSRE-1387)

## Test plan

- [ ] Deploy to personal dev environment: `make pipeline/HypershiftOperator DEPLOY_ENV=pers`
- [ ] Verify the ConfigMap is loaded: `kubectl -n hypershift get configmap sre-metrics-set -o yaml`
- [ ] Verify ServiceMonitor metricRelabelings in an HCP namespace: `kubectl -n <ocm-aro-*-namespace> get servicemonitor -o yaml`
- [ ] Confirm dropped metrics stop appearing in the HCP Azure Monitor Workspace
- [ ] Confirm preserved SLI metrics (`apiserver_request_sli_duration_seconds`, etcd disk/network metrics) are still present
- [ ] Confirm recording rules (`kas:apiserver_request_latency:sli_ratio:rate5m`) continue to evaluate
- [ ] Confirm SRE oncall dashboards (etcd-availability, per-cluster-drill-in, mgmt-cluster-triage) still render

🤖 Generated with [Claude Code](https://claude.com/claude-code)