### PR TITLE
Update observability/OWNERS with people representing SRE

### DIFF
--- a/observability/OWNERS
+++ b/observability/OWNERS
@@ -3,3 +3,9 @@ approvers:
 - geoberle
 - raelga
 - service-lifecycle-approvers
+- swiencki
+- tuxerrante
+- tsatam
+- hawkowl
+- SudoBrendan
+- ehvs


### PR DESCRIPTION
**What**

Adds SRE team members as owners of the observability/ directory

  **Why**

  The SRE team is the primary consumer of Grafana dashboards, alerts, and recording rules defined under observability/. Today, changes to dashboards, alert thresholds, or recording rules require approval from the current owners, which creates unnecessary friction for improvements that the SRE team is best positioned to evaluate.

  Granting ownership allows SRE to iterate autonomously on:
  - Grafana dashboards (especially sre/user-journey/ and sre/cluster-health/)
  - Alert definitions and routing (alerts-sre-*.yaml, alerts/)
  - Recording rules
  - Prometheus and arobit configuration

  This does not remove existing owners -- it adds SRE alongside them.