### PR TITLE
fix: redacting createdBy and lastModifiedBy from HCP Cluster datadumps

### DIFF
--- a/internal/api/arm/resource.go
+++ b/internal/api/arm/resource.go
@@ -16,6 +16,7 @@ package arm
 
 import (
 	"iter"
+	"log/slog"
 	"slices"
 	"time"
 
@@ -105,6 +106,17 @@ type SystemData struct {
 	LastModifiedByType CreatedByType `json:"lastModifiedByType,omitempty"`
 	// LastModifiedAt is the timestamp of resource last modification (UTC)
 	LastModifiedAt *time.Time `json:"lastModifiedAt,omitempty"`
+}
+
+func (s SystemData) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("createdBy", "[REDACTED]"),
+		slog.Any("createdByType", s.CreatedByType),
+		slog.Any("createdAt", s.CreatedAt),
+		slog.String("lastModifiedBy", "[REDACTED]"),
+		slog.Any("lastModifiedByType", s.LastModifiedByType),
+		slog.Any("lastModifiedAt", s.LastModifiedAt),
+	)
 }
 
 // ProvisioningState represents the asynchronous provisioning state of an ARM resource

--- a/internal/database/types_typeddocument.go
+++ b/internal/database/types_typeddocument.go
@@ -16,8 +16,12 @@ package database
 
 import (
 	"encoding/json"
+	"log/slog"
+	"strings"
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/internal/api"
 )
 
 // TypedDocument is a BaseDocument with a ResourceType field to
@@ -30,4 +34,26 @@ type TypedDocument struct {
 	ResourceID   *azcorearm.ResourceID `json:"resourceID"`
 	ResourceType string                `json:"resourceType"`
 	Properties   json.RawMessage       `json:"properties"`
+}
+
+// rawTypedDocument is an alias used to log TypedDocument without recursing
+// back into LogValue.
+type rawTypedDocument TypedDocument
+
+// LogValue implements slog.LogValuer. For HCP cluster documents, Properties is
+// deserialized into the typed struct so that SystemData.LogValue() can redact
+// createdBy/lastModifiedBy. All other resource types are logged as-is.
+func (d TypedDocument) LogValue() slog.Value {
+	if strings.EqualFold(d.ResourceType, api.ClusterResourceType.String()) {
+		var cluster api.HCPOpenShiftCluster
+		if err := json.Unmarshal(d.Properties, &cluster); err != nil {
+			return slog.GroupValue(
+				slog.String("resourceType", d.ResourceType),
+				slog.Any("resourceID", d.ResourceID),
+				slog.String("unmarshalError", err.Error()),
+			)
+		}
+		return slog.AnyValue(cluster)
+	}
+	return slog.AnyValue(rawTypedDocument(d))
 }


### PR DESCRIPTION
[ARO-28164](https://redhat.atlassian.net/browse/ARO-28164)
### What

Redacts CreatedBy and LastModifiedBy from HCP cluster data dump

### Why

These can include customer email addresses

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
