### PR TITLE
fix: use pure-Go SP credential in e2e dev env to avoid az subprocess OOM

### DIFF
--- a/test/util/framework/per_invocation_framework.go
+++ b/test/util/framework/per_invocation_framework.go
@@ -136,6 +136,23 @@ func (tc *perBinaryInvocationTestContext) getAzureCredentials() (azcore.TokenCre
 	}
 
 	if tc.isDevelopmentEnvironment {
+		// The development environment flag controls endpoint routing and relaxed security
+		// (talking directly to the RP frontend rather than ARM); it is intentionally decoupled
+		// from credential acquisition. When service principal env vars are present (as they are
+		// in CI), prefer a pure-Go ClientSecretCredential. AzureCLICredential.GetToken() spawns
+		// an `az` subprocess on every Azure API call, which does not scale under high test
+		// parallelism (dozens of concurrent Python processes) and leads to OOM kills. The CLI
+		// credential is only needed for genuine local `az login`-only developer runs.
+		if clientID, clientSecret, tenantID := os.Getenv("AZURE_CLIENT_ID"), os.Getenv("AZURE_CLIENT_SECRET"), os.Getenv("AZURE_TENANT_ID"); clientID != "" && clientSecret != "" && tenantID != "" {
+			azureCredentials, err := azidentity.NewClientSecretCredential(tenantID, clientID, clientSecret, nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed building development environment client secret credential: %w", err)
+			}
+			tc.azureCredentials = azureCredentials
+
+			return tc.azureCredentials, nil
+		}
+
 		azureCredentials, err := azidentity.NewAzureCLICredential(nil)
 		if err != nil {
 			return nil, fmt.Errorf("failed building development environment CLI credential: %w", err)


### PR DESCRIPTION
Jira: [ARO-28171](https://redhat.atlassian.net/browse/ARO-28171)

### What

Decouples Azure credential acquisition from the `AROHCP_ENV=development` switch in the e2e framework (`test/util/framework/per_invocation_framework.go`, `getAzureCredentials()`).

In the development branch, credentials are now obtained via a pure-Go `ClientSecretCredential` when `AZURE_CLIENT_ID` / `AZURE_CLIENT_SECRET` / `AZURE_TENANT_ID` are set (as they are in CI), falling back to `AzureCLICredential` only for genuine local `az login`-only developer runs. All other development-mode behavior (RP-direct endpoints, proxied transport, relaxed TLS, ARM client policies) is unchanged.

### Why

`AROHCP_ENV=development` was overloaded to control two unrelated concerns:

1. **Endpoint/security mode** — talk directly to the dev RP frontend instead of ARM. This is correct and required for the `e2e-parallel` (`ci01`) job, since there is no real ARM in that on-demand environment.
2. **Credential acquisition** — `AzureCLICredential`, whose `GetToken()` spawns an `az account get-access-token` subprocess on *every* Azure API call, from *every* test goroutine.

After `ARO_HCP_SUITE_PARALLELISM` was raised to 55, concern (2) produces dozens of concurrent `az`/Python subprocesses and OOM-kills the CI pod (`signal: killed`) even after bumping pod memory to 20Gi (the pod-scaler max).

The CI step already provisions a service principal and exports `AZURE_CLIENT_ID` / `AZURE_CLIENT_SECRET` / `AZURE_TENANT_ID` (then runs `az login --service-principal`). Using those directly with a pure-Go `ClientSecretCredential` authenticates the same SP with the same token and `management.core.windows.net` audience the dev HCP client expects — with **zero subprocesses** — so memory becomes bounded by the Go binary regardless of parallelism.

### Testing

- `go build`, `go vet`, `gofmt`, and repo-pinned `golangci-lint v2.5.0` all pass with 0 issues on the changed package.
- No behavioral change for local developer runs without SP env vars (still uses `AzureCLICredential`).
- Functional validation is via the `e2e-parallel` CI job itself, which should no longer OOM at parallelism 55.

### Special notes for your reviewer

The fix is intentionally minimal and surgical: only the credential-selection logic in the development branch changed; endpoint routing, transport, TLS, and ARM policy wiring are untouched.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows Conventional Commits format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if graph/UI/metrics changes) — N/A
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented