### PR TITLE
fix(ci): set GOSUMDB=off to avoid read-only checksum-DB build failures (AROSLSRE-1400)

### DIFF
--- a/dev-infrastructure/openshift-ci/Dockerfile
+++ b/dev-infrastructure/openshift-ci/Dockerfile
@@ -40,6 +40,20 @@ RUN cd /tmp/aro-hcp && \
     GOFLAGS='-mod=readonly' GOBIN=/usr/local/bin make install-tools && \
     go clean -cache -modcache && \
     rm -rf /tmp/aro-hcp
-RUN mkdir -p /go/pkg/mod /go/bin && \
+# Runtime Go builds in CI run as an arbitrary OpenShift UID against a cold module
+# cache. On a checksum miss Go consults the checksum DB and writes
+# /go/pkg/sumdb/sum.golang.org/latest; the runner presents that path read-only to
+# the pod, causing intermittent
+# "verifying module: ... open /go/pkg/sumdb/sum.golang.org/latest: permission denied".
+# GOSUMDB=off removes the sumdb dependency entirely. Integrity is still enforced by the
+# committed go.sum / go.work.sum, which are verified on every build; GOSUMDB is only
+# consulted to authenticate a module hash that is not already recorded in the consulted
+# sum file (e.g. on a cold cache), so disabling it in CI trusts the committed sums alone.
+# Set after install-tools so build-time tool compilation keeps sumdb verification; the
+# ENV persists into the running container, covering the arbitrary-UID runtime builds.
+ENV GOSUMDB=off
+# Pre-create /go/pkg/sumdb so the group-writable perms below also cover it
+# (defense in depth alongside GOSUMDB=off).
+RUN mkdir -p /go/pkg/mod /go/pkg/sumdb /go/bin && \
     chgrp -R 0 /go && \
     chmod -R g=u /go


### PR DESCRIPTION
[AROSLSRE-1400](https://redhat.atlassian.net/browse/AROSLSRE-1400)

### What

Set `GOSUMDB=off` in the OpenShift CI builder image (`dev-infrastructure/openshift-ci/Dockerfile`) and pre-create `/go/pkg/sumdb` so the existing group-writable perms also cover it.

### Why

CI Go build steps intermittently fail with:

```
verifying module: <mod>@<ver>: open /go/pkg/sumdb/sum.golang.org/latest: permission denied
```

Seen in `aro-hcp-provision-environment` (building `./scripts/postgres-access`) and earlier in `config-change-detection` (building `helmtest`). It blocks unrelated PRs from merging and forces repeated `/retest`.

**Root cause:** runtime Go builds run as an arbitrary OpenShift UID against a cold module cache. On a checksum *miss*, Go consults the global checksum DB and writes `/go/pkg/sumdb/sum.golang.org/latest` — a path the runner presents read-only to the pod. It's intermittent because Go only consults GOSUMDB on a miss; a warm cache or complete `go.sum`/`go.work.sum` means no write, so the same build passes on the next pod.

**Why `GOSUMDB=off` is safe:** it does **not** disable verification — `go.sum`/`go.work.sum` are still enforced on every build. GOSUMDB (the global transparency log) is only consulted when a *new* module hash is first added (developer `go get`/`go mod tidy`), which CI never does since sums are already committed and pinned. So GOSUMDB stays on for developers and off in CI, where it adds fragility but no protection.

### Testing

Reproduced and verified in a container mirroring the runner (`golang:1.25`, run as `--user 1000670000:0`, cold module cache, `/go/pkg/sumdb` made read-only `0555`), running a cold `go get` that forces a checksum lookup:

| Condition | Result |
| --- | --- |
| Current (`GOSUMDB` on), read-only `/go/pkg/sumdb` | ❌ `verifying module: ... open /go/pkg/sumdb/sum.golang.org/latest: permission denied` — exact CI signature |
| `GOSUMDB=off`, same read-only sumdb | ✅ pass |
| `GOSUMDB=off` + `unset GOFLAGS` (as in provision script) | ✅ pass (separate env var) |

Also confirmed: with GID 0 and a writable `/go/pkg/sumdb`, the current image passes — proving the trigger is the runner presenting that path read-only, not the Dockerfile perms alone; `GOSUMDB=off` is robust regardless of runner cache mount/ownership.

### Special notes for your reviewer

- `GOFLAGS='-mod=readonly'` on the tool-install step and `unset GOFLAGS` in `hack/ci/provision-environment.sh` are intentionally left untouched — the fix is GOSUMDB-only.
- Regression window: commit `1319cf74c` ("better perms") replaced `chmod -R 777 /go` (always writable) with the GID-0 pattern, which doesn't cover the runtime-created `/go/pkg/sumdb` when the runner mounts it read-only.
- Alternative (guarantee no sum miss + a writable cache) is brittle: a read-only cache mount defeats the perms approach and `go.work.sum` completeness drifts over time.

### PR Checklist

- [x] The commit messages are descriptive and follow [conventionalcommits.org](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] The PR title is descriptive
- [ ] Tested the changes in a running environment
