### PR TITLE
fix(ci): resize DEV e2e mgmt cluster pools to mitigate conntrack and IMDS exhaustion

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1679,10 +1679,10 @@ clouds:
               systemAgentPool:
                 maxCount: 4
                 osDiskSizeGB: 32
-                vmSize: Standard_D4ds_v6
+                vmSize: Standard_D16ds_v6
               userAgentPool:
                 maxCount: 14
-                minCount: 6
+                minCount: 7
                 osDiskSizeGB: 100
                 vmSize: Standard_E16ds_v6
                 secondaryNicCount: 7
@@ -1778,10 +1778,10 @@ clouds:
               systemAgentPool:
                 maxCount: 4
                 osDiskSizeGB: 32
-                vmSize: Standard_D4ds_v6
+                vmSize: Standard_D16ds_v6
               userAgentPool:
                 maxCount: 14
-                minCount: 6
+                minCount: 7
                 osDiskSizeGB: 100
                 vmSize: Standard_E16ds_v6
                 secondaryNicCount: 7

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -630,12 +630,12 @@ mgmt:
       name: system
       osDiskSizeGB: 32
       poolCount: 1
-      vmSize: Standard_D4ds_v6
+      vmSize: Standard_D16ds_v6
       zoneRedundantMode: Auto
       zones: ""
     userAgentPool:
       maxCount: 14
-      minCount: 6
+      minCount: 7
       name: userswft
       osDiskSizeGB: 100
       poolCount: 3

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -630,12 +630,12 @@ mgmt:
       name: system
       osDiskSizeGB: 32
       poolCount: 1
-      vmSize: Standard_D4ds_v6
+      vmSize: Standard_D16ds_v6
       zoneRedundantMode: Auto
       zones: ""
     userAgentPool:
       maxCount: 14
-      minCount: 6
+      minCount: 7
       name: userswft
       osDiskSizeGB: 100
       poolCount: 3


### PR DESCRIPTION
Raise two resource limits on the ci00/ci01 mgmt AKS clusters used by the DEV e2e-parallel Prow jobs. Both pools were undersized for the ~46 HCPs a full CI mgmt cluster hosts, producing two distinct, recurring failure axes that cascade into e2e test timeouts.

1. ConntrackFull on the `system` pool (SKU D4ds_v6 -> D16ds_v6)

   The single `aks-system` node hosts every cluster-wide hostNetwork networking/observability singleton (coredns, konnectivity-agent, kube-proxy, azure-cns, azure-npm, retina-agent, cloud-node-manager, CSI node drivers, ama-metrics). Their aggregate flow count scales with the number of HCPs on the cluster. With the azure dataplane, kube-proxy sets nf_conntrack_max = 32768 * vCPU, so the 4-vCPU D4ds_v6 gets the smallest conntrack table in the cluster: 131072. Under load the node hit `nf_conntrack: table full, dropping packet` (observed "126800 out of 131072"), dropping kubelet/IMDS/DNS packets on that node. Over a rolling 7 days this hit ~24% of mgmt clusters, always on exactly the one system node.

   Because the ceiling is purely vCPU-driven (RAM buys nothing extra per core), the fix is to add cores. D16ds_v6 (16 vCPU) raises the ceiling to 524288 (4x), giving parity with the userswft workload pools and real headroom for full-load traffic. D-series is preferred over the RAM-heavy E-series since conntrack tracks vCPU, not memory.

2. IMDS throttling -> NodeNotReady -> auto-repair on the `userswft` pools (minCount 6 -> 7, i.e. 18 -> 21 nodes across poolCount 3)

   HCP payload/platform agents on the userswft nodes (cloud-provider, identity/CCM, CSI, monitoring) generate high per-VM QPS against the Azure Instance Metadata Service. IMDS throttling is enforced per-VM ("Throttle Result: Too Many Requests"), so nodes emit IMDSUnreachable; when it persists, kubelet's cloud-provider/identity paths stall, the node goes NodeNotReady, and AKS node auto-repair reimages/redeploys it, bouncing the HCP control-plane pods it carried. Over 7 days IMDSUnreachable touched ~95% of mgmt clusters and escalated to NodeNotReady on ~17% and auto-repair on ~14%.

The only short-term lever is scheduling density: because the throttle budget is per-VM, spreading the constant per-cluster HCP load over more nodes lowers per-VM IMDS QPS. A prior 15 -> 18 bump cut per-node IMDS pressure ~30-34% and roughly halved NodeNotReady/auto-repair incidents. This raises the userswft minimum a further step to 21 nodes for additional headroom.

Scope: DEV CI shards ci00 and ci01 only; higher environments already run larger system-pool SKUs and are unaffected. Rendered configs regenerated via `cd config && make materialize`.

https://redhat.atlassian.net/browse/AROSLSRE-1425
https://redhat.atlassian.net/browse/AROSLSRE-1426
