### PR TITLE
feat: add API version into validation options

### DIFF
--- a/frontend/pkg/frontend/cluster.go
+++ b/frontend/pkg/frontend/cluster.go
@@ -341,7 +341,7 @@ func (f *Frontend) createHCPCluster(writer http.ResponseWriter, request *http.Re
 
 	validationOp := operation.Operation{
 		Type:    operation.Create,
-		Options: validation.AFECsToValidationOptions(subscription.GetRegisteredFeatures()),
+		Options: validation.BuildValidationOptions(subscription.GetRegisteredFeatures(), api.APIVersion(versionedInterface.String())),
 	}
 	admissionContext, err := f.newClusterAdmissionContext(ctx, validationOp, subscription, newInternalCluster, nil)
 	if err != nil {
@@ -629,7 +629,7 @@ func (f *Frontend) updateHCPClusterInCosmos(ctx context.Context, writer http.Res
 
 	validationOp := operation.Operation{
 		Type:    operation.Update,
-		Options: validation.AFECsToValidationOptions(subscription.GetRegisteredFeatures()),
+		Options: validation.BuildValidationOptions(subscription.GetRegisteredFeatures(), api.APIVersion(versionedInterface.String())),
 	}
 	admissionContext, err := f.newClusterAdmissionContext(ctx, validationOp, subscription, newInternalCluster, oldInternalCluster.ID)
 	if err != nil {

--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -767,7 +767,7 @@ func (f *Frontend) ArmDeploymentPreflight(writer http.ResponseWriter, request *h
 
 			op := operation.Operation{
 				Type:    operation.Create,
-				Options: validation.AFECsToValidationOptions(subscription.GetRegisteredFeatures()),
+				Options: validation.BuildValidationOptions(subscription.GetRegisteredFeatures(), api.APIVersion(versionedInterface.String())),
 			}
 			validationErrs := validation.ValidateNodePool(ctx, op, newInternalNodePool, nil)
 			preflightErr = arm.CloudErrorFromFieldErrors(validationErrs)

--- a/frontend/pkg/frontend/node_pool.go
+++ b/frontend/pkg/frontend/node_pool.go
@@ -286,7 +286,7 @@ func (f *Frontend) createNodePool(writer http.ResponseWriter, request *http.Requ
 
 	restOperation := operation.Operation{
 		Type:    operation.Create,
-		Options: validation.AFECsToValidationOptions(subscription.GetRegisteredFeatures()),
+		Options: validation.BuildValidationOptions(subscription.GetRegisteredFeatures(), api.APIVersion(versionedInterface.String())),
 	}
 	admissionContext, err := f.newNodePoolAdmissionContext(ctx, restOperation, cluster, nil, nil)
 	if err != nil {
@@ -575,7 +575,7 @@ func (f *Frontend) updateNodePoolInCosmos(ctx context.Context, writer http.Respo
 
 	restOperation := operation.Operation{
 		Type:    operation.Update,
-		Options: validation.AFECsToValidationOptions(subscription.GetRegisteredFeatures()),
+		Options: validation.BuildValidationOptions(subscription.GetRegisteredFeatures(), api.APIVersion(versionedInterface.String())),
 	}
 	admissionContext, err := f.newNodePoolAdmissionContext(ctx, restOperation, cluster, spCluster, spNodePool)
 	if err != nil {

--- a/internal/api/apiversions.go
+++ b/internal/api/apiversions.go
@@ -1,0 +1,117 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"strings"
+)
+
+// APIVersion represents an Azure ARM API version following the uniform versioning
+// guidelines (https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/uniform-versioning.md).
+//
+// Format: YYYY-MM-DD[-preview]
+//
+// Ordering: versions are ordered chronologically by date. The uniform versioning
+// spec requires that each new API version uses a date later than all preceding
+// versions, and that stable and preview versions cannot share the same date
+// (promoting preview to stable requires incrementing the date by at least one day).
+//
+// The comparison functions (LT, LE, GT, GE) implement semantic ordering that
+// additionally handles the hypothetical case of a same-date stable and preview
+// version by ranking stable after preview. This guards against a violation of the
+// uniform versioning guidelines where the date is not incremented when moving from
+// preview to stable — naive lexicographic comparison would incorrectly place the
+// stable version before the preview version in that scenario.
+type APIVersion string
+
+const (
+	apiVersionOptionPrefix = "api-version="
+
+	APIVersionV20240610Preview APIVersion = "2024-06-10-preview"
+	APIVersionV20251223Preview APIVersion = "2025-12-23-preview"
+	APIVersionV20260630Preview APIVersion = "2026-06-30-preview"
+)
+
+// APIVersionOption returns the operation option string for an API version,
+// suitable for inclusion in operation.Operation.Options.
+func APIVersionOption(version APIVersion) string {
+	return apiVersionOptionPrefix + string(version)
+}
+
+// APIVersionFromOptions extracts the API version from operation options.
+// Returns an empty string if no API version option is present.
+func APIVersionFromOptions(options []string) APIVersion {
+	for _, opt := range options {
+		if version, ok := strings.CutPrefix(opt, apiVersionOptionPrefix); ok {
+			return APIVersion(version)
+		}
+	}
+	return APIVersion("")
+}
+
+func (v APIVersion) EQ(other APIVersion) bool {
+	return v == other
+}
+
+func (v APIVersion) NE(other APIVersion) bool {
+	return v != other
+}
+
+func (v APIVersion) LT(other APIVersion) bool {
+	return v.compare(other) < 0
+}
+
+func (v APIVersion) LE(other APIVersion) bool {
+	return v.compare(other) <= 0
+}
+
+func (v APIVersion) GT(other APIVersion) bool {
+	return v.compare(other) > 0
+}
+
+func (v APIVersion) GE(other APIVersion) bool {
+	return v.compare(other) >= 0
+}
+
+// compare returns -1, 0, or 1 comparing v and other semantically.
+// The date portion (YYYY-MM-DD) is compared first. On equal dates, preview
+// (suffix found by CutSuffix) ranks before stable (no suffix).
+//
+// Examples:
+//
+//	APIVersion("2024-06-10-preview").compare("2026-06-30-preview") // -1 (earlier date)
+//	APIVersion("2026-06-30-preview").compare("2026-06-30-preview") //  0 (same)
+//	APIVersion("2026-06-30-preview").compare("2024-06-10-preview") //  1 (later date)
+//	APIVersion("2026-06-30-preview").compare("2026-06-30")         // -1 (preview < stable)
+//	APIVersion("2026-06-30").compare("2026-06-30-preview")         //  1 (stable > preview)
+func (v APIVersion) compare(other APIVersion) int {
+	dateA, suffixA := strings.CutSuffix(string(v), "-preview")
+	dateB, suffixB := strings.CutSuffix(string(other), "-preview")
+
+	if cmp := strings.Compare(dateA, dateB); cmp != 0 {
+		return cmp
+	}
+
+	switch {
+	case suffixA && suffixB:
+		return 0
+	case suffixA:
+		return -1
+	case suffixB:
+		return 1
+	default:
+		return 0
+	}
+}

--- a/internal/api/apiversions_test.go
+++ b/internal/api/apiversions_test.go
@@ -1,0 +1,118 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import "testing"
+
+func TestAPIVersionFromOptions(t *testing.T) {
+	tests := []struct {
+		name    string
+		options []string
+		want    APIVersion
+	}{
+		{"extracts version", []string{APIVersionOption(APIVersionV20260630Preview)}, APIVersionV20260630Preview},
+		{"no version option", []string{"some-other-option"}, APIVersion("")},
+		{"empty options", []string{}, APIVersion("")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := APIVersionFromOptions(tt.options); got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAPIVersionComparisons(t *testing.T) {
+	tests := []struct {
+		name  string
+		v     APIVersion
+		other APIVersion
+		eq    bool
+		ne    bool
+		lt    bool
+		le    bool
+		gt    bool
+		ge    bool
+	}{
+		{
+			name: "equal versions",
+			v:    APIVersionV20260630Preview, other: APIVersionV20260630Preview,
+			eq: true, ne: false, lt: false, le: true, gt: false, ge: true,
+		},
+		{
+			name: "less than",
+			v:    APIVersionV20240610Preview, other: APIVersionV20260630Preview,
+			eq: false, ne: true, lt: true, le: true, gt: false, ge: false,
+		},
+		{
+			name: "greater than",
+			v:    APIVersionV20260630Preview, other: APIVersionV20240610Preview,
+			eq: false, ne: true, lt: false, le: false, gt: true, ge: true,
+		},
+		{
+			name: "middle version v2025 vs v2024",
+			v:    APIVersionV20251223Preview, other: APIVersionV20240610Preview,
+			eq: false, ne: true, lt: false, le: false, gt: true, ge: true,
+		},
+		{
+			name: "middle version v2025 vs v2026",
+			v:    APIVersionV20251223Preview, other: APIVersionV20260630Preview,
+			eq: false, ne: true, lt: true, le: true, gt: false, ge: false,
+		},
+		{
+			name: "stable same date ranks after preview",
+			v:    APIVersion("2026-06-30"), other: APIVersionV20260630Preview,
+			eq: false, ne: true, lt: false, le: false, gt: true, ge: true,
+		},
+		{
+			name: "preview same date ranks before stable",
+			v:    APIVersionV20260630Preview, other: APIVersion("2026-06-30"),
+			eq: false, ne: true, lt: true, le: true, gt: false, ge: false,
+		},
+		{
+			name: "stable later date vs preview",
+			v:    APIVersion("2026-07-01"), other: APIVersionV20260630Preview,
+			eq: false, ne: true, lt: false, le: false, gt: true, ge: true,
+		},
+		{
+			name: "stable earlier date vs preview",
+			v:    APIVersion("2026-06-29"), other: APIVersionV20260630Preview,
+			eq: false, ne: true, lt: true, le: true, gt: false, ge: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.v.EQ(tt.other); got != tt.eq {
+				t.Errorf("EQ: got %v, want %v", got, tt.eq)
+			}
+			if got := tt.v.NE(tt.other); got != tt.ne {
+				t.Errorf("NE: got %v, want %v", got, tt.ne)
+			}
+			if got := tt.v.LT(tt.other); got != tt.lt {
+				t.Errorf("LT: got %v, want %v", got, tt.lt)
+			}
+			if got := tt.v.LE(tt.other); got != tt.le {
+				t.Errorf("LE: got %v, want %v", got, tt.le)
+			}
+			if got := tt.v.GT(tt.other); got != tt.gt {
+				t.Errorf("GT: got %v, want %v", got, tt.gt)
+			}
+			if got := tt.v.GE(tt.other); got != tt.ge {
+				t.Errorf("GE: got %v, want %v", got, tt.ge)
+			}
+		})
+	}
+}

--- a/internal/api/v20240610preview/register.go
+++ b/internal/api/v20240610preview/register.go
@@ -30,7 +30,7 @@ func NewVersion() version {
 
 // String returns the api-version parameter value for this API.
 func (v version) String() string {
-	return "2024-06-10-preview"
+	return string(api.APIVersionV20240610Preview)
 }
 
 func (v version) ValidationPathRewriter(internalObj any) (api.ValidationPathMapperFunc, error) {

--- a/internal/api/v20251223preview/register.go
+++ b/internal/api/v20251223preview/register.go
@@ -30,7 +30,7 @@ func newVersion() version {
 
 // String returns the api-version parameter value for this API.
 func (v version) String() string {
-	return "2025-12-23-preview"
+	return string(api.APIVersionV20251223Preview)
 }
 
 func (v version) ValidationPathRewriter(internalObj any) (api.ValidationPathMapperFunc, error) {

--- a/internal/api/v20260630preview/register.go
+++ b/internal/api/v20260630preview/register.go
@@ -30,7 +30,7 @@ func newVersion() version {
 
 // String returns the api-version parameter value for this API.
 func (v version) String() string {
-	return "2026-06-30-preview"
+	return string(api.APIVersionV20260630Preview)
 }
 
 func (v version) ValidationPathRewriter(internalObj any) (api.ValidationPathMapperFunc, error) {

--- a/internal/validation/validate_common.go
+++ b/internal/validation/validate_common.go
@@ -27,6 +27,7 @@ import (
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
+	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 )
 
@@ -45,6 +46,18 @@ func AFECsToValidationOptions(features []arm.Feature) []string {
 	}
 
 	return ret
+}
+
+// BuildValidationOptions combines AFEC feature flags and the ARM API version
+// into a single options slice for operation.Operation.Options.
+func BuildValidationOptions(features []arm.Feature, apiVersion api.APIVersion) []string {
+	options := AFECsToValidationOptions(features)
+	//apiVersion can be empty if this is call from within the backend
+	// as backend doesn't have this context
+	if apiVersion != "" {
+		options = append(options, api.APIVersionOption(apiVersion))
+	}
+	return options
 }
 
 var (


### PR DESCRIPTION

### What

Introduce an APIVersion type with comparison helpers and centralized constants so validation logic can gate behavior on the request's API version. BuildValidationOptions replaces direct AFECsToValidationOptions calls in the frontend, bundling the API version alongside feature flags into the operation options. Each version's register.go now returns the shared constant instead of a hardcoded string.

### Why

We needed a validation for different API versions so it matches and validates the correct semantic for each one.
https://redhat-external.slack.com/archives/C075PHEFZKQ/p1782899719147639



### Testing

Added unit tests.

### Special notes for your reviewer

Work first introduced in https://github.com/Azure/ARO-HCP/pull/5629. It was required by other PR so we are aligned with this type of validation.

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

