### PR TITLE
fix(kube-applier): add priorityClassName service-lifecycle-critical

### DIFF
--- a/kube-applier/deploy/templates/deployment.yaml
+++ b/kube-applier/deploy/templates/deployment.yaml
@@ -37,6 +37,7 @@ spec:
           matchLabels:
             app: kube-applier
       serviceAccountName: '{{ .Values.serviceAccount.name }}'
+      priorityClassName: service-lifecycle-critical
       containers:
       - name: kube-applier
         image: '{{ .Values.deployment.imageName }}'

--- a/kube-applier/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_kube_applier.yaml
+++ b/kube-applier/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_kube_applier.yaml
@@ -221,6 +221,7 @@ spec:
           matchLabels:
             app: kube-applier
       serviceAccountName: 'kube-applier'
+      priorityClassName: service-lifecycle-critical
       containers:
       - name: kube-applier
         image: 'arohcpsvcdev.azurecr.io/kube-applier@sha256:1234567890'


### PR DESCRIPTION
Ref: [AROSLSRE-1070](https://redhat.atlassian.net/browse/AROSLSRE-1070)

### What

Add `priorityClassName: service-lifecycle-critical` to the kube-applier deployment pod spec.

### Why

kube-applier currently runs with no priority class (effective priority 0), making it among the first pods evicted under node memory pressure — ahead of klusterlet (1M) and hypershift (100M) workloads. This is the wrong eviction order: kube-applier manages manifest reconciliation on management clusters and should survive node pressure longer than unclassified pods.

The `service-lifecycle-critical` priority class (value 1,000,000) gives kube-applier a defined eviction order: it survives longer than default pods but yields to hypershift control plane and system components.

Part of [AROSLSRE-1068](https://redhat.atlassian.net/browse/AROSLSRE-1068) (Manage resources: kube-applier).

### Testing

- Helm fixture regenerated via `cd config && make materialize` — all tests pass.
- No new tests needed: this is a one-line pod spec field addition, validated by existing `TestHelmTemplate` fixture.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows Conventional Commits format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes) — N/A
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented — N/A (one-line change)
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
