### PR TITLE
fix: correct off-by-one error in GetInstallVersionForZStreamUpgrade

### DIFF
--- a/test/util/framework/version_helper.go
+++ b/test/util/framework/version_helper.go
@@ -122,11 +122,12 @@ func GetInstallVersionForZStreamUpgrade(ctx context.Context, channelGroup string
 	// upgrade targets, not y-stream (next-minor) ones.
 	maxVersion := candidates[0].String()
 
-	// When candidates[i] has z-stream upgrade targets, install candidates[i+1] (the
-	// version just before it). This ensures the upgrade target is candidates[i] — a
-	// well-established version — rather than candidates[0] which may be too freshly
-	// released for HyperShift to pick up.
-	for i := 0; i < len(candidates)-1; i++ {
+	// Skip candidates[0] (the latest) — it has no same-minor upgrade targets since
+	// maxVersion equals it. For each remaining candidates[i] that has z-stream upgrade
+	// targets, install candidates[i+1] (the version just before it). This ensures the
+	// upgrade target is candidates[i] — a well-established version — rather than
+	// candidates[0] which may be too freshly released for HyperShift to pick up.
+	for i := 1; i < len(candidates)-1; i++ {
 		upgradeTargets, err := GetUpgradeCandidatesInMaxMinorFromCincinnati(ctx, channelGroup, maxVersion, candidates[i].String())
 		if err != nil {
 			return "", false, err

--- a/test/util/framework/version_helper.go
+++ b/test/util/framework/version_helper.go
@@ -101,14 +101,14 @@ func isRetryableVersionError(err error) bool {
 	return true
 }
 
+var getAllVersionsInMinor = GetAllVersionsInMinorStartingWith
+var getUpgradeCandidates = GetUpgradeCandidatesInMaxMinorFromCincinnati
+
 // GetInstallVersionForZStreamUpgrade returns the version to install the cluster with when testing
 // a z-stream upgrade, and whether that version has an available z-stream upgrade path. It uses
 // configuredVersionID and queries Cincinnati for the given channelGroup (e.g. "candidate", "stable").
 // When no version with an upgrade path is found, it still returns the configured version so the
 // caller can install and optionally skip upgrade assertions.
-var getAllVersionsInMinor = GetAllVersionsInMinorStartingWith
-var getUpgradeCandidates = GetUpgradeCandidatesInMaxMinorFromCincinnati
-
 func GetInstallVersionForZStreamUpgrade(ctx context.Context, channelGroup string, configuredVersionID string) (installVersion string, hasUpgradePath bool, err error) {
 	candidates, err := getAllVersionsInMinor(ctx, channelGroup, configuredVersionID)
 	if err != nil {

--- a/test/util/framework/version_helper.go
+++ b/test/util/framework/version_helper.go
@@ -134,7 +134,7 @@ func GetInstallVersionForZStreamUpgrade(ctx context.Context, channelGroup string
 			return "", false, err
 		}
 		if len(upgradeTargets) > 0 {
-			return candidates[i+1].String(), true, nil
+			return candidates[i].String(), true, nil
 		}
 	}
 	return candidates[0].String(), false, nil

--- a/test/util/framework/version_helper.go
+++ b/test/util/framework/version_helper.go
@@ -122,15 +122,17 @@ func GetInstallVersionForZStreamUpgrade(ctx context.Context, channelGroup string
 	// upgrade targets, not y-stream (next-minor) ones.
 	maxVersion := candidates[0].String()
 
-	// Start from candidates[1] (second-latest) because candidates[0] is already the
-	// latest in the minor and cannot z-stream upgrade further.
-	for i := 1; i < len(candidates); i++ {
+	// When candidates[i] has z-stream upgrade targets, install candidates[i+1] (the
+	// version just before it). This ensures the upgrade target is candidates[i] — a
+	// well-established version — rather than candidates[0] which may be too freshly
+	// released for HyperShift to pick up.
+	for i := 0; i < len(candidates)-1; i++ {
 		upgradeTargets, err := GetUpgradeCandidatesInMaxMinorFromCincinnati(ctx, channelGroup, maxVersion, candidates[i].String())
 		if err != nil {
 			return "", false, err
 		}
 		if len(upgradeTargets) > 0 {
-			return candidates[i].String(), true, nil
+			return candidates[i+1].String(), true, nil
 		}
 	}
 	return candidates[0].String(), false, nil

--- a/test/util/framework/version_helper.go
+++ b/test/util/framework/version_helper.go
@@ -118,17 +118,13 @@ func GetInstallVersionForZStreamUpgrade(ctx context.Context, channelGroup string
 		return candidates[0].String(), false, nil
 	}
 
-	nextMinorStr := fmt.Sprintf("%d.%d", candidates[0].Major, candidates[0].Minor+1)
-	maxVersion, err := GetLatestVersionInMinor(ctx, channelGroup, nextMinorStr)
-	if err != nil {
-		if !cincinnati.IsCincinnatiVersionNotFoundError(err) {
-			return "", false, err
-		}
-		// we don't have the next minor, use the max version in the current minor
-		maxVersion = candidates[0].String()
-	}
+	// Use the current minor's latest as maxVersion so we find z-stream (same-minor)
+	// upgrade targets, not y-stream (next-minor) ones.
+	maxVersion := candidates[0].String()
 
-	for i := 0; i < len(candidates)-1; i++ {
+	// Start from candidates[1] (second-latest) because candidates[0] is already the
+	// latest in the minor and cannot z-stream upgrade further.
+	for i := 1; i < len(candidates); i++ {
 		upgradeTargets, err := GetUpgradeCandidatesInMaxMinorFromCincinnati(ctx, channelGroup, maxVersion, candidates[i].String())
 		if err != nil {
 			return "", false, err

--- a/test/util/framework/version_helper.go
+++ b/test/util/framework/version_helper.go
@@ -122,11 +122,10 @@ func GetInstallVersionForZStreamUpgrade(ctx context.Context, channelGroup string
 	// upgrade targets, not y-stream (next-minor) ones.
 	maxVersion := candidates[0].String()
 
-	// Skip candidates[0] (the latest) — it has no same-minor upgrade targets since
-	// maxVersion equals it. For each remaining candidates[i] that has z-stream upgrade
-	// targets, install candidates[i+1] (the version just before it). This ensures the
-	// upgrade target is candidates[i] — a well-established version — rather than
-	// candidates[0] which may be too freshly released for HyperShift to pick up.
+	// Skip candidates[0] (the latest) — it has no same-minor upgrade targets since maxVersion equals it.
+	// For each candidates[i] that has any same-minor upgrade targets, install candidates[i+1] (one patch older).
+	// This biases the next upgrade away from candidates[0] (which may be too freshly released for HyperShift to pick up)
+	// and toward a more established target version in the same minor.
 	for i := 1; i < len(candidates)-1; i++ {
 		upgradeTargets, err := GetUpgradeCandidatesInMaxMinorFromCincinnati(ctx, channelGroup, maxVersion, candidates[i].String())
 		if err != nil {

--- a/test/util/framework/version_helper.go
+++ b/test/util/framework/version_helper.go
@@ -106,8 +106,11 @@ func isRetryableVersionError(err error) bool {
 // configuredVersionID and queries Cincinnati for the given channelGroup (e.g. "candidate", "stable").
 // When no version with an upgrade path is found, it still returns the configured version so the
 // caller can install and optionally skip upgrade assertions.
+var getAllVersionsInMinor = GetAllVersionsInMinorStartingWith
+var getUpgradeCandidates = GetUpgradeCandidatesInMaxMinorFromCincinnati
+
 func GetInstallVersionForZStreamUpgrade(ctx context.Context, channelGroup string, configuredVersionID string) (installVersion string, hasUpgradePath bool, err error) {
-	candidates, err := GetAllVersionsInMinorStartingWith(ctx, channelGroup, configuredVersionID)
+	candidates, err := getAllVersionsInMinor(ctx, channelGroup, configuredVersionID)
 	if err != nil {
 		return "", false, err
 	}
@@ -127,7 +130,7 @@ func GetInstallVersionForZStreamUpgrade(ctx context.Context, channelGroup string
 	// This biases the next upgrade away from candidates[0] (which may be too freshly released for HyperShift to pick up)
 	// and toward a more established target version in the same minor.
 	for i := 1; i < len(candidates)-1; i++ {
-		upgradeTargets, err := GetUpgradeCandidatesInMaxMinorFromCincinnati(ctx, channelGroup, maxVersion, candidates[i].String())
+		upgradeTargets, err := getUpgradeCandidates(ctx, channelGroup, maxVersion, candidates[i].String())
 		if err != nil {
 			return "", false, err
 		}

--- a/test/util/framework/version_helper_test.go
+++ b/test/util/framework/version_helper_test.go
@@ -1,0 +1,224 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/blang/semver/v4"
+)
+
+func overrideGetAllVersionsInMinor(t *testing.T, fn func(ctx context.Context, channelGroup string, version string) ([]semver.Version, error)) {
+	t.Helper()
+	orig := getAllVersionsInMinor
+	getAllVersionsInMinor = fn
+	t.Cleanup(func() { getAllVersionsInMinor = orig })
+}
+
+func overrideGetUpgradeCandidates(t *testing.T, fn func(ctx context.Context, channelGroup string, maxVersion string, fromVersion string) ([]semver.Version, error)) {
+	t.Helper()
+	orig := getUpgradeCandidates
+	getUpgradeCandidates = fn
+	t.Cleanup(func() { getUpgradeCandidates = orig })
+}
+
+func v(s string) semver.Version {
+	return semver.MustParse(s)
+}
+
+func TestGetInstallVersionForZStreamUpgrade_ReturnsOlderVersionForUpgrade(t *testing.T) {
+	// candidates: 4.19.39, 4.19.38, 4.19.37, 4.19.36 (descending)
+	// candidates[1] (4.19.38) has upgrade targets → install candidates[2] (4.19.37)
+	overrideGetAllVersionsInMinor(t, func(_ context.Context, _ string, _ string) ([]semver.Version, error) {
+		return []semver.Version{v("4.19.39"), v("4.19.38"), v("4.19.37"), v("4.19.36")}, nil
+	})
+	overrideGetUpgradeCandidates(t, func(_ context.Context, _ string, maxVersion string, fromVersion string) ([]semver.Version, error) {
+		if maxVersion != "4.19.39" {
+			t.Errorf("maxVersion should be same-minor latest 4.19.39, got %s", maxVersion)
+		}
+		if fromVersion == "4.19.39" {
+			t.Error("should never query candidates[0] (4.19.39) — loop must start at i=1")
+		}
+		if fromVersion == "4.19.38" {
+			return []semver.Version{v("4.19.39")}, nil
+		}
+		return nil, nil
+	})
+
+	install, hasUpgrade, err := GetInstallVersionForZStreamUpgrade(context.Background(), "candidate", "4.19.25")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if install != "4.19.37" {
+		t.Errorf("expected install=4.19.37 (candidates[i+1]), got %s", install)
+	}
+	if !hasUpgrade {
+		t.Error("expected hasUpgradePath=true")
+	}
+}
+
+func TestGetInstallVersionForZStreamUpgrade_SkipsLatestCandidate(t *testing.T) {
+	// Verify candidates[0] is never queried for upgrade targets
+	overrideGetAllVersionsInMinor(t, func(_ context.Context, _ string, _ string) ([]semver.Version, error) {
+		return []semver.Version{v("4.20.30"), v("4.20.29"), v("4.20.28")}, nil
+	})
+
+	queriedVersions := make(map[string]bool)
+	overrideGetUpgradeCandidates(t, func(_ context.Context, _ string, _ string, fromVersion string) ([]semver.Version, error) {
+		queriedVersions[fromVersion] = true
+		if fromVersion == "4.20.29" {
+			return []semver.Version{v("4.20.30")}, nil
+		}
+		return nil, nil
+	})
+
+	_, _, err := GetInstallVersionForZStreamUpgrade(context.Background(), "candidate", "4.20")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if queriedVersions["4.20.30"] {
+		t.Error("must not query candidates[0] (4.20.30) for upgrade targets")
+	}
+	if !queriedVersions["4.20.29"] {
+		t.Error("should have queried candidates[1] (4.20.29)")
+	}
+}
+
+func TestGetInstallVersionForZStreamUpgrade_UsesSameMinorMaxVersion(t *testing.T) {
+	overrideGetAllVersionsInMinor(t, func(_ context.Context, _ string, _ string) ([]semver.Version, error) {
+		return []semver.Version{v("4.21.10"), v("4.21.9"), v("4.21.8")}, nil
+	})
+	overrideGetUpgradeCandidates(t, func(_ context.Context, _ string, maxVersion string, _ string) ([]semver.Version, error) {
+		if maxVersion != "4.21.10" {
+			t.Errorf("maxVersion must be same-minor latest (4.21.10), got %s", maxVersion)
+		}
+		return nil, nil
+	})
+
+	GetInstallVersionForZStreamUpgrade(context.Background(), "candidate", "4.21")
+}
+
+func TestGetInstallVersionForZStreamUpgrade_NoUpgradePath(t *testing.T) {
+	overrideGetAllVersionsInMinor(t, func(_ context.Context, _ string, _ string) ([]semver.Version, error) {
+		return []semver.Version{v("4.22.5"), v("4.22.4"), v("4.22.3")}, nil
+	})
+	overrideGetUpgradeCandidates(t, func(_ context.Context, _ string, _ string, _ string) ([]semver.Version, error) {
+		return nil, nil
+	})
+
+	install, hasUpgrade, err := GetInstallVersionForZStreamUpgrade(context.Background(), "candidate", "4.22")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if install != "4.22.5" {
+		t.Errorf("expected latest version 4.22.5 when no upgrade path, got %s", install)
+	}
+	if hasUpgrade {
+		t.Error("expected hasUpgradePath=false")
+	}
+}
+
+func TestGetInstallVersionForZStreamUpgrade_SingleCandidate(t *testing.T) {
+	overrideGetAllVersionsInMinor(t, func(_ context.Context, _ string, _ string) ([]semver.Version, error) {
+		return []semver.Version{v("4.23.1")}, nil
+	})
+
+	install, hasUpgrade, err := GetInstallVersionForZStreamUpgrade(context.Background(), "candidate", "4.23")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if install != "4.23.1" {
+		t.Errorf("expected 4.23.1, got %s", install)
+	}
+	if hasUpgrade {
+		t.Error("expected hasUpgradePath=false with single candidate")
+	}
+}
+
+func TestGetInstallVersionForZStreamUpgrade_TwoCandidates(t *testing.T) {
+	// With only 2 candidates, the only upgrade target would be candidates[0]
+	// (the freshest), so hasUpgradePath should be false.
+	overrideGetAllVersionsInMinor(t, func(_ context.Context, _ string, _ string) ([]semver.Version, error) {
+		return []semver.Version{v("4.19.39"), v("4.19.38")}, nil
+	})
+	overrideGetUpgradeCandidates(t, func(_ context.Context, _ string, _ string, fromVersion string) ([]semver.Version, error) {
+		t.Errorf("should not query upgrade targets with only 2 candidates, but queried %s", fromVersion)
+		return nil, nil
+	})
+
+	install, hasUpgrade, err := GetInstallVersionForZStreamUpgrade(context.Background(), "candidate", "4.19.25")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if install != "4.19.39" {
+		t.Errorf("expected latest 4.19.39, got %s", install)
+	}
+	if hasUpgrade {
+		t.Error("expected hasUpgradePath=false with only 2 candidates")
+	}
+}
+
+func TestGetInstallVersionForZStreamUpgrade_NoCandidates(t *testing.T) {
+	overrideGetAllVersionsInMinor(t, func(_ context.Context, _ string, _ string) ([]semver.Version, error) {
+		return nil, nil
+	})
+
+	_, _, err := GetInstallVersionForZStreamUpgrade(context.Background(), "candidate", "4.99")
+	if err == nil {
+		t.Fatal("expected error for empty candidates")
+	}
+}
+
+func TestGetInstallVersionForZStreamUpgrade_UpgradeErrorPropagated(t *testing.T) {
+	overrideGetAllVersionsInMinor(t, func(_ context.Context, _ string, _ string) ([]semver.Version, error) {
+		return []semver.Version{v("4.19.5"), v("4.19.4"), v("4.19.3")}, nil
+	})
+	overrideGetUpgradeCandidates(t, func(_ context.Context, _ string, _ string, _ string) ([]semver.Version, error) {
+		return nil, fmt.Errorf("cincinnati unavailable")
+	})
+
+	_, _, err := GetInstallVersionForZStreamUpgrade(context.Background(), "candidate", "4.19")
+	if err == nil {
+		t.Fatal("expected error to propagate")
+	}
+}
+
+func TestGetInstallVersionForZStreamUpgrade_FirstWithUpgradeTargetsWins(t *testing.T) {
+	// candidates: 4.19.5, 4.19.4, 4.19.3, 4.19.2 (descending)
+	// candidates[1] (4.19.4) has no targets, candidates[2] (4.19.3) has targets
+	// → install candidates[3] (4.19.2)
+	overrideGetAllVersionsInMinor(t, func(_ context.Context, _ string, _ string) ([]semver.Version, error) {
+		return []semver.Version{v("4.19.5"), v("4.19.4"), v("4.19.3"), v("4.19.2")}, nil
+	})
+	overrideGetUpgradeCandidates(t, func(_ context.Context, _ string, _ string, fromVersion string) ([]semver.Version, error) {
+		if fromVersion == "4.19.3" {
+			return []semver.Version{v("4.19.4")}, nil
+		}
+		return nil, nil
+	})
+
+	install, hasUpgrade, err := GetInstallVersionForZStreamUpgrade(context.Background(), "candidate", "4.19")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if install != "4.19.2" {
+		t.Errorf("expected 4.19.2 (candidates[i+1] for first with targets), got %s", install)
+	}
+	if !hasUpgrade {
+		t.Error("expected hasUpgradePath=true")
+	}
+}

--- a/test/util/framework/version_helper_test.go
+++ b/test/util/framework/version_helper_test.go
@@ -102,14 +102,23 @@ func TestGetInstallVersionForZStreamUpgrade_UsesSameMinorMaxVersion(t *testing.T
 	overrideGetAllVersionsInMinor(t, func(_ context.Context, _ string, _ string) ([]semver.Version, error) {
 		return []semver.Version{v("4.21.10"), v("4.21.9"), v("4.21.8")}, nil
 	})
+
+	called := false
 	overrideGetUpgradeCandidates(t, func(_ context.Context, _ string, maxVersion string, _ string) ([]semver.Version, error) {
+		called = true
 		if maxVersion != "4.21.10" {
 			t.Errorf("maxVersion must be same-minor latest (4.21.10), got %s", maxVersion)
 		}
 		return nil, nil
 	})
 
-	GetInstallVersionForZStreamUpgrade(context.Background(), "candidate", "4.21")
+	_, _, err := GetInstallVersionForZStreamUpgrade(context.Background(), "candidate", "4.21")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Fatal("expected upgrade candidates lookup to be invoked")
+	}
 }
 
 func TestGetInstallVersionForZStreamUpgrade_NoUpgradePath(t *testing.T) {


### PR DESCRIPTION
### Jira

Fixes [ARO-27955](https://redhat.atlassian.net/jira/software/c/projects/ARO/boards/11822?selectedIssue=[ARO-27955](https://redhat.atlassian.net/browse/ARO-27955))

### What

  `GetInstallVersionForZStreamUpgrade` had two bugs that combined to return the wrong install version for z-stream
  upgrade testing:

  1. **Wrong Cincinnati channel**: The function queried the *next* minor's channel (`candidate-4.22` when testing 4.21)
  as `maxVersion`. `GetUpgradeCandidatesInMaxMinorFromCincinnati` filters results to `maxVersion`'s minor, so it only
  found **y-stream** (cross-minor) upgrade targets — never z-stream (same-minor) ones. `hasUpgradePath=true` meant "can
  upgrade to the next minor," but the test waited for a same-minor z-stream upgrade that would never happen.

  2. **Off-by-one in the loop**: The loop started at `i=0` (the latest version in the minor). Since the latest version
  can't z-stream upgrade further, it should start at `i=1`.

  The fix:
  - Uses `candidates[0].String()` (current minor's latest) as `maxVersion` so upgrade target lookups find z-stream
  targets
  - Starts the loop at `i=1`, skipping the latest version which has no z-stream upgrade available
  - Removes the unused next-minor lookup (`GetLatestVersionInMinor` call)

### Why

The hosted control plane z-stream upgrade-only verification is failing across dev and stg. 4 contributing tests covering z-stream upgrade verification for 4.x hosted control plane versions. The upgrade path validation or version constraint logic may have a defect.

  All three z-stream upgrade e2e tests (4.19, 4.20, 4.21) timed out after 45 minutes in Prow CI with:
  VerifyHostedControlPlaneZStreamUpgradeOnly(initial=X.Y.Z) failed:
  no version in clusterversion/version status.history is greater than initial "X.Y.Z"
  The function returned the latest version in each minor (4.19.37, 4.20.29, 4.21.0) with `hasUpgradePath=true`, but no
  newer z-stream version existed within the same minor to upgrade to.

### Testing

 The fix will be automatically tested by CI when:
- Prow CI runs the E2E tests
- The `VerifyHostedControlPlaneZStreamUpgradeOnly` test executes for 4.19, 4.20, 4.21, 4.22  
- Monitor the results at: https://prow.ci.openshift.org/?repo=Azure%2FARO-HCP

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

