### PR TITLE
fix: add Security Reader role to cluster-api-azure managed identity

### DIFF
--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/examples/2024-06-10-preview/HcpOperatorIdentityRoleSets_Get_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/examples/2024-06-10-preview/HcpOperatorIdentityRoleSets_Get_MaximumSet_Gen.json
@@ -19,6 +19,10 @@
                 {
                   "name": "Azure Red Hat OpenShift Hosted Control Planes Cluster API Provider",
                   "resourceId": "/providers/Microsoft.Authorization/roleDefinitions/88366f10-ed47-4cc0-9fab-c8a06148393e"
+                },
+                {
+                  "name": "Security Reader",
+                  "resourceId": "/providers/Microsoft.Authorization/roleDefinitions/39bc4728-0917-49c7-9d2c-d95423bc2eb4"
                 }
               ]
             },

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/examples/2024-06-10-preview/HcpOperatorIdentityRoleSets_List_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/examples/2024-06-10-preview/HcpOperatorIdentityRoleSets_List_MaximumSet_Gen.json
@@ -20,6 +20,10 @@
                     {
                       "name": "Azure Red Hat OpenShift Hosted Control Planes Cluster API Provider",
                       "resourceId": "/providers/Microsoft.Authorization/roleDefinitions/88366f10-ed47-4cc0-9fab-c8a06148393e"
+                    },
+                    {
+                      "name": "Security Reader",
+                      "resourceId": "/providers/Microsoft.Authorization/roleDefinitions/39bc4728-0917-49c7-9d2c-d95423bc2eb4"
                     }
                   ]
                 },

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/examples/2025-12-23-preview/HcpOperatorIdentityRoleSets_Get_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/examples/2025-12-23-preview/HcpOperatorIdentityRoleSets_Get_MaximumSet_Gen.json
@@ -19,6 +19,10 @@
                 {
                   "name": "Azure Red Hat OpenShift Hosted Control Planes Cluster API Provider",
                   "resourceId": "/providers/Microsoft.Authorization/roleDefinitions/88366f10-ed47-4cc0-9fab-c8a06148393e"
+                },
+                {
+                  "name": "Security Reader",
+                  "resourceId": "/providers/Microsoft.Authorization/roleDefinitions/39bc4728-0917-49c7-9d2c-d95423bc2eb4"
                 }
               ]
             },

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/examples/2025-12-23-preview/HcpOperatorIdentityRoleSets_List_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/examples/2025-12-23-preview/HcpOperatorIdentityRoleSets_List_MaximumSet_Gen.json
@@ -20,6 +20,10 @@
                     {
                       "name": "Azure Red Hat OpenShift Hosted Control Planes Cluster API Provider",
                       "resourceId": "/providers/Microsoft.Authorization/roleDefinitions/88366f10-ed47-4cc0-9fab-c8a06148393e"
+                    },
+                    {
+                      "name": "Security Reader",
+                      "resourceId": "/providers/Microsoft.Authorization/roleDefinitions/39bc4728-0917-49c7-9d2c-d95423bc2eb4"
                     }
                   ]
                 },

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/examples/2026-06-30-preview/HcpOperatorIdentityRoleSets_Get_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/examples/2026-06-30-preview/HcpOperatorIdentityRoleSets_Get_MaximumSet_Gen.json
@@ -19,6 +19,10 @@
                 {
                   "name": "Azure Red Hat OpenShift Hosted Control Planes Cluster API Provider",
                   "resourceId": "/providers/Microsoft.Authorization/roleDefinitions/88366f10-ed47-4cc0-9fab-c8a06148393e"
+                },
+                {
+                  "name": "Security Reader",
+                  "resourceId": "/providers/Microsoft.Authorization/roleDefinitions/39bc4728-0917-49c7-9d2c-d95423bc2eb4"
                 }
               ]
             },

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/examples/2026-06-30-preview/HcpOperatorIdentityRoleSets_List_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/examples/2026-06-30-preview/HcpOperatorIdentityRoleSets_List_MaximumSet_Gen.json
@@ -20,6 +20,10 @@
                     {
                       "name": "Azure Red Hat OpenShift Hosted Control Planes Cluster API Provider",
                       "resourceId": "/providers/Microsoft.Authorization/roleDefinitions/88366f10-ed47-4cc0-9fab-c8a06148393e"
+                    },
+                    {
+                      "name": "Security Reader",
+                      "resourceId": "/providers/Microsoft.Authorization/roleDefinitions/39bc4728-0917-49c7-9d2c-d95423bc2eb4"
                     }
                   ]
                 },

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2024-06-10-preview/examples/HcpOperatorIdentityRoleSets_Get_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2024-06-10-preview/examples/HcpOperatorIdentityRoleSets_Get_MaximumSet_Gen.json
@@ -19,6 +19,10 @@
                 {
                   "name": "Azure Red Hat OpenShift Hosted Control Planes Cluster API Provider",
                   "resourceId": "/providers/Microsoft.Authorization/roleDefinitions/88366f10-ed47-4cc0-9fab-c8a06148393e"
+                },
+                {
+                  "name": "Security Reader",
+                  "resourceId": "/providers/Microsoft.Authorization/roleDefinitions/39bc4728-0917-49c7-9d2c-d95423bc2eb4"
                 }
               ]
             },

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2024-06-10-preview/examples/HcpOperatorIdentityRoleSets_List_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2024-06-10-preview/examples/HcpOperatorIdentityRoleSets_List_MaximumSet_Gen.json
@@ -20,6 +20,10 @@
                     {
                       "name": "Azure Red Hat OpenShift Hosted Control Planes Cluster API Provider",
                       "resourceId": "/providers/Microsoft.Authorization/roleDefinitions/88366f10-ed47-4cc0-9fab-c8a06148393e"
+                    },
+                    {
+                      "name": "Security Reader",
+                      "resourceId": "/providers/Microsoft.Authorization/roleDefinitions/39bc4728-0917-49c7-9d2c-d95423bc2eb4"
                     }
                   ]
                 },

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2025-12-23-preview/examples/HcpOperatorIdentityRoleSets_Get_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2025-12-23-preview/examples/HcpOperatorIdentityRoleSets_Get_MaximumSet_Gen.json
@@ -19,6 +19,10 @@
                 {
                   "name": "Azure Red Hat OpenShift Hosted Control Planes Cluster API Provider",
                   "resourceId": "/providers/Microsoft.Authorization/roleDefinitions/88366f10-ed47-4cc0-9fab-c8a06148393e"
+                },
+                {
+                  "name": "Security Reader",
+                  "resourceId": "/providers/Microsoft.Authorization/roleDefinitions/39bc4728-0917-49c7-9d2c-d95423bc2eb4"
                 }
               ]
             },

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2025-12-23-preview/examples/HcpOperatorIdentityRoleSets_List_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2025-12-23-preview/examples/HcpOperatorIdentityRoleSets_List_MaximumSet_Gen.json
@@ -20,6 +20,10 @@
                     {
                       "name": "Azure Red Hat OpenShift Hosted Control Planes Cluster API Provider",
                       "resourceId": "/providers/Microsoft.Authorization/roleDefinitions/88366f10-ed47-4cc0-9fab-c8a06148393e"
+                    },
+                    {
+                      "name": "Security Reader",
+                      "resourceId": "/providers/Microsoft.Authorization/roleDefinitions/39bc4728-0917-49c7-9d2c-d95423bc2eb4"
                     }
                   ]
                 },

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2026-06-30-preview/examples/HcpOperatorIdentityRoleSets_Get_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2026-06-30-preview/examples/HcpOperatorIdentityRoleSets_Get_MaximumSet_Gen.json
@@ -19,6 +19,10 @@
                 {
                   "name": "Azure Red Hat OpenShift Hosted Control Planes Cluster API Provider",
                   "resourceId": "/providers/Microsoft.Authorization/roleDefinitions/88366f10-ed47-4cc0-9fab-c8a06148393e"
+                },
+                {
+                  "name": "Security Reader",
+                  "resourceId": "/providers/Microsoft.Authorization/roleDefinitions/39bc4728-0917-49c7-9d2c-d95423bc2eb4"
                 }
               ]
             },

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2026-06-30-preview/examples/HcpOperatorIdentityRoleSets_List_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2026-06-30-preview/examples/HcpOperatorIdentityRoleSets_List_MaximumSet_Gen.json
@@ -20,6 +20,10 @@
                     {
                       "name": "Azure Red Hat OpenShift Hosted Control Planes Cluster API Provider",
                       "resourceId": "/providers/Microsoft.Authorization/roleDefinitions/88366f10-ed47-4cc0-9fab-c8a06148393e"
+                    },
+                    {
+                      "name": "Security Reader",
+                      "resourceId": "/providers/Microsoft.Authorization/roleDefinitions/39bc4728-0917-49c7-9d2c-d95423bc2eb4"
                     }
                   ]
                 },

--- a/cluster-service/values.yaml
+++ b/cluster-service/values.yaml
@@ -231,6 +231,8 @@ azureOperatorsMI:
       roleDefinitions:
       - id: 88366f10-ed47-4cc0-9fab-c8a06148393e
         name: Azure Red Hat OpenShift Hosted Control Planes Cluster API Provider
+      - id: 39bc4728-0917-49c7-9d2c-d95423bc2eb4
+        name: Security Reader
     controlPlane:
       roleDefinitions:
       - id: fc0c873f-45e9-4d0d-a7d1-585aab30c6ed
@@ -272,6 +274,8 @@ azureOperatorsMI:
       roleDefinitions:
       - id: 88366f10-ed47-4cc0-9fab-c8a06148393e
         name: Azure Red Hat OpenShift Hosted Control Planes Cluster API Provider
+      - id: 39bc4728-0917-49c7-9d2c-d95423bc2eb4
+        name: Security Reader
     controlPlane:
       roleDefinitions:
       - id: fc0c873f-45e9-4d0d-a7d1-585aab30c6ed

--- a/demo/bicep/cluster.bicep
+++ b/demo/bicep/cluster.bicep
@@ -97,6 +97,23 @@ resource hcpClusterApiProviderRoleSubnetAssignment 'Microsoft.Authorization/role
   }
 }
 
+// Security Reader: View permissions for Microsoft Defender for Cloud.
+// https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/security#security-reader
+var securityReaderRoleId = subscriptionResourceId(
+  'Microsoft.Authorization/roleDefinitions',
+  '39bc4728-0917-49c7-9d2c-d95423bc2eb4'
+)
+
+resource clusterApiAzureSecurityReaderRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(resourceGroup().id, clusterApiAzureMi.id, securityReaderRoleId)
+  scope: resourceGroup()
+  properties: {
+    principalId: clusterApiAzureMi.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: securityReaderRoleId
+  }
+}
+
 resource serviceManagedIdentityReaderOnClusterApiAzureMi 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   name: guid(resourceGroup().id, serviceManagedIdentity.id, readerRoleId, clusterApiAzureMi.id)
   scope: clusterApiAzureMi

--- a/internal/azure/cluster_scoped_identities_config.go
+++ b/internal/azure/cluster_scoped_identities_config.go
@@ -491,6 +491,16 @@ func newClusterScopedOperatorsIdentitySpecs() map[ClusterOperatorIdentifier]*clu
 								ResourceID:      api.Must(azcorearm.ParseResourceID("/providers/Microsoft.Authorization/roleDefinitions/88366f10-ed47-4cc0-9fab-c8a06148393e")),
 							},
 						},
+						{
+							Dev: &ClusterScopedIdentityRoleDefinition{
+								DescriptiveName: "Security Reader",
+								ResourceID:      api.Must(azcorearm.ParseResourceID("/providers/Microsoft.Authorization/roleDefinitions/39bc4728-0917-49c7-9d2c-d95423bc2eb4")),
+							},
+							Public: &ClusterScopedIdentityRoleDefinition{
+								DescriptiveName: "Security Reader",
+								ResourceID:      api.Must(azcorearm.ParseResourceID("/providers/Microsoft.Authorization/roleDefinitions/39bc4728-0917-49c7-9d2c-d95423bc2eb4")),
+							},
+						},
 					},
 				},
 			},

--- a/test/e2e-setup/bicep/modules-4.19/non-msi-scoped-assignments.bicep
+++ b/test/e2e-setup/bicep/modules-4.19/non-msi-scoped-assignments.bicep
@@ -86,6 +86,23 @@ resource hcpClusterApiProviderRoleSubnetAssignment 'Microsoft.Authorization/role
   }
 }
 
+// Security Reader: View permissions for Microsoft Defender for Cloud.
+// https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/security#security-reader
+var securityReaderRoleId = subscriptionResourceId(
+  'Microsoft.Authorization/roleDefinitions',
+  '39bc4728-0917-49c7-9d2c-d95423bc2eb4'
+)
+
+resource clusterApiAzureSecurityReaderRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(resourceGroup().id, clusterApiAzureMi.id, securityReaderRoleId)
+  scope: resourceGroup()
+  properties: {
+    principalId: clusterApiAzureMi.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: securityReaderRoleId
+  }
+}
+
 
 //
 // C O N T R O L   P L A N E   O P E R A T O R   M A N A G E D   I D E N T I T Y

--- a/test/e2e-setup/bicep/modules/non-msi-scoped-assignments.bicep
+++ b/test/e2e-setup/bicep/modules/non-msi-scoped-assignments.bicep
@@ -93,6 +93,23 @@ resource hcpClusterApiProviderRoleSubnetAssignment 'Microsoft.Authorization/role
   }
 }
 
+// Security Reader: View permissions for Microsoft Defender for Cloud.
+// https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/security#security-reader
+var securityReaderRoleId = subscriptionResourceId(
+  'Microsoft.Authorization/roleDefinitions',
+  '39bc4728-0917-49c7-9d2c-d95423bc2eb4'
+)
+
+resource clusterApiAzureSecurityReaderRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(resourceGroup().id, clusterApiAzureMi.id, securityReaderRoleId)
+  scope: resourceGroup()
+  properties: {
+    principalId: clusterApiAzureMi.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: securityReaderRoleId
+  }
+}
+
 
 //
 // C O N T R O L   P L A N E   O P E R A T O R   M A N A G E D   I D E N T I T Y


### PR DESCRIPTION
### What

fix: add Security Reader role to cluster-api-azure managed identity

### Why

AuditIfNotExists policy actions on worker VMs in the managed resource group were failing because the CAPI provider identity lacked permission to GET Microsoft.Security/assessments. Assign the built-in Security Reader role (39bc4728-0917-49c7-9d2c-d95423bc2eb4) to cluster-api-azure for both dev and public role sets so the identity can satisfy Defender policy evaluation. New clusters will receive this role assignment on the MRG automatically as part of the standard provisioning flow.

[ARO-27739](https://redhat.atlassian.net/browse/ARO-27739)

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

Co-authored-by: Cursor <cursoragent@cursor.com>

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
