### PR TITLE
test: update deletion timeouts based on telemetry

### DIFF
--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -17,7 +17,7 @@
 * **Timeouts:** Add named constants in [`test/util/framework/constants.go`](util/framework/constants.go) only for durations **shared across multiple test cases** (same ARM operation, framework helper, or verifier pattern). A timeout that is unique to one test and used once can stay as a local literal (e.g. in an `Eventually` block). When several tests need the same budget, use the matching constant instead of repeating a magic number:
   * **Provisioning:** `ClusterCreationTimeout`, `NodePoolCreationTimeout`, `ExternalAuthCreationTimeout`
   * **Access Cluster:** `GetAdminRESTConfigTimeout` (for `GetAdminRESTConfigForHCPClusterYYYYMMDD` and similar credential fetches)
-  * **Deletion:** `HCPClusterDeletionTimeout` (for `DeleteHCPClusterYYYYMMDD`, inline delete pollers, and per-cluster deletes in `DeleteAllHCPClusters`)
+  * **Deletion:** `HCPClusterDeletionTimeout` (for `DeleteHCPClusterYYYYMMDD`, inline delete pollers, and per-cluster deletes in `DeleteAllHCPClusters`), `NodePoolDeletionTimeout` (for `DeleteNodePoolYYYYMMDD`), `ExternalAuthDeletionTimeout` (for `DeleteExternalAuthYYYYMMDD`)
   * **Updates:** `UpdateHCPClusterTimeout` (PATCH/update cluster properties), `HCPClusterVersionUpgradeTimeout` (control plane version upgrades), `NodePoolVersionUpgradeTimeout` (node pool version upgrades), `NodePoolScalingTimeout` (replica changes and autoscaling updates)
   Add a new constant only when a second (or later) test needs the same duration. See [`test/e2e/README.md`](e2e/README.md#updating-e2e-timeouts) for the constant table and how to tune shared values from telemetry.
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -245,6 +245,8 @@ Framework helpers include an API version suffix. See [`test/AGENTS.md`](../AGENT
 | Provisioning | `ExternalAuthCreationTimeout` | `CreateOrUpdateExternalAuthAndWait20240610` |
 | Access cluster | `GetAdminRESTConfigTimeout` | `GetAdminRESTConfigForHCPCluster20240610` |
 | Deletion | `HCPClusterDeletionTimeout` | `DeleteHCPCluster20240610`, `DeleteAllHCPClusters20240610`, inline delete pollers |
+| Deletion | `NodePoolDeletionTimeout` | `DeleteNodePool20240610`, inline node pool delete pollers |
+| Deletion | `ExternalAuthDeletionTimeout` | `DeleteExternalAuth20240610`, inline external auth delete pollers |
 | Update | `UpdateHCPClusterTimeout` | `UpdateHCPCluster20240610` (tags, IDMS, autoscaling PATCH); preview: `UpdateHCPCluster20251223` |
 | Update | `HCPClusterVersionUpgradeTimeout` | Control plane version upgrades (`UpdateHCPCluster20240610`, `Eventually` verifiers) |
 | Update | `NodePoolVersionUpgradeTimeout` | Node pool version upgrades (`UpdateNodePoolAndWait20240610`, `Eventually` verifiers) |
@@ -268,6 +270,38 @@ database('ServiceLogs').table('backendLogs')
     by resource_id, resource_type
 | where isnotempty(provisioning_time) and isnotempty(succeeded_time)
 | extend duration = succeeded_time - provisioning_time
+| summarize
+    count  = count(),
+    avg    = avg(duration),
+    p50    = percentile(duration, 50),
+    p90    = percentile(duration, 90),
+    p95    = percentile(duration, 95),
+    p99    = percentile(duration, 99),
+    p999   = percentile(duration, 99.9),
+    p9999  = percentile(duration, 99.99)
+    by resource_type
+```
+
+### Deletion durations (Kusto)
+
+For **delete** timeouts, run the following query. The key differences from the provisioning query are: `controller_name endswith 'delete'`, start is detected via `log.msg == 'checking operation'`, and end via `log.newStatus == 'Succeeded'`.
+
+```kql
+database('ServiceLogs').table('backendLogs')
+| where timestamp between (ago(7d) .. now())
+| where container_name == 'aro-hcp-backend'
+| where log.controller_name endswith 'delete'
+| where log.msg == 'checking operation'
+    or (log.msg has 'Updating operation status' and log.newStatus == 'Succeeded')
+| project timestamp, resource_id = tostring(log.resource_id), resource_type = tostring(log.resourceType),
+    is_start = log.msg == 'checking operation',
+    is_end   = log.newStatus == 'Succeeded'
+| summarize
+    start_time     = minif(timestamp, tobool(is_start)),
+    succeeded_time = minif(timestamp, tobool(is_end))
+    by resource_id, resource_type
+| where isnotempty(start_time) and isnotempty(succeeded_time)
+| extend duration = succeeded_time - start_time
 | summarize
     count  = count(),
     avg    = avg(duration),

--- a/test/e2e/gpu_nodepools_create_delete.go
+++ b/test/e2e/gpu_nodepools_create_delete.go
@@ -17,7 +17,6 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -152,7 +151,7 @@ var _ = Describe("HCP Nodepools GPU instances", func() {
 				*resourceGroup.Name,
 				customerClusterName,
 				gpuNodePoolName,
-				25*time.Minute,
+				framework.NodePoolDeletionTimeout,
 			)).To(Succeed(), "failed to delete GPU nodepool %s", gpuNodePoolName)
 
 			By("confirming GPU nodepool has been deleted")

--- a/test/util/framework/constants.go
+++ b/test/util/framework/constants.go
@@ -28,8 +28,9 @@ const (
 
 // Deletion timeouts
 const (
-	HCPClusterDeletionTimeout   = 45 * time.Minute
-	ExternalAuthDeletionTimeout = 25 * time.Minute
+	HCPClusterDeletionTimeout   = 25 * time.Minute
+	NodePoolDeletionTimeout     = 25 * time.Minute
+	ExternalAuthDeletionTimeout = 15 * time.Minute
 )
 
 // Resource Update timeouts


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-24922

### What

- Updated deletion timeout constants in `test/util/framework/constants.go`
- Replaced the inline `25*time.Minute` literal in `gpu_nodepools_create_delete.go` with the new `framework.NodePoolDeletionTimeout` constant

### Why

E2E deletion timeouts were set conservatively without data. We now have p99 provisioning/deletion telemetry across ~18k clusters, ~12k nodepools, and ~1.2k external auths, which shows the current values are too high for some and the nodepool deletion timeout was not yet extracted into a shared constant.
Updated timeouts based on observed p99 values (with headroom):
- `HCPClusterDeletionTimeout`: 45m → 25m
- `ExternalAuthDeletionTimeout`: 25m → 15m
- `NodePoolDeletionTimeout`: added at 25m as a named constant; replaces the inline `25*time.Minute` literal in `gpu_nodepools_create_delete.go`

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
