### PR TITLE
feat(mgmt-agent): add namespace watcher for HCP namespace lifecycle

### DIFF
--- a/mgmt-agent/cmd/cmd.go
+++ b/mgmt-agent/cmd/cmd.go
@@ -43,7 +43,10 @@ mgmt-agent runs two controllers under a single leader election:
 2. KSM HCP controller (enabled via --ksm-image): watches HostedControlPlane CRs
    and deploys a kube-state-metrics instance per HCP to scrape worker node health
    metrics (kube_node_status_condition, kube_node_info) from each HCP's API server.
-   Metrics are forwarded to the HCP Azure Managed Prometheus workspace.`,
+   Metrics are forwarded to the HCP Azure Managed Prometheus workspace.
+
+It also runs log-only watchers for Pod (when KSM is enabled) and selected CRD
+and core resources to aid operational troubleshooting.`,
 	}
 	subcommands := []func() (*cobra.Command, error){
 		NewControllerCommand,

--- a/mgmt-agent/pkg/controller/resourcewatcher.go
+++ b/mgmt-agent/pkg/controller/resourcewatcher.go
@@ -48,9 +48,8 @@ type ServerResourceDiscoverer interface {
 	ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error)
 }
 
-// ResourceWatcher discovers API resources matching a set of group suffixes
-// and watches them via dynamic informers, logging every event to stdout as
-// structured JSON.
+// ResourceWatcher discovers API resources matching a set of group suffixes, also
+// watches core/v1/namespaces, and logs every event via dynamic informers as structured JSON.
 type ResourceWatcher struct {
 	dynamicClient   dynamic.Interface
 	discoveryClient ServerResourceDiscoverer
@@ -64,9 +63,9 @@ func NewResourceWatcher(dynamicClient dynamic.Interface, discoveryClient ServerR
 	}
 }
 
-// Run discovers GVRs for the configured group suffixes, starts dynamic informers
-// for each, and blocks until the context is cancelled. Events are logged as
-// structured JSON via klog. A CRD informer watches for new CustomResourceDefinitions;
+// Run discovers GVRs for the configured group suffixes, also watches core/v1/namespaces,
+// starts dynamic informers for each, and blocks until the context is cancelled. Events are
+// logged as structured JSON via klog. A CRD informer watches for new CustomResourceDefinitions;
 // if a new CRD is registered whose group matches the watched suffixes and introduces
 // GVRs not known at startup, the process exits so the pod restarts and picks them up.
 func (w *ResourceWatcher) Run(ctx context.Context) error {
@@ -77,6 +76,7 @@ func (w *ResourceWatcher) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	gvrs = append(gvrs, schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"})
 	logger.Info("Discovered resources to watch", "count", len(gvrs))
 
 	knownGVRs := sets.New[schema.GroupVersionResource](gvrs...)

--- a/tooling/hcpctl/pkg/agent/prompts/references/architecture.md
+++ b/tooling/hcpctl/pkg/agent/prompts/references/architecture.md
@@ -65,7 +65,7 @@ Kusto on every relevant change:
 
 | Watcher | Log message | When emitted | Typical use |
 |---|---|---|---|
-| **ResourceWatcher** | `resource event` | Add/Update/Delete on discovered API groups (Hypershift, ACM, CAPI, `multitenancy.acn.azure.com`, …) | CR status timelines — e.g. `PodNetworkInstance` readiness |
+| **ResourceWatcher** | `resource event` | Add/Update/Delete on discovered API groups (Hypershift, ACM, CAPI, `multitenancy.acn.azure.com`, …) and core `v1/namespaces` | CR status timelines — e.g. `PodNetworkInstance` readiness; HCP namespace lifecycle (HostedCluster CR namespace + HCP control-plane namespace per cluster) |
 | **PodWatcher** | `pod event` | Pod add/delete; pod update when a container's state **type** changes (`waiting`→`running`, etc.) | Control plane pod lifecycle without scraping container logs |
 
 PodWatcher does not emit on field-level changes within the same state type (for example a new `waiting.reason` while still `waiting`).


### PR DESCRIPTION


<!-- Link to Jira issue -->

### What

feat(mgmt-agent): add namespace watcher for HCP namespace lifecycle

### Why

ARO-HCP creates two namespaces per HCP cluster deployment (the HostedCluster CR namespace and the HCP control plane namespace). Log namespace create, delete, and termination events on the management cluster to aid operational troubleshooting when those namespaces appear or get stuck terminating.

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->
Co-authored-by: Cursor <cursoragent@cursor.com>

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
