### PR TITLE
fix: disable service account token mount in FIPS check pod

### DIFF
--- a/test/util/verifiers/fips.go
+++ b/test/util/verifiers/fips.go
@@ -80,14 +80,16 @@ func checkNodeFIPSMode(ctx context.Context, kubeClient *kubernetes.Clientset, no
 		_ = kubeClient.CoreV1().Namespaces().Delete(ctx, namespace.Name, metav1.DeleteOptions{})
 	}()
 
+	disableSAToken := false
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "fips-check-",
 			Namespace:    namespace.Name,
 		},
 		Spec: corev1.PodSpec{
-			NodeName:      node.Name,
-			RestartPolicy: corev1.RestartPolicyNever,
+			NodeName:                      node.Name,
+			RestartPolicy:                 corev1.RestartPolicyNever,
+			AutomountServiceAccountToken:  &disableSAToken,
 			Containers: []corev1.Container{
 				{
 					Name:    "fips-check",

--- a/test/util/verifiers/fips.go
+++ b/test/util/verifiers/fips.go
@@ -80,6 +80,15 @@ func checkNodeFIPSMode(ctx context.Context, kubeClient *kubernetes.Clientset, no
 		_ = kubeClient.CoreV1().Namespaces().Delete(ctx, namespace.Name, metav1.DeleteOptions{})
 	}()
 
+	sa, err := kubeClient.CoreV1().ServiceAccounts(namespace.Name).Create(ctx, &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "fips-check",
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		return false, fmt.Errorf("failed to create service account: %w", err)
+	}
+
 	automountSAToken := false
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -89,6 +98,7 @@ func checkNodeFIPSMode(ctx context.Context, kubeClient *kubernetes.Clientset, no
 		Spec: corev1.PodSpec{
 			NodeName:                     node.Name,
 			RestartPolicy:                corev1.RestartPolicyNever,
+			ServiceAccountName:           sa.Name,
 			AutomountServiceAccountToken: &automountSAToken,
 			Containers: []corev1.Container{
 				{

--- a/test/util/verifiers/fips.go
+++ b/test/util/verifiers/fips.go
@@ -80,16 +80,16 @@ func checkNodeFIPSMode(ctx context.Context, kubeClient *kubernetes.Clientset, no
 		_ = kubeClient.CoreV1().Namespaces().Delete(ctx, namespace.Name, metav1.DeleteOptions{})
 	}()
 
-	disableSAToken := false
+	automountSAToken := false
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "fips-check-",
 			Namespace:    namespace.Name,
 		},
 		Spec: corev1.PodSpec{
-			NodeName:                      node.Name,
-			RestartPolicy:                 corev1.RestartPolicyNever,
-			AutomountServiceAccountToken:  &disableSAToken,
+			NodeName:                     node.Name,
+			RestartPolicy:                corev1.RestartPolicyNever,
+			AutomountServiceAccountToken: &automountSAToken,
 			Containers: []corev1.Container{
 				{
 					Name:    "fips-check",


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-1427

- Create a dedicated `fips-check` service account in the test namespace and set `ServiceAccountName` on the pod, so the ServiceAccount admission plugin does not attempt to look up the `default` SA
- Set `AutomountServiceAccountToken=false` since the pod only reads `/proc/sys/crypto/fips_enabled` and requires no Kubernetes API access
- This eliminates the dependency on the `default` service account being provisioned in newly created namespaces, which fails on HCP clusters after a kube-controller-manager rollout

https://search.dptools.openshift.org/?search=serviceaccount+%22default%22+not+found&maxAge=168h&context=1&type=bug%2Bissue%2Bjunit&name=ARO-HCP-main-e2e&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job