### PR TITLE
test(e2e): remove hardcoded ports in Cilium tests

### DIFF
--- a/test/e2e/cluster_create_cni_cilium.go
+++ b/test/e2e/cluster_create_cni_cilium.go
@@ -27,6 +27,10 @@ import (
 )
 
 var _ = Describe("Customer", func() {
+	// This test currently works around an upstream bug in Cilium: https://github.com/cilium/cilium/issues/45792
+	// The hard-coded NodePort collides with dynamically-allocated ports on the kube-apiserver's NodePort range (30000-32767), most commonly with the OpenShift ingress operator's router-default healthCheckNodePort. Around 1/2768 cluster installs are impacted. When port collision occurs, the test fails with "provided port is already allocated". This fix eliminates the collision; the affected probes now test connectivity via ClusterIP rather than NodePort.
+	// Note that the upstream bug in Cilium still exists. If we update the probe manifests in the future (currently located at test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2), this patch will have to be applied again until the bug in Cilium is remediated.
+	// See this PR for an example of how to modify the probe manifests: https://github.com/Azure/ARO-HCP/pull/5934
 	It("should be able to create a HCP cluster and use cilium CNI plugin",
 		labels.RequireNothing,
 		labels.Critical,

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0011.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0011.yaml
@@ -35,7 +35,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - echo-b-host-headless:31414/public
+            - echo-b:8080/public
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -47,7 +47,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - echo-b-host-headless:31414/public
+            - echo-b:8080/public
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0012.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0012.yaml
@@ -35,7 +35,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - echo-b-host-headless:31414/public
+            - echo-b:8080/public
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -47,7 +47,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - echo-b-host-headless:31414/public
+            - echo-b:8080/public
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0014.yaml
+++ b/test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2/connectivity-check-internal.0014.yaml
@@ -11,7 +11,6 @@ spec:
   ports:
   - name: http
     port: 8080
-    nodePort: 31414
   type: NodePort
   selector:
     name: echo-b


### PR DESCRIPTION
Jira: https://redhat.atlassian.net/browse/AROSLSRE-1240

### What

Remove hard-coded `nodePort: 31414` from the Cilium connectivity-check `echo-b` Service and update probe manifests (`0011.yaml`, `0012.yaml`) to use ClusterIP (`echo-b:8080`) instead of NodePort (`echo-b-host-headless:31414`).

### Why

The hard-coded NodePort collides with dynamically-allocated ports on the kube-apiserver's NodePort range (30000-32767), most commonly with the OpenShift ingress operator's router-default healthCheckNodePort. Around 1/2768 cluster installs are impacted. When port collision occurs, the test fails with "provided port is already allocated". This fix eliminates the collision; the affected probes now test connectivity via ClusterIP rather than NodePort.

Note that the upstream bug in Cilium still exists. If we update the probe manifests in the future (currently located at `test/util/verifiers/artifacts/cilium-connectivity-check-1.19.2`), this patch will have to be applied again until the bug in Cilium is remediated.

Github Issue on Cilium repo: https://github.com/cilium/cilium/issues/45792

### Testing

e2e test validation here: https://github.com/Azure/ARO-HCP/pull/5939

This PR filtered the e2e suite to this single test:
<img width="916" height="60" alt="image" src="https://github.com/user-attachments/assets/c2c8ee05-239a-4d11-963f-b706c6ec9995" />

Test passed: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/Azure_ARO-HCP/5939/pull-ci-Azure-ARO-HCP-main-e2e-parallel/2077477561151000576
<img width="1372" height="524" alt="image" src="https://github.com/user-attachments/assets/387891f6-9d80-4eac-a79f-9a9773f4317c" />

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [x] All comment threads resolved before merge
