### PR TITLE
istio: map Phase field to StopAfter checkpoints in pipeline runner

### DIFF
--- a/tooling/templatize/pkg/istio/upgrade.go
+++ b/tooling/templatize/pkg/istio/upgrade.go
@@ -156,6 +156,10 @@ func RunUpgrade(ctx context.Context, opts UpgradeOptions, aksClient AKSClusterCl
 	case ActionInstall:
 		return runInitialInstall(ctx, logger, aksClient, kubeClient, opts, target)
 	case ActionResume:
+		if opts.StopAfter == StopAfterCanaryStart {
+			logger.Info("Canary already in progress — install phase complete, nothing to do")
+			return nil
+		}
 		return runCanaryPostInstall(ctx, logger, aksClient, kubeClient, opts, target, meshProfile.Revisions)
 	case ActionUpgrade:
 		return runCanaryUpgrade(ctx, logger, aksClient, kubeClient, opts, target, meshProfile.Revisions)

--- a/tooling/templatize/pkg/istio/upgrade_test.go
+++ b/tooling/templatize/pkg/istio/upgrade_test.go
@@ -476,6 +476,23 @@ func TestRunUpgrade_Resume(t *testing.T) {
 	assert.Equal(t, "asm-1-29", cm.Labels["istio.io/rev"])
 }
 
+func TestRunUpgrade_ResumeWithStopAfterCanaryStart(t *testing.T) {
+	aks := &fakeAKSClient{
+		clusterInfo: &ClusterInfo{ProvisioningState: "Succeeded"},
+		meshProfile: &MeshProfile{Revisions: []string{"asm-1-28", "asm-1-29"}},
+		upgradeInfo: &MeshUpgradeInfo{UpgradeInProgress: true},
+	}
+	kubeClient := healthyKubeClient()
+
+	opts := baseOpts()
+	opts.StopAfter = StopAfterCanaryStart
+
+	err := RunUpgrade(testCtx(t), opts, aks, kubeClient)
+	require.NoError(t, err)
+	assert.NotContains(t, aks.calls, "StartCanaryUpgrade", "should not start canary — already in progress")
+	assert.NotContains(t, aks.calls, "CompleteCanaryUpgrade", "should not complete canary — install phase is done")
+}
+
 func TestRunUpgrade_TagBasedNamespacesWithoutTagConfig(t *testing.T) {
 	aks := &fakeAKSClient{
 		clusterInfo: &ClusterInfo{ProvisioningState: "Succeeded"},

--- a/tooling/templatize/pkg/pipeline/istio.go
+++ b/tooling/templatize/pkg/pipeline/istio.go
@@ -91,5 +91,13 @@ func runIstioUpgradeStep(id graph.Identifier, step *types.IstioUpgradeStep, ctx 
 	opts.RegionRG = configString(regionRG)
 	opts.DryRun = step.DryRun
 
+	switch step.Phase {
+	case "install":
+		opts.StopAfter = istio.StopAfterCanaryStart
+	case "upgrade", "":
+	default:
+		return fmt.Errorf("unknown IstioUpgrade phase %q: must be \"install\" or \"upgrade\"", step.Phase)
+	}
+
 	return istio.RunUpgrade(ctx, opts, aksClient, kubeClient)
 }

--- a/tooling/templatize/pkg/pipeline/istio.go
+++ b/tooling/templatize/pkg/pipeline/istio.go
@@ -37,6 +37,17 @@ func configString(val any) string {
 	return fmt.Sprintf("%v", val)
 }
 
+func stopAfterForPhase(phase string) (istio.StopAfter, error) {
+	switch phase {
+	case "install":
+		return istio.StopAfterCanaryStart, nil
+	case "upgrade", "":
+		return "", nil
+	default:
+		return "", fmt.Errorf("unknown IstioUpgrade phase %q: must be \"install\", \"upgrade\", or empty", phase)
+	}
+}
+
 func runIstioUpgradeStep(id graph.Identifier, step *types.IstioUpgradeStep, ctx context.Context, options *StepRunOptions, executionTarget ExecutionTarget) error {
 	logger := logr.FromContextOrDiscard(ctx).WithValues("stepID", id)
 
@@ -91,13 +102,11 @@ func runIstioUpgradeStep(id graph.Identifier, step *types.IstioUpgradeStep, ctx 
 	opts.RegionRG = configString(regionRG)
 	opts.DryRun = step.DryRun
 
-	switch step.Phase {
-	case "install":
-		opts.StopAfter = istio.StopAfterCanaryStart
-	case "upgrade", "":
-	default:
-		return fmt.Errorf("unknown IstioUpgrade phase %q: must be \"install\" or \"upgrade\"", step.Phase)
+	stopAfter, err := stopAfterForPhase(step.Phase)
+	if err != nil {
+		return err
 	}
+	opts.StopAfter = stopAfter
 
 	return istio.RunUpgrade(ctx, opts, aksClient, kubeClient)
 }

--- a/tooling/templatize/pkg/pipeline/istio_test.go
+++ b/tooling/templatize/pkg/pipeline/istio_test.go
@@ -1,0 +1,50 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Azure/ARO-HCP/tooling/templatize/pkg/istio"
+)
+
+func TestStopAfterForPhase(t *testing.T) {
+	tests := []struct {
+		name      string
+		phase     string
+		want      istio.StopAfter
+		wantError bool
+	}{
+		{name: "install maps to StopAfterCanaryStart", phase: "install", want: istio.StopAfterCanaryStart},
+		{name: "upgrade runs full lifecycle", phase: "upgrade", want: ""},
+		{name: "empty runs full lifecycle", phase: "", want: ""},
+		{name: "unknown phase returns error", phase: "rollback", wantError: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := stopAfterForPhase(tt.phase)
+			if tt.wantError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "unknown IstioUpgrade phase")
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

 Map the `IstioUpgradeStep.Phase` field to internal `StopAfter` checkpoints in the pipeline runner.

### Why

  The `Phase` field (added in Azure/ARO-Tools#264) enables splitting Istio upgrades into discrete pipeline steps. This PR adds the consuming code that maps `"install"` to `StopAfterCanaryStart` (installs new control plane, stops before workload migration) and lets `"upgrade"` or empty run the full lifecycle. Splitting gives each phase its own EV2 timeout budget and allows a Helm config step to run between control plane installation and workload migration. The pipeline wiring (`svc-pipeline.yaml`) will follow in a subsequent PR.

### Testing

  The switch statement is a straightforward mapping with an error default. The `StopAfter` checkpoint logic is already covered by existing tests in `tooling/templatize/pkg/istio/upgrade_test.go`. Integration validation was performed manually against pers-dev.

### Special notes for your reviewer

 Depends on Azure/ARO-Tools#264 (Phase field).

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
