### PR TITLE
fix(infra): handle service-principal auth in postgres-access step

### DIFF
--- a/dev-infrastructure/scripts/postgres-access/main.go
+++ b/dev-infrastructure/scripts/postgres-access/main.go
@@ -189,6 +189,20 @@ func run(ctx context.Context) error {
 		if err := ensureEntraAdmin(ctx, cred, cfg, claims); err != nil {
 			return fmt.Errorf("enroll operator as Entra admin: %w", err)
 		}
+	} else if !isManagedIdentityToken(claims) {
+		// Running as a service principal (Prow CI). templatize ignores
+		// shellIdentity, so the token belongs to the CI SP, not the rollout
+		// MSI. Enrol the SP as an Entra admin and connect as its appId.
+		// MSI tokens also carry appid but are distinguished by the
+		// xms_mirid claim — those take the default adminUserName path.
+		appID := servicePrincipalAppID(claims)
+		if appID == "" {
+			return fmt.Errorf("token has no UPN, appid, or xms_mirid — cannot determine caller identity")
+		}
+		pgUser = appID
+		if err := ensureEntraAdmin(ctx, cred, cfg, claims); err != nil {
+			return fmt.Errorf("enroll CI service principal as Entra admin: %w", err)
+		}
 	}
 
 	slog.Info("granting database access",
@@ -249,14 +263,23 @@ func lookupIdentityPrincipalID(ctx context.Context, cred azcore.TokenCredential,
 	return *resp.Properties.PrincipalID, nil
 }
 
-// ensureEntraAdmin idempotently enrols the signed-in operator as a server Entra
-// admin. Used only on the local-operator path; EV2 runs as the admin MI.
+// ensureEntraAdmin idempotently enrols the caller as a server Entra admin.
+// Used for the local-operator path (UPN) and the Prow CI path (service
+// principal). EV2 runs as the rollout MSI which is already the admin.
 func ensureEntraAdmin(ctx context.Context, cred azcore.TokenCredential, cfg *config, claims map[string]any) error {
 	objectID, _ := claims["oid"].(string)
 	tenantID, _ := claims["tid"].(string)
-	principalName := userPrincipalName(claims)
 	if objectID == "" || tenantID == "" {
 		return fmt.Errorf("token is missing oid/tid claims required for admin enrolment")
+	}
+
+	principalName := userPrincipalName(claims)
+	principalType := armpostgresqlflexibleservers.PrincipalTypeUser
+	if principalName == "" {
+		// Service principal — use appId as the display name and set the
+		// correct principal type so Entra registers it properly.
+		principalName = servicePrincipalAppID(claims)
+		principalType = armpostgresqlflexibleservers.PrincipalTypeServicePrincipal
 	}
 
 	client, err := armpostgresqlflexibleservers.NewAdministratorsClient(cfg.subscriptionID, cred, nil)
@@ -273,18 +296,18 @@ func ensureEntraAdmin(ctx context.Context, cred azcore.TokenCredential, cfg *con
 		for _, admin := range page.Value {
 			if admin.Properties != nil && admin.Properties.ObjectID != nil &&
 				strings.EqualFold(*admin.Properties.ObjectID, objectID) {
-				slog.Info("operator already enrolled as Entra admin", "objectId", objectID)
+				slog.Info("caller already enrolled as Entra admin", "objectId", objectID)
 				return nil
 			}
 		}
 	}
 
-	slog.Info("enrolling operator as a temporary Entra admin for local execution", "principal", principalName)
+	slog.Info("enrolling caller as Entra admin", "principal", principalName, "principalType", principalType)
 	poller, err := client.BeginCreate(ctx, cfg.resourceGroup, cfg.serverName, objectID,
 		armpostgresqlflexibleservers.ActiveDirectoryAdministratorAdd{
 			Properties: &armpostgresqlflexibleservers.AdministratorPropertiesForAdd{
 				PrincipalName: to.Ptr(principalName),
-				PrincipalType: to.Ptr(armpostgresqlflexibleservers.PrincipalTypeUser),
+				PrincipalType: to.Ptr(principalType),
 				TenantID:      to.Ptr(tenantID),
 			},
 		}, nil)
@@ -409,6 +432,26 @@ func parseTokenClaims(token string) map[string]any {
 // managed-identity / service token (which has no UPN).
 func userPrincipalName(claims map[string]any) string {
 	for _, key := range []string{"upn", "unique_name", "preferred_username"} {
+		if v, ok := claims[key].(string); ok && v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// isManagedIdentityToken returns true when the token was issued to an Azure
+// Managed Identity. MSI tokens carry an "xms_mirid" claim containing the ARM
+// resource ID of the identity; service-principal tokens do not.
+func isManagedIdentityToken(claims map[string]any) bool {
+	v, ok := claims["xms_mirid"].(string)
+	return ok && v != ""
+}
+
+// servicePrincipalAppID returns the appid from a service-principal token, or
+// "" for user tokens. SP and MSI tokens both carry "appid"/"azp", so callers
+// must use isManagedIdentityToken first to distinguish the two.
+func servicePrincipalAppID(claims map[string]any) string {
+	for _, key := range []string{"appid", "azp"} {
 		if v, ok := claims[key].(string); ok && v != "" {
 			return v
 		}

--- a/dev-infrastructure/scripts/postgres-access/main_test.go
+++ b/dev-infrastructure/scripts/postgres-access/main_test.go
@@ -162,6 +162,40 @@ func TestUserPrincipalName(t *testing.T) {
 	}
 }
 
+func TestIsManagedIdentityToken(t *testing.T) {
+	// MSI token has xms_mirid claim.
+	if !isManagedIdentityToken(map[string]any{"xms_mirid": "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-mi", "appid": "abc", "oid": "o"}) {
+		t.Error("expected MSI token to be detected")
+	}
+	// SP token has no xms_mirid.
+	if isManagedIdentityToken(map[string]any{"appid": "abc", "oid": "o"}) {
+		t.Error("SP token should not be detected as MSI")
+	}
+	// User token has no xms_mirid.
+	if isManagedIdentityToken(map[string]any{"upn": "user@x", "oid": "o"}) {
+		t.Error("user token should not be detected as MSI")
+	}
+}
+
+func TestServicePrincipalAppID(t *testing.T) {
+	// SP token with appid claim (v1 token).
+	if got := servicePrincipalAppID(map[string]any{"appid": "abc-123", "oid": "o"}); got != "abc-123" {
+		t.Errorf("appid = %q, want abc-123", got)
+	}
+	// SP token with azp claim (v2 token).
+	if got := servicePrincipalAppID(map[string]any{"azp": "def-456"}); got != "def-456" {
+		t.Errorf("azp = %q, want def-456", got)
+	}
+	// appid takes precedence over azp when both present.
+	if got := servicePrincipalAppID(map[string]any{"appid": "first", "azp": "second"}); got != "first" {
+		t.Errorf("expected appid precedence, got %q", got)
+	}
+	// User token has no appid/azp.
+	if got := servicePrincipalAppID(map[string]any{"upn": "user@x", "oid": "o"}); got != "" {
+		t.Errorf("user token should have empty appid, got %q", got)
+	}
+}
+
 func TestParseTokenClaims(t *testing.T) {
 	// header.payload.signature with payload {"upn":"u@x","oid":"o","tid":"t"}
 	const tok = "aaa.eyJ1cG4iOiJ1QHgiLCJvaWQiOiJvIiwidGlkIjoidCJ9.bbb"


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-1417

## Summary

- The `postgres-access` Go script (introduced in #5851, [ARO-28051](https://redhat.atlassian.net/browse/ARO-28051)) fails in Prow CI with a PostgreSQL `pgaadauth` OID mismatch because it only handles EV2 (managed identity) and local operator (UPN) auth paths
- Add service-principal detection: when the token has no UPN and no `xms_mirid` (MSI marker), enrol the CI SP as an Entra admin and connect as its `appid`
- Distinguish MSI from SP tokens via the `xms_mirid` claim to preserve the EV2 path

## Context

The script has three callers:
1. **EV2** — `shellIdentity` runs as the rollout MSI → token OID matches postgres role → works (unchanged)
2. **Local operator** — has UPN → connects as UPN, enrols as admin → works (unchanged)
3. **Prow CI** — templatize ignores `shellIdentity`, runs as CI service principal → **was broken**, now fixed

Ephemeral CI environments (`ci00`/`ci01`) are unaffected — they use containerized postgres (`deploy: false`), so the step is skipped entirely. The bug only manifests in CSPR, which use Azure Postgres Flexible Server.

This was masked because every CSPR postsubmit since the script landed (June 30) failed earlier at the EventGrid `authenticationName` step before reaching `cs-postgres-access`.

## Failed CI runs

- [2074360206455738368](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/branch-ci-Azure-ARO-HCP-main-cspr-pipeline-postsubmit/2074360206455738368) — `cs-postgres-access` OID mismatch

## Test plan

- [x] Existing unit tests pass (10/10)
- [x] New `TestIsManagedIdentityToken` and `TestServicePrincipalAppID` tests added and passing
- [ ] CSPR postsubmit passes `cs-postgres-access` step after merge