### PR TITLE
Bump CIHealth to https://github.com/roivaz/ARO-HCP-CIHealth/pull/5

### DIFF
--- a/config/config-dev-ci.yaml
+++ b/config/config-dev-ci.yaml
@@ -124,7 +124,7 @@ clouds:
           image:
             registry: "quay.io"
             repository: "roivaz/cihealth"
-            tag: "9763534"
+            tag: "b18f5c1"
           disableRuntimeWorkloads: false
           app:
             replicas: 2


### PR DESCRIPTION
**Changes**

1. New alert failed_at cause

 - Ingests the junit_alerts.xml artifact from the observability gather step and extracts alert failures.
 - failed_at is now multi-valued: a run can fail at both e2e and alert simultaneously. provision remains exclusive (if provision fails, neither e2e nor alert run).
 - Failure details in the UI and APIs are grouped by failure type.
 - Alert failures are counted with an independent metric.
 - Alert identity for clustering is the alert name + scope (not the failure text); alert text is normalized (cluster names and trailing -xxxx pod suffixes stripped) so patterns cluster correctly.
 - Persists the artifact path as the underlying fact; the lane is derived from it.
 - Applies to new runs only — no backfill.

2. Failed-at filter on failure-patterns page + API

 - Adds a "Failed at" selector to /failure-patterns (alongside the existing Environment selector), also exposed as a repeatable failed_at query param on /failure-patterns and /api/failure-patterns/window.
 - Failure-patterns groups by single source (provision/e2e/alert/other), centralized in the new lanes.BucketSource helper. (Run-log stays multi-valued; the two views complement each other.)
 - Fixes both the Environment and Failed-at selectors to submit on change — the failure-patterns chrome controls were missing AutoSubmit, so neither triggered a reload (Environment was already broken there).

3. Serve prepared-window cache for env subsets

 - The prepared-window snapshot is always stored for the full supported env set. Requesting a single env (e.g. dev) previously missed the prewarmed cache with reason=env_mismatch.
 - lookup now matches on subset coverage: a request whose envs are all contained in the primary set is served from the snapshot. Downstream rendering already restricts output to the requested envs.
