### PR TITLE
feat: add autoscaler ReadDesire and update operation gate for cluster autoscaler 

### DIFF
--- a/backend/pkg/controllers/create_cluster_scoped_read_desires_controller.go
+++ b/backend/pkg/controllers/create_cluster_scoped_read_desires_controller.go
@@ -16,6 +16,7 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -27,6 +28,7 @@ import (
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
 	"github.com/Azure/ARO-HCP/backend/pkg/informers"
 	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/backend/pkg/maestrohelpers"
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/kubeapplier"
 	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
@@ -143,13 +145,6 @@ func (c *createClusterScopedReadDesiresSyncer) SyncOnce(ctx context.Context, key
 	}
 	csClusterID := existingCluster.ServiceProviderProperties.ClusterServiceID.ID()
 
-	target := hostedClusterTarget(c.hostedClusterNamespaceEnvIdentifier, csClusterID, csClusterDomainPrefix)
-	desired := buildReadDesire(
-		kubeapplier.ToClusterScopedReadDesireResourceIDString(key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, readDesireNameReadonlyHostedCluster),
-		mcResourceID,
-		target,
-	)
-
 	kaClient := c.kubeApplierDBClients.For(ctx, mcResourceID)
 	if kaClient == nil {
 		// Registry doesn't have an entry yet for this MC (e.g. the fleet
@@ -160,27 +155,29 @@ func (c *createClusterScopedReadDesiresSyncer) SyncOnce(ctx context.Context, key
 	}
 	crud, err := kaClient.ReadDesiresForCluster(key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
 	if err != nil {
-		return utils.TrackError(fmt.Errorf("get ReadDesire CRUD: %w", err))
+		return utils.TrackError(fmt.Errorf("failed to get ReadDesire CRUD: %w", err))
 	}
-	existing, err := getExistingReadDesire(ctx, crud, readDesireNameReadonlyHostedCluster)
-	if err != nil {
-		return err
+
+	desiredReadDesires := []*kubeapplier.ReadDesire{
+		buildReadDesire(
+			kubeapplier.ToClusterScopedReadDesireResourceIDString(key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, readDesireNameReadonlyHostedCluster),
+			mcResourceID,
+			hostedClusterTarget(c.hostedClusterNamespaceEnvIdentifier, csClusterID, csClusterDomainPrefix),
+		),
+		buildReadDesire(
+			kubeapplier.ToClusterScopedReadDesireResourceIDString(key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, maestrohelpers.ReadDesireNameReadonlyHypershiftControlPlaneComponentClusterAutoscaler),
+			mcResourceID,
+			clusterAutoscalerTarget(c.hostedClusterNamespaceEnvIdentifier, csClusterID, csClusterDomainPrefix),
+		),
 	}
-	if !readDesireNeedsWork(existing, desired) {
-		return nil
-	}
-	if existing == nil {
-		if _, err := crud.Create(ctx, desired, nil); err != nil {
-			return utils.TrackError(fmt.Errorf("create ReadDesire: %w", err))
+
+	var errs []error
+	for _, desired := range desiredReadDesires {
+		if err := c.ensureReadDesire(ctx, crud, desired); err != nil {
+			errs = append(errs, err)
 		}
-		return nil
 	}
-	replacement := existing.DeepCopy()
-	replacement.Spec = *desired.Spec.DeepCopy()
-	if _, err := crud.Replace(ctx, replacement, nil); err != nil {
-		return utils.TrackError(fmt.Errorf("replace ReadDesire: %w", err))
-	}
-	return nil
+	return errors.Join(errs...)
 }
 
 // readDesireNameReadonlyHostedCluster is the well-known ReadDesire name
@@ -202,6 +199,18 @@ func hostedClusterTarget(envIdentifier, csClusterID, csClusterDomainPrefix strin
 		Resource:  "hostedclusters",
 		Namespace: hostedClusterNamespace(envIdentifier, csClusterID),
 		Name:      csClusterDomainPrefix,
+	}
+}
+
+// clusterAutoscalerTarget builds the ResourceReference for the cluster-autoscaler
+// ControlPlaneComponent in the HCP control plane namespace.
+func clusterAutoscalerTarget(envIdentifier, csClusterID, csClusterDomainPrefix string) kubeapplier.ResourceReference {
+	return kubeapplier.ResourceReference{
+		Group:     hsv1beta1.SchemeGroupVersion.Group,
+		Version:   hsv1beta1.SchemeGroupVersion.Version,
+		Resource:  "controlplanecomponents",
+		Namespace: hostedControlPlaneNamespace(envIdentifier, csClusterID, csClusterDomainPrefix),
+		Name:      "cluster-autoscaler",
 	}
 }
 
@@ -231,7 +240,7 @@ func getExistingReadDesire(
 		return nil, nil
 	}
 	if err != nil {
-		return nil, utils.TrackError(fmt.Errorf("get ReadDesire: %w", err))
+		return nil, utils.TrackError(fmt.Errorf("failed to get ReadDesire: %w", err))
 	}
 	return existing, nil
 }
@@ -247,4 +256,36 @@ func readDesireNeedsWork(existing, desired *kubeapplier.ReadDesire) bool {
 		return true
 	}
 	return existing.Spec.TargetItem != desired.Spec.TargetItem
+}
+
+// ensureReadDesire creates or updates a ReadDesire when the desired spec differs from cosmos.
+func (c *createClusterScopedReadDesiresSyncer) ensureReadDesire(ctx context.Context, crud database.ResourceCRUD[kubeapplier.ReadDesire, *kubeapplier.ReadDesire], desired *kubeapplier.ReadDesire) error {
+	existing, err := getExistingReadDesire(ctx, crud, desired.ResourceID.Name)
+	if err != nil {
+		return err
+	}
+	if !readDesireNeedsWork(existing, desired) {
+		return nil
+	}
+	name := desired.ResourceID.Name
+	if existing == nil {
+		_, err := crud.Create(ctx, desired, nil)
+		if database.IsConflictError(err) {
+			return nil
+		}
+		if err != nil {
+			return utils.TrackError(fmt.Errorf("failed to create ReadDesire %q: %w", name, err))
+		}
+		return nil
+	}
+	replacement := existing.DeepCopy()
+	replacement.Spec = *desired.Spec.DeepCopy()
+	_, err = crud.Replace(ctx, replacement, nil)
+	if database.IsPreconditionFailedError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to replace ReadDesire %q: %w", name, err))
+	}
+	return nil
 }

--- a/backend/pkg/controllers/create_cluster_scoped_read_desires_controller_test.go
+++ b/backend/pkg/controllers/create_cluster_scoped_read_desires_controller_test.go
@@ -1,0 +1,262 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	hsv1beta1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
+	"github.com/Azure/ARO-HCP/backend/pkg/maestrohelpers"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/api/kubeapplier"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+const (
+	readDesireTestSubscriptionID    = "00000000-0000-0000-0000-000000000000"
+	readDesireTestResourceGroupName = "test-rg"
+	readDesireTestClusterName       = "test-cluster"
+	readDesireTestEnvIdentifier     = "int"
+	readDesireTestDomainPrefix      = "cluster1"
+	readDesireTestClusterServiceID  = "/api/clusters_mgmt/v1/clusters/abc123"
+)
+
+var readDesireTestManagementClusterResourceID = api.Must(azcorearm.ParseResourceID(
+	"/providers/microsoft.redhatopenshift/stamps/1/managementclusters/default",
+))
+
+func readDesireTestKey() controllerutils.HCPClusterKey {
+	return controllerutils.HCPClusterKey{
+		SubscriptionID:    readDesireTestSubscriptionID,
+		ResourceGroupName: readDesireTestResourceGroupName,
+		HCPClusterName:    readDesireTestClusterName,
+	}
+}
+
+func newTestCluster(opts ...func(*api.HCPOpenShiftCluster)) *api.HCPOpenShiftCluster {
+	resourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + readDesireTestSubscriptionID +
+			"/resourceGroups/" + readDesireTestResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + readDesireTestClusterName,
+	))
+	cluster := &api.HCPOpenShiftCluster{
+		CosmosMetadata: arm.CosmosMetadata{
+			ResourceID:   resourceID,
+			PartitionKey: strings.ToLower(resourceID.SubscriptionID),
+		},
+		TrackedResource: arm.TrackedResource{
+			Resource: arm.Resource{
+				ID:   resourceID,
+				Name: readDesireTestClusterName,
+				Type: resourceID.ResourceType.String(),
+			},
+		},
+		ServiceProviderProperties: api.HCPOpenShiftClusterServiceProviderProperties{
+			ClusterServiceID: api.Ptr(api.Must(api.NewInternalID(readDesireTestClusterServiceID))),
+		},
+		CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
+			DNS: api.CustomerDNSProfile{
+				BaseDomainPrefix: readDesireTestDomainPrefix,
+			},
+			Version: api.VersionProfile{
+				ID: "4.20.0",
+			},
+		},
+	}
+	for _, opt := range opts {
+		opt(cluster)
+	}
+	return cluster
+}
+
+func newTestSPC(mcResourceID *azcorearm.ResourceID) *api.ServiceProviderCluster {
+	spcResourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + readDesireTestSubscriptionID +
+			"/resourceGroups/" + readDesireTestResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + readDesireTestClusterName +
+			"/serviceProviderClusters/" + api.ServiceProviderClusterResourceName,
+	))
+	return &api.ServiceProviderCluster{
+		CosmosMetadata: api.CosmosMetadata{
+			ResourceID:   spcResourceID,
+			PartitionKey: strings.ToLower(spcResourceID.SubscriptionID),
+		},
+		Status: api.ServiceProviderClusterStatus{
+			ManagementClusterResourceID: mcResourceID,
+		},
+	}
+}
+
+func TestCreateClusterScopedReadDesires_SyncOnce(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                         string
+		resources                    []any
+		cachedServiceProviderCluster *api.ServiceProviderCluster
+		kubeApplierDesires           []any
+		wantErr                      bool
+		verifyDB                     func(t *testing.T, ctx context.Context, kaClient *databasetesting.MockKubeApplierDBClient)
+	}{
+		{
+			name: "creates HostedCluster and cluster-autoscaler ReadDesires",
+			resources: []any{
+				newTestCluster(),
+			},
+			cachedServiceProviderCluster: newTestSPC(readDesireTestManagementClusterResourceID),
+			verifyDB: func(t *testing.T, ctx context.Context, kaClient *databasetesting.MockKubeApplierDBClient) {
+				t.Helper()
+				crud, err := kaClient.ReadDesiresForCluster(readDesireTestSubscriptionID, readDesireTestResourceGroupName, readDesireTestClusterName)
+				require.NoError(t, err)
+
+				hostedClusterRD, err := crud.Get(ctx, readDesireNameReadonlyHostedCluster)
+				require.NoError(t, err)
+				assert.Equal(t, hostedClusterTarget(readDesireTestEnvIdentifier, "abc123", readDesireTestDomainPrefix), hostedClusterRD.Spec.TargetItem)
+
+				autoscalerRD, err := crud.Get(ctx, maestrohelpers.ReadDesireNameReadonlyHypershiftControlPlaneComponentClusterAutoscaler)
+				require.NoError(t, err)
+				assert.Equal(t, clusterAutoscalerTarget(readDesireTestEnvIdentifier, "abc123", readDesireTestDomainPrefix), autoscalerRD.Spec.TargetItem)
+				assert.Equal(t, "controlplanecomponents", autoscalerRD.Spec.TargetItem.Resource)
+				assert.Equal(t, "cluster-autoscaler", autoscalerRD.Spec.TargetItem.Name)
+				assert.Equal(t, hostedControlPlaneNamespace(readDesireTestEnvIdentifier, "abc123", readDesireTestDomainPrefix), autoscalerRD.Spec.TargetItem.Namespace)
+				assert.Equal(t, hsv1beta1.SchemeGroupVersion.Group, autoscalerRD.Spec.TargetItem.Group)
+				assert.Equal(t, hsv1beta1.SchemeGroupVersion.Version, autoscalerRD.Spec.TargetItem.Version)
+			},
+		},
+		{
+			name: "creates cluster-autoscaler ReadDesire even when cluster version is below 4.20",
+			resources: []any{
+				newTestCluster(func(c *api.HCPOpenShiftCluster) {
+					c.CustomerProperties.Version.ID = "4.19.0"
+				}),
+			},
+			cachedServiceProviderCluster: newTestSPC(readDesireTestManagementClusterResourceID),
+			verifyDB: func(t *testing.T, ctx context.Context, kaClient *databasetesting.MockKubeApplierDBClient) {
+				t.Helper()
+				crud, err := kaClient.ReadDesiresForCluster(readDesireTestSubscriptionID, readDesireTestResourceGroupName, readDesireTestClusterName)
+				require.NoError(t, err)
+
+				_, err = crud.Get(ctx, readDesireNameReadonlyHostedCluster)
+				require.NoError(t, err)
+
+				autoscalerRD, err := crud.Get(ctx, maestrohelpers.ReadDesireNameReadonlyHypershiftControlPlaneComponentClusterAutoscaler)
+				require.NoError(t, err)
+				assert.Equal(t, clusterAutoscalerTarget(readDesireTestEnvIdentifier, "abc123", readDesireTestDomainPrefix), autoscalerRD.Spec.TargetItem)
+			},
+		},
+		{
+			name: "skips when domain prefix is not yet synced",
+			resources: []any{
+				newTestCluster(func(c *api.HCPOpenShiftCluster) {
+					c.CustomerProperties.DNS.BaseDomainPrefix = ""
+				}),
+			},
+			cachedServiceProviderCluster: newTestSPC(readDesireTestManagementClusterResourceID),
+			verifyDB: func(t *testing.T, ctx context.Context, kaClient *databasetesting.MockKubeApplierDBClient) {
+				t.Helper()
+				crud, err := kaClient.ReadDesiresForCluster(readDesireTestSubscriptionID, readDesireTestResourceGroupName, readDesireTestClusterName)
+				require.NoError(t, err)
+				_, err = crud.Get(ctx, readDesireNameReadonlyHostedCluster)
+				require.Error(t, err)
+			},
+		},
+		{
+			name: "skips when management cluster is not placed",
+			resources: []any{
+				newTestCluster(),
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, kaClient *databasetesting.MockKubeApplierDBClient) {
+				t.Helper()
+				crud, err := kaClient.ReadDesiresForCluster(readDesireTestSubscriptionID, readDesireTestResourceGroupName, readDesireTestClusterName)
+				require.NoError(t, err)
+				_, err = crud.Get(ctx, readDesireNameReadonlyHostedCluster)
+				require.Error(t, err)
+			},
+		},
+		{
+			name: "replaces cluster-autoscaler ReadDesire when target namespace changes",
+			resources: []any{
+				newTestCluster(),
+			},
+			cachedServiceProviderCluster: newTestSPC(readDesireTestManagementClusterResourceID),
+			kubeApplierDesires: []any{
+				buildReadDesire(
+					kubeapplier.ToClusterScopedReadDesireResourceIDString(
+						readDesireTestSubscriptionID, readDesireTestResourceGroupName, readDesireTestClusterName, maestrohelpers.ReadDesireNameReadonlyHypershiftControlPlaneComponentClusterAutoscaler),
+					readDesireTestManagementClusterResourceID,
+					clusterAutoscalerTarget(readDesireTestEnvIdentifier, "abc123", "old-prefix"),
+				),
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, kaClient *databasetesting.MockKubeApplierDBClient) {
+				t.Helper()
+				crud, err := kaClient.ReadDesiresForCluster(readDesireTestSubscriptionID, readDesireTestResourceGroupName, readDesireTestClusterName)
+				require.NoError(t, err)
+				autoscalerRD, err := crud.Get(ctx, maestrohelpers.ReadDesireNameReadonlyHypershiftControlPlaneComponentClusterAutoscaler)
+				require.NoError(t, err)
+				assert.Equal(t, hostedControlPlaneNamespace(readDesireTestEnvIdentifier, "abc123", readDesireTestDomainPrefix), autoscalerRD.Spec.TargetItem.Namespace)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+
+			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, tt.resources)
+			require.NoError(t, err)
+
+			mockKubeApplierDBClients := databasetesting.NewMockKubeApplierDBClients()
+			mockKubeApplierClient, err := databasetesting.NewMockKubeApplierDBClientWithResources(ctx, tt.kubeApplierDesires)
+			require.NoError(t, err)
+			mockKubeApplierDBClients.Register(readDesireTestManagementClusterResourceID, mockKubeApplierClient)
+
+			serviceProviderClusterListerStub := &listertesting.SliceServiceProviderClusterLister{}
+			if tt.cachedServiceProviderCluster != nil {
+				serviceProviderClusterListerStub.ServiceProviderClusters = []*api.ServiceProviderCluster{tt.cachedServiceProviderCluster}
+			}
+
+			syncer := &createClusterScopedReadDesiresSyncer{
+				resourcesDBClient:                   mockResourcesDBClient,
+				kubeApplierDBClients:                mockKubeApplierDBClients,
+				serviceProviderClusterLister:        serviceProviderClusterListerStub,
+				hostedClusterNamespaceEnvIdentifier: readDesireTestEnvIdentifier,
+			}
+
+			err = syncer.SyncOnce(ctx, readDesireTestKey())
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			if tt.verifyDB != nil {
+				tt.verifyDB(t, ctx, mockKubeApplierClient)
+			}
+		})
+	}
+}

--- a/backend/pkg/controllers/create_nodepool_scoped_read_desires_controller.go
+++ b/backend/pkg/controllers/create_nodepool_scoped_read_desires_controller.go
@@ -147,7 +147,7 @@ func (c *createNodePoolScopedReadDesiresSyncer) SyncOnce(ctx context.Context, ke
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("get ReadDesire CRUD: %w", err))
 	}
-	existing, err := getExistingReadDesire(ctx, crud, readDesireNameReadonlyNodePool)
+	existing, err := getExistingReadDesire(ctx, crud, desired.ResourceID.Name)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/controllers/cs_maestro_utils.go
+++ b/backend/pkg/controllers/cs_maestro_utils.go
@@ -23,3 +23,10 @@ import "fmt"
 func hostedClusterNamespace(envIdentifier, csClusterID string) string {
 	return fmt.Sprintf("ocm-%s-%s", envIdentifier, csClusterID)
 }
+
+// hostedControlPlaneNamespace returns the management-cluster namespace that hosts a
+// given HCP's control plane workloads (including ControlPlaneComponent CRs).
+// Hypershift names it "ocm-<envIdentifier>-<csClusterID>-<csClusterDomainPrefix>".
+func hostedControlPlaneNamespace(envIdentifier, csClusterID, csClusterDomainPrefix string) string {
+	return fmt.Sprintf("ocm-%s-%s-%s", envIdentifier, csClusterID, csClusterDomainPrefix)
+}

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_update.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_update.go
@@ -220,6 +220,11 @@ func (c *operationClusterUpdate) determineOperationState(ctx context.Context, op
 	} else {
 		operationStates = append(operationStates, operationState.withSource("hypershiftHostedCluster"))
 	}
+	if operationState, autoscalerErr := c.hypershiftControlPlaneClusterAutoscalerState(ctx, existingCluster, existingServiceProviderCluster); autoscalerErr != nil {
+		errs = append(errs, utils.TrackError(autoscalerErr))
+	} else {
+		operationStates = append(operationStates, operationState.withSource("hypershiftControlPlaneClusterAutoscaler"))
+	}
 
 	if err := errors.Join(errs...); err != nil {
 		return nil, err
@@ -240,8 +245,8 @@ func (c *operationClusterUpdate) determineOperationState(ctx context.Context, op
 	return picked, nil
 }
 
-func (c *operationClusterUpdate) desiredVersionResolutionOperationState(ctx context.Context, operation *api.Operation, existingCluster *api.HCPOpenShiftCluster, existingServiceProviderCluster *api.ServiceProviderCluster) (*operationState, error) {
-	resultingDesiredVersion := existingServiceProviderCluster.Spec.ControlPlaneVersion.DesiredVersion
+func (c *operationClusterUpdate) desiredVersionResolutionOperationState(ctx context.Context, operation *api.Operation, existingCluster *api.HCPOpenShiftCluster, spc *api.ServiceProviderCluster) (*operationState, error) {
+	resultingDesiredVersion := spc.Spec.ControlPlaneVersion.DesiredVersion
 	if resultingDesiredVersion == nil {
 		return nil, utils.TrackError(fmt.Errorf("service provider cluster has no desired version"))
 	}

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_update_state_calculation.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_update_state_calculation.go
@@ -20,6 +20,11 @@ import (
 	"slices"
 	"time"
 
+	"github.com/blang/semver/v4"
+
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
 	"github.com/openshift/hypershift/api/hypershift/v1beta1"
 
@@ -28,6 +33,7 @@ import (
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/ocm"
 	"github.com/Azure/ARO-HCP/internal/utils"
+	"github.com/Azure/ARO-HCP/internal/utils/apihelpers"
 )
 
 // Cluster update operation state calculation for the cluster update operation controller.
@@ -476,4 +482,73 @@ func (c *operationClusterUpdate) clusterServiceClusterNodeDrainTimeoutSpecMatche
 		return false, fmt.Sprintf("Cluster Service nodeDrainGracePeriod is %d minutes, want %d", got, desired)
 	}
 	return true, ""
+}
+
+// hypershiftControlPlaneClusterAutoscalerState gates on the
+// cluster-autoscaler ControlPlaneComponent status (Available + RolloutComplete)
+// when the active control plane is 4.20+. HostedCluster autoscaling Spec matching
+// is owned by hypershiftHostedClusterOperationState.
+func (c *operationClusterUpdate) hypershiftControlPlaneClusterAutoscalerState(ctx context.Context, existingCluster *api.HCPOpenShiftCluster, spc *api.ServiceProviderCluster) (*operationState, error) {
+	logger := utils.LoggerFromContext(ctx)
+
+	lowest, _ := apihelpers.FindLowestAndHighestClusterVersion(spc.Status.ControlPlaneVersion.ActiveVersions)
+	if lowest == nil {
+		return newOperationState(arm.ProvisioningStateUpdating, "control plane active versions not yet reported"), nil
+	}
+	// Compare major.minor only so pre-release builds (e.g. nightlies like
+	// 4.20.0-0.nightly-...) still satisfy the 4.20+ autoscaler gate.
+	lowestMajorMinor := semver.Version{Major: lowest.Major, Minor: lowest.Minor}
+	if !lowestMajorMinor.GTE(semver.Version{Major: 4, Minor: 20}) {
+		msg := fmt.Sprintf(
+			`lowest active control plane version %q does not support ControlPlaneComponent cluster-autoscaler (requires 4.20+)`,
+			lowest.String(),
+		)
+		return newOperationState(arm.ProvisioningStateSucceeded, msg), nil
+	}
+
+	controlPlaneComponent, err := maestrohelpers.GetCachedControlPlaneClusterAutoscalerForCluster(
+		ctx, c.readDesireLister,
+		existingCluster.ID.SubscriptionID, existingCluster.ID.ResourceGroupName, existingCluster.ID.Name,
+	)
+	if err != nil {
+		return nil, utils.TrackError(err)
+	}
+	if controlPlaneComponent == nil {
+		return newOperationState(arm.ProvisioningStateUpdating, "cluster autoscaler state not cached yet"), nil
+	}
+	if !c.isControlPlaneClusterAutoscalerReady(controlPlaneComponent) {
+		message := c.controlPlaneClusterAutoscalerNotReadyMessage(controlPlaneComponent)
+		logger.Info("cluster autoscaler ControlPlaneComponent is not ready", "message", message)
+		return newOperationState(arm.ProvisioningStateUpdating, message), nil
+	}
+	return newOperationState(arm.ProvisioningStateSucceeded, ""), nil
+}
+
+func (c *operationClusterUpdate) isControlPlaneClusterAutoscalerReady(controlPlaneComponent *v1beta1.ControlPlaneComponent) bool {
+	return apimeta.IsStatusConditionTrue(controlPlaneComponent.Status.Conditions, string(v1beta1.ControlPlaneComponentAvailable)) &&
+		apimeta.IsStatusConditionTrue(controlPlaneComponent.Status.Conditions, string(v1beta1.ControlPlaneComponentRolloutComplete))
+}
+
+const (
+	clusterAutoscalerNotAvailableMsg       = "cluster autoscaler not available"
+	clusterAutoscalerRolloutNotCompleteMsg = "cluster autoscaler rollout not complete"
+	clusterAutoscalerNotReadyMsg           = "cluster autoscaler not ready"
+)
+
+func (c *operationClusterUpdate) controlPlaneClusterAutoscalerNotReadyMessage(controlPlaneComponent *v1beta1.ControlPlaneComponent) string {
+	available := apimeta.FindStatusCondition(controlPlaneComponent.Status.Conditions, string(v1beta1.ControlPlaneComponentAvailable))
+	rollout := apimeta.FindStatusCondition(controlPlaneComponent.Status.Conditions, string(v1beta1.ControlPlaneComponentRolloutComplete))
+	if available == nil || available.Status != metav1.ConditionTrue {
+		if available != nil && len(available.Message) > 0 {
+			return fmt.Sprintf("%s: %s: %s", clusterAutoscalerNotAvailableMsg, available.Reason, available.Message)
+		}
+		return clusterAutoscalerNotAvailableMsg
+	}
+	if rollout == nil || rollout.Status != metav1.ConditionTrue {
+		if rollout != nil && len(rollout.Message) > 0 {
+			return fmt.Sprintf("%s: %s: %s", clusterAutoscalerRolloutNotCompleteMsg, rollout.Reason, rollout.Message)
+		}
+		return clusterAutoscalerRolloutNotCompleteMsg
+	}
+	return clusterAutoscalerNotReadyMsg
 }

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_update_state_calculation_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_update_state_calculation_test.go
@@ -16,18 +16,26 @@ package operationcontrollers
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/blang/semver/v4"
 	"github.com/go-logr/logr/testr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
 	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
 	"github.com/openshift/hypershift/api/hypershift/v1beta1"
 
+	"github.com/Azure/ARO-HCP/backend/pkg/maestrohelpers"
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/api/kubeapplier"
@@ -90,7 +98,7 @@ func TestHypershiftHostedClusterOperationState(t *testing.T) {
 				}),
 			},
 			wantState:         arm.ProvisioningStateUpdating,
-			wantMessageSubstr: `maxNodesTotal is 5, want 10`,
+			wantMessageSubstr: "hypershift HostedCluster autoscaling maxNodesTotal is 5, want 10",
 		},
 		{
 			name: "autoscaling matches returns Succeeded",
@@ -136,7 +144,7 @@ func TestHypershiftHostedClusterOperationState(t *testing.T) {
 				}),
 			},
 			wantState:         arm.ProvisioningStateUpdating,
-			wantMessageSubstr: `maxNodeProvisionTime is "10m", want "15m"`,
+			wantMessageSubstr: `hypershift HostedCluster autoscaling maxNodeProvisionTime is "10m", want "15m"`,
 		},
 		{
 			name: "maxNodeProvisionTime matches when converted",
@@ -1714,6 +1722,326 @@ func TestClusterServiceClusterSpecOperationState(t *testing.T) {
 			if tt.wantMessageSubstr != "" {
 				assert.Contains(t, state.Message, tt.wantMessageSubstr)
 			}
+		})
+	}
+}
+
+func readyControlPlaneClusterAutoscaler() *v1beta1.ControlPlaneComponent {
+	return &v1beta1.ControlPlaneComponent{
+		Status: v1beta1.ControlPlaneComponentStatus{
+			Conditions: []metav1.Condition{
+				{Type: string(v1beta1.ControlPlaneComponentAvailable), Status: metav1.ConditionTrue},
+				{Type: string(v1beta1.ControlPlaneComponentRolloutComplete), Status: metav1.ConditionTrue},
+			},
+		},
+	}
+}
+
+func newControlPlaneClusterAutoscalerReadDesire(t *testing.T, controlPlaneComponent *v1beta1.ControlPlaneComponent, conditions ...metav1.Condition) *kubeapplier.ReadDesire {
+	t.Helper()
+	raw, err := json.Marshal(controlPlaneComponent)
+	require.NoError(t, err)
+	if conditions == nil {
+		conditions = []metav1.Condition{
+			{Type: kubeapplier.ConditionTypeSuccessful, Status: metav1.ConditionTrue, Reason: kubeapplier.ConditionReasonNoErrors},
+		}
+	}
+
+	resourceID := api.Must(azcorearm.ParseResourceID(
+		kubeapplier.ToClusterScopedReadDesireResourceIDString(
+			testSubscriptionID, testResourceGroupName, testClusterName, maestrohelpers.ReadDesireNameReadonlyHypershiftControlPlaneComponentClusterAutoscaler)))
+
+	return &kubeapplier.ReadDesire{
+		CosmosMetadata: api.CosmosMetadata{
+			ResourceID:   resourceID,
+			PartitionKey: strings.ToLower(resourceID.SubscriptionID),
+		},
+		Status: kubeapplier.ReadDesireStatus{
+			Conditions:  conditions,
+			KubeContent: &kruntime.RawExtension{Raw: raw},
+		},
+	}
+}
+
+func TestIsControlPlaneClusterAutoscalerReady(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                  string
+		controlPlaneComponent *v1beta1.ControlPlaneComponent
+		want                  bool
+	}{
+		{
+			name:                  "both Available and RolloutComplete true is ready",
+			controlPlaneComponent: readyControlPlaneClusterAutoscaler(),
+			want:                  true,
+		},
+		{
+			name: "Available false is not ready",
+			controlPlaneComponent: &v1beta1.ControlPlaneComponent{
+				Status: v1beta1.ControlPlaneComponentStatus{
+					Conditions: []metav1.Condition{
+						{Type: string(v1beta1.ControlPlaneComponentAvailable), Status: metav1.ConditionFalse},
+						{Type: string(v1beta1.ControlPlaneComponentRolloutComplete), Status: metav1.ConditionTrue},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "RolloutComplete is false",
+			controlPlaneComponent: &v1beta1.ControlPlaneComponent{
+				Status: v1beta1.ControlPlaneComponentStatus{
+					Conditions: []metav1.Condition{
+						{Type: string(v1beta1.ControlPlaneComponentAvailable), Status: metav1.ConditionTrue},
+						{Type: string(v1beta1.ControlPlaneComponentRolloutComplete), Status: metav1.ConditionFalse},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Available condition missing is not ready",
+			controlPlaneComponent: &v1beta1.ControlPlaneComponent{
+				Status: v1beta1.ControlPlaneComponentStatus{
+					Conditions: []metav1.Condition{
+						{Type: string(v1beta1.ControlPlaneComponentRolloutComplete), Status: metav1.ConditionTrue},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "RolloutComplete condition missing is not ready",
+			controlPlaneComponent: &v1beta1.ControlPlaneComponent{
+				Status: v1beta1.ControlPlaneComponentStatus{
+					Conditions: []metav1.Condition{
+						{Type: string(v1beta1.ControlPlaneComponentAvailable), Status: metav1.ConditionTrue},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Available condition unknown is not ready",
+			controlPlaneComponent: &v1beta1.ControlPlaneComponent{
+				Status: v1beta1.ControlPlaneComponentStatus{
+					Conditions: []metav1.Condition{
+						{Type: string(v1beta1.ControlPlaneComponentAvailable), Status: metav1.ConditionUnknown},
+						{Type: string(v1beta1.ControlPlaneComponentRolloutComplete), Status: metav1.ConditionTrue},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "RolloutComplete condition unknown is not ready",
+			controlPlaneComponent: &v1beta1.ControlPlaneComponent{
+				Status: v1beta1.ControlPlaneComponentStatus{
+					Conditions: []metav1.Condition{
+						{Type: string(v1beta1.ControlPlaneComponentAvailable), Status: metav1.ConditionTrue},
+						{Type: string(v1beta1.ControlPlaneComponentRolloutComplete), Status: metav1.ConditionUnknown},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, (&operationClusterUpdate{}).isControlPlaneClusterAutoscalerReady(tt.controlPlaneComponent))
+		})
+	}
+}
+
+func TestControlPlaneClusterAutoscalerNotReadyMessage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                  string
+		controlPlaneComponent *v1beta1.ControlPlaneComponent
+		wantExact             string
+		wantContains          []string
+	}{
+		{
+			name: "Available false with reason and message includes both",
+			controlPlaneComponent: &v1beta1.ControlPlaneComponent{
+				Status: v1beta1.ControlPlaneComponentStatus{
+					Conditions: []metav1.Condition{
+						{Type: string(v1beta1.ControlPlaneComponentAvailable), Status: metav1.ConditionFalse, Reason: "PodsNotReady", Message: "waiting for pods"},
+					},
+				},
+			},
+			wantContains: []string{clusterAutoscalerNotAvailableMsg, "PodsNotReady", "waiting for pods"},
+		},
+		{
+			name: "Available false without message returns base message only",
+			controlPlaneComponent: &v1beta1.ControlPlaneComponent{
+				Status: v1beta1.ControlPlaneComponentStatus{
+					Conditions: []metav1.Condition{
+						{Type: string(v1beta1.ControlPlaneComponentAvailable), Status: metav1.ConditionFalse, Reason: "PodsNotReady"},
+					},
+				},
+			},
+			wantExact: clusterAutoscalerNotAvailableMsg,
+		},
+		{
+			name: "Available condition missing returns base not available message",
+			controlPlaneComponent: &v1beta1.ControlPlaneComponent{
+				Status: v1beta1.ControlPlaneComponentStatus{
+					Conditions: []metav1.Condition{
+						{Type: string(v1beta1.ControlPlaneComponentRolloutComplete), Status: metav1.ConditionTrue},
+					},
+				},
+			},
+			wantExact: clusterAutoscalerNotAvailableMsg,
+		},
+		{
+			name: "Available true and Rollout false with reason and message includes both",
+			controlPlaneComponent: &v1beta1.ControlPlaneComponent{
+				Status: v1beta1.ControlPlaneComponentStatus{
+					Conditions: []metav1.Condition{
+						{Type: string(v1beta1.ControlPlaneComponentAvailable), Status: metav1.ConditionTrue},
+						{Type: string(v1beta1.ControlPlaneComponentRolloutComplete), Status: metav1.ConditionFalse, Reason: "RolloutInProgress", Message: "waiting for rollout"},
+					},
+				},
+			},
+			wantContains: []string{clusterAutoscalerRolloutNotCompleteMsg, "RolloutInProgress", "waiting for rollout"},
+		},
+		{
+			name: "Available true and Rollout false without message returns base message only",
+			controlPlaneComponent: &v1beta1.ControlPlaneComponent{
+				Status: v1beta1.ControlPlaneComponentStatus{
+					Conditions: []metav1.Condition{
+						{Type: string(v1beta1.ControlPlaneComponentAvailable), Status: metav1.ConditionTrue},
+						{Type: string(v1beta1.ControlPlaneComponentRolloutComplete), Status: metav1.ConditionFalse, Reason: "RolloutInProgress"},
+					},
+				},
+			},
+			wantExact: clusterAutoscalerRolloutNotCompleteMsg,
+		},
+		{
+			name: "Rollout condition missing returns base rollout not complete message",
+			controlPlaneComponent: &v1beta1.ControlPlaneComponent{
+				Status: v1beta1.ControlPlaneComponentStatus{
+					Conditions: []metav1.Condition{
+						{Type: string(v1beta1.ControlPlaneComponentAvailable), Status: metav1.ConditionTrue},
+					},
+				},
+			},
+			wantExact: clusterAutoscalerRolloutNotCompleteMsg,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			msg := (&operationClusterUpdate{}).controlPlaneClusterAutoscalerNotReadyMessage(tt.controlPlaneComponent)
+			if tt.wantExact != "" {
+				assert.Equal(t, tt.wantExact, msg)
+			}
+			for _, want := range tt.wantContains {
+				assert.Contains(t, msg, want)
+			}
+		})
+	}
+}
+
+func TestHypershiftControlPlaneClusterAutoscalerState(t *testing.T) {
+	t.Parallel()
+
+	ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+	fixture := newClusterTestFixture()
+
+	tests := []struct {
+		name                                          string
+		activeVersions                                []api.HCPClusterActiveVersion
+		cachedControlPlaneClusterAutoscalerReadDesire *kubeapplier.ReadDesire
+		wantState                                     arm.ProvisioningState
+		wantMessage                                   string
+	}{
+		{
+			name:           "skips autoscaler gate when lowest active version is below 4.20",
+			activeVersions: []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.19.0"))}},
+			wantState:      arm.ProvisioningStateSucceeded,
+			wantMessage:    `lowest active control plane version "4.19.0" does not support ControlPlaneComponent cluster-autoscaler (requires 4.20+)`,
+		},
+		{
+			name:        "waits when active versions are not yet reported",
+			wantState:   arm.ProvisioningStateUpdating,
+			wantMessage: "control plane active versions not yet reported",
+		},
+		{
+			name:           "waits when autoscaler ReadDesire is absent on 4.20+",
+			activeVersions: []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.20.0"))}},
+			wantState:      arm.ProvisioningStateUpdating,
+			wantMessage:    "cluster autoscaler state not cached yet",
+		},
+		{
+			name: "nightly pre-release control plane version satisfies the 4.20+ autoscaler gate",
+			activeVersions: []api.HCPClusterActiveVersion{{
+				Version: ptr.To(semver.MustParse("4.20.0-0.nightly-2026-01-01-000000")),
+			}},
+			cachedControlPlaneClusterAutoscalerReadDesire: newControlPlaneClusterAutoscalerReadDesire(t, readyControlPlaneClusterAutoscaler()),
+			wantState:   arm.ProvisioningStateSucceeded,
+			wantMessage: "",
+		},
+		{
+			name:           "succeeds when autoscaler ControlPlaneComponent is ready",
+			activeVersions: []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.20.0"))}},
+			cachedControlPlaneClusterAutoscalerReadDesire: newControlPlaneClusterAutoscalerReadDesire(t, readyControlPlaneClusterAutoscaler()),
+			wantState:   arm.ProvisioningStateSucceeded,
+			wantMessage: "",
+		},
+		{
+			name:           "updates when autoscaler ControlPlaneComponent is not ready",
+			activeVersions: []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.20.0"))}},
+			cachedControlPlaneClusterAutoscalerReadDesire: newControlPlaneClusterAutoscalerReadDesire(t, &v1beta1.ControlPlaneComponent{
+				Status: v1beta1.ControlPlaneComponentStatus{
+					Conditions: []metav1.Condition{
+						{Type: string(v1beta1.ControlPlaneComponentAvailable), Status: metav1.ConditionFalse, Reason: "PodsNotReady", Message: "waiting for pods"},
+					},
+				},
+			}),
+			wantState:   arm.ProvisioningStateUpdating,
+			wantMessage: "cluster autoscaler not available: PodsNotReady: waiting for pods",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cluster := fixture.newCluster(nil)
+
+			spcResourceID := api.Must(azcorearm.ParseResourceID(fmt.Sprintf("%s/%s/%s",
+				fixture.clusterResourceID.String(),
+				api.ServiceProviderClusterResourceTypeName,
+				api.ServiceProviderClusterResourceName,
+			)))
+			spc := &api.ServiceProviderCluster{
+				CosmosMetadata: api.CosmosMetadata{ResourceID: spcResourceID, PartitionKey: strings.ToLower(spcResourceID.SubscriptionID)},
+				Status: api.ServiceProviderClusterStatus{
+					ControlPlaneVersion: api.ServiceProviderClusterStatusVersion{
+						ActiveVersions: tt.activeVersions,
+					},
+				},
+			}
+
+			var readDesires []*kubeapplier.ReadDesire
+			if tt.cachedControlPlaneClusterAutoscalerReadDesire != nil {
+				readDesires = append(readDesires, tt.cachedControlPlaneClusterAutoscalerReadDesire)
+			}
+
+			controller := &operationClusterUpdate{
+				readDesireLister: &internallistertesting.SliceReadDesireLister{Desires: readDesires},
+			}
+
+			got, err := controller.hypershiftControlPlaneClusterAutoscalerState(ctx, cluster, spc)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantState, got.ProvisioningState)
+			assert.Equal(t, tt.wantMessage, got.Message)
 		})
 	}
 }

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_update_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_update_test.go
@@ -43,7 +43,6 @@ import (
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/api/kubeapplier"
 	"github.com/Azure/ARO-HCP/internal/database"
-	dblisters "github.com/Azure/ARO-HCP/internal/database/listers"
 	internallistertesting "github.com/Azure/ARO-HCP/internal/database/listertesting"
 	"github.com/Azure/ARO-HCP/internal/databasetesting"
 	"github.com/Azure/ARO-HCP/internal/ocm"
@@ -104,6 +103,7 @@ func TestOperationClusterUpdate_SynchronizeOperation(t *testing.T) {
 		)))
 		parsedVersion, err := semver.ParseTolerant(version)
 		require.NoError(t, err)
+		activeVersions := []api.HCPClusterActiveVersion{{Version: ptr.To(parsedVersion)}}
 		return &api.ServiceProviderCluster{
 			CosmosMetadata: api.CosmosMetadata{ResourceID: resourceID, PartitionKey: strings.ToLower(resourceID.SubscriptionID)},
 			Spec: api.ServiceProviderClusterSpec{
@@ -111,7 +111,11 @@ func TestOperationClusterUpdate_SynchronizeOperation(t *testing.T) {
 					DesiredVersion: ptr.To(parsedVersion),
 				},
 			},
-			Status: api.ServiceProviderClusterStatus{},
+			Status: api.ServiceProviderClusterStatus{
+				ControlPlaneVersion: api.ServiceProviderClusterStatusVersion{
+					ActiveVersions: activeVersions,
+				},
+			},
 		}
 	}
 	newDefaultControlPlaneDesiredVersionController := func() *api.Controller {
@@ -148,18 +152,20 @@ func TestOperationClusterUpdate_SynchronizeOperation(t *testing.T) {
 		serviceProviderClusterLister                 listers.ServiceProviderClusterLister
 		existingControlPlaneDesiredVersionController *api.Controller
 		// When set, wires a ReadDesireLister containing this cached HostedCluster mirror.
-		cachedHostedClusterReadDesire *kubeapplier.ReadDesire
-		seedMismatchFirstSeenAt       time.Time
-		setupMockCSClient             func(*ocm.MockClusterServiceClientSpec)
-		wantErr                       bool
-		verifyDB                      func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient)
+		cachedHostedClusterReadDesire                 *kubeapplier.ReadDesire
+		cachedControlPlaneClusterAutoscalerReadDesire *kubeapplier.ReadDesire
+		seedMismatchFirstSeenAt                       time.Time
+		setupMockCSClient                             func(*ocm.MockClusterServiceClientSpec)
+		wantErr                                       bool
+		verifyDB                                      func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient)
 	}{
 		{
 			name:                           "cs cluster ready transitions operation to succeeded",
 			existingCluster:                newClusterWithCustomerVersion("4.19"),
 			existingOperation:              newOperationAccepted(),
 			existingServiceProviderCluster: newServiceProviderClusterWithSpecControlPlaneVersion("4.19"),
-			cachedHostedClusterReadDesire:  newPassingCachedHostedClusterReadDesire(),
+
+			cachedHostedClusterReadDesire: newPassingCachedHostedClusterReadDesire(),
 			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
 				mock.EXPECT().
 					GetCluster(gomock.Any(), fixture.clusterInternalID).
@@ -549,6 +555,52 @@ func TestOperationClusterUpdate_SynchronizeOperation(t *testing.T) {
 				assert.Equal(t, testOperationName, cluster.ServiceProviderProperties.ActiveOperationID)
 			},
 		},
+		{
+			name:                           "autoscaler all checks pass but autoscaler ReadDesire not cached yet keeps operation updating",
+			existingCluster:                newClusterWithCustomerVersion("4.20"),
+			existingOperation:              newOperationAccepted(),
+			existingServiceProviderCluster: newServiceProviderClusterWithSpecControlPlaneVersion("4.20"),
+			cachedHostedClusterReadDesire:  newPassingCachedHostedClusterReadDesire(),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetCluster(gomock.Any(), fixture.clusterInternalID).
+					Return(newCSClusterWithState(arohcpv1alpha1.ClusterStateReady), nil)
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateUpdating, op.Status)
+				assert.Nil(t, op.Error)
+
+				cluster, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateUpdating, cluster.ServiceProviderProperties.ProvisioningState)
+				assert.Equal(t, testOperationName, cluster.ServiceProviderProperties.ActiveOperationID)
+			},
+		},
+		{
+			name:                           "autoscaler all checks pass, operation transitions to succeeded",
+			existingCluster:                newClusterWithCustomerVersion("4.20"),
+			existingOperation:              newOperationAccepted(),
+			existingServiceProviderCluster: newServiceProviderClusterWithSpecControlPlaneVersion("4.20"),
+			cachedHostedClusterReadDesire:  newPassingCachedHostedClusterReadDesire(),
+			cachedControlPlaneClusterAutoscalerReadDesire: newControlPlaneClusterAutoscalerReadDesire(t, readyControlPlaneClusterAutoscaler()),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetCluster(gomock.Any(), fixture.clusterInternalID).
+					Return(newCSClusterWithState(arohcpv1alpha1.ClusterStateReady), nil)
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateSucceeded, op.Status)
+
+				cluster, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateSucceeded, cluster.ServiceProviderProperties.ProvisioningState)
+				assert.Empty(t, cluster.ServiceProviderProperties.ActiveOperationID)
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -573,11 +625,12 @@ func TestOperationClusterUpdate_SynchronizeOperation(t *testing.T) {
 			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, resources)
 			require.NoError(t, err)
 
-			var readDesireLister dblisters.ReadDesireLister
+			var readDesires []*kubeapplier.ReadDesire
 			if tc.cachedHostedClusterReadDesire != nil {
-				readDesireLister = &internallistertesting.SliceReadDesireLister{
-					Desires: []*kubeapplier.ReadDesire{tc.cachedHostedClusterReadDesire},
-				}
+				readDesires = append(readDesires, tc.cachedHostedClusterReadDesire)
+			}
+			if tc.cachedControlPlaneClusterAutoscalerReadDesire != nil {
+				readDesires = append(readDesires, tc.cachedControlPlaneClusterAutoscalerReadDesire)
 			}
 
 			clusterLister := tc.clusterLister
@@ -599,13 +652,14 @@ func TestOperationClusterUpdate_SynchronizeOperation(t *testing.T) {
 			}
 
 			fakeClock := clocktesting.NewFakeClock(testClockNow)
+
 			controller := &operationClusterUpdate{
 				resourcesDBClient:               mockResourcesDBClient,
 				clusterServiceClient:            mockCSClient,
 				clusterLister:                   clusterLister,
 				activeOperationsLister:          activeOperationsLister,
 				serviceProviderClusterLister:    serviceProviderClusterLister,
-				readDesireLister:                readDesireLister,
+				readDesireLister:                &internallistertesting.SliceReadDesireLister{Desires: readDesires},
 				notificationClient:              nil,
 				clock:                           fakeClock,
 				desiredVersionMismatchFirstSeen: lru.New(100000),

--- a/backend/pkg/maestrohelpers/controlplanecomponents.go
+++ b/backend/pkg/maestrohelpers/controlplanecomponents.go
@@ -1,0 +1,58 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package maestrohelpers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/json"
+
+	"github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/database"
+	dblisters "github.com/Azure/ARO-HCP/internal/database/listers"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// ReadDesireNameReadonlyHypershiftControlPlaneComponentClusterAutoscaler is the well-known ReadDesire name the
+// backend writes the per-cluster cluster-autoscaler ControlPlaneComponent mirror under.
+var ReadDesireNameReadonlyHypershiftControlPlaneComponentClusterAutoscaler = strings.ToLower(string(api.ReadonlyHypershiftControlPlaneComponentClusterAutoscaler))
+
+// GetCachedControlPlaneClusterAutoscalerForCluster reads the cluster-autoscaler
+// ControlPlaneComponent mirror from the per-cluster ReadDesire.
+func GetCachedControlPlaneClusterAutoscalerForCluster(
+	ctx context.Context,
+	readDesireLister dblisters.ReadDesireLister,
+	subscriptionName, resourceGroupName, clusterName string,
+) (*v1beta1.ControlPlaneComponent, error) {
+	readDesire, err := readDesireLister.GetForCluster(ctx, subscriptionName, resourceGroupName, clusterName, ReadDesireNameReadonlyHypershiftControlPlaneComponentClusterAutoscaler)
+	if database.IsNotFoundError(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, utils.TrackError(fmt.Errorf("failed to get ReadDesire for cluster-autoscaler ControlPlaneComponent: %w", err))
+	}
+	if readDesire.Status.KubeContent == nil || len(readDesire.Status.KubeContent.Raw) == 0 {
+		return nil, nil
+	}
+	controlPlaneComponent := &v1beta1.ControlPlaneComponent{}
+	if err := json.Unmarshal(readDesire.Status.KubeContent.Raw, controlPlaneComponent); err != nil {
+		return nil, utils.TrackError(fmt.Errorf("failed to unmarshal ControlPlaneComponent from ReadDesire kubeContent: %w", err))
+	}
+	return controlPlaneComponent, nil
+}

--- a/internal/api/types_serviceprovider_cluster.go
+++ b/internal/api/types_serviceprovider_cluster.go
@@ -300,4 +300,8 @@ const (
 	// MaestroBundleInternalNameReadonlyHypershiftHostedCluster is the internal name of the Maestro Bundle that represents
 	// the Cluster's Hypershift's HostedCluster K8s resource.
 	MaestroBundleInternalNameReadonlyHypershiftHostedCluster MaestroBundleInternalName = "readonlyHypershiftHostedCluster"
+
+	// ReadonlyHypershiftControlPlaneComponentClusterAutoscaler is the internal name of the ReadDesire that mirrors
+	// the cluster-autoscaler ControlPlaneComponent on the management cluster control plane namespace.
+	ReadonlyHypershiftControlPlaneComponentClusterAutoscaler MaestroBundleInternalName = "readonlyHypershiftControlPlaneComponentClusterAutoscaler"
 )


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

-  Adds a ReadDesire for the cluster-autoscaler ControlPlaneComponent (in addition to the existing HostedCluster ReadDesire).
- Read the autoscaler ControlPlaneComponent from ReadDesire cache and checks Available + RolloutComplete readiness.
- operationClusterUpdate waits for autoscaler readiness 

<!-- Briefly explain why this change is needed -->

### Testing
Created cluster using frontend service. Then update cluster autoscaler properties using request payload as - 
```
payload - {
  "properties": {
    "autoscaling": {
      "maxNodesTotal": 200,
      "maxPodGracePeriodSeconds": 1200,
      "podPriorityThreshold": -10
    }
  }
}
```

> curl -s -X PATCH \
>  "http://localhost:8443/${CLUSTER_RESOURCE_ID}?api-version=${API_VERSION}" \
>  -H "Content-Type: application/json" \
>  -H "X-Ms-Arm-Resource-System-Data: {\"createdBy\":\"aro-hcp-local-testing\",\"createdByType\":\"User\",\"createdAt\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"lastModifiedBy\":\"aro-hcp-local-testing\",\"lastModifiedByType\":\"User\",\"lastModifiedAt\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" \
>  -d @ auto_scalar.json | jq .

After Successful update - 

<img width="1498" height="476" alt="image" src="https://github.com/user-attachments/assets/a568b5e9-6f0c-4c11-88fa-7392de1f94d0" />

Read desire created with "controlplanecomponents" as resource for a cluster.
<img width="1498" height="872" alt="image (1)" src="https://github.com/user-attachments/assets/452e7759-3716-486f-bddc-442d7061885c" />

- Unit tests

### Special notes for your reviewer


E2E tests are included as part of https://redhat.atlassian.net/browse/ARO-27730 

