### PR TITLE
chore(config): unpin clusters-service to test new build (dcaf5af6)

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -987,11 +987,7 @@ defaults:
     image:
       registry: quay.io
       repository: app-sre/aro-hcp-clusters-service
-      # Manually pinned, see AROSLSRE-1395: the next digest (b17f6fe, vcs-ref
-      # ee741db) reproducibly breaks e2e-parallel — candidate 4.22/5.0 data-plane
-      # ingress never becomes reachable. Do not let the automated image bump
-      # advance this until fixed (source tag is pinned in image-updater/config.yaml).
-      digest: sha256:6a49b32884d56e707aafba6d73258cb57857087c261f606df71c74f2a9336bf7 # 18b5a25df4baa3fabe4a2dab97dcca51a5828c79 (2026-06-19 10:48)
+      digest: sha256:00ffebc8fe99adfd59de6d296933fcc4cc553674b7673c2f5578fa15479b94c9 # dcaf5af6aba786f50b1097483a5d32a5feaa4e6d (2026-07-06 14:17)
     # controls how many HCPs can be placed on an MC, sadly not configurable per MC
     provisionShardClusterLimit: 100
     provisionShardStatus: active

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -167,7 +167,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpci00
   image:
-    digest: sha256:6a49b32884d56e707aafba6d73258cb57857087c261f606df71c74f2a9336bf7
+    digest: sha256:00ffebc8fe99adfd59de6d296933fcc4cc553674b7673c2f5578fa15479b94c9
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -167,7 +167,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpci01
   image:
-    digest: sha256:6a49b32884d56e707aafba6d73258cb57857087c261f606df71c74f2a9336bf7
+    digest: sha256:00ffebc8fe99adfd59de6d296933fcc4cc553674b7673c2f5578fa15479b94c9
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -167,7 +167,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpcspr
   image:
-    digest: sha256:6a49b32884d56e707aafba6d73258cb57857087c261f606df71c74f2a9336bf7
+    digest: sha256:00ffebc8fe99adfd59de6d296933fcc4cc553674b7673c2f5578fa15479b94c9
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -167,7 +167,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpdev
   image:
-    digest: sha256:6a49b32884d56e707aafba6d73258cb57857087c261f606df71c74f2a9336bf7
+    digest: sha256:00ffebc8fe99adfd59de6d296933fcc4cc553674b7673c2f5578fa15479b94c9
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -167,7 +167,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpperf
   image:
-    digest: sha256:6a49b32884d56e707aafba6d73258cb57857087c261f606df71c74f2a9336bf7
+    digest: sha256:00ffebc8fe99adfd59de6d296933fcc4cc553674b7673c2f5578fa15479b94c9
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -167,7 +167,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcppers
   image:
-    digest: sha256:6a49b32884d56e707aafba6d73258cb57857087c261f606df71c74f2a9336bf7
+    digest: sha256:00ffebc8fe99adfd59de6d296933fcc4cc553674b7673c2f5578fa15479b94c9
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:

--- a/tooling/image-updater/config.yaml
+++ b/tooling/image-updater/config.yaml
@@ -47,14 +47,7 @@ images:
     group: cs
     source:
       image: quay.io/app-sre/aro-hcp-clusters-service
-      # Pinned, see AROSLSRE-1395. The `latest` build (vcs-ref ee741db, ARO-26913)
-      # sets AzurePlatformSpec.Topology=PublicAndPrivate on the HostedCluster, which
-      # makes HyperShift configure the guest ingress LB scope Internal; on candidate
-      # 4.22/5.0 payloads the guest ingress-operator then flips it back to External,
-      # leaving the *.apps route unreachable and failing e2e-parallel. Keep pinned to
-      # the last-known-good build (vcs-ref 18b5a25) until the topology regression is
-      # fixed, then restore `tag: "latest"`.
-      tag: "18b5a25"
+      tag: "latest"
       versionLabel: "vcs-ref"
       useAuth: true
       keyVault:


### PR DESCRIPTION
Bisecting the e2e-parallel regression on the automated image-digest PR [#5789](https://github.com/Azure/ARO-HCP/pull/5789). Split out from the "rest" PR [#5912](https://github.com/Azure/ARO-HCP/pull/5912).

### What

Bumps **only** the `clusters-service` image digest to the latest value from #5789, on top of current `main`. All other components stay at their `main` digests.

```
app-sre/aro-hcp-clusters-service
  sha256:6a49b32…  (main)
  sha256:b17f6fe…  (#5789 latest)
```

### Why

hypershift (#5910) and ACM/MCE (#5911) were cleared. clusters-service was **not** part of the original pass→fail boundary at `128feb1`, but it is bumped in the overall #5789 update, so this PR verifies it in isolation. clusters-service is the component most directly involved in HCP cluster provisioning.

### Testing

Relies on `ci/prow/e2e-parallel`. `make -C config/ detect-change` is clean. Diagnostic bisect PR — not intended to merge as-is.

### Special notes for your reviewer

Do not merge. Diagnostic bisect of #5789.
