### PR TITLE
NO-JIRA: stop logging raw x-ms-client-principal header values

### DIFF
--- a/admin/server/middleware/ga_calling_identity.go
+++ b/admin/server/middleware/ga_calling_identity.go
@@ -15,7 +15,6 @@
 package middleware
 
 import (
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -31,13 +30,16 @@ const (
 func MiddlewareClientPrincipal(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	logger := utils.LoggerFromContext(r.Context())
 
-	var headers []string
-	for name, values := range r.Header {
+	// Log only the header names, never their values: the x-ms-client-principal-*
+	// headers carry user-supplied, credential-bearing identity data (e.g. principal
+	// name/UPN and object id) that must not be disclosed in cleartext to the logs.
+	var headerNames []string
+	for name := range r.Header {
 		if strings.HasPrefix(strings.ToLower(name), "x-ms-client-principal-") {
-			headers = append(headers, fmt.Sprintf("%s=%s", name, strings.Join(values, ",")))
+			headerNames = append(headerNames, name)
 		}
 	}
-	logger.Info("Geneva Action client principal headers", "headers", strings.Join(headers, "; "))
+	logger.Info("Geneva Action client principal headers", "headerNames", strings.Join(headerNames, "; "))
 
 	clientPrincipalName := r.Header.Get(ClientPrincipalNameHeader)
 	if clientPrincipalName == "" {

--- a/admin/server/middleware/ga_calling_identity.go
+++ b/admin/server/middleware/ga_calling_identity.go
@@ -16,6 +16,7 @@ package middleware
 
 import (
 	"net/http"
+	"sort"
 	"strings"
 
 	"github.com/Azure/ARO-HCP/internal/utils"
@@ -39,7 +40,9 @@ func MiddlewareClientPrincipal(w http.ResponseWriter, r *http.Request, next http
 			headerNames = append(headerNames, name)
 		}
 	}
-	logger.Info("Geneva Action client principal headers", "headerNames", strings.Join(headerNames, "; "))
+	// r.Header iteration order is randomized; sort so the logged value is stable.
+	sort.Strings(headerNames)
+	logger.Info("Geneva Action client principal headers", "headers", strings.Join(headerNames, "; "))
 
 	clientPrincipalName := r.Header.Get(ClientPrincipalNameHeader)
 	if clientPrincipalName == "" {

--- a/admin/server/middleware/ga_calling_identity_test.go
+++ b/admin/server/middleware/ga_calling_identity_test.go
@@ -1,0 +1,95 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr/funcr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// TestMiddlewareClientPrincipalDoesNotLogHeaderValues ensures the middleware logs
+// only the names of the x-ms-client-principal-* headers and never their
+// credential-bearing values.
+func TestMiddlewareClientPrincipalDoesNotLogHeaderValues(t *testing.T) {
+	const (
+		principalName = "test-user@example.com"
+		objectID      = "11111111-1111-1111-1111-111111111111"
+	)
+
+	var logOutput strings.Builder
+	logger := funcr.New(func(prefix, args string) {
+		logOutput.WriteString(prefix)
+		logOutput.WriteString(args)
+	}, funcr.Options{})
+	ctx := utils.ContextWithLogger(context.Background(), logger)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
+	req.Header.Set(ClientPrincipalNameHeader, principalName)
+	req.Header.Set(ClientAADTypeHeader, "User")
+	req.Header.Set("X-Ms-Client-Principal-Id", objectID)
+
+	nextCalled := false
+	next := func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+	}
+
+	rec := httptest.NewRecorder()
+	MiddlewareClientPrincipal(rec, req, next)
+
+	require.True(t, nextCalled, "next handler should have been called")
+
+	output := logOutput.String()
+
+	// Header names must be present in the log.
+	assert.Contains(t, output, ClientPrincipalNameHeader, "log should contain the principal name header name")
+	assert.Contains(t, output, ClientAADTypeHeader, "log should contain the principal type header name")
+	assert.Contains(t, output, "X-Ms-Client-Principal-Id", "log should contain the principal id header name")
+
+	// Header values must never appear in the log.
+	assert.NotContains(t, output, principalName, "log must not contain the principal name value")
+	assert.NotContains(t, output, objectID, "log must not contain the principal id value")
+}
+
+// TestMiddlewareClientPrincipalHeaderNamesAreSorted ensures the logged header
+// names are deterministically ordered regardless of map iteration order.
+func TestMiddlewareClientPrincipalHeaderNamesAreSorted(t *testing.T) {
+	var logOutput strings.Builder
+	logger := funcr.New(func(prefix, args string) {
+		logOutput.WriteString(prefix)
+		logOutput.WriteString(args)
+	}, funcr.Options{})
+	ctx := utils.ContextWithLogger(context.Background(), logger)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
+	req.Header.Set(ClientPrincipalNameHeader, "test-user@example.com")
+	req.Header.Set(ClientAADTypeHeader, "User")
+	req.Header.Set("X-Ms-Client-Principal-Id", "object-id")
+
+	MiddlewareClientPrincipal(httptest.NewRecorder(), req, func(w http.ResponseWriter, r *http.Request) {})
+
+	output := logOutput.String()
+	assert.Contains(t, output,
+		strings.Join([]string{"X-Ms-Client-Principal-Id", ClientPrincipalNameHeader, ClientAADTypeHeader}, "; "),
+		"logged header names should be sorted alphabetically")
+}


### PR DESCRIPTION
The Geneva Action client-principal middleware logged the full x-ms-client-principal-* headers as name=value pairs, disclosing user-supplied, credential-bearing identity data (principal name/UPN, object id, etc.) in cleartext to the logs on every request.

Log only the header names, preserving debuggability without leaking the values.

<!-- Link to Jira issue -->

### What

Stop logging the raw x-ms-client-principal-* header values in the Geneva
Action client-principal middleware. The middleware now:
- Logs only the names of matching x-ms-client-principal-* headers, never
  their values.
- Sorts the header names before logging so the output is deterministic
  (map iteration order is randomized).
- Keeps the structured log field key as "headers" to preserve existing
  log queries.
- Adds unit tests asserting only header names (not values) are logged and
  that the names are emitted in sorted order.
### Why

The middleware previously logged the full x-ms-client-principal-* headers
as name=value pairs. These headers carry user-supplied, credential-bearing
identity data (principal name/UPN, object id, etc.), disclosing sensitive
identity information in cleartext to the logs on every request. Logging
only the header names preserves debuggability without leaking the values.

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
