### PR TITLE
test: Refactor E2E tests to update autoscaling via PATCH cluster API.

### DIFF
--- a/test/e2e/cluster_autoscaling.go
+++ b/test/e2e/cluster_autoscaling.go
@@ -25,6 +25,7 @@ import (
 	hcpsdk20240610preview "github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
 	"github.com/Azure/ARO-HCP/test/util/framework"
 	"github.com/Azure/ARO-HCP/test/util/labels"
+	"github.com/Azure/ARO-HCP/test/util/verifiers"
 )
 
 var _ = Describe("Customer", func() {
@@ -32,7 +33,7 @@ var _ = Describe("Customer", func() {
 		// do nothing.  per test initialization usually ages better than shared.
 	})
 
-	It("should be able to create an HCP cluster with custom autoscaling",
+	It("should be able to create an HCP cluster with custom autoscaling and update the autoscaling configuration",
 		labels.RequireNothing,
 		labels.Medium,
 		labels.Positive,
@@ -51,6 +52,12 @@ var _ = Describe("Customer", func() {
 				autoscalingMaxNodesTotal               int32 = 3    // default is to omit
 				autoscalingMaxNodeProvisionTimeSeconds int32 = 1000 // default is 900
 				autoscalingPodPriorityThreshold        int32 = -11  // default is -10
+
+				// Updated values applied via PATCH after initial provisioning.
+				updatedMaxNodesTotal               int32 = 498
+				updatedMaxPodGracePeriodSeconds    int32 = 650
+				updatedMaxNodeProvisionTimeSeconds int32 = 950
+				updatedPodPriorityThreshold        int32 = -12
 			)
 			tc := framework.NewTestContext()
 
@@ -71,6 +78,7 @@ var _ = Describe("Customer", func() {
 				MaxNodeProvisionTimeSeconds: to.Ptr(autoscalingMaxNodeProvisionTimeSeconds),
 				MaxPodGracePeriodSeconds:    to.Ptr(autoscalingMaxPodGracePeriodSeconds),
 				PodPriorityThreshold:        to.Ptr(autoscalingPodPriorityThreshold),
+				MaxNodesTotal:               to.Ptr(autoscalingMaxNodesTotal),
 			}
 
 			By("creating customer resources")
@@ -87,7 +95,9 @@ var _ = Describe("Customer", func() {
 			)
 			Expect(err).NotTo(HaveOccurred(), "failed to create customer resources for autoscaling cluster")
 
-			By("creating the cluster")
+			hcpClient := tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient()
+
+			By("creating the cluster with custom autoscaling configuration")
 			err = tc.CreateHCPClusterFromParam20240610(ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
@@ -96,18 +106,20 @@ var _ = Describe("Customer", func() {
 			)
 			Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster %q with custom autoscaling", customerClusterName)
 
-			By("ensuring the custom autoscaling was honored")
+			By("ensuring the custom autoscaling configuration was honored at create time")
 			got, err := framework.GetHCPCluster20240610(
 				ctx,
-				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
+				hcpClient,
 				*resourceGroup.Name,
 				customerClusterName,
 			)
 			Expect(err).NotTo(HaveOccurred(), "failed to get cluster %q to verify autoscaling settings", customerClusterName)
+			Expect(got.Properties).NotTo(BeNil(), "cluster response Properties was nil")
 			Expect(got.Properties.Autoscaling).ToNot(BeNil(), "cluster Properties.Autoscaling was nil")
 			Expect(got.Properties.Autoscaling.MaxNodeProvisionTimeSeconds).To(Equal(to.Ptr(autoscalingMaxNodeProvisionTimeSeconds)), "cluster autoscaling MaxNodeProvisionTimeSeconds should be %d", autoscalingMaxNodeProvisionTimeSeconds)
 			Expect(got.Properties.Autoscaling.MaxPodGracePeriodSeconds).To(Equal(to.Ptr(autoscalingMaxPodGracePeriodSeconds)), "cluster autoscaling MaxPodGracePeriodSeconds should be %d", autoscalingMaxPodGracePeriodSeconds)
 			Expect(got.Properties.Autoscaling.PodPriorityThreshold).To(Equal(to.Ptr(autoscalingPodPriorityThreshold)), "cluster autoscaling PodPriorityThreshold should be %d", autoscalingPodPriorityThreshold)
+			Expect(got.Properties.Autoscaling.MaxNodesTotal).To(Equal(to.Ptr(autoscalingMaxNodesTotal)), "cluster autoscaling MaxNodesTotal should be %d", autoscalingMaxNodesTotal)
 
 			By("creating the node pool")
 			nodePoolParams := framework.NewDefaultNodePoolParams20240610()
@@ -125,22 +137,69 @@ var _ = Describe("Customer", func() {
 			)
 			Expect(err).NotTo(HaveOccurred(), "failed to create nodepool %q for autoscaling cluster", customerNodePoolName)
 
-			By("patching the cluster to set maxNodesTotal")
-			_, err = framework.UpdateHCPCluster20240610(
+			By("getting admin credentials for the cluster")
+			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
 				ctx,
-				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
+				hcpClient,
+				*resourceGroup.Name,
+				customerClusterName,
+				framework.GetAdminRESTConfigTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to get admin REST config for cluster %q", customerClusterName)
+
+			By("ensuring the cluster is viable")
+			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig)
+			Expect(err).NotTo(HaveOccurred(), "failed to verify HCP cluster health before autoscaling update")
+
+			By("updating the cluster autoscaling configuration via PATCH")
+			updateResp, err := framework.UpdateHCPCluster20240610(
+				ctx,
+				hcpClient,
 				*resourceGroup.Name,
 				customerClusterName,
 				hcpsdk20240610preview.HcpOpenShiftClusterUpdate{
 					Properties: &hcpsdk20240610preview.HcpOpenShiftClusterPropertiesUpdate{
 						Autoscaling: &hcpsdk20240610preview.ClusterAutoscalingProfile{
-							MaxNodesTotal: to.Ptr(autoscalingMaxNodesTotal),
+							MaxNodesTotal:               to.Ptr(updatedMaxNodesTotal),
+							MaxNodeProvisionTimeSeconds: to.Ptr(updatedMaxNodeProvisionTimeSeconds),
+							MaxPodGracePeriodSeconds:    to.Ptr(updatedMaxPodGracePeriodSeconds),
+							PodPriorityThreshold:        to.Ptr(updatedPodPriorityThreshold),
 						},
 					},
 				},
 				framework.UpdateHCPClusterTimeout,
 			)
-			Expect(err).NotTo(HaveOccurred(), "failed to patch cluster %q to set maxNodesTotal", customerClusterName)
+			Expect(err).NotTo(HaveOccurred(), "failed to update cluster %q autoscaling configuration", customerClusterName)
+
+			By("verifying the autoscaling update operation completed successfully")
+			Expect(updateResp).NotTo(BeNil(), "autoscaling update response was nil")
+			Expect(updateResp.Properties).NotTo(BeNil(), "autoscaling update response Properties was nil")
+			Expect(updateResp.Properties.ProvisioningState).NotTo(BeNil(), "autoscaling update response ProvisioningState was nil")
+			Expect(*updateResp.Properties.ProvisioningState).To(Equal(hcpsdk20240610preview.ProvisioningStateSucceeded), "cluster provisioning state should be Succeeded after autoscaling update")
+			Expect(updateResp.Properties.Autoscaling).NotTo(BeNil(), "autoscaling update response Properties.Autoscaling was nil")
+			Expect(updateResp.Properties.Autoscaling.MaxNodesTotal).To(Equal(to.Ptr(updatedMaxNodesTotal)), "update response MaxNodesTotal should be %d", updatedMaxNodesTotal)
+			Expect(updateResp.Properties.Autoscaling.MaxNodeProvisionTimeSeconds).To(Equal(to.Ptr(updatedMaxNodeProvisionTimeSeconds)), "update response MaxNodeProvisionTimeSeconds should be %d", updatedMaxNodeProvisionTimeSeconds)
+			Expect(updateResp.Properties.Autoscaling.MaxPodGracePeriodSeconds).To(Equal(to.Ptr(updatedMaxPodGracePeriodSeconds)), "update response MaxPodGracePeriodSeconds should be %d", updatedMaxPodGracePeriodSeconds)
+			Expect(updateResp.Properties.Autoscaling.PodPriorityThreshold).To(Equal(to.Ptr(updatedPodPriorityThreshold)), "update response PodPriorityThreshold should be %d", updatedPodPriorityThreshold)
+
+			By("verifying the updated autoscaling configuration via GET")
+			clusterAfterAutoscalingUpdate, err := framework.GetHCPCluster20240610(
+				ctx,
+				hcpClient,
+				*resourceGroup.Name,
+				customerClusterName,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to get cluster %q after autoscaling update", customerClusterName)
+			Expect(clusterAfterAutoscalingUpdate.Properties).NotTo(BeNil(), "cluster response Properties was nil after autoscaling update")
+			Expect(clusterAfterAutoscalingUpdate.Properties.Autoscaling).NotTo(BeNil(), "cluster Properties.Autoscaling was nil after autoscaling update")
+			Expect(clusterAfterAutoscalingUpdate.Properties.Autoscaling.MaxNodesTotal).To(Equal(to.Ptr(updatedMaxNodesTotal)), "GET response MaxNodesTotal should be %d after update", updatedMaxNodesTotal)
+			Expect(clusterAfterAutoscalingUpdate.Properties.Autoscaling.MaxNodeProvisionTimeSeconds).To(Equal(to.Ptr(updatedMaxNodeProvisionTimeSeconds)), "GET response MaxNodeProvisionTimeSeconds should be %d after update", updatedMaxNodeProvisionTimeSeconds)
+			Expect(clusterAfterAutoscalingUpdate.Properties.Autoscaling.MaxPodGracePeriodSeconds).To(Equal(to.Ptr(updatedMaxPodGracePeriodSeconds)), "GET response MaxPodGracePeriodSeconds should be %d after update", updatedMaxPodGracePeriodSeconds)
+			Expect(clusterAfterAutoscalingUpdate.Properties.Autoscaling.PodPriorityThreshold).To(Equal(to.Ptr(updatedPodPriorityThreshold)), "GET response PodPriorityThreshold should be %d after update", updatedPodPriorityThreshold)
+
+			By("verifying cluster workloads and pods remain operational after autoscaling update")
+			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig, verifiers.VerifySimpleWebApp())
+			Expect(err).NotTo(HaveOccurred(), "failed to verify cluster workloads and pods after autoscaling update")
 
 		})
 

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_dev_cd_check_paralleldev_cd_check_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_dev_cd_check_paralleldev_cd_check_parallel.txt
@@ -5,7 +5,7 @@ SRE should be able to retrieve serial console logs for a VM
 Customer should be able to test admin credentials before cluster ready, then full admin credential lifecycle
 Customer should be able to create node pools with ARM64-based VMs
 Authorized CIDRs Connectivity should allow API access only from authorized VM IP
-Customer should be able to create an HCP cluster with custom autoscaling
+Customer should be able to create an HCP cluster with custom autoscaling and update the autoscaling configuration
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
 Customer should be able to create an HCP cluster and custom node pool osDisk size

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
@@ -4,7 +4,7 @@ Customer should be able to list available HCP OpenShift versions and validate re
 Customer should be able to test admin credentials before cluster ready, then full admin credential lifecycle
 Customer should be able to create node pools with ARM64-based VMs
 Authorized CIDRs Connectivity should allow API access only from authorized VM IP
-Customer should be able to create an HCP cluster with custom autoscaling
+Customer should be able to create an HCP cluster with custom autoscaling and update the autoscaling configuration
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
 Customer should be able to create an HCP cluster and custom node pool osDisk size

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
@@ -4,7 +4,7 @@ Customer should be able to list available HCP OpenShift versions and validate re
 Customer should be able to test admin credentials before cluster ready, then full admin credential lifecycle
 Customer should be able to create node pools with ARM64-based VMs
 Authorized CIDRs Connectivity should allow API access only from authorized VM IP
-Customer should be able to create an HCP cluster with custom autoscaling
+Customer should be able to create an HCP cluster with custom autoscaling and update the autoscaling configuration
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
 Customer should be able to create an HCP cluster and custom node pool osDisk size

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
@@ -7,7 +7,7 @@ SRE should return 409 when boot diagnostics is disabled on a VM
 Customer should be able to test admin credentials before cluster ready, then full admin credential lifecycle
 Customer should be able to create node pools with ARM64-based VMs
 Authorized CIDRs Connectivity should allow API access only from authorized VM IP
-Customer should be able to create an HCP cluster with custom autoscaling
+Customer should be able to create an HCP cluster with custom autoscaling and update the autoscaling configuration
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
 Customer should be able to create an HCP cluster and custom node pool osDisk size

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
@@ -4,7 +4,7 @@ Customer should be able to list available HCP OpenShift versions and validate re
 Customer should be able to test admin credentials before cluster ready, then full admin credential lifecycle
 Customer should be able to create node pools with ARM64-based VMs
 Authorized CIDRs Connectivity should allow API access only from authorized VM IP
-Customer should be able to create an HCP cluster with custom autoscaling
+Customer should be able to create an HCP cluster with custom autoscaling and update the autoscaling configuration
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
 Customer should be able to create an HCP cluster and custom node pool osDisk size

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
@@ -4,7 +4,7 @@ Customer should be able to list available HCP OpenShift versions and validate re
 Customer should be able to test admin credentials before cluster ready, then full admin credential lifecycle
 Customer should be able to create node pools with ARM64-based VMs
 Authorized CIDRs Connectivity should allow API access only from authorized VM IP
-Customer should be able to create an HCP cluster with custom autoscaling
+Customer should be able to create an HCP cluster with custom autoscaling and update the autoscaling configuration
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
 Customer should be able to create an HCP cluster and custom node pool osDisk size


### PR DESCRIPTION


[Add E2E tests in ARO HCP repository for async global autoscaling](https://redhat.atlassian.net/browse/ARO-27730)

### What

<!-- Briefly describe what this PR does -->
Expanded test/e2e/cluster_autoscaling.go from “create with custom autoscaling” into a full create → PATCH → verify flow:

- Create cluster with non-default autoscaling (including MaxNodesTotal)
- Create node pool + verify cluster healthy
- PATCH all autoscaling fields (MaxNodesTotal, MaxNodeProvisionTimeSeconds, MaxPodGracePeriodSeconds, PodPriorityThreshold) via UpdateHCPCluster20240610
- Assert update response + GET show new values (Succeeded)


### Why

<!-- Briefly explain why this change is needed -->

Autoscaling is now updated through the cluster PATCH path (nested autoscaler, not a separate autoscaler API). The old e2e only checked create + a partial MaxNodesTotal patch. This change covers the real customer path: update multiple autoscaling fields after provision and prove the cluster stays operational — matching the new RP/controller design.

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [x] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
