### PR TITLE
fix: add missing inflight request limits to xxlarge CSC tier

### DIFF
--- a/hypershiftoperator/deploy/templates/cluster.clustersizingconfiguration.yaml
+++ b/hypershiftoperator/deploy/templates/cluster.clustersizingconfiguration.yaml
@@ -210,6 +210,8 @@ spec:
       to: 999998
     effects:
       kasGoMemLimit: 72GiB
+      maximumMutatingRequestsInflight: 1000
+      maximumRequestsInflight: 3000
       resourceRequests:
       - containerName: kube-apiserver
         deploymentName: kube-apiserver


### PR DESCRIPTION
## Why

The `xxlarge` ClusterSizingConfiguration tier omits `maximumRequestsInflight` and `maximumMutatingRequestsInflight`, unlike every other tier (small–xlarge). When a cluster transitions to `xxlarge` via `cluster-size-override`, the HyperShift scheduler does not delete the previous tier's inflight annotations — causing the cluster to retain stale limits from its prior tier rather than getting the intended xxlarge values.

This is relevant now because the `DesiredHostedClusterControlPlaneSize` admin API (#5617) is deploying to prod and will be used to resize the Adobe/IBM `arohcp4` cluster.

## What

Explicitly set `maximumRequestsInflight: 3000` and `maximumMutatingRequestsInflight: 1000` on the `xxlarge` tier, matching HyperShift CPO compiled-in defaults and ARO Classic configuration.

## Jira

[AROSLSRE-1431](https://redhat.atlassian.net/browse/AROSLSRE-1431)

## Related

- [ARO-27688](https://redhat.atlassian.net/browse/ARO-27688) — Apply cluster-size-override=large on Adobe arohcp4
- [ARO-27690](https://redhat.atlassian.net/browse/ARO-27690) — Expose cluster-size-override via Admin API
- #5617 — feat: add DesiredHostedClusterControlPlaneSize knob