### PR TITLE
fix: redacting CreatedBy and LastModifiedBy from SystemData

### DIFF
--- a/internal/serverutils/dump_data.go
+++ b/internal/serverutils/dump_data.go
@@ -16,15 +16,20 @@ package serverutils
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
 	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
+
+const RedactStr = "REDACTED"
 
 // DumpDataToLogger writes a structured-log entry for every document related
 // to resourceID. It covers three storage layers:
@@ -61,6 +66,10 @@ func DumpDataToLogger(
 	if err != nil {
 		return utils.TrackError(err)
 	}
+	err = redactTypedDocument(startingCosmosRecord)
+	if err != nil {
+		return utils.TrackError(err)
+	}
 	logger.Info(fmt.Sprintf("dumping resourceID %v", startingCosmosRecord.ResourceID),
 		"currentResourceID", resourceIDToString(startingCosmosRecord.ResourceID),
 		"content", startingCosmosRecord,
@@ -73,6 +82,10 @@ func DumpDataToLogger(
 
 	errs := []error{}
 	for _, typedDocument := range allCosmosRecords.Items(ctx) {
+		if err := redactTypedDocument(typedDocument); err != nil {
+			errs = append(errs, utils.TrackError(err))
+			continue
+		}
 		logger.Info(fmt.Sprintf("dumping resourceID %v", typedDocument.ResourceID),
 			"currentResourceID", resourceIDToString(typedDocument.ResourceID),
 			"content", typedDocument,
@@ -211,5 +224,44 @@ func DumpBillingToLogger(ctx context.Context, resourcesDBClient database.Resourc
 		"content", billingDoc,
 	)
 
+	return nil
+}
+
+func redactTypedDocument(d *database.TypedDocument) error {
+	if d == nil {
+		return fmt.Errorf("typed document is nil")
+	}
+
+	if len(d.Properties) == 0 {
+		return nil
+	}
+
+	var props unstructured.Unstructured
+	if err := json.Unmarshal(d.Properties, &props.Object); err != nil {
+		return fmt.Errorf("failed to unmarshal typed document properties for %s: %w", resourceIDToString(d.ResourceID), err)
+	}
+
+	if _, found, err := unstructured.NestedString(props.Object, "systemData", "createdBy"); err != nil {
+		return fmt.Errorf("failed to read systemData.createdBy for %s: %w", resourceIDToString(d.ResourceID), err)
+	} else if found {
+		if err := unstructured.SetNestedField(props.Object, RedactStr, "systemData", "createdBy"); err != nil {
+			return fmt.Errorf("failed to set systemData.createdBy for %s: %w", resourceIDToString(d.ResourceID), err)
+		}
+	}
+
+	if _, found, err := unstructured.NestedString(props.Object, "systemData", "lastModifiedBy"); err != nil {
+		return fmt.Errorf("failed to read systemData.lastModifiedBy for %s: %w", resourceIDToString(d.ResourceID), err)
+	} else if found {
+		if err := unstructured.SetNestedField(props.Object, RedactStr, "systemData", "lastModifiedBy"); err != nil {
+			return fmt.Errorf("failed to set systemData.lastModifiedBy for %s: %w", resourceIDToString(d.ResourceID), err)
+		}
+	}
+
+	redactedProps, err := json.Marshal(props.Object)
+	if err != nil {
+		return fmt.Errorf("failed to marshal redacted typed document properties for %s: %w", resourceIDToString(d.ResourceID), err)
+	}
+
+	d.Properties = redactedProps
 	return nil
 }

--- a/internal/serverutils/dump_data_test.go
+++ b/internal/serverutils/dump_data_test.go
@@ -1,0 +1,209 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package serverutils
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/database"
+)
+
+func TestRedactTypedDocument_RedactsSupportedResourceTypes(t *testing.T) {
+	tests := []struct {
+		name         string
+		resourceID   string
+		resourceType string
+		newDocument  func() (any, *database.TypedDocument)
+	}{
+		{
+			name:         "cluster",
+			resourceID:   api.TestClusterResourceID,
+			resourceType: api.ClusterResourceType.String(),
+			newDocument: func() (any, *database.TypedDocument) {
+				resourceID := mustParseResourceID(t, api.TestClusterResourceID)
+				createdAt := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+				obj := &api.HCPOpenShiftCluster{
+					TrackedResource: arm.TrackedResource{
+						Resource: arm.Resource{
+							ID:   resourceID,
+							Name: resourceID.Name,
+							Type: api.ClusterResourceType.String(),
+							SystemData: &arm.SystemData{
+								CreatedBy:      "cluster-created-by",
+								LastModifiedBy: "cluster-last-modified-by",
+								CreatedAt:      &createdAt,
+							},
+						},
+					},
+				}
+				return obj, newTypedDocument(t, resourceID, api.ClusterResourceType.String(), obj)
+			},
+		},
+		{
+			name:         "nodepool",
+			resourceID:   api.TestNodePoolResourceID,
+			resourceType: api.NodePoolResourceType.String(),
+			newDocument: func() (any, *database.TypedDocument) {
+				resourceID := mustParseResourceID(t, api.TestNodePoolResourceID)
+				createdAt := time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC)
+				obj := &api.HCPOpenShiftClusterNodePool{
+					TrackedResource: arm.TrackedResource{
+						Resource: arm.Resource{
+							ID:   resourceID,
+							Name: resourceID.Name,
+							Type: api.NodePoolResourceType.String(),
+							SystemData: &arm.SystemData{
+								CreatedBy:      "nodepool-created-by",
+								LastModifiedBy: "nodepool-last-modified-by",
+								CreatedAt:      &createdAt,
+							},
+						},
+					},
+				}
+				return obj, newTypedDocument(t, resourceID, api.NodePoolResourceType.String(), obj)
+			},
+		},
+		{
+			name:         "external-auth",
+			resourceID:   api.TestExternalAuthResourceID,
+			resourceType: api.ExternalAuthResourceType.String(),
+			newDocument: func() (any, *database.TypedDocument) {
+				resourceID := mustParseResourceID(t, api.TestExternalAuthResourceID)
+				createdAt := time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC)
+				obj := &api.HCPOpenShiftClusterExternalAuth{
+					ProxyResource: arm.ProxyResource{
+						Resource: arm.Resource{
+							ID:   resourceID,
+							Name: resourceID.Name,
+							Type: api.ExternalAuthResourceType.String(),
+							SystemData: &arm.SystemData{
+								CreatedBy:      "external-auth-created-by",
+								LastModifiedBy: "external-auth-last-modified-by",
+								CreatedAt:      &createdAt,
+							},
+						},
+					},
+				}
+				return obj, newTypedDocument(t, resourceID, api.ExternalAuthResourceType.String(), obj)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expectedObject, doc := tt.newDocument()
+			originalProperties := append(json.RawMessage(nil), doc.Properties...)
+
+			if err := redactTypedDocument(doc); err != nil {
+				t.Fatalf("redactTypedDocument() error = %v", err)
+			}
+
+			if doc.ResourceType != tt.resourceType {
+				t.Fatalf("ResourceType = %q, want %q", doc.ResourceType, tt.resourceType)
+			}
+
+			if doc.ResourceID == nil {
+				t.Fatal("ResourceID was nil")
+			}
+			if doc.ResourceID.String() != tt.resourceID {
+				t.Fatalf("ResourceID = %q, want %q", doc.ResourceID.String(), tt.resourceID)
+			}
+
+			var raw map[string]any
+			if err := json.Unmarshal(doc.Properties, &raw); err != nil {
+				t.Fatalf("unmarshal redacted properties: %v", err)
+			}
+
+			systemData, ok := raw["systemData"].(map[string]any)
+			if !ok {
+				t.Fatalf("redacted properties missing systemData: %#v", raw)
+			}
+			if systemData["createdBy"] != RedactStr {
+				t.Fatalf("systemData.createdBy = %v, want %q", systemData["createdBy"], RedactStr)
+			}
+			if systemData["lastModifiedBy"] != RedactStr {
+				t.Fatalf("systemData.lastModifiedBy = %v, want %q", systemData["lastModifiedBy"], RedactStr)
+			}
+
+			if string(doc.Properties) == string(originalProperties) {
+				t.Fatalf("redacted document properties matched original properties JSON")
+			}
+
+			if expectedObject == nil {
+				t.Fatal("expected object was nil")
+			}
+		})
+	}
+}
+
+func TestRedactTypedDocument_ReturnsNestedFieldTypeError(t *testing.T) {
+	resourceID := mustParseResourceID(t, api.TestClusterResourceID)
+	doc := &database.TypedDocument{
+		BaseDocument: database.BaseDocument{
+			ID: resourceID.Name,
+		},
+		PartitionKey: resourceID.SubscriptionID,
+		ResourceID:   resourceID,
+		ResourceType: api.ClusterResourceType.String(),
+		Properties:   json.RawMessage(`{"systemData":{"createdBy":123}}`),
+	}
+
+	err := redactTypedDocument(doc)
+	if err == nil {
+		t.Fatal("redactTypedDocument() error = nil, want nested field type error")
+	}
+	if !strings.Contains(err.Error(), "failed to read systemData.createdBy") {
+		t.Fatalf("error = %q, want it to mention createdBy read failure", err.Error())
+	}
+	if !strings.Contains(err.Error(), resourceID.String()) {
+		t.Fatalf("error = %q, want it to include the resource ID", err.Error())
+	}
+}
+
+func newTypedDocument(t *testing.T, resourceID *azcorearm.ResourceID, resourceType string, properties any) *database.TypedDocument {
+	t.Helper()
+
+	propertiesBytes, err := json.Marshal(properties)
+	if err != nil {
+		t.Fatalf("marshal properties: %v", err)
+	}
+
+	return &database.TypedDocument{
+		BaseDocument: database.BaseDocument{
+			ID: resourceID.Name,
+		},
+		PartitionKey: resourceID.SubscriptionID,
+		ResourceID:   resourceID,
+		ResourceType: resourceType,
+		Properties:   propertiesBytes,
+	}
+}
+
+func mustParseResourceID(t *testing.T, resourceID string) *azcorearm.ResourceID {
+	t.Helper()
+
+	id, err := azcorearm.ParseResourceID(resourceID)
+	if err != nil {
+		t.Fatalf("parse resource ID %q: %v", resourceID, err)
+	}
+	return id
+}


### PR DESCRIPTION
[ARO-28164](https://redhat.atlassian.net/browse/ARO-28164)

What
Redacts CreatedBy and LastModifiedBy from HCP cluster data dump

Why
These can include customer email addresses

### Testing

Added unit tests to confirm the fields we need are redacted from hcp cluster, nodepool, and external auth.


### Special notes for your reviewer

I wanted a more general solution than this, so I was planning on using the same library that AKS uses, https://github.com/Azure/redact, but I ran into a number of issues. The library redacts by default, which I think is reasonable. However, some of our objects have types that are in external libraries, like arm.ResourceId, and we can't add the appropriate tags to that type to ensure they are unredacted. I'm planning on making a PR on the redact repo to add the functionality I need, but for now, this will redact the fields that we need.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [x] All comment threads resolved before merge

If E2E tests are included:

- [x] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [x] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
