### PR TITLE
fleet: add istio revision label to fleet registration namespace

### DIFF
--- a/fleet/registration/namespace.yaml
+++ b/fleet/registration/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "{{ .fleet.k8s.namespace }}"
+  labels:
+    "istio.io/rev": "{{ .svc.istio.tag }}"

--- a/fleet/registration/pipeline.yaml
+++ b/fleet/registration/pipeline.yaml
@@ -81,6 +81,8 @@ resourceGroups:
     releaseNamespace: '{{ .fleet.k8s.namespace }}'
     chartDir: ./deploy
     valuesFile: ./values.yaml
+    namespaceFiles:
+    - namespace.yaml
     kustoEndpoint:
       resourceGroup: kusto
       step: kusto-lookup


### PR DESCRIPTION
  ### What
  
  Add `namespaceFiles` to the fleet registration Helm step and a namespace manifest with the `istio.io/rev` label.
  
  ### Why
  
  Fleet registration deploys a Helm release to the same namespace as the parent fleet pipeline. The parent applies the `istio.io/rev` label via `namespaceFiles`, but the registration step — which lacked its own `namespaceFiles`, overwrites the namespace and removes the label during Helm release management. This prevents sidecar injection for fleet pods during Istio upgrades.
  
  ### Steps to reproduce
  
  ```bash
  # 1. Run the parent fleet pipeline (applies the label)
  make pipeline/Fleet STEP_CACHE_DIR=""
  
  # 2. Confirm label exists
  kubectl get namespace fleet --show-labels | grep istio
  # fleet   Active   48m   istio.io/rev=prod-stable,...
  
  # 3. Run fleet registration (removes the label)
  make pipeline/Fleet.Registration STEP_CACHE_DIR=""
  
  # 4. Label is gone
  kubectl get namespace fleet --show-labels | grep istio
  # (empty)
  
  Testing
  
  Verified on pers-dev that the label is removed by the registration step and preserved after the fix is applied.
  
  Special notes for your reviewer
  
  Every other service pipeline already uses namespaceFiles to set the Istio revision label, this brings fleet registration in line with the existing pattern.


### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
