### PR TITLE
fix(monitoring): use raw AMW ingestion for low alert

### DIFF
--- a/dev-infrastructure/modules/metrics/amw-ingestion-alerts.bicep
+++ b/dev-infrastructure/modules/metrics/amw-ingestion-alerts.bicep
@@ -171,7 +171,7 @@ resource lowEventIngestion 'Microsoft.Insights/metricAlerts@2018-03-01' = [
     name: 'AMW Low Event Ingestion Utilization - ${ws.label}'
     location: 'global'
     properties: {
-      description: 'Events Per Minute utilization is below limit. This may indicate that Prometheus remote write is broken or that very few metrics are being ingested. Investigate the ingestion pipeline. https://learn.microsoft.com/azure/azure-monitor/metrics/azure-monitor-workspace-monitor-ingest-limits'
+      description: 'Events Per Minute ingestion is below ${ws.lowEventIngestionThreshold}. This may indicate that Prometheus remote write is broken or that very few metrics are being ingested. Investigate the ingestion pipeline. https://learn.microsoft.com/azure/azure-monitor/metrics/azure-monitor-workspace-monitor-ingest-limits'
       severity: 3
       enabled: enabled
       autoMitigate: true
@@ -186,7 +186,7 @@ resource lowEventIngestion 'Microsoft.Insights/metricAlerts@2018-03-01' = [
           {
             threshold: ws.lowEventIngestionThreshold
             name: 'EventsPerMinuteCriteria'
-            metricName: 'EventsPerMinuteIngestedPercentUtilization'
+            metricName: 'EventsPerMinuteIngested'
             operator: 'LessThan'
             timeAggregation: 'Average'
             criterionType: 'StaticThresholdCriterion'

--- a/dev-infrastructure/templates/monitoring.bicep
+++ b/dev-infrastructure/templates/monitoring.bicep
@@ -173,12 +173,12 @@ module ingestionAlerts '../modules/metrics/amw-ingestion-alerts.bicep' = {
       {
         id: azureMonitoringWorkspaceId
         label: 'svc'
-        lowEventIngestionThreshold: 1
+        lowEventIngestionThreshold: 100
       }
       {
         id: hcpAzureMonitoringWorkspaceId
         label: 'hcp'
-        lowEventIngestionThreshold: 5
+        lowEventIngestionThreshold: 100
       }
     ]
   }


### PR DESCRIPTION
### What

Change the AMW Low Event Ingestion Utilization alert to use raw event ingestion instead of percent utilization:

- `metricName`: `EventsPerMinuteIngested`
- `operator`: `LessThan`
- `threshold`: `100` for both svc and hcp AMWs
- keep the existing evaluation frequency/window: `PT5M` / `PT30M`

### Why

Percent of max limit is not a reliable value for this alert, especially for HCP AMWs. If this alert is to work without false positives, it can only indicate when it looks like there is nothing coming into the AMW, and percent utilization does not work for that signal.
