### PR TITLE
chore(config): bump opstool AKS to 1.33 toward fleet parity (AROSLSRE-1414)

### DIFF
--- a/config/config-dev-ci.yaml
+++ b/config/config-dev-ci.yaml
@@ -38,7 +38,7 @@ clouds:
           vnetAddressPrefix: "10.0.0.0/16"
           subnetPrefix: "10.0.1.0/24"
           podSubnetPrefix: "10.0.2.0/24"
-          kubernetesVersion: 1.32.5
+          kubernetesVersion: "1.33"
           networkDataplane: "cilium"
           networkPolicy: "cilium"
           clusterOutboundIPAddressIPTags: ""


### PR DESCRIPTION
[AROSLSRE-1414](https://redhat.atlassian.net/browse/AROSLSRE-1414) (parent [AROSLSRE-863](https://redhat.atlassian.net/browse/AROSLSRE-863))

### What

Bump the `opstool` AKS `kubernetesVersion` in `config/config-dev-ci.yaml` from `1.32.5` to `"1.33"` — the first step toward fleet parity (`1.35`).

### Why

`opstool-usw3` was pinned at `1.32.5` (running `1.32.11`) while the rest of the fleet runs `1.35`, and its `NodeImage` auto-upgrade had stalled ~3 months, leaving it on kernel `6.6.126.1-1.azl3` — below the AzureLinux 3.0 fix (`6.6.139.1-1.azl3`) for **CVE-2026-31431 (Copy Fail / `algif_aead`)**. Ref: [Azure/AKS#5753](https://github.com/Azure/AKS/issues/5753).

Node image version is not a repo/Bicep knob (it is the AKS auto `NodeImage` channel), so the sanctioned repo lever is `kubernetesVersion`: bumping it drives the `opstool-aks-pipeline` (`dev-infrastructure/scripts/upgrade-aks-cluster.sh` → `az aks upgrade`) to upgrade the control plane and **reimage node pools onto a current, fixed-kernel node image**.

AKS upgrades one minor at a time, so this is the **first of a sequence** (`1.32` → `1.33` → `1.34` → `1.35`); follow-up PRs will advance the remaining minors as each completes.

### Testing

No code paths change; this is a config version bump validated by the existing config schema (`config/config-dev-ci.schema.json` types `kubernetesVersion` as a string).

Post-deploy validation on `opstool-usw3`:

- `az aks show ... --query currentKubernetesVersion` → `1.33.x`
- `az aks command invoke ... --command "uname -r"` → `>= 6.6.139.1-1.azl3`

Note: an out-of-band `az aks upgrade --node-image-only` was already applied as a stopgap (tracked in [AROSLSRE-1413](https://redhat.atlassian.net/browse/AROSLSRE-1413)); `opstool-usw3` is currently on `6.6.139.1-1.azl3`. This PR codifies the currency in the repo.

### Special notes for your reviewer

Scope is intentionally limited to `opstool` (dev-ci). The product svc/mgmt clusters are already on `1.35` with current node images and are not affected by this change.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
