### PR TITLE
Bump e2e swift nodepools to 18

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1666,7 +1666,7 @@ clouds:
                 vmSize: Standard_D4ds_v6
               userAgentPool:
                 maxCount: 14
-                minCount: 5
+                minCount: 6
                 osDiskSizeGB: 100
                 vmSize: Standard_E16ds_v6
                 secondaryNicCount: 7
@@ -1765,7 +1765,7 @@ clouds:
                 vmSize: Standard_D4ds_v6
               userAgentPool:
                 maxCount: 14
-                minCount: 5
+                minCount: 6
                 osDiskSizeGB: 100
                 vmSize: Standard_E16ds_v6
                 secondaryNicCount: 7

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -624,7 +624,7 @@ mgmt:
       zones: ""
     userAgentPool:
       maxCount: 14
-      minCount: 5
+      minCount: 6
       name: userswft
       osDiskSizeGB: 100
       poolCount: 3

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -624,7 +624,7 @@ mgmt:
       zones: ""
     userAgentPool:
       maxCount: 14
-      minCount: 5
+      minCount: 6
       name: userswft
       osDiskSizeGB: 100
       poolCount: 3


### PR DESCRIPTION
With almost 50 HCPs created concurrently during e2e, maxPods is reached in some nodes causing pod scheduling delays.