### PR TITLE
feat: alert on stale int and stg HCP clusters

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
@@ -1642,6 +1642,48 @@ This may indicate that finalizers are stuck or resources are failing to cleanup.
   }
 }
 
+resource hcpTestClustersRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'hcp-test-clusters-rules'
+  location: location
+  properties: {
+    interval: 'PT1M'
+    rules: [
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'HCPClusterOlderThan3Hours'
+        enabled: true
+        labels: {
+          severity: '3'
+        }
+        annotations: {
+          correlationId: 'IntStgClusterOlderThan3Hours{{ $labels.resource_id }}'
+          description: '''HCP cluster {{ $labels.resource_id }} in {{ $labels.environment }} on service cluster {{ $labels.cluster }} has existed for more than 3 hours.
+'''
+          info: '''HCP cluster {{ $labels.resource_id }} in {{ $labels.environment }} on service cluster {{ $labels.cluster }} has existed for more than 3 hours.
+'''
+          runbook_url: 'TBD'
+          summary: 'HCP in {{ $labels.environment }} is older than 3h'
+          title: 'HCP in {{ $labels.environment }} is older than 3h resource_id:{{ $labels.resource_id }} cluster:{{ $labels.cluster }}'
+        }
+        expression: 'max by (cluster, resource_id, environment) (time() - backend_cluster_created_time_seconds{environment=~"int|stg"}) > 3 * 3600'
+        for: 'PT5M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+    ]
+    scopes: [
+      azureMonitoring
+    ]
+  }
+}
+
 resource kubeContainerOomRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
   name: 'kube-container-oom-rules'
   location: location

--- a/observability/alerts-sl-services.yaml
+++ b/observability/alerts-sl-services.yaml
@@ -10,6 +10,7 @@ prometheusRules:
   - alerts/arobit-prometheusRule.yaml
   - alerts/service-tag-public-ip-usage.yaml
   - alerts/HCPdeletionStuck-prometheusRule.yaml
+  - alerts/hcp-test-clusters-prometheusRule.yaml
   - alerts/kubeContainerOOM-prometheusRule.yaml
   - alerts/kubeNode-prometheusRule.yaml
   - alerts/imageRegistryPolicy-prometheusRule.yaml

--- a/observability/alerts/hcp-test-clusters-prometheusRule.yaml
+++ b/observability/alerts/hcp-test-clusters-prometheusRule.yaml
@@ -1,0 +1,23 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: hcp-test-clusters-monitoring-rules
+  namespace: monitoring
+spec:
+  groups:
+  - name: hcp-test-clusters-rules
+    rules:
+    - alert: HCPClusterOlderThan3Hours
+      expr: |
+        max by (cluster, resource_id, environment) (
+          time() - backend_cluster_created_time_seconds{environment=~"int|stg"}
+        ) > 3 * 3600
+      for: 5m
+      labels:
+        severity: "3"
+      annotations:
+        correlationId: 'IntStgClusterOlderThan3Hours{{ $labels.resource_id }}'
+        description: |
+          HCP cluster {{ $labels.resource_id }} in {{ $labels.environment }} on service cluster {{ $labels.cluster }} has existed for more than 3 hours.
+        runbook_url: TBD
+        summary: HCP in {{ $labels.environment }} is older than 3h

--- a/observability/alerts/hcp-test-clusters-prometheusRule_test.yaml
+++ b/observability/alerts/hcp-test-clusters-prometheusRule_test.yaml
@@ -1,0 +1,64 @@
+rule_files:
+- hcp-test-clusters-prometheusRule.yaml
+evaluation_interval: 1m
+tests:
+# HCPClusterOlderThan3Hours - alert fires for int clusters older than 3 hours
+- interval: 1m
+  input_series:
+  - series: 'backend_cluster_created_time_seconds{cluster="int-uksouth-svc-1",environment="int",resource_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/test-cluster"}'
+    values: "0+0x200"
+  alert_rule_test:
+  - eval_time: 3h6m
+    alertname: HCPClusterOlderThan3Hours
+    exp_alerts:
+    - exp_labels:
+        alertname: HCPClusterOlderThan3Hours
+        severity: "3"
+        cluster: int-uksouth-svc-1
+        environment: int
+        resource_id: /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/test-cluster
+      exp_annotations:
+        correlationId: 'IntStgClusterOlderThan3Hours/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/test-cluster'
+        description: |
+          HCP cluster /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/test-cluster in int on service cluster int-uksouth-svc-1 has existed for more than 3 hours.
+        runbook_url: TBD
+        summary: HCP in int is older than 3h
+# HCPClusterOlderThan3Hours - alert fires for stg clusters older than 3 hours
+- interval: 1m
+  input_series:
+  - series: 'backend_cluster_created_time_seconds{cluster="stg-uksouth-svc-1",environment="stg",resource_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/test-cluster"}'
+    values: "0+0x200"
+  alert_rule_test:
+  - eval_time: 3h6m
+    alertname: HCPClusterOlderThan3Hours
+    exp_alerts:
+    - exp_labels:
+        alertname: HCPClusterOlderThan3Hours
+        severity: "3"
+        cluster: stg-uksouth-svc-1
+        environment: stg
+        resource_id: /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/test-cluster
+      exp_annotations:
+        correlationId: 'IntStgClusterOlderThan3Hours/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/test-cluster'
+        description: |
+          HCP cluster /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/test-cluster in stg on service cluster stg-uksouth-svc-1 has existed for more than 3 hours.
+        runbook_url: TBD
+        summary: HCP in stg is older than 3h
+# HCPClusterOlderThan3Hours - no alert for prod clusters
+- interval: 1m
+  input_series:
+  - series: 'backend_cluster_created_time_seconds{cluster="prod-uksouth-svc-1",environment="prod",resource_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/test-cluster"}'
+    values: "0+0x200"
+  alert_rule_test:
+  - eval_time: 3h6m
+    alertname: HCPClusterOlderThan3Hours
+    exp_alerts: []
+# HCPClusterOlderThan3Hours - no alert before the cluster is older than 3 hours
+- interval: 1m
+  input_series:
+  - series: 'backend_cluster_created_time_seconds{cluster="int-uksouth-svc-1",environment="int",resource_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/test-cluster"}'
+    values: "0+0x200"
+  alert_rule_test:
+  - eval_time: 3h4m
+    alertname: HCPClusterOlderThan3Hours
+    exp_alerts: []


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-1421

## Why
Int and stg HCP cluster objects should not remain around indefinitely. This adds an SL services alert for any HCP cluster object older than 3 hours in those environments.

## What
- Adds `HCPClusterOlderThan3Hours` in `observability/alerts/hcp-test-clusters-prometheusRule.yaml`.
- Wires the rule into the SL services alert config.
- Uses `max by (cluster, resource_id, environment)` over `backend_cluster_created_time_seconds{environment=~"int|stg"}`.
- Fires after `for: 5m` when cluster object age exceeds 3h.
- Includes `environment` in the summary and description.
- Sets the correlation ID to `IntStgClusterOlderThan3Hours{{ $labels.resource_id }}`.
- Adds rule coverage for int, stg, prod exclusion, and pre-threshold behavior.

## Testing
- `make -C tooling/prometheus-rules run-sl-services`

No screenshots; alert rule only.