### PR TITLE
fix(swift-vnet): retry az login on transient DNS error at container cold start (ARO-28135)

### DIFF
--- a/dev-infrastructure/scripts/swift-vnet.sh
+++ b/dev-infrastructure/scripts/swift-vnet.sh
@@ -53,10 +53,6 @@ az container delete \
 read -r -d '' CONTAINER_SCRIPT <<EOF || true
 set -euo pipefail
 
-echo "Logging in with the Swift-registered managed identity..."
-az login --identity --username "${DEPLOYMENT_MSI_ID}" --output none
-az account set --subscription "${SUBSCRIPTION_ID}"
-
 MAX_WAIT=180
 POLL_INTERVAL=5
 
@@ -67,10 +63,17 @@ retry() {
       echo "'\$*' still failing after \$((SECONDS - start))s" >&2
       return 1
     fi
-    echo "Command failed (likely RBAC propagation); retrying in \${POLL_INTERVAL}s..." >&2
+    echo "Command failed (likely RBAC propagation or network cold-start); retrying in \${POLL_INTERVAL}s..." >&2
     sleep "\${POLL_INTERVAL}"
   done
 }
+
+# Log in as globalMSI. The container's network/DNS stack may not be ready the instant it
+# starts, so az login can fail with a transient DNS error ([Errno -3] Try again) on a cold
+# start. Wrap login and account-set in retry so that self-heals instead of killing the step.
+echo "Logging in with the Swift-registered managed identity..."
+retry az login --identity --username "${DEPLOYMENT_MSI_ID}" --output none
+retry az account set --subscription "${SUBSCRIPTION_ID}"
 
 # Wait until the managed identity can actually read the resource group before deciding whether
 # the VNet exists. The Network/Tag Contributor assignments are created in a preceding step and


### PR DESCRIPTION
Fixes [ARO-28135](https://redhat.atlassian.net/browse/ARO-28135) — follow-up hardening for the Swift VNet Shell step from #5889 (relates to [ARO-28045](https://redhat.atlassian.net/browse/ARO-28045)).

### What

Wrap the container's `az login --identity` and `az account set` in the existing `retry()` helper. This required hoisting `retry()` (and `MAX_WAIT`/`POLL_INTERVAL`) above the login block.

### Why

`swift-vnet.sh` launches a container group that runs as `globalMSI` and logs in via `az login --identity` as its very first action. On an ACI cold start the network/DNS stack is occasionally not ready the instant the container runs, so login fails with a transient DNS error and `set -e` kills the whole step:

```text
Logging in with the Swift-registered managed identity...
ERROR: <urllib3.connection.HTTPSConnection object at ...>: Failed to establish a new connection: [Errno -3] Try again
✗ swift-vnet-aks-net exited with code 1
```

`[Errno -3] Try again` is `getaddrinfo` EAI_AGAIN — a temporary name-resolution failure. The `retry()` helper already absorbs eventually-consistent failures (RBAC propagation) for `az group show`, `az resource tag`, and `az network vnet create`, but it was defined *after* the login, so the two most network-sensitive first calls ran unguarded. A single cold-start blip failed the step even though a retry seconds later succeeds.

### Testing

`bash -n` syntax check passes. The change only reorders existing helper definitions and adds `retry` in front of two `az` calls; no behavioral change beyond retrying transient failures within the existing 180s window.

### Special notes for your reviewer

Pure hardening — no change to what the step does, only its resilience to cold-start DNS races. Same class of eventual-consistency handling the rest of the script already relies on, now extended to the login path.

### PR Checklist

- [x] Does this change require documentation? No — internal script resilience only.
- [x] Does this change require tests? Covered by existing CI + EV2 rollout of the step.
