### PR TITLE
fix: preserve role assignment GUIDs for geneva certificate access

### DIFF
--- a/dev-infrastructure/templates/mgmt-cluster.bicep
+++ b/dev-infrastructure/templates/mgmt-cluster.bicep
@@ -497,22 +497,20 @@ resource mgmtKeyVault 'Microsoft.KeyVault/vaults@2024-04-01-preview' existing = 
 //   G E N E V A   C E R T I F I C A T E   A C C E S S
 //
 
-module genevaRpLogsCertCSIAccess '../modules/keyvault/keyvault-secret-access.bicep' = {
+module genevaRpLogsCertCSIAccess '../modules/keyvault/key-vault-secret-access.bicep' = {
   name: 'geneva-mgmt-rp-certificate'
   params: {
     keyVaultName: mgmtKeyVaultName
-    roleName: 'Key Vault Secrets User'
-    managedIdentityPrincipalIds: [mgmtCluster.outputs.aksClusterKeyVaultSecretsProviderPrincipalId]
+    principalId: mgmtCluster.outputs.aksClusterKeyVaultSecretsProviderPrincipalId
     secretName: genevaRpLogsName
   }
 }
 
-module genevaClusterLogsCertCSIAccess '../modules/keyvault/keyvault-secret-access.bicep' = {
+module genevaClusterLogsCertCSIAccess '../modules/keyvault/key-vault-secret-access.bicep' = {
   name: 'geneva-cluster-log-certificate'
   params: {
     keyVaultName: mgmtKeyVaultName
-    roleName: 'Key Vault Secrets User'
-    managedIdentityPrincipalIds: [mgmtCluster.outputs.aksClusterKeyVaultSecretsProviderPrincipalId]
+    principalId: mgmtCluster.outputs.aksClusterKeyVaultSecretsProviderPrincipalId
     secretName: genevaClusterLogsName
   }
 }

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -1058,13 +1058,12 @@ module sessiongateDNS '../modules/dns/a-record.bicep' = {
 //   G E N E V A   C E R T I F I C A T E   A C C E S S
 //
 
-module genevaRpLogsCertCSIAccess '../modules/keyvault/keyvault-secret-access.bicep' = {
+module genevaRpLogsCertCSIAccess '../modules/keyvault/key-vault-secret-access.bicep' = {
   name: 'geneva-crt-access-${uniqueString(resourceGroup().name)}'
   scope: resourceGroup(serviceKeyVaultSubscription, serviceKeyVaultResourceGroup)
   params: {
     keyVaultName: serviceKeyVaultName
-    roleName: 'Key Vault Secrets User'
-    managedIdentityPrincipalIds: [svcCluster.outputs.aksClusterKeyVaultSecretsProviderPrincipalId]
+    principalId: svcCluster.outputs.aksClusterKeyVaultSecretsProviderPrincipalId
     secretName: genevaRpLogsName
   }
 }


### PR DESCRIPTION
### What

Switch geneva certificate access from `keyvault-secret-access.bicep` to
`key-vault-secret-access.bicep` in mgmt-cluster and svc-cluster templates
(3 module references).

Changes per module reference:
- Module path: `keyvault-secret-access.bicep` → `key-vault-secret-access.bicep`
- Parameter: `managedIdentityPrincipalIds` (array) → `principalId` (scalar)
- Parameter: `roleName` removed (built into new module)

### Why

`keyvault-secret-access.bicep` produces different role assignment resource
names, causing deployment conflicts with existing assignments.

### Testing

Infrastructure change — no new tests. Verified by deployment.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Self-reviewed the diff
- [x] Commit history is clean (rebased/squashed)