### PR TITLE
fix: add automated retry for DeploymentStackInNonTerminalState error

### DIFF
--- a/dev-infrastructure/monitoring-pipeline.yaml
+++ b/dev-infrastructure/monitoring-pipeline.yaml
@@ -26,6 +26,11 @@ resourceGroups:
     deploymentLevel: ResourceGroup
     actionOnUnmanage: delete
     bypassStackOutOfSyncError: false
+    automatedRetry:
+      errorContainsAny:
+      - "DeploymentStackInNonTerminalState"
+      maximumRetryCount: 3
+      durationBetweenRetries: 2m
     variables:
     - name: azureMonitoringWorkspaceId
       input:
@@ -54,6 +59,11 @@ resourceGroups:
     deploymentLevel: ResourceGroup
     actionOnUnmanage: delete
     bypassStackOutOfSyncError: false
+    automatedRetry:
+      errorContainsAny:
+      - "DeploymentStackInNonTerminalState"
+      maximumRetryCount: 3
+      durationBetweenRetries: 2m
     variables:
     - name: kustoClusterId
       input:


### PR DESCRIPTION
## Summary

- Add `automatedRetry` to both `ARMStack` steps in `monitoring-pipeline.yaml` to handle the `DeploymentStackInNonTerminalState` Azure error
- Retries up to 3 times with a 2-minute delay, giving a stuck deployment stack time to reach a terminal state

Ref: [ARO-27959](https://redhat.atlassian.net/browse/ARO-27959)

## Problem

CIHealth flagged `DeploymentStackInNonTerminalState` errors affecting 5 of 403 dev environment runs (1.24%) between June 17–24, 2026. Azure Deployment Stacks get stuck in a non-terminal state (Creating/Updating) when a previous operation fails, times out, or is interrupted (e.g., a killed CI run). The next run that tries to `BeginCreateOrUpdate` on the same stack is rejected by Azure because the stack isn't in a terminal state (Succeeded/Failed/Canceled).

The two `ARMStack` steps in `monitoring-pipeline.yaml` are the only deployment stack operations in the codebase, and neither had any retry or recovery logic for this transient error.

## Solution

The pipeline framework already has a well-established `automatedRetry` mechanism used by many other steps for transient Azure errors (e.g., `InternalServerError`, `Resource is in Updating state`, `DeploymentScriptACIProvisioningTimeout` in `mgmt-pipeline.yaml` and `global-pipeline.yaml`). The `ARMStackStep` type embeds `StepMeta`, so it already supports this configuration — it just wasn't wired up.

Adding `automatedRetry` with `maximumRetryCount: 3` and `durationBetweenRetries: 2m` gives the stuck stack up to ~4 extra minutes to reach a terminal state before reattempting. Azure stack operations typically complete within a few minutes, so this window should be sufficient for the previous operation to finish.

## Test plan

- [x] `make verify` passes
- [x] `cd config && make materialize` produces no unexpected changes
- [ ] Monitor CI runs of the monitoring pipeline for `DeploymentStackInNonTerminalState` errors — retries should now be logged and the step should recover

🤖 Generated with [Claude Code](https://claude.com/claude-code)