### PR TITLE
ARO-9982 | feat: Add VM quota family to instance type catalog

### DIFF
--- a/cluster-service/deploy/templates/cloud-resources-config.configmap.yaml
+++ b/cluster-service/deploy/templates/cloud-resources-config.configmap.yaml
@@ -8,639 +8,82 @@ data:
         supports_multi_az: true
   instance-types.yaml: |
     instance_types:
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_nc4as_t4_v3
-      id: Standard_NC4as_T4_v3
-      memory: 30064771072
-      name: Standard_NC4as_T4_v3
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_nc8as_t4_v3
-      id: Standard_NC8as_T4_v3
-      memory: 60129542144
-      name: Standard_NC8as_T4_v3
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_nc16as_t4_v3
-      id: Standard_NC16as_T4_v3
-      memory: 118111600640
-      name: Standard_NC16as_T4_v3
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_nc64as_t4_v3
-      id: Standard_NC64as_T4_v3
-      memory: 472446402560
-      name: Standard_NC64as_T4_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2_v4
-      id: Standard_E2_v4
-      memory: 17179869184
-      name: Standard_E2_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4_v4
-      id: Standard_E4_v4
-      memory: 34359738368
-      name: Standard_E4_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8_v4
-      id: Standard_E8_v4
-      memory: 68719476736
-      name: Standard_E8_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16_v4
-      id: Standard_E16_v4
-      memory: 137438953472
-      name: Standard_E16_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20_v4
-      id: Standard_E20_v4
-      memory: 171798691840
-      name: Standard_E20_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32_v4
-      id: Standard_E32_v4
-      memory: 274877906944
-      name: Standard_E32_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48_v4
-      id: Standard_E48_v4
-      memory: 412316860416
-      name: Standard_E48_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64_v4
-      id: Standard_E64_v4
-      memory: 541165879296
-      name: Standard_E64_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2d_v4
-      id: Standard_E2d_v4
-      memory: 17179869184
-      name: Standard_E2d_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4d_v4
-      id: Standard_E4d_v4
-      memory: 34359738368
-      name: Standard_E4d_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8d_v4
-      id: Standard_E8d_v4
-      memory: 68719476736
-      name: Standard_E8d_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16d_v4
-      id: Standard_E16d_v4
-      memory: 137438953472
-      name: Standard_E16d_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20d_v4
-      id: Standard_E20d_v4
-      memory: 171798691840
-      name: Standard_E20d_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32d_v4
-      id: Standard_E32d_v4
-      memory: 274877906944
-      name: Standard_E32d_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48d_v4
-      id: Standard_E48d_v4
-      memory: 412316860416
-      name: Standard_E48d_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64d_v4
-      id: Standard_E64d_v4
-      memory: 541165879296
-      name: Standard_E64d_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2s_v4
-      id: Standard_E2s_v4
-      memory: 17179869184
-      name: Standard_E2s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2s_v4
-      id: Standard_E4-2s_v4
-      memory: 34359738368
-      name: Standard_E4-2s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4s_v4
-      id: Standard_E4s_v4
-      memory: 34359738368
-      name: Standard_E4s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2s_v4
-      id: Standard_E8-2s_v4
-      memory: 68719476736
-      name: Standard_E8-2s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4s_v4
-      id: Standard_E8-4s_v4
-      memory: 68719476736
-      name: Standard_E8-4s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8s_v4
-      id: Standard_E8s_v4
-      memory: 68719476736
-      name: Standard_E8s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-4s_v4
-      id: Standard_E16-4s_v4
-      memory: 137438953472
-      name: Standard_E16-4s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8s_v4
-      id: Standard_E16-8s_v4
-      memory: 137438953472
-      name: Standard_E16-8s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16s_v4
-      id: Standard_E16s_v4
-      memory: 137438953472
-      name: Standard_E16s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20s_v4
-      id: Standard_E20s_v4
-      memory: 171798691840
-      name: Standard_E20s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8s_v4
-      id: Standard_E32-8s_v4
-      memory: 274877906944
-      name: Standard_E32-8s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16s_v4
-      id: Standard_E32-16s_v4
-      memory: 274877906944
-      name: Standard_E32-16s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32s_v4
-      id: Standard_E32s_v4
-      memory: 274877906944
-      name: Standard_E32s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48s_v4
-      id: Standard_E48s_v4
-      memory: 412316860416
-      name: Standard_E48s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16s_v4
-      id: Standard_E64-16s_v4
-      memory: 541165879296
-      name: Standard_E64-16s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32s_v4
-      id: Standard_E64-32s_v4
-      memory: 541165879296
-      name: Standard_E64-32s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64s_v4
-      id: Standard_E64s_v4
-      memory: 541165879296
-      name: Standard_E64s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_e80is_v4
-      id: Standard_E80is_v4
-      memory: 541165879296
-      name: Standard_E80is_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2ds_v4
-      id: Standard_E2ds_v4
-      memory: 17179869184
-      name: Standard_E2ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2ds_v4
-      id: Standard_E4-2ds_v4
-      memory: 34359738368
-      name: Standard_E4-2ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4ds_v4
-      id: Standard_E4ds_v4
-      memory: 34359738368
-      name: Standard_E4ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2ds_v4
-      id: Standard_E8-2ds_v4
-      memory: 68719476736
-      name: Standard_E8-2ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4ds_v4
-      id: Standard_E8-4ds_v4
-      memory: 68719476736
-      name: Standard_E8-4ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8ds_v4
-      id: Standard_E8ds_v4
-      memory: 68719476736
-      name: Standard_E8ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-4ds_v4
-      id: Standard_E16-4ds_v4
-      memory: 137438953472
-      name: Standard_E16-4ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8ds_v4
-      id: Standard_E16-8ds_v4
-      memory: 137438953472
-      name: Standard_E16-8ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16ds_v4
-      id: Standard_E16ds_v4
-      memory: 137438953472
-      name: Standard_E16ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20ds_v4
-      id: Standard_E20ds_v4
-      memory: 171798691840
-      name: Standard_E20ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8ds_v4
-      id: Standard_E32-8ds_v4
-      memory: 274877906944
-      name: Standard_E32-8ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16ds_v4
-      id: Standard_E32-16ds_v4
-      memory: 274877906944
-      name: Standard_E32-16ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32ds_v4
-      id: Standard_E32ds_v4
-      memory: 274877906944
-      name: Standard_E32ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48ds_v4
-      id: Standard_E48ds_v4
-      memory: 412316860416
-      name: Standard_E48ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16ds_v4
-      id: Standard_E64-16ds_v4
-      memory: 541165879296
-      name: Standard_E64-16ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32ds_v4
-      id: Standard_E64-32ds_v4
-      memory: 541165879296
-      name: Standard_E64-32ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64ds_v4
-      id: Standard_E64ds_v4
-      memory: 541165879296
-      name: Standard_E64ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_e80ids_v4
-      id: Standard_E80ids_v4
-      memory: 541165879296
-      name: Standard_E80ids_v4
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 2
-      generic_name: standard_d2d_v4
-      id: Standard_D2d_v4
-      memory: 8589934592
-      name: Standard_D2d_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4d_v4
-      id: Standard_D4d_v4
-      memory: 17179869184
-      name: Standard_D4d_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8d_v4
-      id: Standard_D8d_v4
-      memory: 34359738368
-      name: Standard_D8d_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16d_v4
-      id: Standard_D16d_v4
-      memory: 68719476736
-      name: Standard_D16d_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32d_v4
-      id: Standard_D32d_v4
-      memory: 137438953472
-      name: Standard_D32d_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48d_v4
-      id: Standard_D48d_v4
-      memory: 206158430208
-      name: Standard_D48d_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64d_v4
-      id: Standard_D64d_v4
-      memory: 274877906944
-      name: Standard_D64d_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2_v4
-      id: Standard_D2_v4
-      memory: 8589934592
-      name: Standard_D2_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4_v4
-      id: Standard_D4_v4
-      memory: 17179869184
-      name: Standard_D4_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8_v4
-      id: Standard_D8_v4
-      memory: 34359738368
-      name: Standard_D8_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16_v4
-      id: Standard_D16_v4
-      memory: 68719476736
-      name: Standard_D16_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32_v4
-      id: Standard_D32_v4
-      memory: 137438953472
-      name: Standard_D32_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48_v4
-      id: Standard_D48_v4
-      memory: 206158430208
-      name: Standard_D48_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64_v4
-      id: Standard_D64_v4
-      memory: 274877906944
-      name: Standard_D64_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2ds_v4
-      id: Standard_D2ds_v4
-      memory: 8589934592
-      name: Standard_D2ds_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4ds_v4
-      id: Standard_D4ds_v4
-      memory: 17179869184
-      name: Standard_D4ds_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8ds_v4
-      id: Standard_D8ds_v4
-      memory: 34359738368
-      name: Standard_D8ds_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16ds_v4
-      id: Standard_D16ds_v4
-      memory: 68719476736
-      name: Standard_D16ds_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32ds_v4
-      id: Standard_D32ds_v4
-      memory: 137438953472
-      name: Standard_D32ds_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48ds_v4
-      id: Standard_D48ds_v4
-      memory: 206158430208
-      name: Standard_D48ds_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64ds_v4
-      id: Standard_D64ds_v4
-      memory: 274877906944
-      name: Standard_D64ds_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2s_v4
-      id: Standard_D2s_v4
-      memory: 8589934592
-      name: Standard_D2s_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4s_v4
-      id: Standard_D4s_v4
-      memory: 17179869184
-      name: Standard_D4s_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8s_v4
-      id: Standard_D8s_v4
-      memory: 34359738368
-      name: Standard_D8s_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16s_v4
-      id: Standard_D16s_v4
-      memory: 68719476736
-      name: Standard_D16s_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32s_v4
-      id: Standard_D32s_v4
-      memory: 137438953472
-      name: Standard_D32s_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48s_v4
-      id: Standard_D48s_v4
-      memory: 206158430208
-      name: Standard_D48s_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64s_v4
-      id: Standard_D64s_v4
-      memory: 274877906944
-      name: Standard_D64s_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 1
-      generic_name: standard_d1_v2
-      id: Standard_D1_v2
-      memory: 3758096384
-      name: Standard_D1_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2_v2
-      id: Standard_D2_v2
-      memory: 7516192768
-      name: Standard_D2_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d3_v2
-      id: Standard_D3_v2
-      memory: 15032385536
-      name: Standard_D3_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d4_v2
-      id: Standard_D4_v2
-      memory: 30064771072
-      name: Standard_D4_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d5_v2
-      id: Standard_D5_v2
-      memory: 60129542144
-      name: Standard_D5_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
+      family: standardDv2Family
       generic_name: standard_d11_v2
       id: Standard_D11_v2
       memory: 15032385536
       name: Standard_D11_v2
     - category: general_purpose
       cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardDadsv7Family
+      generic_name: standard_d128ads_v7
+      id: Standard_D128ads_v7
+      memory: 549755813888
+      name: Standard_D128ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardDaldsv7Family
+      generic_name: standard_d128alds_v7
+      id: Standard_D128alds_v7
+      memory: 274877906944
+      name: Standard_D128alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardDalsv7Family
+      generic_name: standard_d128als_v7
+      id: Standard_D128als_v7
+      memory: 274877906944
+      name: Standard_D128als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardDasv7Family
+      generic_name: standard_d128as_v7
+      id: Standard_D128as_v7
+      memory: 549755813888
+      name: Standard_D128as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardDdsv6Family
+      generic_name: standard_d128ds_v6
+      id: Standard_D128ds_v6
+      memory: 549755813888
+      name: Standard_D128ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardDldsv6Family
+      generic_name: standard_d128lds_v6
+      id: Standard_D128lds_v6
+      memory: 274877906944
+      name: Standard_D128lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardDlsv6Family
+      generic_name: standard_d128ls_v6
+      id: Standard_D128ls_v6
+      memory: 274877906944
+      name: Standard_D128ls_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardDsv6Family
+      generic_name: standard_d128s_v6
+      id: Standard_D128s_v6
+      memory: 549755813888
+      name: Standard_D128s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
       cpu_cores: 4
+      family: standardDv2Family
       generic_name: standard_d12_v2
       id: Standard_D12_v2
       memory: 30064771072
@@ -648,6 +91,7 @@ data:
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 8
+      family: standardDv2Family
       generic_name: standard_d13_v2
       id: Standard_D13_v2
       memory: 60129542144
@@ -655,6 +99,7 @@ data:
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
+      family: standardDv2Family
       generic_name: standard_d14_v2
       id: Standard_D14_v2
       memory: 120259084288
@@ -662,3559 +107,216 @@ data:
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 20
+      family: standardDv2Family
       generic_name: standard_d15_v2
       id: Standard_D15_v2
       memory: 150323855360
       name: Standard_D15_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 1
-      generic_name: standard_f1
-      id: Standard_F1
-      memory: 2147483648
-      name: Standard_F1
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2
-      id: Standard_F2
-      memory: 4294967296
-      name: Standard_F2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4
-      id: Standard_F4
-      memory: 8589934592
-      name: Standard_F4
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8
-      id: Standard_F8
-      memory: 17179869184
-      name: Standard_F8
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16
-      id: Standard_F16
-      memory: 34359738368
-      name: Standard_F16
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 1
-      generic_name: standard_ds1_v2
-      id: Standard_DS1_v2
-      memory: 3758096384
-      name: Standard_DS1_v2
+      cpu_cores: 160
+      family: StandardDadsv7Family
+      generic_name: standard_d160ads_v7
+      id: Standard_D160ads_v7
+      memory: 687194767360
+      name: Standard_D160ads_v7
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_ds2_v2
-      id: Standard_DS2_v2
-      memory: 7516192768
-      name: Standard_DS2_v2
+      cpu_cores: 160
+      family: StandardDaldsv7Family
+      generic_name: standard_d160alds_v7
+      id: Standard_D160alds_v7
+      memory: 343597383680
+      name: Standard_D160alds_v7
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_ds3_v2
-      id: Standard_DS3_v2
-      memory: 15032385536
-      name: Standard_DS3_v2
+      cpu_cores: 160
+      family: StandardDalsv7Family
+      generic_name: standard_d160als_v7
+      id: Standard_D160als_v7
+      memory: 343597383680
+      name: Standard_D160als_v7
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_ds4_v2
-      id: Standard_DS4_v2
-      memory: 30064771072
-      name: Standard_DS4_v2
+      cpu_cores: 160
+      family: StandardDasv7Family
+      generic_name: standard_d160as_v7
+      id: Standard_D160as_v7
+      memory: 687194767360
+      name: Standard_D160as_v7
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_ds5_v2
-      id: Standard_DS5_v2
-      memory: 60129542144
-      name: Standard_DS5_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_ds11-1_v2
-      id: Standard_DS11-1_v2
-      memory: 15032385536
-      name: Standard_DS11-1_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_ds11_v2
-      id: Standard_DS11_v2
-      memory: 15032385536
-      name: Standard_DS11_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_ds12-1_v2
-      id: Standard_DS12-1_v2
-      memory: 30064771072
-      name: Standard_DS12-1_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_ds12-2_v2
-      id: Standard_DS12-2_v2
-      memory: 30064771072
-      name: Standard_DS12-2_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_ds12_v2
-      id: Standard_DS12_v2
-      memory: 30064771072
-      name: Standard_DS12_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_ds13-2_v2
-      id: Standard_DS13-2_v2
-      memory: 60129542144
-      name: Standard_DS13-2_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_ds13-4_v2
-      id: Standard_DS13-4_v2
-      memory: 60129542144
-      name: Standard_DS13-4_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_ds13_v2
-      id: Standard_DS13_v2
-      memory: 60129542144
-      name: Standard_DS13_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_ds14-4_v2
-      id: Standard_DS14-4_v2
-      memory: 120259084288
-      name: Standard_DS14-4_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_ds14-8_v2
-      id: Standard_DS14-8_v2
-      memory: 120259084288
-      name: Standard_DS14-8_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_ds14_v2
-      id: Standard_DS14_v2
-      memory: 120259084288
-      name: Standard_DS14_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_ds15_v2
-      id: Standard_DS15_v2
-      memory: 150323855360
-      name: Standard_DS15_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 1
-      generic_name: standard_f1s
-      id: Standard_F1s
-      memory: 2147483648
-      name: Standard_F1s
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2s
-      id: Standard_F2s
-      memory: 4294967296
-      name: Standard_F2s
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4s
-      id: Standard_F4s
-      memory: 8589934592
-      name: Standard_F4s
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8s
-      id: Standard_F8s
-      memory: 17179869184
-      name: Standard_F8s
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16s
-      id: Standard_F16s
-      memory: 34359738368
-      name: Standard_F16s
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2_v3
-      id: Standard_D2_v3
-      memory: 8589934592
-      name: Standard_D2_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4_v3
-      id: Standard_D4_v3
-      memory: 17179869184
-      name: Standard_D4_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8_v3
-      id: Standard_D8_v3
-      memory: 34359738368
-      name: Standard_D8_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16_v3
-      id: Standard_D16_v3
-      memory: 68719476736
-      name: Standard_D16_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32_v3
-      id: Standard_D32_v3
-      memory: 137438953472
-      name: Standard_D32_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48_v3
-      id: Standard_D48_v3
-      memory: 206158430208
-      name: Standard_D48_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64_v3
-      id: Standard_D64_v3
-      memory: 274877906944
-      name: Standard_D64_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2s_v3
-      id: Standard_D2s_v3
-      memory: 8589934592
-      name: Standard_D2s_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4s_v3
-      id: Standard_D4s_v3
-      memory: 17179869184
-      name: Standard_D4s_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8s_v3
-      id: Standard_D8s_v3
-      memory: 34359738368
-      name: Standard_D8s_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16s_v3
-      id: Standard_D16s_v3
-      memory: 68719476736
-      name: Standard_D16s_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32s_v3
-      id: Standard_D32s_v3
-      memory: 137438953472
-      name: Standard_D32s_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48s_v3
-      id: Standard_D48s_v3
-      memory: 206158430208
-      name: Standard_D48s_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64s_v3
-      id: Standard_D64s_v3
-      memory: 274877906944
-      name: Standard_D64s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2_v3
-      id: Standard_E2_v3
-      memory: 17179869184
-      name: Standard_E2_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4_v3
-      id: Standard_E4_v3
-      memory: 34359738368
-      name: Standard_E4_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8_v3
-      id: Standard_E8_v3
-      memory: 68719476736
-      name: Standard_E8_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16_v3
-      id: Standard_E16_v3
-      memory: 137438953472
-      name: Standard_E16_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20_v3
-      id: Standard_E20_v3
-      memory: 171798691840
-      name: Standard_E20_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32_v3
-      id: Standard_E32_v3
-      memory: 274877906944
-      name: Standard_E32_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48_v3
-      id: Standard_E48_v3
-      memory: 412316860416
-      name: Standard_E48_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64_v3
-      id: Standard_E64_v3
-      memory: 463856467968
-      name: Standard_E64_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2s_v3
-      id: Standard_E2s_v3
-      memory: 17179869184
-      name: Standard_E2s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2s_v3
-      id: Standard_E4-2s_v3
-      memory: 34359738368
-      name: Standard_E4-2s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4s_v3
-      id: Standard_E4s_v3
-      memory: 34359738368
-      name: Standard_E4s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2s_v3
-      id: Standard_E8-2s_v3
-      memory: 68719476736
-      name: Standard_E8-2s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4s_v3
-      id: Standard_E8-4s_v3
-      memory: 68719476736
-      name: Standard_E8-4s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8s_v3
-      id: Standard_E8s_v3
-      memory: 68719476736
-      name: Standard_E8s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-4s_v3
-      id: Standard_E16-4s_v3
-      memory: 137438953472
-      name: Standard_E16-4s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8s_v3
-      id: Standard_E16-8s_v3
-      memory: 137438953472
-      name: Standard_E16-8s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16s_v3
-      id: Standard_E16s_v3
-      memory: 137438953472
-      name: Standard_E16s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20s_v3
-      id: Standard_E20s_v3
-      memory: 171798691840
-      name: Standard_E20s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8s_v3
-      id: Standard_E32-8s_v3
-      memory: 274877906944
-      name: Standard_E32-8s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16s_v3
-      id: Standard_E32-16s_v3
-      memory: 274877906944
-      name: Standard_E32-16s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32s_v3
-      id: Standard_E32s_v3
-      memory: 274877906944
-      name: Standard_E32s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48s_v3
-      id: Standard_E48s_v3
-      memory: 412316860416
-      name: Standard_E48s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16s_v3
-      id: Standard_E64-16s_v3
-      memory: 463856467968
-      name: Standard_E64-16s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32s_v3
-      id: Standard_E64-32s_v3
-      memory: 463856467968
-      name: Standard_E64-32s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64s_v3
-      id: Standard_E64s_v3
-      memory: 463856467968
-      name: Standard_E64s_v3
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2s_v2
-      id: Standard_F2s_v2
-      memory: 4294967296
-      name: Standard_F2s_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4s_v2
-      id: Standard_F4s_v2
-      memory: 8589934592
-      name: Standard_F4s_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8s_v2
-      id: Standard_F8s_v2
-      memory: 17179869184
-      name: Standard_F8s_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16s_v2
-      id: Standard_F16s_v2
-      memory: 34359738368
-      name: Standard_F16s_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32s_v2
-      id: Standard_F32s_v2
-      memory: 68719476736
-      name: Standard_F32s_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_f48s_v2
-      id: Standard_F48s_v2
-      memory: 103079215104
-      name: Standard_F48s_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64s_v2
-      id: Standard_F64s_v2
-      memory: 137438953472
-      name: Standard_F64s_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 72
-      generic_name: standard_f72s_v2
-      id: Standard_F72s_v2
-      memory: 154618822656
-      name: Standard_F72s_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2as_v5
-      id: Standard_D2as_v5
-      memory: 8589934592
-      name: Standard_D2as_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4as_v5
-      id: Standard_D4as_v5
-      memory: 17179869184
-      name: Standard_D4as_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8as_v5
-      id: Standard_D8as_v5
-      memory: 34359738368
-      name: Standard_D8as_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16as_v5
-      id: Standard_D16as_v5
-      memory: 68719476736
-      name: Standard_D16as_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32as_v5
-      id: Standard_D32as_v5
-      memory: 137438953472
-      name: Standard_D32as_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48as_v5
-      id: Standard_D48as_v5
-      memory: 206158430208
-      name: Standard_D48as_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64as_v5
-      id: Standard_D64as_v5
-      memory: 274877906944
-      name: Standard_D64as_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96as_v5
-      id: Standard_D96as_v5
-      memory: 412316860416
-      name: Standard_D96as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2as_v5
-      id: Standard_E2as_v5
-      memory: 17179869184
-      name: Standard_E2as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2as_v5
-      id: Standard_E4-2as_v5
-      memory: 34359738368
-      name: Standard_E4-2as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4as_v5
-      id: Standard_E4as_v5
-      memory: 34359738368
-      name: Standard_E4as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2as_v5
-      id: Standard_E8-2as_v5
-      memory: 68719476736
-      name: Standard_E8-2as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4as_v5
-      id: Standard_E8-4as_v5
-      memory: 68719476736
-      name: Standard_E8-4as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8as_v5
-      id: Standard_E8as_v5
-      memory: 68719476736
-      name: Standard_E8as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-4as_v5
-      id: Standard_E16-4as_v5
-      memory: 137438953472
-      name: Standard_E16-4as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8as_v5
-      id: Standard_E16-8as_v5
-      memory: 137438953472
-      name: Standard_E16-8as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16as_v5
-      id: Standard_E16as_v5
-      memory: 137438953472
-      name: Standard_E16as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20as_v5
-      id: Standard_E20as_v5
-      memory: 171798691840
-      name: Standard_E20as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8as_v5
-      id: Standard_E32-8as_v5
-      memory: 274877906944
-      name: Standard_E32-8as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16as_v5
-      id: Standard_E32-16as_v5
-      memory: 274877906944
-      name: Standard_E32-16as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32as_v5
-      id: Standard_E32as_v5
-      memory: 274877906944
-      name: Standard_E32as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48as_v5
-      id: Standard_E48as_v5
-      memory: 412316860416
-      name: Standard_E48as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16as_v5
-      id: Standard_E64-16as_v5
-      memory: 549755813888
-      name: Standard_E64-16as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32as_v5
-      id: Standard_E64-32as_v5
-      memory: 549755813888
-      name: Standard_E64-32as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64as_v5
-      id: Standard_E64as_v5
-      memory: 549755813888
-      name: Standard_E64as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-24as_v5
-      id: Standard_E96-24as_v5
-      memory: 721554505728
-      name: Standard_E96-24as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-48as_v5
-      id: Standard_E96-48as_v5
-      memory: 721554505728
-      name: Standard_E96-48as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96as_v5
-      id: Standard_E96as_v5
-      memory: 721554505728
-      name: Standard_E96as_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2ads_v5
-      id: Standard_D2ads_v5
-      memory: 8589934592
-      name: Standard_D2ads_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4ads_v5
-      id: Standard_D4ads_v5
-      memory: 17179869184
-      name: Standard_D4ads_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8ads_v5
-      id: Standard_D8ads_v5
-      memory: 34359738368
-      name: Standard_D8ads_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
+      family: standardDADSv5Family
       generic_name: standard_d16ads_v5
       id: Standard_D16ads_v5
       memory: 68719476736
       name: Standard_D16ads_v5
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32ads_v5
-      id: Standard_D32ads_v5
-      memory: 137438953472
-      name: Standard_D32ads_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48ads_v5
-      id: Standard_D48ads_v5
-      memory: 206158430208
-      name: Standard_D48ads_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64ads_v5
-      id: Standard_D64ads_v5
-      memory: 274877906944
-      name: Standard_D64ads_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96ads_v5
-      id: Standard_D96ads_v5
-      memory: 412316860416
-      name: Standard_D96ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2ads_v5
-      id: Standard_E2ads_v5
-      memory: 17179869184
-      name: Standard_E2ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2ads_v5
-      id: Standard_E4-2ads_v5
-      memory: 34359738368
-      name: Standard_E4-2ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4ads_v5
-      id: Standard_E4ads_v5
-      memory: 34359738368
-      name: Standard_E4ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2ads_v5
-      id: Standard_E8-2ads_v5
-      memory: 68719476736
-      name: Standard_E8-2ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4ads_v5
-      id: Standard_E8-4ads_v5
-      memory: 68719476736
-      name: Standard_E8-4ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8ads_v5
-      id: Standard_E8ads_v5
-      memory: 68719476736
-      name: Standard_E8ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_e16-4ads_v5
-      id: Standard_E16-4ads_v5
-      memory: 137438953472
-      name: Standard_E16-4ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8ads_v5
-      id: Standard_E16-8ads_v5
-      memory: 137438953472
-      name: Standard_E16-8ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16ads_v5
-      id: Standard_E16ads_v5
-      memory: 137438953472
-      name: Standard_E16ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20ads_v5
-      id: Standard_E20ads_v5
-      memory: 171798691840
-      name: Standard_E20ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8ads_v5
-      id: Standard_E32-8ads_v5
-      memory: 274877906944
-      name: Standard_E32-8ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16ads_v5
-      id: Standard_E32-16ads_v5
-      memory: 274877906944
-      name: Standard_E32-16ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32ads_v5
-      id: Standard_E32ads_v5
-      memory: 274877906944
-      name: Standard_E32ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48ads_v5
-      id: Standard_E48ads_v5
-      memory: 412316860416
-      name: Standard_E48ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16ads_v5
-      id: Standard_E64-16ads_v5
-      memory: 549755813888
-      name: Standard_E64-16ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32ads_v5
-      id: Standard_E64-32ads_v5
-      memory: 549755813888
-      name: Standard_E64-32ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64ads_v5
-      id: Standard_E64ads_v5
-      memory: 549755813888
-      name: Standard_E64ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-24ads_v5
-      id: Standard_E96-24ads_v5
-      memory: 721554505728
-      name: Standard_E96-24ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-48ads_v5
-      id: Standard_E96-48ads_v5
-      memory: 721554505728
-      name: Standard_E96-48ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96ads_v5
-      id: Standard_E96ads_v5
-      memory: 721554505728
-      name: Standard_E96ads_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2as_v6
-      id: Standard_D2as_v6
-      memory: 8589934592
-      name: Standard_D2as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4as_v6
-      id: Standard_D4as_v6
-      memory: 17179869184
-      name: Standard_D4as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8as_v6
-      id: Standard_D8as_v6
-      memory: 34359738368
-      name: Standard_D8as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16as_v6
-      id: Standard_D16as_v6
-      memory: 68719476736
-      name: Standard_D16as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32as_v6
-      id: Standard_D32as_v6
-      memory: 137438953472
-      name: Standard_D32as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48as_v6
-      id: Standard_D48as_v6
-      memory: 206158430208
-      name: Standard_D48as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64as_v6
-      id: Standard_D64as_v6
-      memory: 274877906944
-      name: Standard_D64as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96as_v6
-      id: Standard_D96as_v6
-      memory: 412316860416
-      name: Standard_D96as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2as_v6
-      id: Standard_E2as_v6
-      memory: 17179869184
-      name: Standard_E2as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4as_v6
-      id: Standard_E4as_v6
-      memory: 34359738368
-      name: Standard_E4as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8as_v6
-      id: Standard_E8as_v6
-      memory: 68719476736
-      name: Standard_E8as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16as_v6
-      id: Standard_E16as_v6
-      memory: 137438953472
-      name: Standard_E16as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20as_v6
-      id: Standard_E20as_v6
-      memory: 171798691840
-      name: Standard_E20as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32as_v6
-      id: Standard_E32as_v6
-      memory: 274877906944
-      name: Standard_E32as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48as_v6
-      id: Standard_E48as_v6
-      memory: 412316860416
-      name: Standard_E48as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64as_v6
-      id: Standard_E64as_v6
-      memory: 549755813888
-      name: Standard_E64as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96as_v6
-      id: Standard_E96as_v6
-      memory: 721554505728
-      name: Standard_E96as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2ads_v6
-      id: Standard_D2ads_v6
-      memory: 8589934592
-      name: Standard_D2ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4ads_v6
-      id: Standard_D4ads_v6
-      memory: 17179869184
-      name: Standard_D4ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8ads_v6
-      id: Standard_D8ads_v6
-      memory: 34359738368
-      name: Standard_D8ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
+      family: standardDadv6Family
       generic_name: standard_d16ads_v6
       id: Standard_D16ads_v6
       memory: 68719476736
       name: Standard_D16ads_v6
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32ads_v6
-      id: Standard_D32ads_v6
-      memory: 137438953472
-      name: Standard_D32ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48ads_v6
-      id: Standard_D48ads_v6
-      memory: 206158430208
-      name: Standard_D48ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64ads_v6
-      id: Standard_D64ads_v6
-      memory: 274877906944
-      name: Standard_D64ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96ads_v6
-      id: Standard_D96ads_v6
-      memory: 412316860416
-      name: Standard_D96ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2als_v6
-      id: Standard_D2als_v6
-      memory: 4294967296
-      name: Standard_D2als_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4als_v6
-      id: Standard_D4als_v6
-      memory: 8589934592
-      name: Standard_D4als_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8als_v6
-      id: Standard_D8als_v6
-      memory: 17179869184
-      name: Standard_D8als_v6
-    - category: general_purpose
-      cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_d16als_v6
-      id: Standard_D16als_v6
-      memory: 34359738368
-      name: Standard_D16als_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32als_v6
-      id: Standard_D32als_v6
+      family: StandardDadsv7Family
+      generic_name: standard_d16ads_v7
+      id: Standard_D16ads_v7
       memory: 68719476736
-      name: Standard_D32als_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48als_v6
-      id: Standard_D48als_v6
-      memory: 103079215104
-      name: Standard_D48als_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64als_v6
-      id: Standard_D64als_v6
-      memory: 137438953472
-      name: Standard_D64als_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96als_v6
-      id: Standard_D96als_v6
-      memory: 206158430208
-      name: Standard_D96als_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2alds_v6
-      id: Standard_D2alds_v6
-      memory: 4294967296
-      name: Standard_D2alds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4alds_v6
-      id: Standard_D4alds_v6
-      memory: 8589934592
-      name: Standard_D4alds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8alds_v6
-      id: Standard_D8alds_v6
-      memory: 17179869184
-      name: Standard_D8alds_v6
+      name: Standard_D16ads_v7
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
+      family: standardDaldv6Family
       generic_name: standard_d16alds_v6
       id: Standard_D16alds_v6
       memory: 34359738368
       name: Standard_D16alds_v6
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32alds_v6
-      id: Standard_D32alds_v6
-      memory: 68719476736
-      name: Standard_D32alds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48alds_v6
-      id: Standard_D48alds_v6
-      memory: 103079215104
-      name: Standard_D48alds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64alds_v6
-      id: Standard_D64alds_v6
-      memory: 137438953472
-      name: Standard_D64alds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96alds_v6
-      id: Standard_D96alds_v6
-      memory: 206158430208
-      name: Standard_D96alds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2ads_v6
-      id: Standard_E2ads_v6
-      memory: 17179869184
-      name: Standard_E2ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4ads_v6
-      id: Standard_E4ads_v6
+      cpu_cores: 16
+      family: StandardDaldsv7Family
+      generic_name: standard_d16alds_v7
+      id: Standard_D16alds_v7
       memory: 34359738368
-      name: Standard_E4ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8ads_v6
-      id: Standard_E8ads_v6
-      memory: 68719476736
-      name: Standard_E8ads_v6
-    - category: memory_optimized
+      name: Standard_D16alds_v7
+    - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_e16ads_v6
-      id: Standard_E16ads_v6
-      memory: 137438953472
-      name: Standard_E16ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20ads_v6
-      id: Standard_E20ads_v6
-      memory: 171798691840
-      name: Standard_E20ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32ads_v6
-      id: Standard_E32ads_v6
-      memory: 274877906944
-      name: Standard_E32ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48ads_v6
-      id: Standard_E48ads_v6
-      memory: 412316860416
-      name: Standard_E48ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64ads_v6
-      id: Standard_E64ads_v6
-      memory: 549755813888
-      name: Standard_E64ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-24ads_v6
-      id: Standard_E96-24ads_v6
-      memory: 721554505728
-      name: Standard_E96-24ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-48ads_v6
-      id: Standard_E96-48ads_v6
-      memory: 721554505728
-      name: Standard_E96-48ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96ads_v6
-      id: Standard_E96ads_v6
-      memory: 721554505728
-      name: Standard_E96ads_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2as_v6
-      id: Standard_F2as_v6
-      memory: 8589934592
-      name: Standard_F2as_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4as_v6
-      id: Standard_F4as_v6
-      memory: 17179869184
-      name: Standard_F4as_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8as_v6
-      id: Standard_F8as_v6
+      family: standardDalv6Family
+      generic_name: standard_d16als_v6
+      id: Standard_D16als_v6
       memory: 34359738368
-      name: Standard_F8as_v6
-    - category: compute_optimized
+      name: Standard_D16als_v6
+    - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_f16as_v6
-      id: Standard_F16as_v6
-      memory: 68719476736
-      name: Standard_F16as_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32as_v6
-      id: Standard_F32as_v6
-      memory: 137438953472
-      name: Standard_F32as_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_f48as_v6
-      id: Standard_F48as_v6
-      memory: 206158430208
-      name: Standard_F48as_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64as_v6
-      id: Standard_F64as_v6
-      memory: 274877906944
-      name: Standard_F64as_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2als_v6
-      id: Standard_F2als_v6
-      memory: 4294967296
-      name: Standard_F2als_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4als_v6
-      id: Standard_F4als_v6
-      memory: 8589934592
-      name: Standard_F4als_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8als_v6
-      id: Standard_F8als_v6
-      memory: 17179869184
-      name: Standard_F8als_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16als_v6
-      id: Standard_F16als_v6
+      family: StandardDalsv7Family
+      generic_name: standard_d16als_v7
+      id: Standard_D16als_v7
       memory: 34359738368
-      name: Standard_F16als_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32als_v6
-      id: Standard_F32als_v6
-      memory: 68719476736
-      name: Standard_F32als_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_f48als_v6
-      id: Standard_F48als_v6
-      memory: 103079215104
-      name: Standard_F48als_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64als_v6
-      id: Standard_F64als_v6
-      memory: 137438953472
-      name: Standard_F64als_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2ams_v6
-      id: Standard_F2ams_v6
-      memory: 17179869184
-      name: Standard_F2ams_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4ams_v6
-      id: Standard_F4ams_v6
-      memory: 34359738368
-      name: Standard_F4ams_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8ams_v6
-      id: Standard_F8ams_v6
-      memory: 68719476736
-      name: Standard_F8ams_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16ams_v6
-      id: Standard_F16ams_v6
-      memory: 137438953472
-      name: Standard_F16ams_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32ams_v6
-      id: Standard_F32ams_v6
-      memory: 274877906944
-      name: Standard_F32ams_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_f48ams_v6
-      id: Standard_F48ams_v6
-      memory: 412316860416
-      name: Standard_F48ams_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64ams_v6
-      id: Standard_F64ams_v6
-      memory: 549755813888
-      name: Standard_F64ams_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2ds_v5
-      id: Standard_D2ds_v5
-      memory: 8589934592
-      name: Standard_D2ds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4ds_v5
-      id: Standard_D4ds_v5
-      memory: 17179869184
-      name: Standard_D4ds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8ds_v5
-      id: Standard_D8ds_v5
-      memory: 34359738368
-      name: Standard_D8ds_v5
+      name: Standard_D16als_v7
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_d16ds_v5
-      id: Standard_D16ds_v5
-      memory: 68719476736
-      name: Standard_D16ds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32ds_v5
-      id: Standard_D32ds_v5
-      memory: 137438953472
-      name: Standard_D32ds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48ds_v5
-      id: Standard_D48ds_v5
-      memory: 206158430208
-      name: Standard_D48ds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64ds_v5
-      id: Standard_D64ds_v5
-      memory: 274877906944
-      name: Standard_D64ds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96ds_v5
-      id: Standard_D96ds_v5
-      memory: 412316860416
-      name: Standard_D96ds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2d_v5
-      id: Standard_D2d_v5
-      memory: 8589934592
-      name: Standard_D2d_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4d_v5
-      id: Standard_D4d_v5
-      memory: 17179869184
-      name: Standard_D4d_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8d_v5
-      id: Standard_D8d_v5
-      memory: 34359738368
-      name: Standard_D8d_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16d_v5
-      id: Standard_D16d_v5
-      memory: 68719476736
-      name: Standard_D16d_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32d_v5
-      id: Standard_D32d_v5
-      memory: 137438953472
-      name: Standard_D32d_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48d_v5
-      id: Standard_D48d_v5
-      memory: 206158430208
-      name: Standard_D48d_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64d_v5
-      id: Standard_D64d_v5
-      memory: 274877906944
-      name: Standard_D64d_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96d_v5
-      id: Standard_D96d_v5
-      memory: 412316860416
-      name: Standard_D96d_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2s_v5
-      id: Standard_D2s_v5
-      memory: 8589934592
-      name: Standard_D2s_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4s_v5
-      id: Standard_D4s_v5
-      memory: 17179869184
-      name: Standard_D4s_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8s_v5
-      id: Standard_D8s_v5
-      memory: 34359738368
-      name: Standard_D8s_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16s_v5
-      id: Standard_D16s_v5
-      memory: 68719476736
-      name: Standard_D16s_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32s_v5
-      id: Standard_D32s_v5
-      memory: 137438953472
-      name: Standard_D32s_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48s_v5
-      id: Standard_D48s_v5
-      memory: 206158430208
-      name: Standard_D48s_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64s_v5
-      id: Standard_D64s_v5
-      memory: 274877906944
-      name: Standard_D64s_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96s_v5
-      id: Standard_D96s_v5
-      memory: 412316860416
-      name: Standard_D96s_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2_v5
-      id: Standard_D2_v5
-      memory: 8589934592
-      name: Standard_D2_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4_v5
-      id: Standard_D4_v5
-      memory: 17179869184
-      name: Standard_D4_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8_v5
-      id: Standard_D8_v5
-      memory: 34359738368
-      name: Standard_D8_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16_v5
-      id: Standard_D16_v5
-      memory: 68719476736
-      name: Standard_D16_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32_v5
-      id: Standard_D32_v5
-      memory: 137438953472
-      name: Standard_D32_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48_v5
-      id: Standard_D48_v5
-      memory: 206158430208
-      name: Standard_D48_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64_v5
-      id: Standard_D64_v5
-      memory: 274877906944
-      name: Standard_D64_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96_v5
-      id: Standard_D96_v5
-      memory: 412316860416
-      name: Standard_D96_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2ds_v5
-      id: Standard_E2ds_v5
-      memory: 17179869184
-      name: Standard_E2ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2ds_v5
-      id: Standard_E4-2ds_v5
-      memory: 34359738368
-      name: Standard_E4-2ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4ds_v5
-      id: Standard_E4ds_v5
-      memory: 34359738368
-      name: Standard_E4ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2ds_v5
-      id: Standard_E8-2ds_v5
-      memory: 68719476736
-      name: Standard_E8-2ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4ds_v5
-      id: Standard_E8-4ds_v5
-      memory: 68719476736
-      name: Standard_E8-4ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8ds_v5
-      id: Standard_E8ds_v5
-      memory: 68719476736
-      name: Standard_E8ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-4ds_v5
-      id: Standard_E16-4ds_v5
-      memory: 137438953472
-      name: Standard_E16-4ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8ds_v5
-      id: Standard_E16-8ds_v5
-      memory: 137438953472
-      name: Standard_E16-8ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16ds_v5
-      id: Standard_E16ds_v5
-      memory: 137438953472
-      name: Standard_E16ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20ds_v5
-      id: Standard_E20ds_v5
-      memory: 171798691840
-      name: Standard_E20ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8ds_v5
-      id: Standard_E32-8ds_v5
-      memory: 274877906944
-      name: Standard_E32-8ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16ds_v5
-      id: Standard_E32-16ds_v5
-      memory: 274877906944
-      name: Standard_E32-16ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32ds_v5
-      id: Standard_E32ds_v5
-      memory: 274877906944
-      name: Standard_E32ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48ds_v5
-      id: Standard_E48ds_v5
-      memory: 412316860416
-      name: Standard_E48ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16ds_v5
-      id: Standard_E64-16ds_v5
-      memory: 549755813888
-      name: Standard_E64-16ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32ds_v5
-      id: Standard_E64-32ds_v5
-      memory: 549755813888
-      name: Standard_E64-32ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64ds_v5
-      id: Standard_E64ds_v5
-      memory: 549755813888
-      name: Standard_E64ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-24ds_v5
-      id: Standard_E96-24ds_v5
-      memory: 721554505728
-      name: Standard_E96-24ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-48ds_v5
-      id: Standard_E96-48ds_v5
-      memory: 721554505728
-      name: Standard_E96-48ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96ds_v5
-      id: Standard_E96ds_v5
-      memory: 721554505728
-      name: Standard_E96ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 104
-      generic_name: standard_e104ids_v5
-      id: Standard_E104ids_v5
-      memory: 721554505728
-      name: Standard_E104ids_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2d_v5
-      id: Standard_E2d_v5
-      memory: 17179869184
-      name: Standard_E2d_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4d_v5
-      id: Standard_E4d_v5
-      memory: 34359738368
-      name: Standard_E4d_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8d_v5
-      id: Standard_E8d_v5
-      memory: 68719476736
-      name: Standard_E8d_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16d_v5
-      id: Standard_E16d_v5
-      memory: 137438953472
-      name: Standard_E16d_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20d_v5
-      id: Standard_E20d_v5
-      memory: 171798691840
-      name: Standard_E20d_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32d_v5
-      id: Standard_E32d_v5
-      memory: 274877906944
-      name: Standard_E32d_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48d_v5
-      id: Standard_E48d_v5
-      memory: 412316860416
-      name: Standard_E48d_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64d_v5
-      id: Standard_E64d_v5
-      memory: 549755813888
-      name: Standard_E64d_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96d_v5
-      id: Standard_E96d_v5
-      memory: 721554505728
-      name: Standard_E96d_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 104
-      generic_name: standard_e104id_v5
-      id: Standard_E104id_v5
-      memory: 721554505728
-      name: Standard_E104id_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2s_v5
-      id: Standard_E2s_v5
-      memory: 17179869184
-      name: Standard_E2s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2s_v5
-      id: Standard_E4-2s_v5
-      memory: 34359738368
-      name: Standard_E4-2s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4s_v5
-      id: Standard_E4s_v5
-      memory: 34359738368
-      name: Standard_E4s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2s_v5
-      id: Standard_E8-2s_v5
-      memory: 68719476736
-      name: Standard_E8-2s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4s_v5
-      id: Standard_E8-4s_v5
-      memory: 68719476736
-      name: Standard_E8-4s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8s_v5
-      id: Standard_E8s_v5
-      memory: 68719476736
-      name: Standard_E8s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-4s_v5
-      id: Standard_E16-4s_v5
-      memory: 137438953472
-      name: Standard_E16-4s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8s_v5
-      id: Standard_E16-8s_v5
-      memory: 137438953472
-      name: Standard_E16-8s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16s_v5
-      id: Standard_E16s_v5
-      memory: 137438953472
-      name: Standard_E16s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20s_v5
-      id: Standard_E20s_v5
-      memory: 171798691840
-      name: Standard_E20s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8s_v5
-      id: Standard_E32-8s_v5
-      memory: 274877906944
-      name: Standard_E32-8s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16s_v5
-      id: Standard_E32-16s_v5
-      memory: 274877906944
-      name: Standard_E32-16s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32s_v5
-      id: Standard_E32s_v5
-      memory: 274877906944
-      name: Standard_E32s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48s_v5
-      id: Standard_E48s_v5
-      memory: 412316860416
-      name: Standard_E48s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16s_v5
-      id: Standard_E64-16s_v5
-      memory: 549755813888
-      name: Standard_E64-16s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32s_v5
-      id: Standard_E64-32s_v5
-      memory: 549755813888
-      name: Standard_E64-32s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64s_v5
-      id: Standard_E64s_v5
-      memory: 549755813888
-      name: Standard_E64s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-24s_v5
-      id: Standard_E96-24s_v5
-      memory: 721554505728
-      name: Standard_E96-24s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-48s_v5
-      id: Standard_E96-48s_v5
-      memory: 721554505728
-      name: Standard_E96-48s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96s_v5
-      id: Standard_E96s_v5
-      memory: 721554505728
-      name: Standard_E96s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 104
-      generic_name: standard_e104is_v5
-      id: Standard_E104is_v5
-      memory: 721554505728
-      name: Standard_E104is_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2_v5
-      id: Standard_E2_v5
-      memory: 17179869184
-      name: Standard_E2_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4_v5
-      id: Standard_E4_v5
-      memory: 34359738368
-      name: Standard_E4_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8_v5
-      id: Standard_E8_v5
-      memory: 68719476736
-      name: Standard_E8_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16_v5
-      id: Standard_E16_v5
-      memory: 137438953472
-      name: Standard_E16_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20_v5
-      id: Standard_E20_v5
-      memory: 171798691840
-      name: Standard_E20_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32_v5
-      id: Standard_E32_v5
-      memory: 274877906944
-      name: Standard_E32_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48_v5
-      id: Standard_E48_v5
-      memory: 412316860416
-      name: Standard_E48_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64_v5
-      id: Standard_E64_v5
-      memory: 549755813888
-      name: Standard_E64_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96_v5
-      id: Standard_E96_v5
-      memory: 721554505728
-      name: Standard_E96_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 104
-      generic_name: standard_e104i_v5
-      id: Standard_E104i_v5
-      memory: 721554505728
-      name: Standard_E104i_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2bs_v5
-      id: Standard_E2bs_v5
-      memory: 17179869184
-      name: Standard_E2bs_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4bs_v5
-      id: Standard_E4bs_v5
-      memory: 34359738368
-      name: Standard_E4bs_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8bs_v5
-      id: Standard_E8bs_v5
-      memory: 68719476736
-      name: Standard_E8bs_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16bs_v5
-      id: Standard_E16bs_v5
-      memory: 137438953472
-      name: Standard_E16bs_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32bs_v5
-      id: Standard_E32bs_v5
-      memory: 274877906944
-      name: Standard_E32bs_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48bs_v5
-      id: Standard_E48bs_v5
-      memory: 412316860416
-      name: Standard_E48bs_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64bs_v5
-      id: Standard_E64bs_v5
-      memory: 549755813888
-      name: Standard_E64bs_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96bs_v5
-      id: Standard_E96bs_v5
-      memory: 721554505728
-      name: Standard_E96bs_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 112
-      generic_name: standard_e112ibs_v5
-      id: Standard_E112ibs_v5
-      memory: 721554505728
-      name: Standard_E112ibs_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2bds_v5
-      id: Standard_E2bds_v5
-      memory: 17179869184
-      name: Standard_E2bds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4bds_v5
-      id: Standard_E4bds_v5
-      memory: 34359738368
-      name: Standard_E4bds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8bds_v5
-      id: Standard_E8bds_v5
-      memory: 68719476736
-      name: Standard_E8bds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16bds_v5
-      id: Standard_E16bds_v5
-      memory: 137438953472
-      name: Standard_E16bds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32bds_v5
-      id: Standard_E32bds_v5
-      memory: 274877906944
-      name: Standard_E32bds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48bds_v5
-      id: Standard_E48bds_v5
-      memory: 412316860416
-      name: Standard_E48bds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64bds_v5
-      id: Standard_E64bds_v5
-      memory: 549755813888
-      name: Standard_E64bds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96bds_v5
-      id: Standard_E96bds_v5
-      memory: 721554505728
-      name: Standard_E96bds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 112
-      generic_name: standard_e112ibds_v5
-      id: Standard_E112ibds_v5
-      memory: 721554505728
-      name: Standard_E112ibds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2ls_v5
-      id: Standard_D2ls_v5
-      memory: 4294967296
-      name: Standard_D2ls_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4ls_v5
-      id: Standard_D4ls_v5
-      memory: 8589934592
-      name: Standard_D4ls_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8ls_v5
-      id: Standard_D8ls_v5
-      memory: 17179869184
-      name: Standard_D8ls_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16ls_v5
-      id: Standard_D16ls_v5
-      memory: 34359738368
-      name: Standard_D16ls_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32ls_v5
-      id: Standard_D32ls_v5
-      memory: 68719476736
-      name: Standard_D32ls_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48ls_v5
-      id: Standard_D48ls_v5
-      memory: 103079215104
-      name: Standard_D48ls_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64ls_v5
-      id: Standard_D64ls_v5
-      memory: 137438953472
-      name: Standard_D64ls_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96ls_v5
-      id: Standard_D96ls_v5
-      memory: 206158430208
-      name: Standard_D96ls_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2lds_v5
-      id: Standard_D2lds_v5
-      memory: 4294967296
-      name: Standard_D2lds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4lds_v5
-      id: Standard_D4lds_v5
-      memory: 8589934592
-      name: Standard_D4lds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8lds_v5
-      id: Standard_D8lds_v5
-      memory: 17179869184
-      name: Standard_D8lds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16lds_v5
-      id: Standard_D16lds_v5
-      memory: 34359738368
-      name: Standard_D16lds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32lds_v5
-      id: Standard_D32lds_v5
-      memory: 68719476736
-      name: Standard_D32lds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48lds_v5
-      id: Standard_D48lds_v5
-      memory: 103079215104
-      name: Standard_D48lds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64lds_v5
-      id: Standard_D64lds_v5
-      memory: 137438953472
-      name: Standard_D64lds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96lds_v5
-      id: Standard_D96lds_v5
-      memory: 206158430208
-      name: Standard_D96lds_v5
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_nc8ads_a10_v4
-      id: Standard_NC8ads_A10_v4
-      memory: 107374182400
-      name: Standard_NC8ads_A10_v4
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_nc16ads_a10_v4
-      id: Standard_NC16ads_A10_v4
-      memory: 214748364800
-      name: Standard_NC16ads_A10_v4
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_nc32ads_a10_v4
-      id: Standard_NC32ads_A10_v4
-      memory: 429496729600
-      name: Standard_NC32ads_A10_v4
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 40
-      generic_name: standard_nc40ads_h100_v5
-      id: Standard_NC40ads_H100_v5
-      memory: 343597383680
-      name: Standard_NC40ads_H100_v5
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_nc80adis_h100_v5
-      id: Standard_NC80adis_H100_v5
-      memory: 687194767360
-      name: Standard_NC80adis_H100_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2ls_v6
-      id: Standard_D2ls_v6
-      memory: 4294967296
-      name: Standard_D2ls_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4ls_v6
-      id: Standard_D4ls_v6
-      memory: 8589934592
-      name: Standard_D4ls_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8ls_v6
-      id: Standard_D8ls_v6
-      memory: 17179869184
-      name: Standard_D8ls_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16ls_v6
-      id: Standard_D16ls_v6
-      memory: 34359738368
-      name: Standard_D16ls_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32ls_v6
-      id: Standard_D32ls_v6
-      memory: 68719476736
-      name: Standard_D32ls_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48ls_v6
-      id: Standard_D48ls_v6
-      memory: 103079215104
-      name: Standard_D48ls_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64ls_v6
-      id: Standard_D64ls_v6
-      memory: 137438953472
-      name: Standard_D64ls_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96ls_v6
-      id: Standard_D96ls_v6
-      memory: 206158430208
-      name: Standard_D96ls_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_d128ls_v6
-      id: Standard_D128ls_v6
-      memory: 274877906944
-      name: Standard_D128ls_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2lds_v6
-      id: Standard_D2lds_v6
-      memory: 4294967296
-      name: Standard_D2lds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4lds_v6
-      id: Standard_D4lds_v6
-      memory: 8589934592
-      name: Standard_D4lds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8lds_v6
-      id: Standard_D8lds_v6
-      memory: 17179869184
-      name: Standard_D8lds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16lds_v6
-      id: Standard_D16lds_v6
-      memory: 34359738368
-      name: Standard_D16lds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32lds_v6
-      id: Standard_D32lds_v6
-      memory: 68719476736
-      name: Standard_D32lds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48lds_v6
-      id: Standard_D48lds_v6
-      memory: 103079215104
-      name: Standard_D48lds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64lds_v6
-      id: Standard_D64lds_v6
-      memory: 137438953472
-      name: Standard_D64lds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96lds_v6
-      id: Standard_D96lds_v6
-      memory: 206158430208
-      name: Standard_D96lds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_d128lds_v6
-      id: Standard_D128lds_v6
-      memory: 274877906944
-      name: Standard_D128lds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2s_v6
-      id: Standard_D2s_v6
-      memory: 8589934592
-      name: Standard_D2s_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4s_v6
-      id: Standard_D4s_v6
-      memory: 17179869184
-      name: Standard_D4s_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8s_v6
-      id: Standard_D8s_v6
-      memory: 34359738368
-      name: Standard_D8s_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16s_v6
-      id: Standard_D16s_v6
-      memory: 68719476736
-      name: Standard_D16s_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32s_v6
-      id: Standard_D32s_v6
-      memory: 137438953472
-      name: Standard_D32s_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48s_v6
-      id: Standard_D48s_v6
-      memory: 206158430208
-      name: Standard_D48s_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64s_v6
-      id: Standard_D64s_v6
-      memory: 274877906944
-      name: Standard_D64s_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96s_v6
-      id: Standard_D96s_v6
-      memory: 412316860416
-      name: Standard_D96s_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_d128s_v6
-      id: Standard_D128s_v6
-      memory: 549755813888
-      name: Standard_D128s_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 192
-      generic_name: standard_d192s_v6
-      id: Standard_D192s_v6
-      memory: 824633720832
-      name: Standard_D192s_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2ds_v6
-      id: Standard_D2ds_v6
-      memory: 8589934592
-      name: Standard_D2ds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4ds_v6
-      id: Standard_D4ds_v6
-      memory: 17179869184
-      name: Standard_D4ds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8ds_v6
-      id: Standard_D8ds_v6
-      memory: 34359738368
-      name: Standard_D8ds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16ds_v6
-      id: Standard_D16ds_v6
-      memory: 68719476736
-      name: Standard_D16ds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32ds_v6
-      id: Standard_D32ds_v6
-      memory: 137438953472
-      name: Standard_D32ds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48ds_v6
-      id: Standard_D48ds_v6
-      memory: 206158430208
-      name: Standard_D48ds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64ds_v6
-      id: Standard_D64ds_v6
-      memory: 274877906944
-      name: Standard_D64ds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96ds_v6
-      id: Standard_D96ds_v6
-      memory: 412316860416
-      name: Standard_D96ds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_d128ds_v6
-      id: Standard_D128ds_v6
-      memory: 549755813888
-      name: Standard_D128ds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 192
-      generic_name: standard_d192ds_v6
-      id: Standard_D192ds_v6
-      memory: 824633720832
-      name: Standard_D192ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2s_v6
-      id: Standard_E2s_v6
-      memory: 17179869184
-      name: Standard_E2s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2s_v6
-      id: Standard_E4-2s_v6
-      memory: 34359738368
-      name: Standard_E4-2s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4s_v6
-      id: Standard_E4s_v6
-      memory: 34359738368
-      name: Standard_E4s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2s_v6
-      id: Standard_E8-2s_v6
-      memory: 68719476736
-      name: Standard_E8-2s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4s_v6
-      id: Standard_E8-4s_v6
-      memory: 68719476736
-      name: Standard_E8-4s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8s_v6
-      id: Standard_E8s_v6
-      memory: 68719476736
-      name: Standard_E8s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-4s_v6
-      id: Standard_E16-4s_v6
-      memory: 137438953472
-      name: Standard_E16-4s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8s_v6
-      id: Standard_E16-8s_v6
-      memory: 137438953472
-      name: Standard_E16-8s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16s_v6
-      id: Standard_E16s_v6
-      memory: 137438953472
-      name: Standard_E16s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20s_v6
-      id: Standard_E20s_v6
-      memory: 171798691840
-      name: Standard_E20s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8s_v6
-      id: Standard_E32-8s_v6
-      memory: 274877906944
-      name: Standard_E32-8s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16s_v6
-      id: Standard_E32-16s_v6
-      memory: 274877906944
-      name: Standard_E32-16s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32s_v6
-      id: Standard_E32s_v6
-      memory: 274877906944
-      name: Standard_E32s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48s_v6
-      id: Standard_E48s_v6
-      memory: 412316860416
-      name: Standard_E48s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16s_v6
-      id: Standard_E64-16s_v6
-      memory: 549755813888
-      name: Standard_E64-16s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32s_v6
-      id: Standard_E64-32s_v6
-      memory: 549755813888
-      name: Standard_E64-32s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64s_v6
-      id: Standard_E64s_v6
-      memory: 549755813888
-      name: Standard_E64s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-24s_v6
-      id: Standard_E96-24s_v6
-      memory: 824633720832
-      name: Standard_E96-24s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-48s_v6
-      id: Standard_E96-48s_v6
-      memory: 824633720832
-      name: Standard_E96-48s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96s_v6
-      id: Standard_E96s_v6
-      memory: 824633720832
-      name: Standard_E96s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2ds_v6
-      id: Standard_E2ds_v6
-      memory: 17179869184
-      name: Standard_E2ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2ds_v6
-      id: Standard_E4-2ds_v6
-      memory: 34359738368
-      name: Standard_E4-2ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4ds_v6
-      id: Standard_E4ds_v6
-      memory: 34359738368
-      name: Standard_E4ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2ds_v6
-      id: Standard_E8-2ds_v6
-      memory: 68719476736
-      name: Standard_E8-2ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4ds_v6
-      id: Standard_E8-4ds_v6
-      memory: 68719476736
-      name: Standard_E8-4ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8ds_v6
-      id: Standard_E8ds_v6
-      memory: 68719476736
-      name: Standard_E8ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-4ds_v6
-      id: Standard_E16-4ds_v6
-      memory: 137438953472
-      name: Standard_E16-4ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8ds_v6
-      id: Standard_E16-8ds_v6
-      memory: 137438953472
-      name: Standard_E16-8ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16ds_v6
-      id: Standard_E16ds_v6
-      memory: 137438953472
-      name: Standard_E16ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20ds_v6
-      id: Standard_E20ds_v6
-      memory: 171798691840
-      name: Standard_E20ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8ds_v6
-      id: Standard_E32-8ds_v6
-      memory: 274877906944
-      name: Standard_E32-8ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16ds_v6
-      id: Standard_E32-16ds_v6
-      memory: 274877906944
-      name: Standard_E32-16ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32ds_v6
-      id: Standard_E32ds_v6
-      memory: 274877906944
-      name: Standard_E32ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48ds_v6
-      id: Standard_E48ds_v6
-      memory: 412316860416
-      name: Standard_E48ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16ds_v6
-      id: Standard_E64-16ds_v6
-      memory: 549755813888
-      name: Standard_E64-16ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32ds_v6
-      id: Standard_E64-32ds_v6
-      memory: 549755813888
-      name: Standard_E64-32ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64ds_v6
-      id: Standard_E64ds_v6
-      memory: 549755813888
-      name: Standard_E64ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-24ds_v6
-      id: Standard_E96-24ds_v6
-      memory: 824633720832
-      name: Standard_E96-24ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-48ds_v6
-      id: Standard_E96-48ds_v6
-      memory: 824633720832
-      name: Standard_E96-48ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96ds_v6
-      id: Standard_E96ds_v6
-      memory: 824633720832
-      name: Standard_E96ds_v6
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_l8as_v3
-      id: Standard_L8as_v3
-      memory: 68719476736
-      name: Standard_L8as_v3
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_l16as_v3
-      id: Standard_L16as_v3
-      memory: 137438953472
-      name: Standard_L16as_v3
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_l32as_v3
-      id: Standard_L32as_v3
-      memory: 274877906944
-      name: Standard_L32as_v3
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_l48as_v3
-      id: Standard_L48as_v3
-      memory: 412316860416
-      name: Standard_L48as_v3
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_l64as_v3
-      id: Standard_L64as_v3
-      memory: 549755813888
-      name: Standard_L64as_v3
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_l80as_v3
-      id: Standard_L80as_v3
-      memory: 687194767360
-      name: Standard_L80as_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2a_v4
-      id: Standard_D2a_v4
-      memory: 8589934592
-      name: Standard_D2a_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4a_v4
-      id: Standard_D4a_v4
-      memory: 17179869184
-      name: Standard_D4a_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8a_v4
-      id: Standard_D8a_v4
-      memory: 34359738368
-      name: Standard_D8a_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16a_v4
-      id: Standard_D16a_v4
-      memory: 68719476736
-      name: Standard_D16a_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32a_v4
-      id: Standard_D32a_v4
-      memory: 137438953472
-      name: Standard_D32a_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48a_v4
-      id: Standard_D48a_v4
-      memory: 206158430208
-      name: Standard_D48a_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64a_v4
-      id: Standard_D64a_v4
-      memory: 274877906944
-      name: Standard_D64a_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96a_v4
-      id: Standard_D96a_v4
-      memory: 412316860416
-      name: Standard_D96a_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2as_v4
-      id: Standard_D2as_v4
-      memory: 8589934592
-      name: Standard_D2as_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4as_v4
-      id: Standard_D4as_v4
-      memory: 17179869184
-      name: Standard_D4as_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8as_v4
-      id: Standard_D8as_v4
-      memory: 34359738368
-      name: Standard_D8as_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
+      family: standardDASv4Family
       generic_name: standard_d16as_v4
       id: Standard_D16as_v4
       memory: 68719476736
       name: Standard_D16as_v4
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32as_v4
-      id: Standard_D32as_v4
-      memory: 137438953472
-      name: Standard_D32as_v4
+      cpu_cores: 16
+      family: standardDASv5Family
+      generic_name: standard_d16as_v5
+      id: Standard_D16as_v5
+      memory: 68719476736
+      name: Standard_D16as_v5
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48as_v4
-      id: Standard_D48as_v4
-      memory: 206158430208
-      name: Standard_D48as_v4
+      cpu_cores: 16
+      family: standardDav6Family
+      generic_name: standard_d16as_v6
+      id: Standard_D16as_v6
+      memory: 68719476736
+      name: Standard_D16as_v6
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64as_v4
-      id: Standard_D64as_v4
-      memory: 274877906944
-      name: Standard_D64as_v4
+      cpu_cores: 16
+      family: StandardDasv7Family
+      generic_name: standard_d16as_v7
+      id: Standard_D16as_v7
+      memory: 68719476736
+      name: Standard_D16as_v7
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96as_v4
-      id: Standard_D96as_v4
-      memory: 412316860416
-      name: Standard_D96as_v4
-    - category: memory_optimized
+      cpu_cores: 16
+      family: standardDAv4Family
+      generic_name: standard_d16a_v4
+      id: Standard_D16a_v4
+      memory: 68719476736
+      name: Standard_D16a_v4
+    - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2a_v4
-      id: Standard_E2a_v4
-      memory: 17179869184
-      name: Standard_E2a_v4
-    - category: memory_optimized
+      cpu_cores: 16
+      family: standardDDSv4Family
+      generic_name: standard_d16ds_v4
+      id: Standard_D16ds_v4
+      memory: 68719476736
+      name: Standard_D16ds_v4
+    - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4a_v4
-      id: Standard_E4a_v4
+      cpu_cores: 16
+      family: standardDDSv5Family
+      generic_name: standard_d16ds_v5
+      id: Standard_D16ds_v5
+      memory: 68719476736
+      name: Standard_D16ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardDdsv6Family
+      generic_name: standard_d16ds_v6
+      id: Standard_D16ds_v6
+      memory: 68719476736
+      name: Standard_D16ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDDv4Family
+      generic_name: standard_d16d_v4
+      id: Standard_D16d_v4
+      memory: 68719476736
+      name: Standard_D16d_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDDv5Family
+      generic_name: standard_d16d_v5
+      id: Standard_D16d_v5
+      memory: 68719476736
+      name: Standard_D16d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDLDSv5Family
+      generic_name: standard_d16lds_v5
+      id: Standard_D16lds_v5
       memory: 34359738368
-      name: Standard_E4a_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8a_v4
-      id: Standard_E8a_v4
-      memory: 68719476736
-      name: Standard_E8a_v4
-    - category: memory_optimized
+      name: Standard_D16lds_v5
+    - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_e16a_v4
-      id: Standard_E16a_v4
-      memory: 137438953472
-      name: Standard_E16a_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20a_v4
-      id: Standard_E20a_v4
-      memory: 171798691840
-      name: Standard_E20a_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32a_v4
-      id: Standard_E32a_v4
-      memory: 274877906944
-      name: Standard_E32a_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48a_v4
-      id: Standard_E48a_v4
-      memory: 412316860416
-      name: Standard_E48a_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64a_v4
-      id: Standard_E64a_v4
-      memory: 549755813888
-      name: Standard_E64a_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96a_v4
-      id: Standard_E96a_v4
-      memory: 721554505728
-      name: Standard_E96a_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2as_v4
-      id: Standard_E2as_v4
-      memory: 17179869184
-      name: Standard_E2as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2as_v4
-      id: Standard_E4-2as_v4
+      family: StandardDldsv6Family
+      generic_name: standard_d16lds_v6
+      id: Standard_D16lds_v6
       memory: 34359738368
-      name: Standard_E4-2as_v4
-    - category: memory_optimized
+      name: Standard_D16lds_v6
+    - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4as_v4
-      id: Standard_E4as_v4
+      cpu_cores: 16
+      family: standardDLSv5Family
+      generic_name: standard_d16ls_v5
+      id: Standard_D16ls_v5
       memory: 34359738368
-      name: Standard_E4as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2as_v4
-      id: Standard_E8-2as_v4
-      memory: 68719476736
-      name: Standard_E8-2as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4as_v4
-      id: Standard_E8-4as_v4
-      memory: 68719476736
-      name: Standard_E8-4as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8as_v4
-      id: Standard_E8as_v4
-      memory: 68719476736
-      name: Standard_E8as_v4
-    - category: memory_optimized
+      name: Standard_D16ls_v5
+    - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_e16-4as_v4
-      id: Standard_E16-4as_v4
-      memory: 137438953472
-      name: Standard_E16-4as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8as_v4
-      id: Standard_E16-8as_v4
-      memory: 137438953472
-      name: Standard_E16-8as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16as_v4
-      id: Standard_E16as_v4
-      memory: 137438953472
-      name: Standard_E16as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20as_v4
-      id: Standard_E20as_v4
-      memory: 171798691840
-      name: Standard_E20as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8as_v4
-      id: Standard_E32-8as_v4
-      memory: 274877906944
-      name: Standard_E32-8as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16as_v4
-      id: Standard_E32-16as_v4
-      memory: 274877906944
-      name: Standard_E32-16as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32as_v4
-      id: Standard_E32as_v4
-      memory: 274877906944
-      name: Standard_E32as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48as_v4
-      id: Standard_E48as_v4
-      memory: 412316860416
-      name: Standard_E48as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16as_v4
-      id: Standard_E64-16as_v4
-      memory: 549755813888
-      name: Standard_E64-16as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32as_v4
-      id: Standard_E64-32as_v4
-      memory: 549755813888
-      name: Standard_E64-32as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64as_v4
-      id: Standard_E64as_v4
-      memory: 549755813888
-      name: Standard_E64as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-24as_v4
-      id: Standard_E96-24as_v4
-      memory: 721554505728
-      name: Standard_E96-24as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-48as_v4
-      id: Standard_E96-48as_v4
-      memory: 721554505728
-      name: Standard_E96-48as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96as_v4
-      id: Standard_E96as_v4
-      memory: 721554505728
-      name: Standard_E96as_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_l8s_v3
-      id: Standard_L8s_v3
-      memory: 68719476736
-      name: Standard_L8s_v3
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_l16s_v3
-      id: Standard_L16s_v3
-      memory: 137438953472
-      name: Standard_L16s_v3
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_l32s_v3
-      id: Standard_L32s_v3
-      memory: 274877906944
-      name: Standard_L32s_v3
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_l48s_v3
-      id: Standard_L48s_v3
-      memory: 412316860416
-      name: Standard_L48s_v3
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_l64s_v3
-      id: Standard_L64s_v3
-      memory: 549755813888
-      name: Standard_L64s_v3
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_l80s_v3
-      id: Standard_L80s_v3
-      memory: 687194767360
-      name: Standard_L80s_v3
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_l2aos_v4
-      id: Standard_L2aos_v4
-      memory: 17179869184
-      name: Standard_L2aos_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_l4aos_v4
-      id: Standard_L4aos_v4
+      family: StandardDlsv6Family
+      generic_name: standard_d16ls_v6
+      id: Standard_D16ls_v6
       memory: 34359738368
-      name: Standard_L4aos_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_l8aos_v4
-      id: Standard_L8aos_v4
-      memory: 68719476736
-      name: Standard_L8aos_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 12
-      generic_name: standard_l12aos_v4
-      id: Standard_L12aos_v4
-      memory: 103079215104
-      name: Standard_L12aos_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_l16aos_v4
-      id: Standard_L16aos_v4
-      memory: 137438953472
-      name: Standard_L16aos_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 24
-      generic_name: standard_l24aos_v4
-      id: Standard_L24aos_v4
-      memory: 206158430208
-      name: Standard_L24aos_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_l32aos_v4
-      id: Standard_L32aos_v4
-      memory: 274877906944
-      name: Standard_L32aos_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_l2as_v4
-      id: Standard_L2as_v4
-      memory: 17179869184
-      name: Standard_L2as_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_l4as_v4
-      id: Standard_L4as_v4
-      memory: 34359738368
-      name: Standard_L4as_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_l8as_v4
-      id: Standard_L8as_v4
-      memory: 68719476736
-      name: Standard_L8as_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_l16as_v4
-      id: Standard_L16as_v4
-      memory: 137438953472
-      name: Standard_L16as_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_l32as_v4
-      id: Standard_L32as_v4
-      memory: 274877906944
-      name: Standard_L32as_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_l48as_v4
-      id: Standard_L48as_v4
-      memory: 412316860416
-      name: Standard_L48as_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_l64as_v4
-      id: Standard_L64as_v4
-      memory: 549755813888
-      name: Standard_L64as_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_l80as_v4
-      id: Standard_L80as_v4
-      memory: 687194767360
-      name: Standard_L80as_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_l96as_v4
-      id: Standard_L96as_v4
-      memory: 824633720832
-      name: Standard_L96as_v4
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2plds_v5
-      id: Standard_D2plds_v5
-      memory: 4294967296
-      name: Standard_D2plds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4plds_v5
-      id: Standard_D4plds_v5
-      memory: 8589934592
-      name: Standard_D4plds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8plds_v5
-      id: Standard_D8plds_v5
-      memory: 17179869184
-      name: Standard_D8plds_v5
+      name: Standard_D16ls_v6
     - architecture: arm64
       category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_d16plds_v5
-      id: Standard_D16plds_v5
-      memory: 34359738368
-      name: Standard_D16plds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32plds_v5
-      id: Standard_D32plds_v5
-      memory: 68719476736
-      name: Standard_D32plds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48plds_v5
-      id: Standard_D48plds_v5
-      memory: 103079215104
-      name: Standard_D48plds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64plds_v5
-      id: Standard_D64plds_v5
-      memory: 137438953472
-      name: Standard_D64plds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2pls_v5
-      id: Standard_D2pls_v5
-      memory: 4294967296
-      name: Standard_D2pls_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4pls_v5
-      id: Standard_D4pls_v5
-      memory: 8589934592
-      name: Standard_D4pls_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8pls_v5
-      id: Standard_D8pls_v5
-      memory: 17179869184
-      name: Standard_D8pls_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16pls_v5
-      id: Standard_D16pls_v5
-      memory: 34359738368
-      name: Standard_D16pls_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32pls_v5
-      id: Standard_D32pls_v5
-      memory: 68719476736
-      name: Standard_D32pls_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48pls_v5
-      id: Standard_D48pls_v5
-      memory: 103079215104
-      name: Standard_D48pls_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64pls_v5
-      id: Standard_D64pls_v5
-      memory: 137438953472
-      name: Standard_D64pls_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2pds_v5
-      id: Standard_D2pds_v5
-      memory: 8589934592
-      name: Standard_D2pds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4pds_v5
-      id: Standard_D4pds_v5
-      memory: 17179869184
-      name: Standard_D4pds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8pds_v5
-      id: Standard_D8pds_v5
-      memory: 34359738368
-      name: Standard_D8pds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
+      family: standardDPDSv5Family
       generic_name: standard_d16pds_v5
       id: Standard_D16pds_v5
       memory: 68719476736
@@ -4222,845 +324,8 @@ data:
     - architecture: arm64
       category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32pds_v5
-      id: Standard_D32pds_v5
-      memory: 137438953472
-      name: Standard_D32pds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48pds_v5
-      id: Standard_D48pds_v5
-      memory: 206158430208
-      name: Standard_D48pds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64pds_v5
-      id: Standard_D64pds_v5
-      memory: 223338299392
-      name: Standard_D64pds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2ps_v5
-      id: Standard_D2ps_v5
-      memory: 8589934592
-      name: Standard_D2ps_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4ps_v5
-      id: Standard_D4ps_v5
-      memory: 17179869184
-      name: Standard_D4ps_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8ps_v5
-      id: Standard_D8ps_v5
-      memory: 34359738368
-      name: Standard_D8ps_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_d16ps_v5
-      id: Standard_D16ps_v5
-      memory: 68719476736
-      name: Standard_D16ps_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32ps_v5
-      id: Standard_D32ps_v5
-      memory: 137438953472
-      name: Standard_D32ps_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48ps_v5
-      id: Standard_D48ps_v5
-      memory: 206158430208
-      name: Standard_D48ps_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64ps_v5
-      id: Standard_D64ps_v5
-      memory: 223338299392
-      name: Standard_D64ps_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2pds_v5
-      id: Standard_E2pds_v5
-      memory: 17179869184
-      name: Standard_E2pds_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4pds_v5
-      id: Standard_E4pds_v5
-      memory: 34359738368
-      name: Standard_E4pds_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8pds_v5
-      id: Standard_E8pds_v5
-      memory: 68719476736
-      name: Standard_E8pds_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16pds_v5
-      id: Standard_E16pds_v5
-      memory: 137438953472
-      name: Standard_E16pds_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20pds_v5
-      id: Standard_E20pds_v5
-      memory: 171798691840
-      name: Standard_E20pds_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32pds_v5
-      id: Standard_E32pds_v5
-      memory: 223338299392
-      name: Standard_E32pds_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2ps_v5
-      id: Standard_E2ps_v5
-      memory: 17179869184
-      name: Standard_E2ps_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4ps_v5
-      id: Standard_E4ps_v5
-      memory: 34359738368
-      name: Standard_E4ps_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8ps_v5
-      id: Standard_E8ps_v5
-      memory: 68719476736
-      name: Standard_E8ps_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16ps_v5
-      id: Standard_E16ps_v5
-      memory: 137438953472
-      name: Standard_E16ps_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20ps_v5
-      id: Standard_E20ps_v5
-      memory: 171798691840
-      name: Standard_E20ps_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32ps_v5
-      id: Standard_E32ps_v5
-      memory: 223338299392
-      name: Standard_E32ps_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128-32s_v6
-      id: Standard_E128-32s_v6
-      memory: 1099511627776
-      name: Standard_E128-32s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128-64s_v6
-      id: Standard_E128-64s_v6
-      memory: 1099511627776
-      name: Standard_E128-64s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128s_v6
-      id: Standard_E128s_v6
-      memory: 1099511627776
-      name: Standard_E128s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 192
-      generic_name: standard_e192is_v6
-      id: Standard_E192is_v6
-      memory: 1967095021568
-      name: Standard_E192is_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128-32ds_v6
-      id: Standard_E128-32ds_v6
-      memory: 1099511627776
-      name: Standard_E128-32ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128-64ds_v6
-      id: Standard_E128-64ds_v6
-      memory: 1099511627776
-      name: Standard_E128-64ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128ds_v6
-      id: Standard_E128ds_v6
-      memory: 1099511627776
-      name: Standard_E128ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 192
-      generic_name: standard_e192ids_v6
-      id: Standard_E192ids_v6
-      memory: 1967095021568
-      name: Standard_E192ids_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_fx2ms_v2
-      id: Standard_FX2ms_v2
-      memory: 45097156608
-      name: Standard_FX2ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_fx4-2ms_v2
-      id: Standard_FX4-2ms_v2
-      memory: 90194313216
-      name: Standard_FX4-2ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_fx4ms_v2
-      id: Standard_FX4ms_v2
-      memory: 90194313216
-      name: Standard_FX4ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_fx8-2ms_v2
-      id: Standard_FX8-2ms_v2
-      memory: 180388626432
-      name: Standard_FX8-2ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_fx8-4ms_v2
-      id: Standard_FX8-4ms_v2
-      memory: 180388626432
-      name: Standard_FX8-4ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_fx8ms_v2
-      id: Standard_FX8ms_v2
-      memory: 180388626432
-      name: Standard_FX8ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 12
-      generic_name: standard_fx12-6ms_v2
-      id: Standard_FX12-6ms_v2
-      memory: 270582939648
-      name: Standard_FX12-6ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 12
-      generic_name: standard_fx12ms_v2
-      id: Standard_FX12ms_v2
-      memory: 270582939648
-      name: Standard_FX12ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_fx16-4ms_v2
-      id: Standard_FX16-4ms_v2
-      memory: 360777252864
-      name: Standard_FX16-4ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_fx16-8ms_v2
-      id: Standard_FX16-8ms_v2
-      memory: 360777252864
-      name: Standard_FX16-8ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_fx16ms_v2
-      id: Standard_FX16ms_v2
-      memory: 360777252864
-      name: Standard_FX16ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 24
-      generic_name: standard_fx24-6ms_v2
-      id: Standard_FX24-6ms_v2
-      memory: 541165879296
-      name: Standard_FX24-6ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 24
-      generic_name: standard_fx24-12ms_v2
-      id: Standard_FX24-12ms_v2
-      memory: 541165879296
-      name: Standard_FX24-12ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 24
-      generic_name: standard_fx24ms_v2
-      id: Standard_FX24ms_v2
-      memory: 541165879296
-      name: Standard_FX24ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_fx32-8ms_v2
-      id: Standard_FX32-8ms_v2
-      memory: 721554505728
-      name: Standard_FX32-8ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_fx32-16ms_v2
-      id: Standard_FX32-16ms_v2
-      memory: 721554505728
-      name: Standard_FX32-16ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_fx32ms_v2
-      id: Standard_FX32ms_v2
-      memory: 721554505728
-      name: Standard_FX32ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_fx48-12ms_v2
-      id: Standard_FX48-12ms_v2
-      memory: 1082331758592
-      name: Standard_FX48-12ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_fx48-24ms_v2
-      id: Standard_FX48-24ms_v2
-      memory: 1082331758592
-      name: Standard_FX48-24ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_fx48ms_v2
-      id: Standard_FX48ms_v2
-      memory: 1082331758592
-      name: Standard_FX48ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_fx64-16ms_v2
-      id: Standard_FX64-16ms_v2
-      memory: 1443109011456
-      name: Standard_FX64-16ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_fx64-32ms_v2
-      id: Standard_FX64-32ms_v2
-      memory: 1443109011456
-      name: Standard_FX64-32ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_fx64ms_v2
-      id: Standard_FX64ms_v2
-      memory: 1443109011456
-      name: Standard_FX64ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_fx96-24ms_v2
-      id: Standard_FX96-24ms_v2
-      memory: 1967095021568
-      name: Standard_FX96-24ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_fx96-48ms_v2
-      id: Standard_FX96-48ms_v2
-      memory: 1967095021568
-      name: Standard_FX96-48ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_fx96ms_v2
-      id: Standard_FX96ms_v2
-      memory: 1967095021568
-      name: Standard_FX96ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_fx2mds_v2
-      id: Standard_FX2mds_v2
-      memory: 45097156608
-      name: Standard_FX2mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_fx4-2mds_v2
-      id: Standard_FX4-2mds_v2
-      memory: 90194313216
-      name: Standard_FX4-2mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_fx4mds_v2
-      id: Standard_FX4mds_v2
-      memory: 90194313216
-      name: Standard_FX4mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_fx8-2mds_v2
-      id: Standard_FX8-2mds_v2
-      memory: 180388626432
-      name: Standard_FX8-2mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_fx8-4mds_v2
-      id: Standard_FX8-4mds_v2
-      memory: 180388626432
-      name: Standard_FX8-4mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_fx8mds_v2
-      id: Standard_FX8mds_v2
-      memory: 180388626432
-      name: Standard_FX8mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 12
-      generic_name: standard_fx12-6mds_v2
-      id: Standard_FX12-6mds_v2
-      memory: 270582939648
-      name: Standard_FX12-6mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 12
-      generic_name: standard_fx12mds_v2
-      id: Standard_FX12mds_v2
-      memory: 270582939648
-      name: Standard_FX12mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_fx16-4mds_v2
-      id: Standard_FX16-4mds_v2
-      memory: 360777252864
-      name: Standard_FX16-4mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_fx16-8mds_v2
-      id: Standard_FX16-8mds_v2
-      memory: 360777252864
-      name: Standard_FX16-8mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_fx16mds_v2
-      id: Standard_FX16mds_v2
-      memory: 360777252864
-      name: Standard_FX16mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 24
-      generic_name: standard_fx24-6mds_v2
-      id: Standard_FX24-6mds_v2
-      memory: 541165879296
-      name: Standard_FX24-6mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 24
-      generic_name: standard_fx24-12mds_v2
-      id: Standard_FX24-12mds_v2
-      memory: 541165879296
-      name: Standard_FX24-12mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 24
-      generic_name: standard_fx24mds_v2
-      id: Standard_FX24mds_v2
-      memory: 541165879296
-      name: Standard_FX24mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_fx32-8mds_v2
-      id: Standard_FX32-8mds_v2
-      memory: 721554505728
-      name: Standard_FX32-8mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_fx32-16mds_v2
-      id: Standard_FX32-16mds_v2
-      memory: 721554505728
-      name: Standard_FX32-16mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_fx32mds_v2
-      id: Standard_FX32mds_v2
-      memory: 721554505728
-      name: Standard_FX32mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_fx48-12mds_v2
-      id: Standard_FX48-12mds_v2
-      memory: 1082331758592
-      name: Standard_FX48-12mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_fx48-24mds_v2
-      id: Standard_FX48-24mds_v2
-      memory: 1082331758592
-      name: Standard_FX48-24mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_fx48mds_v2
-      id: Standard_FX48mds_v2
-      memory: 1082331758592
-      name: Standard_FX48mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_fx64-16mds_v2
-      id: Standard_FX64-16mds_v2
-      memory: 1443109011456
-      name: Standard_FX64-16mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_fx64-32mds_v2
-      id: Standard_FX64-32mds_v2
-      memory: 1443109011456
-      name: Standard_FX64-32mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_fx64mds_v2
-      id: Standard_FX64mds_v2
-      memory: 1443109011456
-      name: Standard_FX64mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_fx96-24mds_v2
-      id: Standard_FX96-24mds_v2
-      memory: 1967095021568
-      name: Standard_FX96-24mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_fx96-48mds_v2
-      id: Standard_FX96-48mds_v2
-      memory: 1967095021568
-      name: Standard_FX96-48mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_fx96mds_v2
-      id: Standard_FX96mds_v2
-      memory: 1967095021568
-      name: Standard_FX96mds_v2
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_l2s_v4
-      id: Standard_L2s_v4
-      memory: 17179869184
-      name: Standard_L2s_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_l4s_v4
-      id: Standard_L4s_v4
-      memory: 34359738368
-      name: Standard_L4s_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_l8s_v4
-      id: Standard_L8s_v4
-      memory: 68719476736
-      name: Standard_L8s_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_l16s_v4
-      id: Standard_L16s_v4
-      memory: 137438953472
-      name: Standard_L16s_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_l32s_v4
-      id: Standard_L32s_v4
-      memory: 274877906944
-      name: Standard_L32s_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_l48s_v4
-      id: Standard_L48s_v4
-      memory: 412316860416
-      name: Standard_L48s_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_l64s_v4
-      id: Standard_L64s_v4
-      memory: 549755813888
-      name: Standard_L64s_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_l80s_v4
-      id: Standard_L80s_v4
-      memory: 687194767360
-      name: Standard_L80s_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_l96s_v4
-      id: Standard_L96s_v4
-      memory: 824633720832
-      name: Standard_L96s_v4
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 6
-      generic_name: standard_nv6ads_a10_v5
-      id: Standard_NV6ads_A10_v5
-      memory: 59055800320
-      name: Standard_NV6ads_A10_v5
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 12
-      generic_name: standard_nv12ads_a10_v5
-      id: Standard_NV12ads_A10_v5
-      memory: 118111600640
-      name: Standard_NV12ads_A10_v5
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 18
-      generic_name: standard_nv18ads_a10_v5
-      id: Standard_NV18ads_A10_v5
-      memory: 236223201280
-      name: Standard_NV18ads_A10_v5
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 36
-      generic_name: standard_nv36adms_a10_v5
-      id: Standard_NV36adms_A10_v5
-      memory: 944892805120
-      name: Standard_NV36adms_A10_v5
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 36
-      generic_name: standard_nv36ads_a10_v5
-      id: Standard_NV36ads_A10_v5
-      memory: 472446402560
-      name: Standard_NV36ads_A10_v5
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 72
-      generic_name: standard_nv72ads_a10_v5
-      id: Standard_NV72ads_A10_v5
-      memory: 944892805120
-      name: Standard_NV72ads_A10_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 112
-      generic_name: standard_e112ias_v5
-      id: Standard_E112ias_v5
-      memory: 721554505728
-      name: Standard_E112ias_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 112
-      generic_name: standard_e112iads_v5
-      id: Standard_E112iads_v5
-      memory: 721554505728
-      name: Standard_E112iads_v5
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_fx4mds
-      id: Standard_FX4mds
-      memory: 90194313216
-      name: Standard_FX4mds
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 12
-      generic_name: standard_fx12mds
-      id: Standard_FX12mds
-      memory: 270582939648
-      name: Standard_FX12mds
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 24
-      generic_name: standard_fx24mds
-      id: Standard_FX24mds
-      memory: 541165879296
-      name: Standard_FX24mds
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 36
-      generic_name: standard_fx36mds
-      id: Standard_FX36mds
-      memory: 811748818944
-      name: Standard_FX36mds
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_fx48mds
-      id: Standard_FX48mds
-      memory: 1082331758592
-      name: Standard_FX48mds
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2pls_v6
-      id: Standard_D2pls_v6
-      memory: 4294967296
-      name: Standard_D2pls_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4pls_v6
-      id: Standard_D4pls_v6
-      memory: 8589934592
-      name: Standard_D4pls_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8pls_v6
-      id: Standard_D8pls_v6
-      memory: 17179869184
-      name: Standard_D8pls_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16pls_v6
-      id: Standard_D16pls_v6
-      memory: 34359738368
-      name: Standard_D16pls_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32pls_v6
-      id: Standard_D32pls_v6
-      memory: 68719476736
-      name: Standard_D32pls_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48pls_v6
-      id: Standard_D48pls_v6
-      memory: 103079215104
-      name: Standard_D48pls_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64pls_v6
-      id: Standard_D64pls_v6
-      memory: 137438953472
-      name: Standard_D64pls_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96pls_v6
-      id: Standard_D96pls_v6
-      memory: 206158430208
-      name: Standard_D96pls_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2pds_v6
-      id: Standard_D2pds_v6
-      memory: 8589934592
-      name: Standard_D2pds_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4pds_v6
-      id: Standard_D4pds_v6
-      memory: 17179869184
-      name: Standard_D4pds_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8pds_v6
-      id: Standard_D8pds_v6
-      memory: 34359738368
-      name: Standard_D8pds_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
+      family: StandardDpdsv6Family
       generic_name: standard_d16pds_v6
       id: Standard_D16pds_v6
       memory: 68719476736
@@ -5068,63 +333,17 @@ data:
     - architecture: arm64
       category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32pds_v6
-      id: Standard_D32pds_v6
-      memory: 137438953472
-      name: Standard_D32pds_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48pds_v6
-      id: Standard_D48pds_v6
-      memory: 206158430208
-      name: Standard_D48pds_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64pds_v6
-      id: Standard_D64pds_v6
-      memory: 274877906944
-      name: Standard_D64pds_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96pds_v6
-      id: Standard_D96pds_v6
-      memory: 412316860416
-      name: Standard_D96pds_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2plds_v6
-      id: Standard_D2plds_v6
-      memory: 4294967296
-      name: Standard_D2plds_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4plds_v6
-      id: Standard_D4plds_v6
-      memory: 8589934592
-      name: Standard_D4plds_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8plds_v6
-      id: Standard_D8plds_v6
-      memory: 17179869184
-      name: Standard_D8plds_v6
+      cpu_cores: 16
+      family: standardDPLDSv5Family
+      generic_name: standard_d16plds_v5
+      id: Standard_D16plds_v5
+      memory: 34359738368
+      name: Standard_D16plds_v5
     - architecture: arm64
       category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
+      family: StandardDpldsv6Family
       generic_name: standard_d16plds_v6
       id: Standard_D16plds_v6
       memory: 34359738368
@@ -5132,7 +351,623 @@ data:
     - architecture: arm64
       category: general_purpose
       cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDPLSv5Family
+      generic_name: standard_d16pls_v5
+      id: Standard_D16pls_v5
+      memory: 34359738368
+      name: Standard_D16pls_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardDplsv6Family
+      generic_name: standard_d16pls_v6
+      id: Standard_D16pls_v6
+      memory: 34359738368
+      name: Standard_D16pls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDPSv5Family
+      generic_name: standard_d16ps_v5
+      id: Standard_D16ps_v5
+      memory: 68719476736
+      name: Standard_D16ps_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardDpsv6Family
+      generic_name: standard_d16ps_v6
+      id: Standard_D16ps_v6
+      memory: 68719476736
+      name: Standard_D16ps_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDSv3Family
+      generic_name: standard_d16s_v3
+      id: Standard_D16s_v3
+      memory: 68719476736
+      name: Standard_D16s_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDSv4Family
+      generic_name: standard_d16s_v4
+      id: Standard_D16s_v4
+      memory: 68719476736
+      name: Standard_D16s_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDSv5Family
+      generic_name: standard_d16s_v5
+      id: Standard_D16s_v5
+      memory: 68719476736
+      name: Standard_D16s_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardDsv6Family
+      generic_name: standard_d16s_v6
+      id: Standard_D16s_v6
+      memory: 68719476736
+      name: Standard_D16s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDv3Family
+      generic_name: standard_d16_v3
+      id: Standard_D16_v3
+      memory: 68719476736
+      name: Standard_D16_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDv4Family
+      generic_name: standard_d16_v4
+      id: Standard_D16_v4
+      memory: 68719476736
+      name: Standard_D16_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDv5Family
+      generic_name: standard_d16_v5
+      id: Standard_D16_v5
+      memory: 68719476736
+      name: Standard_D16_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 192
+      family: StandardDdsv6Family
+      generic_name: standard_d192ds_v6
+      id: Standard_D192ds_v6
+      memory: 824633720832
+      name: Standard_D192ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 192
+      family: StandardDsv6Family
+      generic_name: standard_d192s_v6
+      id: Standard_D192s_v6
+      memory: 824633720832
+      name: Standard_D192s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 1
+      family: standardDv2Family
+      generic_name: standard_d1_v2
+      id: Standard_D1_v2
+      memory: 3221225472
+      name: Standard_D1_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDADSv5Family
+      generic_name: standard_d2ads_v5
+      id: Standard_D2ads_v5
+      memory: 8589934592
+      name: Standard_D2ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDadv6Family
+      generic_name: standard_d2ads_v6
+      id: Standard_D2ads_v6
+      memory: 8589934592
+      name: Standard_D2ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDadsv7Family
+      generic_name: standard_d2ads_v7
+      id: Standard_D2ads_v7
+      memory: 8589934592
+      name: Standard_D2ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDaldv6Family
+      generic_name: standard_d2alds_v6
+      id: Standard_D2alds_v6
+      memory: 4294967296
+      name: Standard_D2alds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDaldsv7Family
+      generic_name: standard_d2alds_v7
+      id: Standard_D2alds_v7
+      memory: 4294967296
+      name: Standard_D2alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDalv6Family
+      generic_name: standard_d2als_v6
+      id: Standard_D2als_v6
+      memory: 4294967296
+      name: Standard_D2als_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDalsv7Family
+      generic_name: standard_d2als_v7
+      id: Standard_D2als_v7
+      memory: 4294967296
+      name: Standard_D2als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDASv4Family
+      generic_name: standard_d2as_v4
+      id: Standard_D2as_v4
+      memory: 8589934592
+      name: Standard_D2as_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDASv5Family
+      generic_name: standard_d2as_v5
+      id: Standard_D2as_v5
+      memory: 8589934592
+      name: Standard_D2as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDav6Family
+      generic_name: standard_d2as_v6
+      id: Standard_D2as_v6
+      memory: 8589934592
+      name: Standard_D2as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDasv7Family
+      generic_name: standard_d2as_v7
+      id: Standard_D2as_v7
+      memory: 8589934592
+      name: Standard_D2as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDAv4Family
+      generic_name: standard_d2a_v4
+      id: Standard_D2a_v4
+      memory: 8589934592
+      name: Standard_D2a_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDDSv4Family
+      generic_name: standard_d2ds_v4
+      id: Standard_D2ds_v4
+      memory: 8589934592
+      name: Standard_D2ds_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDDSv5Family
+      generic_name: standard_d2ds_v5
+      id: Standard_D2ds_v5
+      memory: 8589934592
+      name: Standard_D2ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDdsv6Family
+      generic_name: standard_d2ds_v6
+      id: Standard_D2ds_v6
+      memory: 8589934592
+      name: Standard_D2ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDDv4Family
+      generic_name: standard_d2d_v4
+      id: Standard_D2d_v4
+      memory: 8589934592
+      name: Standard_D2d_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDDv5Family
+      generic_name: standard_d2d_v5
+      id: Standard_D2d_v5
+      memory: 8589934592
+      name: Standard_D2d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDLDSv5Family
+      generic_name: standard_d2lds_v5
+      id: Standard_D2lds_v5
+      memory: 4294967296
+      name: Standard_D2lds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDldsv6Family
+      generic_name: standard_d2lds_v6
+      id: Standard_D2lds_v6
+      memory: 4294967296
+      name: Standard_D2lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDLSv5Family
+      generic_name: standard_d2ls_v5
+      id: Standard_D2ls_v5
+      memory: 4294967296
+      name: Standard_D2ls_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDlsv6Family
+      generic_name: standard_d2ls_v6
+      id: Standard_D2ls_v6
+      memory: 4294967296
+      name: Standard_D2ls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDPDSv5Family
+      generic_name: standard_d2pds_v5
+      id: Standard_D2pds_v5
+      memory: 8589934592
+      name: Standard_D2pds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDpdsv6Family
+      generic_name: standard_d2pds_v6
+      id: Standard_D2pds_v6
+      memory: 8589934592
+      name: Standard_D2pds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDPLDSv5Family
+      generic_name: standard_d2plds_v5
+      id: Standard_D2plds_v5
+      memory: 4294967296
+      name: Standard_D2plds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDpldsv6Family
+      generic_name: standard_d2plds_v6
+      id: Standard_D2plds_v6
+      memory: 4294967296
+      name: Standard_D2plds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDPLSv5Family
+      generic_name: standard_d2pls_v5
+      id: Standard_D2pls_v5
+      memory: 4294967296
+      name: Standard_D2pls_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDplsv6Family
+      generic_name: standard_d2pls_v6
+      id: Standard_D2pls_v6
+      memory: 4294967296
+      name: Standard_D2pls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDPSv5Family
+      generic_name: standard_d2ps_v5
+      id: Standard_D2ps_v5
+      memory: 8589934592
+      name: Standard_D2ps_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDpsv6Family
+      generic_name: standard_d2ps_v6
+      id: Standard_D2ps_v6
+      memory: 8589934592
+      name: Standard_D2ps_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDSv3Family
+      generic_name: standard_d2s_v3
+      id: Standard_D2s_v3
+      memory: 8589934592
+      name: Standard_D2s_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDSv4Family
+      generic_name: standard_d2s_v4
+      id: Standard_D2s_v4
+      memory: 8589934592
+      name: Standard_D2s_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDSv5Family
+      generic_name: standard_d2s_v5
+      id: Standard_D2s_v5
+      memory: 8589934592
+      name: Standard_D2s_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDsv6Family
+      generic_name: standard_d2s_v6
+      id: Standard_D2s_v6
+      memory: 8589934592
+      name: Standard_D2s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDv2Family
+      generic_name: standard_d2_v2
+      id: Standard_D2_v2
+      memory: 7516192768
+      name: Standard_D2_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDv3Family
+      generic_name: standard_d2_v3
+      id: Standard_D2_v3
+      memory: 8589934592
+      name: Standard_D2_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDv4Family
+      generic_name: standard_d2_v4
+      id: Standard_D2_v4
+      memory: 8589934592
+      name: Standard_D2_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDv5Family
+      generic_name: standard_d2_v5
+      id: Standard_D2_v5
+      memory: 8589934592
+      name: Standard_D2_v5
+    - category: general_purpose
+      cloud_provider_id: azure
       cpu_cores: 32
+      family: standardDADSv5Family
+      generic_name: standard_d32ads_v5
+      id: Standard_D32ads_v5
+      memory: 137438953472
+      name: Standard_D32ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDadv6Family
+      generic_name: standard_d32ads_v6
+      id: Standard_D32ads_v6
+      memory: 137438953472
+      name: Standard_D32ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDadsv7Family
+      generic_name: standard_d32ads_v7
+      id: Standard_D32ads_v7
+      memory: 137438953472
+      name: Standard_D32ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDaldv6Family
+      generic_name: standard_d32alds_v6
+      id: Standard_D32alds_v6
+      memory: 68719476736
+      name: Standard_D32alds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDaldsv7Family
+      generic_name: standard_d32alds_v7
+      id: Standard_D32alds_v7
+      memory: 68719476736
+      name: Standard_D32alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDalv6Family
+      generic_name: standard_d32als_v6
+      id: Standard_D32als_v6
+      memory: 68719476736
+      name: Standard_D32als_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDalsv7Family
+      generic_name: standard_d32als_v7
+      id: Standard_D32als_v7
+      memory: 68719476736
+      name: Standard_D32als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDASv4Family
+      generic_name: standard_d32as_v4
+      id: Standard_D32as_v4
+      memory: 137438953472
+      name: Standard_D32as_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDASv5Family
+      generic_name: standard_d32as_v5
+      id: Standard_D32as_v5
+      memory: 137438953472
+      name: Standard_D32as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDav6Family
+      generic_name: standard_d32as_v6
+      id: Standard_D32as_v6
+      memory: 137438953472
+      name: Standard_D32as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDasv7Family
+      generic_name: standard_d32as_v7
+      id: Standard_D32as_v7
+      memory: 137438953472
+      name: Standard_D32as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDAv4Family
+      generic_name: standard_d32a_v4
+      id: Standard_D32a_v4
+      memory: 137438953472
+      name: Standard_D32a_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDDSv4Family
+      generic_name: standard_d32ds_v4
+      id: Standard_D32ds_v4
+      memory: 137438953472
+      name: Standard_D32ds_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDDSv5Family
+      generic_name: standard_d32ds_v5
+      id: Standard_D32ds_v5
+      memory: 137438953472
+      name: Standard_D32ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDdsv6Family
+      generic_name: standard_d32ds_v6
+      id: Standard_D32ds_v6
+      memory: 137438953472
+      name: Standard_D32ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDDv4Family
+      generic_name: standard_d32d_v4
+      id: Standard_D32d_v4
+      memory: 137438953472
+      name: Standard_D32d_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDDv5Family
+      generic_name: standard_d32d_v5
+      id: Standard_D32d_v5
+      memory: 137438953472
+      name: Standard_D32d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDLDSv5Family
+      generic_name: standard_d32lds_v5
+      id: Standard_D32lds_v5
+      memory: 68719476736
+      name: Standard_D32lds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDldsv6Family
+      generic_name: standard_d32lds_v6
+      id: Standard_D32lds_v6
+      memory: 68719476736
+      name: Standard_D32lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDLSv5Family
+      generic_name: standard_d32ls_v5
+      id: Standard_D32ls_v5
+      memory: 68719476736
+      name: Standard_D32ls_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDlsv6Family
+      generic_name: standard_d32ls_v6
+      id: Standard_D32ls_v6
+      memory: 68719476736
+      name: Standard_D32ls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDPDSv5Family
+      generic_name: standard_d32pds_v5
+      id: Standard_D32pds_v5
+      memory: 137438953472
+      name: Standard_D32pds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDpdsv6Family
+      generic_name: standard_d32pds_v6
+      id: Standard_D32pds_v6
+      memory: 137438953472
+      name: Standard_D32pds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDPLDSv5Family
+      generic_name: standard_d32plds_v5
+      id: Standard_D32plds_v5
+      memory: 68719476736
+      name: Standard_D32plds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDpldsv6Family
       generic_name: standard_d32plds_v6
       id: Standard_D32plds_v6
       memory: 68719476736
@@ -5140,7 +975,303 @@ data:
     - architecture: arm64
       category: general_purpose
       cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDPLSv5Family
+      generic_name: standard_d32pls_v5
+      id: Standard_D32pls_v5
+      memory: 68719476736
+      name: Standard_D32pls_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDplsv6Family
+      generic_name: standard_d32pls_v6
+      id: Standard_D32pls_v6
+      memory: 68719476736
+      name: Standard_D32pls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDPSv5Family
+      generic_name: standard_d32ps_v5
+      id: Standard_D32ps_v5
+      memory: 137438953472
+      name: Standard_D32ps_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDpsv6Family
+      generic_name: standard_d32ps_v6
+      id: Standard_D32ps_v6
+      memory: 137438953472
+      name: Standard_D32ps_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDSv3Family
+      generic_name: standard_d32s_v3
+      id: Standard_D32s_v3
+      memory: 137438953472
+      name: Standard_D32s_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDSv4Family
+      generic_name: standard_d32s_v4
+      id: Standard_D32s_v4
+      memory: 137438953472
+      name: Standard_D32s_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDSv5Family
+      generic_name: standard_d32s_v5
+      id: Standard_D32s_v5
+      memory: 137438953472
+      name: Standard_D32s_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDsv6Family
+      generic_name: standard_d32s_v6
+      id: Standard_D32s_v6
+      memory: 137438953472
+      name: Standard_D32s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDv3Family
+      generic_name: standard_d32_v3
+      id: Standard_D32_v3
+      memory: 137438953472
+      name: Standard_D32_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDv4Family
+      generic_name: standard_d32_v4
+      id: Standard_D32_v4
+      memory: 137438953472
+      name: Standard_D32_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDv5Family
+      generic_name: standard_d32_v5
+      id: Standard_D32_v5
+      memory: 137438953472
+      name: Standard_D32_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDv2Family
+      generic_name: standard_d3_v2
+      id: Standard_D3_v2
+      memory: 15032385536
+      name: Standard_D3_v2
+    - category: general_purpose
+      cloud_provider_id: azure
       cpu_cores: 48
+      family: standardDADSv5Family
+      generic_name: standard_d48ads_v5
+      id: Standard_D48ads_v5
+      memory: 206158430208
+      name: Standard_D48ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDadv6Family
+      generic_name: standard_d48ads_v6
+      id: Standard_D48ads_v6
+      memory: 206158430208
+      name: Standard_D48ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDadsv7Family
+      generic_name: standard_d48ads_v7
+      id: Standard_D48ads_v7
+      memory: 206158430208
+      name: Standard_D48ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDaldv6Family
+      generic_name: standard_d48alds_v6
+      id: Standard_D48alds_v6
+      memory: 103079215104
+      name: Standard_D48alds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDaldsv7Family
+      generic_name: standard_d48alds_v7
+      id: Standard_D48alds_v7
+      memory: 103079215104
+      name: Standard_D48alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDalv6Family
+      generic_name: standard_d48als_v6
+      id: Standard_D48als_v6
+      memory: 103079215104
+      name: Standard_D48als_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDalsv7Family
+      generic_name: standard_d48als_v7
+      id: Standard_D48als_v7
+      memory: 103079215104
+      name: Standard_D48als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDASv4Family
+      generic_name: standard_d48as_v4
+      id: Standard_D48as_v4
+      memory: 206158430208
+      name: Standard_D48as_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDASv5Family
+      generic_name: standard_d48as_v5
+      id: Standard_D48as_v5
+      memory: 206158430208
+      name: Standard_D48as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDav6Family
+      generic_name: standard_d48as_v6
+      id: Standard_D48as_v6
+      memory: 206158430208
+      name: Standard_D48as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDasv7Family
+      generic_name: standard_d48as_v7
+      id: Standard_D48as_v7
+      memory: 206158430208
+      name: Standard_D48as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDAv4Family
+      generic_name: standard_d48a_v4
+      id: Standard_D48a_v4
+      memory: 206158430208
+      name: Standard_D48a_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDDSv4Family
+      generic_name: standard_d48ds_v4
+      id: Standard_D48ds_v4
+      memory: 206158430208
+      name: Standard_D48ds_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDDSv5Family
+      generic_name: standard_d48ds_v5
+      id: Standard_D48ds_v5
+      memory: 206158430208
+      name: Standard_D48ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDdsv6Family
+      generic_name: standard_d48ds_v6
+      id: Standard_D48ds_v6
+      memory: 206158430208
+      name: Standard_D48ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDDv4Family
+      generic_name: standard_d48d_v4
+      id: Standard_D48d_v4
+      memory: 206158430208
+      name: Standard_D48d_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDDv5Family
+      generic_name: standard_d48d_v5
+      id: Standard_D48d_v5
+      memory: 206158430208
+      name: Standard_D48d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDLDSv5Family
+      generic_name: standard_d48lds_v5
+      id: Standard_D48lds_v5
+      memory: 103079215104
+      name: Standard_D48lds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDldsv6Family
+      generic_name: standard_d48lds_v6
+      id: Standard_D48lds_v6
+      memory: 103079215104
+      name: Standard_D48lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDLSv5Family
+      generic_name: standard_d48ls_v5
+      id: Standard_D48ls_v5
+      memory: 103079215104
+      name: Standard_D48ls_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDlsv6Family
+      generic_name: standard_d48ls_v6
+      id: Standard_D48ls_v6
+      memory: 103079215104
+      name: Standard_D48ls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDPDSv5Family
+      generic_name: standard_d48pds_v5
+      id: Standard_D48pds_v5
+      memory: 206158430208
+      name: Standard_D48pds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDpdsv6Family
+      generic_name: standard_d48pds_v6
+      id: Standard_D48pds_v6
+      memory: 206158430208
+      name: Standard_D48pds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDPLDSv5Family
+      generic_name: standard_d48plds_v5
+      id: Standard_D48plds_v5
+      memory: 103079215104
+      name: Standard_D48plds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDpldsv6Family
       generic_name: standard_d48plds_v6
       id: Standard_D48plds_v6
       memory: 103079215104
@@ -5148,7 +1279,607 @@ data:
     - architecture: arm64
       category: general_purpose
       cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDPLSv5Family
+      generic_name: standard_d48pls_v5
+      id: Standard_D48pls_v5
+      memory: 103079215104
+      name: Standard_D48pls_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDplsv6Family
+      generic_name: standard_d48pls_v6
+      id: Standard_D48pls_v6
+      memory: 103079215104
+      name: Standard_D48pls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDPSv5Family
+      generic_name: standard_d48ps_v5
+      id: Standard_D48ps_v5
+      memory: 206158430208
+      name: Standard_D48ps_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDpsv6Family
+      generic_name: standard_d48ps_v6
+      id: Standard_D48ps_v6
+      memory: 206158430208
+      name: Standard_D48ps_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDSv3Family
+      generic_name: standard_d48s_v3
+      id: Standard_D48s_v3
+      memory: 206158430208
+      name: Standard_D48s_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDSv4Family
+      generic_name: standard_d48s_v4
+      id: Standard_D48s_v4
+      memory: 206158430208
+      name: Standard_D48s_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDSv5Family
+      generic_name: standard_d48s_v5
+      id: Standard_D48s_v5
+      memory: 206158430208
+      name: Standard_D48s_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDsv6Family
+      generic_name: standard_d48s_v6
+      id: Standard_D48s_v6
+      memory: 206158430208
+      name: Standard_D48s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDv3Family
+      generic_name: standard_d48_v3
+      id: Standard_D48_v3
+      memory: 206158430208
+      name: Standard_D48_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDv4Family
+      generic_name: standard_d48_v4
+      id: Standard_D48_v4
+      memory: 206158430208
+      name: Standard_D48_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDv5Family
+      generic_name: standard_d48_v5
+      id: Standard_D48_v5
+      memory: 206158430208
+      name: Standard_D48_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDADSv5Family
+      generic_name: standard_d4ads_v5
+      id: Standard_D4ads_v5
+      memory: 17179869184
+      name: Standard_D4ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDadv6Family
+      generic_name: standard_d4ads_v6
+      id: Standard_D4ads_v6
+      memory: 17179869184
+      name: Standard_D4ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDadsv7Family
+      generic_name: standard_d4ads_v7
+      id: Standard_D4ads_v7
+      memory: 17179869184
+      name: Standard_D4ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDaldv6Family
+      generic_name: standard_d4alds_v6
+      id: Standard_D4alds_v6
+      memory: 8589934592
+      name: Standard_D4alds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDaldsv7Family
+      generic_name: standard_d4alds_v7
+      id: Standard_D4alds_v7
+      memory: 8589934592
+      name: Standard_D4alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDalv6Family
+      generic_name: standard_d4als_v6
+      id: Standard_D4als_v6
+      memory: 8589934592
+      name: Standard_D4als_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDalsv7Family
+      generic_name: standard_d4als_v7
+      id: Standard_D4als_v7
+      memory: 8589934592
+      name: Standard_D4als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDASv4Family
+      generic_name: standard_d4as_v4
+      id: Standard_D4as_v4
+      memory: 17179869184
+      name: Standard_D4as_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDASv5Family
+      generic_name: standard_d4as_v5
+      id: Standard_D4as_v5
+      memory: 17179869184
+      name: Standard_D4as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDav6Family
+      generic_name: standard_d4as_v6
+      id: Standard_D4as_v6
+      memory: 17179869184
+      name: Standard_D4as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDasv7Family
+      generic_name: standard_d4as_v7
+      id: Standard_D4as_v7
+      memory: 17179869184
+      name: Standard_D4as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDAv4Family
+      generic_name: standard_d4a_v4
+      id: Standard_D4a_v4
+      memory: 17179869184
+      name: Standard_D4a_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDDSv4Family
+      generic_name: standard_d4ds_v4
+      id: Standard_D4ds_v4
+      memory: 17179869184
+      name: Standard_D4ds_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDDSv5Family
+      generic_name: standard_d4ds_v5
+      id: Standard_D4ds_v5
+      memory: 17179869184
+      name: Standard_D4ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDdsv6Family
+      generic_name: standard_d4ds_v6
+      id: Standard_D4ds_v6
+      memory: 17179869184
+      name: Standard_D4ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDDv4Family
+      generic_name: standard_d4d_v4
+      id: Standard_D4d_v4
+      memory: 17179869184
+      name: Standard_D4d_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDDv5Family
+      generic_name: standard_d4d_v5
+      id: Standard_D4d_v5
+      memory: 17179869184
+      name: Standard_D4d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDLDSv5Family
+      generic_name: standard_d4lds_v5
+      id: Standard_D4lds_v5
+      memory: 8589934592
+      name: Standard_D4lds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDldsv6Family
+      generic_name: standard_d4lds_v6
+      id: Standard_D4lds_v6
+      memory: 8589934592
+      name: Standard_D4lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDLSv5Family
+      generic_name: standard_d4ls_v5
+      id: Standard_D4ls_v5
+      memory: 8589934592
+      name: Standard_D4ls_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDlsv6Family
+      generic_name: standard_d4ls_v6
+      id: Standard_D4ls_v6
+      memory: 8589934592
+      name: Standard_D4ls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDPDSv5Family
+      generic_name: standard_d4pds_v5
+      id: Standard_D4pds_v5
+      memory: 17179869184
+      name: Standard_D4pds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDpdsv6Family
+      generic_name: standard_d4pds_v6
+      id: Standard_D4pds_v6
+      memory: 17179869184
+      name: Standard_D4pds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDPLDSv5Family
+      generic_name: standard_d4plds_v5
+      id: Standard_D4plds_v5
+      memory: 8589934592
+      name: Standard_D4plds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDpldsv6Family
+      generic_name: standard_d4plds_v6
+      id: Standard_D4plds_v6
+      memory: 8589934592
+      name: Standard_D4plds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDPLSv5Family
+      generic_name: standard_d4pls_v5
+      id: Standard_D4pls_v5
+      memory: 8589934592
+      name: Standard_D4pls_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDplsv6Family
+      generic_name: standard_d4pls_v6
+      id: Standard_D4pls_v6
+      memory: 8589934592
+      name: Standard_D4pls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDPSv5Family
+      generic_name: standard_d4ps_v5
+      id: Standard_D4ps_v5
+      memory: 17179869184
+      name: Standard_D4ps_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDpsv6Family
+      generic_name: standard_d4ps_v6
+      id: Standard_D4ps_v6
+      memory: 17179869184
+      name: Standard_D4ps_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDSv3Family
+      generic_name: standard_d4s_v3
+      id: Standard_D4s_v3
+      memory: 17179869184
+      name: Standard_D4s_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDSv4Family
+      generic_name: standard_d4s_v4
+      id: Standard_D4s_v4
+      memory: 17179869184
+      name: Standard_D4s_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDSv5Family
+      generic_name: standard_d4s_v5
+      id: Standard_D4s_v5
+      memory: 17179869184
+      name: Standard_D4s_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDsv6Family
+      generic_name: standard_d4s_v6
+      id: Standard_D4s_v6
+      memory: 17179869184
+      name: Standard_D4s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDv2Family
+      generic_name: standard_d4_v2
+      id: Standard_D4_v2
+      memory: 30064771072
+      name: Standard_D4_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDv3Family
+      generic_name: standard_d4_v3
+      id: Standard_D4_v3
+      memory: 17179869184
+      name: Standard_D4_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDv4Family
+      generic_name: standard_d4_v4
+      id: Standard_D4_v4
+      memory: 17179869184
+      name: Standard_D4_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDv5Family
+      generic_name: standard_d4_v5
+      id: Standard_D4_v5
+      memory: 17179869184
+      name: Standard_D4_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDv2Family
+      generic_name: standard_d5_v2
+      id: Standard_D5_v2
+      memory: 60129542144
+      name: Standard_D5_v2
+    - category: general_purpose
+      cloud_provider_id: azure
       cpu_cores: 64
+      family: standardDADSv5Family
+      generic_name: standard_d64ads_v5
+      id: Standard_D64ads_v5
+      memory: 274877906944
+      name: Standard_D64ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDadv6Family
+      generic_name: standard_d64ads_v6
+      id: Standard_D64ads_v6
+      memory: 274877906944
+      name: Standard_D64ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDadsv7Family
+      generic_name: standard_d64ads_v7
+      id: Standard_D64ads_v7
+      memory: 274877906944
+      name: Standard_D64ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDaldv6Family
+      generic_name: standard_d64alds_v6
+      id: Standard_D64alds_v6
+      memory: 137438953472
+      name: Standard_D64alds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDaldsv7Family
+      generic_name: standard_d64alds_v7
+      id: Standard_D64alds_v7
+      memory: 137438953472
+      name: Standard_D64alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDalv6Family
+      generic_name: standard_d64als_v6
+      id: Standard_D64als_v6
+      memory: 137438953472
+      name: Standard_D64als_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDalsv7Family
+      generic_name: standard_d64als_v7
+      id: Standard_D64als_v7
+      memory: 137438953472
+      name: Standard_D64als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDASv4Family
+      generic_name: standard_d64as_v4
+      id: Standard_D64as_v4
+      memory: 274877906944
+      name: Standard_D64as_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDASv5Family
+      generic_name: standard_d64as_v5
+      id: Standard_D64as_v5
+      memory: 274877906944
+      name: Standard_D64as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDav6Family
+      generic_name: standard_d64as_v6
+      id: Standard_D64as_v6
+      memory: 274877906944
+      name: Standard_D64as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDasv7Family
+      generic_name: standard_d64as_v7
+      id: Standard_D64as_v7
+      memory: 274877906944
+      name: Standard_D64as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDAv4Family
+      generic_name: standard_d64a_v4
+      id: Standard_D64a_v4
+      memory: 274877906944
+      name: Standard_D64a_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDDSv4Family
+      generic_name: standard_d64ds_v4
+      id: Standard_D64ds_v4
+      memory: 274877906944
+      name: Standard_D64ds_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDDSv5Family
+      generic_name: standard_d64ds_v5
+      id: Standard_D64ds_v5
+      memory: 274877906944
+      name: Standard_D64ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDdsv6Family
+      generic_name: standard_d64ds_v6
+      id: Standard_D64ds_v6
+      memory: 274877906944
+      name: Standard_D64ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDDv4Family
+      generic_name: standard_d64d_v4
+      id: Standard_D64d_v4
+      memory: 274877906944
+      name: Standard_D64d_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDDv5Family
+      generic_name: standard_d64d_v5
+      id: Standard_D64d_v5
+      memory: 274877906944
+      name: Standard_D64d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDLDSv5Family
+      generic_name: standard_d64lds_v5
+      id: Standard_D64lds_v5
+      memory: 137438953472
+      name: Standard_D64lds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDldsv6Family
+      generic_name: standard_d64lds_v6
+      id: Standard_D64lds_v6
+      memory: 137438953472
+      name: Standard_D64lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDLSv5Family
+      generic_name: standard_d64ls_v5
+      id: Standard_D64ls_v5
+      memory: 137438953472
+      name: Standard_D64ls_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDlsv6Family
+      generic_name: standard_d64ls_v6
+      id: Standard_D64ls_v6
+      memory: 137438953472
+      name: Standard_D64ls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDPDSv5Family
+      generic_name: standard_d64pds_v5
+      id: Standard_D64pds_v5
+      memory: 223338299392
+      name: Standard_D64pds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDpdsv6Family
+      generic_name: standard_d64pds_v6
+      id: Standard_D64pds_v6
+      memory: 274877906944
+      name: Standard_D64pds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDPLDSv5Family
+      generic_name: standard_d64plds_v5
+      id: Standard_D64plds_v5
+      memory: 137438953472
+      name: Standard_D64plds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDpldsv6Family
       generic_name: standard_d64plds_v6
       id: Standard_D64plds_v6
       memory: 137438953472
@@ -5156,7 +1887,557 @@ data:
     - architecture: arm64
       category: general_purpose
       cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDPLSv5Family
+      generic_name: standard_d64pls_v5
+      id: Standard_D64pls_v5
+      memory: 137438953472
+      name: Standard_D64pls_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDplsv6Family
+      generic_name: standard_d64pls_v6
+      id: Standard_D64pls_v6
+      memory: 137438953472
+      name: Standard_D64pls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDPSv5Family
+      generic_name: standard_d64ps_v5
+      id: Standard_D64ps_v5
+      memory: 223338299392
+      name: Standard_D64ps_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDpsv6Family
+      generic_name: standard_d64ps_v6
+      id: Standard_D64ps_v6
+      memory: 274877906944
+      name: Standard_D64ps_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDSv3Family
+      generic_name: standard_d64s_v3
+      id: Standard_D64s_v3
+      memory: 274877906944
+      name: Standard_D64s_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDSv4Family
+      generic_name: standard_d64s_v4
+      id: Standard_D64s_v4
+      memory: 274877906944
+      name: Standard_D64s_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDSv5Family
+      generic_name: standard_d64s_v5
+      id: Standard_D64s_v5
+      memory: 274877906944
+      name: Standard_D64s_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDsv6Family
+      generic_name: standard_d64s_v6
+      id: Standard_D64s_v6
+      memory: 274877906944
+      name: Standard_D64s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDv3Family
+      generic_name: standard_d64_v3
+      id: Standard_D64_v3
+      memory: 274877906944
+      name: Standard_D64_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDv4Family
+      generic_name: standard_d64_v4
+      id: Standard_D64_v4
+      memory: 274877906944
+      name: Standard_D64_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDv5Family
+      generic_name: standard_d64_v5
+      id: Standard_D64_v5
+      memory: 274877906944
+      name: Standard_D64_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDADSv5Family
+      generic_name: standard_d8ads_v5
+      id: Standard_D8ads_v5
+      memory: 34359738368
+      name: Standard_D8ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDadv6Family
+      generic_name: standard_d8ads_v6
+      id: Standard_D8ads_v6
+      memory: 34359738368
+      name: Standard_D8ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDadsv7Family
+      generic_name: standard_d8ads_v7
+      id: Standard_D8ads_v7
+      memory: 34359738368
+      name: Standard_D8ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDaldv6Family
+      generic_name: standard_d8alds_v6
+      id: Standard_D8alds_v6
+      memory: 17179869184
+      name: Standard_D8alds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDaldsv7Family
+      generic_name: standard_d8alds_v7
+      id: Standard_D8alds_v7
+      memory: 17179869184
+      name: Standard_D8alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDalv6Family
+      generic_name: standard_d8als_v6
+      id: Standard_D8als_v6
+      memory: 17179869184
+      name: Standard_D8als_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDalsv7Family
+      generic_name: standard_d8als_v7
+      id: Standard_D8als_v7
+      memory: 17179869184
+      name: Standard_D8als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDASv4Family
+      generic_name: standard_d8as_v4
+      id: Standard_D8as_v4
+      memory: 34359738368
+      name: Standard_D8as_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDASv5Family
+      generic_name: standard_d8as_v5
+      id: Standard_D8as_v5
+      memory: 34359738368
+      name: Standard_D8as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDav6Family
+      generic_name: standard_d8as_v6
+      id: Standard_D8as_v6
+      memory: 34359738368
+      name: Standard_D8as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDasv7Family
+      generic_name: standard_d8as_v7
+      id: Standard_D8as_v7
+      memory: 34359738368
+      name: Standard_D8as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDAv4Family
+      generic_name: standard_d8a_v4
+      id: Standard_D8a_v4
+      memory: 34359738368
+      name: Standard_D8a_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDDSv4Family
+      generic_name: standard_d8ds_v4
+      id: Standard_D8ds_v4
+      memory: 34359738368
+      name: Standard_D8ds_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDDSv5Family
+      generic_name: standard_d8ds_v5
+      id: Standard_D8ds_v5
+      memory: 34359738368
+      name: Standard_D8ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDdsv6Family
+      generic_name: standard_d8ds_v6
+      id: Standard_D8ds_v6
+      memory: 34359738368
+      name: Standard_D8ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDDv4Family
+      generic_name: standard_d8d_v4
+      id: Standard_D8d_v4
+      memory: 34359738368
+      name: Standard_D8d_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDDv5Family
+      generic_name: standard_d8d_v5
+      id: Standard_D8d_v5
+      memory: 34359738368
+      name: Standard_D8d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDLDSv5Family
+      generic_name: standard_d8lds_v5
+      id: Standard_D8lds_v5
+      memory: 17179869184
+      name: Standard_D8lds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDldsv6Family
+      generic_name: standard_d8lds_v6
+      id: Standard_D8lds_v6
+      memory: 17179869184
+      name: Standard_D8lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDLSv5Family
+      generic_name: standard_d8ls_v5
+      id: Standard_D8ls_v5
+      memory: 17179869184
+      name: Standard_D8ls_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDlsv6Family
+      generic_name: standard_d8ls_v6
+      id: Standard_D8ls_v6
+      memory: 17179869184
+      name: Standard_D8ls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDPDSv5Family
+      generic_name: standard_d8pds_v5
+      id: Standard_D8pds_v5
+      memory: 34359738368
+      name: Standard_D8pds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDpdsv6Family
+      generic_name: standard_d8pds_v6
+      id: Standard_D8pds_v6
+      memory: 34359738368
+      name: Standard_D8pds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDPLDSv5Family
+      generic_name: standard_d8plds_v5
+      id: Standard_D8plds_v5
+      memory: 17179869184
+      name: Standard_D8plds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDpldsv6Family
+      generic_name: standard_d8plds_v6
+      id: Standard_D8plds_v6
+      memory: 17179869184
+      name: Standard_D8plds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDPLSv5Family
+      generic_name: standard_d8pls_v5
+      id: Standard_D8pls_v5
+      memory: 17179869184
+      name: Standard_D8pls_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDplsv6Family
+      generic_name: standard_d8pls_v6
+      id: Standard_D8pls_v6
+      memory: 17179869184
+      name: Standard_D8pls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDPSv5Family
+      generic_name: standard_d8ps_v5
+      id: Standard_D8ps_v5
+      memory: 34359738368
+      name: Standard_D8ps_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDpsv6Family
+      generic_name: standard_d8ps_v6
+      id: Standard_D8ps_v6
+      memory: 34359738368
+      name: Standard_D8ps_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDSv3Family
+      generic_name: standard_d8s_v3
+      id: Standard_D8s_v3
+      memory: 34359738368
+      name: Standard_D8s_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDSv4Family
+      generic_name: standard_d8s_v4
+      id: Standard_D8s_v4
+      memory: 34359738368
+      name: Standard_D8s_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDSv5Family
+      generic_name: standard_d8s_v5
+      id: Standard_D8s_v5
+      memory: 34359738368
+      name: Standard_D8s_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDsv6Family
+      generic_name: standard_d8s_v6
+      id: Standard_D8s_v6
+      memory: 34359738368
+      name: Standard_D8s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDv3Family
+      generic_name: standard_d8_v3
+      id: Standard_D8_v3
+      memory: 34359738368
+      name: Standard_D8_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDv4Family
+      generic_name: standard_d8_v4
+      id: Standard_D8_v4
+      memory: 34359738368
+      name: Standard_D8_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDv5Family
+      generic_name: standard_d8_v5
+      id: Standard_D8_v5
+      memory: 34359738368
+      name: Standard_D8_v5
+    - category: general_purpose
+      cloud_provider_id: azure
       cpu_cores: 96
+      family: standardDADSv5Family
+      generic_name: standard_d96ads_v5
+      id: Standard_D96ads_v5
+      memory: 412316860416
+      name: Standard_D96ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDadv6Family
+      generic_name: standard_d96ads_v6
+      id: Standard_D96ads_v6
+      memory: 412316860416
+      name: Standard_D96ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardDadsv7Family
+      generic_name: standard_d96ads_v7
+      id: Standard_D96ads_v7
+      memory: 412316860416
+      name: Standard_D96ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDaldv6Family
+      generic_name: standard_d96alds_v6
+      id: Standard_D96alds_v6
+      memory: 206158430208
+      name: Standard_D96alds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardDaldsv7Family
+      generic_name: standard_d96alds_v7
+      id: Standard_D96alds_v7
+      memory: 206158430208
+      name: Standard_D96alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDalv6Family
+      generic_name: standard_d96als_v6
+      id: Standard_D96als_v6
+      memory: 206158430208
+      name: Standard_D96als_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardDalsv7Family
+      generic_name: standard_d96als_v7
+      id: Standard_D96als_v7
+      memory: 206158430208
+      name: Standard_D96als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDASv4Family
+      generic_name: standard_d96as_v4
+      id: Standard_D96as_v4
+      memory: 412316860416
+      name: Standard_D96as_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDASv5Family
+      generic_name: standard_d96as_v5
+      id: Standard_D96as_v5
+      memory: 412316860416
+      name: Standard_D96as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDav6Family
+      generic_name: standard_d96as_v6
+      id: Standard_D96as_v6
+      memory: 412316860416
+      name: Standard_D96as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardDasv7Family
+      generic_name: standard_d96as_v7
+      id: Standard_D96as_v7
+      memory: 412316860416
+      name: Standard_D96as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDAv4Family
+      generic_name: standard_d96a_v4
+      id: Standard_D96a_v4
+      memory: 412316860416
+      name: Standard_D96a_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDDSv5Family
+      generic_name: standard_d96ds_v5
+      id: Standard_D96ds_v5
+      memory: 412316860416
+      name: Standard_D96ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardDdsv6Family
+      generic_name: standard_d96ds_v6
+      id: Standard_D96ds_v6
+      memory: 412316860416
+      name: Standard_D96ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDDv5Family
+      generic_name: standard_d96d_v5
+      id: Standard_D96d_v5
+      memory: 412316860416
+      name: Standard_D96d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDLDSv5Family
+      generic_name: standard_d96lds_v5
+      id: Standard_D96lds_v5
+      memory: 206158430208
+      name: Standard_D96lds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardDldsv6Family
+      generic_name: standard_d96lds_v6
+      id: Standard_D96lds_v6
+      memory: 206158430208
+      name: Standard_D96lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDLSv5Family
+      generic_name: standard_d96ls_v5
+      id: Standard_D96ls_v5
+      memory: 206158430208
+      name: Standard_D96ls_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardDlsv6Family
+      generic_name: standard_d96ls_v6
+      id: Standard_D96ls_v6
+      memory: 206158430208
+      name: Standard_D96ls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardDpdsv6Family
+      generic_name: standard_d96pds_v6
+      id: Standard_D96pds_v6
+      memory: 412316860416
+      name: Standard_D96pds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardDpldsv6Family
       generic_name: standard_d96plds_v6
       id: Standard_D96plds_v6
       memory: 206158430208
@@ -5164,1675 +2445,233 @@ data:
     - architecture: arm64
       category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2ps_v6
-      id: Standard_D2ps_v6
-      memory: 8589934592
-      name: Standard_D2ps_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4ps_v6
-      id: Standard_D4ps_v6
-      memory: 17179869184
-      name: Standard_D4ps_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8ps_v6
-      id: Standard_D8ps_v6
-      memory: 34359738368
-      name: Standard_D8ps_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16ps_v6
-      id: Standard_D16ps_v6
-      memory: 68719476736
-      name: Standard_D16ps_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32ps_v6
-      id: Standard_D32ps_v6
-      memory: 137438953472
-      name: Standard_D32ps_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48ps_v6
-      id: Standard_D48ps_v6
+      cpu_cores: 96
+      family: StandardDplsv6Family
+      generic_name: standard_d96pls_v6
+      id: Standard_D96pls_v6
       memory: 206158430208
-      name: Standard_D48ps_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64ps_v6
-      id: Standard_D64ps_v6
-      memory: 274877906944
-      name: Standard_D64ps_v6
+      name: Standard_D96pls_v6
     - architecture: arm64
       category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 96
+      family: StandardDpsv6Family
       generic_name: standard_d96ps_v6
       id: Standard_D96ps_v6
       memory: 412316860416
       name: Standard_D96ps_v6
-    - architecture: arm64
-      category: memory_optimized
+    - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2ps_v6
-      id: Standard_E2ps_v6
-      memory: 17179869184
-      name: Standard_E2ps_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4ps_v6
-      id: Standard_E4ps_v6
-      memory: 34359738368
-      name: Standard_E4ps_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8ps_v6
-      id: Standard_E8ps_v6
-      memory: 68719476736
-      name: Standard_E8ps_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16ps_v6
-      id: Standard_E16ps_v6
-      memory: 137438953472
-      name: Standard_E16ps_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32ps_v6
-      id: Standard_E32ps_v6
-      memory: 274877906944
-      name: Standard_E32ps_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48ps_v6
-      id: Standard_E48ps_v6
+      cpu_cores: 96
+      family: standardDSv5Family
+      generic_name: standard_d96s_v5
+      id: Standard_D96s_v5
       memory: 412316860416
-      name: Standard_E48ps_v6
-    - architecture: arm64
-      category: memory_optimized
+      name: Standard_D96s_v5
+    - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64ps_v6
-      id: Standard_E64ps_v6
+      cpu_cores: 96
+      family: StandardDsv6Family
+      generic_name: standard_d96s_v6
+      id: Standard_D96s_v6
+      memory: 412316860416
+      name: Standard_D96s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDv5Family
+      generic_name: standard_d96_v5
+      id: Standard_D96_v5
+      memory: 412316860416
+      name: Standard_D96_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: standardDCEDV6Family
+      generic_name: standard_dc128eds_v6
+      id: Standard_DC128eds_v6
       memory: 549755813888
-      name: Standard_E64ps_v6
-    - architecture: arm64
-      category: memory_optimized
+      name: Standard_DC128eds_v6
+    - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96ps_v6
-      id: Standard_E96ps_v6
-      memory: 721554505728
-      name: Standard_E96ps_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2pds_v6
-      id: Standard_E2pds_v6
-      memory: 17179869184
-      name: Standard_E2pds_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4pds_v6
-      id: Standard_E4pds_v6
-      memory: 34359738368
-      name: Standard_E4pds_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8pds_v6
-      id: Standard_E8pds_v6
-      memory: 68719476736
-      name: Standard_E8pds_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16pds_v6
-      id: Standard_E16pds_v6
-      memory: 137438953472
-      name: Standard_E16pds_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32pds_v6
-      id: Standard_E32pds_v6
-      memory: 274877906944
-      name: Standard_E32pds_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48pds_v6
-      id: Standard_E48pds_v6
-      memory: 412316860416
-      name: Standard_E48pds_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64pds_v6
-      id: Standard_E64pds_v6
+      cpu_cores: 128
+      family: standardDCEV6Family
+      generic_name: standard_dc128es_v6
+      id: Standard_DC128es_v6
       memory: 549755813888
-      name: Standard_E64pds_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96pds_v6
-      id: Standard_E96pds_v6
-      memory: 721554505728
-      name: Standard_E96pds_v6
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 24
-      generic_name: standard_nc24ads_a100_v4
-      id: Standard_NC24ads_A100_v4
-      memory: 236223201280
-      name: Standard_NC24ads_A100_v4
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_nc48ads_a100_v4
-      id: Standard_NC48ads_A100_v4
-      memory: 472446402560
-      name: Standard_NC48ads_A100_v4
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_nc96ads_a100_v4
-      id: Standard_NC96ads_A100_v4
-      memory: 944892805120
-      name: Standard_NC96ads_A100_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_dc2as_v6
-      id: Standard_DC2as_v6
-      memory: 8589934592
-      name: Standard_DC2as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_dc4as_v6
-      id: Standard_DC4as_v6
-      memory: 17179869184
-      name: Standard_DC4as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_dc8as_v6
-      id: Standard_DC8as_v6
-      memory: 34359738368
-      name: Standard_DC8as_v6
+      name: Standard_DC128es_v6
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_dc16as_v6
-      id: Standard_DC16as_v6
+      family: standardDCADCCV5Family
+      generic_name: standard_dc16ads_cc_v5
+      id: Standard_DC16ads_cc_v5
       memory: 68719476736
-      name: Standard_DC16as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_dc32as_v6
-      id: Standard_DC32as_v6
-      memory: 137438953472
-      name: Standard_DC32as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_dc48as_v6
-      id: Standard_DC48as_v6
-      memory: 206158430208
-      name: Standard_DC48as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_dc64as_v6
-      id: Standard_DC64as_v6
-      memory: 274877906944
-      name: Standard_DC64as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_dc96as_v6
-      id: Standard_DC96as_v6
-      memory: 412316860416
-      name: Standard_DC96as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_dc2ads_v6
-      id: Standard_DC2ads_v6
-      memory: 8589934592
-      name: Standard_DC2ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_dc4ads_v6
-      id: Standard_DC4ads_v6
-      memory: 17179869184
-      name: Standard_DC4ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_dc8ads_v6
-      id: Standard_DC8ads_v6
-      memory: 34359738368
-      name: Standard_DC8ads_v6
+      name: Standard_DC16ads_cc_v5
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
+      family: standardDCADSv5Family
+      generic_name: standard_dc16ads_v5
+      id: Standard_DC16ads_v5
+      memory: 68719476736
+      name: Standard_DC16ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDCadsv6Family
       generic_name: standard_dc16ads_v6
       id: Standard_DC16ads_v6
       memory: 68719476736
       name: Standard_DC16ads_v6
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_dc32ads_v6
-      id: Standard_DC32ads_v6
-      memory: 137438953472
-      name: Standard_DC32ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_dc48ads_v6
-      id: Standard_DC48ads_v6
-      memory: 206158430208
-      name: Standard_DC48ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_dc64ads_v6
-      id: Standard_DC64ads_v6
-      memory: 274877906944
-      name: Standard_DC64ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_dc96ads_v6
-      id: Standard_DC96ads_v6
-      memory: 412316860416
-      name: Standard_DC96ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_ec2as_v6
-      id: Standard_EC2as_v6
-      memory: 17179869184
-      name: Standard_EC2as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_ec4as_v6
-      id: Standard_EC4as_v6
-      memory: 34359738368
-      name: Standard_EC4as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_ec8as_v6
-      id: Standard_EC8as_v6
+      cpu_cores: 16
+      family: standardDCACCV5Family
+      generic_name: standard_dc16as_cc_v5
+      id: Standard_DC16as_cc_v5
       memory: 68719476736
-      name: Standard_EC8as_v6
-    - category: memory_optimized
+      name: Standard_DC16as_cc_v5
+    - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_ec16as_v6
-      id: Standard_EC16as_v6
-      memory: 137438953472
-      name: Standard_EC16as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_ec32as_v6
-      id: Standard_EC32as_v6
-      memory: 274877906944
-      name: Standard_EC32as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_ec48as_v6
-      id: Standard_EC48as_v6
-      memory: 412316860416
-      name: Standard_EC48as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_ec64as_v6
-      id: Standard_EC64as_v6
-      memory: 549755813888
-      name: Standard_EC64as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_ec96as_v6
-      id: Standard_EC96as_v6
-      memory: 721554505728
-      name: Standard_EC96as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_ec2ads_v6
-      id: Standard_EC2ads_v6
-      memory: 17179869184
-      name: Standard_EC2ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_ec4ads_v6
-      id: Standard_EC4ads_v6
-      memory: 34359738368
-      name: Standard_EC4ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_ec8ads_v6
-      id: Standard_EC8ads_v6
+      family: standardDCASv5Family
+      generic_name: standard_dc16as_v5
+      id: Standard_DC16as_v5
       memory: 68719476736
-      name: Standard_EC8ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_ec16ads_v6
-      id: Standard_EC16ads_v6
-      memory: 137438953472
-      name: Standard_EC16ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_ec32ads_v6
-      id: Standard_EC32ads_v6
-      memory: 274877906944
-      name: Standard_EC32ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_ec48ads_v6
-      id: Standard_EC48ads_v6
-      memory: 412316860416
-      name: Standard_EC48ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_ec64ads_v6
-      id: Standard_EC64ads_v6
-      memory: 549755813888
-      name: Standard_EC64ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_ec96ads_v6
-      id: Standard_EC96ads_v6
-      memory: 721554505728
-      name: Standard_EC96ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2als_v7
-      id: Standard_D2als_v7
-      memory: 4294967296
-      name: Standard_D2als_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4als_v7
-      id: Standard_D4als_v7
-      memory: 8589934592
-      name: Standard_D4als_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8als_v7
-      id: Standard_D8als_v7
-      memory: 17179869184
-      name: Standard_D8als_v7
+      name: Standard_DC16as_v5
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_d16als_v7
-      id: Standard_D16als_v7
-      memory: 34359738368
-      name: Standard_D16als_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32als_v7
-      id: Standard_D32als_v7
+      family: standardDCasv6Family
+      generic_name: standard_dc16as_v6
+      id: Standard_DC16as_v6
       memory: 68719476736
-      name: Standard_D32als_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48als_v7
-      id: Standard_D48als_v7
-      memory: 103079215104
-      name: Standard_D48als_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64als_v7
-      id: Standard_D64als_v7
-      memory: 137438953472
-      name: Standard_D64als_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96als_v7
-      id: Standard_D96als_v7
-      memory: 206158430208
-      name: Standard_D96als_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_d128als_v7
-      id: Standard_D128als_v7
-      memory: 274877906944
-      name: Standard_D128als_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 160
-      generic_name: standard_d160als_v7
-      id: Standard_D160als_v7
-      memory: 343597383680
-      name: Standard_D160als_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2alds_v7
-      id: Standard_D2alds_v7
-      memory: 4294967296
-      name: Standard_D2alds_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4alds_v7
-      id: Standard_D4alds_v7
-      memory: 8589934592
-      name: Standard_D4alds_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8alds_v7
-      id: Standard_D8alds_v7
-      memory: 17179869184
-      name: Standard_D8alds_v7
+      name: Standard_DC16as_v6
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_d16alds_v7
-      id: Standard_D16alds_v7
-      memory: 34359738368
-      name: Standard_D16alds_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32alds_v7
-      id: Standard_D32alds_v7
+      family: standardDCEDV6Family
+      generic_name: standard_dc16eds_v6
+      id: Standard_DC16eds_v6
       memory: 68719476736
-      name: Standard_D32alds_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48alds_v7
-      id: Standard_D48alds_v7
-      memory: 103079215104
-      name: Standard_D48alds_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64alds_v7
-      id: Standard_D64alds_v7
-      memory: 137438953472
-      name: Standard_D64alds_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96alds_v7
-      id: Standard_D96alds_v7
-      memory: 206158430208
-      name: Standard_D96alds_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_d128alds_v7
-      id: Standard_D128alds_v7
-      memory: 274877906944
-      name: Standard_D128alds_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 160
-      generic_name: standard_d160alds_v7
-      id: Standard_D160alds_v7
-      memory: 343597383680
-      name: Standard_D160alds_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2as_v7
-      id: Standard_D2as_v7
-      memory: 8589934592
-      name: Standard_D2as_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4as_v7
-      id: Standard_D4as_v7
-      memory: 17179869184
-      name: Standard_D4as_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8as_v7
-      id: Standard_D8as_v7
-      memory: 34359738368
-      name: Standard_D8as_v7
+      name: Standard_DC16eds_v6
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_d16as_v7
-      id: Standard_D16as_v7
-      memory: 68719476736
-      name: Standard_D16as_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32as_v7
-      id: Standard_D32as_v7
-      memory: 137438953472
-      name: Standard_D32as_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48as_v7
-      id: Standard_D48as_v7
-      memory: 206158430208
-      name: Standard_D48as_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64as_v7
-      id: Standard_D64as_v7
-      memory: 274877906944
-      name: Standard_D64as_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96as_v7
-      id: Standard_D96as_v7
-      memory: 412316860416
-      name: Standard_D96as_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_d128as_v7
-      id: Standard_D128as_v7
-      memory: 549755813888
-      name: Standard_D128as_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 160
-      generic_name: standard_d160as_v7
-      id: Standard_D160as_v7
-      memory: 687194767360
-      name: Standard_D160as_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2ads_v7
-      id: Standard_D2ads_v7
-      memory: 8589934592
-      name: Standard_D2ads_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4ads_v7
-      id: Standard_D4ads_v7
-      memory: 17179869184
-      name: Standard_D4ads_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8ads_v7
-      id: Standard_D8ads_v7
-      memory: 34359738368
-      name: Standard_D8ads_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16ads_v7
-      id: Standard_D16ads_v7
-      memory: 68719476736
-      name: Standard_D16ads_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32ads_v7
-      id: Standard_D32ads_v7
-      memory: 137438953472
-      name: Standard_D32ads_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48ads_v7
-      id: Standard_D48ads_v7
-      memory: 206158430208
-      name: Standard_D48ads_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64ads_v7
-      id: Standard_D64ads_v7
-      memory: 274877906944
-      name: Standard_D64ads_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96ads_v7
-      id: Standard_D96ads_v7
-      memory: 412316860416
-      name: Standard_D96ads_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_d128ads_v7
-      id: Standard_D128ads_v7
-      memory: 549755813888
-      name: Standard_D128ads_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 160
-      generic_name: standard_d160ads_v7
-      id: Standard_D160ads_v7
-      memory: 687194767360
-      name: Standard_D160ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2as_v7
-      id: Standard_E2as_v7
-      memory: 17179869184
-      name: Standard_E2as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2as_v7
-      id: Standard_E4-2as_v7
-      memory: 34359738368
-      name: Standard_E4-2as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4as_v7
-      id: Standard_E4as_v7
-      memory: 34359738368
-      name: Standard_E4as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2as_v7
-      id: Standard_E8-2as_v7
-      memory: 68719476736
-      name: Standard_E8-2as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4as_v7
-      id: Standard_E8-4as_v7
-      memory: 68719476736
-      name: Standard_E8-4as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8as_v7
-      id: Standard_E8as_v7
-      memory: 68719476736
-      name: Standard_E8as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-4as_v7
-      id: Standard_E16-4as_v7
-      memory: 137438953472
-      name: Standard_E16-4as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8as_v7
-      id: Standard_E16-8as_v7
-      memory: 137438953472
-      name: Standard_E16-8as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16as_v7
-      id: Standard_E16as_v7
-      memory: 137438953472
-      name: Standard_E16as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8as_v7
-      id: Standard_E32-8as_v7
-      memory: 274877906944
-      name: Standard_E32-8as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16as_v7
-      id: Standard_E32-16as_v7
-      memory: 274877906944
-      name: Standard_E32-16as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32as_v7
-      id: Standard_E32as_v7
-      memory: 274877906944
-      name: Standard_E32as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48as_v7
-      id: Standard_E48as_v7
-      memory: 412316860416
-      name: Standard_E48as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16as_v7
-      id: Standard_E64-16as_v7
-      memory: 549755813888
-      name: Standard_E64-16as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32as_v7
-      id: Standard_E64-32as_v7
-      memory: 549755813888
-      name: Standard_E64-32as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64as_v7
-      id: Standard_E64as_v7
-      memory: 549755813888
-      name: Standard_E64as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-24as_v7
-      id: Standard_E96-24as_v7
-      memory: 824633720832
-      name: Standard_E96-24as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-48as_v7
-      id: Standard_E96-48as_v7
-      memory: 824633720832
-      name: Standard_E96-48as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96as_v7
-      id: Standard_E96as_v7
-      memory: 824633720832
-      name: Standard_E96as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128-32as_v7
-      id: Standard_E128-32as_v7
-      memory: 1099511627776
-      name: Standard_E128-32as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128-64as_v7
-      id: Standard_E128-64as_v7
-      memory: 1099511627776
-      name: Standard_E128-64as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128as_v7
-      id: Standard_E128as_v7
-      memory: 1099511627776
-      name: Standard_E128as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2ads_v7
-      id: Standard_E2ads_v7
-      memory: 17179869184
-      name: Standard_E2ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2ads_v7
-      id: Standard_E4-2ads_v7
-      memory: 34359738368
-      name: Standard_E4-2ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4ads_v7
-      id: Standard_E4ads_v7
-      memory: 34359738368
-      name: Standard_E4ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2ads_v7
-      id: Standard_E8-2ads_v7
-      memory: 68719476736
-      name: Standard_E8-2ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4ads_v7
-      id: Standard_E8-4ads_v7
-      memory: 68719476736
-      name: Standard_E8-4ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8ads_v7
-      id: Standard_E8ads_v7
-      memory: 68719476736
-      name: Standard_E8ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-4ads_v7
-      id: Standard_E16-4ads_v7
-      memory: 137438953472
-      name: Standard_E16-4ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8ads_v7
-      id: Standard_E16-8ads_v7
-      memory: 137438953472
-      name: Standard_E16-8ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16ads_v7
-      id: Standard_E16ads_v7
-      memory: 137438953472
-      name: Standard_E16ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8ads_v7
-      id: Standard_E32-8ads_v7
-      memory: 274877906944
-      name: Standard_E32-8ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16ads_v7
-      id: Standard_E32-16ads_v7
-      memory: 274877906944
-      name: Standard_E32-16ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32ads_v7
-      id: Standard_E32ads_v7
-      memory: 274877906944
-      name: Standard_E32ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48ads_v7
-      id: Standard_E48ads_v7
-      memory: 412316860416
-      name: Standard_E48ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16ads_v7
-      id: Standard_E64-16ads_v7
-      memory: 549755813888
-      name: Standard_E64-16ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32ads_v7
-      id: Standard_E64-32ads_v7
-      memory: 549755813888
-      name: Standard_E64-32ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64ads_v7
-      id: Standard_E64ads_v7
-      memory: 549755813888
-      name: Standard_E64ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-24ads_v7
-      id: Standard_E96-24ads_v7
-      memory: 824633720832
-      name: Standard_E96-24ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-48ads_v7
-      id: Standard_E96-48ads_v7
-      memory: 824633720832
-      name: Standard_E96-48ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96ads_v7
-      id: Standard_E96ads_v7
-      memory: 824633720832
-      name: Standard_E96ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128-32ads_v7
-      id: Standard_E128-32ads_v7
-      memory: 1099511627776
-      name: Standard_E128-32ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128-64ads_v7
-      id: Standard_E128-64ads_v7
-      memory: 1099511627776
-      name: Standard_E128-64ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128ads_v7
-      id: Standard_E128ads_v7
-      memory: 1099511627776
-      name: Standard_E128ads_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 1
-      generic_name: standard_f1als_v7
-      id: Standard_F1als_v7
-      memory: 2147483648
-      name: Standard_F1als_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2als_v7
-      id: Standard_F2als_v7
-      memory: 4294967296
-      name: Standard_F2als_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4als_v7
-      id: Standard_F4als_v7
-      memory: 8589934592
-      name: Standard_F4als_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8als_v7
-      id: Standard_F8als_v7
-      memory: 17179869184
-      name: Standard_F8als_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16als_v7
-      id: Standard_F16als_v7
-      memory: 34359738368
-      name: Standard_F16als_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32als_v7
-      id: Standard_F32als_v7
-      memory: 68719476736
-      name: Standard_F32als_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_f48als_v7
-      id: Standard_F48als_v7
-      memory: 103079215104
-      name: Standard_F48als_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64als_v7
-      id: Standard_F64als_v7
-      memory: 137438953472
-      name: Standard_F64als_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_f80als_v7
-      id: Standard_F80als_v7
-      memory: 171798691840
-      name: Standard_F80als_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 1
-      generic_name: standard_f1alds_v7
-      id: Standard_F1alds_v7
-      memory: 2147483648
-      name: Standard_F1alds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2alds_v7
-      id: Standard_F2alds_v7
-      memory: 4294967296
-      name: Standard_F2alds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4alds_v7
-      id: Standard_F4alds_v7
-      memory: 8589934592
-      name: Standard_F4alds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8alds_v7
-      id: Standard_F8alds_v7
-      memory: 17179869184
-      name: Standard_F8alds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16alds_v7
-      id: Standard_F16alds_v7
-      memory: 34359738368
-      name: Standard_F16alds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32alds_v7
-      id: Standard_F32alds_v7
-      memory: 68719476736
-      name: Standard_F32alds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_f48alds_v7
-      id: Standard_F48alds_v7
-      memory: 103079215104
-      name: Standard_F48alds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64alds_v7
-      id: Standard_F64alds_v7
-      memory: 137438953472
-      name: Standard_F64alds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_f80alds_v7
-      id: Standard_F80alds_v7
-      memory: 171798691840
-      name: Standard_F80alds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 1
-      generic_name: standard_f1as_v7
-      id: Standard_F1as_v7
-      memory: 4294967296
-      name: Standard_F1as_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2as_v7
-      id: Standard_F2as_v7
-      memory: 8589934592
-      name: Standard_F2as_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4as_v7
-      id: Standard_F4as_v7
-      memory: 17179869184
-      name: Standard_F4as_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8as_v7
-      id: Standard_F8as_v7
-      memory: 34359738368
-      name: Standard_F8as_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16as_v7
-      id: Standard_F16as_v7
-      memory: 68719476736
-      name: Standard_F16as_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32as_v7
-      id: Standard_F32as_v7
-      memory: 137438953472
-      name: Standard_F32as_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_f48as_v7
-      id: Standard_F48as_v7
-      memory: 206158430208
-      name: Standard_F48as_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64as_v7
-      id: Standard_F64as_v7
-      memory: 274877906944
-      name: Standard_F64as_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_f80as_v7
-      id: Standard_F80as_v7
-      memory: 343597383680
-      name: Standard_F80as_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 1
-      generic_name: standard_f1ads_v7
-      id: Standard_F1ads_v7
-      memory: 4294967296
-      name: Standard_F1ads_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2ads_v7
-      id: Standard_F2ads_v7
-      memory: 8589934592
-      name: Standard_F2ads_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4ads_v7
-      id: Standard_F4ads_v7
-      memory: 17179869184
-      name: Standard_F4ads_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8ads_v7
-      id: Standard_F8ads_v7
-      memory: 34359738368
-      name: Standard_F8ads_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16ads_v7
-      id: Standard_F16ads_v7
-      memory: 68719476736
-      name: Standard_F16ads_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32ads_v7
-      id: Standard_F32ads_v7
-      memory: 137438953472
-      name: Standard_F32ads_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_f48ads_v7
-      id: Standard_F48ads_v7
-      memory: 206158430208
-      name: Standard_F48ads_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64ads_v7
-      id: Standard_F64ads_v7
-      memory: 274877906944
-      name: Standard_F64ads_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_f80ads_v7
-      id: Standard_F80ads_v7
-      memory: 343597383680
-      name: Standard_F80ads_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 1
-      generic_name: standard_f1ams_v7
-      id: Standard_F1ams_v7
-      memory: 8589934592
-      name: Standard_F1ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2-1ams_v7
-      id: Standard_F2-1ams_v7
-      memory: 17179869184
-      name: Standard_F2-1ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2ams_v7
-      id: Standard_F2ams_v7
-      memory: 17179869184
-      name: Standard_F2ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4-1ams_v7
-      id: Standard_F4-1ams_v7
-      memory: 34359738368
-      name: Standard_F4-1ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4-2ams_v7
-      id: Standard_F4-2ams_v7
-      memory: 34359738368
-      name: Standard_F4-2ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4ams_v7
-      id: Standard_F4ams_v7
-      memory: 34359738368
-      name: Standard_F4ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8-2ams_v7
-      id: Standard_F8-2ams_v7
-      memory: 68719476736
-      name: Standard_F8-2ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8-4ams_v7
-      id: Standard_F8-4ams_v7
-      memory: 68719476736
-      name: Standard_F8-4ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8ams_v7
-      id: Standard_F8ams_v7
-      memory: 68719476736
-      name: Standard_F8ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16-4ams_v7
-      id: Standard_F16-4ams_v7
-      memory: 137438953472
-      name: Standard_F16-4ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16-8ams_v7
-      id: Standard_F16-8ams_v7
-      memory: 137438953472
-      name: Standard_F16-8ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16ams_v7
-      id: Standard_F16ams_v7
-      memory: 137438953472
-      name: Standard_F16ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32-8ams_v7
-      id: Standard_F32-8ams_v7
-      memory: 274877906944
-      name: Standard_F32-8ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32-16ams_v7
-      id: Standard_F32-16ams_v7
-      memory: 274877906944
-      name: Standard_F32-16ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32ams_v7
-      id: Standard_F32ams_v7
-      memory: 274877906944
-      name: Standard_F32ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_f48ams_v7
-      id: Standard_F48ams_v7
-      memory: 412316860416
-      name: Standard_F48ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_f64-16ams_v7
-      id: Standard_F64-16ams_v7
-      memory: 549755813888
-      name: Standard_F64-16ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64-32ams_v7
-      id: Standard_F64-32ams_v7
-      memory: 549755813888
-      name: Standard_F64-32ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64ams_v7
-      id: Standard_F64ams_v7
-      memory: 549755813888
-      name: Standard_F64ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_f80ams_v7
-      id: Standard_F80ams_v7
-      memory: 687194767360
-      name: Standard_F80ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 1
-      generic_name: standard_f1amds_v7
-      id: Standard_F1amds_v7
-      memory: 8589934592
-      name: Standard_F1amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2-1amds_v7
-      id: Standard_F2-1amds_v7
-      memory: 17179869184
-      name: Standard_F2-1amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2amds_v7
-      id: Standard_F2amds_v7
-      memory: 17179869184
-      name: Standard_F2amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4-1amds_v7
-      id: Standard_F4-1amds_v7
-      memory: 34359738368
-      name: Standard_F4-1amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4-2amds_v7
-      id: Standard_F4-2amds_v7
-      memory: 34359738368
-      name: Standard_F4-2amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4amds_v7
-      id: Standard_F4amds_v7
-      memory: 34359738368
-      name: Standard_F4amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8-2amds_v7
-      id: Standard_F8-2amds_v7
-      memory: 68719476736
-      name: Standard_F8-2amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8-4amds_v7
-      id: Standard_F8-4amds_v7
-      memory: 68719476736
-      name: Standard_F8-4amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8amds_v7
-      id: Standard_F8amds_v7
-      memory: 68719476736
-      name: Standard_F8amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16-4amds_v7
-      id: Standard_F16-4amds_v7
-      memory: 137438953472
-      name: Standard_F16-4amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16-8amds_v7
-      id: Standard_F16-8amds_v7
-      memory: 137438953472
-      name: Standard_F16-8amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16amds_v7
-      id: Standard_F16amds_v7
-      memory: 137438953472
-      name: Standard_F16amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32-8amds_v7
-      id: Standard_F32-8amds_v7
-      memory: 274877906944
-      name: Standard_F32-8amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32-16amds_v7
-      id: Standard_F32-16amds_v7
-      memory: 274877906944
-      name: Standard_F32-16amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32amds_v7
-      id: Standard_F32amds_v7
-      memory: 274877906944
-      name: Standard_F32amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_f48amds_v7
-      id: Standard_F48amds_v7
-      memory: 412316860416
-      name: Standard_F48amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64-16amds_v7
-      id: Standard_F64-16amds_v7
-      memory: 549755813888
-      name: Standard_F64-16amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64-32amds_v7
-      id: Standard_F64-32amds_v7
-      memory: 549755813888
-      name: Standard_F64-32amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64amds_v7
-      id: Standard_F64amds_v7
-      memory: 549755813888
-      name: Standard_F64amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_f80amds_v7
-      id: Standard_F80amds_v7
-      memory: 687194767360
-      name: Standard_F80amds_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96ias_v4
-      id: Standard_E96ias_v4
-      memory: 721554505728
-      name: Standard_E96ias_v4
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_nd96isr_h200_v5
-      id: Standard_ND96isr_H200_v5
-      memory: 1986422374400
-      name: Standard_ND96isr_H200_v5
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_nv4as_v4
-      id: Standard_NV4as_v4
-      memory: 15032385536
-      name: Standard_NV4as_v4
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_nv8as_v4
-      id: Standard_NV8as_v4
-      memory: 30064771072
-      name: Standard_NV8as_v4
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_nv16as_v4
-      id: Standard_NV16as_v4
-      memory: 60129542144
-      name: Standard_NV16as_v4
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_nv32as_v4
-      id: Standard_NV32as_v4
-      memory: 120259084288
-      name: Standard_NV32as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 160
-      generic_name: standard_e160as_v7
-      id: Standard_E160as_v7
-      memory: 1374389534720
-      name: Standard_E160as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 160
-      generic_name: standard_e160ads_v7
-      id: Standard_E160ads_v7
-      memory: 1374389534720
-      name: Standard_E160ads_v7
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 6
-      generic_name: standard_nc6s_v3
-      id: Standard_NC6s_v3
-      memory: 120259084288
-      name: Standard_NC6s_v3
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 12
-      generic_name: standard_nc12s_v3
-      id: Standard_NC12s_v3
-      memory: 240518168576
-      name: Standard_NC12s_v3
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 24
-      generic_name: standard_nc24rs_v3
-      id: Standard_NC24rs_v3
-      memory: 481036337152
-      name: Standard_NC24rs_v3
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 24
-      generic_name: standard_nc24s_v3
-      id: Standard_NC24s_v3
-      memory: 481036337152
-      name: Standard_NC24s_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_dc2es_v6
-      id: Standard_DC2es_v6
-      memory: 8589934592
-      name: Standard_DC2es_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_dc4es_v6
-      id: Standard_DC4es_v6
-      memory: 17179869184
-      name: Standard_DC4es_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_dc8es_v6
-      id: Standard_DC8es_v6
-      memory: 34359738368
-      name: Standard_DC8es_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
+      family: standardDCEV6Family
       generic_name: standard_dc16es_v6
       id: Standard_DC16es_v6
       memory: 68719476736
       name: Standard_DC16es_v6
     - category: general_purpose
       cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDCADSv5Family
+      generic_name: standard_dc2ads_v5
+      id: Standard_DC2ads_v5
+      memory: 8589934592
+      name: Standard_DC2ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDCadsv6Family
+      generic_name: standard_dc2ads_v6
+      id: Standard_DC2ads_v6
+      memory: 8589934592
+      name: Standard_DC2ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDCASv5Family
+      generic_name: standard_dc2as_v5
+      id: Standard_DC2as_v5
+      memory: 8589934592
+      name: Standard_DC2as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDCasv6Family
+      generic_name: standard_dc2as_v6
+      id: Standard_DC2as_v6
+      memory: 8589934592
+      name: Standard_DC2as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDCEDV6Family
+      generic_name: standard_dc2eds_v6
+      id: Standard_DC2eds_v6
+      memory: 8589934592
+      name: Standard_DC2eds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDCEV6Family
+      generic_name: standard_dc2es_v6
+      id: Standard_DC2es_v6
+      memory: 8589934592
+      name: Standard_DC2es_v6
+    - category: general_purpose
+      cloud_provider_id: azure
       cpu_cores: 32
+      family: standardDCADCCV5Family
+      generic_name: standard_dc32ads_cc_v5
+      id: Standard_DC32ads_cc_v5
+      memory: 137438953472
+      name: Standard_DC32ads_cc_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDCADSv5Family
+      generic_name: standard_dc32ads_v5
+      id: Standard_DC32ads_v5
+      memory: 137438953472
+      name: Standard_DC32ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDCadsv6Family
+      generic_name: standard_dc32ads_v6
+      id: Standard_DC32ads_v6
+      memory: 137438953472
+      name: Standard_DC32ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDCACCV5Family
+      generic_name: standard_dc32as_cc_v5
+      id: Standard_DC32as_cc_v5
+      memory: 137438953472
+      name: Standard_DC32as_cc_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDCASv5Family
+      generic_name: standard_dc32as_v5
+      id: Standard_DC32as_v5
+      memory: 137438953472
+      name: Standard_DC32as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDCasv6Family
+      generic_name: standard_dc32as_v6
+      id: Standard_DC32as_v6
+      memory: 137438953472
+      name: Standard_DC32as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDCEDV6Family
+      generic_name: standard_dc32eds_v6
+      id: Standard_DC32eds_v6
+      memory: 137438953472
+      name: Standard_DC32eds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDCEV6Family
       generic_name: standard_dc32es_v6
       id: Standard_DC32es_v6
       memory: 137438953472
@@ -6840,125 +2679,3659 @@ data:
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 48
-      generic_name: standard_dc48es_v6
-      id: Standard_DC48es_v6
+      family: standardDCADCCV5Family
+      generic_name: standard_dc48ads_cc_v5
+      id: Standard_DC48ads_cc_v5
       memory: 206158430208
-      name: Standard_DC48es_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_dc64es_v6
-      id: Standard_DC64es_v6
-      memory: 274877906944
-      name: Standard_DC64es_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_dc96es_v6
-      id: Standard_DC96es_v6
-      memory: 412316860416
-      name: Standard_DC96es_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_dc128es_v6
-      id: Standard_DC128es_v6
-      memory: 549755813888
-      name: Standard_DC128es_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_dc2eds_v6
-      id: Standard_DC2eds_v6
-      memory: 8589934592
-      name: Standard_DC2eds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_dc4eds_v6
-      id: Standard_DC4eds_v6
-      memory: 17179869184
-      name: Standard_DC4eds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_dc8eds_v6
-      id: Standard_DC8eds_v6
-      memory: 34359738368
-      name: Standard_DC8eds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_dc16eds_v6
-      id: Standard_DC16eds_v6
-      memory: 68719476736
-      name: Standard_DC16eds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_dc32eds_v6
-      id: Standard_DC32eds_v6
-      memory: 137438953472
-      name: Standard_DC32eds_v6
+      name: Standard_DC48ads_cc_v5
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 48
+      family: standardDCADSv5Family
+      generic_name: standard_dc48ads_v5
+      id: Standard_DC48ads_v5
+      memory: 206158430208
+      name: Standard_DC48ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDCadsv6Family
+      generic_name: standard_dc48ads_v6
+      id: Standard_DC48ads_v6
+      memory: 206158430208
+      name: Standard_DC48ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDCACCV5Family
+      generic_name: standard_dc48as_cc_v5
+      id: Standard_DC48as_cc_v5
+      memory: 206158430208
+      name: Standard_DC48as_cc_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDCASv5Family
+      generic_name: standard_dc48as_v5
+      id: Standard_DC48as_v5
+      memory: 206158430208
+      name: Standard_DC48as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDCasv6Family
+      generic_name: standard_dc48as_v6
+      id: Standard_DC48as_v6
+      memory: 206158430208
+      name: Standard_DC48as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDCEDV6Family
       generic_name: standard_dc48eds_v6
       id: Standard_DC48eds_v6
       memory: 206158430208
       name: Standard_DC48eds_v6
     - category: general_purpose
       cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDCEV6Family
+      generic_name: standard_dc48es_v6
+      id: Standard_DC48es_v6
+      memory: 206158430208
+      name: Standard_DC48es_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDCADCCV5Family
+      generic_name: standard_dc4ads_cc_v5
+      id: Standard_DC4ads_cc_v5
+      memory: 17179869184
+      name: Standard_DC4ads_cc_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDCADSv5Family
+      generic_name: standard_dc4ads_v5
+      id: Standard_DC4ads_v5
+      memory: 17179869184
+      name: Standard_DC4ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDCadsv6Family
+      generic_name: standard_dc4ads_v6
+      id: Standard_DC4ads_v6
+      memory: 17179869184
+      name: Standard_DC4ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDCACCV5Family
+      generic_name: standard_dc4as_cc_v5
+      id: Standard_DC4as_cc_v5
+      memory: 17179869184
+      name: Standard_DC4as_cc_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDCASv5Family
+      generic_name: standard_dc4as_v5
+      id: Standard_DC4as_v5
+      memory: 17179869184
+      name: Standard_DC4as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDCasv6Family
+      generic_name: standard_dc4as_v6
+      id: Standard_DC4as_v6
+      memory: 17179869184
+      name: Standard_DC4as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDCEDV6Family
+      generic_name: standard_dc4eds_v6
+      id: Standard_DC4eds_v6
+      memory: 17179869184
+      name: Standard_DC4eds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDCEV6Family
+      generic_name: standard_dc4es_v6
+      id: Standard_DC4es_v6
+      memory: 17179869184
+      name: Standard_DC4es_v6
+    - category: general_purpose
+      cloud_provider_id: azure
       cpu_cores: 64
+      family: standardDCADCCV5Family
+      generic_name: standard_dc64ads_cc_v5
+      id: Standard_DC64ads_cc_v5
+      memory: 274877906944
+      name: Standard_DC64ads_cc_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDCADSv5Family
+      generic_name: standard_dc64ads_v5
+      id: Standard_DC64ads_v5
+      memory: 274877906944
+      name: Standard_DC64ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDCadsv6Family
+      generic_name: standard_dc64ads_v6
+      id: Standard_DC64ads_v6
+      memory: 274877906944
+      name: Standard_DC64ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDCACCV5Family
+      generic_name: standard_dc64as_cc_v5
+      id: Standard_DC64as_cc_v5
+      memory: 274877906944
+      name: Standard_DC64as_cc_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDCASv5Family
+      generic_name: standard_dc64as_v5
+      id: Standard_DC64as_v5
+      memory: 274877906944
+      name: Standard_DC64as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDCasv6Family
+      generic_name: standard_dc64as_v6
+      id: Standard_DC64as_v6
+      memory: 274877906944
+      name: Standard_DC64as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDCEDV6Family
       generic_name: standard_dc64eds_v6
       id: Standard_DC64eds_v6
       memory: 274877906944
       name: Standard_DC64eds_v6
     - category: general_purpose
       cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDCEV6Family
+      generic_name: standard_dc64es_v6
+      id: Standard_DC64es_v6
+      memory: 274877906944
+      name: Standard_DC64es_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDCADCCV5Family
+      generic_name: standard_dc8ads_cc_v5
+      id: Standard_DC8ads_cc_v5
+      memory: 34359738368
+      name: Standard_DC8ads_cc_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDCADSv5Family
+      generic_name: standard_dc8ads_v5
+      id: Standard_DC8ads_v5
+      memory: 34359738368
+      name: Standard_DC8ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDCadsv6Family
+      generic_name: standard_dc8ads_v6
+      id: Standard_DC8ads_v6
+      memory: 34359738368
+      name: Standard_DC8ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDCACCV5Family
+      generic_name: standard_dc8as_cc_v5
+      id: Standard_DC8as_cc_v5
+      memory: 34359738368
+      name: Standard_DC8as_cc_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDCASv5Family
+      generic_name: standard_dc8as_v5
+      id: Standard_DC8as_v5
+      memory: 34359738368
+      name: Standard_DC8as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDCasv6Family
+      generic_name: standard_dc8as_v6
+      id: Standard_DC8as_v6
+      memory: 34359738368
+      name: Standard_DC8as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDCEDV6Family
+      generic_name: standard_dc8eds_v6
+      id: Standard_DC8eds_v6
+      memory: 34359738368
+      name: Standard_DC8eds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDCEV6Family
+      generic_name: standard_dc8es_v6
+      id: Standard_DC8es_v6
+      memory: 34359738368
+      name: Standard_DC8es_v6
+    - category: general_purpose
+      cloud_provider_id: azure
       cpu_cores: 96
+      family: standardDCADCCV5Family
+      generic_name: standard_dc96ads_cc_v5
+      id: Standard_DC96ads_cc_v5
+      memory: 412316860416
+      name: Standard_DC96ads_cc_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDCADSv5Family
+      generic_name: standard_dc96ads_v5
+      id: Standard_DC96ads_v5
+      memory: 412316860416
+      name: Standard_DC96ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDCadsv6Family
+      generic_name: standard_dc96ads_v6
+      id: Standard_DC96ads_v6
+      memory: 412316860416
+      name: Standard_DC96ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDCACCV5Family
+      generic_name: standard_dc96as_cc_v5
+      id: Standard_DC96as_cc_v5
+      memory: 412316860416
+      name: Standard_DC96as_cc_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDCASv5Family
+      generic_name: standard_dc96as_v5
+      id: Standard_DC96as_v5
+      memory: 412316860416
+      name: Standard_DC96as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDCasv6Family
+      generic_name: standard_dc96as_v6
+      id: Standard_DC96as_v6
+      memory: 412316860416
+      name: Standard_DC96as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDCEDV6Family
       generic_name: standard_dc96eds_v6
       id: Standard_DC96eds_v6
       memory: 412316860416
       name: Standard_DC96eds_v6
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_dc128eds_v6
-      id: Standard_DC128eds_v6
-      memory: 549755813888
-      name: Standard_DC128eds_v6
-    - category: memory_optimized
+      cpu_cores: 96
+      family: standardDCEV6Family
+      generic_name: standard_dc96es_v6
+      id: Standard_DC96es_v6
+      memory: 412316860416
+      name: Standard_DC96es_v6
+    - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 2
-      generic_name: standard_ec2es_v6
-      id: Standard_EC2es_v6
-      memory: 17179869184
-      name: Standard_EC2es_v6
-    - category: memory_optimized
+      family: standardDSv2Family
+      generic_name: standard_ds11-1_v2
+      id: Standard_DS11-1_v2
+      memory: 15032385536
+      name: Standard_DS11-1_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDSv2Family
+      generic_name: standard_ds11_v2
+      id: Standard_DS11_v2
+      memory: 15032385536
+      name: Standard_DS11_v2
+    - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 4
-      generic_name: standard_ec4es_v6
-      id: Standard_EC4es_v6
-      memory: 34359738368
-      name: Standard_EC4es_v6
-    - category: memory_optimized
+      family: standardDSv2Family
+      generic_name: standard_ds12-1_v2
+      id: Standard_DS12-1_v2
+      memory: 30064771072
+      name: Standard_DS12-1_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDSv2Family
+      generic_name: standard_ds12-2_v2
+      id: Standard_DS12-2_v2
+      memory: 30064771072
+      name: Standard_DS12-2_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDSv2Family
+      generic_name: standard_ds12_v2
+      id: Standard_DS12_v2
+      memory: 30064771072
+      name: Standard_DS12_v2
+    - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 8
-      generic_name: standard_ec8es_v6
-      id: Standard_EC8es_v6
-      memory: 68719476736
-      name: Standard_EC8es_v6
+      family: standardDSv2Family
+      generic_name: standard_ds13-2_v2
+      id: Standard_DS13-2_v2
+      memory: 60129542144
+      name: Standard_DS13-2_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDSv2Family
+      generic_name: standard_ds13-4_v2
+      id: Standard_DS13-4_v2
+      memory: 60129542144
+      name: Standard_DS13-4_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDSv2Family
+      generic_name: standard_ds13_v2
+      id: Standard_DS13_v2
+      memory: 60129542144
+      name: Standard_DS13_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDSv2Family
+      generic_name: standard_ds14-4_v2
+      id: Standard_DS14-4_v2
+      memory: 120259084288
+      name: Standard_DS14-4_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDSv2Family
+      generic_name: standard_ds14-8_v2
+      id: Standard_DS14-8_v2
+      memory: 120259084288
+      name: Standard_DS14-8_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDSv2Family
+      generic_name: standard_ds14_v2
+      id: Standard_DS14_v2
+      memory: 120259084288
+      name: Standard_DS14_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardDSv2Family
+      generic_name: standard_ds15_v2
+      id: Standard_DS15_v2
+      memory: 150323855360
+      name: Standard_DS15_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 1
+      family: standardDSv2Family
+      generic_name: standard_ds1_v2
+      id: Standard_DS1_v2
+      memory: 3221225472
+      name: Standard_DS1_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDSv2Family
+      generic_name: standard_ds2_v2
+      id: Standard_DS2_v2
+      memory: 7516192768
+      name: Standard_DS2_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDSv2Family
+      generic_name: standard_ds3_v2
+      id: Standard_DS3_v2
+      memory: 15032385536
+      name: Standard_DS3_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDSv2Family
+      generic_name: standard_ds4_v2
+      id: Standard_DS4_v2
+      memory: 30064771072
+      name: Standard_DS4_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDSv2Family
+      generic_name: standard_ds5_v2
+      id: Standard_DS5_v2
+      memory: 60129542144
+      name: Standard_DS5_v2
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 104
+      family: standardEIDSv5Family
+      generic_name: standard_e104ids_v5
+      id: Standard_E104ids_v5
+      memory: 721554505728
+      name: Standard_E104ids_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 104
+      family: standardEIDv5Family
+      generic_name: standard_e104id_v5
+      id: Standard_E104id_v5
+      memory: 721554505728
+      name: Standard_E104id_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 104
+      family: standardEISv5Family
+      generic_name: standard_e104is_v5
+      id: Standard_E104is_v5
+      memory: 721554505728
+      name: Standard_E104is_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 104
+      family: standardEIv5Family
+      generic_name: standard_e104i_v5
+      id: Standard_E104i_v5
+      memory: 721554505728
+      name: Standard_E104i_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 112
+      family: standardEIADSv5Family
+      generic_name: standard_e112iads_v5
+      id: Standard_E112iads_v5
+      memory: 721554505728
+      name: Standard_E112iads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 112
+      family: standardEIASv5Family
+      generic_name: standard_e112ias_v5
+      id: Standard_E112ias_v5
+      memory: 721554505728
+      name: Standard_E112ias_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 112
+      family: standardEIBDSv5Family
+      generic_name: standard_e112ibds_v5
+      id: Standard_E112ibds_v5
+      memory: 721554505728
+      name: Standard_E112ibds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 112
+      family: standardEIBSv5Family
+      generic_name: standard_e112ibs_v5
+      id: Standard_E112ibs_v5
+      memory: 721554505728
+      name: Standard_E112ibs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEadsv7Family
+      generic_name: standard_e128-32ads_v7
+      id: Standard_E128-32ads_v7
+      memory: 1099511627776
+      name: Standard_E128-32ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEasv7Family
+      generic_name: standard_e128-32as_v7
+      id: Standard_E128-32as_v7
+      memory: 1099511627776
+      name: Standard_E128-32as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEdsv6Family
+      generic_name: standard_e128-32ds_v6
+      id: Standard_E128-32ds_v6
+      memory: 1099511627776
+      name: Standard_E128-32ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEsv6Family
+      generic_name: standard_e128-32s_v6
+      id: Standard_E128-32s_v6
+      memory: 1099511627776
+      name: Standard_E128-32s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEadsv7Family
+      generic_name: standard_e128-64ads_v7
+      id: Standard_E128-64ads_v7
+      memory: 1099511627776
+      name: Standard_E128-64ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEasv7Family
+      generic_name: standard_e128-64as_v7
+      id: Standard_E128-64as_v7
+      memory: 1099511627776
+      name: Standard_E128-64as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEdsv6Family
+      generic_name: standard_e128-64ds_v6
+      id: Standard_E128-64ds_v6
+      memory: 1099511627776
+      name: Standard_E128-64ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEsv6Family
+      generic_name: standard_e128-64s_v6
+      id: Standard_E128-64s_v6
+      memory: 1099511627776
+      name: Standard_E128-64s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEadsv7Family
+      generic_name: standard_e128ads_v7
+      id: Standard_E128ads_v7
+      memory: 1099511627776
+      name: Standard_E128ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEasv7Family
+      generic_name: standard_e128as_v7
+      id: Standard_E128as_v7
+      memory: 1099511627776
+      name: Standard_E128as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEdsv6Family
+      generic_name: standard_e128ds_v6
+      id: Standard_E128ds_v6
+      memory: 1099511627776
+      name: Standard_E128ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEsv6Family
+      generic_name: standard_e128s_v6
+      id: Standard_E128s_v6
+      memory: 1099511627776
+      name: Standard_E128s_v6
     - category: memory_optimized
       cloud_provider_id: azure
       cpu_cores: 16
+      family: standardEADSv5Family
+      generic_name: standard_e16-4ads_v5
+      id: Standard_E16-4ads_v5
+      memory: 137438953472
+      name: Standard_E16-4ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEadsv7Family
+      generic_name: standard_e16-4ads_v7
+      id: Standard_E16-4ads_v7
+      memory: 137438953472
+      name: Standard_E16-4ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEASv4Family
+      generic_name: standard_e16-4as_v4
+      id: Standard_E16-4as_v4
+      memory: 137438953472
+      name: Standard_E16-4as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEASv5Family
+      generic_name: standard_e16-4as_v5
+      id: Standard_E16-4as_v5
+      memory: 137438953472
+      name: Standard_E16-4as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEasv7Family
+      generic_name: standard_e16-4as_v7
+      id: Standard_E16-4as_v7
+      memory: 137438953472
+      name: Standard_E16-4as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEDSv4Family
+      generic_name: standard_e16-4ds_v4
+      id: Standard_E16-4ds_v4
+      memory: 137438953472
+      name: Standard_E16-4ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEDSv5Family
+      generic_name: standard_e16-4ds_v5
+      id: Standard_E16-4ds_v5
+      memory: 137438953472
+      name: Standard_E16-4ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEdsv6Family
+      generic_name: standard_e16-4ds_v6
+      id: Standard_E16-4ds_v6
+      memory: 137438953472
+      name: Standard_E16-4ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardESv3Family
+      generic_name: standard_e16-4s_v3
+      id: Standard_E16-4s_v3
+      memory: 137438953472
+      name: Standard_E16-4s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardESv4Family
+      generic_name: standard_e16-4s_v4
+      id: Standard_E16-4s_v4
+      memory: 137438953472
+      name: Standard_E16-4s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardESv5Family
+      generic_name: standard_e16-4s_v5
+      id: Standard_E16-4s_v5
+      memory: 137438953472
+      name: Standard_E16-4s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEsv6Family
+      generic_name: standard_e16-4s_v6
+      id: Standard_E16-4s_v6
+      memory: 137438953472
+      name: Standard_E16-4s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEADSv5Family
+      generic_name: standard_e16-8ads_v5
+      id: Standard_E16-8ads_v5
+      memory: 137438953472
+      name: Standard_E16-8ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEadsv7Family
+      generic_name: standard_e16-8ads_v7
+      id: Standard_E16-8ads_v7
+      memory: 137438953472
+      name: Standard_E16-8ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEASv4Family
+      generic_name: standard_e16-8as_v4
+      id: Standard_E16-8as_v4
+      memory: 137438953472
+      name: Standard_E16-8as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEASv5Family
+      generic_name: standard_e16-8as_v5
+      id: Standard_E16-8as_v5
+      memory: 137438953472
+      name: Standard_E16-8as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEasv7Family
+      generic_name: standard_e16-8as_v7
+      id: Standard_E16-8as_v7
+      memory: 137438953472
+      name: Standard_E16-8as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEDSv4Family
+      generic_name: standard_e16-8ds_v4
+      id: Standard_E16-8ds_v4
+      memory: 137438953472
+      name: Standard_E16-8ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEDSv5Family
+      generic_name: standard_e16-8ds_v5
+      id: Standard_E16-8ds_v5
+      memory: 137438953472
+      name: Standard_E16-8ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEdsv6Family
+      generic_name: standard_e16-8ds_v6
+      id: Standard_E16-8ds_v6
+      memory: 137438953472
+      name: Standard_E16-8ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardESv3Family
+      generic_name: standard_e16-8s_v3
+      id: Standard_E16-8s_v3
+      memory: 137438953472
+      name: Standard_E16-8s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardESv4Family
+      generic_name: standard_e16-8s_v4
+      id: Standard_E16-8s_v4
+      memory: 137438953472
+      name: Standard_E16-8s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardESv5Family
+      generic_name: standard_e16-8s_v5
+      id: Standard_E16-8s_v5
+      memory: 137438953472
+      name: Standard_E16-8s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEsv6Family
+      generic_name: standard_e16-8s_v6
+      id: Standard_E16-8s_v6
+      memory: 137438953472
+      name: Standard_E16-8s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 160
+      family: StandardEadsv7Family
+      generic_name: standard_e160ads_v7
+      id: Standard_E160ads_v7
+      memory: 1374389534720
+      name: Standard_E160ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 160
+      family: StandardEasv7Family
+      generic_name: standard_e160as_v7
+      id: Standard_E160as_v7
+      memory: 1374389534720
+      name: Standard_E160as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEADSv5Family
+      generic_name: standard_e16ads_v5
+      id: Standard_E16ads_v5
+      memory: 137438953472
+      name: Standard_E16ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEadv6Family
+      generic_name: standard_e16ads_v6
+      id: Standard_E16ads_v6
+      memory: 137438953472
+      name: Standard_E16ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEadsv7Family
+      generic_name: standard_e16ads_v7
+      id: Standard_E16ads_v7
+      memory: 137438953472
+      name: Standard_E16ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEASv4Family
+      generic_name: standard_e16as_v4
+      id: Standard_E16as_v4
+      memory: 137438953472
+      name: Standard_E16as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEASv5Family
+      generic_name: standard_e16as_v5
+      id: Standard_E16as_v5
+      memory: 137438953472
+      name: Standard_E16as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEav6Family
+      generic_name: standard_e16as_v6
+      id: Standard_E16as_v6
+      memory: 137438953472
+      name: Standard_E16as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEasv7Family
+      generic_name: standard_e16as_v7
+      id: Standard_E16as_v7
+      memory: 137438953472
+      name: Standard_E16as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEAv4Family
+      generic_name: standard_e16a_v4
+      id: Standard_E16a_v4
+      memory: 137438953472
+      name: Standard_E16a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEBDSv5Family
+      generic_name: standard_e16bds_v5
+      id: Standard_E16bds_v5
+      memory: 137438953472
+      name: Standard_E16bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEBSv5Family
+      generic_name: standard_e16bs_v5
+      id: Standard_E16bs_v5
+      memory: 137438953472
+      name: Standard_E16bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEDSv4Family
+      generic_name: standard_e16ds_v4
+      id: Standard_E16ds_v4
+      memory: 137438953472
+      name: Standard_E16ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEDSv5Family
+      generic_name: standard_e16ds_v5
+      id: Standard_E16ds_v5
+      memory: 137438953472
+      name: Standard_E16ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEdsv6Family
+      generic_name: standard_e16ds_v6
+      id: Standard_E16ds_v6
+      memory: 137438953472
+      name: Standard_E16ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEDv4Family
+      generic_name: standard_e16d_v4
+      id: Standard_E16d_v4
+      memory: 137438953472
+      name: Standard_E16d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEDv5Family
+      generic_name: standard_e16d_v5
+      id: Standard_E16d_v5
+      memory: 137438953472
+      name: Standard_E16d_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEPDSv5Family
+      generic_name: standard_e16pds_v5
+      id: Standard_E16pds_v5
+      memory: 137438953472
+      name: Standard_E16pds_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEpdsv6Family
+      generic_name: standard_e16pds_v6
+      id: Standard_E16pds_v6
+      memory: 137438953472
+      name: Standard_E16pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEPSv5Family
+      generic_name: standard_e16ps_v5
+      id: Standard_E16ps_v5
+      memory: 137438953472
+      name: Standard_E16ps_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEpsv6Family
+      generic_name: standard_e16ps_v6
+      id: Standard_E16ps_v6
+      memory: 137438953472
+      name: Standard_E16ps_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardESv3Family
+      generic_name: standard_e16s_v3
+      id: Standard_E16s_v3
+      memory: 137438953472
+      name: Standard_E16s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardESv4Family
+      generic_name: standard_e16s_v4
+      id: Standard_E16s_v4
+      memory: 137438953472
+      name: Standard_E16s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardESv5Family
+      generic_name: standard_e16s_v5
+      id: Standard_E16s_v5
+      memory: 137438953472
+      name: Standard_E16s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEsv6Family
+      generic_name: standard_e16s_v6
+      id: Standard_E16s_v6
+      memory: 137438953472
+      name: Standard_E16s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEv3Family
+      generic_name: standard_e16_v3
+      id: Standard_E16_v3
+      memory: 137438953472
+      name: Standard_E16_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEv4Family
+      generic_name: standard_e16_v4
+      id: Standard_E16_v4
+      memory: 137438953472
+      name: Standard_E16_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEv5Family
+      generic_name: standard_e16_v5
+      id: Standard_E16_v5
+      memory: 137438953472
+      name: Standard_E16_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 192
+      family: StandardEdsv6Family
+      generic_name: standard_e192ids_v6
+      id: Standard_E192ids_v6
+      memory: 1967095021568
+      name: Standard_E192ids_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 192
+      family: StandardEsv6Family
+      generic_name: standard_e192is_v6
+      id: Standard_E192is_v6
+      memory: 1967095021568
+      name: Standard_E192is_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEADSv5Family
+      generic_name: standard_e20ads_v5
+      id: Standard_E20ads_v5
+      memory: 171798691840
+      name: Standard_E20ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEadv6Family
+      generic_name: standard_e20ads_v6
+      id: Standard_E20ads_v6
+      memory: 171798691840
+      name: Standard_E20ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEASv4Family
+      generic_name: standard_e20as_v4
+      id: Standard_E20as_v4
+      memory: 171798691840
+      name: Standard_E20as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEASv5Family
+      generic_name: standard_e20as_v5
+      id: Standard_E20as_v5
+      memory: 171798691840
+      name: Standard_E20as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEav6Family
+      generic_name: standard_e20as_v6
+      id: Standard_E20as_v6
+      memory: 171798691840
+      name: Standard_E20as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEAv4Family
+      generic_name: standard_e20a_v4
+      id: Standard_E20a_v4
+      memory: 171798691840
+      name: Standard_E20a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEDSv4Family
+      generic_name: standard_e20ds_v4
+      id: Standard_E20ds_v4
+      memory: 171798691840
+      name: Standard_E20ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEDSv5Family
+      generic_name: standard_e20ds_v5
+      id: Standard_E20ds_v5
+      memory: 171798691840
+      name: Standard_E20ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: StandardEdsv6Family
+      generic_name: standard_e20ds_v6
+      id: Standard_E20ds_v6
+      memory: 171798691840
+      name: Standard_E20ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEDv4Family
+      generic_name: standard_e20d_v4
+      id: Standard_E20d_v4
+      memory: 171798691840
+      name: Standard_E20d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEDv5Family
+      generic_name: standard_e20d_v5
+      id: Standard_E20d_v5
+      memory: 171798691840
+      name: Standard_E20d_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEPDSv5Family
+      generic_name: standard_e20pds_v5
+      id: Standard_E20pds_v5
+      memory: 171798691840
+      name: Standard_E20pds_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEPSv5Family
+      generic_name: standard_e20ps_v5
+      id: Standard_E20ps_v5
+      memory: 171798691840
+      name: Standard_E20ps_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardESv3Family
+      generic_name: standard_e20s_v3
+      id: Standard_E20s_v3
+      memory: 171798691840
+      name: Standard_E20s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardESv4Family
+      generic_name: standard_e20s_v4
+      id: Standard_E20s_v4
+      memory: 171798691840
+      name: Standard_E20s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardESv5Family
+      generic_name: standard_e20s_v5
+      id: Standard_E20s_v5
+      memory: 171798691840
+      name: Standard_E20s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: StandardEsv6Family
+      generic_name: standard_e20s_v6
+      id: Standard_E20s_v6
+      memory: 171798691840
+      name: Standard_E20s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEv3Family
+      generic_name: standard_e20_v3
+      id: Standard_E20_v3
+      memory: 171798691840
+      name: Standard_E20_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEv4Family
+      generic_name: standard_e20_v4
+      id: Standard_E20_v4
+      memory: 171798691840
+      name: Standard_E20_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEv5Family
+      generic_name: standard_e20_v5
+      id: Standard_E20_v5
+      memory: 171798691840
+      name: Standard_E20_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEADSv5Family
+      generic_name: standard_e2ads_v5
+      id: Standard_E2ads_v5
+      memory: 17179869184
+      name: Standard_E2ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEadv6Family
+      generic_name: standard_e2ads_v6
+      id: Standard_E2ads_v6
+      memory: 17179869184
+      name: Standard_E2ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardEadsv7Family
+      generic_name: standard_e2ads_v7
+      id: Standard_E2ads_v7
+      memory: 17179869184
+      name: Standard_E2ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEASv4Family
+      generic_name: standard_e2as_v4
+      id: Standard_E2as_v4
+      memory: 17179869184
+      name: Standard_E2as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEASv5Family
+      generic_name: standard_e2as_v5
+      id: Standard_E2as_v5
+      memory: 17179869184
+      name: Standard_E2as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEav6Family
+      generic_name: standard_e2as_v6
+      id: Standard_E2as_v6
+      memory: 17179869184
+      name: Standard_E2as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardEasv7Family
+      generic_name: standard_e2as_v7
+      id: Standard_E2as_v7
+      memory: 17179869184
+      name: Standard_E2as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEAv4Family
+      generic_name: standard_e2a_v4
+      id: Standard_E2a_v4
+      memory: 17179869184
+      name: Standard_E2a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEBDSv5Family
+      generic_name: standard_e2bds_v5
+      id: Standard_E2bds_v5
+      memory: 17179869184
+      name: Standard_E2bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEBSv5Family
+      generic_name: standard_e2bs_v5
+      id: Standard_E2bs_v5
+      memory: 17179869184
+      name: Standard_E2bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEDSv4Family
+      generic_name: standard_e2ds_v4
+      id: Standard_E2ds_v4
+      memory: 17179869184
+      name: Standard_E2ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEDSv5Family
+      generic_name: standard_e2ds_v5
+      id: Standard_E2ds_v5
+      memory: 17179869184
+      name: Standard_E2ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardEdsv6Family
+      generic_name: standard_e2ds_v6
+      id: Standard_E2ds_v6
+      memory: 17179869184
+      name: Standard_E2ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEDv4Family
+      generic_name: standard_e2d_v4
+      id: Standard_E2d_v4
+      memory: 17179869184
+      name: Standard_E2d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEDv5Family
+      generic_name: standard_e2d_v5
+      id: Standard_E2d_v5
+      memory: 17179869184
+      name: Standard_E2d_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEPDSv5Family
+      generic_name: standard_e2pds_v5
+      id: Standard_E2pds_v5
+      memory: 17179869184
+      name: Standard_E2pds_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardEpdsv6Family
+      generic_name: standard_e2pds_v6
+      id: Standard_E2pds_v6
+      memory: 17179869184
+      name: Standard_E2pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEPSv5Family
+      generic_name: standard_e2ps_v5
+      id: Standard_E2ps_v5
+      memory: 17179869184
+      name: Standard_E2ps_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardEpsv6Family
+      generic_name: standard_e2ps_v6
+      id: Standard_E2ps_v6
+      memory: 17179869184
+      name: Standard_E2ps_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardESv3Family
+      generic_name: standard_e2s_v3
+      id: Standard_E2s_v3
+      memory: 17179869184
+      name: Standard_E2s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardESv4Family
+      generic_name: standard_e2s_v4
+      id: Standard_E2s_v4
+      memory: 17179869184
+      name: Standard_E2s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardESv5Family
+      generic_name: standard_e2s_v5
+      id: Standard_E2s_v5
+      memory: 17179869184
+      name: Standard_E2s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardEsv6Family
+      generic_name: standard_e2s_v6
+      id: Standard_E2s_v6
+      memory: 17179869184
+      name: Standard_E2s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEv3Family
+      generic_name: standard_e2_v3
+      id: Standard_E2_v3
+      memory: 17179869184
+      name: Standard_E2_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEv4Family
+      generic_name: standard_e2_v4
+      id: Standard_E2_v4
+      memory: 17179869184
+      name: Standard_E2_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEv5Family
+      generic_name: standard_e2_v5
+      id: Standard_E2_v5
+      memory: 17179869184
+      name: Standard_E2_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEADSv5Family
+      generic_name: standard_e32-16ads_v5
+      id: Standard_E32-16ads_v5
+      memory: 274877906944
+      name: Standard_E32-16ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEadsv7Family
+      generic_name: standard_e32-16ads_v7
+      id: Standard_E32-16ads_v7
+      memory: 274877906944
+      name: Standard_E32-16ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEASv4Family
+      generic_name: standard_e32-16as_v4
+      id: Standard_E32-16as_v4
+      memory: 274877906944
+      name: Standard_E32-16as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEASv5Family
+      generic_name: standard_e32-16as_v5
+      id: Standard_E32-16as_v5
+      memory: 274877906944
+      name: Standard_E32-16as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEasv7Family
+      generic_name: standard_e32-16as_v7
+      id: Standard_E32-16as_v7
+      memory: 274877906944
+      name: Standard_E32-16as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEDSv4Family
+      generic_name: standard_e32-16ds_v4
+      id: Standard_E32-16ds_v4
+      memory: 274877906944
+      name: Standard_E32-16ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEDSv5Family
+      generic_name: standard_e32-16ds_v5
+      id: Standard_E32-16ds_v5
+      memory: 274877906944
+      name: Standard_E32-16ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEdsv6Family
+      generic_name: standard_e32-16ds_v6
+      id: Standard_E32-16ds_v6
+      memory: 274877906944
+      name: Standard_E32-16ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardESv3Family
+      generic_name: standard_e32-16s_v3
+      id: Standard_E32-16s_v3
+      memory: 274877906944
+      name: Standard_E32-16s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardESv4Family
+      generic_name: standard_e32-16s_v4
+      id: Standard_E32-16s_v4
+      memory: 274877906944
+      name: Standard_E32-16s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardESv5Family
+      generic_name: standard_e32-16s_v5
+      id: Standard_E32-16s_v5
+      memory: 274877906944
+      name: Standard_E32-16s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEsv6Family
+      generic_name: standard_e32-16s_v6
+      id: Standard_E32-16s_v6
+      memory: 274877906944
+      name: Standard_E32-16s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEADSv5Family
+      generic_name: standard_e32-8ads_v5
+      id: Standard_E32-8ads_v5
+      memory: 274877906944
+      name: Standard_E32-8ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEadsv7Family
+      generic_name: standard_e32-8ads_v7
+      id: Standard_E32-8ads_v7
+      memory: 274877906944
+      name: Standard_E32-8ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEASv4Family
+      generic_name: standard_e32-8as_v4
+      id: Standard_E32-8as_v4
+      memory: 274877906944
+      name: Standard_E32-8as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEASv5Family
+      generic_name: standard_e32-8as_v5
+      id: Standard_E32-8as_v5
+      memory: 274877906944
+      name: Standard_E32-8as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEasv7Family
+      generic_name: standard_e32-8as_v7
+      id: Standard_E32-8as_v7
+      memory: 274877906944
+      name: Standard_E32-8as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEDSv4Family
+      generic_name: standard_e32-8ds_v4
+      id: Standard_E32-8ds_v4
+      memory: 274877906944
+      name: Standard_E32-8ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEDSv5Family
+      generic_name: standard_e32-8ds_v5
+      id: Standard_E32-8ds_v5
+      memory: 274877906944
+      name: Standard_E32-8ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEdsv6Family
+      generic_name: standard_e32-8ds_v6
+      id: Standard_E32-8ds_v6
+      memory: 274877906944
+      name: Standard_E32-8ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardESv3Family
+      generic_name: standard_e32-8s_v3
+      id: Standard_E32-8s_v3
+      memory: 274877906944
+      name: Standard_E32-8s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardESv4Family
+      generic_name: standard_e32-8s_v4
+      id: Standard_E32-8s_v4
+      memory: 274877906944
+      name: Standard_E32-8s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardESv5Family
+      generic_name: standard_e32-8s_v5
+      id: Standard_E32-8s_v5
+      memory: 274877906944
+      name: Standard_E32-8s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEsv6Family
+      generic_name: standard_e32-8s_v6
+      id: Standard_E32-8s_v6
+      memory: 274877906944
+      name: Standard_E32-8s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEADSv5Family
+      generic_name: standard_e32ads_v5
+      id: Standard_E32ads_v5
+      memory: 274877906944
+      name: Standard_E32ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEadv6Family
+      generic_name: standard_e32ads_v6
+      id: Standard_E32ads_v6
+      memory: 274877906944
+      name: Standard_E32ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEadsv7Family
+      generic_name: standard_e32ads_v7
+      id: Standard_E32ads_v7
+      memory: 274877906944
+      name: Standard_E32ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEASv4Family
+      generic_name: standard_e32as_v4
+      id: Standard_E32as_v4
+      memory: 274877906944
+      name: Standard_E32as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEASv5Family
+      generic_name: standard_e32as_v5
+      id: Standard_E32as_v5
+      memory: 274877906944
+      name: Standard_E32as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEav6Family
+      generic_name: standard_e32as_v6
+      id: Standard_E32as_v6
+      memory: 274877906944
+      name: Standard_E32as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEasv7Family
+      generic_name: standard_e32as_v7
+      id: Standard_E32as_v7
+      memory: 274877906944
+      name: Standard_E32as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEAv4Family
+      generic_name: standard_e32a_v4
+      id: Standard_E32a_v4
+      memory: 274877906944
+      name: Standard_E32a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEBDSv5Family
+      generic_name: standard_e32bds_v5
+      id: Standard_E32bds_v5
+      memory: 274877906944
+      name: Standard_E32bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEBSv5Family
+      generic_name: standard_e32bs_v5
+      id: Standard_E32bs_v5
+      memory: 274877906944
+      name: Standard_E32bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEDSv4Family
+      generic_name: standard_e32ds_v4
+      id: Standard_E32ds_v4
+      memory: 274877906944
+      name: Standard_E32ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEDSv5Family
+      generic_name: standard_e32ds_v5
+      id: Standard_E32ds_v5
+      memory: 274877906944
+      name: Standard_E32ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEdsv6Family
+      generic_name: standard_e32ds_v6
+      id: Standard_E32ds_v6
+      memory: 274877906944
+      name: Standard_E32ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEDv4Family
+      generic_name: standard_e32d_v4
+      id: Standard_E32d_v4
+      memory: 274877906944
+      name: Standard_E32d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEDv5Family
+      generic_name: standard_e32d_v5
+      id: Standard_E32d_v5
+      memory: 274877906944
+      name: Standard_E32d_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEPDSv5Family
+      generic_name: standard_e32pds_v5
+      id: Standard_E32pds_v5
+      memory: 223338299392
+      name: Standard_E32pds_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEpdsv6Family
+      generic_name: standard_e32pds_v6
+      id: Standard_E32pds_v6
+      memory: 274877906944
+      name: Standard_E32pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEPSv5Family
+      generic_name: standard_e32ps_v5
+      id: Standard_E32ps_v5
+      memory: 223338299392
+      name: Standard_E32ps_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEpsv6Family
+      generic_name: standard_e32ps_v6
+      id: Standard_E32ps_v6
+      memory: 274877906944
+      name: Standard_E32ps_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardESv3Family
+      generic_name: standard_e32s_v3
+      id: Standard_E32s_v3
+      memory: 274877906944
+      name: Standard_E32s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardESv4Family
+      generic_name: standard_e32s_v4
+      id: Standard_E32s_v4
+      memory: 274877906944
+      name: Standard_E32s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardESv5Family
+      generic_name: standard_e32s_v5
+      id: Standard_E32s_v5
+      memory: 274877906944
+      name: Standard_E32s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEsv6Family
+      generic_name: standard_e32s_v6
+      id: Standard_E32s_v6
+      memory: 274877906944
+      name: Standard_E32s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEv3Family
+      generic_name: standard_e32_v3
+      id: Standard_E32_v3
+      memory: 274877906944
+      name: Standard_E32_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEv4Family
+      generic_name: standard_e32_v4
+      id: Standard_E32_v4
+      memory: 274877906944
+      name: Standard_E32_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEv5Family
+      generic_name: standard_e32_v5
+      id: Standard_E32_v5
+      memory: 274877906944
+      name: Standard_E32_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEADSv5Family
+      generic_name: standard_e4-2ads_v5
+      id: Standard_E4-2ads_v5
+      memory: 34359738368
+      name: Standard_E4-2ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardEadsv7Family
+      generic_name: standard_e4-2ads_v7
+      id: Standard_E4-2ads_v7
+      memory: 34359738368
+      name: Standard_E4-2ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEASv4Family
+      generic_name: standard_e4-2as_v4
+      id: Standard_E4-2as_v4
+      memory: 34359738368
+      name: Standard_E4-2as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEASv5Family
+      generic_name: standard_e4-2as_v5
+      id: Standard_E4-2as_v5
+      memory: 34359738368
+      name: Standard_E4-2as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardEasv7Family
+      generic_name: standard_e4-2as_v7
+      id: Standard_E4-2as_v7
+      memory: 34359738368
+      name: Standard_E4-2as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEDSv4Family
+      generic_name: standard_e4-2ds_v4
+      id: Standard_E4-2ds_v4
+      memory: 34359738368
+      name: Standard_E4-2ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEDSv5Family
+      generic_name: standard_e4-2ds_v5
+      id: Standard_E4-2ds_v5
+      memory: 34359738368
+      name: Standard_E4-2ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardEdsv6Family
+      generic_name: standard_e4-2ds_v6
+      id: Standard_E4-2ds_v6
+      memory: 34359738368
+      name: Standard_E4-2ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardESv3Family
+      generic_name: standard_e4-2s_v3
+      id: Standard_E4-2s_v3
+      memory: 34359738368
+      name: Standard_E4-2s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardESv4Family
+      generic_name: standard_e4-2s_v4
+      id: Standard_E4-2s_v4
+      memory: 34359738368
+      name: Standard_E4-2s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardESv5Family
+      generic_name: standard_e4-2s_v5
+      id: Standard_E4-2s_v5
+      memory: 34359738368
+      name: Standard_E4-2s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardEsv6Family
+      generic_name: standard_e4-2s_v6
+      id: Standard_E4-2s_v6
+      memory: 34359738368
+      name: Standard_E4-2s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEADSv5Family
+      generic_name: standard_e48ads_v5
+      id: Standard_E48ads_v5
+      memory: 412316860416
+      name: Standard_E48ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEadv6Family
+      generic_name: standard_e48ads_v6
+      id: Standard_E48ads_v6
+      memory: 412316860416
+      name: Standard_E48ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardEadsv7Family
+      generic_name: standard_e48ads_v7
+      id: Standard_E48ads_v7
+      memory: 412316860416
+      name: Standard_E48ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEASv4Family
+      generic_name: standard_e48as_v4
+      id: Standard_E48as_v4
+      memory: 412316860416
+      name: Standard_E48as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEASv5Family
+      generic_name: standard_e48as_v5
+      id: Standard_E48as_v5
+      memory: 412316860416
+      name: Standard_E48as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEav6Family
+      generic_name: standard_e48as_v6
+      id: Standard_E48as_v6
+      memory: 412316860416
+      name: Standard_E48as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardEasv7Family
+      generic_name: standard_e48as_v7
+      id: Standard_E48as_v7
+      memory: 412316860416
+      name: Standard_E48as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEAv4Family
+      generic_name: standard_e48a_v4
+      id: Standard_E48a_v4
+      memory: 412316860416
+      name: Standard_E48a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEBDSv5Family
+      generic_name: standard_e48bds_v5
+      id: Standard_E48bds_v5
+      memory: 412316860416
+      name: Standard_E48bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEBSv5Family
+      generic_name: standard_e48bs_v5
+      id: Standard_E48bs_v5
+      memory: 412316860416
+      name: Standard_E48bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEDSv4Family
+      generic_name: standard_e48ds_v4
+      id: Standard_E48ds_v4
+      memory: 412316860416
+      name: Standard_E48ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEDSv5Family
+      generic_name: standard_e48ds_v5
+      id: Standard_E48ds_v5
+      memory: 412316860416
+      name: Standard_E48ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardEdsv6Family
+      generic_name: standard_e48ds_v6
+      id: Standard_E48ds_v6
+      memory: 412316860416
+      name: Standard_E48ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEDv4Family
+      generic_name: standard_e48d_v4
+      id: Standard_E48d_v4
+      memory: 412316860416
+      name: Standard_E48d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEDv5Family
+      generic_name: standard_e48d_v5
+      id: Standard_E48d_v5
+      memory: 412316860416
+      name: Standard_E48d_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardEpdsv6Family
+      generic_name: standard_e48pds_v6
+      id: Standard_E48pds_v6
+      memory: 412316860416
+      name: Standard_E48pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardEpsv6Family
+      generic_name: standard_e48ps_v6
+      id: Standard_E48ps_v6
+      memory: 412316860416
+      name: Standard_E48ps_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardESv3Family
+      generic_name: standard_e48s_v3
+      id: Standard_E48s_v3
+      memory: 412316860416
+      name: Standard_E48s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardESv4Family
+      generic_name: standard_e48s_v4
+      id: Standard_E48s_v4
+      memory: 412316860416
+      name: Standard_E48s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardESv5Family
+      generic_name: standard_e48s_v5
+      id: Standard_E48s_v5
+      memory: 412316860416
+      name: Standard_E48s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardEsv6Family
+      generic_name: standard_e48s_v6
+      id: Standard_E48s_v6
+      memory: 412316860416
+      name: Standard_E48s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEv3Family
+      generic_name: standard_e48_v3
+      id: Standard_E48_v3
+      memory: 412316860416
+      name: Standard_E48_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEv4Family
+      generic_name: standard_e48_v4
+      id: Standard_E48_v4
+      memory: 412316860416
+      name: Standard_E48_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEv5Family
+      generic_name: standard_e48_v5
+      id: Standard_E48_v5
+      memory: 412316860416
+      name: Standard_E48_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEADSv5Family
+      generic_name: standard_e4ads_v5
+      id: Standard_E4ads_v5
+      memory: 34359738368
+      name: Standard_E4ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEadv6Family
+      generic_name: standard_e4ads_v6
+      id: Standard_E4ads_v6
+      memory: 34359738368
+      name: Standard_E4ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardEadsv7Family
+      generic_name: standard_e4ads_v7
+      id: Standard_E4ads_v7
+      memory: 34359738368
+      name: Standard_E4ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEASv4Family
+      generic_name: standard_e4as_v4
+      id: Standard_E4as_v4
+      memory: 34359738368
+      name: Standard_E4as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEASv5Family
+      generic_name: standard_e4as_v5
+      id: Standard_E4as_v5
+      memory: 34359738368
+      name: Standard_E4as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEav6Family
+      generic_name: standard_e4as_v6
+      id: Standard_E4as_v6
+      memory: 34359738368
+      name: Standard_E4as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardEasv7Family
+      generic_name: standard_e4as_v7
+      id: Standard_E4as_v7
+      memory: 34359738368
+      name: Standard_E4as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEAv4Family
+      generic_name: standard_e4a_v4
+      id: Standard_E4a_v4
+      memory: 34359738368
+      name: Standard_E4a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEBDSv5Family
+      generic_name: standard_e4bds_v5
+      id: Standard_E4bds_v5
+      memory: 34359738368
+      name: Standard_E4bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEBSv5Family
+      generic_name: standard_e4bs_v5
+      id: Standard_E4bs_v5
+      memory: 34359738368
+      name: Standard_E4bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEDSv4Family
+      generic_name: standard_e4ds_v4
+      id: Standard_E4ds_v4
+      memory: 34359738368
+      name: Standard_E4ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEDSv5Family
+      generic_name: standard_e4ds_v5
+      id: Standard_E4ds_v5
+      memory: 34359738368
+      name: Standard_E4ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardEdsv6Family
+      generic_name: standard_e4ds_v6
+      id: Standard_E4ds_v6
+      memory: 34359738368
+      name: Standard_E4ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEDv4Family
+      generic_name: standard_e4d_v4
+      id: Standard_E4d_v4
+      memory: 34359738368
+      name: Standard_E4d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEDv5Family
+      generic_name: standard_e4d_v5
+      id: Standard_E4d_v5
+      memory: 34359738368
+      name: Standard_E4d_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEPDSv5Family
+      generic_name: standard_e4pds_v5
+      id: Standard_E4pds_v5
+      memory: 34359738368
+      name: Standard_E4pds_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardEpdsv6Family
+      generic_name: standard_e4pds_v6
+      id: Standard_E4pds_v6
+      memory: 34359738368
+      name: Standard_E4pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEPSv5Family
+      generic_name: standard_e4ps_v5
+      id: Standard_E4ps_v5
+      memory: 34359738368
+      name: Standard_E4ps_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardEpsv6Family
+      generic_name: standard_e4ps_v6
+      id: Standard_E4ps_v6
+      memory: 34359738368
+      name: Standard_E4ps_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardESv3Family
+      generic_name: standard_e4s_v3
+      id: Standard_E4s_v3
+      memory: 34359738368
+      name: Standard_E4s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardESv4Family
+      generic_name: standard_e4s_v4
+      id: Standard_E4s_v4
+      memory: 34359738368
+      name: Standard_E4s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardESv5Family
+      generic_name: standard_e4s_v5
+      id: Standard_E4s_v5
+      memory: 34359738368
+      name: Standard_E4s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardEsv6Family
+      generic_name: standard_e4s_v6
+      id: Standard_E4s_v6
+      memory: 34359738368
+      name: Standard_E4s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEv3Family
+      generic_name: standard_e4_v3
+      id: Standard_E4_v3
+      memory: 34359738368
+      name: Standard_E4_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEv4Family
+      generic_name: standard_e4_v4
+      id: Standard_E4_v4
+      memory: 34359738368
+      name: Standard_E4_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEv5Family
+      generic_name: standard_e4_v5
+      id: Standard_E4_v5
+      memory: 34359738368
+      name: Standard_E4_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEADSv5Family
+      generic_name: standard_e64-16ads_v5
+      id: Standard_E64-16ads_v5
+      memory: 549755813888
+      name: Standard_E64-16ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEadsv7Family
+      generic_name: standard_e64-16ads_v7
+      id: Standard_E64-16ads_v7
+      memory: 549755813888
+      name: Standard_E64-16ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEASv4Family
+      generic_name: standard_e64-16as_v4
+      id: Standard_E64-16as_v4
+      memory: 549755813888
+      name: Standard_E64-16as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEASv5Family
+      generic_name: standard_e64-16as_v5
+      id: Standard_E64-16as_v5
+      memory: 549755813888
+      name: Standard_E64-16as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEasv7Family
+      generic_name: standard_e64-16as_v7
+      id: Standard_E64-16as_v7
+      memory: 549755813888
+      name: Standard_E64-16as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEDSv4Family
+      generic_name: standard_e64-16ds_v4
+      id: Standard_E64-16ds_v4
+      memory: 541165879296
+      name: Standard_E64-16ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEDSv5Family
+      generic_name: standard_e64-16ds_v5
+      id: Standard_E64-16ds_v5
+      memory: 549755813888
+      name: Standard_E64-16ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEdsv6Family
+      generic_name: standard_e64-16ds_v6
+      id: Standard_E64-16ds_v6
+      memory: 549755813888
+      name: Standard_E64-16ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardESv3Family
+      generic_name: standard_e64-16s_v3
+      id: Standard_E64-16s_v3
+      memory: 463856467968
+      name: Standard_E64-16s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardESv4Family
+      generic_name: standard_e64-16s_v4
+      id: Standard_E64-16s_v4
+      memory: 541165879296
+      name: Standard_E64-16s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardESv5Family
+      generic_name: standard_e64-16s_v5
+      id: Standard_E64-16s_v5
+      memory: 549755813888
+      name: Standard_E64-16s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEsv6Family
+      generic_name: standard_e64-16s_v6
+      id: Standard_E64-16s_v6
+      memory: 549755813888
+      name: Standard_E64-16s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEADSv5Family
+      generic_name: standard_e64-32ads_v5
+      id: Standard_E64-32ads_v5
+      memory: 549755813888
+      name: Standard_E64-32ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEadsv7Family
+      generic_name: standard_e64-32ads_v7
+      id: Standard_E64-32ads_v7
+      memory: 549755813888
+      name: Standard_E64-32ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEASv4Family
+      generic_name: standard_e64-32as_v4
+      id: Standard_E64-32as_v4
+      memory: 549755813888
+      name: Standard_E64-32as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEASv5Family
+      generic_name: standard_e64-32as_v5
+      id: Standard_E64-32as_v5
+      memory: 549755813888
+      name: Standard_E64-32as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEasv7Family
+      generic_name: standard_e64-32as_v7
+      id: Standard_E64-32as_v7
+      memory: 549755813888
+      name: Standard_E64-32as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEDSv4Family
+      generic_name: standard_e64-32ds_v4
+      id: Standard_E64-32ds_v4
+      memory: 541165879296
+      name: Standard_E64-32ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEDSv5Family
+      generic_name: standard_e64-32ds_v5
+      id: Standard_E64-32ds_v5
+      memory: 549755813888
+      name: Standard_E64-32ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEdsv6Family
+      generic_name: standard_e64-32ds_v6
+      id: Standard_E64-32ds_v6
+      memory: 549755813888
+      name: Standard_E64-32ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardESv3Family
+      generic_name: standard_e64-32s_v3
+      id: Standard_E64-32s_v3
+      memory: 463856467968
+      name: Standard_E64-32s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardESv4Family
+      generic_name: standard_e64-32s_v4
+      id: Standard_E64-32s_v4
+      memory: 541165879296
+      name: Standard_E64-32s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardESv5Family
+      generic_name: standard_e64-32s_v5
+      id: Standard_E64-32s_v5
+      memory: 549755813888
+      name: Standard_E64-32s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEsv6Family
+      generic_name: standard_e64-32s_v6
+      id: Standard_E64-32s_v6
+      memory: 549755813888
+      name: Standard_E64-32s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEADSv5Family
+      generic_name: standard_e64ads_v5
+      id: Standard_E64ads_v5
+      memory: 549755813888
+      name: Standard_E64ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEadv6Family
+      generic_name: standard_e64ads_v6
+      id: Standard_E64ads_v6
+      memory: 549755813888
+      name: Standard_E64ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEadsv7Family
+      generic_name: standard_e64ads_v7
+      id: Standard_E64ads_v7
+      memory: 549755813888
+      name: Standard_E64ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEASv4Family
+      generic_name: standard_e64as_v4
+      id: Standard_E64as_v4
+      memory: 549755813888
+      name: Standard_E64as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEASv5Family
+      generic_name: standard_e64as_v5
+      id: Standard_E64as_v5
+      memory: 549755813888
+      name: Standard_E64as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEav6Family
+      generic_name: standard_e64as_v6
+      id: Standard_E64as_v6
+      memory: 549755813888
+      name: Standard_E64as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEasv7Family
+      generic_name: standard_e64as_v7
+      id: Standard_E64as_v7
+      memory: 549755813888
+      name: Standard_E64as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEAv4Family
+      generic_name: standard_e64a_v4
+      id: Standard_E64a_v4
+      memory: 549755813888
+      name: Standard_E64a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEBDSv5Family
+      generic_name: standard_e64bds_v5
+      id: Standard_E64bds_v5
+      memory: 549755813888
+      name: Standard_E64bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEBSv5Family
+      generic_name: standard_e64bs_v5
+      id: Standard_E64bs_v5
+      memory: 549755813888
+      name: Standard_E64bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEDSv4Family
+      generic_name: standard_e64ds_v4
+      id: Standard_E64ds_v4
+      memory: 541165879296
+      name: Standard_E64ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEDSv5Family
+      generic_name: standard_e64ds_v5
+      id: Standard_E64ds_v5
+      memory: 549755813888
+      name: Standard_E64ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEdsv6Family
+      generic_name: standard_e64ds_v6
+      id: Standard_E64ds_v6
+      memory: 549755813888
+      name: Standard_E64ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEDv4Family
+      generic_name: standard_e64d_v4
+      id: Standard_E64d_v4
+      memory: 541165879296
+      name: Standard_E64d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEDv5Family
+      generic_name: standard_e64d_v5
+      id: Standard_E64d_v5
+      memory: 549755813888
+      name: Standard_E64d_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEpdsv6Family
+      generic_name: standard_e64pds_v6
+      id: Standard_E64pds_v6
+      memory: 549755813888
+      name: Standard_E64pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEpsv6Family
+      generic_name: standard_e64ps_v6
+      id: Standard_E64ps_v6
+      memory: 549755813888
+      name: Standard_E64ps_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardESv3Family
+      generic_name: standard_e64s_v3
+      id: Standard_E64s_v3
+      memory: 463856467968
+      name: Standard_E64s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardESv4Family
+      generic_name: standard_e64s_v4
+      id: Standard_E64s_v4
+      memory: 541165879296
+      name: Standard_E64s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardESv5Family
+      generic_name: standard_e64s_v5
+      id: Standard_E64s_v5
+      memory: 549755813888
+      name: Standard_E64s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEsv6Family
+      generic_name: standard_e64s_v6
+      id: Standard_E64s_v6
+      memory: 549755813888
+      name: Standard_E64s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEv3Family
+      generic_name: standard_e64_v3
+      id: Standard_E64_v3
+      memory: 463856467968
+      name: Standard_E64_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEv4Family
+      generic_name: standard_e64_v4
+      id: Standard_E64_v4
+      memory: 541165879296
+      name: Standard_E64_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEv5Family
+      generic_name: standard_e64_v5
+      id: Standard_E64_v5
+      memory: 549755813888
+      name: Standard_E64_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEADSv5Family
+      generic_name: standard_e8-2ads_v5
+      id: Standard_E8-2ads_v5
+      memory: 68719476736
+      name: Standard_E8-2ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEadsv7Family
+      generic_name: standard_e8-2ads_v7
+      id: Standard_E8-2ads_v7
+      memory: 68719476736
+      name: Standard_E8-2ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEASv4Family
+      generic_name: standard_e8-2as_v4
+      id: Standard_E8-2as_v4
+      memory: 68719476736
+      name: Standard_E8-2as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEASv5Family
+      generic_name: standard_e8-2as_v5
+      id: Standard_E8-2as_v5
+      memory: 68719476736
+      name: Standard_E8-2as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEasv7Family
+      generic_name: standard_e8-2as_v7
+      id: Standard_E8-2as_v7
+      memory: 68719476736
+      name: Standard_E8-2as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEDSv4Family
+      generic_name: standard_e8-2ds_v4
+      id: Standard_E8-2ds_v4
+      memory: 68719476736
+      name: Standard_E8-2ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEDSv5Family
+      generic_name: standard_e8-2ds_v5
+      id: Standard_E8-2ds_v5
+      memory: 68719476736
+      name: Standard_E8-2ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEdsv6Family
+      generic_name: standard_e8-2ds_v6
+      id: Standard_E8-2ds_v6
+      memory: 68719476736
+      name: Standard_E8-2ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardESv3Family
+      generic_name: standard_e8-2s_v3
+      id: Standard_E8-2s_v3
+      memory: 68719476736
+      name: Standard_E8-2s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardESv4Family
+      generic_name: standard_e8-2s_v4
+      id: Standard_E8-2s_v4
+      memory: 68719476736
+      name: Standard_E8-2s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardESv5Family
+      generic_name: standard_e8-2s_v5
+      id: Standard_E8-2s_v5
+      memory: 68719476736
+      name: Standard_E8-2s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEsv6Family
+      generic_name: standard_e8-2s_v6
+      id: Standard_E8-2s_v6
+      memory: 68719476736
+      name: Standard_E8-2s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEADSv5Family
+      generic_name: standard_e8-4ads_v5
+      id: Standard_E8-4ads_v5
+      memory: 68719476736
+      name: Standard_E8-4ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEadsv7Family
+      generic_name: standard_e8-4ads_v7
+      id: Standard_E8-4ads_v7
+      memory: 68719476736
+      name: Standard_E8-4ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEASv4Family
+      generic_name: standard_e8-4as_v4
+      id: Standard_E8-4as_v4
+      memory: 68719476736
+      name: Standard_E8-4as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEASv5Family
+      generic_name: standard_e8-4as_v5
+      id: Standard_E8-4as_v5
+      memory: 68719476736
+      name: Standard_E8-4as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEasv7Family
+      generic_name: standard_e8-4as_v7
+      id: Standard_E8-4as_v7
+      memory: 68719476736
+      name: Standard_E8-4as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEDSv4Family
+      generic_name: standard_e8-4ds_v4
+      id: Standard_E8-4ds_v4
+      memory: 68719476736
+      name: Standard_E8-4ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEDSv5Family
+      generic_name: standard_e8-4ds_v5
+      id: Standard_E8-4ds_v5
+      memory: 68719476736
+      name: Standard_E8-4ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEdsv6Family
+      generic_name: standard_e8-4ds_v6
+      id: Standard_E8-4ds_v6
+      memory: 68719476736
+      name: Standard_E8-4ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardESv3Family
+      generic_name: standard_e8-4s_v3
+      id: Standard_E8-4s_v3
+      memory: 68719476736
+      name: Standard_E8-4s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardESv4Family
+      generic_name: standard_e8-4s_v4
+      id: Standard_E8-4s_v4
+      memory: 68719476736
+      name: Standard_E8-4s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardESv5Family
+      generic_name: standard_e8-4s_v5
+      id: Standard_E8-4s_v5
+      memory: 68719476736
+      name: Standard_E8-4s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEsv6Family
+      generic_name: standard_e8-4s_v6
+      id: Standard_E8-4s_v6
+      memory: 68719476736
+      name: Standard_E8-4s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: standardXEIDSv4Family
+      generic_name: standard_e80ids_v4
+      id: Standard_E80ids_v4
+      memory: 541165879296
+      name: Standard_E80ids_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: standardXEISv4Family
+      generic_name: standard_e80is_v4
+      id: Standard_E80is_v4
+      memory: 541165879296
+      name: Standard_E80is_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEADSv5Family
+      generic_name: standard_e8ads_v5
+      id: Standard_E8ads_v5
+      memory: 68719476736
+      name: Standard_E8ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEadv6Family
+      generic_name: standard_e8ads_v6
+      id: Standard_E8ads_v6
+      memory: 68719476736
+      name: Standard_E8ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEadsv7Family
+      generic_name: standard_e8ads_v7
+      id: Standard_E8ads_v7
+      memory: 68719476736
+      name: Standard_E8ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEASv4Family
+      generic_name: standard_e8as_v4
+      id: Standard_E8as_v4
+      memory: 68719476736
+      name: Standard_E8as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEASv5Family
+      generic_name: standard_e8as_v5
+      id: Standard_E8as_v5
+      memory: 68719476736
+      name: Standard_E8as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEav6Family
+      generic_name: standard_e8as_v6
+      id: Standard_E8as_v6
+      memory: 68719476736
+      name: Standard_E8as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEasv7Family
+      generic_name: standard_e8as_v7
+      id: Standard_E8as_v7
+      memory: 68719476736
+      name: Standard_E8as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEAv4Family
+      generic_name: standard_e8a_v4
+      id: Standard_E8a_v4
+      memory: 68719476736
+      name: Standard_E8a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEBDSv5Family
+      generic_name: standard_e8bds_v5
+      id: Standard_E8bds_v5
+      memory: 68719476736
+      name: Standard_E8bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEBSv5Family
+      generic_name: standard_e8bs_v5
+      id: Standard_E8bs_v5
+      memory: 68719476736
+      name: Standard_E8bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEDSv4Family
+      generic_name: standard_e8ds_v4
+      id: Standard_E8ds_v4
+      memory: 68719476736
+      name: Standard_E8ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEDSv5Family
+      generic_name: standard_e8ds_v5
+      id: Standard_E8ds_v5
+      memory: 68719476736
+      name: Standard_E8ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEdsv6Family
+      generic_name: standard_e8ds_v6
+      id: Standard_E8ds_v6
+      memory: 68719476736
+      name: Standard_E8ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEDv4Family
+      generic_name: standard_e8d_v4
+      id: Standard_E8d_v4
+      memory: 68719476736
+      name: Standard_E8d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEDv5Family
+      generic_name: standard_e8d_v5
+      id: Standard_E8d_v5
+      memory: 68719476736
+      name: Standard_E8d_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEPDSv5Family
+      generic_name: standard_e8pds_v5
+      id: Standard_E8pds_v5
+      memory: 68719476736
+      name: Standard_E8pds_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEpdsv6Family
+      generic_name: standard_e8pds_v6
+      id: Standard_E8pds_v6
+      memory: 68719476736
+      name: Standard_E8pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEPSv5Family
+      generic_name: standard_e8ps_v5
+      id: Standard_E8ps_v5
+      memory: 68719476736
+      name: Standard_E8ps_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEpsv6Family
+      generic_name: standard_e8ps_v6
+      id: Standard_E8ps_v6
+      memory: 68719476736
+      name: Standard_E8ps_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardESv3Family
+      generic_name: standard_e8s_v3
+      id: Standard_E8s_v3
+      memory: 68719476736
+      name: Standard_E8s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardESv4Family
+      generic_name: standard_e8s_v4
+      id: Standard_E8s_v4
+      memory: 68719476736
+      name: Standard_E8s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardESv5Family
+      generic_name: standard_e8s_v5
+      id: Standard_E8s_v5
+      memory: 68719476736
+      name: Standard_E8s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEsv6Family
+      generic_name: standard_e8s_v6
+      id: Standard_E8s_v6
+      memory: 68719476736
+      name: Standard_E8s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEv3Family
+      generic_name: standard_e8_v3
+      id: Standard_E8_v3
+      memory: 68719476736
+      name: Standard_E8_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEv4Family
+      generic_name: standard_e8_v4
+      id: Standard_E8_v4
+      memory: 68719476736
+      name: Standard_E8_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEv5Family
+      generic_name: standard_e8_v5
+      id: Standard_E8_v5
+      memory: 68719476736
+      name: Standard_E8_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEADSv5Family
+      generic_name: standard_e96-24ads_v5
+      id: Standard_E96-24ads_v5
+      memory: 721554505728
+      name: Standard_E96-24ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEadv6Family
+      generic_name: standard_e96-24ads_v6
+      id: Standard_E96-24ads_v6
+      memory: 721554505728
+      name: Standard_E96-24ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEadsv7Family
+      generic_name: standard_e96-24ads_v7
+      id: Standard_E96-24ads_v7
+      memory: 824633720832
+      name: Standard_E96-24ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEASv4Family
+      generic_name: standard_e96-24as_v4
+      id: Standard_E96-24as_v4
+      memory: 721554505728
+      name: Standard_E96-24as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEASv5Family
+      generic_name: standard_e96-24as_v5
+      id: Standard_E96-24as_v5
+      memory: 721554505728
+      name: Standard_E96-24as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEasv7Family
+      generic_name: standard_e96-24as_v7
+      id: Standard_E96-24as_v7
+      memory: 824633720832
+      name: Standard_E96-24as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEDSv5Family
+      generic_name: standard_e96-24ds_v5
+      id: Standard_E96-24ds_v5
+      memory: 721554505728
+      name: Standard_E96-24ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEdsv6Family
+      generic_name: standard_e96-24ds_v6
+      id: Standard_E96-24ds_v6
+      memory: 824633720832
+      name: Standard_E96-24ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardESv5Family
+      generic_name: standard_e96-24s_v5
+      id: Standard_E96-24s_v5
+      memory: 721554505728
+      name: Standard_E96-24s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEsv6Family
+      generic_name: standard_e96-24s_v6
+      id: Standard_E96-24s_v6
+      memory: 824633720832
+      name: Standard_E96-24s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEADSv5Family
+      generic_name: standard_e96-48ads_v5
+      id: Standard_E96-48ads_v5
+      memory: 721554505728
+      name: Standard_E96-48ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEadv6Family
+      generic_name: standard_e96-48ads_v6
+      id: Standard_E96-48ads_v6
+      memory: 721554505728
+      name: Standard_E96-48ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEadsv7Family
+      generic_name: standard_e96-48ads_v7
+      id: Standard_E96-48ads_v7
+      memory: 824633720832
+      name: Standard_E96-48ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEASv4Family
+      generic_name: standard_e96-48as_v4
+      id: Standard_E96-48as_v4
+      memory: 721554505728
+      name: Standard_E96-48as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEASv5Family
+      generic_name: standard_e96-48as_v5
+      id: Standard_E96-48as_v5
+      memory: 721554505728
+      name: Standard_E96-48as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEasv7Family
+      generic_name: standard_e96-48as_v7
+      id: Standard_E96-48as_v7
+      memory: 824633720832
+      name: Standard_E96-48as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEDSv5Family
+      generic_name: standard_e96-48ds_v5
+      id: Standard_E96-48ds_v5
+      memory: 721554505728
+      name: Standard_E96-48ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEdsv6Family
+      generic_name: standard_e96-48ds_v6
+      id: Standard_E96-48ds_v6
+      memory: 824633720832
+      name: Standard_E96-48ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardESv5Family
+      generic_name: standard_e96-48s_v5
+      id: Standard_E96-48s_v5
+      memory: 721554505728
+      name: Standard_E96-48s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEsv6Family
+      generic_name: standard_e96-48s_v6
+      id: Standard_E96-48s_v6
+      memory: 824633720832
+      name: Standard_E96-48s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEADSv5Family
+      generic_name: standard_e96ads_v5
+      id: Standard_E96ads_v5
+      memory: 721554505728
+      name: Standard_E96ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEadv6Family
+      generic_name: standard_e96ads_v6
+      id: Standard_E96ads_v6
+      memory: 721554505728
+      name: Standard_E96ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEadsv7Family
+      generic_name: standard_e96ads_v7
+      id: Standard_E96ads_v7
+      memory: 824633720832
+      name: Standard_E96ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEASv4Family
+      generic_name: standard_e96as_v4
+      id: Standard_E96as_v4
+      memory: 721554505728
+      name: Standard_E96as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEASv5Family
+      generic_name: standard_e96as_v5
+      id: Standard_E96as_v5
+      memory: 721554505728
+      name: Standard_E96as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEav6Family
+      generic_name: standard_e96as_v6
+      id: Standard_E96as_v6
+      memory: 721554505728
+      name: Standard_E96as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEasv7Family
+      generic_name: standard_e96as_v7
+      id: Standard_E96as_v7
+      memory: 824633720832
+      name: Standard_E96as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEAv4Family
+      generic_name: standard_e96a_v4
+      id: Standard_E96a_v4
+      memory: 721554505728
+      name: Standard_E96a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEBDSv5Family
+      generic_name: standard_e96bds_v5
+      id: Standard_E96bds_v5
+      memory: 721554505728
+      name: Standard_E96bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEBSv5Family
+      generic_name: standard_e96bs_v5
+      id: Standard_E96bs_v5
+      memory: 721554505728
+      name: Standard_E96bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEDSv5Family
+      generic_name: standard_e96ds_v5
+      id: Standard_E96ds_v5
+      memory: 721554505728
+      name: Standard_E96ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEdsv6Family
+      generic_name: standard_e96ds_v6
+      id: Standard_E96ds_v6
+      memory: 824633720832
+      name: Standard_E96ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEDv5Family
+      generic_name: standard_e96d_v5
+      id: Standard_E96d_v5
+      memory: 721554505728
+      name: Standard_E96d_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEIASv4Family
+      generic_name: standard_e96ias_v4
+      id: Standard_E96ias_v4
+      memory: 721554505728
+      name: Standard_E96ias_v4
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEpdsv6Family
+      generic_name: standard_e96pds_v6
+      id: Standard_E96pds_v6
+      memory: 721554505728
+      name: Standard_E96pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEpsv6Family
+      generic_name: standard_e96ps_v6
+      id: Standard_E96ps_v6
+      memory: 721554505728
+      name: Standard_E96ps_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardESv5Family
+      generic_name: standard_e96s_v5
+      id: Standard_E96s_v5
+      memory: 721554505728
+      name: Standard_E96s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEsv6Family
+      generic_name: standard_e96s_v6
+      id: Standard_E96s_v6
+      memory: 824633720832
+      name: Standard_E96s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEv5Family
+      generic_name: standard_e96_v5
+      id: Standard_E96_v5
+      memory: 721554505728
+      name: Standard_E96_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardECADCCV5Family
+      generic_name: standard_ec16ads_cc_v5
+      id: Standard_EC16ads_cc_v5
+      memory: 137438953472
+      name: Standard_EC16ads_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardECADSv5Family
+      generic_name: standard_ec16ads_v5
+      id: Standard_EC16ads_v5
+      memory: 137438953472
+      name: Standard_EC16ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardECadsv6Family
+      generic_name: standard_ec16ads_v6
+      id: Standard_EC16ads_v6
+      memory: 137438953472
+      name: Standard_EC16ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardECACCV5Family
+      generic_name: standard_ec16as_cc_v5
+      id: Standard_EC16as_cc_v5
+      memory: 137438953472
+      name: Standard_EC16as_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardECASv5Family
+      generic_name: standard_ec16as_v5
+      id: Standard_EC16as_v5
+      memory: 137438953472
+      name: Standard_EC16as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardECasv6Family
+      generic_name: standard_ec16as_v6
+      id: Standard_EC16as_v6
+      memory: 137438953472
+      name: Standard_EC16as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardECEDV6Family
+      generic_name: standard_ec16eds_v6
+      id: Standard_EC16eds_v6
+      memory: 137438953472
+      name: Standard_EC16eds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardECEV6Family
       generic_name: standard_ec16es_v6
       id: Standard_EC16es_v6
       memory: 137438953472
       name: Standard_EC16es_v6
     - category: memory_optimized
       cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardECADCCV5Family
+      generic_name: standard_ec20ads_cc_v5
+      id: Standard_EC20ads_cc_v5
+      memory: 171798691840
+      name: Standard_EC20ads_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardECADSv5Family
+      generic_name: standard_ec20ads_v5
+      id: Standard_EC20ads_v5
+      memory: 171798691840
+      name: Standard_EC20ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardECACCV5Family
+      generic_name: standard_ec20as_cc_v5
+      id: Standard_EC20as_cc_v5
+      memory: 171798691840
+      name: Standard_EC20as_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardECASv5Family
+      generic_name: standard_ec20as_v5
+      id: Standard_EC20as_v5
+      memory: 171798691840
+      name: Standard_EC20as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardECADSv5Family
+      generic_name: standard_ec2ads_v5
+      id: Standard_EC2ads_v5
+      memory: 17179869184
+      name: Standard_EC2ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardECadsv6Family
+      generic_name: standard_ec2ads_v6
+      id: Standard_EC2ads_v6
+      memory: 17179869184
+      name: Standard_EC2ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardECASv5Family
+      generic_name: standard_ec2as_v5
+      id: Standard_EC2as_v5
+      memory: 17179869184
+      name: Standard_EC2as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardECasv6Family
+      generic_name: standard_ec2as_v6
+      id: Standard_EC2as_v6
+      memory: 17179869184
+      name: Standard_EC2as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardECEDV6Family
+      generic_name: standard_ec2eds_v6
+      id: Standard_EC2eds_v6
+      memory: 17179869184
+      name: Standard_EC2eds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardECEV6Family
+      generic_name: standard_ec2es_v6
+      id: Standard_EC2es_v6
+      memory: 17179869184
+      name: Standard_EC2es_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
       cpu_cores: 32
+      family: standardECADCCV5Family
+      generic_name: standard_ec32ads_cc_v5
+      id: Standard_EC32ads_cc_v5
+      memory: 206158430208
+      name: Standard_EC32ads_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardECADSv5Family
+      generic_name: standard_ec32ads_v5
+      id: Standard_EC32ads_v5
+      memory: 206158430208
+      name: Standard_EC32ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardECadsv6Family
+      generic_name: standard_ec32ads_v6
+      id: Standard_EC32ads_v6
+      memory: 274877906944
+      name: Standard_EC32ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardECACCV5Family
+      generic_name: standard_ec32as_cc_v5
+      id: Standard_EC32as_cc_v5
+      memory: 206158430208
+      name: Standard_EC32as_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardECASv5Family
+      generic_name: standard_ec32as_v5
+      id: Standard_EC32as_v5
+      memory: 206158430208
+      name: Standard_EC32as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardECasv6Family
+      generic_name: standard_ec32as_v6
+      id: Standard_EC32as_v6
+      memory: 274877906944
+      name: Standard_EC32as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardECEDV6Family
+      generic_name: standard_ec32eds_v6
+      id: Standard_EC32eds_v6
+      memory: 274877906944
+      name: Standard_EC32eds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardECEV6Family
       generic_name: standard_ec32es_v6
       id: Standard_EC32es_v6
       memory: 274877906944
@@ -6966,66 +6339,2147 @@ data:
     - category: memory_optimized
       cloud_provider_id: azure
       cpu_cores: 48
-      generic_name: standard_ec48es_v6
-      id: Standard_EC48es_v6
+      family: standardECADCCV5Family
+      generic_name: standard_ec48ads_cc_v5
+      id: Standard_EC48ads_cc_v5
       memory: 412316860416
-      name: Standard_EC48es_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_ec64es_v6
-      id: Standard_EC64es_v6
-      memory: 549755813888
-      name: Standard_EC64es_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_ec2eds_v6
-      id: Standard_EC2eds_v6
-      memory: 17179869184
-      name: Standard_EC2eds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_ec4eds_v6
-      id: Standard_EC4eds_v6
-      memory: 34359738368
-      name: Standard_EC4eds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_ec8eds_v6
-      id: Standard_EC8eds_v6
-      memory: 68719476736
-      name: Standard_EC8eds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_ec16eds_v6
-      id: Standard_EC16eds_v6
-      memory: 137438953472
-      name: Standard_EC16eds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_ec32eds_v6
-      id: Standard_EC32eds_v6
-      memory: 274877906944
-      name: Standard_EC32eds_v6
+      name: Standard_EC48ads_cc_v5
     - category: memory_optimized
       cloud_provider_id: azure
       cpu_cores: 48
+      family: standardECADSv5Family
+      generic_name: standard_ec48ads_v5
+      id: Standard_EC48ads_v5
+      memory: 412316860416
+      name: Standard_EC48ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardECadsv6Family
+      generic_name: standard_ec48ads_v6
+      id: Standard_EC48ads_v6
+      memory: 412316860416
+      name: Standard_EC48ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardECACCV5Family
+      generic_name: standard_ec48as_cc_v5
+      id: Standard_EC48as_cc_v5
+      memory: 412316860416
+      name: Standard_EC48as_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardECASv5Family
+      generic_name: standard_ec48as_v5
+      id: Standard_EC48as_v5
+      memory: 412316860416
+      name: Standard_EC48as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardECasv6Family
+      generic_name: standard_ec48as_v6
+      id: Standard_EC48as_v6
+      memory: 412316860416
+      name: Standard_EC48as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardECEDV6Family
       generic_name: standard_ec48eds_v6
       id: Standard_EC48eds_v6
       memory: 412316860416
       name: Standard_EC48eds_v6
     - category: memory_optimized
       cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardECEV6Family
+      generic_name: standard_ec48es_v6
+      id: Standard_EC48es_v6
+      memory: 412316860416
+      name: Standard_EC48es_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardECADCCV5Family
+      generic_name: standard_ec4ads_cc_v5
+      id: Standard_EC4ads_cc_v5
+      memory: 34359738368
+      name: Standard_EC4ads_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardECADSv5Family
+      generic_name: standard_ec4ads_v5
+      id: Standard_EC4ads_v5
+      memory: 34359738368
+      name: Standard_EC4ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardECadsv6Family
+      generic_name: standard_ec4ads_v6
+      id: Standard_EC4ads_v6
+      memory: 34359738368
+      name: Standard_EC4ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardECACCV5Family
+      generic_name: standard_ec4as_cc_v5
+      id: Standard_EC4as_cc_v5
+      memory: 34359738368
+      name: Standard_EC4as_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardECASv5Family
+      generic_name: standard_ec4as_v5
+      id: Standard_EC4as_v5
+      memory: 34359738368
+      name: Standard_EC4as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardECasv6Family
+      generic_name: standard_ec4as_v6
+      id: Standard_EC4as_v6
+      memory: 34359738368
+      name: Standard_EC4as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardECEDV6Family
+      generic_name: standard_ec4eds_v6
+      id: Standard_EC4eds_v6
+      memory: 34359738368
+      name: Standard_EC4eds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardECEV6Family
+      generic_name: standard_ec4es_v6
+      id: Standard_EC4es_v6
+      memory: 34359738368
+      name: Standard_EC4es_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
       cpu_cores: 64
+      family: standardECADCCV5Family
+      generic_name: standard_ec64ads_cc_v5
+      id: Standard_EC64ads_cc_v5
+      memory: 549755813888
+      name: Standard_EC64ads_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardECADSv5Family
+      generic_name: standard_ec64ads_v5
+      id: Standard_EC64ads_v5
+      memory: 549755813888
+      name: Standard_EC64ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardECadsv6Family
+      generic_name: standard_ec64ads_v6
+      id: Standard_EC64ads_v6
+      memory: 549755813888
+      name: Standard_EC64ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardECACCV5Family
+      generic_name: standard_ec64as_cc_v5
+      id: Standard_EC64as_cc_v5
+      memory: 549755813888
+      name: Standard_EC64as_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardECASv5Family
+      generic_name: standard_ec64as_v5
+      id: Standard_EC64as_v5
+      memory: 549755813888
+      name: Standard_EC64as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardECasv6Family
+      generic_name: standard_ec64as_v6
+      id: Standard_EC64as_v6
+      memory: 549755813888
+      name: Standard_EC64as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardECEDV6Family
       generic_name: standard_ec64eds_v6
       id: Standard_EC64eds_v6
       memory: 549755813888
       name: Standard_EC64eds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardECEV6Family
+      generic_name: standard_ec64es_v6
+      id: Standard_EC64es_v6
+      memory: 549755813888
+      name: Standard_EC64es_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardECADCCV5Family
+      generic_name: standard_ec8ads_cc_v5
+      id: Standard_EC8ads_cc_v5
+      memory: 68719476736
+      name: Standard_EC8ads_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardECADSv5Family
+      generic_name: standard_ec8ads_v5
+      id: Standard_EC8ads_v5
+      memory: 68719476736
+      name: Standard_EC8ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardECadsv6Family
+      generic_name: standard_ec8ads_v6
+      id: Standard_EC8ads_v6
+      memory: 68719476736
+      name: Standard_EC8ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardECACCV5Family
+      generic_name: standard_ec8as_cc_v5
+      id: Standard_EC8as_cc_v5
+      memory: 68719476736
+      name: Standard_EC8as_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardECASv5Family
+      generic_name: standard_ec8as_v5
+      id: Standard_EC8as_v5
+      memory: 68719476736
+      name: Standard_EC8as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardECasv6Family
+      generic_name: standard_ec8as_v6
+      id: Standard_EC8as_v6
+      memory: 68719476736
+      name: Standard_EC8as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardECEDV6Family
+      generic_name: standard_ec8eds_v6
+      id: Standard_EC8eds_v6
+      memory: 68719476736
+      name: Standard_EC8eds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardECEV6Family
+      generic_name: standard_ec8es_v6
+      id: Standard_EC8es_v6
+      memory: 68719476736
+      name: Standard_EC8es_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardECADCCV5Family
+      generic_name: standard_ec96ads_cc_v5
+      id: Standard_EC96ads_cc_v5
+      memory: 721554505728
+      name: Standard_EC96ads_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardECADSv5Family
+      generic_name: standard_ec96ads_v5
+      id: Standard_EC96ads_v5
+      memory: 721554505728
+      name: Standard_EC96ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardECadsv6Family
+      generic_name: standard_ec96ads_v6
+      id: Standard_EC96ads_v6
+      memory: 721554505728
+      name: Standard_EC96ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardECACCV5Family
+      generic_name: standard_ec96as_cc_v5
+      id: Standard_EC96as_cc_v5
+      memory: 721554505728
+      name: Standard_EC96as_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardECASv5Family
+      generic_name: standard_ec96as_v5
+      id: Standard_EC96as_v5
+      memory: 721554505728
+      name: Standard_EC96as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardECasv6Family
+      generic_name: standard_ec96as_v6
+      id: Standard_EC96as_v6
+      memory: 721554505728
+      name: Standard_EC96as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardECIADSv5Family
+      generic_name: standard_ec96iads_v5
+      id: Standard_EC96iads_v5
+      memory: 721554505728
+      name: Standard_EC96iads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardECIASv5Family
+      generic_name: standard_ec96ias_v5
+      id: Standard_EC96ias_v5
+      memory: 721554505728
+      name: Standard_EC96ias_v5
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      family: standardFFamily
+      generic_name: standard_f1
+      id: Standard_F1
+      memory: 2147483648
+      name: Standard_F1
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardFFamily
+      generic_name: standard_f16
+      id: Standard_F16
+      memory: 34359738368
+      name: Standard_F16
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFamdsv7Family
+      generic_name: standard_f16-4amds_v7
+      id: Standard_F16-4amds_v7
+      memory: 137438953472
+      name: Standard_F16-4amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFamsv7Family
+      generic_name: standard_f16-4ams_v7
+      id: Standard_F16-4ams_v7
+      memory: 137438953472
+      name: Standard_F16-4ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFamdsv7Family
+      generic_name: standard_f16-8amds_v7
+      id: Standard_F16-8amds_v7
+      memory: 137438953472
+      name: Standard_F16-8amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFamsv7Family
+      generic_name: standard_f16-8ams_v7
+      id: Standard_F16-8ams_v7
+      memory: 137438953472
+      name: Standard_F16-8ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFadsv7Family
+      generic_name: standard_f16ads_v7
+      id: Standard_F16ads_v7
+      memory: 68719476736
+      name: Standard_F16ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFaldsv7Family
+      generic_name: standard_f16alds_v7
+      id: Standard_F16alds_v7
+      memory: 34359738368
+      name: Standard_F16alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFalsv6Family
+      generic_name: standard_f16als_v6
+      id: Standard_F16als_v6
+      memory: 34359738368
+      name: Standard_F16als_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFalsv7Family
+      generic_name: standard_f16als_v7
+      id: Standard_F16als_v7
+      memory: 34359738368
+      name: Standard_F16als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFamdsv7Family
+      generic_name: standard_f16amds_v7
+      id: Standard_F16amds_v7
+      memory: 137438953472
+      name: Standard_F16amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFamsv6Family
+      generic_name: standard_f16ams_v6
+      id: Standard_F16ams_v6
+      memory: 137438953472
+      name: Standard_F16ams_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFamsv7Family
+      generic_name: standard_f16ams_v7
+      id: Standard_F16ams_v7
+      memory: 137438953472
+      name: Standard_F16ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFasv6Family
+      generic_name: standard_f16as_v6
+      id: Standard_F16as_v6
+      memory: 68719476736
+      name: Standard_F16as_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFasv7Family
+      generic_name: standard_f16as_v7
+      id: Standard_F16as_v7
+      memory: 68719476736
+      name: Standard_F16as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardFSFamily
+      generic_name: standard_f16s
+      id: Standard_F16s
+      memory: 34359738368
+      name: Standard_F16s
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardFSv2Family
+      generic_name: standard_f16s_v2
+      id: Standard_F16s_v2
+      memory: 34359738368
+      name: Standard_F16s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      family: StandardFadsv7Family
+      generic_name: standard_f1ads_v7
+      id: Standard_F1ads_v7
+      memory: 4294967296
+      name: Standard_F1ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      family: StandardFaldsv7Family
+      generic_name: standard_f1alds_v7
+      id: Standard_F1alds_v7
+      memory: 2147483648
+      name: Standard_F1alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      family: StandardFalsv7Family
+      generic_name: standard_f1als_v7
+      id: Standard_F1als_v7
+      memory: 2147483648
+      name: Standard_F1als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      family: StandardFamdsv7Family
+      generic_name: standard_f1amds_v7
+      id: Standard_F1amds_v7
+      memory: 8589934592
+      name: Standard_F1amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      family: StandardFamsv7Family
+      generic_name: standard_f1ams_v7
+      id: Standard_F1ams_v7
+      memory: 8589934592
+      name: Standard_F1ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      family: StandardFasv7Family
+      generic_name: standard_f1as_v7
+      id: Standard_F1as_v7
+      memory: 4294967296
+      name: Standard_F1as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      family: standardFSFamily
+      generic_name: standard_f1s
+      id: Standard_F1s
+      memory: 2147483648
+      name: Standard_F1s
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardFFamily
+      generic_name: standard_f2
+      id: Standard_F2
+      memory: 4294967296
+      name: Standard_F2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFamdsv7Family
+      generic_name: standard_f2-1amds_v7
+      id: Standard_F2-1amds_v7
+      memory: 17179869184
+      name: Standard_F2-1amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFamsv7Family
+      generic_name: standard_f2-1ams_v7
+      id: Standard_F2-1ams_v7
+      memory: 17179869184
+      name: Standard_F2-1ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFadsv7Family
+      generic_name: standard_f2ads_v7
+      id: Standard_F2ads_v7
+      memory: 8589934592
+      name: Standard_F2ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFaldsv7Family
+      generic_name: standard_f2alds_v7
+      id: Standard_F2alds_v7
+      memory: 4294967296
+      name: Standard_F2alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFalsv6Family
+      generic_name: standard_f2als_v6
+      id: Standard_F2als_v6
+      memory: 4294967296
+      name: Standard_F2als_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFalsv7Family
+      generic_name: standard_f2als_v7
+      id: Standard_F2als_v7
+      memory: 4294967296
+      name: Standard_F2als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFamdsv7Family
+      generic_name: standard_f2amds_v7
+      id: Standard_F2amds_v7
+      memory: 17179869184
+      name: Standard_F2amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFamsv6Family
+      generic_name: standard_f2ams_v6
+      id: Standard_F2ams_v6
+      memory: 17179869184
+      name: Standard_F2ams_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFamsv7Family
+      generic_name: standard_f2ams_v7
+      id: Standard_F2ams_v7
+      memory: 17179869184
+      name: Standard_F2ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFasv6Family
+      generic_name: standard_f2as_v6
+      id: Standard_F2as_v6
+      memory: 8589934592
+      name: Standard_F2as_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFasv7Family
+      generic_name: standard_f2as_v7
+      id: Standard_F2as_v7
+      memory: 8589934592
+      name: Standard_F2as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardFSFamily
+      generic_name: standard_f2s
+      id: Standard_F2s
+      memory: 4294967296
+      name: Standard_F2s
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardFSv2Family
+      generic_name: standard_f2s_v2
+      id: Standard_F2s_v2
+      memory: 4294967296
+      name: Standard_F2s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFamdsv7Family
+      generic_name: standard_f32-16amds_v7
+      id: Standard_F32-16amds_v7
+      memory: 274877906944
+      name: Standard_F32-16amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFamsv7Family
+      generic_name: standard_f32-16ams_v7
+      id: Standard_F32-16ams_v7
+      memory: 274877906944
+      name: Standard_F32-16ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFamdsv7Family
+      generic_name: standard_f32-8amds_v7
+      id: Standard_F32-8amds_v7
+      memory: 274877906944
+      name: Standard_F32-8amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFamsv7Family
+      generic_name: standard_f32-8ams_v7
+      id: Standard_F32-8ams_v7
+      memory: 274877906944
+      name: Standard_F32-8ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFadsv7Family
+      generic_name: standard_f32ads_v7
+      id: Standard_F32ads_v7
+      memory: 137438953472
+      name: Standard_F32ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFaldsv7Family
+      generic_name: standard_f32alds_v7
+      id: Standard_F32alds_v7
+      memory: 68719476736
+      name: Standard_F32alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFalsv6Family
+      generic_name: standard_f32als_v6
+      id: Standard_F32als_v6
+      memory: 68719476736
+      name: Standard_F32als_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFalsv7Family
+      generic_name: standard_f32als_v7
+      id: Standard_F32als_v7
+      memory: 68719476736
+      name: Standard_F32als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFamdsv7Family
+      generic_name: standard_f32amds_v7
+      id: Standard_F32amds_v7
+      memory: 274877906944
+      name: Standard_F32amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFamsv6Family
+      generic_name: standard_f32ams_v6
+      id: Standard_F32ams_v6
+      memory: 274877906944
+      name: Standard_F32ams_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFamsv7Family
+      generic_name: standard_f32ams_v7
+      id: Standard_F32ams_v7
+      memory: 274877906944
+      name: Standard_F32ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFasv6Family
+      generic_name: standard_f32as_v6
+      id: Standard_F32as_v6
+      memory: 137438953472
+      name: Standard_F32as_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFasv7Family
+      generic_name: standard_f32as_v7
+      id: Standard_F32as_v7
+      memory: 137438953472
+      name: Standard_F32as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardFSv2Family
+      generic_name: standard_f32s_v2
+      id: Standard_F32s_v2
+      memory: 68719476736
+      name: Standard_F32s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardFFamily
+      generic_name: standard_f4
+      id: Standard_F4
+      memory: 8589934592
+      name: Standard_F4
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFamdsv7Family
+      generic_name: standard_f4-1amds_v7
+      id: Standard_F4-1amds_v7
+      memory: 34359738368
+      name: Standard_F4-1amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFamsv7Family
+      generic_name: standard_f4-1ams_v7
+      id: Standard_F4-1ams_v7
+      memory: 34359738368
+      name: Standard_F4-1ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFamdsv7Family
+      generic_name: standard_f4-2amds_v7
+      id: Standard_F4-2amds_v7
+      memory: 34359738368
+      name: Standard_F4-2amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFamsv7Family
+      generic_name: standard_f4-2ams_v7
+      id: Standard_F4-2ams_v7
+      memory: 34359738368
+      name: Standard_F4-2ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFadsv7Family
+      generic_name: standard_f48ads_v7
+      id: Standard_F48ads_v7
+      memory: 206158430208
+      name: Standard_F48ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFaldsv7Family
+      generic_name: standard_f48alds_v7
+      id: Standard_F48alds_v7
+      memory: 103079215104
+      name: Standard_F48alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFalsv6Family
+      generic_name: standard_f48als_v6
+      id: Standard_F48als_v6
+      memory: 103079215104
+      name: Standard_F48als_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFalsv7Family
+      generic_name: standard_f48als_v7
+      id: Standard_F48als_v7
+      memory: 103079215104
+      name: Standard_F48als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFamdsv7Family
+      generic_name: standard_f48amds_v7
+      id: Standard_F48amds_v7
+      memory: 412316860416
+      name: Standard_F48amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFamsv6Family
+      generic_name: standard_f48ams_v6
+      id: Standard_F48ams_v6
+      memory: 412316860416
+      name: Standard_F48ams_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFamsv7Family
+      generic_name: standard_f48ams_v7
+      id: Standard_F48ams_v7
+      memory: 412316860416
+      name: Standard_F48ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFasv6Family
+      generic_name: standard_f48as_v6
+      id: Standard_F48as_v6
+      memory: 206158430208
+      name: Standard_F48as_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFasv7Family
+      generic_name: standard_f48as_v7
+      id: Standard_F48as_v7
+      memory: 206158430208
+      name: Standard_F48as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardFSv2Family
+      generic_name: standard_f48s_v2
+      id: Standard_F48s_v2
+      memory: 103079215104
+      name: Standard_F48s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFadsv7Family
+      generic_name: standard_f4ads_v7
+      id: Standard_F4ads_v7
+      memory: 17179869184
+      name: Standard_F4ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFaldsv7Family
+      generic_name: standard_f4alds_v7
+      id: Standard_F4alds_v7
+      memory: 8589934592
+      name: Standard_F4alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFalsv6Family
+      generic_name: standard_f4als_v6
+      id: Standard_F4als_v6
+      memory: 8589934592
+      name: Standard_F4als_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFalsv7Family
+      generic_name: standard_f4als_v7
+      id: Standard_F4als_v7
+      memory: 8589934592
+      name: Standard_F4als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFamdsv7Family
+      generic_name: standard_f4amds_v7
+      id: Standard_F4amds_v7
+      memory: 34359738368
+      name: Standard_F4amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFamsv6Family
+      generic_name: standard_f4ams_v6
+      id: Standard_F4ams_v6
+      memory: 34359738368
+      name: Standard_F4ams_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFamsv7Family
+      generic_name: standard_f4ams_v7
+      id: Standard_F4ams_v7
+      memory: 34359738368
+      name: Standard_F4ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFasv6Family
+      generic_name: standard_f4as_v6
+      id: Standard_F4as_v6
+      memory: 17179869184
+      name: Standard_F4as_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFasv7Family
+      generic_name: standard_f4as_v7
+      id: Standard_F4as_v7
+      memory: 17179869184
+      name: Standard_F4as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardFSFamily
+      generic_name: standard_f4s
+      id: Standard_F4s
+      memory: 8589934592
+      name: Standard_F4s
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardFSv2Family
+      generic_name: standard_f4s_v2
+      id: Standard_F4s_v2
+      memory: 8589934592
+      name: Standard_F4s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFamdsv7Family
+      generic_name: standard_f64-16amds_v7
+      id: Standard_F64-16amds_v7
+      memory: 549755813888
+      name: Standard_F64-16amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: StandardFamsv7Family
+      generic_name: standard_f64-16ams_v7
+      id: Standard_F64-16ams_v7
+      memory: 549755813888
+      name: Standard_F64-16ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFamdsv7Family
+      generic_name: standard_f64-32amds_v7
+      id: Standard_F64-32amds_v7
+      memory: 549755813888
+      name: Standard_F64-32amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFamsv7Family
+      generic_name: standard_f64-32ams_v7
+      id: Standard_F64-32ams_v7
+      memory: 549755813888
+      name: Standard_F64-32ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFadsv7Family
+      generic_name: standard_f64ads_v7
+      id: Standard_F64ads_v7
+      memory: 274877906944
+      name: Standard_F64ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFaldsv7Family
+      generic_name: standard_f64alds_v7
+      id: Standard_F64alds_v7
+      memory: 137438953472
+      name: Standard_F64alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFalsv6Family
+      generic_name: standard_f64als_v6
+      id: Standard_F64als_v6
+      memory: 137438953472
+      name: Standard_F64als_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFalsv7Family
+      generic_name: standard_f64als_v7
+      id: Standard_F64als_v7
+      memory: 137438953472
+      name: Standard_F64als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFamdsv7Family
+      generic_name: standard_f64amds_v7
+      id: Standard_F64amds_v7
+      memory: 549755813888
+      name: Standard_F64amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFamsv6Family
+      generic_name: standard_f64ams_v6
+      id: Standard_F64ams_v6
+      memory: 549755813888
+      name: Standard_F64ams_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFamsv7Family
+      generic_name: standard_f64ams_v7
+      id: Standard_F64ams_v7
+      memory: 549755813888
+      name: Standard_F64ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFasv6Family
+      generic_name: standard_f64as_v6
+      id: Standard_F64as_v6
+      memory: 274877906944
+      name: Standard_F64as_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFasv7Family
+      generic_name: standard_f64as_v7
+      id: Standard_F64as_v7
+      memory: 274877906944
+      name: Standard_F64as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardFSv2Family
+      generic_name: standard_f64s_v2
+      id: Standard_F64s_v2
+      memory: 137438953472
+      name: Standard_F64s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 72
+      family: standardFSv2Family
+      generic_name: standard_f72s_v2
+      id: Standard_F72s_v2
+      memory: 154618822656
+      name: Standard_F72s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardFFamily
+      generic_name: standard_f8
+      id: Standard_F8
+      memory: 17179869184
+      name: Standard_F8
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFamdsv7Family
+      generic_name: standard_f8-2amds_v7
+      id: Standard_F8-2amds_v7
+      memory: 68719476736
+      name: Standard_F8-2amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFamsv7Family
+      generic_name: standard_f8-2ams_v7
+      id: Standard_F8-2ams_v7
+      memory: 68719476736
+      name: Standard_F8-2ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFamdsv7Family
+      generic_name: standard_f8-4amds_v7
+      id: Standard_F8-4amds_v7
+      memory: 68719476736
+      name: Standard_F8-4amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFamsv7Family
+      generic_name: standard_f8-4ams_v7
+      id: Standard_F8-4ams_v7
+      memory: 68719476736
+      name: Standard_F8-4ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: StandardFadsv7Family
+      generic_name: standard_f80ads_v7
+      id: Standard_F80ads_v7
+      memory: 343597383680
+      name: Standard_F80ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: StandardFaldsv7Family
+      generic_name: standard_f80alds_v7
+      id: Standard_F80alds_v7
+      memory: 171798691840
+      name: Standard_F80alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: StandardFalsv7Family
+      generic_name: standard_f80als_v7
+      id: Standard_F80als_v7
+      memory: 171798691840
+      name: Standard_F80als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: StandardFamdsv7Family
+      generic_name: standard_f80amds_v7
+      id: Standard_F80amds_v7
+      memory: 687194767360
+      name: Standard_F80amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: StandardFamsv7Family
+      generic_name: standard_f80ams_v7
+      id: Standard_F80ams_v7
+      memory: 687194767360
+      name: Standard_F80ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: StandardFasv7Family
+      generic_name: standard_f80as_v7
+      id: Standard_F80as_v7
+      memory: 343597383680
+      name: Standard_F80as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFadsv7Family
+      generic_name: standard_f8ads_v7
+      id: Standard_F8ads_v7
+      memory: 34359738368
+      name: Standard_F8ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFaldsv7Family
+      generic_name: standard_f8alds_v7
+      id: Standard_F8alds_v7
+      memory: 17179869184
+      name: Standard_F8alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFalsv6Family
+      generic_name: standard_f8als_v6
+      id: Standard_F8als_v6
+      memory: 17179869184
+      name: Standard_F8als_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFalsv7Family
+      generic_name: standard_f8als_v7
+      id: Standard_F8als_v7
+      memory: 17179869184
+      name: Standard_F8als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFamdsv7Family
+      generic_name: standard_f8amds_v7
+      id: Standard_F8amds_v7
+      memory: 68719476736
+      name: Standard_F8amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFamsv6Family
+      generic_name: standard_f8ams_v6
+      id: Standard_F8ams_v6
+      memory: 68719476736
+      name: Standard_F8ams_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFamsv7Family
+      generic_name: standard_f8ams_v7
+      id: Standard_F8ams_v7
+      memory: 68719476736
+      name: Standard_F8ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFasv6Family
+      generic_name: standard_f8as_v6
+      id: Standard_F8as_v6
+      memory: 34359738368
+      name: Standard_F8as_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFasv7Family
+      generic_name: standard_f8as_v7
+      id: Standard_F8as_v7
+      memory: 34359738368
+      name: Standard_F8as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardFSFamily
+      generic_name: standard_f8s
+      id: Standard_F8s
+      memory: 17179869184
+      name: Standard_F8s
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardFSv2Family
+      generic_name: standard_f8s_v2
+      id: Standard_F8s_v2
+      memory: 17179869184
+      name: Standard_F8s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 12
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx12-6mds_v2
+      id: Standard_FX12-6mds_v2
+      memory: 270582939648
+      name: Standard_FX12-6mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 12
+      family: StandardFXmsv2Family
+      generic_name: standard_fx12-6ms_v2
+      id: Standard_FX12-6ms_v2
+      memory: 270582939648
+      name: Standard_FX12-6ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 12
+      family: standardFXMDVSFamily
+      generic_name: standard_fx12mds
+      id: Standard_FX12mds
+      memory: 270582939648
+      name: Standard_FX12mds
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 12
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx12mds_v2
+      id: Standard_FX12mds_v2
+      memory: 270582939648
+      name: Standard_FX12mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 12
+      family: StandardFXmsv2Family
+      generic_name: standard_fx12ms_v2
+      id: Standard_FX12ms_v2
+      memory: 270582939648
+      name: Standard_FX12ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx16-4mds_v2
+      id: Standard_FX16-4mds_v2
+      memory: 360777252864
+      name: Standard_FX16-4mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFXmsv2Family
+      generic_name: standard_fx16-4ms_v2
+      id: Standard_FX16-4ms_v2
+      memory: 360777252864
+      name: Standard_FX16-4ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx16-8mds_v2
+      id: Standard_FX16-8mds_v2
+      memory: 360777252864
+      name: Standard_FX16-8mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFXmsv2Family
+      generic_name: standard_fx16-8ms_v2
+      id: Standard_FX16-8ms_v2
+      memory: 360777252864
+      name: Standard_FX16-8ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx16mds_v2
+      id: Standard_FX16mds_v2
+      memory: 360777252864
+      name: Standard_FX16mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFXmsv2Family
+      generic_name: standard_fx16ms_v2
+      id: Standard_FX16ms_v2
+      memory: 360777252864
+      name: Standard_FX16ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx24-12mds_v2
+      id: Standard_FX24-12mds_v2
+      memory: 541165879296
+      name: Standard_FX24-12mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      family: StandardFXmsv2Family
+      generic_name: standard_fx24-12ms_v2
+      id: Standard_FX24-12ms_v2
+      memory: 541165879296
+      name: Standard_FX24-12ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx24-6mds_v2
+      id: Standard_FX24-6mds_v2
+      memory: 541165879296
+      name: Standard_FX24-6mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      family: StandardFXmsv2Family
+      generic_name: standard_fx24-6ms_v2
+      id: Standard_FX24-6ms_v2
+      memory: 541165879296
+      name: Standard_FX24-6ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      family: standardFXMDVSFamily
+      generic_name: standard_fx24mds
+      id: Standard_FX24mds
+      memory: 541165879296
+      name: Standard_FX24mds
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx24mds_v2
+      id: Standard_FX24mds_v2
+      memory: 541165879296
+      name: Standard_FX24mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      family: StandardFXmsv2Family
+      generic_name: standard_fx24ms_v2
+      id: Standard_FX24ms_v2
+      memory: 541165879296
+      name: Standard_FX24ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx2mds_v2
+      id: Standard_FX2mds_v2
+      memory: 45097156608
+      name: Standard_FX2mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFXmsv2Family
+      generic_name: standard_fx2ms_v2
+      id: Standard_FX2ms_v2
+      memory: 45097156608
+      name: Standard_FX2ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx32-16mds_v2
+      id: Standard_FX32-16mds_v2
+      memory: 721554505728
+      name: Standard_FX32-16mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFXmsv2Family
+      generic_name: standard_fx32-16ms_v2
+      id: Standard_FX32-16ms_v2
+      memory: 721554505728
+      name: Standard_FX32-16ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx32-8mds_v2
+      id: Standard_FX32-8mds_v2
+      memory: 721554505728
+      name: Standard_FX32-8mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFXmsv2Family
+      generic_name: standard_fx32-8ms_v2
+      id: Standard_FX32-8ms_v2
+      memory: 721554505728
+      name: Standard_FX32-8ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx32mds_v2
+      id: Standard_FX32mds_v2
+      memory: 721554505728
+      name: Standard_FX32mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFXmsv2Family
+      generic_name: standard_fx32ms_v2
+      id: Standard_FX32ms_v2
+      memory: 721554505728
+      name: Standard_FX32ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 36
+      family: standardFXMDVSFamily
+      generic_name: standard_fx36mds
+      id: Standard_FX36mds
+      memory: 811748818944
+      name: Standard_FX36mds
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx4-2mds_v2
+      id: Standard_FX4-2mds_v2
+      memory: 90194313216
+      name: Standard_FX4-2mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFXmsv2Family
+      generic_name: standard_fx4-2ms_v2
+      id: Standard_FX4-2ms_v2
+      memory: 90194313216
+      name: Standard_FX4-2ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx48-12mds_v2
+      id: Standard_FX48-12mds_v2
+      memory: 1082331758592
+      name: Standard_FX48-12mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFXmsv2Family
+      generic_name: standard_fx48-12ms_v2
+      id: Standard_FX48-12ms_v2
+      memory: 1082331758592
+      name: Standard_FX48-12ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx48-24mds_v2
+      id: Standard_FX48-24mds_v2
+      memory: 1082331758592
+      name: Standard_FX48-24mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFXmsv2Family
+      generic_name: standard_fx48-24ms_v2
+      id: Standard_FX48-24ms_v2
+      memory: 1082331758592
+      name: Standard_FX48-24ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardFXMDVSFamily
+      generic_name: standard_fx48mds
+      id: Standard_FX48mds
+      memory: 1082331758592
+      name: Standard_FX48mds
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx48mds_v2
+      id: Standard_FX48mds_v2
+      memory: 1082331758592
+      name: Standard_FX48mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFXmsv2Family
+      generic_name: standard_fx48ms_v2
+      id: Standard_FX48ms_v2
+      memory: 1082331758592
+      name: Standard_FX48ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardFXMDVSFamily
+      generic_name: standard_fx4mds
+      id: Standard_FX4mds
+      memory: 90194313216
+      name: Standard_FX4mds
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx4mds_v2
+      id: Standard_FX4mds_v2
+      memory: 90194313216
+      name: Standard_FX4mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFXmsv2Family
+      generic_name: standard_fx4ms_v2
+      id: Standard_FX4ms_v2
+      memory: 90194313216
+      name: Standard_FX4ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx64-16mds_v2
+      id: Standard_FX64-16mds_v2
+      memory: 1443109011456
+      name: Standard_FX64-16mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFXmsv2Family
+      generic_name: standard_fx64-16ms_v2
+      id: Standard_FX64-16ms_v2
+      memory: 1443109011456
+      name: Standard_FX64-16ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx64-32mds_v2
+      id: Standard_FX64-32mds_v2
+      memory: 1443109011456
+      name: Standard_FX64-32mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFXmsv2Family
+      generic_name: standard_fx64-32ms_v2
+      id: Standard_FX64-32ms_v2
+      memory: 1443109011456
+      name: Standard_FX64-32ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx64mds_v2
+      id: Standard_FX64mds_v2
+      memory: 1443109011456
+      name: Standard_FX64mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFXmsv2Family
+      generic_name: standard_fx64ms_v2
+      id: Standard_FX64ms_v2
+      memory: 1443109011456
+      name: Standard_FX64ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx8-2mds_v2
+      id: Standard_FX8-2mds_v2
+      memory: 180388626432
+      name: Standard_FX8-2mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFXmsv2Family
+      generic_name: standard_fx8-2ms_v2
+      id: Standard_FX8-2ms_v2
+      memory: 180388626432
+      name: Standard_FX8-2ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx8-4mds_v2
+      id: Standard_FX8-4mds_v2
+      memory: 180388626432
+      name: Standard_FX8-4mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFXmsv2Family
+      generic_name: standard_fx8-4ms_v2
+      id: Standard_FX8-4ms_v2
+      memory: 180388626432
+      name: Standard_FX8-4ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx8mds_v2
+      id: Standard_FX8mds_v2
+      memory: 180388626432
+      name: Standard_FX8mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFXmsv2Family
+      generic_name: standard_fx8ms_v2
+      id: Standard_FX8ms_v2
+      memory: 180388626432
+      name: Standard_FX8ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx96-24mds_v2
+      id: Standard_FX96-24mds_v2
+      memory: 1967095021568
+      name: Standard_FX96-24mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardFXmsv2Family
+      generic_name: standard_fx96-24ms_v2
+      id: Standard_FX96-24ms_v2
+      memory: 1967095021568
+      name: Standard_FX96-24ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx96-48mds_v2
+      id: Standard_FX96-48mds_v2
+      memory: 1967095021568
+      name: Standard_FX96-48mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardFXmsv2Family
+      generic_name: standard_fx96-48ms_v2
+      id: Standard_FX96-48ms_v2
+      memory: 1967095021568
+      name: Standard_FX96-48ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx96mds_v2
+      id: Standard_FX96mds_v2
+      memory: 1967095021568
+      name: Standard_FX96mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardFXmsv2Family
+      generic_name: standard_fx96ms_v2
+      id: Standard_FX96ms_v2
+      memory: 1967095021568
+      name: Standard_FX96ms_v2
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 12
+      family: standardLaosv4Family
+      generic_name: standard_l12aos_v4
+      id: Standard_L12aos_v4
+      memory: 103079215104
+      name: Standard_L12aos_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardLaosv4Family
+      generic_name: standard_l16aos_v4
+      id: Standard_L16aos_v4
+      memory: 137438953472
+      name: Standard_L16aos_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardLASv3Family
+      generic_name: standard_l16as_v3
+      id: Standard_L16as_v3
+      memory: 137438953472
+      name: Standard_L16as_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardLasv4Family
+      generic_name: standard_l16as_v4
+      id: Standard_L16as_v4
+      memory: 137438953472
+      name: Standard_L16as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardLSv3Family
+      generic_name: standard_l16s_v3
+      id: Standard_L16s_v3
+      memory: 137438953472
+      name: Standard_L16s_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardLsv4Family
+      generic_name: standard_l16s_v4
+      id: Standard_L16s_v4
+      memory: 137438953472
+      name: Standard_L16s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      family: standardLaosv4Family
+      generic_name: standard_l24aos_v4
+      id: Standard_L24aos_v4
+      memory: 206158430208
+      name: Standard_L24aos_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardLaosv4Family
+      generic_name: standard_l2aos_v4
+      id: Standard_L2aos_v4
+      memory: 17179869184
+      name: Standard_L2aos_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardLasv4Family
+      generic_name: standard_l2as_v4
+      id: Standard_L2as_v4
+      memory: 17179869184
+      name: Standard_L2as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardLsv4Family
+      generic_name: standard_l2s_v4
+      id: Standard_L2s_v4
+      memory: 17179869184
+      name: Standard_L2s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardLaosv4Family
+      generic_name: standard_l32aos_v4
+      id: Standard_L32aos_v4
+      memory: 274877906944
+      name: Standard_L32aos_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardLASv3Family
+      generic_name: standard_l32as_v3
+      id: Standard_L32as_v3
+      memory: 274877906944
+      name: Standard_L32as_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardLasv4Family
+      generic_name: standard_l32as_v4
+      id: Standard_L32as_v4
+      memory: 274877906944
+      name: Standard_L32as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardLSv3Family
+      generic_name: standard_l32s_v3
+      id: Standard_L32s_v3
+      memory: 274877906944
+      name: Standard_L32s_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardLsv4Family
+      generic_name: standard_l32s_v4
+      id: Standard_L32s_v4
+      memory: 274877906944
+      name: Standard_L32s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardLASv3Family
+      generic_name: standard_l48as_v3
+      id: Standard_L48as_v3
+      memory: 412316860416
+      name: Standard_L48as_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardLasv4Family
+      generic_name: standard_l48as_v4
+      id: Standard_L48as_v4
+      memory: 412316860416
+      name: Standard_L48as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardLSv3Family
+      generic_name: standard_l48s_v3
+      id: Standard_L48s_v3
+      memory: 412316860416
+      name: Standard_L48s_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardLsv4Family
+      generic_name: standard_l48s_v4
+      id: Standard_L48s_v4
+      memory: 412316860416
+      name: Standard_L48s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardLaosv4Family
+      generic_name: standard_l4aos_v4
+      id: Standard_L4aos_v4
+      memory: 34359738368
+      name: Standard_L4aos_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardLasv4Family
+      generic_name: standard_l4as_v4
+      id: Standard_L4as_v4
+      memory: 34359738368
+      name: Standard_L4as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardLsv4Family
+      generic_name: standard_l4s_v4
+      id: Standard_L4s_v4
+      memory: 34359738368
+      name: Standard_L4s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardLASv3Family
+      generic_name: standard_l64as_v3
+      id: Standard_L64as_v3
+      memory: 549755813888
+      name: Standard_L64as_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardLasv4Family
+      generic_name: standard_l64as_v4
+      id: Standard_L64as_v4
+      memory: 549755813888
+      name: Standard_L64as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardLSv3Family
+      generic_name: standard_l64s_v3
+      id: Standard_L64s_v3
+      memory: 549755813888
+      name: Standard_L64s_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardLsv4Family
+      generic_name: standard_l64s_v4
+      id: Standard_L64s_v4
+      memory: 549755813888
+      name: Standard_L64s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: standardLASv3Family
+      generic_name: standard_l80as_v3
+      id: Standard_L80as_v3
+      memory: 687194767360
+      name: Standard_L80as_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: standardLasv4Family
+      generic_name: standard_l80as_v4
+      id: Standard_L80as_v4
+      memory: 687194767360
+      name: Standard_L80as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: standardLSv3Family
+      generic_name: standard_l80s_v3
+      id: Standard_L80s_v3
+      memory: 687194767360
+      name: Standard_L80s_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: standardLsv4Family
+      generic_name: standard_l80s_v4
+      id: Standard_L80s_v4
+      memory: 687194767360
+      name: Standard_L80s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardLaosv4Family
+      generic_name: standard_l8aos_v4
+      id: Standard_L8aos_v4
+      memory: 68719476736
+      name: Standard_L8aos_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardLASv3Family
+      generic_name: standard_l8as_v3
+      id: Standard_L8as_v3
+      memory: 68719476736
+      name: Standard_L8as_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardLasv4Family
+      generic_name: standard_l8as_v4
+      id: Standard_L8as_v4
+      memory: 68719476736
+      name: Standard_L8as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardLSv3Family
+      generic_name: standard_l8s_v3
+      id: Standard_L8s_v3
+      memory: 68719476736
+      name: Standard_L8s_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardLsv4Family
+      generic_name: standard_l8s_v4
+      id: Standard_L8s_v4
+      memory: 68719476736
+      name: Standard_L8s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardLasv4Family
+      generic_name: standard_l96as_v4
+      id: Standard_L96as_v4
+      memory: 824633720832
+      name: Standard_L96as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardLsv4Family
+      generic_name: standard_l96s_v4
+      id: Standard_L96s_v4
+      memory: 824633720832
+      name: Standard_L96s_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: Standard NCASv3_T4 Family
+      generic_name: standard_nc16as_t4_v3
+      id: Standard_NC16as_T4_v3
+      memory: 118111600640
+      name: Standard_NC16as_T4_v3
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 24
+      family: StandardNCADSA100v4Family
+      generic_name: standard_nc24ads_a100_v4
+      id: Standard_NC24ads_A100_v4
+      memory: 236223201280
+      name: Standard_NC24ads_A100_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 40
+      family: StandardNCadsH100v5Family
+      generic_name: standard_nc40ads_h100_v5
+      id: Standard_NC40ads_H100_v5
+      memory: 343597383680
+      name: Standard_NC40ads_H100_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardNCADSA100v4Family
+      generic_name: standard_nc48ads_a100_v4
+      id: Standard_NC48ads_A100_v4
+      memory: 472446402560
+      name: Standard_NC48ads_A100_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: Standard NCASv3_T4 Family
+      generic_name: standard_nc4as_t4_v3
+      id: Standard_NC4as_T4_v3
+      memory: 30064771072
+      name: Standard_NC4as_T4_v3
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: Standard NCASv3_T4 Family
+      generic_name: standard_nc64as_t4_v3
+      id: Standard_NC64as_T4_v3
+      memory: 472446402560
+      name: Standard_NC64as_T4_v3
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: StandardNCadsH100v5Family
+      generic_name: standard_nc80adis_h100_v5
+      id: Standard_NC80adis_H100_v5
+      memory: 687194767360
+      name: Standard_NC80adis_H100_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: Standard NCASv3_T4 Family
+      generic_name: standard_nc8as_t4_v3
+      id: Standard_NC8as_T4_v3
+      memory: 60129542144
+      name: Standard_NC8as_T4_v3
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardNCADSA100v4Family
+      generic_name: standard_nc96ads_a100_v4
+      id: Standard_NC96ads_A100_v4
+      memory: 944892805120
+      name: Standard_NC96ads_A100_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 12
+      family: StandardNVADSA10v5Family
+      generic_name: standard_nv12ads_a10_v5
+      id: Standard_NV12ads_A10_v5
+      memory: 118111600640
+      name: Standard_NV12ads_A10_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardNVSv4Family
+      generic_name: standard_nv16as_v4
+      id: Standard_NV16as_v4
+      memory: 60129542144
+      name: Standard_NV16as_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 18
+      family: StandardNVADSA10v5Family
+      generic_name: standard_nv18ads_a10_v5
+      id: Standard_NV18ads_A10_v5
+      memory: 236223201280
+      name: Standard_NV18ads_A10_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardNVSv4Family
+      generic_name: standard_nv32as_v4
+      id: Standard_NV32as_v4
+      memory: 120259084288
+      name: Standard_NV32as_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 36
+      family: StandardNVADSA10v5Family
+      generic_name: standard_nv36adms_a10_v5
+      id: Standard_NV36adms_A10_v5
+      memory: 944892805120
+      name: Standard_NV36adms_A10_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 36
+      family: StandardNVADSA10v5Family
+      generic_name: standard_nv36ads_a10_v5
+      id: Standard_NV36ads_A10_v5
+      memory: 472446402560
+      name: Standard_NV36ads_A10_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardNVSv4Family
+      generic_name: standard_nv4as_v4
+      id: Standard_NV4as_v4
+      memory: 15032385536
+      name: Standard_NV4as_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 6
+      family: StandardNVADSA10v5Family
+      generic_name: standard_nv6ads_a10_v5
+      id: Standard_NV6ads_A10_v5
+      memory: 59055800320
+      name: Standard_NV6ads_A10_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 72
+      family: StandardNVADSA10v5Family
+      generic_name: standard_nv72ads_a10_v5
+      id: Standard_NV72ads_A10_v5
+      memory: 944892805120
+      name: Standard_NV72ads_A10_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardNVSv4Family
+      generic_name: standard_nv8as_v4
+      id: Standard_NV8as_v4
+      memory: 30064771072
+      name: Standard_NV8as_v4
 kind: ConfigMap
 metadata:
   name: cloud-resources-config

--- a/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_azuredb.yaml
+++ b/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_azuredb.yaml
@@ -751,639 +751,82 @@ data:
         supports_multi_az: true
   instance-types.yaml: |
     instance_types:
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_nc4as_t4_v3
-      id: Standard_NC4as_T4_v3
-      memory: 30064771072
-      name: Standard_NC4as_T4_v3
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_nc8as_t4_v3
-      id: Standard_NC8as_T4_v3
-      memory: 60129542144
-      name: Standard_NC8as_T4_v3
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_nc16as_t4_v3
-      id: Standard_NC16as_T4_v3
-      memory: 118111600640
-      name: Standard_NC16as_T4_v3
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_nc64as_t4_v3
-      id: Standard_NC64as_T4_v3
-      memory: 472446402560
-      name: Standard_NC64as_T4_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2_v4
-      id: Standard_E2_v4
-      memory: 17179869184
-      name: Standard_E2_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4_v4
-      id: Standard_E4_v4
-      memory: 34359738368
-      name: Standard_E4_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8_v4
-      id: Standard_E8_v4
-      memory: 68719476736
-      name: Standard_E8_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16_v4
-      id: Standard_E16_v4
-      memory: 137438953472
-      name: Standard_E16_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20_v4
-      id: Standard_E20_v4
-      memory: 171798691840
-      name: Standard_E20_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32_v4
-      id: Standard_E32_v4
-      memory: 274877906944
-      name: Standard_E32_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48_v4
-      id: Standard_E48_v4
-      memory: 412316860416
-      name: Standard_E48_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64_v4
-      id: Standard_E64_v4
-      memory: 541165879296
-      name: Standard_E64_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2d_v4
-      id: Standard_E2d_v4
-      memory: 17179869184
-      name: Standard_E2d_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4d_v4
-      id: Standard_E4d_v4
-      memory: 34359738368
-      name: Standard_E4d_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8d_v4
-      id: Standard_E8d_v4
-      memory: 68719476736
-      name: Standard_E8d_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16d_v4
-      id: Standard_E16d_v4
-      memory: 137438953472
-      name: Standard_E16d_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20d_v4
-      id: Standard_E20d_v4
-      memory: 171798691840
-      name: Standard_E20d_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32d_v4
-      id: Standard_E32d_v4
-      memory: 274877906944
-      name: Standard_E32d_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48d_v4
-      id: Standard_E48d_v4
-      memory: 412316860416
-      name: Standard_E48d_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64d_v4
-      id: Standard_E64d_v4
-      memory: 541165879296
-      name: Standard_E64d_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2s_v4
-      id: Standard_E2s_v4
-      memory: 17179869184
-      name: Standard_E2s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2s_v4
-      id: Standard_E4-2s_v4
-      memory: 34359738368
-      name: Standard_E4-2s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4s_v4
-      id: Standard_E4s_v4
-      memory: 34359738368
-      name: Standard_E4s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2s_v4
-      id: Standard_E8-2s_v4
-      memory: 68719476736
-      name: Standard_E8-2s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4s_v4
-      id: Standard_E8-4s_v4
-      memory: 68719476736
-      name: Standard_E8-4s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8s_v4
-      id: Standard_E8s_v4
-      memory: 68719476736
-      name: Standard_E8s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-4s_v4
-      id: Standard_E16-4s_v4
-      memory: 137438953472
-      name: Standard_E16-4s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8s_v4
-      id: Standard_E16-8s_v4
-      memory: 137438953472
-      name: Standard_E16-8s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16s_v4
-      id: Standard_E16s_v4
-      memory: 137438953472
-      name: Standard_E16s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20s_v4
-      id: Standard_E20s_v4
-      memory: 171798691840
-      name: Standard_E20s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8s_v4
-      id: Standard_E32-8s_v4
-      memory: 274877906944
-      name: Standard_E32-8s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16s_v4
-      id: Standard_E32-16s_v4
-      memory: 274877906944
-      name: Standard_E32-16s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32s_v4
-      id: Standard_E32s_v4
-      memory: 274877906944
-      name: Standard_E32s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48s_v4
-      id: Standard_E48s_v4
-      memory: 412316860416
-      name: Standard_E48s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16s_v4
-      id: Standard_E64-16s_v4
-      memory: 541165879296
-      name: Standard_E64-16s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32s_v4
-      id: Standard_E64-32s_v4
-      memory: 541165879296
-      name: Standard_E64-32s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64s_v4
-      id: Standard_E64s_v4
-      memory: 541165879296
-      name: Standard_E64s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_e80is_v4
-      id: Standard_E80is_v4
-      memory: 541165879296
-      name: Standard_E80is_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2ds_v4
-      id: Standard_E2ds_v4
-      memory: 17179869184
-      name: Standard_E2ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2ds_v4
-      id: Standard_E4-2ds_v4
-      memory: 34359738368
-      name: Standard_E4-2ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4ds_v4
-      id: Standard_E4ds_v4
-      memory: 34359738368
-      name: Standard_E4ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2ds_v4
-      id: Standard_E8-2ds_v4
-      memory: 68719476736
-      name: Standard_E8-2ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4ds_v4
-      id: Standard_E8-4ds_v4
-      memory: 68719476736
-      name: Standard_E8-4ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8ds_v4
-      id: Standard_E8ds_v4
-      memory: 68719476736
-      name: Standard_E8ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-4ds_v4
-      id: Standard_E16-4ds_v4
-      memory: 137438953472
-      name: Standard_E16-4ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8ds_v4
-      id: Standard_E16-8ds_v4
-      memory: 137438953472
-      name: Standard_E16-8ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16ds_v4
-      id: Standard_E16ds_v4
-      memory: 137438953472
-      name: Standard_E16ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20ds_v4
-      id: Standard_E20ds_v4
-      memory: 171798691840
-      name: Standard_E20ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8ds_v4
-      id: Standard_E32-8ds_v4
-      memory: 274877906944
-      name: Standard_E32-8ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16ds_v4
-      id: Standard_E32-16ds_v4
-      memory: 274877906944
-      name: Standard_E32-16ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32ds_v4
-      id: Standard_E32ds_v4
-      memory: 274877906944
-      name: Standard_E32ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48ds_v4
-      id: Standard_E48ds_v4
-      memory: 412316860416
-      name: Standard_E48ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16ds_v4
-      id: Standard_E64-16ds_v4
-      memory: 541165879296
-      name: Standard_E64-16ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32ds_v4
-      id: Standard_E64-32ds_v4
-      memory: 541165879296
-      name: Standard_E64-32ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64ds_v4
-      id: Standard_E64ds_v4
-      memory: 541165879296
-      name: Standard_E64ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_e80ids_v4
-      id: Standard_E80ids_v4
-      memory: 541165879296
-      name: Standard_E80ids_v4
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 2
-      generic_name: standard_d2d_v4
-      id: Standard_D2d_v4
-      memory: 8589934592
-      name: Standard_D2d_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4d_v4
-      id: Standard_D4d_v4
-      memory: 17179869184
-      name: Standard_D4d_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8d_v4
-      id: Standard_D8d_v4
-      memory: 34359738368
-      name: Standard_D8d_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16d_v4
-      id: Standard_D16d_v4
-      memory: 68719476736
-      name: Standard_D16d_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32d_v4
-      id: Standard_D32d_v4
-      memory: 137438953472
-      name: Standard_D32d_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48d_v4
-      id: Standard_D48d_v4
-      memory: 206158430208
-      name: Standard_D48d_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64d_v4
-      id: Standard_D64d_v4
-      memory: 274877906944
-      name: Standard_D64d_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2_v4
-      id: Standard_D2_v4
-      memory: 8589934592
-      name: Standard_D2_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4_v4
-      id: Standard_D4_v4
-      memory: 17179869184
-      name: Standard_D4_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8_v4
-      id: Standard_D8_v4
-      memory: 34359738368
-      name: Standard_D8_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16_v4
-      id: Standard_D16_v4
-      memory: 68719476736
-      name: Standard_D16_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32_v4
-      id: Standard_D32_v4
-      memory: 137438953472
-      name: Standard_D32_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48_v4
-      id: Standard_D48_v4
-      memory: 206158430208
-      name: Standard_D48_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64_v4
-      id: Standard_D64_v4
-      memory: 274877906944
-      name: Standard_D64_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2ds_v4
-      id: Standard_D2ds_v4
-      memory: 8589934592
-      name: Standard_D2ds_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4ds_v4
-      id: Standard_D4ds_v4
-      memory: 17179869184
-      name: Standard_D4ds_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8ds_v4
-      id: Standard_D8ds_v4
-      memory: 34359738368
-      name: Standard_D8ds_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16ds_v4
-      id: Standard_D16ds_v4
-      memory: 68719476736
-      name: Standard_D16ds_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32ds_v4
-      id: Standard_D32ds_v4
-      memory: 137438953472
-      name: Standard_D32ds_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48ds_v4
-      id: Standard_D48ds_v4
-      memory: 206158430208
-      name: Standard_D48ds_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64ds_v4
-      id: Standard_D64ds_v4
-      memory: 274877906944
-      name: Standard_D64ds_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2s_v4
-      id: Standard_D2s_v4
-      memory: 8589934592
-      name: Standard_D2s_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4s_v4
-      id: Standard_D4s_v4
-      memory: 17179869184
-      name: Standard_D4s_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8s_v4
-      id: Standard_D8s_v4
-      memory: 34359738368
-      name: Standard_D8s_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16s_v4
-      id: Standard_D16s_v4
-      memory: 68719476736
-      name: Standard_D16s_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32s_v4
-      id: Standard_D32s_v4
-      memory: 137438953472
-      name: Standard_D32s_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48s_v4
-      id: Standard_D48s_v4
-      memory: 206158430208
-      name: Standard_D48s_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64s_v4
-      id: Standard_D64s_v4
-      memory: 274877906944
-      name: Standard_D64s_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 1
-      generic_name: standard_d1_v2
-      id: Standard_D1_v2
-      memory: 3758096384
-      name: Standard_D1_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2_v2
-      id: Standard_D2_v2
-      memory: 7516192768
-      name: Standard_D2_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d3_v2
-      id: Standard_D3_v2
-      memory: 15032385536
-      name: Standard_D3_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d4_v2
-      id: Standard_D4_v2
-      memory: 30064771072
-      name: Standard_D4_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d5_v2
-      id: Standard_D5_v2
-      memory: 60129542144
-      name: Standard_D5_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
+      family: standardDv2Family
       generic_name: standard_d11_v2
       id: Standard_D11_v2
       memory: 15032385536
       name: Standard_D11_v2
     - category: general_purpose
       cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardDadsv7Family
+      generic_name: standard_d128ads_v7
+      id: Standard_D128ads_v7
+      memory: 549755813888
+      name: Standard_D128ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardDaldsv7Family
+      generic_name: standard_d128alds_v7
+      id: Standard_D128alds_v7
+      memory: 274877906944
+      name: Standard_D128alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardDalsv7Family
+      generic_name: standard_d128als_v7
+      id: Standard_D128als_v7
+      memory: 274877906944
+      name: Standard_D128als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardDasv7Family
+      generic_name: standard_d128as_v7
+      id: Standard_D128as_v7
+      memory: 549755813888
+      name: Standard_D128as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardDdsv6Family
+      generic_name: standard_d128ds_v6
+      id: Standard_D128ds_v6
+      memory: 549755813888
+      name: Standard_D128ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardDldsv6Family
+      generic_name: standard_d128lds_v6
+      id: Standard_D128lds_v6
+      memory: 274877906944
+      name: Standard_D128lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardDlsv6Family
+      generic_name: standard_d128ls_v6
+      id: Standard_D128ls_v6
+      memory: 274877906944
+      name: Standard_D128ls_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardDsv6Family
+      generic_name: standard_d128s_v6
+      id: Standard_D128s_v6
+      memory: 549755813888
+      name: Standard_D128s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
       cpu_cores: 4
+      family: standardDv2Family
       generic_name: standard_d12_v2
       id: Standard_D12_v2
       memory: 30064771072
@@ -1391,6 +834,7 @@ data:
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 8
+      family: standardDv2Family
       generic_name: standard_d13_v2
       id: Standard_D13_v2
       memory: 60129542144
@@ -1398,6 +842,7 @@ data:
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
+      family: standardDv2Family
       generic_name: standard_d14_v2
       id: Standard_D14_v2
       memory: 120259084288
@@ -1405,3559 +850,216 @@ data:
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 20
+      family: standardDv2Family
       generic_name: standard_d15_v2
       id: Standard_D15_v2
       memory: 150323855360
       name: Standard_D15_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 1
-      generic_name: standard_f1
-      id: Standard_F1
-      memory: 2147483648
-      name: Standard_F1
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2
-      id: Standard_F2
-      memory: 4294967296
-      name: Standard_F2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4
-      id: Standard_F4
-      memory: 8589934592
-      name: Standard_F4
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8
-      id: Standard_F8
-      memory: 17179869184
-      name: Standard_F8
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16
-      id: Standard_F16
-      memory: 34359738368
-      name: Standard_F16
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 1
-      generic_name: standard_ds1_v2
-      id: Standard_DS1_v2
-      memory: 3758096384
-      name: Standard_DS1_v2
+      cpu_cores: 160
+      family: StandardDadsv7Family
+      generic_name: standard_d160ads_v7
+      id: Standard_D160ads_v7
+      memory: 687194767360
+      name: Standard_D160ads_v7
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_ds2_v2
-      id: Standard_DS2_v2
-      memory: 7516192768
-      name: Standard_DS2_v2
+      cpu_cores: 160
+      family: StandardDaldsv7Family
+      generic_name: standard_d160alds_v7
+      id: Standard_D160alds_v7
+      memory: 343597383680
+      name: Standard_D160alds_v7
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_ds3_v2
-      id: Standard_DS3_v2
-      memory: 15032385536
-      name: Standard_DS3_v2
+      cpu_cores: 160
+      family: StandardDalsv7Family
+      generic_name: standard_d160als_v7
+      id: Standard_D160als_v7
+      memory: 343597383680
+      name: Standard_D160als_v7
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_ds4_v2
-      id: Standard_DS4_v2
-      memory: 30064771072
-      name: Standard_DS4_v2
+      cpu_cores: 160
+      family: StandardDasv7Family
+      generic_name: standard_d160as_v7
+      id: Standard_D160as_v7
+      memory: 687194767360
+      name: Standard_D160as_v7
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_ds5_v2
-      id: Standard_DS5_v2
-      memory: 60129542144
-      name: Standard_DS5_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_ds11-1_v2
-      id: Standard_DS11-1_v2
-      memory: 15032385536
-      name: Standard_DS11-1_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_ds11_v2
-      id: Standard_DS11_v2
-      memory: 15032385536
-      name: Standard_DS11_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_ds12-1_v2
-      id: Standard_DS12-1_v2
-      memory: 30064771072
-      name: Standard_DS12-1_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_ds12-2_v2
-      id: Standard_DS12-2_v2
-      memory: 30064771072
-      name: Standard_DS12-2_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_ds12_v2
-      id: Standard_DS12_v2
-      memory: 30064771072
-      name: Standard_DS12_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_ds13-2_v2
-      id: Standard_DS13-2_v2
-      memory: 60129542144
-      name: Standard_DS13-2_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_ds13-4_v2
-      id: Standard_DS13-4_v2
-      memory: 60129542144
-      name: Standard_DS13-4_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_ds13_v2
-      id: Standard_DS13_v2
-      memory: 60129542144
-      name: Standard_DS13_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_ds14-4_v2
-      id: Standard_DS14-4_v2
-      memory: 120259084288
-      name: Standard_DS14-4_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_ds14-8_v2
-      id: Standard_DS14-8_v2
-      memory: 120259084288
-      name: Standard_DS14-8_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_ds14_v2
-      id: Standard_DS14_v2
-      memory: 120259084288
-      name: Standard_DS14_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_ds15_v2
-      id: Standard_DS15_v2
-      memory: 150323855360
-      name: Standard_DS15_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 1
-      generic_name: standard_f1s
-      id: Standard_F1s
-      memory: 2147483648
-      name: Standard_F1s
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2s
-      id: Standard_F2s
-      memory: 4294967296
-      name: Standard_F2s
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4s
-      id: Standard_F4s
-      memory: 8589934592
-      name: Standard_F4s
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8s
-      id: Standard_F8s
-      memory: 17179869184
-      name: Standard_F8s
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16s
-      id: Standard_F16s
-      memory: 34359738368
-      name: Standard_F16s
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2_v3
-      id: Standard_D2_v3
-      memory: 8589934592
-      name: Standard_D2_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4_v3
-      id: Standard_D4_v3
-      memory: 17179869184
-      name: Standard_D4_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8_v3
-      id: Standard_D8_v3
-      memory: 34359738368
-      name: Standard_D8_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16_v3
-      id: Standard_D16_v3
-      memory: 68719476736
-      name: Standard_D16_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32_v3
-      id: Standard_D32_v3
-      memory: 137438953472
-      name: Standard_D32_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48_v3
-      id: Standard_D48_v3
-      memory: 206158430208
-      name: Standard_D48_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64_v3
-      id: Standard_D64_v3
-      memory: 274877906944
-      name: Standard_D64_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2s_v3
-      id: Standard_D2s_v3
-      memory: 8589934592
-      name: Standard_D2s_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4s_v3
-      id: Standard_D4s_v3
-      memory: 17179869184
-      name: Standard_D4s_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8s_v3
-      id: Standard_D8s_v3
-      memory: 34359738368
-      name: Standard_D8s_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16s_v3
-      id: Standard_D16s_v3
-      memory: 68719476736
-      name: Standard_D16s_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32s_v3
-      id: Standard_D32s_v3
-      memory: 137438953472
-      name: Standard_D32s_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48s_v3
-      id: Standard_D48s_v3
-      memory: 206158430208
-      name: Standard_D48s_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64s_v3
-      id: Standard_D64s_v3
-      memory: 274877906944
-      name: Standard_D64s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2_v3
-      id: Standard_E2_v3
-      memory: 17179869184
-      name: Standard_E2_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4_v3
-      id: Standard_E4_v3
-      memory: 34359738368
-      name: Standard_E4_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8_v3
-      id: Standard_E8_v3
-      memory: 68719476736
-      name: Standard_E8_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16_v3
-      id: Standard_E16_v3
-      memory: 137438953472
-      name: Standard_E16_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20_v3
-      id: Standard_E20_v3
-      memory: 171798691840
-      name: Standard_E20_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32_v3
-      id: Standard_E32_v3
-      memory: 274877906944
-      name: Standard_E32_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48_v3
-      id: Standard_E48_v3
-      memory: 412316860416
-      name: Standard_E48_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64_v3
-      id: Standard_E64_v3
-      memory: 463856467968
-      name: Standard_E64_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2s_v3
-      id: Standard_E2s_v3
-      memory: 17179869184
-      name: Standard_E2s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2s_v3
-      id: Standard_E4-2s_v3
-      memory: 34359738368
-      name: Standard_E4-2s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4s_v3
-      id: Standard_E4s_v3
-      memory: 34359738368
-      name: Standard_E4s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2s_v3
-      id: Standard_E8-2s_v3
-      memory: 68719476736
-      name: Standard_E8-2s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4s_v3
-      id: Standard_E8-4s_v3
-      memory: 68719476736
-      name: Standard_E8-4s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8s_v3
-      id: Standard_E8s_v3
-      memory: 68719476736
-      name: Standard_E8s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-4s_v3
-      id: Standard_E16-4s_v3
-      memory: 137438953472
-      name: Standard_E16-4s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8s_v3
-      id: Standard_E16-8s_v3
-      memory: 137438953472
-      name: Standard_E16-8s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16s_v3
-      id: Standard_E16s_v3
-      memory: 137438953472
-      name: Standard_E16s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20s_v3
-      id: Standard_E20s_v3
-      memory: 171798691840
-      name: Standard_E20s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8s_v3
-      id: Standard_E32-8s_v3
-      memory: 274877906944
-      name: Standard_E32-8s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16s_v3
-      id: Standard_E32-16s_v3
-      memory: 274877906944
-      name: Standard_E32-16s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32s_v3
-      id: Standard_E32s_v3
-      memory: 274877906944
-      name: Standard_E32s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48s_v3
-      id: Standard_E48s_v3
-      memory: 412316860416
-      name: Standard_E48s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16s_v3
-      id: Standard_E64-16s_v3
-      memory: 463856467968
-      name: Standard_E64-16s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32s_v3
-      id: Standard_E64-32s_v3
-      memory: 463856467968
-      name: Standard_E64-32s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64s_v3
-      id: Standard_E64s_v3
-      memory: 463856467968
-      name: Standard_E64s_v3
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2s_v2
-      id: Standard_F2s_v2
-      memory: 4294967296
-      name: Standard_F2s_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4s_v2
-      id: Standard_F4s_v2
-      memory: 8589934592
-      name: Standard_F4s_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8s_v2
-      id: Standard_F8s_v2
-      memory: 17179869184
-      name: Standard_F8s_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16s_v2
-      id: Standard_F16s_v2
-      memory: 34359738368
-      name: Standard_F16s_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32s_v2
-      id: Standard_F32s_v2
-      memory: 68719476736
-      name: Standard_F32s_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_f48s_v2
-      id: Standard_F48s_v2
-      memory: 103079215104
-      name: Standard_F48s_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64s_v2
-      id: Standard_F64s_v2
-      memory: 137438953472
-      name: Standard_F64s_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 72
-      generic_name: standard_f72s_v2
-      id: Standard_F72s_v2
-      memory: 154618822656
-      name: Standard_F72s_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2as_v5
-      id: Standard_D2as_v5
-      memory: 8589934592
-      name: Standard_D2as_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4as_v5
-      id: Standard_D4as_v5
-      memory: 17179869184
-      name: Standard_D4as_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8as_v5
-      id: Standard_D8as_v5
-      memory: 34359738368
-      name: Standard_D8as_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16as_v5
-      id: Standard_D16as_v5
-      memory: 68719476736
-      name: Standard_D16as_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32as_v5
-      id: Standard_D32as_v5
-      memory: 137438953472
-      name: Standard_D32as_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48as_v5
-      id: Standard_D48as_v5
-      memory: 206158430208
-      name: Standard_D48as_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64as_v5
-      id: Standard_D64as_v5
-      memory: 274877906944
-      name: Standard_D64as_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96as_v5
-      id: Standard_D96as_v5
-      memory: 412316860416
-      name: Standard_D96as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2as_v5
-      id: Standard_E2as_v5
-      memory: 17179869184
-      name: Standard_E2as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2as_v5
-      id: Standard_E4-2as_v5
-      memory: 34359738368
-      name: Standard_E4-2as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4as_v5
-      id: Standard_E4as_v5
-      memory: 34359738368
-      name: Standard_E4as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2as_v5
-      id: Standard_E8-2as_v5
-      memory: 68719476736
-      name: Standard_E8-2as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4as_v5
-      id: Standard_E8-4as_v5
-      memory: 68719476736
-      name: Standard_E8-4as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8as_v5
-      id: Standard_E8as_v5
-      memory: 68719476736
-      name: Standard_E8as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-4as_v5
-      id: Standard_E16-4as_v5
-      memory: 137438953472
-      name: Standard_E16-4as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8as_v5
-      id: Standard_E16-8as_v5
-      memory: 137438953472
-      name: Standard_E16-8as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16as_v5
-      id: Standard_E16as_v5
-      memory: 137438953472
-      name: Standard_E16as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20as_v5
-      id: Standard_E20as_v5
-      memory: 171798691840
-      name: Standard_E20as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8as_v5
-      id: Standard_E32-8as_v5
-      memory: 274877906944
-      name: Standard_E32-8as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16as_v5
-      id: Standard_E32-16as_v5
-      memory: 274877906944
-      name: Standard_E32-16as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32as_v5
-      id: Standard_E32as_v5
-      memory: 274877906944
-      name: Standard_E32as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48as_v5
-      id: Standard_E48as_v5
-      memory: 412316860416
-      name: Standard_E48as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16as_v5
-      id: Standard_E64-16as_v5
-      memory: 549755813888
-      name: Standard_E64-16as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32as_v5
-      id: Standard_E64-32as_v5
-      memory: 549755813888
-      name: Standard_E64-32as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64as_v5
-      id: Standard_E64as_v5
-      memory: 549755813888
-      name: Standard_E64as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-24as_v5
-      id: Standard_E96-24as_v5
-      memory: 721554505728
-      name: Standard_E96-24as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-48as_v5
-      id: Standard_E96-48as_v5
-      memory: 721554505728
-      name: Standard_E96-48as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96as_v5
-      id: Standard_E96as_v5
-      memory: 721554505728
-      name: Standard_E96as_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2ads_v5
-      id: Standard_D2ads_v5
-      memory: 8589934592
-      name: Standard_D2ads_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4ads_v5
-      id: Standard_D4ads_v5
-      memory: 17179869184
-      name: Standard_D4ads_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8ads_v5
-      id: Standard_D8ads_v5
-      memory: 34359738368
-      name: Standard_D8ads_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
+      family: standardDADSv5Family
       generic_name: standard_d16ads_v5
       id: Standard_D16ads_v5
       memory: 68719476736
       name: Standard_D16ads_v5
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32ads_v5
-      id: Standard_D32ads_v5
-      memory: 137438953472
-      name: Standard_D32ads_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48ads_v5
-      id: Standard_D48ads_v5
-      memory: 206158430208
-      name: Standard_D48ads_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64ads_v5
-      id: Standard_D64ads_v5
-      memory: 274877906944
-      name: Standard_D64ads_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96ads_v5
-      id: Standard_D96ads_v5
-      memory: 412316860416
-      name: Standard_D96ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2ads_v5
-      id: Standard_E2ads_v5
-      memory: 17179869184
-      name: Standard_E2ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2ads_v5
-      id: Standard_E4-2ads_v5
-      memory: 34359738368
-      name: Standard_E4-2ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4ads_v5
-      id: Standard_E4ads_v5
-      memory: 34359738368
-      name: Standard_E4ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2ads_v5
-      id: Standard_E8-2ads_v5
-      memory: 68719476736
-      name: Standard_E8-2ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4ads_v5
-      id: Standard_E8-4ads_v5
-      memory: 68719476736
-      name: Standard_E8-4ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8ads_v5
-      id: Standard_E8ads_v5
-      memory: 68719476736
-      name: Standard_E8ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_e16-4ads_v5
-      id: Standard_E16-4ads_v5
-      memory: 137438953472
-      name: Standard_E16-4ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8ads_v5
-      id: Standard_E16-8ads_v5
-      memory: 137438953472
-      name: Standard_E16-8ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16ads_v5
-      id: Standard_E16ads_v5
-      memory: 137438953472
-      name: Standard_E16ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20ads_v5
-      id: Standard_E20ads_v5
-      memory: 171798691840
-      name: Standard_E20ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8ads_v5
-      id: Standard_E32-8ads_v5
-      memory: 274877906944
-      name: Standard_E32-8ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16ads_v5
-      id: Standard_E32-16ads_v5
-      memory: 274877906944
-      name: Standard_E32-16ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32ads_v5
-      id: Standard_E32ads_v5
-      memory: 274877906944
-      name: Standard_E32ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48ads_v5
-      id: Standard_E48ads_v5
-      memory: 412316860416
-      name: Standard_E48ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16ads_v5
-      id: Standard_E64-16ads_v5
-      memory: 549755813888
-      name: Standard_E64-16ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32ads_v5
-      id: Standard_E64-32ads_v5
-      memory: 549755813888
-      name: Standard_E64-32ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64ads_v5
-      id: Standard_E64ads_v5
-      memory: 549755813888
-      name: Standard_E64ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-24ads_v5
-      id: Standard_E96-24ads_v5
-      memory: 721554505728
-      name: Standard_E96-24ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-48ads_v5
-      id: Standard_E96-48ads_v5
-      memory: 721554505728
-      name: Standard_E96-48ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96ads_v5
-      id: Standard_E96ads_v5
-      memory: 721554505728
-      name: Standard_E96ads_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2as_v6
-      id: Standard_D2as_v6
-      memory: 8589934592
-      name: Standard_D2as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4as_v6
-      id: Standard_D4as_v6
-      memory: 17179869184
-      name: Standard_D4as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8as_v6
-      id: Standard_D8as_v6
-      memory: 34359738368
-      name: Standard_D8as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16as_v6
-      id: Standard_D16as_v6
-      memory: 68719476736
-      name: Standard_D16as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32as_v6
-      id: Standard_D32as_v6
-      memory: 137438953472
-      name: Standard_D32as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48as_v6
-      id: Standard_D48as_v6
-      memory: 206158430208
-      name: Standard_D48as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64as_v6
-      id: Standard_D64as_v6
-      memory: 274877906944
-      name: Standard_D64as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96as_v6
-      id: Standard_D96as_v6
-      memory: 412316860416
-      name: Standard_D96as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2as_v6
-      id: Standard_E2as_v6
-      memory: 17179869184
-      name: Standard_E2as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4as_v6
-      id: Standard_E4as_v6
-      memory: 34359738368
-      name: Standard_E4as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8as_v6
-      id: Standard_E8as_v6
-      memory: 68719476736
-      name: Standard_E8as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16as_v6
-      id: Standard_E16as_v6
-      memory: 137438953472
-      name: Standard_E16as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20as_v6
-      id: Standard_E20as_v6
-      memory: 171798691840
-      name: Standard_E20as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32as_v6
-      id: Standard_E32as_v6
-      memory: 274877906944
-      name: Standard_E32as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48as_v6
-      id: Standard_E48as_v6
-      memory: 412316860416
-      name: Standard_E48as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64as_v6
-      id: Standard_E64as_v6
-      memory: 549755813888
-      name: Standard_E64as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96as_v6
-      id: Standard_E96as_v6
-      memory: 721554505728
-      name: Standard_E96as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2ads_v6
-      id: Standard_D2ads_v6
-      memory: 8589934592
-      name: Standard_D2ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4ads_v6
-      id: Standard_D4ads_v6
-      memory: 17179869184
-      name: Standard_D4ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8ads_v6
-      id: Standard_D8ads_v6
-      memory: 34359738368
-      name: Standard_D8ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
+      family: standardDadv6Family
       generic_name: standard_d16ads_v6
       id: Standard_D16ads_v6
       memory: 68719476736
       name: Standard_D16ads_v6
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32ads_v6
-      id: Standard_D32ads_v6
-      memory: 137438953472
-      name: Standard_D32ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48ads_v6
-      id: Standard_D48ads_v6
-      memory: 206158430208
-      name: Standard_D48ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64ads_v6
-      id: Standard_D64ads_v6
-      memory: 274877906944
-      name: Standard_D64ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96ads_v6
-      id: Standard_D96ads_v6
-      memory: 412316860416
-      name: Standard_D96ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2als_v6
-      id: Standard_D2als_v6
-      memory: 4294967296
-      name: Standard_D2als_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4als_v6
-      id: Standard_D4als_v6
-      memory: 8589934592
-      name: Standard_D4als_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8als_v6
-      id: Standard_D8als_v6
-      memory: 17179869184
-      name: Standard_D8als_v6
-    - category: general_purpose
-      cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_d16als_v6
-      id: Standard_D16als_v6
-      memory: 34359738368
-      name: Standard_D16als_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32als_v6
-      id: Standard_D32als_v6
+      family: StandardDadsv7Family
+      generic_name: standard_d16ads_v7
+      id: Standard_D16ads_v7
       memory: 68719476736
-      name: Standard_D32als_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48als_v6
-      id: Standard_D48als_v6
-      memory: 103079215104
-      name: Standard_D48als_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64als_v6
-      id: Standard_D64als_v6
-      memory: 137438953472
-      name: Standard_D64als_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96als_v6
-      id: Standard_D96als_v6
-      memory: 206158430208
-      name: Standard_D96als_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2alds_v6
-      id: Standard_D2alds_v6
-      memory: 4294967296
-      name: Standard_D2alds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4alds_v6
-      id: Standard_D4alds_v6
-      memory: 8589934592
-      name: Standard_D4alds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8alds_v6
-      id: Standard_D8alds_v6
-      memory: 17179869184
-      name: Standard_D8alds_v6
+      name: Standard_D16ads_v7
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
+      family: standardDaldv6Family
       generic_name: standard_d16alds_v6
       id: Standard_D16alds_v6
       memory: 34359738368
       name: Standard_D16alds_v6
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32alds_v6
-      id: Standard_D32alds_v6
-      memory: 68719476736
-      name: Standard_D32alds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48alds_v6
-      id: Standard_D48alds_v6
-      memory: 103079215104
-      name: Standard_D48alds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64alds_v6
-      id: Standard_D64alds_v6
-      memory: 137438953472
-      name: Standard_D64alds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96alds_v6
-      id: Standard_D96alds_v6
-      memory: 206158430208
-      name: Standard_D96alds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2ads_v6
-      id: Standard_E2ads_v6
-      memory: 17179869184
-      name: Standard_E2ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4ads_v6
-      id: Standard_E4ads_v6
+      cpu_cores: 16
+      family: StandardDaldsv7Family
+      generic_name: standard_d16alds_v7
+      id: Standard_D16alds_v7
       memory: 34359738368
-      name: Standard_E4ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8ads_v6
-      id: Standard_E8ads_v6
-      memory: 68719476736
-      name: Standard_E8ads_v6
-    - category: memory_optimized
+      name: Standard_D16alds_v7
+    - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_e16ads_v6
-      id: Standard_E16ads_v6
-      memory: 137438953472
-      name: Standard_E16ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20ads_v6
-      id: Standard_E20ads_v6
-      memory: 171798691840
-      name: Standard_E20ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32ads_v6
-      id: Standard_E32ads_v6
-      memory: 274877906944
-      name: Standard_E32ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48ads_v6
-      id: Standard_E48ads_v6
-      memory: 412316860416
-      name: Standard_E48ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64ads_v6
-      id: Standard_E64ads_v6
-      memory: 549755813888
-      name: Standard_E64ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-24ads_v6
-      id: Standard_E96-24ads_v6
-      memory: 721554505728
-      name: Standard_E96-24ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-48ads_v6
-      id: Standard_E96-48ads_v6
-      memory: 721554505728
-      name: Standard_E96-48ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96ads_v6
-      id: Standard_E96ads_v6
-      memory: 721554505728
-      name: Standard_E96ads_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2as_v6
-      id: Standard_F2as_v6
-      memory: 8589934592
-      name: Standard_F2as_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4as_v6
-      id: Standard_F4as_v6
-      memory: 17179869184
-      name: Standard_F4as_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8as_v6
-      id: Standard_F8as_v6
+      family: standardDalv6Family
+      generic_name: standard_d16als_v6
+      id: Standard_D16als_v6
       memory: 34359738368
-      name: Standard_F8as_v6
-    - category: compute_optimized
+      name: Standard_D16als_v6
+    - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_f16as_v6
-      id: Standard_F16as_v6
-      memory: 68719476736
-      name: Standard_F16as_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32as_v6
-      id: Standard_F32as_v6
-      memory: 137438953472
-      name: Standard_F32as_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_f48as_v6
-      id: Standard_F48as_v6
-      memory: 206158430208
-      name: Standard_F48as_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64as_v6
-      id: Standard_F64as_v6
-      memory: 274877906944
-      name: Standard_F64as_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2als_v6
-      id: Standard_F2als_v6
-      memory: 4294967296
-      name: Standard_F2als_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4als_v6
-      id: Standard_F4als_v6
-      memory: 8589934592
-      name: Standard_F4als_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8als_v6
-      id: Standard_F8als_v6
-      memory: 17179869184
-      name: Standard_F8als_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16als_v6
-      id: Standard_F16als_v6
+      family: StandardDalsv7Family
+      generic_name: standard_d16als_v7
+      id: Standard_D16als_v7
       memory: 34359738368
-      name: Standard_F16als_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32als_v6
-      id: Standard_F32als_v6
-      memory: 68719476736
-      name: Standard_F32als_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_f48als_v6
-      id: Standard_F48als_v6
-      memory: 103079215104
-      name: Standard_F48als_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64als_v6
-      id: Standard_F64als_v6
-      memory: 137438953472
-      name: Standard_F64als_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2ams_v6
-      id: Standard_F2ams_v6
-      memory: 17179869184
-      name: Standard_F2ams_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4ams_v6
-      id: Standard_F4ams_v6
-      memory: 34359738368
-      name: Standard_F4ams_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8ams_v6
-      id: Standard_F8ams_v6
-      memory: 68719476736
-      name: Standard_F8ams_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16ams_v6
-      id: Standard_F16ams_v6
-      memory: 137438953472
-      name: Standard_F16ams_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32ams_v6
-      id: Standard_F32ams_v6
-      memory: 274877906944
-      name: Standard_F32ams_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_f48ams_v6
-      id: Standard_F48ams_v6
-      memory: 412316860416
-      name: Standard_F48ams_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64ams_v6
-      id: Standard_F64ams_v6
-      memory: 549755813888
-      name: Standard_F64ams_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2ds_v5
-      id: Standard_D2ds_v5
-      memory: 8589934592
-      name: Standard_D2ds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4ds_v5
-      id: Standard_D4ds_v5
-      memory: 17179869184
-      name: Standard_D4ds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8ds_v5
-      id: Standard_D8ds_v5
-      memory: 34359738368
-      name: Standard_D8ds_v5
+      name: Standard_D16als_v7
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_d16ds_v5
-      id: Standard_D16ds_v5
-      memory: 68719476736
-      name: Standard_D16ds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32ds_v5
-      id: Standard_D32ds_v5
-      memory: 137438953472
-      name: Standard_D32ds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48ds_v5
-      id: Standard_D48ds_v5
-      memory: 206158430208
-      name: Standard_D48ds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64ds_v5
-      id: Standard_D64ds_v5
-      memory: 274877906944
-      name: Standard_D64ds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96ds_v5
-      id: Standard_D96ds_v5
-      memory: 412316860416
-      name: Standard_D96ds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2d_v5
-      id: Standard_D2d_v5
-      memory: 8589934592
-      name: Standard_D2d_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4d_v5
-      id: Standard_D4d_v5
-      memory: 17179869184
-      name: Standard_D4d_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8d_v5
-      id: Standard_D8d_v5
-      memory: 34359738368
-      name: Standard_D8d_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16d_v5
-      id: Standard_D16d_v5
-      memory: 68719476736
-      name: Standard_D16d_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32d_v5
-      id: Standard_D32d_v5
-      memory: 137438953472
-      name: Standard_D32d_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48d_v5
-      id: Standard_D48d_v5
-      memory: 206158430208
-      name: Standard_D48d_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64d_v5
-      id: Standard_D64d_v5
-      memory: 274877906944
-      name: Standard_D64d_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96d_v5
-      id: Standard_D96d_v5
-      memory: 412316860416
-      name: Standard_D96d_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2s_v5
-      id: Standard_D2s_v5
-      memory: 8589934592
-      name: Standard_D2s_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4s_v5
-      id: Standard_D4s_v5
-      memory: 17179869184
-      name: Standard_D4s_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8s_v5
-      id: Standard_D8s_v5
-      memory: 34359738368
-      name: Standard_D8s_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16s_v5
-      id: Standard_D16s_v5
-      memory: 68719476736
-      name: Standard_D16s_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32s_v5
-      id: Standard_D32s_v5
-      memory: 137438953472
-      name: Standard_D32s_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48s_v5
-      id: Standard_D48s_v5
-      memory: 206158430208
-      name: Standard_D48s_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64s_v5
-      id: Standard_D64s_v5
-      memory: 274877906944
-      name: Standard_D64s_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96s_v5
-      id: Standard_D96s_v5
-      memory: 412316860416
-      name: Standard_D96s_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2_v5
-      id: Standard_D2_v5
-      memory: 8589934592
-      name: Standard_D2_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4_v5
-      id: Standard_D4_v5
-      memory: 17179869184
-      name: Standard_D4_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8_v5
-      id: Standard_D8_v5
-      memory: 34359738368
-      name: Standard_D8_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16_v5
-      id: Standard_D16_v5
-      memory: 68719476736
-      name: Standard_D16_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32_v5
-      id: Standard_D32_v5
-      memory: 137438953472
-      name: Standard_D32_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48_v5
-      id: Standard_D48_v5
-      memory: 206158430208
-      name: Standard_D48_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64_v5
-      id: Standard_D64_v5
-      memory: 274877906944
-      name: Standard_D64_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96_v5
-      id: Standard_D96_v5
-      memory: 412316860416
-      name: Standard_D96_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2ds_v5
-      id: Standard_E2ds_v5
-      memory: 17179869184
-      name: Standard_E2ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2ds_v5
-      id: Standard_E4-2ds_v5
-      memory: 34359738368
-      name: Standard_E4-2ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4ds_v5
-      id: Standard_E4ds_v5
-      memory: 34359738368
-      name: Standard_E4ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2ds_v5
-      id: Standard_E8-2ds_v5
-      memory: 68719476736
-      name: Standard_E8-2ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4ds_v5
-      id: Standard_E8-4ds_v5
-      memory: 68719476736
-      name: Standard_E8-4ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8ds_v5
-      id: Standard_E8ds_v5
-      memory: 68719476736
-      name: Standard_E8ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-4ds_v5
-      id: Standard_E16-4ds_v5
-      memory: 137438953472
-      name: Standard_E16-4ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8ds_v5
-      id: Standard_E16-8ds_v5
-      memory: 137438953472
-      name: Standard_E16-8ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16ds_v5
-      id: Standard_E16ds_v5
-      memory: 137438953472
-      name: Standard_E16ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20ds_v5
-      id: Standard_E20ds_v5
-      memory: 171798691840
-      name: Standard_E20ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8ds_v5
-      id: Standard_E32-8ds_v5
-      memory: 274877906944
-      name: Standard_E32-8ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16ds_v5
-      id: Standard_E32-16ds_v5
-      memory: 274877906944
-      name: Standard_E32-16ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32ds_v5
-      id: Standard_E32ds_v5
-      memory: 274877906944
-      name: Standard_E32ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48ds_v5
-      id: Standard_E48ds_v5
-      memory: 412316860416
-      name: Standard_E48ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16ds_v5
-      id: Standard_E64-16ds_v5
-      memory: 549755813888
-      name: Standard_E64-16ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32ds_v5
-      id: Standard_E64-32ds_v5
-      memory: 549755813888
-      name: Standard_E64-32ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64ds_v5
-      id: Standard_E64ds_v5
-      memory: 549755813888
-      name: Standard_E64ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-24ds_v5
-      id: Standard_E96-24ds_v5
-      memory: 721554505728
-      name: Standard_E96-24ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-48ds_v5
-      id: Standard_E96-48ds_v5
-      memory: 721554505728
-      name: Standard_E96-48ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96ds_v5
-      id: Standard_E96ds_v5
-      memory: 721554505728
-      name: Standard_E96ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 104
-      generic_name: standard_e104ids_v5
-      id: Standard_E104ids_v5
-      memory: 721554505728
-      name: Standard_E104ids_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2d_v5
-      id: Standard_E2d_v5
-      memory: 17179869184
-      name: Standard_E2d_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4d_v5
-      id: Standard_E4d_v5
-      memory: 34359738368
-      name: Standard_E4d_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8d_v5
-      id: Standard_E8d_v5
-      memory: 68719476736
-      name: Standard_E8d_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16d_v5
-      id: Standard_E16d_v5
-      memory: 137438953472
-      name: Standard_E16d_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20d_v5
-      id: Standard_E20d_v5
-      memory: 171798691840
-      name: Standard_E20d_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32d_v5
-      id: Standard_E32d_v5
-      memory: 274877906944
-      name: Standard_E32d_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48d_v5
-      id: Standard_E48d_v5
-      memory: 412316860416
-      name: Standard_E48d_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64d_v5
-      id: Standard_E64d_v5
-      memory: 549755813888
-      name: Standard_E64d_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96d_v5
-      id: Standard_E96d_v5
-      memory: 721554505728
-      name: Standard_E96d_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 104
-      generic_name: standard_e104id_v5
-      id: Standard_E104id_v5
-      memory: 721554505728
-      name: Standard_E104id_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2s_v5
-      id: Standard_E2s_v5
-      memory: 17179869184
-      name: Standard_E2s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2s_v5
-      id: Standard_E4-2s_v5
-      memory: 34359738368
-      name: Standard_E4-2s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4s_v5
-      id: Standard_E4s_v5
-      memory: 34359738368
-      name: Standard_E4s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2s_v5
-      id: Standard_E8-2s_v5
-      memory: 68719476736
-      name: Standard_E8-2s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4s_v5
-      id: Standard_E8-4s_v5
-      memory: 68719476736
-      name: Standard_E8-4s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8s_v5
-      id: Standard_E8s_v5
-      memory: 68719476736
-      name: Standard_E8s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-4s_v5
-      id: Standard_E16-4s_v5
-      memory: 137438953472
-      name: Standard_E16-4s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8s_v5
-      id: Standard_E16-8s_v5
-      memory: 137438953472
-      name: Standard_E16-8s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16s_v5
-      id: Standard_E16s_v5
-      memory: 137438953472
-      name: Standard_E16s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20s_v5
-      id: Standard_E20s_v5
-      memory: 171798691840
-      name: Standard_E20s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8s_v5
-      id: Standard_E32-8s_v5
-      memory: 274877906944
-      name: Standard_E32-8s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16s_v5
-      id: Standard_E32-16s_v5
-      memory: 274877906944
-      name: Standard_E32-16s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32s_v5
-      id: Standard_E32s_v5
-      memory: 274877906944
-      name: Standard_E32s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48s_v5
-      id: Standard_E48s_v5
-      memory: 412316860416
-      name: Standard_E48s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16s_v5
-      id: Standard_E64-16s_v5
-      memory: 549755813888
-      name: Standard_E64-16s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32s_v5
-      id: Standard_E64-32s_v5
-      memory: 549755813888
-      name: Standard_E64-32s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64s_v5
-      id: Standard_E64s_v5
-      memory: 549755813888
-      name: Standard_E64s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-24s_v5
-      id: Standard_E96-24s_v5
-      memory: 721554505728
-      name: Standard_E96-24s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-48s_v5
-      id: Standard_E96-48s_v5
-      memory: 721554505728
-      name: Standard_E96-48s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96s_v5
-      id: Standard_E96s_v5
-      memory: 721554505728
-      name: Standard_E96s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 104
-      generic_name: standard_e104is_v5
-      id: Standard_E104is_v5
-      memory: 721554505728
-      name: Standard_E104is_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2_v5
-      id: Standard_E2_v5
-      memory: 17179869184
-      name: Standard_E2_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4_v5
-      id: Standard_E4_v5
-      memory: 34359738368
-      name: Standard_E4_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8_v5
-      id: Standard_E8_v5
-      memory: 68719476736
-      name: Standard_E8_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16_v5
-      id: Standard_E16_v5
-      memory: 137438953472
-      name: Standard_E16_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20_v5
-      id: Standard_E20_v5
-      memory: 171798691840
-      name: Standard_E20_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32_v5
-      id: Standard_E32_v5
-      memory: 274877906944
-      name: Standard_E32_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48_v5
-      id: Standard_E48_v5
-      memory: 412316860416
-      name: Standard_E48_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64_v5
-      id: Standard_E64_v5
-      memory: 549755813888
-      name: Standard_E64_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96_v5
-      id: Standard_E96_v5
-      memory: 721554505728
-      name: Standard_E96_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 104
-      generic_name: standard_e104i_v5
-      id: Standard_E104i_v5
-      memory: 721554505728
-      name: Standard_E104i_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2bs_v5
-      id: Standard_E2bs_v5
-      memory: 17179869184
-      name: Standard_E2bs_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4bs_v5
-      id: Standard_E4bs_v5
-      memory: 34359738368
-      name: Standard_E4bs_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8bs_v5
-      id: Standard_E8bs_v5
-      memory: 68719476736
-      name: Standard_E8bs_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16bs_v5
-      id: Standard_E16bs_v5
-      memory: 137438953472
-      name: Standard_E16bs_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32bs_v5
-      id: Standard_E32bs_v5
-      memory: 274877906944
-      name: Standard_E32bs_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48bs_v5
-      id: Standard_E48bs_v5
-      memory: 412316860416
-      name: Standard_E48bs_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64bs_v5
-      id: Standard_E64bs_v5
-      memory: 549755813888
-      name: Standard_E64bs_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96bs_v5
-      id: Standard_E96bs_v5
-      memory: 721554505728
-      name: Standard_E96bs_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 112
-      generic_name: standard_e112ibs_v5
-      id: Standard_E112ibs_v5
-      memory: 721554505728
-      name: Standard_E112ibs_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2bds_v5
-      id: Standard_E2bds_v5
-      memory: 17179869184
-      name: Standard_E2bds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4bds_v5
-      id: Standard_E4bds_v5
-      memory: 34359738368
-      name: Standard_E4bds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8bds_v5
-      id: Standard_E8bds_v5
-      memory: 68719476736
-      name: Standard_E8bds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16bds_v5
-      id: Standard_E16bds_v5
-      memory: 137438953472
-      name: Standard_E16bds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32bds_v5
-      id: Standard_E32bds_v5
-      memory: 274877906944
-      name: Standard_E32bds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48bds_v5
-      id: Standard_E48bds_v5
-      memory: 412316860416
-      name: Standard_E48bds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64bds_v5
-      id: Standard_E64bds_v5
-      memory: 549755813888
-      name: Standard_E64bds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96bds_v5
-      id: Standard_E96bds_v5
-      memory: 721554505728
-      name: Standard_E96bds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 112
-      generic_name: standard_e112ibds_v5
-      id: Standard_E112ibds_v5
-      memory: 721554505728
-      name: Standard_E112ibds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2ls_v5
-      id: Standard_D2ls_v5
-      memory: 4294967296
-      name: Standard_D2ls_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4ls_v5
-      id: Standard_D4ls_v5
-      memory: 8589934592
-      name: Standard_D4ls_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8ls_v5
-      id: Standard_D8ls_v5
-      memory: 17179869184
-      name: Standard_D8ls_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16ls_v5
-      id: Standard_D16ls_v5
-      memory: 34359738368
-      name: Standard_D16ls_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32ls_v5
-      id: Standard_D32ls_v5
-      memory: 68719476736
-      name: Standard_D32ls_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48ls_v5
-      id: Standard_D48ls_v5
-      memory: 103079215104
-      name: Standard_D48ls_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64ls_v5
-      id: Standard_D64ls_v5
-      memory: 137438953472
-      name: Standard_D64ls_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96ls_v5
-      id: Standard_D96ls_v5
-      memory: 206158430208
-      name: Standard_D96ls_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2lds_v5
-      id: Standard_D2lds_v5
-      memory: 4294967296
-      name: Standard_D2lds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4lds_v5
-      id: Standard_D4lds_v5
-      memory: 8589934592
-      name: Standard_D4lds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8lds_v5
-      id: Standard_D8lds_v5
-      memory: 17179869184
-      name: Standard_D8lds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16lds_v5
-      id: Standard_D16lds_v5
-      memory: 34359738368
-      name: Standard_D16lds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32lds_v5
-      id: Standard_D32lds_v5
-      memory: 68719476736
-      name: Standard_D32lds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48lds_v5
-      id: Standard_D48lds_v5
-      memory: 103079215104
-      name: Standard_D48lds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64lds_v5
-      id: Standard_D64lds_v5
-      memory: 137438953472
-      name: Standard_D64lds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96lds_v5
-      id: Standard_D96lds_v5
-      memory: 206158430208
-      name: Standard_D96lds_v5
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_nc8ads_a10_v4
-      id: Standard_NC8ads_A10_v4
-      memory: 107374182400
-      name: Standard_NC8ads_A10_v4
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_nc16ads_a10_v4
-      id: Standard_NC16ads_A10_v4
-      memory: 214748364800
-      name: Standard_NC16ads_A10_v4
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_nc32ads_a10_v4
-      id: Standard_NC32ads_A10_v4
-      memory: 429496729600
-      name: Standard_NC32ads_A10_v4
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 40
-      generic_name: standard_nc40ads_h100_v5
-      id: Standard_NC40ads_H100_v5
-      memory: 343597383680
-      name: Standard_NC40ads_H100_v5
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_nc80adis_h100_v5
-      id: Standard_NC80adis_H100_v5
-      memory: 687194767360
-      name: Standard_NC80adis_H100_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2ls_v6
-      id: Standard_D2ls_v6
-      memory: 4294967296
-      name: Standard_D2ls_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4ls_v6
-      id: Standard_D4ls_v6
-      memory: 8589934592
-      name: Standard_D4ls_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8ls_v6
-      id: Standard_D8ls_v6
-      memory: 17179869184
-      name: Standard_D8ls_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16ls_v6
-      id: Standard_D16ls_v6
-      memory: 34359738368
-      name: Standard_D16ls_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32ls_v6
-      id: Standard_D32ls_v6
-      memory: 68719476736
-      name: Standard_D32ls_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48ls_v6
-      id: Standard_D48ls_v6
-      memory: 103079215104
-      name: Standard_D48ls_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64ls_v6
-      id: Standard_D64ls_v6
-      memory: 137438953472
-      name: Standard_D64ls_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96ls_v6
-      id: Standard_D96ls_v6
-      memory: 206158430208
-      name: Standard_D96ls_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_d128ls_v6
-      id: Standard_D128ls_v6
-      memory: 274877906944
-      name: Standard_D128ls_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2lds_v6
-      id: Standard_D2lds_v6
-      memory: 4294967296
-      name: Standard_D2lds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4lds_v6
-      id: Standard_D4lds_v6
-      memory: 8589934592
-      name: Standard_D4lds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8lds_v6
-      id: Standard_D8lds_v6
-      memory: 17179869184
-      name: Standard_D8lds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16lds_v6
-      id: Standard_D16lds_v6
-      memory: 34359738368
-      name: Standard_D16lds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32lds_v6
-      id: Standard_D32lds_v6
-      memory: 68719476736
-      name: Standard_D32lds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48lds_v6
-      id: Standard_D48lds_v6
-      memory: 103079215104
-      name: Standard_D48lds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64lds_v6
-      id: Standard_D64lds_v6
-      memory: 137438953472
-      name: Standard_D64lds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96lds_v6
-      id: Standard_D96lds_v6
-      memory: 206158430208
-      name: Standard_D96lds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_d128lds_v6
-      id: Standard_D128lds_v6
-      memory: 274877906944
-      name: Standard_D128lds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2s_v6
-      id: Standard_D2s_v6
-      memory: 8589934592
-      name: Standard_D2s_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4s_v6
-      id: Standard_D4s_v6
-      memory: 17179869184
-      name: Standard_D4s_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8s_v6
-      id: Standard_D8s_v6
-      memory: 34359738368
-      name: Standard_D8s_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16s_v6
-      id: Standard_D16s_v6
-      memory: 68719476736
-      name: Standard_D16s_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32s_v6
-      id: Standard_D32s_v6
-      memory: 137438953472
-      name: Standard_D32s_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48s_v6
-      id: Standard_D48s_v6
-      memory: 206158430208
-      name: Standard_D48s_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64s_v6
-      id: Standard_D64s_v6
-      memory: 274877906944
-      name: Standard_D64s_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96s_v6
-      id: Standard_D96s_v6
-      memory: 412316860416
-      name: Standard_D96s_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_d128s_v6
-      id: Standard_D128s_v6
-      memory: 549755813888
-      name: Standard_D128s_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 192
-      generic_name: standard_d192s_v6
-      id: Standard_D192s_v6
-      memory: 824633720832
-      name: Standard_D192s_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2ds_v6
-      id: Standard_D2ds_v6
-      memory: 8589934592
-      name: Standard_D2ds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4ds_v6
-      id: Standard_D4ds_v6
-      memory: 17179869184
-      name: Standard_D4ds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8ds_v6
-      id: Standard_D8ds_v6
-      memory: 34359738368
-      name: Standard_D8ds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16ds_v6
-      id: Standard_D16ds_v6
-      memory: 68719476736
-      name: Standard_D16ds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32ds_v6
-      id: Standard_D32ds_v6
-      memory: 137438953472
-      name: Standard_D32ds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48ds_v6
-      id: Standard_D48ds_v6
-      memory: 206158430208
-      name: Standard_D48ds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64ds_v6
-      id: Standard_D64ds_v6
-      memory: 274877906944
-      name: Standard_D64ds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96ds_v6
-      id: Standard_D96ds_v6
-      memory: 412316860416
-      name: Standard_D96ds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_d128ds_v6
-      id: Standard_D128ds_v6
-      memory: 549755813888
-      name: Standard_D128ds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 192
-      generic_name: standard_d192ds_v6
-      id: Standard_D192ds_v6
-      memory: 824633720832
-      name: Standard_D192ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2s_v6
-      id: Standard_E2s_v6
-      memory: 17179869184
-      name: Standard_E2s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2s_v6
-      id: Standard_E4-2s_v6
-      memory: 34359738368
-      name: Standard_E4-2s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4s_v6
-      id: Standard_E4s_v6
-      memory: 34359738368
-      name: Standard_E4s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2s_v6
-      id: Standard_E8-2s_v6
-      memory: 68719476736
-      name: Standard_E8-2s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4s_v6
-      id: Standard_E8-4s_v6
-      memory: 68719476736
-      name: Standard_E8-4s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8s_v6
-      id: Standard_E8s_v6
-      memory: 68719476736
-      name: Standard_E8s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-4s_v6
-      id: Standard_E16-4s_v6
-      memory: 137438953472
-      name: Standard_E16-4s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8s_v6
-      id: Standard_E16-8s_v6
-      memory: 137438953472
-      name: Standard_E16-8s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16s_v6
-      id: Standard_E16s_v6
-      memory: 137438953472
-      name: Standard_E16s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20s_v6
-      id: Standard_E20s_v6
-      memory: 171798691840
-      name: Standard_E20s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8s_v6
-      id: Standard_E32-8s_v6
-      memory: 274877906944
-      name: Standard_E32-8s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16s_v6
-      id: Standard_E32-16s_v6
-      memory: 274877906944
-      name: Standard_E32-16s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32s_v6
-      id: Standard_E32s_v6
-      memory: 274877906944
-      name: Standard_E32s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48s_v6
-      id: Standard_E48s_v6
-      memory: 412316860416
-      name: Standard_E48s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16s_v6
-      id: Standard_E64-16s_v6
-      memory: 549755813888
-      name: Standard_E64-16s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32s_v6
-      id: Standard_E64-32s_v6
-      memory: 549755813888
-      name: Standard_E64-32s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64s_v6
-      id: Standard_E64s_v6
-      memory: 549755813888
-      name: Standard_E64s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-24s_v6
-      id: Standard_E96-24s_v6
-      memory: 824633720832
-      name: Standard_E96-24s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-48s_v6
-      id: Standard_E96-48s_v6
-      memory: 824633720832
-      name: Standard_E96-48s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96s_v6
-      id: Standard_E96s_v6
-      memory: 824633720832
-      name: Standard_E96s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2ds_v6
-      id: Standard_E2ds_v6
-      memory: 17179869184
-      name: Standard_E2ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2ds_v6
-      id: Standard_E4-2ds_v6
-      memory: 34359738368
-      name: Standard_E4-2ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4ds_v6
-      id: Standard_E4ds_v6
-      memory: 34359738368
-      name: Standard_E4ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2ds_v6
-      id: Standard_E8-2ds_v6
-      memory: 68719476736
-      name: Standard_E8-2ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4ds_v6
-      id: Standard_E8-4ds_v6
-      memory: 68719476736
-      name: Standard_E8-4ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8ds_v6
-      id: Standard_E8ds_v6
-      memory: 68719476736
-      name: Standard_E8ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-4ds_v6
-      id: Standard_E16-4ds_v6
-      memory: 137438953472
-      name: Standard_E16-4ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8ds_v6
-      id: Standard_E16-8ds_v6
-      memory: 137438953472
-      name: Standard_E16-8ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16ds_v6
-      id: Standard_E16ds_v6
-      memory: 137438953472
-      name: Standard_E16ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20ds_v6
-      id: Standard_E20ds_v6
-      memory: 171798691840
-      name: Standard_E20ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8ds_v6
-      id: Standard_E32-8ds_v6
-      memory: 274877906944
-      name: Standard_E32-8ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16ds_v6
-      id: Standard_E32-16ds_v6
-      memory: 274877906944
-      name: Standard_E32-16ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32ds_v6
-      id: Standard_E32ds_v6
-      memory: 274877906944
-      name: Standard_E32ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48ds_v6
-      id: Standard_E48ds_v6
-      memory: 412316860416
-      name: Standard_E48ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16ds_v6
-      id: Standard_E64-16ds_v6
-      memory: 549755813888
-      name: Standard_E64-16ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32ds_v6
-      id: Standard_E64-32ds_v6
-      memory: 549755813888
-      name: Standard_E64-32ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64ds_v6
-      id: Standard_E64ds_v6
-      memory: 549755813888
-      name: Standard_E64ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-24ds_v6
-      id: Standard_E96-24ds_v6
-      memory: 824633720832
-      name: Standard_E96-24ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-48ds_v6
-      id: Standard_E96-48ds_v6
-      memory: 824633720832
-      name: Standard_E96-48ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96ds_v6
-      id: Standard_E96ds_v6
-      memory: 824633720832
-      name: Standard_E96ds_v6
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_l8as_v3
-      id: Standard_L8as_v3
-      memory: 68719476736
-      name: Standard_L8as_v3
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_l16as_v3
-      id: Standard_L16as_v3
-      memory: 137438953472
-      name: Standard_L16as_v3
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_l32as_v3
-      id: Standard_L32as_v3
-      memory: 274877906944
-      name: Standard_L32as_v3
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_l48as_v3
-      id: Standard_L48as_v3
-      memory: 412316860416
-      name: Standard_L48as_v3
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_l64as_v3
-      id: Standard_L64as_v3
-      memory: 549755813888
-      name: Standard_L64as_v3
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_l80as_v3
-      id: Standard_L80as_v3
-      memory: 687194767360
-      name: Standard_L80as_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2a_v4
-      id: Standard_D2a_v4
-      memory: 8589934592
-      name: Standard_D2a_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4a_v4
-      id: Standard_D4a_v4
-      memory: 17179869184
-      name: Standard_D4a_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8a_v4
-      id: Standard_D8a_v4
-      memory: 34359738368
-      name: Standard_D8a_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16a_v4
-      id: Standard_D16a_v4
-      memory: 68719476736
-      name: Standard_D16a_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32a_v4
-      id: Standard_D32a_v4
-      memory: 137438953472
-      name: Standard_D32a_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48a_v4
-      id: Standard_D48a_v4
-      memory: 206158430208
-      name: Standard_D48a_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64a_v4
-      id: Standard_D64a_v4
-      memory: 274877906944
-      name: Standard_D64a_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96a_v4
-      id: Standard_D96a_v4
-      memory: 412316860416
-      name: Standard_D96a_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2as_v4
-      id: Standard_D2as_v4
-      memory: 8589934592
-      name: Standard_D2as_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4as_v4
-      id: Standard_D4as_v4
-      memory: 17179869184
-      name: Standard_D4as_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8as_v4
-      id: Standard_D8as_v4
-      memory: 34359738368
-      name: Standard_D8as_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
+      family: standardDASv4Family
       generic_name: standard_d16as_v4
       id: Standard_D16as_v4
       memory: 68719476736
       name: Standard_D16as_v4
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32as_v4
-      id: Standard_D32as_v4
-      memory: 137438953472
-      name: Standard_D32as_v4
+      cpu_cores: 16
+      family: standardDASv5Family
+      generic_name: standard_d16as_v5
+      id: Standard_D16as_v5
+      memory: 68719476736
+      name: Standard_D16as_v5
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48as_v4
-      id: Standard_D48as_v4
-      memory: 206158430208
-      name: Standard_D48as_v4
+      cpu_cores: 16
+      family: standardDav6Family
+      generic_name: standard_d16as_v6
+      id: Standard_D16as_v6
+      memory: 68719476736
+      name: Standard_D16as_v6
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64as_v4
-      id: Standard_D64as_v4
-      memory: 274877906944
-      name: Standard_D64as_v4
+      cpu_cores: 16
+      family: StandardDasv7Family
+      generic_name: standard_d16as_v7
+      id: Standard_D16as_v7
+      memory: 68719476736
+      name: Standard_D16as_v7
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96as_v4
-      id: Standard_D96as_v4
-      memory: 412316860416
-      name: Standard_D96as_v4
-    - category: memory_optimized
+      cpu_cores: 16
+      family: standardDAv4Family
+      generic_name: standard_d16a_v4
+      id: Standard_D16a_v4
+      memory: 68719476736
+      name: Standard_D16a_v4
+    - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2a_v4
-      id: Standard_E2a_v4
-      memory: 17179869184
-      name: Standard_E2a_v4
-    - category: memory_optimized
+      cpu_cores: 16
+      family: standardDDSv4Family
+      generic_name: standard_d16ds_v4
+      id: Standard_D16ds_v4
+      memory: 68719476736
+      name: Standard_D16ds_v4
+    - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4a_v4
-      id: Standard_E4a_v4
+      cpu_cores: 16
+      family: standardDDSv5Family
+      generic_name: standard_d16ds_v5
+      id: Standard_D16ds_v5
+      memory: 68719476736
+      name: Standard_D16ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardDdsv6Family
+      generic_name: standard_d16ds_v6
+      id: Standard_D16ds_v6
+      memory: 68719476736
+      name: Standard_D16ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDDv4Family
+      generic_name: standard_d16d_v4
+      id: Standard_D16d_v4
+      memory: 68719476736
+      name: Standard_D16d_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDDv5Family
+      generic_name: standard_d16d_v5
+      id: Standard_D16d_v5
+      memory: 68719476736
+      name: Standard_D16d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDLDSv5Family
+      generic_name: standard_d16lds_v5
+      id: Standard_D16lds_v5
       memory: 34359738368
-      name: Standard_E4a_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8a_v4
-      id: Standard_E8a_v4
-      memory: 68719476736
-      name: Standard_E8a_v4
-    - category: memory_optimized
+      name: Standard_D16lds_v5
+    - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_e16a_v4
-      id: Standard_E16a_v4
-      memory: 137438953472
-      name: Standard_E16a_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20a_v4
-      id: Standard_E20a_v4
-      memory: 171798691840
-      name: Standard_E20a_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32a_v4
-      id: Standard_E32a_v4
-      memory: 274877906944
-      name: Standard_E32a_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48a_v4
-      id: Standard_E48a_v4
-      memory: 412316860416
-      name: Standard_E48a_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64a_v4
-      id: Standard_E64a_v4
-      memory: 549755813888
-      name: Standard_E64a_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96a_v4
-      id: Standard_E96a_v4
-      memory: 721554505728
-      name: Standard_E96a_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2as_v4
-      id: Standard_E2as_v4
-      memory: 17179869184
-      name: Standard_E2as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2as_v4
-      id: Standard_E4-2as_v4
+      family: StandardDldsv6Family
+      generic_name: standard_d16lds_v6
+      id: Standard_D16lds_v6
       memory: 34359738368
-      name: Standard_E4-2as_v4
-    - category: memory_optimized
+      name: Standard_D16lds_v6
+    - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4as_v4
-      id: Standard_E4as_v4
+      cpu_cores: 16
+      family: standardDLSv5Family
+      generic_name: standard_d16ls_v5
+      id: Standard_D16ls_v5
       memory: 34359738368
-      name: Standard_E4as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2as_v4
-      id: Standard_E8-2as_v4
-      memory: 68719476736
-      name: Standard_E8-2as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4as_v4
-      id: Standard_E8-4as_v4
-      memory: 68719476736
-      name: Standard_E8-4as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8as_v4
-      id: Standard_E8as_v4
-      memory: 68719476736
-      name: Standard_E8as_v4
-    - category: memory_optimized
+      name: Standard_D16ls_v5
+    - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_e16-4as_v4
-      id: Standard_E16-4as_v4
-      memory: 137438953472
-      name: Standard_E16-4as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8as_v4
-      id: Standard_E16-8as_v4
-      memory: 137438953472
-      name: Standard_E16-8as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16as_v4
-      id: Standard_E16as_v4
-      memory: 137438953472
-      name: Standard_E16as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20as_v4
-      id: Standard_E20as_v4
-      memory: 171798691840
-      name: Standard_E20as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8as_v4
-      id: Standard_E32-8as_v4
-      memory: 274877906944
-      name: Standard_E32-8as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16as_v4
-      id: Standard_E32-16as_v4
-      memory: 274877906944
-      name: Standard_E32-16as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32as_v4
-      id: Standard_E32as_v4
-      memory: 274877906944
-      name: Standard_E32as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48as_v4
-      id: Standard_E48as_v4
-      memory: 412316860416
-      name: Standard_E48as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16as_v4
-      id: Standard_E64-16as_v4
-      memory: 549755813888
-      name: Standard_E64-16as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32as_v4
-      id: Standard_E64-32as_v4
-      memory: 549755813888
-      name: Standard_E64-32as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64as_v4
-      id: Standard_E64as_v4
-      memory: 549755813888
-      name: Standard_E64as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-24as_v4
-      id: Standard_E96-24as_v4
-      memory: 721554505728
-      name: Standard_E96-24as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-48as_v4
-      id: Standard_E96-48as_v4
-      memory: 721554505728
-      name: Standard_E96-48as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96as_v4
-      id: Standard_E96as_v4
-      memory: 721554505728
-      name: Standard_E96as_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_l8s_v3
-      id: Standard_L8s_v3
-      memory: 68719476736
-      name: Standard_L8s_v3
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_l16s_v3
-      id: Standard_L16s_v3
-      memory: 137438953472
-      name: Standard_L16s_v3
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_l32s_v3
-      id: Standard_L32s_v3
-      memory: 274877906944
-      name: Standard_L32s_v3
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_l48s_v3
-      id: Standard_L48s_v3
-      memory: 412316860416
-      name: Standard_L48s_v3
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_l64s_v3
-      id: Standard_L64s_v3
-      memory: 549755813888
-      name: Standard_L64s_v3
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_l80s_v3
-      id: Standard_L80s_v3
-      memory: 687194767360
-      name: Standard_L80s_v3
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_l2aos_v4
-      id: Standard_L2aos_v4
-      memory: 17179869184
-      name: Standard_L2aos_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_l4aos_v4
-      id: Standard_L4aos_v4
+      family: StandardDlsv6Family
+      generic_name: standard_d16ls_v6
+      id: Standard_D16ls_v6
       memory: 34359738368
-      name: Standard_L4aos_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_l8aos_v4
-      id: Standard_L8aos_v4
-      memory: 68719476736
-      name: Standard_L8aos_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 12
-      generic_name: standard_l12aos_v4
-      id: Standard_L12aos_v4
-      memory: 103079215104
-      name: Standard_L12aos_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_l16aos_v4
-      id: Standard_L16aos_v4
-      memory: 137438953472
-      name: Standard_L16aos_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 24
-      generic_name: standard_l24aos_v4
-      id: Standard_L24aos_v4
-      memory: 206158430208
-      name: Standard_L24aos_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_l32aos_v4
-      id: Standard_L32aos_v4
-      memory: 274877906944
-      name: Standard_L32aos_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_l2as_v4
-      id: Standard_L2as_v4
-      memory: 17179869184
-      name: Standard_L2as_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_l4as_v4
-      id: Standard_L4as_v4
-      memory: 34359738368
-      name: Standard_L4as_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_l8as_v4
-      id: Standard_L8as_v4
-      memory: 68719476736
-      name: Standard_L8as_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_l16as_v4
-      id: Standard_L16as_v4
-      memory: 137438953472
-      name: Standard_L16as_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_l32as_v4
-      id: Standard_L32as_v4
-      memory: 274877906944
-      name: Standard_L32as_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_l48as_v4
-      id: Standard_L48as_v4
-      memory: 412316860416
-      name: Standard_L48as_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_l64as_v4
-      id: Standard_L64as_v4
-      memory: 549755813888
-      name: Standard_L64as_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_l80as_v4
-      id: Standard_L80as_v4
-      memory: 687194767360
-      name: Standard_L80as_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_l96as_v4
-      id: Standard_L96as_v4
-      memory: 824633720832
-      name: Standard_L96as_v4
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2plds_v5
-      id: Standard_D2plds_v5
-      memory: 4294967296
-      name: Standard_D2plds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4plds_v5
-      id: Standard_D4plds_v5
-      memory: 8589934592
-      name: Standard_D4plds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8plds_v5
-      id: Standard_D8plds_v5
-      memory: 17179869184
-      name: Standard_D8plds_v5
+      name: Standard_D16ls_v6
     - architecture: arm64
       category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_d16plds_v5
-      id: Standard_D16plds_v5
-      memory: 34359738368
-      name: Standard_D16plds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32plds_v5
-      id: Standard_D32plds_v5
-      memory: 68719476736
-      name: Standard_D32plds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48plds_v5
-      id: Standard_D48plds_v5
-      memory: 103079215104
-      name: Standard_D48plds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64plds_v5
-      id: Standard_D64plds_v5
-      memory: 137438953472
-      name: Standard_D64plds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2pls_v5
-      id: Standard_D2pls_v5
-      memory: 4294967296
-      name: Standard_D2pls_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4pls_v5
-      id: Standard_D4pls_v5
-      memory: 8589934592
-      name: Standard_D4pls_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8pls_v5
-      id: Standard_D8pls_v5
-      memory: 17179869184
-      name: Standard_D8pls_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16pls_v5
-      id: Standard_D16pls_v5
-      memory: 34359738368
-      name: Standard_D16pls_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32pls_v5
-      id: Standard_D32pls_v5
-      memory: 68719476736
-      name: Standard_D32pls_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48pls_v5
-      id: Standard_D48pls_v5
-      memory: 103079215104
-      name: Standard_D48pls_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64pls_v5
-      id: Standard_D64pls_v5
-      memory: 137438953472
-      name: Standard_D64pls_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2pds_v5
-      id: Standard_D2pds_v5
-      memory: 8589934592
-      name: Standard_D2pds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4pds_v5
-      id: Standard_D4pds_v5
-      memory: 17179869184
-      name: Standard_D4pds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8pds_v5
-      id: Standard_D8pds_v5
-      memory: 34359738368
-      name: Standard_D8pds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
+      family: standardDPDSv5Family
       generic_name: standard_d16pds_v5
       id: Standard_D16pds_v5
       memory: 68719476736
@@ -4965,845 +1067,8 @@ data:
     - architecture: arm64
       category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32pds_v5
-      id: Standard_D32pds_v5
-      memory: 137438953472
-      name: Standard_D32pds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48pds_v5
-      id: Standard_D48pds_v5
-      memory: 206158430208
-      name: Standard_D48pds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64pds_v5
-      id: Standard_D64pds_v5
-      memory: 223338299392
-      name: Standard_D64pds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2ps_v5
-      id: Standard_D2ps_v5
-      memory: 8589934592
-      name: Standard_D2ps_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4ps_v5
-      id: Standard_D4ps_v5
-      memory: 17179869184
-      name: Standard_D4ps_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8ps_v5
-      id: Standard_D8ps_v5
-      memory: 34359738368
-      name: Standard_D8ps_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_d16ps_v5
-      id: Standard_D16ps_v5
-      memory: 68719476736
-      name: Standard_D16ps_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32ps_v5
-      id: Standard_D32ps_v5
-      memory: 137438953472
-      name: Standard_D32ps_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48ps_v5
-      id: Standard_D48ps_v5
-      memory: 206158430208
-      name: Standard_D48ps_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64ps_v5
-      id: Standard_D64ps_v5
-      memory: 223338299392
-      name: Standard_D64ps_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2pds_v5
-      id: Standard_E2pds_v5
-      memory: 17179869184
-      name: Standard_E2pds_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4pds_v5
-      id: Standard_E4pds_v5
-      memory: 34359738368
-      name: Standard_E4pds_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8pds_v5
-      id: Standard_E8pds_v5
-      memory: 68719476736
-      name: Standard_E8pds_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16pds_v5
-      id: Standard_E16pds_v5
-      memory: 137438953472
-      name: Standard_E16pds_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20pds_v5
-      id: Standard_E20pds_v5
-      memory: 171798691840
-      name: Standard_E20pds_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32pds_v5
-      id: Standard_E32pds_v5
-      memory: 223338299392
-      name: Standard_E32pds_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2ps_v5
-      id: Standard_E2ps_v5
-      memory: 17179869184
-      name: Standard_E2ps_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4ps_v5
-      id: Standard_E4ps_v5
-      memory: 34359738368
-      name: Standard_E4ps_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8ps_v5
-      id: Standard_E8ps_v5
-      memory: 68719476736
-      name: Standard_E8ps_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16ps_v5
-      id: Standard_E16ps_v5
-      memory: 137438953472
-      name: Standard_E16ps_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20ps_v5
-      id: Standard_E20ps_v5
-      memory: 171798691840
-      name: Standard_E20ps_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32ps_v5
-      id: Standard_E32ps_v5
-      memory: 223338299392
-      name: Standard_E32ps_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128-32s_v6
-      id: Standard_E128-32s_v6
-      memory: 1099511627776
-      name: Standard_E128-32s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128-64s_v6
-      id: Standard_E128-64s_v6
-      memory: 1099511627776
-      name: Standard_E128-64s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128s_v6
-      id: Standard_E128s_v6
-      memory: 1099511627776
-      name: Standard_E128s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 192
-      generic_name: standard_e192is_v6
-      id: Standard_E192is_v6
-      memory: 1967095021568
-      name: Standard_E192is_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128-32ds_v6
-      id: Standard_E128-32ds_v6
-      memory: 1099511627776
-      name: Standard_E128-32ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128-64ds_v6
-      id: Standard_E128-64ds_v6
-      memory: 1099511627776
-      name: Standard_E128-64ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128ds_v6
-      id: Standard_E128ds_v6
-      memory: 1099511627776
-      name: Standard_E128ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 192
-      generic_name: standard_e192ids_v6
-      id: Standard_E192ids_v6
-      memory: 1967095021568
-      name: Standard_E192ids_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_fx2ms_v2
-      id: Standard_FX2ms_v2
-      memory: 45097156608
-      name: Standard_FX2ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_fx4-2ms_v2
-      id: Standard_FX4-2ms_v2
-      memory: 90194313216
-      name: Standard_FX4-2ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_fx4ms_v2
-      id: Standard_FX4ms_v2
-      memory: 90194313216
-      name: Standard_FX4ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_fx8-2ms_v2
-      id: Standard_FX8-2ms_v2
-      memory: 180388626432
-      name: Standard_FX8-2ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_fx8-4ms_v2
-      id: Standard_FX8-4ms_v2
-      memory: 180388626432
-      name: Standard_FX8-4ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_fx8ms_v2
-      id: Standard_FX8ms_v2
-      memory: 180388626432
-      name: Standard_FX8ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 12
-      generic_name: standard_fx12-6ms_v2
-      id: Standard_FX12-6ms_v2
-      memory: 270582939648
-      name: Standard_FX12-6ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 12
-      generic_name: standard_fx12ms_v2
-      id: Standard_FX12ms_v2
-      memory: 270582939648
-      name: Standard_FX12ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_fx16-4ms_v2
-      id: Standard_FX16-4ms_v2
-      memory: 360777252864
-      name: Standard_FX16-4ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_fx16-8ms_v2
-      id: Standard_FX16-8ms_v2
-      memory: 360777252864
-      name: Standard_FX16-8ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_fx16ms_v2
-      id: Standard_FX16ms_v2
-      memory: 360777252864
-      name: Standard_FX16ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 24
-      generic_name: standard_fx24-6ms_v2
-      id: Standard_FX24-6ms_v2
-      memory: 541165879296
-      name: Standard_FX24-6ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 24
-      generic_name: standard_fx24-12ms_v2
-      id: Standard_FX24-12ms_v2
-      memory: 541165879296
-      name: Standard_FX24-12ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 24
-      generic_name: standard_fx24ms_v2
-      id: Standard_FX24ms_v2
-      memory: 541165879296
-      name: Standard_FX24ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_fx32-8ms_v2
-      id: Standard_FX32-8ms_v2
-      memory: 721554505728
-      name: Standard_FX32-8ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_fx32-16ms_v2
-      id: Standard_FX32-16ms_v2
-      memory: 721554505728
-      name: Standard_FX32-16ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_fx32ms_v2
-      id: Standard_FX32ms_v2
-      memory: 721554505728
-      name: Standard_FX32ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_fx48-12ms_v2
-      id: Standard_FX48-12ms_v2
-      memory: 1082331758592
-      name: Standard_FX48-12ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_fx48-24ms_v2
-      id: Standard_FX48-24ms_v2
-      memory: 1082331758592
-      name: Standard_FX48-24ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_fx48ms_v2
-      id: Standard_FX48ms_v2
-      memory: 1082331758592
-      name: Standard_FX48ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_fx64-16ms_v2
-      id: Standard_FX64-16ms_v2
-      memory: 1443109011456
-      name: Standard_FX64-16ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_fx64-32ms_v2
-      id: Standard_FX64-32ms_v2
-      memory: 1443109011456
-      name: Standard_FX64-32ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_fx64ms_v2
-      id: Standard_FX64ms_v2
-      memory: 1443109011456
-      name: Standard_FX64ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_fx96-24ms_v2
-      id: Standard_FX96-24ms_v2
-      memory: 1967095021568
-      name: Standard_FX96-24ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_fx96-48ms_v2
-      id: Standard_FX96-48ms_v2
-      memory: 1967095021568
-      name: Standard_FX96-48ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_fx96ms_v2
-      id: Standard_FX96ms_v2
-      memory: 1967095021568
-      name: Standard_FX96ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_fx2mds_v2
-      id: Standard_FX2mds_v2
-      memory: 45097156608
-      name: Standard_FX2mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_fx4-2mds_v2
-      id: Standard_FX4-2mds_v2
-      memory: 90194313216
-      name: Standard_FX4-2mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_fx4mds_v2
-      id: Standard_FX4mds_v2
-      memory: 90194313216
-      name: Standard_FX4mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_fx8-2mds_v2
-      id: Standard_FX8-2mds_v2
-      memory: 180388626432
-      name: Standard_FX8-2mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_fx8-4mds_v2
-      id: Standard_FX8-4mds_v2
-      memory: 180388626432
-      name: Standard_FX8-4mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_fx8mds_v2
-      id: Standard_FX8mds_v2
-      memory: 180388626432
-      name: Standard_FX8mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 12
-      generic_name: standard_fx12-6mds_v2
-      id: Standard_FX12-6mds_v2
-      memory: 270582939648
-      name: Standard_FX12-6mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 12
-      generic_name: standard_fx12mds_v2
-      id: Standard_FX12mds_v2
-      memory: 270582939648
-      name: Standard_FX12mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_fx16-4mds_v2
-      id: Standard_FX16-4mds_v2
-      memory: 360777252864
-      name: Standard_FX16-4mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_fx16-8mds_v2
-      id: Standard_FX16-8mds_v2
-      memory: 360777252864
-      name: Standard_FX16-8mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_fx16mds_v2
-      id: Standard_FX16mds_v2
-      memory: 360777252864
-      name: Standard_FX16mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 24
-      generic_name: standard_fx24-6mds_v2
-      id: Standard_FX24-6mds_v2
-      memory: 541165879296
-      name: Standard_FX24-6mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 24
-      generic_name: standard_fx24-12mds_v2
-      id: Standard_FX24-12mds_v2
-      memory: 541165879296
-      name: Standard_FX24-12mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 24
-      generic_name: standard_fx24mds_v2
-      id: Standard_FX24mds_v2
-      memory: 541165879296
-      name: Standard_FX24mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_fx32-8mds_v2
-      id: Standard_FX32-8mds_v2
-      memory: 721554505728
-      name: Standard_FX32-8mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_fx32-16mds_v2
-      id: Standard_FX32-16mds_v2
-      memory: 721554505728
-      name: Standard_FX32-16mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_fx32mds_v2
-      id: Standard_FX32mds_v2
-      memory: 721554505728
-      name: Standard_FX32mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_fx48-12mds_v2
-      id: Standard_FX48-12mds_v2
-      memory: 1082331758592
-      name: Standard_FX48-12mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_fx48-24mds_v2
-      id: Standard_FX48-24mds_v2
-      memory: 1082331758592
-      name: Standard_FX48-24mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_fx48mds_v2
-      id: Standard_FX48mds_v2
-      memory: 1082331758592
-      name: Standard_FX48mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_fx64-16mds_v2
-      id: Standard_FX64-16mds_v2
-      memory: 1443109011456
-      name: Standard_FX64-16mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_fx64-32mds_v2
-      id: Standard_FX64-32mds_v2
-      memory: 1443109011456
-      name: Standard_FX64-32mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_fx64mds_v2
-      id: Standard_FX64mds_v2
-      memory: 1443109011456
-      name: Standard_FX64mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_fx96-24mds_v2
-      id: Standard_FX96-24mds_v2
-      memory: 1967095021568
-      name: Standard_FX96-24mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_fx96-48mds_v2
-      id: Standard_FX96-48mds_v2
-      memory: 1967095021568
-      name: Standard_FX96-48mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_fx96mds_v2
-      id: Standard_FX96mds_v2
-      memory: 1967095021568
-      name: Standard_FX96mds_v2
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_l2s_v4
-      id: Standard_L2s_v4
-      memory: 17179869184
-      name: Standard_L2s_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_l4s_v4
-      id: Standard_L4s_v4
-      memory: 34359738368
-      name: Standard_L4s_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_l8s_v4
-      id: Standard_L8s_v4
-      memory: 68719476736
-      name: Standard_L8s_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_l16s_v4
-      id: Standard_L16s_v4
-      memory: 137438953472
-      name: Standard_L16s_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_l32s_v4
-      id: Standard_L32s_v4
-      memory: 274877906944
-      name: Standard_L32s_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_l48s_v4
-      id: Standard_L48s_v4
-      memory: 412316860416
-      name: Standard_L48s_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_l64s_v4
-      id: Standard_L64s_v4
-      memory: 549755813888
-      name: Standard_L64s_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_l80s_v4
-      id: Standard_L80s_v4
-      memory: 687194767360
-      name: Standard_L80s_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_l96s_v4
-      id: Standard_L96s_v4
-      memory: 824633720832
-      name: Standard_L96s_v4
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 6
-      generic_name: standard_nv6ads_a10_v5
-      id: Standard_NV6ads_A10_v5
-      memory: 59055800320
-      name: Standard_NV6ads_A10_v5
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 12
-      generic_name: standard_nv12ads_a10_v5
-      id: Standard_NV12ads_A10_v5
-      memory: 118111600640
-      name: Standard_NV12ads_A10_v5
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 18
-      generic_name: standard_nv18ads_a10_v5
-      id: Standard_NV18ads_A10_v5
-      memory: 236223201280
-      name: Standard_NV18ads_A10_v5
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 36
-      generic_name: standard_nv36adms_a10_v5
-      id: Standard_NV36adms_A10_v5
-      memory: 944892805120
-      name: Standard_NV36adms_A10_v5
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 36
-      generic_name: standard_nv36ads_a10_v5
-      id: Standard_NV36ads_A10_v5
-      memory: 472446402560
-      name: Standard_NV36ads_A10_v5
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 72
-      generic_name: standard_nv72ads_a10_v5
-      id: Standard_NV72ads_A10_v5
-      memory: 944892805120
-      name: Standard_NV72ads_A10_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 112
-      generic_name: standard_e112ias_v5
-      id: Standard_E112ias_v5
-      memory: 721554505728
-      name: Standard_E112ias_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 112
-      generic_name: standard_e112iads_v5
-      id: Standard_E112iads_v5
-      memory: 721554505728
-      name: Standard_E112iads_v5
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_fx4mds
-      id: Standard_FX4mds
-      memory: 90194313216
-      name: Standard_FX4mds
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 12
-      generic_name: standard_fx12mds
-      id: Standard_FX12mds
-      memory: 270582939648
-      name: Standard_FX12mds
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 24
-      generic_name: standard_fx24mds
-      id: Standard_FX24mds
-      memory: 541165879296
-      name: Standard_FX24mds
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 36
-      generic_name: standard_fx36mds
-      id: Standard_FX36mds
-      memory: 811748818944
-      name: Standard_FX36mds
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_fx48mds
-      id: Standard_FX48mds
-      memory: 1082331758592
-      name: Standard_FX48mds
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2pls_v6
-      id: Standard_D2pls_v6
-      memory: 4294967296
-      name: Standard_D2pls_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4pls_v6
-      id: Standard_D4pls_v6
-      memory: 8589934592
-      name: Standard_D4pls_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8pls_v6
-      id: Standard_D8pls_v6
-      memory: 17179869184
-      name: Standard_D8pls_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16pls_v6
-      id: Standard_D16pls_v6
-      memory: 34359738368
-      name: Standard_D16pls_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32pls_v6
-      id: Standard_D32pls_v6
-      memory: 68719476736
-      name: Standard_D32pls_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48pls_v6
-      id: Standard_D48pls_v6
-      memory: 103079215104
-      name: Standard_D48pls_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64pls_v6
-      id: Standard_D64pls_v6
-      memory: 137438953472
-      name: Standard_D64pls_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96pls_v6
-      id: Standard_D96pls_v6
-      memory: 206158430208
-      name: Standard_D96pls_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2pds_v6
-      id: Standard_D2pds_v6
-      memory: 8589934592
-      name: Standard_D2pds_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4pds_v6
-      id: Standard_D4pds_v6
-      memory: 17179869184
-      name: Standard_D4pds_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8pds_v6
-      id: Standard_D8pds_v6
-      memory: 34359738368
-      name: Standard_D8pds_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
+      family: StandardDpdsv6Family
       generic_name: standard_d16pds_v6
       id: Standard_D16pds_v6
       memory: 68719476736
@@ -5811,63 +1076,17 @@ data:
     - architecture: arm64
       category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32pds_v6
-      id: Standard_D32pds_v6
-      memory: 137438953472
-      name: Standard_D32pds_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48pds_v6
-      id: Standard_D48pds_v6
-      memory: 206158430208
-      name: Standard_D48pds_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64pds_v6
-      id: Standard_D64pds_v6
-      memory: 274877906944
-      name: Standard_D64pds_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96pds_v6
-      id: Standard_D96pds_v6
-      memory: 412316860416
-      name: Standard_D96pds_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2plds_v6
-      id: Standard_D2plds_v6
-      memory: 4294967296
-      name: Standard_D2plds_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4plds_v6
-      id: Standard_D4plds_v6
-      memory: 8589934592
-      name: Standard_D4plds_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8plds_v6
-      id: Standard_D8plds_v6
-      memory: 17179869184
-      name: Standard_D8plds_v6
+      cpu_cores: 16
+      family: standardDPLDSv5Family
+      generic_name: standard_d16plds_v5
+      id: Standard_D16plds_v5
+      memory: 34359738368
+      name: Standard_D16plds_v5
     - architecture: arm64
       category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
+      family: StandardDpldsv6Family
       generic_name: standard_d16plds_v6
       id: Standard_D16plds_v6
       memory: 34359738368
@@ -5875,7 +1094,623 @@ data:
     - architecture: arm64
       category: general_purpose
       cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDPLSv5Family
+      generic_name: standard_d16pls_v5
+      id: Standard_D16pls_v5
+      memory: 34359738368
+      name: Standard_D16pls_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardDplsv6Family
+      generic_name: standard_d16pls_v6
+      id: Standard_D16pls_v6
+      memory: 34359738368
+      name: Standard_D16pls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDPSv5Family
+      generic_name: standard_d16ps_v5
+      id: Standard_D16ps_v5
+      memory: 68719476736
+      name: Standard_D16ps_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardDpsv6Family
+      generic_name: standard_d16ps_v6
+      id: Standard_D16ps_v6
+      memory: 68719476736
+      name: Standard_D16ps_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDSv3Family
+      generic_name: standard_d16s_v3
+      id: Standard_D16s_v3
+      memory: 68719476736
+      name: Standard_D16s_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDSv4Family
+      generic_name: standard_d16s_v4
+      id: Standard_D16s_v4
+      memory: 68719476736
+      name: Standard_D16s_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDSv5Family
+      generic_name: standard_d16s_v5
+      id: Standard_D16s_v5
+      memory: 68719476736
+      name: Standard_D16s_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardDsv6Family
+      generic_name: standard_d16s_v6
+      id: Standard_D16s_v6
+      memory: 68719476736
+      name: Standard_D16s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDv3Family
+      generic_name: standard_d16_v3
+      id: Standard_D16_v3
+      memory: 68719476736
+      name: Standard_D16_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDv4Family
+      generic_name: standard_d16_v4
+      id: Standard_D16_v4
+      memory: 68719476736
+      name: Standard_D16_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDv5Family
+      generic_name: standard_d16_v5
+      id: Standard_D16_v5
+      memory: 68719476736
+      name: Standard_D16_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 192
+      family: StandardDdsv6Family
+      generic_name: standard_d192ds_v6
+      id: Standard_D192ds_v6
+      memory: 824633720832
+      name: Standard_D192ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 192
+      family: StandardDsv6Family
+      generic_name: standard_d192s_v6
+      id: Standard_D192s_v6
+      memory: 824633720832
+      name: Standard_D192s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 1
+      family: standardDv2Family
+      generic_name: standard_d1_v2
+      id: Standard_D1_v2
+      memory: 3221225472
+      name: Standard_D1_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDADSv5Family
+      generic_name: standard_d2ads_v5
+      id: Standard_D2ads_v5
+      memory: 8589934592
+      name: Standard_D2ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDadv6Family
+      generic_name: standard_d2ads_v6
+      id: Standard_D2ads_v6
+      memory: 8589934592
+      name: Standard_D2ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDadsv7Family
+      generic_name: standard_d2ads_v7
+      id: Standard_D2ads_v7
+      memory: 8589934592
+      name: Standard_D2ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDaldv6Family
+      generic_name: standard_d2alds_v6
+      id: Standard_D2alds_v6
+      memory: 4294967296
+      name: Standard_D2alds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDaldsv7Family
+      generic_name: standard_d2alds_v7
+      id: Standard_D2alds_v7
+      memory: 4294967296
+      name: Standard_D2alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDalv6Family
+      generic_name: standard_d2als_v6
+      id: Standard_D2als_v6
+      memory: 4294967296
+      name: Standard_D2als_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDalsv7Family
+      generic_name: standard_d2als_v7
+      id: Standard_D2als_v7
+      memory: 4294967296
+      name: Standard_D2als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDASv4Family
+      generic_name: standard_d2as_v4
+      id: Standard_D2as_v4
+      memory: 8589934592
+      name: Standard_D2as_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDASv5Family
+      generic_name: standard_d2as_v5
+      id: Standard_D2as_v5
+      memory: 8589934592
+      name: Standard_D2as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDav6Family
+      generic_name: standard_d2as_v6
+      id: Standard_D2as_v6
+      memory: 8589934592
+      name: Standard_D2as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDasv7Family
+      generic_name: standard_d2as_v7
+      id: Standard_D2as_v7
+      memory: 8589934592
+      name: Standard_D2as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDAv4Family
+      generic_name: standard_d2a_v4
+      id: Standard_D2a_v4
+      memory: 8589934592
+      name: Standard_D2a_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDDSv4Family
+      generic_name: standard_d2ds_v4
+      id: Standard_D2ds_v4
+      memory: 8589934592
+      name: Standard_D2ds_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDDSv5Family
+      generic_name: standard_d2ds_v5
+      id: Standard_D2ds_v5
+      memory: 8589934592
+      name: Standard_D2ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDdsv6Family
+      generic_name: standard_d2ds_v6
+      id: Standard_D2ds_v6
+      memory: 8589934592
+      name: Standard_D2ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDDv4Family
+      generic_name: standard_d2d_v4
+      id: Standard_D2d_v4
+      memory: 8589934592
+      name: Standard_D2d_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDDv5Family
+      generic_name: standard_d2d_v5
+      id: Standard_D2d_v5
+      memory: 8589934592
+      name: Standard_D2d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDLDSv5Family
+      generic_name: standard_d2lds_v5
+      id: Standard_D2lds_v5
+      memory: 4294967296
+      name: Standard_D2lds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDldsv6Family
+      generic_name: standard_d2lds_v6
+      id: Standard_D2lds_v6
+      memory: 4294967296
+      name: Standard_D2lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDLSv5Family
+      generic_name: standard_d2ls_v5
+      id: Standard_D2ls_v5
+      memory: 4294967296
+      name: Standard_D2ls_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDlsv6Family
+      generic_name: standard_d2ls_v6
+      id: Standard_D2ls_v6
+      memory: 4294967296
+      name: Standard_D2ls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDPDSv5Family
+      generic_name: standard_d2pds_v5
+      id: Standard_D2pds_v5
+      memory: 8589934592
+      name: Standard_D2pds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDpdsv6Family
+      generic_name: standard_d2pds_v6
+      id: Standard_D2pds_v6
+      memory: 8589934592
+      name: Standard_D2pds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDPLDSv5Family
+      generic_name: standard_d2plds_v5
+      id: Standard_D2plds_v5
+      memory: 4294967296
+      name: Standard_D2plds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDpldsv6Family
+      generic_name: standard_d2plds_v6
+      id: Standard_D2plds_v6
+      memory: 4294967296
+      name: Standard_D2plds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDPLSv5Family
+      generic_name: standard_d2pls_v5
+      id: Standard_D2pls_v5
+      memory: 4294967296
+      name: Standard_D2pls_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDplsv6Family
+      generic_name: standard_d2pls_v6
+      id: Standard_D2pls_v6
+      memory: 4294967296
+      name: Standard_D2pls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDPSv5Family
+      generic_name: standard_d2ps_v5
+      id: Standard_D2ps_v5
+      memory: 8589934592
+      name: Standard_D2ps_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDpsv6Family
+      generic_name: standard_d2ps_v6
+      id: Standard_D2ps_v6
+      memory: 8589934592
+      name: Standard_D2ps_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDSv3Family
+      generic_name: standard_d2s_v3
+      id: Standard_D2s_v3
+      memory: 8589934592
+      name: Standard_D2s_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDSv4Family
+      generic_name: standard_d2s_v4
+      id: Standard_D2s_v4
+      memory: 8589934592
+      name: Standard_D2s_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDSv5Family
+      generic_name: standard_d2s_v5
+      id: Standard_D2s_v5
+      memory: 8589934592
+      name: Standard_D2s_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDsv6Family
+      generic_name: standard_d2s_v6
+      id: Standard_D2s_v6
+      memory: 8589934592
+      name: Standard_D2s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDv2Family
+      generic_name: standard_d2_v2
+      id: Standard_D2_v2
+      memory: 7516192768
+      name: Standard_D2_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDv3Family
+      generic_name: standard_d2_v3
+      id: Standard_D2_v3
+      memory: 8589934592
+      name: Standard_D2_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDv4Family
+      generic_name: standard_d2_v4
+      id: Standard_D2_v4
+      memory: 8589934592
+      name: Standard_D2_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDv5Family
+      generic_name: standard_d2_v5
+      id: Standard_D2_v5
+      memory: 8589934592
+      name: Standard_D2_v5
+    - category: general_purpose
+      cloud_provider_id: azure
       cpu_cores: 32
+      family: standardDADSv5Family
+      generic_name: standard_d32ads_v5
+      id: Standard_D32ads_v5
+      memory: 137438953472
+      name: Standard_D32ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDadv6Family
+      generic_name: standard_d32ads_v6
+      id: Standard_D32ads_v6
+      memory: 137438953472
+      name: Standard_D32ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDadsv7Family
+      generic_name: standard_d32ads_v7
+      id: Standard_D32ads_v7
+      memory: 137438953472
+      name: Standard_D32ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDaldv6Family
+      generic_name: standard_d32alds_v6
+      id: Standard_D32alds_v6
+      memory: 68719476736
+      name: Standard_D32alds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDaldsv7Family
+      generic_name: standard_d32alds_v7
+      id: Standard_D32alds_v7
+      memory: 68719476736
+      name: Standard_D32alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDalv6Family
+      generic_name: standard_d32als_v6
+      id: Standard_D32als_v6
+      memory: 68719476736
+      name: Standard_D32als_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDalsv7Family
+      generic_name: standard_d32als_v7
+      id: Standard_D32als_v7
+      memory: 68719476736
+      name: Standard_D32als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDASv4Family
+      generic_name: standard_d32as_v4
+      id: Standard_D32as_v4
+      memory: 137438953472
+      name: Standard_D32as_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDASv5Family
+      generic_name: standard_d32as_v5
+      id: Standard_D32as_v5
+      memory: 137438953472
+      name: Standard_D32as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDav6Family
+      generic_name: standard_d32as_v6
+      id: Standard_D32as_v6
+      memory: 137438953472
+      name: Standard_D32as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDasv7Family
+      generic_name: standard_d32as_v7
+      id: Standard_D32as_v7
+      memory: 137438953472
+      name: Standard_D32as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDAv4Family
+      generic_name: standard_d32a_v4
+      id: Standard_D32a_v4
+      memory: 137438953472
+      name: Standard_D32a_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDDSv4Family
+      generic_name: standard_d32ds_v4
+      id: Standard_D32ds_v4
+      memory: 137438953472
+      name: Standard_D32ds_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDDSv5Family
+      generic_name: standard_d32ds_v5
+      id: Standard_D32ds_v5
+      memory: 137438953472
+      name: Standard_D32ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDdsv6Family
+      generic_name: standard_d32ds_v6
+      id: Standard_D32ds_v6
+      memory: 137438953472
+      name: Standard_D32ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDDv4Family
+      generic_name: standard_d32d_v4
+      id: Standard_D32d_v4
+      memory: 137438953472
+      name: Standard_D32d_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDDv5Family
+      generic_name: standard_d32d_v5
+      id: Standard_D32d_v5
+      memory: 137438953472
+      name: Standard_D32d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDLDSv5Family
+      generic_name: standard_d32lds_v5
+      id: Standard_D32lds_v5
+      memory: 68719476736
+      name: Standard_D32lds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDldsv6Family
+      generic_name: standard_d32lds_v6
+      id: Standard_D32lds_v6
+      memory: 68719476736
+      name: Standard_D32lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDLSv5Family
+      generic_name: standard_d32ls_v5
+      id: Standard_D32ls_v5
+      memory: 68719476736
+      name: Standard_D32ls_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDlsv6Family
+      generic_name: standard_d32ls_v6
+      id: Standard_D32ls_v6
+      memory: 68719476736
+      name: Standard_D32ls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDPDSv5Family
+      generic_name: standard_d32pds_v5
+      id: Standard_D32pds_v5
+      memory: 137438953472
+      name: Standard_D32pds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDpdsv6Family
+      generic_name: standard_d32pds_v6
+      id: Standard_D32pds_v6
+      memory: 137438953472
+      name: Standard_D32pds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDPLDSv5Family
+      generic_name: standard_d32plds_v5
+      id: Standard_D32plds_v5
+      memory: 68719476736
+      name: Standard_D32plds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDpldsv6Family
       generic_name: standard_d32plds_v6
       id: Standard_D32plds_v6
       memory: 68719476736
@@ -5883,7 +1718,303 @@ data:
     - architecture: arm64
       category: general_purpose
       cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDPLSv5Family
+      generic_name: standard_d32pls_v5
+      id: Standard_D32pls_v5
+      memory: 68719476736
+      name: Standard_D32pls_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDplsv6Family
+      generic_name: standard_d32pls_v6
+      id: Standard_D32pls_v6
+      memory: 68719476736
+      name: Standard_D32pls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDPSv5Family
+      generic_name: standard_d32ps_v5
+      id: Standard_D32ps_v5
+      memory: 137438953472
+      name: Standard_D32ps_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDpsv6Family
+      generic_name: standard_d32ps_v6
+      id: Standard_D32ps_v6
+      memory: 137438953472
+      name: Standard_D32ps_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDSv3Family
+      generic_name: standard_d32s_v3
+      id: Standard_D32s_v3
+      memory: 137438953472
+      name: Standard_D32s_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDSv4Family
+      generic_name: standard_d32s_v4
+      id: Standard_D32s_v4
+      memory: 137438953472
+      name: Standard_D32s_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDSv5Family
+      generic_name: standard_d32s_v5
+      id: Standard_D32s_v5
+      memory: 137438953472
+      name: Standard_D32s_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDsv6Family
+      generic_name: standard_d32s_v6
+      id: Standard_D32s_v6
+      memory: 137438953472
+      name: Standard_D32s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDv3Family
+      generic_name: standard_d32_v3
+      id: Standard_D32_v3
+      memory: 137438953472
+      name: Standard_D32_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDv4Family
+      generic_name: standard_d32_v4
+      id: Standard_D32_v4
+      memory: 137438953472
+      name: Standard_D32_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDv5Family
+      generic_name: standard_d32_v5
+      id: Standard_D32_v5
+      memory: 137438953472
+      name: Standard_D32_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDv2Family
+      generic_name: standard_d3_v2
+      id: Standard_D3_v2
+      memory: 15032385536
+      name: Standard_D3_v2
+    - category: general_purpose
+      cloud_provider_id: azure
       cpu_cores: 48
+      family: standardDADSv5Family
+      generic_name: standard_d48ads_v5
+      id: Standard_D48ads_v5
+      memory: 206158430208
+      name: Standard_D48ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDadv6Family
+      generic_name: standard_d48ads_v6
+      id: Standard_D48ads_v6
+      memory: 206158430208
+      name: Standard_D48ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDadsv7Family
+      generic_name: standard_d48ads_v7
+      id: Standard_D48ads_v7
+      memory: 206158430208
+      name: Standard_D48ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDaldv6Family
+      generic_name: standard_d48alds_v6
+      id: Standard_D48alds_v6
+      memory: 103079215104
+      name: Standard_D48alds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDaldsv7Family
+      generic_name: standard_d48alds_v7
+      id: Standard_D48alds_v7
+      memory: 103079215104
+      name: Standard_D48alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDalv6Family
+      generic_name: standard_d48als_v6
+      id: Standard_D48als_v6
+      memory: 103079215104
+      name: Standard_D48als_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDalsv7Family
+      generic_name: standard_d48als_v7
+      id: Standard_D48als_v7
+      memory: 103079215104
+      name: Standard_D48als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDASv4Family
+      generic_name: standard_d48as_v4
+      id: Standard_D48as_v4
+      memory: 206158430208
+      name: Standard_D48as_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDASv5Family
+      generic_name: standard_d48as_v5
+      id: Standard_D48as_v5
+      memory: 206158430208
+      name: Standard_D48as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDav6Family
+      generic_name: standard_d48as_v6
+      id: Standard_D48as_v6
+      memory: 206158430208
+      name: Standard_D48as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDasv7Family
+      generic_name: standard_d48as_v7
+      id: Standard_D48as_v7
+      memory: 206158430208
+      name: Standard_D48as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDAv4Family
+      generic_name: standard_d48a_v4
+      id: Standard_D48a_v4
+      memory: 206158430208
+      name: Standard_D48a_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDDSv4Family
+      generic_name: standard_d48ds_v4
+      id: Standard_D48ds_v4
+      memory: 206158430208
+      name: Standard_D48ds_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDDSv5Family
+      generic_name: standard_d48ds_v5
+      id: Standard_D48ds_v5
+      memory: 206158430208
+      name: Standard_D48ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDdsv6Family
+      generic_name: standard_d48ds_v6
+      id: Standard_D48ds_v6
+      memory: 206158430208
+      name: Standard_D48ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDDv4Family
+      generic_name: standard_d48d_v4
+      id: Standard_D48d_v4
+      memory: 206158430208
+      name: Standard_D48d_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDDv5Family
+      generic_name: standard_d48d_v5
+      id: Standard_D48d_v5
+      memory: 206158430208
+      name: Standard_D48d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDLDSv5Family
+      generic_name: standard_d48lds_v5
+      id: Standard_D48lds_v5
+      memory: 103079215104
+      name: Standard_D48lds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDldsv6Family
+      generic_name: standard_d48lds_v6
+      id: Standard_D48lds_v6
+      memory: 103079215104
+      name: Standard_D48lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDLSv5Family
+      generic_name: standard_d48ls_v5
+      id: Standard_D48ls_v5
+      memory: 103079215104
+      name: Standard_D48ls_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDlsv6Family
+      generic_name: standard_d48ls_v6
+      id: Standard_D48ls_v6
+      memory: 103079215104
+      name: Standard_D48ls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDPDSv5Family
+      generic_name: standard_d48pds_v5
+      id: Standard_D48pds_v5
+      memory: 206158430208
+      name: Standard_D48pds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDpdsv6Family
+      generic_name: standard_d48pds_v6
+      id: Standard_D48pds_v6
+      memory: 206158430208
+      name: Standard_D48pds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDPLDSv5Family
+      generic_name: standard_d48plds_v5
+      id: Standard_D48plds_v5
+      memory: 103079215104
+      name: Standard_D48plds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDpldsv6Family
       generic_name: standard_d48plds_v6
       id: Standard_D48plds_v6
       memory: 103079215104
@@ -5891,7 +2022,607 @@ data:
     - architecture: arm64
       category: general_purpose
       cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDPLSv5Family
+      generic_name: standard_d48pls_v5
+      id: Standard_D48pls_v5
+      memory: 103079215104
+      name: Standard_D48pls_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDplsv6Family
+      generic_name: standard_d48pls_v6
+      id: Standard_D48pls_v6
+      memory: 103079215104
+      name: Standard_D48pls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDPSv5Family
+      generic_name: standard_d48ps_v5
+      id: Standard_D48ps_v5
+      memory: 206158430208
+      name: Standard_D48ps_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDpsv6Family
+      generic_name: standard_d48ps_v6
+      id: Standard_D48ps_v6
+      memory: 206158430208
+      name: Standard_D48ps_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDSv3Family
+      generic_name: standard_d48s_v3
+      id: Standard_D48s_v3
+      memory: 206158430208
+      name: Standard_D48s_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDSv4Family
+      generic_name: standard_d48s_v4
+      id: Standard_D48s_v4
+      memory: 206158430208
+      name: Standard_D48s_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDSv5Family
+      generic_name: standard_d48s_v5
+      id: Standard_D48s_v5
+      memory: 206158430208
+      name: Standard_D48s_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDsv6Family
+      generic_name: standard_d48s_v6
+      id: Standard_D48s_v6
+      memory: 206158430208
+      name: Standard_D48s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDv3Family
+      generic_name: standard_d48_v3
+      id: Standard_D48_v3
+      memory: 206158430208
+      name: Standard_D48_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDv4Family
+      generic_name: standard_d48_v4
+      id: Standard_D48_v4
+      memory: 206158430208
+      name: Standard_D48_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDv5Family
+      generic_name: standard_d48_v5
+      id: Standard_D48_v5
+      memory: 206158430208
+      name: Standard_D48_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDADSv5Family
+      generic_name: standard_d4ads_v5
+      id: Standard_D4ads_v5
+      memory: 17179869184
+      name: Standard_D4ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDadv6Family
+      generic_name: standard_d4ads_v6
+      id: Standard_D4ads_v6
+      memory: 17179869184
+      name: Standard_D4ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDadsv7Family
+      generic_name: standard_d4ads_v7
+      id: Standard_D4ads_v7
+      memory: 17179869184
+      name: Standard_D4ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDaldv6Family
+      generic_name: standard_d4alds_v6
+      id: Standard_D4alds_v6
+      memory: 8589934592
+      name: Standard_D4alds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDaldsv7Family
+      generic_name: standard_d4alds_v7
+      id: Standard_D4alds_v7
+      memory: 8589934592
+      name: Standard_D4alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDalv6Family
+      generic_name: standard_d4als_v6
+      id: Standard_D4als_v6
+      memory: 8589934592
+      name: Standard_D4als_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDalsv7Family
+      generic_name: standard_d4als_v7
+      id: Standard_D4als_v7
+      memory: 8589934592
+      name: Standard_D4als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDASv4Family
+      generic_name: standard_d4as_v4
+      id: Standard_D4as_v4
+      memory: 17179869184
+      name: Standard_D4as_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDASv5Family
+      generic_name: standard_d4as_v5
+      id: Standard_D4as_v5
+      memory: 17179869184
+      name: Standard_D4as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDav6Family
+      generic_name: standard_d4as_v6
+      id: Standard_D4as_v6
+      memory: 17179869184
+      name: Standard_D4as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDasv7Family
+      generic_name: standard_d4as_v7
+      id: Standard_D4as_v7
+      memory: 17179869184
+      name: Standard_D4as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDAv4Family
+      generic_name: standard_d4a_v4
+      id: Standard_D4a_v4
+      memory: 17179869184
+      name: Standard_D4a_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDDSv4Family
+      generic_name: standard_d4ds_v4
+      id: Standard_D4ds_v4
+      memory: 17179869184
+      name: Standard_D4ds_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDDSv5Family
+      generic_name: standard_d4ds_v5
+      id: Standard_D4ds_v5
+      memory: 17179869184
+      name: Standard_D4ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDdsv6Family
+      generic_name: standard_d4ds_v6
+      id: Standard_D4ds_v6
+      memory: 17179869184
+      name: Standard_D4ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDDv4Family
+      generic_name: standard_d4d_v4
+      id: Standard_D4d_v4
+      memory: 17179869184
+      name: Standard_D4d_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDDv5Family
+      generic_name: standard_d4d_v5
+      id: Standard_D4d_v5
+      memory: 17179869184
+      name: Standard_D4d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDLDSv5Family
+      generic_name: standard_d4lds_v5
+      id: Standard_D4lds_v5
+      memory: 8589934592
+      name: Standard_D4lds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDldsv6Family
+      generic_name: standard_d4lds_v6
+      id: Standard_D4lds_v6
+      memory: 8589934592
+      name: Standard_D4lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDLSv5Family
+      generic_name: standard_d4ls_v5
+      id: Standard_D4ls_v5
+      memory: 8589934592
+      name: Standard_D4ls_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDlsv6Family
+      generic_name: standard_d4ls_v6
+      id: Standard_D4ls_v6
+      memory: 8589934592
+      name: Standard_D4ls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDPDSv5Family
+      generic_name: standard_d4pds_v5
+      id: Standard_D4pds_v5
+      memory: 17179869184
+      name: Standard_D4pds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDpdsv6Family
+      generic_name: standard_d4pds_v6
+      id: Standard_D4pds_v6
+      memory: 17179869184
+      name: Standard_D4pds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDPLDSv5Family
+      generic_name: standard_d4plds_v5
+      id: Standard_D4plds_v5
+      memory: 8589934592
+      name: Standard_D4plds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDpldsv6Family
+      generic_name: standard_d4plds_v6
+      id: Standard_D4plds_v6
+      memory: 8589934592
+      name: Standard_D4plds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDPLSv5Family
+      generic_name: standard_d4pls_v5
+      id: Standard_D4pls_v5
+      memory: 8589934592
+      name: Standard_D4pls_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDplsv6Family
+      generic_name: standard_d4pls_v6
+      id: Standard_D4pls_v6
+      memory: 8589934592
+      name: Standard_D4pls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDPSv5Family
+      generic_name: standard_d4ps_v5
+      id: Standard_D4ps_v5
+      memory: 17179869184
+      name: Standard_D4ps_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDpsv6Family
+      generic_name: standard_d4ps_v6
+      id: Standard_D4ps_v6
+      memory: 17179869184
+      name: Standard_D4ps_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDSv3Family
+      generic_name: standard_d4s_v3
+      id: Standard_D4s_v3
+      memory: 17179869184
+      name: Standard_D4s_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDSv4Family
+      generic_name: standard_d4s_v4
+      id: Standard_D4s_v4
+      memory: 17179869184
+      name: Standard_D4s_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDSv5Family
+      generic_name: standard_d4s_v5
+      id: Standard_D4s_v5
+      memory: 17179869184
+      name: Standard_D4s_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDsv6Family
+      generic_name: standard_d4s_v6
+      id: Standard_D4s_v6
+      memory: 17179869184
+      name: Standard_D4s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDv2Family
+      generic_name: standard_d4_v2
+      id: Standard_D4_v2
+      memory: 30064771072
+      name: Standard_D4_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDv3Family
+      generic_name: standard_d4_v3
+      id: Standard_D4_v3
+      memory: 17179869184
+      name: Standard_D4_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDv4Family
+      generic_name: standard_d4_v4
+      id: Standard_D4_v4
+      memory: 17179869184
+      name: Standard_D4_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDv5Family
+      generic_name: standard_d4_v5
+      id: Standard_D4_v5
+      memory: 17179869184
+      name: Standard_D4_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDv2Family
+      generic_name: standard_d5_v2
+      id: Standard_D5_v2
+      memory: 60129542144
+      name: Standard_D5_v2
+    - category: general_purpose
+      cloud_provider_id: azure
       cpu_cores: 64
+      family: standardDADSv5Family
+      generic_name: standard_d64ads_v5
+      id: Standard_D64ads_v5
+      memory: 274877906944
+      name: Standard_D64ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDadv6Family
+      generic_name: standard_d64ads_v6
+      id: Standard_D64ads_v6
+      memory: 274877906944
+      name: Standard_D64ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDadsv7Family
+      generic_name: standard_d64ads_v7
+      id: Standard_D64ads_v7
+      memory: 274877906944
+      name: Standard_D64ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDaldv6Family
+      generic_name: standard_d64alds_v6
+      id: Standard_D64alds_v6
+      memory: 137438953472
+      name: Standard_D64alds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDaldsv7Family
+      generic_name: standard_d64alds_v7
+      id: Standard_D64alds_v7
+      memory: 137438953472
+      name: Standard_D64alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDalv6Family
+      generic_name: standard_d64als_v6
+      id: Standard_D64als_v6
+      memory: 137438953472
+      name: Standard_D64als_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDalsv7Family
+      generic_name: standard_d64als_v7
+      id: Standard_D64als_v7
+      memory: 137438953472
+      name: Standard_D64als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDASv4Family
+      generic_name: standard_d64as_v4
+      id: Standard_D64as_v4
+      memory: 274877906944
+      name: Standard_D64as_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDASv5Family
+      generic_name: standard_d64as_v5
+      id: Standard_D64as_v5
+      memory: 274877906944
+      name: Standard_D64as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDav6Family
+      generic_name: standard_d64as_v6
+      id: Standard_D64as_v6
+      memory: 274877906944
+      name: Standard_D64as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDasv7Family
+      generic_name: standard_d64as_v7
+      id: Standard_D64as_v7
+      memory: 274877906944
+      name: Standard_D64as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDAv4Family
+      generic_name: standard_d64a_v4
+      id: Standard_D64a_v4
+      memory: 274877906944
+      name: Standard_D64a_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDDSv4Family
+      generic_name: standard_d64ds_v4
+      id: Standard_D64ds_v4
+      memory: 274877906944
+      name: Standard_D64ds_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDDSv5Family
+      generic_name: standard_d64ds_v5
+      id: Standard_D64ds_v5
+      memory: 274877906944
+      name: Standard_D64ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDdsv6Family
+      generic_name: standard_d64ds_v6
+      id: Standard_D64ds_v6
+      memory: 274877906944
+      name: Standard_D64ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDDv4Family
+      generic_name: standard_d64d_v4
+      id: Standard_D64d_v4
+      memory: 274877906944
+      name: Standard_D64d_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDDv5Family
+      generic_name: standard_d64d_v5
+      id: Standard_D64d_v5
+      memory: 274877906944
+      name: Standard_D64d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDLDSv5Family
+      generic_name: standard_d64lds_v5
+      id: Standard_D64lds_v5
+      memory: 137438953472
+      name: Standard_D64lds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDldsv6Family
+      generic_name: standard_d64lds_v6
+      id: Standard_D64lds_v6
+      memory: 137438953472
+      name: Standard_D64lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDLSv5Family
+      generic_name: standard_d64ls_v5
+      id: Standard_D64ls_v5
+      memory: 137438953472
+      name: Standard_D64ls_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDlsv6Family
+      generic_name: standard_d64ls_v6
+      id: Standard_D64ls_v6
+      memory: 137438953472
+      name: Standard_D64ls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDPDSv5Family
+      generic_name: standard_d64pds_v5
+      id: Standard_D64pds_v5
+      memory: 223338299392
+      name: Standard_D64pds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDpdsv6Family
+      generic_name: standard_d64pds_v6
+      id: Standard_D64pds_v6
+      memory: 274877906944
+      name: Standard_D64pds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDPLDSv5Family
+      generic_name: standard_d64plds_v5
+      id: Standard_D64plds_v5
+      memory: 137438953472
+      name: Standard_D64plds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDpldsv6Family
       generic_name: standard_d64plds_v6
       id: Standard_D64plds_v6
       memory: 137438953472
@@ -5899,7 +2630,557 @@ data:
     - architecture: arm64
       category: general_purpose
       cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDPLSv5Family
+      generic_name: standard_d64pls_v5
+      id: Standard_D64pls_v5
+      memory: 137438953472
+      name: Standard_D64pls_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDplsv6Family
+      generic_name: standard_d64pls_v6
+      id: Standard_D64pls_v6
+      memory: 137438953472
+      name: Standard_D64pls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDPSv5Family
+      generic_name: standard_d64ps_v5
+      id: Standard_D64ps_v5
+      memory: 223338299392
+      name: Standard_D64ps_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDpsv6Family
+      generic_name: standard_d64ps_v6
+      id: Standard_D64ps_v6
+      memory: 274877906944
+      name: Standard_D64ps_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDSv3Family
+      generic_name: standard_d64s_v3
+      id: Standard_D64s_v3
+      memory: 274877906944
+      name: Standard_D64s_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDSv4Family
+      generic_name: standard_d64s_v4
+      id: Standard_D64s_v4
+      memory: 274877906944
+      name: Standard_D64s_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDSv5Family
+      generic_name: standard_d64s_v5
+      id: Standard_D64s_v5
+      memory: 274877906944
+      name: Standard_D64s_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDsv6Family
+      generic_name: standard_d64s_v6
+      id: Standard_D64s_v6
+      memory: 274877906944
+      name: Standard_D64s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDv3Family
+      generic_name: standard_d64_v3
+      id: Standard_D64_v3
+      memory: 274877906944
+      name: Standard_D64_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDv4Family
+      generic_name: standard_d64_v4
+      id: Standard_D64_v4
+      memory: 274877906944
+      name: Standard_D64_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDv5Family
+      generic_name: standard_d64_v5
+      id: Standard_D64_v5
+      memory: 274877906944
+      name: Standard_D64_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDADSv5Family
+      generic_name: standard_d8ads_v5
+      id: Standard_D8ads_v5
+      memory: 34359738368
+      name: Standard_D8ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDadv6Family
+      generic_name: standard_d8ads_v6
+      id: Standard_D8ads_v6
+      memory: 34359738368
+      name: Standard_D8ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDadsv7Family
+      generic_name: standard_d8ads_v7
+      id: Standard_D8ads_v7
+      memory: 34359738368
+      name: Standard_D8ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDaldv6Family
+      generic_name: standard_d8alds_v6
+      id: Standard_D8alds_v6
+      memory: 17179869184
+      name: Standard_D8alds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDaldsv7Family
+      generic_name: standard_d8alds_v7
+      id: Standard_D8alds_v7
+      memory: 17179869184
+      name: Standard_D8alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDalv6Family
+      generic_name: standard_d8als_v6
+      id: Standard_D8als_v6
+      memory: 17179869184
+      name: Standard_D8als_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDalsv7Family
+      generic_name: standard_d8als_v7
+      id: Standard_D8als_v7
+      memory: 17179869184
+      name: Standard_D8als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDASv4Family
+      generic_name: standard_d8as_v4
+      id: Standard_D8as_v4
+      memory: 34359738368
+      name: Standard_D8as_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDASv5Family
+      generic_name: standard_d8as_v5
+      id: Standard_D8as_v5
+      memory: 34359738368
+      name: Standard_D8as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDav6Family
+      generic_name: standard_d8as_v6
+      id: Standard_D8as_v6
+      memory: 34359738368
+      name: Standard_D8as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDasv7Family
+      generic_name: standard_d8as_v7
+      id: Standard_D8as_v7
+      memory: 34359738368
+      name: Standard_D8as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDAv4Family
+      generic_name: standard_d8a_v4
+      id: Standard_D8a_v4
+      memory: 34359738368
+      name: Standard_D8a_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDDSv4Family
+      generic_name: standard_d8ds_v4
+      id: Standard_D8ds_v4
+      memory: 34359738368
+      name: Standard_D8ds_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDDSv5Family
+      generic_name: standard_d8ds_v5
+      id: Standard_D8ds_v5
+      memory: 34359738368
+      name: Standard_D8ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDdsv6Family
+      generic_name: standard_d8ds_v6
+      id: Standard_D8ds_v6
+      memory: 34359738368
+      name: Standard_D8ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDDv4Family
+      generic_name: standard_d8d_v4
+      id: Standard_D8d_v4
+      memory: 34359738368
+      name: Standard_D8d_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDDv5Family
+      generic_name: standard_d8d_v5
+      id: Standard_D8d_v5
+      memory: 34359738368
+      name: Standard_D8d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDLDSv5Family
+      generic_name: standard_d8lds_v5
+      id: Standard_D8lds_v5
+      memory: 17179869184
+      name: Standard_D8lds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDldsv6Family
+      generic_name: standard_d8lds_v6
+      id: Standard_D8lds_v6
+      memory: 17179869184
+      name: Standard_D8lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDLSv5Family
+      generic_name: standard_d8ls_v5
+      id: Standard_D8ls_v5
+      memory: 17179869184
+      name: Standard_D8ls_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDlsv6Family
+      generic_name: standard_d8ls_v6
+      id: Standard_D8ls_v6
+      memory: 17179869184
+      name: Standard_D8ls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDPDSv5Family
+      generic_name: standard_d8pds_v5
+      id: Standard_D8pds_v5
+      memory: 34359738368
+      name: Standard_D8pds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDpdsv6Family
+      generic_name: standard_d8pds_v6
+      id: Standard_D8pds_v6
+      memory: 34359738368
+      name: Standard_D8pds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDPLDSv5Family
+      generic_name: standard_d8plds_v5
+      id: Standard_D8plds_v5
+      memory: 17179869184
+      name: Standard_D8plds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDpldsv6Family
+      generic_name: standard_d8plds_v6
+      id: Standard_D8plds_v6
+      memory: 17179869184
+      name: Standard_D8plds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDPLSv5Family
+      generic_name: standard_d8pls_v5
+      id: Standard_D8pls_v5
+      memory: 17179869184
+      name: Standard_D8pls_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDplsv6Family
+      generic_name: standard_d8pls_v6
+      id: Standard_D8pls_v6
+      memory: 17179869184
+      name: Standard_D8pls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDPSv5Family
+      generic_name: standard_d8ps_v5
+      id: Standard_D8ps_v5
+      memory: 34359738368
+      name: Standard_D8ps_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDpsv6Family
+      generic_name: standard_d8ps_v6
+      id: Standard_D8ps_v6
+      memory: 34359738368
+      name: Standard_D8ps_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDSv3Family
+      generic_name: standard_d8s_v3
+      id: Standard_D8s_v3
+      memory: 34359738368
+      name: Standard_D8s_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDSv4Family
+      generic_name: standard_d8s_v4
+      id: Standard_D8s_v4
+      memory: 34359738368
+      name: Standard_D8s_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDSv5Family
+      generic_name: standard_d8s_v5
+      id: Standard_D8s_v5
+      memory: 34359738368
+      name: Standard_D8s_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDsv6Family
+      generic_name: standard_d8s_v6
+      id: Standard_D8s_v6
+      memory: 34359738368
+      name: Standard_D8s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDv3Family
+      generic_name: standard_d8_v3
+      id: Standard_D8_v3
+      memory: 34359738368
+      name: Standard_D8_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDv4Family
+      generic_name: standard_d8_v4
+      id: Standard_D8_v4
+      memory: 34359738368
+      name: Standard_D8_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDv5Family
+      generic_name: standard_d8_v5
+      id: Standard_D8_v5
+      memory: 34359738368
+      name: Standard_D8_v5
+    - category: general_purpose
+      cloud_provider_id: azure
       cpu_cores: 96
+      family: standardDADSv5Family
+      generic_name: standard_d96ads_v5
+      id: Standard_D96ads_v5
+      memory: 412316860416
+      name: Standard_D96ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDadv6Family
+      generic_name: standard_d96ads_v6
+      id: Standard_D96ads_v6
+      memory: 412316860416
+      name: Standard_D96ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardDadsv7Family
+      generic_name: standard_d96ads_v7
+      id: Standard_D96ads_v7
+      memory: 412316860416
+      name: Standard_D96ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDaldv6Family
+      generic_name: standard_d96alds_v6
+      id: Standard_D96alds_v6
+      memory: 206158430208
+      name: Standard_D96alds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardDaldsv7Family
+      generic_name: standard_d96alds_v7
+      id: Standard_D96alds_v7
+      memory: 206158430208
+      name: Standard_D96alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDalv6Family
+      generic_name: standard_d96als_v6
+      id: Standard_D96als_v6
+      memory: 206158430208
+      name: Standard_D96als_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardDalsv7Family
+      generic_name: standard_d96als_v7
+      id: Standard_D96als_v7
+      memory: 206158430208
+      name: Standard_D96als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDASv4Family
+      generic_name: standard_d96as_v4
+      id: Standard_D96as_v4
+      memory: 412316860416
+      name: Standard_D96as_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDASv5Family
+      generic_name: standard_d96as_v5
+      id: Standard_D96as_v5
+      memory: 412316860416
+      name: Standard_D96as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDav6Family
+      generic_name: standard_d96as_v6
+      id: Standard_D96as_v6
+      memory: 412316860416
+      name: Standard_D96as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardDasv7Family
+      generic_name: standard_d96as_v7
+      id: Standard_D96as_v7
+      memory: 412316860416
+      name: Standard_D96as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDAv4Family
+      generic_name: standard_d96a_v4
+      id: Standard_D96a_v4
+      memory: 412316860416
+      name: Standard_D96a_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDDSv5Family
+      generic_name: standard_d96ds_v5
+      id: Standard_D96ds_v5
+      memory: 412316860416
+      name: Standard_D96ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardDdsv6Family
+      generic_name: standard_d96ds_v6
+      id: Standard_D96ds_v6
+      memory: 412316860416
+      name: Standard_D96ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDDv5Family
+      generic_name: standard_d96d_v5
+      id: Standard_D96d_v5
+      memory: 412316860416
+      name: Standard_D96d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDLDSv5Family
+      generic_name: standard_d96lds_v5
+      id: Standard_D96lds_v5
+      memory: 206158430208
+      name: Standard_D96lds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardDldsv6Family
+      generic_name: standard_d96lds_v6
+      id: Standard_D96lds_v6
+      memory: 206158430208
+      name: Standard_D96lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDLSv5Family
+      generic_name: standard_d96ls_v5
+      id: Standard_D96ls_v5
+      memory: 206158430208
+      name: Standard_D96ls_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardDlsv6Family
+      generic_name: standard_d96ls_v6
+      id: Standard_D96ls_v6
+      memory: 206158430208
+      name: Standard_D96ls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardDpdsv6Family
+      generic_name: standard_d96pds_v6
+      id: Standard_D96pds_v6
+      memory: 412316860416
+      name: Standard_D96pds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardDpldsv6Family
       generic_name: standard_d96plds_v6
       id: Standard_D96plds_v6
       memory: 206158430208
@@ -5907,1675 +3188,233 @@ data:
     - architecture: arm64
       category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2ps_v6
-      id: Standard_D2ps_v6
-      memory: 8589934592
-      name: Standard_D2ps_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4ps_v6
-      id: Standard_D4ps_v6
-      memory: 17179869184
-      name: Standard_D4ps_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8ps_v6
-      id: Standard_D8ps_v6
-      memory: 34359738368
-      name: Standard_D8ps_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16ps_v6
-      id: Standard_D16ps_v6
-      memory: 68719476736
-      name: Standard_D16ps_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32ps_v6
-      id: Standard_D32ps_v6
-      memory: 137438953472
-      name: Standard_D32ps_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48ps_v6
-      id: Standard_D48ps_v6
+      cpu_cores: 96
+      family: StandardDplsv6Family
+      generic_name: standard_d96pls_v6
+      id: Standard_D96pls_v6
       memory: 206158430208
-      name: Standard_D48ps_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64ps_v6
-      id: Standard_D64ps_v6
-      memory: 274877906944
-      name: Standard_D64ps_v6
+      name: Standard_D96pls_v6
     - architecture: arm64
       category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 96
+      family: StandardDpsv6Family
       generic_name: standard_d96ps_v6
       id: Standard_D96ps_v6
       memory: 412316860416
       name: Standard_D96ps_v6
-    - architecture: arm64
-      category: memory_optimized
+    - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2ps_v6
-      id: Standard_E2ps_v6
-      memory: 17179869184
-      name: Standard_E2ps_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4ps_v6
-      id: Standard_E4ps_v6
-      memory: 34359738368
-      name: Standard_E4ps_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8ps_v6
-      id: Standard_E8ps_v6
-      memory: 68719476736
-      name: Standard_E8ps_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16ps_v6
-      id: Standard_E16ps_v6
-      memory: 137438953472
-      name: Standard_E16ps_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32ps_v6
-      id: Standard_E32ps_v6
-      memory: 274877906944
-      name: Standard_E32ps_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48ps_v6
-      id: Standard_E48ps_v6
+      cpu_cores: 96
+      family: standardDSv5Family
+      generic_name: standard_d96s_v5
+      id: Standard_D96s_v5
       memory: 412316860416
-      name: Standard_E48ps_v6
-    - architecture: arm64
-      category: memory_optimized
+      name: Standard_D96s_v5
+    - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64ps_v6
-      id: Standard_E64ps_v6
+      cpu_cores: 96
+      family: StandardDsv6Family
+      generic_name: standard_d96s_v6
+      id: Standard_D96s_v6
+      memory: 412316860416
+      name: Standard_D96s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDv5Family
+      generic_name: standard_d96_v5
+      id: Standard_D96_v5
+      memory: 412316860416
+      name: Standard_D96_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: standardDCEDV6Family
+      generic_name: standard_dc128eds_v6
+      id: Standard_DC128eds_v6
       memory: 549755813888
-      name: Standard_E64ps_v6
-    - architecture: arm64
-      category: memory_optimized
+      name: Standard_DC128eds_v6
+    - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96ps_v6
-      id: Standard_E96ps_v6
-      memory: 721554505728
-      name: Standard_E96ps_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2pds_v6
-      id: Standard_E2pds_v6
-      memory: 17179869184
-      name: Standard_E2pds_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4pds_v6
-      id: Standard_E4pds_v6
-      memory: 34359738368
-      name: Standard_E4pds_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8pds_v6
-      id: Standard_E8pds_v6
-      memory: 68719476736
-      name: Standard_E8pds_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16pds_v6
-      id: Standard_E16pds_v6
-      memory: 137438953472
-      name: Standard_E16pds_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32pds_v6
-      id: Standard_E32pds_v6
-      memory: 274877906944
-      name: Standard_E32pds_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48pds_v6
-      id: Standard_E48pds_v6
-      memory: 412316860416
-      name: Standard_E48pds_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64pds_v6
-      id: Standard_E64pds_v6
+      cpu_cores: 128
+      family: standardDCEV6Family
+      generic_name: standard_dc128es_v6
+      id: Standard_DC128es_v6
       memory: 549755813888
-      name: Standard_E64pds_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96pds_v6
-      id: Standard_E96pds_v6
-      memory: 721554505728
-      name: Standard_E96pds_v6
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 24
-      generic_name: standard_nc24ads_a100_v4
-      id: Standard_NC24ads_A100_v4
-      memory: 236223201280
-      name: Standard_NC24ads_A100_v4
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_nc48ads_a100_v4
-      id: Standard_NC48ads_A100_v4
-      memory: 472446402560
-      name: Standard_NC48ads_A100_v4
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_nc96ads_a100_v4
-      id: Standard_NC96ads_A100_v4
-      memory: 944892805120
-      name: Standard_NC96ads_A100_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_dc2as_v6
-      id: Standard_DC2as_v6
-      memory: 8589934592
-      name: Standard_DC2as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_dc4as_v6
-      id: Standard_DC4as_v6
-      memory: 17179869184
-      name: Standard_DC4as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_dc8as_v6
-      id: Standard_DC8as_v6
-      memory: 34359738368
-      name: Standard_DC8as_v6
+      name: Standard_DC128es_v6
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_dc16as_v6
-      id: Standard_DC16as_v6
+      family: standardDCADCCV5Family
+      generic_name: standard_dc16ads_cc_v5
+      id: Standard_DC16ads_cc_v5
       memory: 68719476736
-      name: Standard_DC16as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_dc32as_v6
-      id: Standard_DC32as_v6
-      memory: 137438953472
-      name: Standard_DC32as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_dc48as_v6
-      id: Standard_DC48as_v6
-      memory: 206158430208
-      name: Standard_DC48as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_dc64as_v6
-      id: Standard_DC64as_v6
-      memory: 274877906944
-      name: Standard_DC64as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_dc96as_v6
-      id: Standard_DC96as_v6
-      memory: 412316860416
-      name: Standard_DC96as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_dc2ads_v6
-      id: Standard_DC2ads_v6
-      memory: 8589934592
-      name: Standard_DC2ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_dc4ads_v6
-      id: Standard_DC4ads_v6
-      memory: 17179869184
-      name: Standard_DC4ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_dc8ads_v6
-      id: Standard_DC8ads_v6
-      memory: 34359738368
-      name: Standard_DC8ads_v6
+      name: Standard_DC16ads_cc_v5
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
+      family: standardDCADSv5Family
+      generic_name: standard_dc16ads_v5
+      id: Standard_DC16ads_v5
+      memory: 68719476736
+      name: Standard_DC16ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDCadsv6Family
       generic_name: standard_dc16ads_v6
       id: Standard_DC16ads_v6
       memory: 68719476736
       name: Standard_DC16ads_v6
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_dc32ads_v6
-      id: Standard_DC32ads_v6
-      memory: 137438953472
-      name: Standard_DC32ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_dc48ads_v6
-      id: Standard_DC48ads_v6
-      memory: 206158430208
-      name: Standard_DC48ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_dc64ads_v6
-      id: Standard_DC64ads_v6
-      memory: 274877906944
-      name: Standard_DC64ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_dc96ads_v6
-      id: Standard_DC96ads_v6
-      memory: 412316860416
-      name: Standard_DC96ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_ec2as_v6
-      id: Standard_EC2as_v6
-      memory: 17179869184
-      name: Standard_EC2as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_ec4as_v6
-      id: Standard_EC4as_v6
-      memory: 34359738368
-      name: Standard_EC4as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_ec8as_v6
-      id: Standard_EC8as_v6
+      cpu_cores: 16
+      family: standardDCACCV5Family
+      generic_name: standard_dc16as_cc_v5
+      id: Standard_DC16as_cc_v5
       memory: 68719476736
-      name: Standard_EC8as_v6
-    - category: memory_optimized
+      name: Standard_DC16as_cc_v5
+    - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_ec16as_v6
-      id: Standard_EC16as_v6
-      memory: 137438953472
-      name: Standard_EC16as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_ec32as_v6
-      id: Standard_EC32as_v6
-      memory: 274877906944
-      name: Standard_EC32as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_ec48as_v6
-      id: Standard_EC48as_v6
-      memory: 412316860416
-      name: Standard_EC48as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_ec64as_v6
-      id: Standard_EC64as_v6
-      memory: 549755813888
-      name: Standard_EC64as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_ec96as_v6
-      id: Standard_EC96as_v6
-      memory: 721554505728
-      name: Standard_EC96as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_ec2ads_v6
-      id: Standard_EC2ads_v6
-      memory: 17179869184
-      name: Standard_EC2ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_ec4ads_v6
-      id: Standard_EC4ads_v6
-      memory: 34359738368
-      name: Standard_EC4ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_ec8ads_v6
-      id: Standard_EC8ads_v6
+      family: standardDCASv5Family
+      generic_name: standard_dc16as_v5
+      id: Standard_DC16as_v5
       memory: 68719476736
-      name: Standard_EC8ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_ec16ads_v6
-      id: Standard_EC16ads_v6
-      memory: 137438953472
-      name: Standard_EC16ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_ec32ads_v6
-      id: Standard_EC32ads_v6
-      memory: 274877906944
-      name: Standard_EC32ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_ec48ads_v6
-      id: Standard_EC48ads_v6
-      memory: 412316860416
-      name: Standard_EC48ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_ec64ads_v6
-      id: Standard_EC64ads_v6
-      memory: 549755813888
-      name: Standard_EC64ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_ec96ads_v6
-      id: Standard_EC96ads_v6
-      memory: 721554505728
-      name: Standard_EC96ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2als_v7
-      id: Standard_D2als_v7
-      memory: 4294967296
-      name: Standard_D2als_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4als_v7
-      id: Standard_D4als_v7
-      memory: 8589934592
-      name: Standard_D4als_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8als_v7
-      id: Standard_D8als_v7
-      memory: 17179869184
-      name: Standard_D8als_v7
+      name: Standard_DC16as_v5
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_d16als_v7
-      id: Standard_D16als_v7
-      memory: 34359738368
-      name: Standard_D16als_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32als_v7
-      id: Standard_D32als_v7
+      family: standardDCasv6Family
+      generic_name: standard_dc16as_v6
+      id: Standard_DC16as_v6
       memory: 68719476736
-      name: Standard_D32als_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48als_v7
-      id: Standard_D48als_v7
-      memory: 103079215104
-      name: Standard_D48als_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64als_v7
-      id: Standard_D64als_v7
-      memory: 137438953472
-      name: Standard_D64als_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96als_v7
-      id: Standard_D96als_v7
-      memory: 206158430208
-      name: Standard_D96als_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_d128als_v7
-      id: Standard_D128als_v7
-      memory: 274877906944
-      name: Standard_D128als_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 160
-      generic_name: standard_d160als_v7
-      id: Standard_D160als_v7
-      memory: 343597383680
-      name: Standard_D160als_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2alds_v7
-      id: Standard_D2alds_v7
-      memory: 4294967296
-      name: Standard_D2alds_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4alds_v7
-      id: Standard_D4alds_v7
-      memory: 8589934592
-      name: Standard_D4alds_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8alds_v7
-      id: Standard_D8alds_v7
-      memory: 17179869184
-      name: Standard_D8alds_v7
+      name: Standard_DC16as_v6
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_d16alds_v7
-      id: Standard_D16alds_v7
-      memory: 34359738368
-      name: Standard_D16alds_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32alds_v7
-      id: Standard_D32alds_v7
+      family: standardDCEDV6Family
+      generic_name: standard_dc16eds_v6
+      id: Standard_DC16eds_v6
       memory: 68719476736
-      name: Standard_D32alds_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48alds_v7
-      id: Standard_D48alds_v7
-      memory: 103079215104
-      name: Standard_D48alds_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64alds_v7
-      id: Standard_D64alds_v7
-      memory: 137438953472
-      name: Standard_D64alds_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96alds_v7
-      id: Standard_D96alds_v7
-      memory: 206158430208
-      name: Standard_D96alds_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_d128alds_v7
-      id: Standard_D128alds_v7
-      memory: 274877906944
-      name: Standard_D128alds_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 160
-      generic_name: standard_d160alds_v7
-      id: Standard_D160alds_v7
-      memory: 343597383680
-      name: Standard_D160alds_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2as_v7
-      id: Standard_D2as_v7
-      memory: 8589934592
-      name: Standard_D2as_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4as_v7
-      id: Standard_D4as_v7
-      memory: 17179869184
-      name: Standard_D4as_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8as_v7
-      id: Standard_D8as_v7
-      memory: 34359738368
-      name: Standard_D8as_v7
+      name: Standard_DC16eds_v6
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_d16as_v7
-      id: Standard_D16as_v7
-      memory: 68719476736
-      name: Standard_D16as_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32as_v7
-      id: Standard_D32as_v7
-      memory: 137438953472
-      name: Standard_D32as_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48as_v7
-      id: Standard_D48as_v7
-      memory: 206158430208
-      name: Standard_D48as_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64as_v7
-      id: Standard_D64as_v7
-      memory: 274877906944
-      name: Standard_D64as_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96as_v7
-      id: Standard_D96as_v7
-      memory: 412316860416
-      name: Standard_D96as_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_d128as_v7
-      id: Standard_D128as_v7
-      memory: 549755813888
-      name: Standard_D128as_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 160
-      generic_name: standard_d160as_v7
-      id: Standard_D160as_v7
-      memory: 687194767360
-      name: Standard_D160as_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2ads_v7
-      id: Standard_D2ads_v7
-      memory: 8589934592
-      name: Standard_D2ads_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4ads_v7
-      id: Standard_D4ads_v7
-      memory: 17179869184
-      name: Standard_D4ads_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8ads_v7
-      id: Standard_D8ads_v7
-      memory: 34359738368
-      name: Standard_D8ads_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16ads_v7
-      id: Standard_D16ads_v7
-      memory: 68719476736
-      name: Standard_D16ads_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32ads_v7
-      id: Standard_D32ads_v7
-      memory: 137438953472
-      name: Standard_D32ads_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48ads_v7
-      id: Standard_D48ads_v7
-      memory: 206158430208
-      name: Standard_D48ads_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64ads_v7
-      id: Standard_D64ads_v7
-      memory: 274877906944
-      name: Standard_D64ads_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96ads_v7
-      id: Standard_D96ads_v7
-      memory: 412316860416
-      name: Standard_D96ads_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_d128ads_v7
-      id: Standard_D128ads_v7
-      memory: 549755813888
-      name: Standard_D128ads_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 160
-      generic_name: standard_d160ads_v7
-      id: Standard_D160ads_v7
-      memory: 687194767360
-      name: Standard_D160ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2as_v7
-      id: Standard_E2as_v7
-      memory: 17179869184
-      name: Standard_E2as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2as_v7
-      id: Standard_E4-2as_v7
-      memory: 34359738368
-      name: Standard_E4-2as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4as_v7
-      id: Standard_E4as_v7
-      memory: 34359738368
-      name: Standard_E4as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2as_v7
-      id: Standard_E8-2as_v7
-      memory: 68719476736
-      name: Standard_E8-2as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4as_v7
-      id: Standard_E8-4as_v7
-      memory: 68719476736
-      name: Standard_E8-4as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8as_v7
-      id: Standard_E8as_v7
-      memory: 68719476736
-      name: Standard_E8as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-4as_v7
-      id: Standard_E16-4as_v7
-      memory: 137438953472
-      name: Standard_E16-4as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8as_v7
-      id: Standard_E16-8as_v7
-      memory: 137438953472
-      name: Standard_E16-8as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16as_v7
-      id: Standard_E16as_v7
-      memory: 137438953472
-      name: Standard_E16as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8as_v7
-      id: Standard_E32-8as_v7
-      memory: 274877906944
-      name: Standard_E32-8as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16as_v7
-      id: Standard_E32-16as_v7
-      memory: 274877906944
-      name: Standard_E32-16as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32as_v7
-      id: Standard_E32as_v7
-      memory: 274877906944
-      name: Standard_E32as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48as_v7
-      id: Standard_E48as_v7
-      memory: 412316860416
-      name: Standard_E48as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16as_v7
-      id: Standard_E64-16as_v7
-      memory: 549755813888
-      name: Standard_E64-16as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32as_v7
-      id: Standard_E64-32as_v7
-      memory: 549755813888
-      name: Standard_E64-32as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64as_v7
-      id: Standard_E64as_v7
-      memory: 549755813888
-      name: Standard_E64as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-24as_v7
-      id: Standard_E96-24as_v7
-      memory: 824633720832
-      name: Standard_E96-24as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-48as_v7
-      id: Standard_E96-48as_v7
-      memory: 824633720832
-      name: Standard_E96-48as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96as_v7
-      id: Standard_E96as_v7
-      memory: 824633720832
-      name: Standard_E96as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128-32as_v7
-      id: Standard_E128-32as_v7
-      memory: 1099511627776
-      name: Standard_E128-32as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128-64as_v7
-      id: Standard_E128-64as_v7
-      memory: 1099511627776
-      name: Standard_E128-64as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128as_v7
-      id: Standard_E128as_v7
-      memory: 1099511627776
-      name: Standard_E128as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2ads_v7
-      id: Standard_E2ads_v7
-      memory: 17179869184
-      name: Standard_E2ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2ads_v7
-      id: Standard_E4-2ads_v7
-      memory: 34359738368
-      name: Standard_E4-2ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4ads_v7
-      id: Standard_E4ads_v7
-      memory: 34359738368
-      name: Standard_E4ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2ads_v7
-      id: Standard_E8-2ads_v7
-      memory: 68719476736
-      name: Standard_E8-2ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4ads_v7
-      id: Standard_E8-4ads_v7
-      memory: 68719476736
-      name: Standard_E8-4ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8ads_v7
-      id: Standard_E8ads_v7
-      memory: 68719476736
-      name: Standard_E8ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-4ads_v7
-      id: Standard_E16-4ads_v7
-      memory: 137438953472
-      name: Standard_E16-4ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8ads_v7
-      id: Standard_E16-8ads_v7
-      memory: 137438953472
-      name: Standard_E16-8ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16ads_v7
-      id: Standard_E16ads_v7
-      memory: 137438953472
-      name: Standard_E16ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8ads_v7
-      id: Standard_E32-8ads_v7
-      memory: 274877906944
-      name: Standard_E32-8ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16ads_v7
-      id: Standard_E32-16ads_v7
-      memory: 274877906944
-      name: Standard_E32-16ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32ads_v7
-      id: Standard_E32ads_v7
-      memory: 274877906944
-      name: Standard_E32ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48ads_v7
-      id: Standard_E48ads_v7
-      memory: 412316860416
-      name: Standard_E48ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16ads_v7
-      id: Standard_E64-16ads_v7
-      memory: 549755813888
-      name: Standard_E64-16ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32ads_v7
-      id: Standard_E64-32ads_v7
-      memory: 549755813888
-      name: Standard_E64-32ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64ads_v7
-      id: Standard_E64ads_v7
-      memory: 549755813888
-      name: Standard_E64ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-24ads_v7
-      id: Standard_E96-24ads_v7
-      memory: 824633720832
-      name: Standard_E96-24ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-48ads_v7
-      id: Standard_E96-48ads_v7
-      memory: 824633720832
-      name: Standard_E96-48ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96ads_v7
-      id: Standard_E96ads_v7
-      memory: 824633720832
-      name: Standard_E96ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128-32ads_v7
-      id: Standard_E128-32ads_v7
-      memory: 1099511627776
-      name: Standard_E128-32ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128-64ads_v7
-      id: Standard_E128-64ads_v7
-      memory: 1099511627776
-      name: Standard_E128-64ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128ads_v7
-      id: Standard_E128ads_v7
-      memory: 1099511627776
-      name: Standard_E128ads_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 1
-      generic_name: standard_f1als_v7
-      id: Standard_F1als_v7
-      memory: 2147483648
-      name: Standard_F1als_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2als_v7
-      id: Standard_F2als_v7
-      memory: 4294967296
-      name: Standard_F2als_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4als_v7
-      id: Standard_F4als_v7
-      memory: 8589934592
-      name: Standard_F4als_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8als_v7
-      id: Standard_F8als_v7
-      memory: 17179869184
-      name: Standard_F8als_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16als_v7
-      id: Standard_F16als_v7
-      memory: 34359738368
-      name: Standard_F16als_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32als_v7
-      id: Standard_F32als_v7
-      memory: 68719476736
-      name: Standard_F32als_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_f48als_v7
-      id: Standard_F48als_v7
-      memory: 103079215104
-      name: Standard_F48als_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64als_v7
-      id: Standard_F64als_v7
-      memory: 137438953472
-      name: Standard_F64als_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_f80als_v7
-      id: Standard_F80als_v7
-      memory: 171798691840
-      name: Standard_F80als_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 1
-      generic_name: standard_f1alds_v7
-      id: Standard_F1alds_v7
-      memory: 2147483648
-      name: Standard_F1alds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2alds_v7
-      id: Standard_F2alds_v7
-      memory: 4294967296
-      name: Standard_F2alds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4alds_v7
-      id: Standard_F4alds_v7
-      memory: 8589934592
-      name: Standard_F4alds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8alds_v7
-      id: Standard_F8alds_v7
-      memory: 17179869184
-      name: Standard_F8alds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16alds_v7
-      id: Standard_F16alds_v7
-      memory: 34359738368
-      name: Standard_F16alds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32alds_v7
-      id: Standard_F32alds_v7
-      memory: 68719476736
-      name: Standard_F32alds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_f48alds_v7
-      id: Standard_F48alds_v7
-      memory: 103079215104
-      name: Standard_F48alds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64alds_v7
-      id: Standard_F64alds_v7
-      memory: 137438953472
-      name: Standard_F64alds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_f80alds_v7
-      id: Standard_F80alds_v7
-      memory: 171798691840
-      name: Standard_F80alds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 1
-      generic_name: standard_f1as_v7
-      id: Standard_F1as_v7
-      memory: 4294967296
-      name: Standard_F1as_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2as_v7
-      id: Standard_F2as_v7
-      memory: 8589934592
-      name: Standard_F2as_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4as_v7
-      id: Standard_F4as_v7
-      memory: 17179869184
-      name: Standard_F4as_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8as_v7
-      id: Standard_F8as_v7
-      memory: 34359738368
-      name: Standard_F8as_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16as_v7
-      id: Standard_F16as_v7
-      memory: 68719476736
-      name: Standard_F16as_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32as_v7
-      id: Standard_F32as_v7
-      memory: 137438953472
-      name: Standard_F32as_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_f48as_v7
-      id: Standard_F48as_v7
-      memory: 206158430208
-      name: Standard_F48as_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64as_v7
-      id: Standard_F64as_v7
-      memory: 274877906944
-      name: Standard_F64as_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_f80as_v7
-      id: Standard_F80as_v7
-      memory: 343597383680
-      name: Standard_F80as_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 1
-      generic_name: standard_f1ads_v7
-      id: Standard_F1ads_v7
-      memory: 4294967296
-      name: Standard_F1ads_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2ads_v7
-      id: Standard_F2ads_v7
-      memory: 8589934592
-      name: Standard_F2ads_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4ads_v7
-      id: Standard_F4ads_v7
-      memory: 17179869184
-      name: Standard_F4ads_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8ads_v7
-      id: Standard_F8ads_v7
-      memory: 34359738368
-      name: Standard_F8ads_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16ads_v7
-      id: Standard_F16ads_v7
-      memory: 68719476736
-      name: Standard_F16ads_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32ads_v7
-      id: Standard_F32ads_v7
-      memory: 137438953472
-      name: Standard_F32ads_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_f48ads_v7
-      id: Standard_F48ads_v7
-      memory: 206158430208
-      name: Standard_F48ads_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64ads_v7
-      id: Standard_F64ads_v7
-      memory: 274877906944
-      name: Standard_F64ads_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_f80ads_v7
-      id: Standard_F80ads_v7
-      memory: 343597383680
-      name: Standard_F80ads_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 1
-      generic_name: standard_f1ams_v7
-      id: Standard_F1ams_v7
-      memory: 8589934592
-      name: Standard_F1ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2-1ams_v7
-      id: Standard_F2-1ams_v7
-      memory: 17179869184
-      name: Standard_F2-1ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2ams_v7
-      id: Standard_F2ams_v7
-      memory: 17179869184
-      name: Standard_F2ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4-1ams_v7
-      id: Standard_F4-1ams_v7
-      memory: 34359738368
-      name: Standard_F4-1ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4-2ams_v7
-      id: Standard_F4-2ams_v7
-      memory: 34359738368
-      name: Standard_F4-2ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4ams_v7
-      id: Standard_F4ams_v7
-      memory: 34359738368
-      name: Standard_F4ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8-2ams_v7
-      id: Standard_F8-2ams_v7
-      memory: 68719476736
-      name: Standard_F8-2ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8-4ams_v7
-      id: Standard_F8-4ams_v7
-      memory: 68719476736
-      name: Standard_F8-4ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8ams_v7
-      id: Standard_F8ams_v7
-      memory: 68719476736
-      name: Standard_F8ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16-4ams_v7
-      id: Standard_F16-4ams_v7
-      memory: 137438953472
-      name: Standard_F16-4ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16-8ams_v7
-      id: Standard_F16-8ams_v7
-      memory: 137438953472
-      name: Standard_F16-8ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16ams_v7
-      id: Standard_F16ams_v7
-      memory: 137438953472
-      name: Standard_F16ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32-8ams_v7
-      id: Standard_F32-8ams_v7
-      memory: 274877906944
-      name: Standard_F32-8ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32-16ams_v7
-      id: Standard_F32-16ams_v7
-      memory: 274877906944
-      name: Standard_F32-16ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32ams_v7
-      id: Standard_F32ams_v7
-      memory: 274877906944
-      name: Standard_F32ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_f48ams_v7
-      id: Standard_F48ams_v7
-      memory: 412316860416
-      name: Standard_F48ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_f64-16ams_v7
-      id: Standard_F64-16ams_v7
-      memory: 549755813888
-      name: Standard_F64-16ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64-32ams_v7
-      id: Standard_F64-32ams_v7
-      memory: 549755813888
-      name: Standard_F64-32ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64ams_v7
-      id: Standard_F64ams_v7
-      memory: 549755813888
-      name: Standard_F64ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_f80ams_v7
-      id: Standard_F80ams_v7
-      memory: 687194767360
-      name: Standard_F80ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 1
-      generic_name: standard_f1amds_v7
-      id: Standard_F1amds_v7
-      memory: 8589934592
-      name: Standard_F1amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2-1amds_v7
-      id: Standard_F2-1amds_v7
-      memory: 17179869184
-      name: Standard_F2-1amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2amds_v7
-      id: Standard_F2amds_v7
-      memory: 17179869184
-      name: Standard_F2amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4-1amds_v7
-      id: Standard_F4-1amds_v7
-      memory: 34359738368
-      name: Standard_F4-1amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4-2amds_v7
-      id: Standard_F4-2amds_v7
-      memory: 34359738368
-      name: Standard_F4-2amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4amds_v7
-      id: Standard_F4amds_v7
-      memory: 34359738368
-      name: Standard_F4amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8-2amds_v7
-      id: Standard_F8-2amds_v7
-      memory: 68719476736
-      name: Standard_F8-2amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8-4amds_v7
-      id: Standard_F8-4amds_v7
-      memory: 68719476736
-      name: Standard_F8-4amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8amds_v7
-      id: Standard_F8amds_v7
-      memory: 68719476736
-      name: Standard_F8amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16-4amds_v7
-      id: Standard_F16-4amds_v7
-      memory: 137438953472
-      name: Standard_F16-4amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16-8amds_v7
-      id: Standard_F16-8amds_v7
-      memory: 137438953472
-      name: Standard_F16-8amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16amds_v7
-      id: Standard_F16amds_v7
-      memory: 137438953472
-      name: Standard_F16amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32-8amds_v7
-      id: Standard_F32-8amds_v7
-      memory: 274877906944
-      name: Standard_F32-8amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32-16amds_v7
-      id: Standard_F32-16amds_v7
-      memory: 274877906944
-      name: Standard_F32-16amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32amds_v7
-      id: Standard_F32amds_v7
-      memory: 274877906944
-      name: Standard_F32amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_f48amds_v7
-      id: Standard_F48amds_v7
-      memory: 412316860416
-      name: Standard_F48amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64-16amds_v7
-      id: Standard_F64-16amds_v7
-      memory: 549755813888
-      name: Standard_F64-16amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64-32amds_v7
-      id: Standard_F64-32amds_v7
-      memory: 549755813888
-      name: Standard_F64-32amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64amds_v7
-      id: Standard_F64amds_v7
-      memory: 549755813888
-      name: Standard_F64amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_f80amds_v7
-      id: Standard_F80amds_v7
-      memory: 687194767360
-      name: Standard_F80amds_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96ias_v4
-      id: Standard_E96ias_v4
-      memory: 721554505728
-      name: Standard_E96ias_v4
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_nd96isr_h200_v5
-      id: Standard_ND96isr_H200_v5
-      memory: 1986422374400
-      name: Standard_ND96isr_H200_v5
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_nv4as_v4
-      id: Standard_NV4as_v4
-      memory: 15032385536
-      name: Standard_NV4as_v4
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_nv8as_v4
-      id: Standard_NV8as_v4
-      memory: 30064771072
-      name: Standard_NV8as_v4
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_nv16as_v4
-      id: Standard_NV16as_v4
-      memory: 60129542144
-      name: Standard_NV16as_v4
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_nv32as_v4
-      id: Standard_NV32as_v4
-      memory: 120259084288
-      name: Standard_NV32as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 160
-      generic_name: standard_e160as_v7
-      id: Standard_E160as_v7
-      memory: 1374389534720
-      name: Standard_E160as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 160
-      generic_name: standard_e160ads_v7
-      id: Standard_E160ads_v7
-      memory: 1374389534720
-      name: Standard_E160ads_v7
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 6
-      generic_name: standard_nc6s_v3
-      id: Standard_NC6s_v3
-      memory: 120259084288
-      name: Standard_NC6s_v3
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 12
-      generic_name: standard_nc12s_v3
-      id: Standard_NC12s_v3
-      memory: 240518168576
-      name: Standard_NC12s_v3
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 24
-      generic_name: standard_nc24rs_v3
-      id: Standard_NC24rs_v3
-      memory: 481036337152
-      name: Standard_NC24rs_v3
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 24
-      generic_name: standard_nc24s_v3
-      id: Standard_NC24s_v3
-      memory: 481036337152
-      name: Standard_NC24s_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_dc2es_v6
-      id: Standard_DC2es_v6
-      memory: 8589934592
-      name: Standard_DC2es_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_dc4es_v6
-      id: Standard_DC4es_v6
-      memory: 17179869184
-      name: Standard_DC4es_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_dc8es_v6
-      id: Standard_DC8es_v6
-      memory: 34359738368
-      name: Standard_DC8es_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
+      family: standardDCEV6Family
       generic_name: standard_dc16es_v6
       id: Standard_DC16es_v6
       memory: 68719476736
       name: Standard_DC16es_v6
     - category: general_purpose
       cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDCADSv5Family
+      generic_name: standard_dc2ads_v5
+      id: Standard_DC2ads_v5
+      memory: 8589934592
+      name: Standard_DC2ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDCadsv6Family
+      generic_name: standard_dc2ads_v6
+      id: Standard_DC2ads_v6
+      memory: 8589934592
+      name: Standard_DC2ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDCASv5Family
+      generic_name: standard_dc2as_v5
+      id: Standard_DC2as_v5
+      memory: 8589934592
+      name: Standard_DC2as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDCasv6Family
+      generic_name: standard_dc2as_v6
+      id: Standard_DC2as_v6
+      memory: 8589934592
+      name: Standard_DC2as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDCEDV6Family
+      generic_name: standard_dc2eds_v6
+      id: Standard_DC2eds_v6
+      memory: 8589934592
+      name: Standard_DC2eds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDCEV6Family
+      generic_name: standard_dc2es_v6
+      id: Standard_DC2es_v6
+      memory: 8589934592
+      name: Standard_DC2es_v6
+    - category: general_purpose
+      cloud_provider_id: azure
       cpu_cores: 32
+      family: standardDCADCCV5Family
+      generic_name: standard_dc32ads_cc_v5
+      id: Standard_DC32ads_cc_v5
+      memory: 137438953472
+      name: Standard_DC32ads_cc_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDCADSv5Family
+      generic_name: standard_dc32ads_v5
+      id: Standard_DC32ads_v5
+      memory: 137438953472
+      name: Standard_DC32ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDCadsv6Family
+      generic_name: standard_dc32ads_v6
+      id: Standard_DC32ads_v6
+      memory: 137438953472
+      name: Standard_DC32ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDCACCV5Family
+      generic_name: standard_dc32as_cc_v5
+      id: Standard_DC32as_cc_v5
+      memory: 137438953472
+      name: Standard_DC32as_cc_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDCASv5Family
+      generic_name: standard_dc32as_v5
+      id: Standard_DC32as_v5
+      memory: 137438953472
+      name: Standard_DC32as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDCasv6Family
+      generic_name: standard_dc32as_v6
+      id: Standard_DC32as_v6
+      memory: 137438953472
+      name: Standard_DC32as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDCEDV6Family
+      generic_name: standard_dc32eds_v6
+      id: Standard_DC32eds_v6
+      memory: 137438953472
+      name: Standard_DC32eds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDCEV6Family
       generic_name: standard_dc32es_v6
       id: Standard_DC32es_v6
       memory: 137438953472
@@ -7583,125 +3422,3659 @@ data:
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 48
-      generic_name: standard_dc48es_v6
-      id: Standard_DC48es_v6
+      family: standardDCADCCV5Family
+      generic_name: standard_dc48ads_cc_v5
+      id: Standard_DC48ads_cc_v5
       memory: 206158430208
-      name: Standard_DC48es_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_dc64es_v6
-      id: Standard_DC64es_v6
-      memory: 274877906944
-      name: Standard_DC64es_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_dc96es_v6
-      id: Standard_DC96es_v6
-      memory: 412316860416
-      name: Standard_DC96es_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_dc128es_v6
-      id: Standard_DC128es_v6
-      memory: 549755813888
-      name: Standard_DC128es_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_dc2eds_v6
-      id: Standard_DC2eds_v6
-      memory: 8589934592
-      name: Standard_DC2eds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_dc4eds_v6
-      id: Standard_DC4eds_v6
-      memory: 17179869184
-      name: Standard_DC4eds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_dc8eds_v6
-      id: Standard_DC8eds_v6
-      memory: 34359738368
-      name: Standard_DC8eds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_dc16eds_v6
-      id: Standard_DC16eds_v6
-      memory: 68719476736
-      name: Standard_DC16eds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_dc32eds_v6
-      id: Standard_DC32eds_v6
-      memory: 137438953472
-      name: Standard_DC32eds_v6
+      name: Standard_DC48ads_cc_v5
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 48
+      family: standardDCADSv5Family
+      generic_name: standard_dc48ads_v5
+      id: Standard_DC48ads_v5
+      memory: 206158430208
+      name: Standard_DC48ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDCadsv6Family
+      generic_name: standard_dc48ads_v6
+      id: Standard_DC48ads_v6
+      memory: 206158430208
+      name: Standard_DC48ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDCACCV5Family
+      generic_name: standard_dc48as_cc_v5
+      id: Standard_DC48as_cc_v5
+      memory: 206158430208
+      name: Standard_DC48as_cc_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDCASv5Family
+      generic_name: standard_dc48as_v5
+      id: Standard_DC48as_v5
+      memory: 206158430208
+      name: Standard_DC48as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDCasv6Family
+      generic_name: standard_dc48as_v6
+      id: Standard_DC48as_v6
+      memory: 206158430208
+      name: Standard_DC48as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDCEDV6Family
       generic_name: standard_dc48eds_v6
       id: Standard_DC48eds_v6
       memory: 206158430208
       name: Standard_DC48eds_v6
     - category: general_purpose
       cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDCEV6Family
+      generic_name: standard_dc48es_v6
+      id: Standard_DC48es_v6
+      memory: 206158430208
+      name: Standard_DC48es_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDCADCCV5Family
+      generic_name: standard_dc4ads_cc_v5
+      id: Standard_DC4ads_cc_v5
+      memory: 17179869184
+      name: Standard_DC4ads_cc_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDCADSv5Family
+      generic_name: standard_dc4ads_v5
+      id: Standard_DC4ads_v5
+      memory: 17179869184
+      name: Standard_DC4ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDCadsv6Family
+      generic_name: standard_dc4ads_v6
+      id: Standard_DC4ads_v6
+      memory: 17179869184
+      name: Standard_DC4ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDCACCV5Family
+      generic_name: standard_dc4as_cc_v5
+      id: Standard_DC4as_cc_v5
+      memory: 17179869184
+      name: Standard_DC4as_cc_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDCASv5Family
+      generic_name: standard_dc4as_v5
+      id: Standard_DC4as_v5
+      memory: 17179869184
+      name: Standard_DC4as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDCasv6Family
+      generic_name: standard_dc4as_v6
+      id: Standard_DC4as_v6
+      memory: 17179869184
+      name: Standard_DC4as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDCEDV6Family
+      generic_name: standard_dc4eds_v6
+      id: Standard_DC4eds_v6
+      memory: 17179869184
+      name: Standard_DC4eds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDCEV6Family
+      generic_name: standard_dc4es_v6
+      id: Standard_DC4es_v6
+      memory: 17179869184
+      name: Standard_DC4es_v6
+    - category: general_purpose
+      cloud_provider_id: azure
       cpu_cores: 64
+      family: standardDCADCCV5Family
+      generic_name: standard_dc64ads_cc_v5
+      id: Standard_DC64ads_cc_v5
+      memory: 274877906944
+      name: Standard_DC64ads_cc_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDCADSv5Family
+      generic_name: standard_dc64ads_v5
+      id: Standard_DC64ads_v5
+      memory: 274877906944
+      name: Standard_DC64ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDCadsv6Family
+      generic_name: standard_dc64ads_v6
+      id: Standard_DC64ads_v6
+      memory: 274877906944
+      name: Standard_DC64ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDCACCV5Family
+      generic_name: standard_dc64as_cc_v5
+      id: Standard_DC64as_cc_v5
+      memory: 274877906944
+      name: Standard_DC64as_cc_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDCASv5Family
+      generic_name: standard_dc64as_v5
+      id: Standard_DC64as_v5
+      memory: 274877906944
+      name: Standard_DC64as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDCasv6Family
+      generic_name: standard_dc64as_v6
+      id: Standard_DC64as_v6
+      memory: 274877906944
+      name: Standard_DC64as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDCEDV6Family
       generic_name: standard_dc64eds_v6
       id: Standard_DC64eds_v6
       memory: 274877906944
       name: Standard_DC64eds_v6
     - category: general_purpose
       cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDCEV6Family
+      generic_name: standard_dc64es_v6
+      id: Standard_DC64es_v6
+      memory: 274877906944
+      name: Standard_DC64es_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDCADCCV5Family
+      generic_name: standard_dc8ads_cc_v5
+      id: Standard_DC8ads_cc_v5
+      memory: 34359738368
+      name: Standard_DC8ads_cc_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDCADSv5Family
+      generic_name: standard_dc8ads_v5
+      id: Standard_DC8ads_v5
+      memory: 34359738368
+      name: Standard_DC8ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDCadsv6Family
+      generic_name: standard_dc8ads_v6
+      id: Standard_DC8ads_v6
+      memory: 34359738368
+      name: Standard_DC8ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDCACCV5Family
+      generic_name: standard_dc8as_cc_v5
+      id: Standard_DC8as_cc_v5
+      memory: 34359738368
+      name: Standard_DC8as_cc_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDCASv5Family
+      generic_name: standard_dc8as_v5
+      id: Standard_DC8as_v5
+      memory: 34359738368
+      name: Standard_DC8as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDCasv6Family
+      generic_name: standard_dc8as_v6
+      id: Standard_DC8as_v6
+      memory: 34359738368
+      name: Standard_DC8as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDCEDV6Family
+      generic_name: standard_dc8eds_v6
+      id: Standard_DC8eds_v6
+      memory: 34359738368
+      name: Standard_DC8eds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDCEV6Family
+      generic_name: standard_dc8es_v6
+      id: Standard_DC8es_v6
+      memory: 34359738368
+      name: Standard_DC8es_v6
+    - category: general_purpose
+      cloud_provider_id: azure
       cpu_cores: 96
+      family: standardDCADCCV5Family
+      generic_name: standard_dc96ads_cc_v5
+      id: Standard_DC96ads_cc_v5
+      memory: 412316860416
+      name: Standard_DC96ads_cc_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDCADSv5Family
+      generic_name: standard_dc96ads_v5
+      id: Standard_DC96ads_v5
+      memory: 412316860416
+      name: Standard_DC96ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDCadsv6Family
+      generic_name: standard_dc96ads_v6
+      id: Standard_DC96ads_v6
+      memory: 412316860416
+      name: Standard_DC96ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDCACCV5Family
+      generic_name: standard_dc96as_cc_v5
+      id: Standard_DC96as_cc_v5
+      memory: 412316860416
+      name: Standard_DC96as_cc_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDCASv5Family
+      generic_name: standard_dc96as_v5
+      id: Standard_DC96as_v5
+      memory: 412316860416
+      name: Standard_DC96as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDCasv6Family
+      generic_name: standard_dc96as_v6
+      id: Standard_DC96as_v6
+      memory: 412316860416
+      name: Standard_DC96as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDCEDV6Family
       generic_name: standard_dc96eds_v6
       id: Standard_DC96eds_v6
       memory: 412316860416
       name: Standard_DC96eds_v6
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_dc128eds_v6
-      id: Standard_DC128eds_v6
-      memory: 549755813888
-      name: Standard_DC128eds_v6
-    - category: memory_optimized
+      cpu_cores: 96
+      family: standardDCEV6Family
+      generic_name: standard_dc96es_v6
+      id: Standard_DC96es_v6
+      memory: 412316860416
+      name: Standard_DC96es_v6
+    - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 2
-      generic_name: standard_ec2es_v6
-      id: Standard_EC2es_v6
-      memory: 17179869184
-      name: Standard_EC2es_v6
-    - category: memory_optimized
+      family: standardDSv2Family
+      generic_name: standard_ds11-1_v2
+      id: Standard_DS11-1_v2
+      memory: 15032385536
+      name: Standard_DS11-1_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDSv2Family
+      generic_name: standard_ds11_v2
+      id: Standard_DS11_v2
+      memory: 15032385536
+      name: Standard_DS11_v2
+    - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 4
-      generic_name: standard_ec4es_v6
-      id: Standard_EC4es_v6
-      memory: 34359738368
-      name: Standard_EC4es_v6
-    - category: memory_optimized
+      family: standardDSv2Family
+      generic_name: standard_ds12-1_v2
+      id: Standard_DS12-1_v2
+      memory: 30064771072
+      name: Standard_DS12-1_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDSv2Family
+      generic_name: standard_ds12-2_v2
+      id: Standard_DS12-2_v2
+      memory: 30064771072
+      name: Standard_DS12-2_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDSv2Family
+      generic_name: standard_ds12_v2
+      id: Standard_DS12_v2
+      memory: 30064771072
+      name: Standard_DS12_v2
+    - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 8
-      generic_name: standard_ec8es_v6
-      id: Standard_EC8es_v6
-      memory: 68719476736
-      name: Standard_EC8es_v6
+      family: standardDSv2Family
+      generic_name: standard_ds13-2_v2
+      id: Standard_DS13-2_v2
+      memory: 60129542144
+      name: Standard_DS13-2_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDSv2Family
+      generic_name: standard_ds13-4_v2
+      id: Standard_DS13-4_v2
+      memory: 60129542144
+      name: Standard_DS13-4_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDSv2Family
+      generic_name: standard_ds13_v2
+      id: Standard_DS13_v2
+      memory: 60129542144
+      name: Standard_DS13_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDSv2Family
+      generic_name: standard_ds14-4_v2
+      id: Standard_DS14-4_v2
+      memory: 120259084288
+      name: Standard_DS14-4_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDSv2Family
+      generic_name: standard_ds14-8_v2
+      id: Standard_DS14-8_v2
+      memory: 120259084288
+      name: Standard_DS14-8_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDSv2Family
+      generic_name: standard_ds14_v2
+      id: Standard_DS14_v2
+      memory: 120259084288
+      name: Standard_DS14_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardDSv2Family
+      generic_name: standard_ds15_v2
+      id: Standard_DS15_v2
+      memory: 150323855360
+      name: Standard_DS15_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 1
+      family: standardDSv2Family
+      generic_name: standard_ds1_v2
+      id: Standard_DS1_v2
+      memory: 3221225472
+      name: Standard_DS1_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDSv2Family
+      generic_name: standard_ds2_v2
+      id: Standard_DS2_v2
+      memory: 7516192768
+      name: Standard_DS2_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDSv2Family
+      generic_name: standard_ds3_v2
+      id: Standard_DS3_v2
+      memory: 15032385536
+      name: Standard_DS3_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDSv2Family
+      generic_name: standard_ds4_v2
+      id: Standard_DS4_v2
+      memory: 30064771072
+      name: Standard_DS4_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDSv2Family
+      generic_name: standard_ds5_v2
+      id: Standard_DS5_v2
+      memory: 60129542144
+      name: Standard_DS5_v2
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 104
+      family: standardEIDSv5Family
+      generic_name: standard_e104ids_v5
+      id: Standard_E104ids_v5
+      memory: 721554505728
+      name: Standard_E104ids_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 104
+      family: standardEIDv5Family
+      generic_name: standard_e104id_v5
+      id: Standard_E104id_v5
+      memory: 721554505728
+      name: Standard_E104id_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 104
+      family: standardEISv5Family
+      generic_name: standard_e104is_v5
+      id: Standard_E104is_v5
+      memory: 721554505728
+      name: Standard_E104is_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 104
+      family: standardEIv5Family
+      generic_name: standard_e104i_v5
+      id: Standard_E104i_v5
+      memory: 721554505728
+      name: Standard_E104i_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 112
+      family: standardEIADSv5Family
+      generic_name: standard_e112iads_v5
+      id: Standard_E112iads_v5
+      memory: 721554505728
+      name: Standard_E112iads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 112
+      family: standardEIASv5Family
+      generic_name: standard_e112ias_v5
+      id: Standard_E112ias_v5
+      memory: 721554505728
+      name: Standard_E112ias_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 112
+      family: standardEIBDSv5Family
+      generic_name: standard_e112ibds_v5
+      id: Standard_E112ibds_v5
+      memory: 721554505728
+      name: Standard_E112ibds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 112
+      family: standardEIBSv5Family
+      generic_name: standard_e112ibs_v5
+      id: Standard_E112ibs_v5
+      memory: 721554505728
+      name: Standard_E112ibs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEadsv7Family
+      generic_name: standard_e128-32ads_v7
+      id: Standard_E128-32ads_v7
+      memory: 1099511627776
+      name: Standard_E128-32ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEasv7Family
+      generic_name: standard_e128-32as_v7
+      id: Standard_E128-32as_v7
+      memory: 1099511627776
+      name: Standard_E128-32as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEdsv6Family
+      generic_name: standard_e128-32ds_v6
+      id: Standard_E128-32ds_v6
+      memory: 1099511627776
+      name: Standard_E128-32ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEsv6Family
+      generic_name: standard_e128-32s_v6
+      id: Standard_E128-32s_v6
+      memory: 1099511627776
+      name: Standard_E128-32s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEadsv7Family
+      generic_name: standard_e128-64ads_v7
+      id: Standard_E128-64ads_v7
+      memory: 1099511627776
+      name: Standard_E128-64ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEasv7Family
+      generic_name: standard_e128-64as_v7
+      id: Standard_E128-64as_v7
+      memory: 1099511627776
+      name: Standard_E128-64as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEdsv6Family
+      generic_name: standard_e128-64ds_v6
+      id: Standard_E128-64ds_v6
+      memory: 1099511627776
+      name: Standard_E128-64ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEsv6Family
+      generic_name: standard_e128-64s_v6
+      id: Standard_E128-64s_v6
+      memory: 1099511627776
+      name: Standard_E128-64s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEadsv7Family
+      generic_name: standard_e128ads_v7
+      id: Standard_E128ads_v7
+      memory: 1099511627776
+      name: Standard_E128ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEasv7Family
+      generic_name: standard_e128as_v7
+      id: Standard_E128as_v7
+      memory: 1099511627776
+      name: Standard_E128as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEdsv6Family
+      generic_name: standard_e128ds_v6
+      id: Standard_E128ds_v6
+      memory: 1099511627776
+      name: Standard_E128ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEsv6Family
+      generic_name: standard_e128s_v6
+      id: Standard_E128s_v6
+      memory: 1099511627776
+      name: Standard_E128s_v6
     - category: memory_optimized
       cloud_provider_id: azure
       cpu_cores: 16
+      family: standardEADSv5Family
+      generic_name: standard_e16-4ads_v5
+      id: Standard_E16-4ads_v5
+      memory: 137438953472
+      name: Standard_E16-4ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEadsv7Family
+      generic_name: standard_e16-4ads_v7
+      id: Standard_E16-4ads_v7
+      memory: 137438953472
+      name: Standard_E16-4ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEASv4Family
+      generic_name: standard_e16-4as_v4
+      id: Standard_E16-4as_v4
+      memory: 137438953472
+      name: Standard_E16-4as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEASv5Family
+      generic_name: standard_e16-4as_v5
+      id: Standard_E16-4as_v5
+      memory: 137438953472
+      name: Standard_E16-4as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEasv7Family
+      generic_name: standard_e16-4as_v7
+      id: Standard_E16-4as_v7
+      memory: 137438953472
+      name: Standard_E16-4as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEDSv4Family
+      generic_name: standard_e16-4ds_v4
+      id: Standard_E16-4ds_v4
+      memory: 137438953472
+      name: Standard_E16-4ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEDSv5Family
+      generic_name: standard_e16-4ds_v5
+      id: Standard_E16-4ds_v5
+      memory: 137438953472
+      name: Standard_E16-4ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEdsv6Family
+      generic_name: standard_e16-4ds_v6
+      id: Standard_E16-4ds_v6
+      memory: 137438953472
+      name: Standard_E16-4ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardESv3Family
+      generic_name: standard_e16-4s_v3
+      id: Standard_E16-4s_v3
+      memory: 137438953472
+      name: Standard_E16-4s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardESv4Family
+      generic_name: standard_e16-4s_v4
+      id: Standard_E16-4s_v4
+      memory: 137438953472
+      name: Standard_E16-4s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardESv5Family
+      generic_name: standard_e16-4s_v5
+      id: Standard_E16-4s_v5
+      memory: 137438953472
+      name: Standard_E16-4s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEsv6Family
+      generic_name: standard_e16-4s_v6
+      id: Standard_E16-4s_v6
+      memory: 137438953472
+      name: Standard_E16-4s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEADSv5Family
+      generic_name: standard_e16-8ads_v5
+      id: Standard_E16-8ads_v5
+      memory: 137438953472
+      name: Standard_E16-8ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEadsv7Family
+      generic_name: standard_e16-8ads_v7
+      id: Standard_E16-8ads_v7
+      memory: 137438953472
+      name: Standard_E16-8ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEASv4Family
+      generic_name: standard_e16-8as_v4
+      id: Standard_E16-8as_v4
+      memory: 137438953472
+      name: Standard_E16-8as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEASv5Family
+      generic_name: standard_e16-8as_v5
+      id: Standard_E16-8as_v5
+      memory: 137438953472
+      name: Standard_E16-8as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEasv7Family
+      generic_name: standard_e16-8as_v7
+      id: Standard_E16-8as_v7
+      memory: 137438953472
+      name: Standard_E16-8as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEDSv4Family
+      generic_name: standard_e16-8ds_v4
+      id: Standard_E16-8ds_v4
+      memory: 137438953472
+      name: Standard_E16-8ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEDSv5Family
+      generic_name: standard_e16-8ds_v5
+      id: Standard_E16-8ds_v5
+      memory: 137438953472
+      name: Standard_E16-8ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEdsv6Family
+      generic_name: standard_e16-8ds_v6
+      id: Standard_E16-8ds_v6
+      memory: 137438953472
+      name: Standard_E16-8ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardESv3Family
+      generic_name: standard_e16-8s_v3
+      id: Standard_E16-8s_v3
+      memory: 137438953472
+      name: Standard_E16-8s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardESv4Family
+      generic_name: standard_e16-8s_v4
+      id: Standard_E16-8s_v4
+      memory: 137438953472
+      name: Standard_E16-8s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardESv5Family
+      generic_name: standard_e16-8s_v5
+      id: Standard_E16-8s_v5
+      memory: 137438953472
+      name: Standard_E16-8s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEsv6Family
+      generic_name: standard_e16-8s_v6
+      id: Standard_E16-8s_v6
+      memory: 137438953472
+      name: Standard_E16-8s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 160
+      family: StandardEadsv7Family
+      generic_name: standard_e160ads_v7
+      id: Standard_E160ads_v7
+      memory: 1374389534720
+      name: Standard_E160ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 160
+      family: StandardEasv7Family
+      generic_name: standard_e160as_v7
+      id: Standard_E160as_v7
+      memory: 1374389534720
+      name: Standard_E160as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEADSv5Family
+      generic_name: standard_e16ads_v5
+      id: Standard_E16ads_v5
+      memory: 137438953472
+      name: Standard_E16ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEadv6Family
+      generic_name: standard_e16ads_v6
+      id: Standard_E16ads_v6
+      memory: 137438953472
+      name: Standard_E16ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEadsv7Family
+      generic_name: standard_e16ads_v7
+      id: Standard_E16ads_v7
+      memory: 137438953472
+      name: Standard_E16ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEASv4Family
+      generic_name: standard_e16as_v4
+      id: Standard_E16as_v4
+      memory: 137438953472
+      name: Standard_E16as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEASv5Family
+      generic_name: standard_e16as_v5
+      id: Standard_E16as_v5
+      memory: 137438953472
+      name: Standard_E16as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEav6Family
+      generic_name: standard_e16as_v6
+      id: Standard_E16as_v6
+      memory: 137438953472
+      name: Standard_E16as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEasv7Family
+      generic_name: standard_e16as_v7
+      id: Standard_E16as_v7
+      memory: 137438953472
+      name: Standard_E16as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEAv4Family
+      generic_name: standard_e16a_v4
+      id: Standard_E16a_v4
+      memory: 137438953472
+      name: Standard_E16a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEBDSv5Family
+      generic_name: standard_e16bds_v5
+      id: Standard_E16bds_v5
+      memory: 137438953472
+      name: Standard_E16bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEBSv5Family
+      generic_name: standard_e16bs_v5
+      id: Standard_E16bs_v5
+      memory: 137438953472
+      name: Standard_E16bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEDSv4Family
+      generic_name: standard_e16ds_v4
+      id: Standard_E16ds_v4
+      memory: 137438953472
+      name: Standard_E16ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEDSv5Family
+      generic_name: standard_e16ds_v5
+      id: Standard_E16ds_v5
+      memory: 137438953472
+      name: Standard_E16ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEdsv6Family
+      generic_name: standard_e16ds_v6
+      id: Standard_E16ds_v6
+      memory: 137438953472
+      name: Standard_E16ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEDv4Family
+      generic_name: standard_e16d_v4
+      id: Standard_E16d_v4
+      memory: 137438953472
+      name: Standard_E16d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEDv5Family
+      generic_name: standard_e16d_v5
+      id: Standard_E16d_v5
+      memory: 137438953472
+      name: Standard_E16d_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEPDSv5Family
+      generic_name: standard_e16pds_v5
+      id: Standard_E16pds_v5
+      memory: 137438953472
+      name: Standard_E16pds_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEpdsv6Family
+      generic_name: standard_e16pds_v6
+      id: Standard_E16pds_v6
+      memory: 137438953472
+      name: Standard_E16pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEPSv5Family
+      generic_name: standard_e16ps_v5
+      id: Standard_E16ps_v5
+      memory: 137438953472
+      name: Standard_E16ps_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEpsv6Family
+      generic_name: standard_e16ps_v6
+      id: Standard_E16ps_v6
+      memory: 137438953472
+      name: Standard_E16ps_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardESv3Family
+      generic_name: standard_e16s_v3
+      id: Standard_E16s_v3
+      memory: 137438953472
+      name: Standard_E16s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardESv4Family
+      generic_name: standard_e16s_v4
+      id: Standard_E16s_v4
+      memory: 137438953472
+      name: Standard_E16s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardESv5Family
+      generic_name: standard_e16s_v5
+      id: Standard_E16s_v5
+      memory: 137438953472
+      name: Standard_E16s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEsv6Family
+      generic_name: standard_e16s_v6
+      id: Standard_E16s_v6
+      memory: 137438953472
+      name: Standard_E16s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEv3Family
+      generic_name: standard_e16_v3
+      id: Standard_E16_v3
+      memory: 137438953472
+      name: Standard_E16_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEv4Family
+      generic_name: standard_e16_v4
+      id: Standard_E16_v4
+      memory: 137438953472
+      name: Standard_E16_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEv5Family
+      generic_name: standard_e16_v5
+      id: Standard_E16_v5
+      memory: 137438953472
+      name: Standard_E16_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 192
+      family: StandardEdsv6Family
+      generic_name: standard_e192ids_v6
+      id: Standard_E192ids_v6
+      memory: 1967095021568
+      name: Standard_E192ids_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 192
+      family: StandardEsv6Family
+      generic_name: standard_e192is_v6
+      id: Standard_E192is_v6
+      memory: 1967095021568
+      name: Standard_E192is_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEADSv5Family
+      generic_name: standard_e20ads_v5
+      id: Standard_E20ads_v5
+      memory: 171798691840
+      name: Standard_E20ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEadv6Family
+      generic_name: standard_e20ads_v6
+      id: Standard_E20ads_v6
+      memory: 171798691840
+      name: Standard_E20ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEASv4Family
+      generic_name: standard_e20as_v4
+      id: Standard_E20as_v4
+      memory: 171798691840
+      name: Standard_E20as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEASv5Family
+      generic_name: standard_e20as_v5
+      id: Standard_E20as_v5
+      memory: 171798691840
+      name: Standard_E20as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEav6Family
+      generic_name: standard_e20as_v6
+      id: Standard_E20as_v6
+      memory: 171798691840
+      name: Standard_E20as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEAv4Family
+      generic_name: standard_e20a_v4
+      id: Standard_E20a_v4
+      memory: 171798691840
+      name: Standard_E20a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEDSv4Family
+      generic_name: standard_e20ds_v4
+      id: Standard_E20ds_v4
+      memory: 171798691840
+      name: Standard_E20ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEDSv5Family
+      generic_name: standard_e20ds_v5
+      id: Standard_E20ds_v5
+      memory: 171798691840
+      name: Standard_E20ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: StandardEdsv6Family
+      generic_name: standard_e20ds_v6
+      id: Standard_E20ds_v6
+      memory: 171798691840
+      name: Standard_E20ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEDv4Family
+      generic_name: standard_e20d_v4
+      id: Standard_E20d_v4
+      memory: 171798691840
+      name: Standard_E20d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEDv5Family
+      generic_name: standard_e20d_v5
+      id: Standard_E20d_v5
+      memory: 171798691840
+      name: Standard_E20d_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEPDSv5Family
+      generic_name: standard_e20pds_v5
+      id: Standard_E20pds_v5
+      memory: 171798691840
+      name: Standard_E20pds_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEPSv5Family
+      generic_name: standard_e20ps_v5
+      id: Standard_E20ps_v5
+      memory: 171798691840
+      name: Standard_E20ps_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardESv3Family
+      generic_name: standard_e20s_v3
+      id: Standard_E20s_v3
+      memory: 171798691840
+      name: Standard_E20s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardESv4Family
+      generic_name: standard_e20s_v4
+      id: Standard_E20s_v4
+      memory: 171798691840
+      name: Standard_E20s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardESv5Family
+      generic_name: standard_e20s_v5
+      id: Standard_E20s_v5
+      memory: 171798691840
+      name: Standard_E20s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: StandardEsv6Family
+      generic_name: standard_e20s_v6
+      id: Standard_E20s_v6
+      memory: 171798691840
+      name: Standard_E20s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEv3Family
+      generic_name: standard_e20_v3
+      id: Standard_E20_v3
+      memory: 171798691840
+      name: Standard_E20_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEv4Family
+      generic_name: standard_e20_v4
+      id: Standard_E20_v4
+      memory: 171798691840
+      name: Standard_E20_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEv5Family
+      generic_name: standard_e20_v5
+      id: Standard_E20_v5
+      memory: 171798691840
+      name: Standard_E20_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEADSv5Family
+      generic_name: standard_e2ads_v5
+      id: Standard_E2ads_v5
+      memory: 17179869184
+      name: Standard_E2ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEadv6Family
+      generic_name: standard_e2ads_v6
+      id: Standard_E2ads_v6
+      memory: 17179869184
+      name: Standard_E2ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardEadsv7Family
+      generic_name: standard_e2ads_v7
+      id: Standard_E2ads_v7
+      memory: 17179869184
+      name: Standard_E2ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEASv4Family
+      generic_name: standard_e2as_v4
+      id: Standard_E2as_v4
+      memory: 17179869184
+      name: Standard_E2as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEASv5Family
+      generic_name: standard_e2as_v5
+      id: Standard_E2as_v5
+      memory: 17179869184
+      name: Standard_E2as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEav6Family
+      generic_name: standard_e2as_v6
+      id: Standard_E2as_v6
+      memory: 17179869184
+      name: Standard_E2as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardEasv7Family
+      generic_name: standard_e2as_v7
+      id: Standard_E2as_v7
+      memory: 17179869184
+      name: Standard_E2as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEAv4Family
+      generic_name: standard_e2a_v4
+      id: Standard_E2a_v4
+      memory: 17179869184
+      name: Standard_E2a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEBDSv5Family
+      generic_name: standard_e2bds_v5
+      id: Standard_E2bds_v5
+      memory: 17179869184
+      name: Standard_E2bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEBSv5Family
+      generic_name: standard_e2bs_v5
+      id: Standard_E2bs_v5
+      memory: 17179869184
+      name: Standard_E2bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEDSv4Family
+      generic_name: standard_e2ds_v4
+      id: Standard_E2ds_v4
+      memory: 17179869184
+      name: Standard_E2ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEDSv5Family
+      generic_name: standard_e2ds_v5
+      id: Standard_E2ds_v5
+      memory: 17179869184
+      name: Standard_E2ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardEdsv6Family
+      generic_name: standard_e2ds_v6
+      id: Standard_E2ds_v6
+      memory: 17179869184
+      name: Standard_E2ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEDv4Family
+      generic_name: standard_e2d_v4
+      id: Standard_E2d_v4
+      memory: 17179869184
+      name: Standard_E2d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEDv5Family
+      generic_name: standard_e2d_v5
+      id: Standard_E2d_v5
+      memory: 17179869184
+      name: Standard_E2d_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEPDSv5Family
+      generic_name: standard_e2pds_v5
+      id: Standard_E2pds_v5
+      memory: 17179869184
+      name: Standard_E2pds_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardEpdsv6Family
+      generic_name: standard_e2pds_v6
+      id: Standard_E2pds_v6
+      memory: 17179869184
+      name: Standard_E2pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEPSv5Family
+      generic_name: standard_e2ps_v5
+      id: Standard_E2ps_v5
+      memory: 17179869184
+      name: Standard_E2ps_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardEpsv6Family
+      generic_name: standard_e2ps_v6
+      id: Standard_E2ps_v6
+      memory: 17179869184
+      name: Standard_E2ps_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardESv3Family
+      generic_name: standard_e2s_v3
+      id: Standard_E2s_v3
+      memory: 17179869184
+      name: Standard_E2s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardESv4Family
+      generic_name: standard_e2s_v4
+      id: Standard_E2s_v4
+      memory: 17179869184
+      name: Standard_E2s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardESv5Family
+      generic_name: standard_e2s_v5
+      id: Standard_E2s_v5
+      memory: 17179869184
+      name: Standard_E2s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardEsv6Family
+      generic_name: standard_e2s_v6
+      id: Standard_E2s_v6
+      memory: 17179869184
+      name: Standard_E2s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEv3Family
+      generic_name: standard_e2_v3
+      id: Standard_E2_v3
+      memory: 17179869184
+      name: Standard_E2_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEv4Family
+      generic_name: standard_e2_v4
+      id: Standard_E2_v4
+      memory: 17179869184
+      name: Standard_E2_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEv5Family
+      generic_name: standard_e2_v5
+      id: Standard_E2_v5
+      memory: 17179869184
+      name: Standard_E2_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEADSv5Family
+      generic_name: standard_e32-16ads_v5
+      id: Standard_E32-16ads_v5
+      memory: 274877906944
+      name: Standard_E32-16ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEadsv7Family
+      generic_name: standard_e32-16ads_v7
+      id: Standard_E32-16ads_v7
+      memory: 274877906944
+      name: Standard_E32-16ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEASv4Family
+      generic_name: standard_e32-16as_v4
+      id: Standard_E32-16as_v4
+      memory: 274877906944
+      name: Standard_E32-16as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEASv5Family
+      generic_name: standard_e32-16as_v5
+      id: Standard_E32-16as_v5
+      memory: 274877906944
+      name: Standard_E32-16as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEasv7Family
+      generic_name: standard_e32-16as_v7
+      id: Standard_E32-16as_v7
+      memory: 274877906944
+      name: Standard_E32-16as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEDSv4Family
+      generic_name: standard_e32-16ds_v4
+      id: Standard_E32-16ds_v4
+      memory: 274877906944
+      name: Standard_E32-16ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEDSv5Family
+      generic_name: standard_e32-16ds_v5
+      id: Standard_E32-16ds_v5
+      memory: 274877906944
+      name: Standard_E32-16ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEdsv6Family
+      generic_name: standard_e32-16ds_v6
+      id: Standard_E32-16ds_v6
+      memory: 274877906944
+      name: Standard_E32-16ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardESv3Family
+      generic_name: standard_e32-16s_v3
+      id: Standard_E32-16s_v3
+      memory: 274877906944
+      name: Standard_E32-16s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardESv4Family
+      generic_name: standard_e32-16s_v4
+      id: Standard_E32-16s_v4
+      memory: 274877906944
+      name: Standard_E32-16s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardESv5Family
+      generic_name: standard_e32-16s_v5
+      id: Standard_E32-16s_v5
+      memory: 274877906944
+      name: Standard_E32-16s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEsv6Family
+      generic_name: standard_e32-16s_v6
+      id: Standard_E32-16s_v6
+      memory: 274877906944
+      name: Standard_E32-16s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEADSv5Family
+      generic_name: standard_e32-8ads_v5
+      id: Standard_E32-8ads_v5
+      memory: 274877906944
+      name: Standard_E32-8ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEadsv7Family
+      generic_name: standard_e32-8ads_v7
+      id: Standard_E32-8ads_v7
+      memory: 274877906944
+      name: Standard_E32-8ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEASv4Family
+      generic_name: standard_e32-8as_v4
+      id: Standard_E32-8as_v4
+      memory: 274877906944
+      name: Standard_E32-8as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEASv5Family
+      generic_name: standard_e32-8as_v5
+      id: Standard_E32-8as_v5
+      memory: 274877906944
+      name: Standard_E32-8as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEasv7Family
+      generic_name: standard_e32-8as_v7
+      id: Standard_E32-8as_v7
+      memory: 274877906944
+      name: Standard_E32-8as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEDSv4Family
+      generic_name: standard_e32-8ds_v4
+      id: Standard_E32-8ds_v4
+      memory: 274877906944
+      name: Standard_E32-8ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEDSv5Family
+      generic_name: standard_e32-8ds_v5
+      id: Standard_E32-8ds_v5
+      memory: 274877906944
+      name: Standard_E32-8ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEdsv6Family
+      generic_name: standard_e32-8ds_v6
+      id: Standard_E32-8ds_v6
+      memory: 274877906944
+      name: Standard_E32-8ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardESv3Family
+      generic_name: standard_e32-8s_v3
+      id: Standard_E32-8s_v3
+      memory: 274877906944
+      name: Standard_E32-8s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardESv4Family
+      generic_name: standard_e32-8s_v4
+      id: Standard_E32-8s_v4
+      memory: 274877906944
+      name: Standard_E32-8s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardESv5Family
+      generic_name: standard_e32-8s_v5
+      id: Standard_E32-8s_v5
+      memory: 274877906944
+      name: Standard_E32-8s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEsv6Family
+      generic_name: standard_e32-8s_v6
+      id: Standard_E32-8s_v6
+      memory: 274877906944
+      name: Standard_E32-8s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEADSv5Family
+      generic_name: standard_e32ads_v5
+      id: Standard_E32ads_v5
+      memory: 274877906944
+      name: Standard_E32ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEadv6Family
+      generic_name: standard_e32ads_v6
+      id: Standard_E32ads_v6
+      memory: 274877906944
+      name: Standard_E32ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEadsv7Family
+      generic_name: standard_e32ads_v7
+      id: Standard_E32ads_v7
+      memory: 274877906944
+      name: Standard_E32ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEASv4Family
+      generic_name: standard_e32as_v4
+      id: Standard_E32as_v4
+      memory: 274877906944
+      name: Standard_E32as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEASv5Family
+      generic_name: standard_e32as_v5
+      id: Standard_E32as_v5
+      memory: 274877906944
+      name: Standard_E32as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEav6Family
+      generic_name: standard_e32as_v6
+      id: Standard_E32as_v6
+      memory: 274877906944
+      name: Standard_E32as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEasv7Family
+      generic_name: standard_e32as_v7
+      id: Standard_E32as_v7
+      memory: 274877906944
+      name: Standard_E32as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEAv4Family
+      generic_name: standard_e32a_v4
+      id: Standard_E32a_v4
+      memory: 274877906944
+      name: Standard_E32a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEBDSv5Family
+      generic_name: standard_e32bds_v5
+      id: Standard_E32bds_v5
+      memory: 274877906944
+      name: Standard_E32bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEBSv5Family
+      generic_name: standard_e32bs_v5
+      id: Standard_E32bs_v5
+      memory: 274877906944
+      name: Standard_E32bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEDSv4Family
+      generic_name: standard_e32ds_v4
+      id: Standard_E32ds_v4
+      memory: 274877906944
+      name: Standard_E32ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEDSv5Family
+      generic_name: standard_e32ds_v5
+      id: Standard_E32ds_v5
+      memory: 274877906944
+      name: Standard_E32ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEdsv6Family
+      generic_name: standard_e32ds_v6
+      id: Standard_E32ds_v6
+      memory: 274877906944
+      name: Standard_E32ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEDv4Family
+      generic_name: standard_e32d_v4
+      id: Standard_E32d_v4
+      memory: 274877906944
+      name: Standard_E32d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEDv5Family
+      generic_name: standard_e32d_v5
+      id: Standard_E32d_v5
+      memory: 274877906944
+      name: Standard_E32d_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEPDSv5Family
+      generic_name: standard_e32pds_v5
+      id: Standard_E32pds_v5
+      memory: 223338299392
+      name: Standard_E32pds_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEpdsv6Family
+      generic_name: standard_e32pds_v6
+      id: Standard_E32pds_v6
+      memory: 274877906944
+      name: Standard_E32pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEPSv5Family
+      generic_name: standard_e32ps_v5
+      id: Standard_E32ps_v5
+      memory: 223338299392
+      name: Standard_E32ps_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEpsv6Family
+      generic_name: standard_e32ps_v6
+      id: Standard_E32ps_v6
+      memory: 274877906944
+      name: Standard_E32ps_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardESv3Family
+      generic_name: standard_e32s_v3
+      id: Standard_E32s_v3
+      memory: 274877906944
+      name: Standard_E32s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardESv4Family
+      generic_name: standard_e32s_v4
+      id: Standard_E32s_v4
+      memory: 274877906944
+      name: Standard_E32s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardESv5Family
+      generic_name: standard_e32s_v5
+      id: Standard_E32s_v5
+      memory: 274877906944
+      name: Standard_E32s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEsv6Family
+      generic_name: standard_e32s_v6
+      id: Standard_E32s_v6
+      memory: 274877906944
+      name: Standard_E32s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEv3Family
+      generic_name: standard_e32_v3
+      id: Standard_E32_v3
+      memory: 274877906944
+      name: Standard_E32_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEv4Family
+      generic_name: standard_e32_v4
+      id: Standard_E32_v4
+      memory: 274877906944
+      name: Standard_E32_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEv5Family
+      generic_name: standard_e32_v5
+      id: Standard_E32_v5
+      memory: 274877906944
+      name: Standard_E32_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEADSv5Family
+      generic_name: standard_e4-2ads_v5
+      id: Standard_E4-2ads_v5
+      memory: 34359738368
+      name: Standard_E4-2ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardEadsv7Family
+      generic_name: standard_e4-2ads_v7
+      id: Standard_E4-2ads_v7
+      memory: 34359738368
+      name: Standard_E4-2ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEASv4Family
+      generic_name: standard_e4-2as_v4
+      id: Standard_E4-2as_v4
+      memory: 34359738368
+      name: Standard_E4-2as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEASv5Family
+      generic_name: standard_e4-2as_v5
+      id: Standard_E4-2as_v5
+      memory: 34359738368
+      name: Standard_E4-2as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardEasv7Family
+      generic_name: standard_e4-2as_v7
+      id: Standard_E4-2as_v7
+      memory: 34359738368
+      name: Standard_E4-2as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEDSv4Family
+      generic_name: standard_e4-2ds_v4
+      id: Standard_E4-2ds_v4
+      memory: 34359738368
+      name: Standard_E4-2ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEDSv5Family
+      generic_name: standard_e4-2ds_v5
+      id: Standard_E4-2ds_v5
+      memory: 34359738368
+      name: Standard_E4-2ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardEdsv6Family
+      generic_name: standard_e4-2ds_v6
+      id: Standard_E4-2ds_v6
+      memory: 34359738368
+      name: Standard_E4-2ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardESv3Family
+      generic_name: standard_e4-2s_v3
+      id: Standard_E4-2s_v3
+      memory: 34359738368
+      name: Standard_E4-2s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardESv4Family
+      generic_name: standard_e4-2s_v4
+      id: Standard_E4-2s_v4
+      memory: 34359738368
+      name: Standard_E4-2s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardESv5Family
+      generic_name: standard_e4-2s_v5
+      id: Standard_E4-2s_v5
+      memory: 34359738368
+      name: Standard_E4-2s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardEsv6Family
+      generic_name: standard_e4-2s_v6
+      id: Standard_E4-2s_v6
+      memory: 34359738368
+      name: Standard_E4-2s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEADSv5Family
+      generic_name: standard_e48ads_v5
+      id: Standard_E48ads_v5
+      memory: 412316860416
+      name: Standard_E48ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEadv6Family
+      generic_name: standard_e48ads_v6
+      id: Standard_E48ads_v6
+      memory: 412316860416
+      name: Standard_E48ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardEadsv7Family
+      generic_name: standard_e48ads_v7
+      id: Standard_E48ads_v7
+      memory: 412316860416
+      name: Standard_E48ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEASv4Family
+      generic_name: standard_e48as_v4
+      id: Standard_E48as_v4
+      memory: 412316860416
+      name: Standard_E48as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEASv5Family
+      generic_name: standard_e48as_v5
+      id: Standard_E48as_v5
+      memory: 412316860416
+      name: Standard_E48as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEav6Family
+      generic_name: standard_e48as_v6
+      id: Standard_E48as_v6
+      memory: 412316860416
+      name: Standard_E48as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardEasv7Family
+      generic_name: standard_e48as_v7
+      id: Standard_E48as_v7
+      memory: 412316860416
+      name: Standard_E48as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEAv4Family
+      generic_name: standard_e48a_v4
+      id: Standard_E48a_v4
+      memory: 412316860416
+      name: Standard_E48a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEBDSv5Family
+      generic_name: standard_e48bds_v5
+      id: Standard_E48bds_v5
+      memory: 412316860416
+      name: Standard_E48bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEBSv5Family
+      generic_name: standard_e48bs_v5
+      id: Standard_E48bs_v5
+      memory: 412316860416
+      name: Standard_E48bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEDSv4Family
+      generic_name: standard_e48ds_v4
+      id: Standard_E48ds_v4
+      memory: 412316860416
+      name: Standard_E48ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEDSv5Family
+      generic_name: standard_e48ds_v5
+      id: Standard_E48ds_v5
+      memory: 412316860416
+      name: Standard_E48ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardEdsv6Family
+      generic_name: standard_e48ds_v6
+      id: Standard_E48ds_v6
+      memory: 412316860416
+      name: Standard_E48ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEDv4Family
+      generic_name: standard_e48d_v4
+      id: Standard_E48d_v4
+      memory: 412316860416
+      name: Standard_E48d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEDv5Family
+      generic_name: standard_e48d_v5
+      id: Standard_E48d_v5
+      memory: 412316860416
+      name: Standard_E48d_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardEpdsv6Family
+      generic_name: standard_e48pds_v6
+      id: Standard_E48pds_v6
+      memory: 412316860416
+      name: Standard_E48pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardEpsv6Family
+      generic_name: standard_e48ps_v6
+      id: Standard_E48ps_v6
+      memory: 412316860416
+      name: Standard_E48ps_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardESv3Family
+      generic_name: standard_e48s_v3
+      id: Standard_E48s_v3
+      memory: 412316860416
+      name: Standard_E48s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardESv4Family
+      generic_name: standard_e48s_v4
+      id: Standard_E48s_v4
+      memory: 412316860416
+      name: Standard_E48s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardESv5Family
+      generic_name: standard_e48s_v5
+      id: Standard_E48s_v5
+      memory: 412316860416
+      name: Standard_E48s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardEsv6Family
+      generic_name: standard_e48s_v6
+      id: Standard_E48s_v6
+      memory: 412316860416
+      name: Standard_E48s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEv3Family
+      generic_name: standard_e48_v3
+      id: Standard_E48_v3
+      memory: 412316860416
+      name: Standard_E48_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEv4Family
+      generic_name: standard_e48_v4
+      id: Standard_E48_v4
+      memory: 412316860416
+      name: Standard_E48_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEv5Family
+      generic_name: standard_e48_v5
+      id: Standard_E48_v5
+      memory: 412316860416
+      name: Standard_E48_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEADSv5Family
+      generic_name: standard_e4ads_v5
+      id: Standard_E4ads_v5
+      memory: 34359738368
+      name: Standard_E4ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEadv6Family
+      generic_name: standard_e4ads_v6
+      id: Standard_E4ads_v6
+      memory: 34359738368
+      name: Standard_E4ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardEadsv7Family
+      generic_name: standard_e4ads_v7
+      id: Standard_E4ads_v7
+      memory: 34359738368
+      name: Standard_E4ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEASv4Family
+      generic_name: standard_e4as_v4
+      id: Standard_E4as_v4
+      memory: 34359738368
+      name: Standard_E4as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEASv5Family
+      generic_name: standard_e4as_v5
+      id: Standard_E4as_v5
+      memory: 34359738368
+      name: Standard_E4as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEav6Family
+      generic_name: standard_e4as_v6
+      id: Standard_E4as_v6
+      memory: 34359738368
+      name: Standard_E4as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardEasv7Family
+      generic_name: standard_e4as_v7
+      id: Standard_E4as_v7
+      memory: 34359738368
+      name: Standard_E4as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEAv4Family
+      generic_name: standard_e4a_v4
+      id: Standard_E4a_v4
+      memory: 34359738368
+      name: Standard_E4a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEBDSv5Family
+      generic_name: standard_e4bds_v5
+      id: Standard_E4bds_v5
+      memory: 34359738368
+      name: Standard_E4bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEBSv5Family
+      generic_name: standard_e4bs_v5
+      id: Standard_E4bs_v5
+      memory: 34359738368
+      name: Standard_E4bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEDSv4Family
+      generic_name: standard_e4ds_v4
+      id: Standard_E4ds_v4
+      memory: 34359738368
+      name: Standard_E4ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEDSv5Family
+      generic_name: standard_e4ds_v5
+      id: Standard_E4ds_v5
+      memory: 34359738368
+      name: Standard_E4ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardEdsv6Family
+      generic_name: standard_e4ds_v6
+      id: Standard_E4ds_v6
+      memory: 34359738368
+      name: Standard_E4ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEDv4Family
+      generic_name: standard_e4d_v4
+      id: Standard_E4d_v4
+      memory: 34359738368
+      name: Standard_E4d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEDv5Family
+      generic_name: standard_e4d_v5
+      id: Standard_E4d_v5
+      memory: 34359738368
+      name: Standard_E4d_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEPDSv5Family
+      generic_name: standard_e4pds_v5
+      id: Standard_E4pds_v5
+      memory: 34359738368
+      name: Standard_E4pds_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardEpdsv6Family
+      generic_name: standard_e4pds_v6
+      id: Standard_E4pds_v6
+      memory: 34359738368
+      name: Standard_E4pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEPSv5Family
+      generic_name: standard_e4ps_v5
+      id: Standard_E4ps_v5
+      memory: 34359738368
+      name: Standard_E4ps_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardEpsv6Family
+      generic_name: standard_e4ps_v6
+      id: Standard_E4ps_v6
+      memory: 34359738368
+      name: Standard_E4ps_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardESv3Family
+      generic_name: standard_e4s_v3
+      id: Standard_E4s_v3
+      memory: 34359738368
+      name: Standard_E4s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardESv4Family
+      generic_name: standard_e4s_v4
+      id: Standard_E4s_v4
+      memory: 34359738368
+      name: Standard_E4s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardESv5Family
+      generic_name: standard_e4s_v5
+      id: Standard_E4s_v5
+      memory: 34359738368
+      name: Standard_E4s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardEsv6Family
+      generic_name: standard_e4s_v6
+      id: Standard_E4s_v6
+      memory: 34359738368
+      name: Standard_E4s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEv3Family
+      generic_name: standard_e4_v3
+      id: Standard_E4_v3
+      memory: 34359738368
+      name: Standard_E4_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEv4Family
+      generic_name: standard_e4_v4
+      id: Standard_E4_v4
+      memory: 34359738368
+      name: Standard_E4_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEv5Family
+      generic_name: standard_e4_v5
+      id: Standard_E4_v5
+      memory: 34359738368
+      name: Standard_E4_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEADSv5Family
+      generic_name: standard_e64-16ads_v5
+      id: Standard_E64-16ads_v5
+      memory: 549755813888
+      name: Standard_E64-16ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEadsv7Family
+      generic_name: standard_e64-16ads_v7
+      id: Standard_E64-16ads_v7
+      memory: 549755813888
+      name: Standard_E64-16ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEASv4Family
+      generic_name: standard_e64-16as_v4
+      id: Standard_E64-16as_v4
+      memory: 549755813888
+      name: Standard_E64-16as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEASv5Family
+      generic_name: standard_e64-16as_v5
+      id: Standard_E64-16as_v5
+      memory: 549755813888
+      name: Standard_E64-16as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEasv7Family
+      generic_name: standard_e64-16as_v7
+      id: Standard_E64-16as_v7
+      memory: 549755813888
+      name: Standard_E64-16as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEDSv4Family
+      generic_name: standard_e64-16ds_v4
+      id: Standard_E64-16ds_v4
+      memory: 541165879296
+      name: Standard_E64-16ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEDSv5Family
+      generic_name: standard_e64-16ds_v5
+      id: Standard_E64-16ds_v5
+      memory: 549755813888
+      name: Standard_E64-16ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEdsv6Family
+      generic_name: standard_e64-16ds_v6
+      id: Standard_E64-16ds_v6
+      memory: 549755813888
+      name: Standard_E64-16ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardESv3Family
+      generic_name: standard_e64-16s_v3
+      id: Standard_E64-16s_v3
+      memory: 463856467968
+      name: Standard_E64-16s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardESv4Family
+      generic_name: standard_e64-16s_v4
+      id: Standard_E64-16s_v4
+      memory: 541165879296
+      name: Standard_E64-16s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardESv5Family
+      generic_name: standard_e64-16s_v5
+      id: Standard_E64-16s_v5
+      memory: 549755813888
+      name: Standard_E64-16s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEsv6Family
+      generic_name: standard_e64-16s_v6
+      id: Standard_E64-16s_v6
+      memory: 549755813888
+      name: Standard_E64-16s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEADSv5Family
+      generic_name: standard_e64-32ads_v5
+      id: Standard_E64-32ads_v5
+      memory: 549755813888
+      name: Standard_E64-32ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEadsv7Family
+      generic_name: standard_e64-32ads_v7
+      id: Standard_E64-32ads_v7
+      memory: 549755813888
+      name: Standard_E64-32ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEASv4Family
+      generic_name: standard_e64-32as_v4
+      id: Standard_E64-32as_v4
+      memory: 549755813888
+      name: Standard_E64-32as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEASv5Family
+      generic_name: standard_e64-32as_v5
+      id: Standard_E64-32as_v5
+      memory: 549755813888
+      name: Standard_E64-32as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEasv7Family
+      generic_name: standard_e64-32as_v7
+      id: Standard_E64-32as_v7
+      memory: 549755813888
+      name: Standard_E64-32as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEDSv4Family
+      generic_name: standard_e64-32ds_v4
+      id: Standard_E64-32ds_v4
+      memory: 541165879296
+      name: Standard_E64-32ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEDSv5Family
+      generic_name: standard_e64-32ds_v5
+      id: Standard_E64-32ds_v5
+      memory: 549755813888
+      name: Standard_E64-32ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEdsv6Family
+      generic_name: standard_e64-32ds_v6
+      id: Standard_E64-32ds_v6
+      memory: 549755813888
+      name: Standard_E64-32ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardESv3Family
+      generic_name: standard_e64-32s_v3
+      id: Standard_E64-32s_v3
+      memory: 463856467968
+      name: Standard_E64-32s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardESv4Family
+      generic_name: standard_e64-32s_v4
+      id: Standard_E64-32s_v4
+      memory: 541165879296
+      name: Standard_E64-32s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardESv5Family
+      generic_name: standard_e64-32s_v5
+      id: Standard_E64-32s_v5
+      memory: 549755813888
+      name: Standard_E64-32s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEsv6Family
+      generic_name: standard_e64-32s_v6
+      id: Standard_E64-32s_v6
+      memory: 549755813888
+      name: Standard_E64-32s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEADSv5Family
+      generic_name: standard_e64ads_v5
+      id: Standard_E64ads_v5
+      memory: 549755813888
+      name: Standard_E64ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEadv6Family
+      generic_name: standard_e64ads_v6
+      id: Standard_E64ads_v6
+      memory: 549755813888
+      name: Standard_E64ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEadsv7Family
+      generic_name: standard_e64ads_v7
+      id: Standard_E64ads_v7
+      memory: 549755813888
+      name: Standard_E64ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEASv4Family
+      generic_name: standard_e64as_v4
+      id: Standard_E64as_v4
+      memory: 549755813888
+      name: Standard_E64as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEASv5Family
+      generic_name: standard_e64as_v5
+      id: Standard_E64as_v5
+      memory: 549755813888
+      name: Standard_E64as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEav6Family
+      generic_name: standard_e64as_v6
+      id: Standard_E64as_v6
+      memory: 549755813888
+      name: Standard_E64as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEasv7Family
+      generic_name: standard_e64as_v7
+      id: Standard_E64as_v7
+      memory: 549755813888
+      name: Standard_E64as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEAv4Family
+      generic_name: standard_e64a_v4
+      id: Standard_E64a_v4
+      memory: 549755813888
+      name: Standard_E64a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEBDSv5Family
+      generic_name: standard_e64bds_v5
+      id: Standard_E64bds_v5
+      memory: 549755813888
+      name: Standard_E64bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEBSv5Family
+      generic_name: standard_e64bs_v5
+      id: Standard_E64bs_v5
+      memory: 549755813888
+      name: Standard_E64bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEDSv4Family
+      generic_name: standard_e64ds_v4
+      id: Standard_E64ds_v4
+      memory: 541165879296
+      name: Standard_E64ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEDSv5Family
+      generic_name: standard_e64ds_v5
+      id: Standard_E64ds_v5
+      memory: 549755813888
+      name: Standard_E64ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEdsv6Family
+      generic_name: standard_e64ds_v6
+      id: Standard_E64ds_v6
+      memory: 549755813888
+      name: Standard_E64ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEDv4Family
+      generic_name: standard_e64d_v4
+      id: Standard_E64d_v4
+      memory: 541165879296
+      name: Standard_E64d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEDv5Family
+      generic_name: standard_e64d_v5
+      id: Standard_E64d_v5
+      memory: 549755813888
+      name: Standard_E64d_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEpdsv6Family
+      generic_name: standard_e64pds_v6
+      id: Standard_E64pds_v6
+      memory: 549755813888
+      name: Standard_E64pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEpsv6Family
+      generic_name: standard_e64ps_v6
+      id: Standard_E64ps_v6
+      memory: 549755813888
+      name: Standard_E64ps_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardESv3Family
+      generic_name: standard_e64s_v3
+      id: Standard_E64s_v3
+      memory: 463856467968
+      name: Standard_E64s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardESv4Family
+      generic_name: standard_e64s_v4
+      id: Standard_E64s_v4
+      memory: 541165879296
+      name: Standard_E64s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardESv5Family
+      generic_name: standard_e64s_v5
+      id: Standard_E64s_v5
+      memory: 549755813888
+      name: Standard_E64s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEsv6Family
+      generic_name: standard_e64s_v6
+      id: Standard_E64s_v6
+      memory: 549755813888
+      name: Standard_E64s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEv3Family
+      generic_name: standard_e64_v3
+      id: Standard_E64_v3
+      memory: 463856467968
+      name: Standard_E64_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEv4Family
+      generic_name: standard_e64_v4
+      id: Standard_E64_v4
+      memory: 541165879296
+      name: Standard_E64_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEv5Family
+      generic_name: standard_e64_v5
+      id: Standard_E64_v5
+      memory: 549755813888
+      name: Standard_E64_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEADSv5Family
+      generic_name: standard_e8-2ads_v5
+      id: Standard_E8-2ads_v5
+      memory: 68719476736
+      name: Standard_E8-2ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEadsv7Family
+      generic_name: standard_e8-2ads_v7
+      id: Standard_E8-2ads_v7
+      memory: 68719476736
+      name: Standard_E8-2ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEASv4Family
+      generic_name: standard_e8-2as_v4
+      id: Standard_E8-2as_v4
+      memory: 68719476736
+      name: Standard_E8-2as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEASv5Family
+      generic_name: standard_e8-2as_v5
+      id: Standard_E8-2as_v5
+      memory: 68719476736
+      name: Standard_E8-2as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEasv7Family
+      generic_name: standard_e8-2as_v7
+      id: Standard_E8-2as_v7
+      memory: 68719476736
+      name: Standard_E8-2as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEDSv4Family
+      generic_name: standard_e8-2ds_v4
+      id: Standard_E8-2ds_v4
+      memory: 68719476736
+      name: Standard_E8-2ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEDSv5Family
+      generic_name: standard_e8-2ds_v5
+      id: Standard_E8-2ds_v5
+      memory: 68719476736
+      name: Standard_E8-2ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEdsv6Family
+      generic_name: standard_e8-2ds_v6
+      id: Standard_E8-2ds_v6
+      memory: 68719476736
+      name: Standard_E8-2ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardESv3Family
+      generic_name: standard_e8-2s_v3
+      id: Standard_E8-2s_v3
+      memory: 68719476736
+      name: Standard_E8-2s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardESv4Family
+      generic_name: standard_e8-2s_v4
+      id: Standard_E8-2s_v4
+      memory: 68719476736
+      name: Standard_E8-2s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardESv5Family
+      generic_name: standard_e8-2s_v5
+      id: Standard_E8-2s_v5
+      memory: 68719476736
+      name: Standard_E8-2s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEsv6Family
+      generic_name: standard_e8-2s_v6
+      id: Standard_E8-2s_v6
+      memory: 68719476736
+      name: Standard_E8-2s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEADSv5Family
+      generic_name: standard_e8-4ads_v5
+      id: Standard_E8-4ads_v5
+      memory: 68719476736
+      name: Standard_E8-4ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEadsv7Family
+      generic_name: standard_e8-4ads_v7
+      id: Standard_E8-4ads_v7
+      memory: 68719476736
+      name: Standard_E8-4ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEASv4Family
+      generic_name: standard_e8-4as_v4
+      id: Standard_E8-4as_v4
+      memory: 68719476736
+      name: Standard_E8-4as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEASv5Family
+      generic_name: standard_e8-4as_v5
+      id: Standard_E8-4as_v5
+      memory: 68719476736
+      name: Standard_E8-4as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEasv7Family
+      generic_name: standard_e8-4as_v7
+      id: Standard_E8-4as_v7
+      memory: 68719476736
+      name: Standard_E8-4as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEDSv4Family
+      generic_name: standard_e8-4ds_v4
+      id: Standard_E8-4ds_v4
+      memory: 68719476736
+      name: Standard_E8-4ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEDSv5Family
+      generic_name: standard_e8-4ds_v5
+      id: Standard_E8-4ds_v5
+      memory: 68719476736
+      name: Standard_E8-4ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEdsv6Family
+      generic_name: standard_e8-4ds_v6
+      id: Standard_E8-4ds_v6
+      memory: 68719476736
+      name: Standard_E8-4ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardESv3Family
+      generic_name: standard_e8-4s_v3
+      id: Standard_E8-4s_v3
+      memory: 68719476736
+      name: Standard_E8-4s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardESv4Family
+      generic_name: standard_e8-4s_v4
+      id: Standard_E8-4s_v4
+      memory: 68719476736
+      name: Standard_E8-4s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardESv5Family
+      generic_name: standard_e8-4s_v5
+      id: Standard_E8-4s_v5
+      memory: 68719476736
+      name: Standard_E8-4s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEsv6Family
+      generic_name: standard_e8-4s_v6
+      id: Standard_E8-4s_v6
+      memory: 68719476736
+      name: Standard_E8-4s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: standardXEIDSv4Family
+      generic_name: standard_e80ids_v4
+      id: Standard_E80ids_v4
+      memory: 541165879296
+      name: Standard_E80ids_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: standardXEISv4Family
+      generic_name: standard_e80is_v4
+      id: Standard_E80is_v4
+      memory: 541165879296
+      name: Standard_E80is_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEADSv5Family
+      generic_name: standard_e8ads_v5
+      id: Standard_E8ads_v5
+      memory: 68719476736
+      name: Standard_E8ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEadv6Family
+      generic_name: standard_e8ads_v6
+      id: Standard_E8ads_v6
+      memory: 68719476736
+      name: Standard_E8ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEadsv7Family
+      generic_name: standard_e8ads_v7
+      id: Standard_E8ads_v7
+      memory: 68719476736
+      name: Standard_E8ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEASv4Family
+      generic_name: standard_e8as_v4
+      id: Standard_E8as_v4
+      memory: 68719476736
+      name: Standard_E8as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEASv5Family
+      generic_name: standard_e8as_v5
+      id: Standard_E8as_v5
+      memory: 68719476736
+      name: Standard_E8as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEav6Family
+      generic_name: standard_e8as_v6
+      id: Standard_E8as_v6
+      memory: 68719476736
+      name: Standard_E8as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEasv7Family
+      generic_name: standard_e8as_v7
+      id: Standard_E8as_v7
+      memory: 68719476736
+      name: Standard_E8as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEAv4Family
+      generic_name: standard_e8a_v4
+      id: Standard_E8a_v4
+      memory: 68719476736
+      name: Standard_E8a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEBDSv5Family
+      generic_name: standard_e8bds_v5
+      id: Standard_E8bds_v5
+      memory: 68719476736
+      name: Standard_E8bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEBSv5Family
+      generic_name: standard_e8bs_v5
+      id: Standard_E8bs_v5
+      memory: 68719476736
+      name: Standard_E8bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEDSv4Family
+      generic_name: standard_e8ds_v4
+      id: Standard_E8ds_v4
+      memory: 68719476736
+      name: Standard_E8ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEDSv5Family
+      generic_name: standard_e8ds_v5
+      id: Standard_E8ds_v5
+      memory: 68719476736
+      name: Standard_E8ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEdsv6Family
+      generic_name: standard_e8ds_v6
+      id: Standard_E8ds_v6
+      memory: 68719476736
+      name: Standard_E8ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEDv4Family
+      generic_name: standard_e8d_v4
+      id: Standard_E8d_v4
+      memory: 68719476736
+      name: Standard_E8d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEDv5Family
+      generic_name: standard_e8d_v5
+      id: Standard_E8d_v5
+      memory: 68719476736
+      name: Standard_E8d_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEPDSv5Family
+      generic_name: standard_e8pds_v5
+      id: Standard_E8pds_v5
+      memory: 68719476736
+      name: Standard_E8pds_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEpdsv6Family
+      generic_name: standard_e8pds_v6
+      id: Standard_E8pds_v6
+      memory: 68719476736
+      name: Standard_E8pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEPSv5Family
+      generic_name: standard_e8ps_v5
+      id: Standard_E8ps_v5
+      memory: 68719476736
+      name: Standard_E8ps_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEpsv6Family
+      generic_name: standard_e8ps_v6
+      id: Standard_E8ps_v6
+      memory: 68719476736
+      name: Standard_E8ps_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardESv3Family
+      generic_name: standard_e8s_v3
+      id: Standard_E8s_v3
+      memory: 68719476736
+      name: Standard_E8s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardESv4Family
+      generic_name: standard_e8s_v4
+      id: Standard_E8s_v4
+      memory: 68719476736
+      name: Standard_E8s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardESv5Family
+      generic_name: standard_e8s_v5
+      id: Standard_E8s_v5
+      memory: 68719476736
+      name: Standard_E8s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEsv6Family
+      generic_name: standard_e8s_v6
+      id: Standard_E8s_v6
+      memory: 68719476736
+      name: Standard_E8s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEv3Family
+      generic_name: standard_e8_v3
+      id: Standard_E8_v3
+      memory: 68719476736
+      name: Standard_E8_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEv4Family
+      generic_name: standard_e8_v4
+      id: Standard_E8_v4
+      memory: 68719476736
+      name: Standard_E8_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEv5Family
+      generic_name: standard_e8_v5
+      id: Standard_E8_v5
+      memory: 68719476736
+      name: Standard_E8_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEADSv5Family
+      generic_name: standard_e96-24ads_v5
+      id: Standard_E96-24ads_v5
+      memory: 721554505728
+      name: Standard_E96-24ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEadv6Family
+      generic_name: standard_e96-24ads_v6
+      id: Standard_E96-24ads_v6
+      memory: 721554505728
+      name: Standard_E96-24ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEadsv7Family
+      generic_name: standard_e96-24ads_v7
+      id: Standard_E96-24ads_v7
+      memory: 824633720832
+      name: Standard_E96-24ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEASv4Family
+      generic_name: standard_e96-24as_v4
+      id: Standard_E96-24as_v4
+      memory: 721554505728
+      name: Standard_E96-24as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEASv5Family
+      generic_name: standard_e96-24as_v5
+      id: Standard_E96-24as_v5
+      memory: 721554505728
+      name: Standard_E96-24as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEasv7Family
+      generic_name: standard_e96-24as_v7
+      id: Standard_E96-24as_v7
+      memory: 824633720832
+      name: Standard_E96-24as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEDSv5Family
+      generic_name: standard_e96-24ds_v5
+      id: Standard_E96-24ds_v5
+      memory: 721554505728
+      name: Standard_E96-24ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEdsv6Family
+      generic_name: standard_e96-24ds_v6
+      id: Standard_E96-24ds_v6
+      memory: 824633720832
+      name: Standard_E96-24ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardESv5Family
+      generic_name: standard_e96-24s_v5
+      id: Standard_E96-24s_v5
+      memory: 721554505728
+      name: Standard_E96-24s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEsv6Family
+      generic_name: standard_e96-24s_v6
+      id: Standard_E96-24s_v6
+      memory: 824633720832
+      name: Standard_E96-24s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEADSv5Family
+      generic_name: standard_e96-48ads_v5
+      id: Standard_E96-48ads_v5
+      memory: 721554505728
+      name: Standard_E96-48ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEadv6Family
+      generic_name: standard_e96-48ads_v6
+      id: Standard_E96-48ads_v6
+      memory: 721554505728
+      name: Standard_E96-48ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEadsv7Family
+      generic_name: standard_e96-48ads_v7
+      id: Standard_E96-48ads_v7
+      memory: 824633720832
+      name: Standard_E96-48ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEASv4Family
+      generic_name: standard_e96-48as_v4
+      id: Standard_E96-48as_v4
+      memory: 721554505728
+      name: Standard_E96-48as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEASv5Family
+      generic_name: standard_e96-48as_v5
+      id: Standard_E96-48as_v5
+      memory: 721554505728
+      name: Standard_E96-48as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEasv7Family
+      generic_name: standard_e96-48as_v7
+      id: Standard_E96-48as_v7
+      memory: 824633720832
+      name: Standard_E96-48as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEDSv5Family
+      generic_name: standard_e96-48ds_v5
+      id: Standard_E96-48ds_v5
+      memory: 721554505728
+      name: Standard_E96-48ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEdsv6Family
+      generic_name: standard_e96-48ds_v6
+      id: Standard_E96-48ds_v6
+      memory: 824633720832
+      name: Standard_E96-48ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardESv5Family
+      generic_name: standard_e96-48s_v5
+      id: Standard_E96-48s_v5
+      memory: 721554505728
+      name: Standard_E96-48s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEsv6Family
+      generic_name: standard_e96-48s_v6
+      id: Standard_E96-48s_v6
+      memory: 824633720832
+      name: Standard_E96-48s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEADSv5Family
+      generic_name: standard_e96ads_v5
+      id: Standard_E96ads_v5
+      memory: 721554505728
+      name: Standard_E96ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEadv6Family
+      generic_name: standard_e96ads_v6
+      id: Standard_E96ads_v6
+      memory: 721554505728
+      name: Standard_E96ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEadsv7Family
+      generic_name: standard_e96ads_v7
+      id: Standard_E96ads_v7
+      memory: 824633720832
+      name: Standard_E96ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEASv4Family
+      generic_name: standard_e96as_v4
+      id: Standard_E96as_v4
+      memory: 721554505728
+      name: Standard_E96as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEASv5Family
+      generic_name: standard_e96as_v5
+      id: Standard_E96as_v5
+      memory: 721554505728
+      name: Standard_E96as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEav6Family
+      generic_name: standard_e96as_v6
+      id: Standard_E96as_v6
+      memory: 721554505728
+      name: Standard_E96as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEasv7Family
+      generic_name: standard_e96as_v7
+      id: Standard_E96as_v7
+      memory: 824633720832
+      name: Standard_E96as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEAv4Family
+      generic_name: standard_e96a_v4
+      id: Standard_E96a_v4
+      memory: 721554505728
+      name: Standard_E96a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEBDSv5Family
+      generic_name: standard_e96bds_v5
+      id: Standard_E96bds_v5
+      memory: 721554505728
+      name: Standard_E96bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEBSv5Family
+      generic_name: standard_e96bs_v5
+      id: Standard_E96bs_v5
+      memory: 721554505728
+      name: Standard_E96bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEDSv5Family
+      generic_name: standard_e96ds_v5
+      id: Standard_E96ds_v5
+      memory: 721554505728
+      name: Standard_E96ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEdsv6Family
+      generic_name: standard_e96ds_v6
+      id: Standard_E96ds_v6
+      memory: 824633720832
+      name: Standard_E96ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEDv5Family
+      generic_name: standard_e96d_v5
+      id: Standard_E96d_v5
+      memory: 721554505728
+      name: Standard_E96d_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEIASv4Family
+      generic_name: standard_e96ias_v4
+      id: Standard_E96ias_v4
+      memory: 721554505728
+      name: Standard_E96ias_v4
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEpdsv6Family
+      generic_name: standard_e96pds_v6
+      id: Standard_E96pds_v6
+      memory: 721554505728
+      name: Standard_E96pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEpsv6Family
+      generic_name: standard_e96ps_v6
+      id: Standard_E96ps_v6
+      memory: 721554505728
+      name: Standard_E96ps_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardESv5Family
+      generic_name: standard_e96s_v5
+      id: Standard_E96s_v5
+      memory: 721554505728
+      name: Standard_E96s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEsv6Family
+      generic_name: standard_e96s_v6
+      id: Standard_E96s_v6
+      memory: 824633720832
+      name: Standard_E96s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEv5Family
+      generic_name: standard_e96_v5
+      id: Standard_E96_v5
+      memory: 721554505728
+      name: Standard_E96_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardECADCCV5Family
+      generic_name: standard_ec16ads_cc_v5
+      id: Standard_EC16ads_cc_v5
+      memory: 137438953472
+      name: Standard_EC16ads_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardECADSv5Family
+      generic_name: standard_ec16ads_v5
+      id: Standard_EC16ads_v5
+      memory: 137438953472
+      name: Standard_EC16ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardECadsv6Family
+      generic_name: standard_ec16ads_v6
+      id: Standard_EC16ads_v6
+      memory: 137438953472
+      name: Standard_EC16ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardECACCV5Family
+      generic_name: standard_ec16as_cc_v5
+      id: Standard_EC16as_cc_v5
+      memory: 137438953472
+      name: Standard_EC16as_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardECASv5Family
+      generic_name: standard_ec16as_v5
+      id: Standard_EC16as_v5
+      memory: 137438953472
+      name: Standard_EC16as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardECasv6Family
+      generic_name: standard_ec16as_v6
+      id: Standard_EC16as_v6
+      memory: 137438953472
+      name: Standard_EC16as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardECEDV6Family
+      generic_name: standard_ec16eds_v6
+      id: Standard_EC16eds_v6
+      memory: 137438953472
+      name: Standard_EC16eds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardECEV6Family
       generic_name: standard_ec16es_v6
       id: Standard_EC16es_v6
       memory: 137438953472
       name: Standard_EC16es_v6
     - category: memory_optimized
       cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardECADCCV5Family
+      generic_name: standard_ec20ads_cc_v5
+      id: Standard_EC20ads_cc_v5
+      memory: 171798691840
+      name: Standard_EC20ads_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardECADSv5Family
+      generic_name: standard_ec20ads_v5
+      id: Standard_EC20ads_v5
+      memory: 171798691840
+      name: Standard_EC20ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardECACCV5Family
+      generic_name: standard_ec20as_cc_v5
+      id: Standard_EC20as_cc_v5
+      memory: 171798691840
+      name: Standard_EC20as_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardECASv5Family
+      generic_name: standard_ec20as_v5
+      id: Standard_EC20as_v5
+      memory: 171798691840
+      name: Standard_EC20as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardECADSv5Family
+      generic_name: standard_ec2ads_v5
+      id: Standard_EC2ads_v5
+      memory: 17179869184
+      name: Standard_EC2ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardECadsv6Family
+      generic_name: standard_ec2ads_v6
+      id: Standard_EC2ads_v6
+      memory: 17179869184
+      name: Standard_EC2ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardECASv5Family
+      generic_name: standard_ec2as_v5
+      id: Standard_EC2as_v5
+      memory: 17179869184
+      name: Standard_EC2as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardECasv6Family
+      generic_name: standard_ec2as_v6
+      id: Standard_EC2as_v6
+      memory: 17179869184
+      name: Standard_EC2as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardECEDV6Family
+      generic_name: standard_ec2eds_v6
+      id: Standard_EC2eds_v6
+      memory: 17179869184
+      name: Standard_EC2eds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardECEV6Family
+      generic_name: standard_ec2es_v6
+      id: Standard_EC2es_v6
+      memory: 17179869184
+      name: Standard_EC2es_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
       cpu_cores: 32
+      family: standardECADCCV5Family
+      generic_name: standard_ec32ads_cc_v5
+      id: Standard_EC32ads_cc_v5
+      memory: 206158430208
+      name: Standard_EC32ads_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardECADSv5Family
+      generic_name: standard_ec32ads_v5
+      id: Standard_EC32ads_v5
+      memory: 206158430208
+      name: Standard_EC32ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardECadsv6Family
+      generic_name: standard_ec32ads_v6
+      id: Standard_EC32ads_v6
+      memory: 274877906944
+      name: Standard_EC32ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardECACCV5Family
+      generic_name: standard_ec32as_cc_v5
+      id: Standard_EC32as_cc_v5
+      memory: 206158430208
+      name: Standard_EC32as_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardECASv5Family
+      generic_name: standard_ec32as_v5
+      id: Standard_EC32as_v5
+      memory: 206158430208
+      name: Standard_EC32as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardECasv6Family
+      generic_name: standard_ec32as_v6
+      id: Standard_EC32as_v6
+      memory: 274877906944
+      name: Standard_EC32as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardECEDV6Family
+      generic_name: standard_ec32eds_v6
+      id: Standard_EC32eds_v6
+      memory: 274877906944
+      name: Standard_EC32eds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardECEV6Family
       generic_name: standard_ec32es_v6
       id: Standard_EC32es_v6
       memory: 274877906944
@@ -7709,66 +7082,2147 @@ data:
     - category: memory_optimized
       cloud_provider_id: azure
       cpu_cores: 48
-      generic_name: standard_ec48es_v6
-      id: Standard_EC48es_v6
+      family: standardECADCCV5Family
+      generic_name: standard_ec48ads_cc_v5
+      id: Standard_EC48ads_cc_v5
       memory: 412316860416
-      name: Standard_EC48es_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_ec64es_v6
-      id: Standard_EC64es_v6
-      memory: 549755813888
-      name: Standard_EC64es_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_ec2eds_v6
-      id: Standard_EC2eds_v6
-      memory: 17179869184
-      name: Standard_EC2eds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_ec4eds_v6
-      id: Standard_EC4eds_v6
-      memory: 34359738368
-      name: Standard_EC4eds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_ec8eds_v6
-      id: Standard_EC8eds_v6
-      memory: 68719476736
-      name: Standard_EC8eds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_ec16eds_v6
-      id: Standard_EC16eds_v6
-      memory: 137438953472
-      name: Standard_EC16eds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_ec32eds_v6
-      id: Standard_EC32eds_v6
-      memory: 274877906944
-      name: Standard_EC32eds_v6
+      name: Standard_EC48ads_cc_v5
     - category: memory_optimized
       cloud_provider_id: azure
       cpu_cores: 48
+      family: standardECADSv5Family
+      generic_name: standard_ec48ads_v5
+      id: Standard_EC48ads_v5
+      memory: 412316860416
+      name: Standard_EC48ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardECadsv6Family
+      generic_name: standard_ec48ads_v6
+      id: Standard_EC48ads_v6
+      memory: 412316860416
+      name: Standard_EC48ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardECACCV5Family
+      generic_name: standard_ec48as_cc_v5
+      id: Standard_EC48as_cc_v5
+      memory: 412316860416
+      name: Standard_EC48as_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardECASv5Family
+      generic_name: standard_ec48as_v5
+      id: Standard_EC48as_v5
+      memory: 412316860416
+      name: Standard_EC48as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardECasv6Family
+      generic_name: standard_ec48as_v6
+      id: Standard_EC48as_v6
+      memory: 412316860416
+      name: Standard_EC48as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardECEDV6Family
       generic_name: standard_ec48eds_v6
       id: Standard_EC48eds_v6
       memory: 412316860416
       name: Standard_EC48eds_v6
     - category: memory_optimized
       cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardECEV6Family
+      generic_name: standard_ec48es_v6
+      id: Standard_EC48es_v6
+      memory: 412316860416
+      name: Standard_EC48es_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardECADCCV5Family
+      generic_name: standard_ec4ads_cc_v5
+      id: Standard_EC4ads_cc_v5
+      memory: 34359738368
+      name: Standard_EC4ads_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardECADSv5Family
+      generic_name: standard_ec4ads_v5
+      id: Standard_EC4ads_v5
+      memory: 34359738368
+      name: Standard_EC4ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardECadsv6Family
+      generic_name: standard_ec4ads_v6
+      id: Standard_EC4ads_v6
+      memory: 34359738368
+      name: Standard_EC4ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardECACCV5Family
+      generic_name: standard_ec4as_cc_v5
+      id: Standard_EC4as_cc_v5
+      memory: 34359738368
+      name: Standard_EC4as_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardECASv5Family
+      generic_name: standard_ec4as_v5
+      id: Standard_EC4as_v5
+      memory: 34359738368
+      name: Standard_EC4as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardECasv6Family
+      generic_name: standard_ec4as_v6
+      id: Standard_EC4as_v6
+      memory: 34359738368
+      name: Standard_EC4as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardECEDV6Family
+      generic_name: standard_ec4eds_v6
+      id: Standard_EC4eds_v6
+      memory: 34359738368
+      name: Standard_EC4eds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardECEV6Family
+      generic_name: standard_ec4es_v6
+      id: Standard_EC4es_v6
+      memory: 34359738368
+      name: Standard_EC4es_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
       cpu_cores: 64
+      family: standardECADCCV5Family
+      generic_name: standard_ec64ads_cc_v5
+      id: Standard_EC64ads_cc_v5
+      memory: 549755813888
+      name: Standard_EC64ads_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardECADSv5Family
+      generic_name: standard_ec64ads_v5
+      id: Standard_EC64ads_v5
+      memory: 549755813888
+      name: Standard_EC64ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardECadsv6Family
+      generic_name: standard_ec64ads_v6
+      id: Standard_EC64ads_v6
+      memory: 549755813888
+      name: Standard_EC64ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardECACCV5Family
+      generic_name: standard_ec64as_cc_v5
+      id: Standard_EC64as_cc_v5
+      memory: 549755813888
+      name: Standard_EC64as_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardECASv5Family
+      generic_name: standard_ec64as_v5
+      id: Standard_EC64as_v5
+      memory: 549755813888
+      name: Standard_EC64as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardECasv6Family
+      generic_name: standard_ec64as_v6
+      id: Standard_EC64as_v6
+      memory: 549755813888
+      name: Standard_EC64as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardECEDV6Family
       generic_name: standard_ec64eds_v6
       id: Standard_EC64eds_v6
       memory: 549755813888
       name: Standard_EC64eds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardECEV6Family
+      generic_name: standard_ec64es_v6
+      id: Standard_EC64es_v6
+      memory: 549755813888
+      name: Standard_EC64es_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardECADCCV5Family
+      generic_name: standard_ec8ads_cc_v5
+      id: Standard_EC8ads_cc_v5
+      memory: 68719476736
+      name: Standard_EC8ads_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardECADSv5Family
+      generic_name: standard_ec8ads_v5
+      id: Standard_EC8ads_v5
+      memory: 68719476736
+      name: Standard_EC8ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardECadsv6Family
+      generic_name: standard_ec8ads_v6
+      id: Standard_EC8ads_v6
+      memory: 68719476736
+      name: Standard_EC8ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardECACCV5Family
+      generic_name: standard_ec8as_cc_v5
+      id: Standard_EC8as_cc_v5
+      memory: 68719476736
+      name: Standard_EC8as_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardECASv5Family
+      generic_name: standard_ec8as_v5
+      id: Standard_EC8as_v5
+      memory: 68719476736
+      name: Standard_EC8as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardECasv6Family
+      generic_name: standard_ec8as_v6
+      id: Standard_EC8as_v6
+      memory: 68719476736
+      name: Standard_EC8as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardECEDV6Family
+      generic_name: standard_ec8eds_v6
+      id: Standard_EC8eds_v6
+      memory: 68719476736
+      name: Standard_EC8eds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardECEV6Family
+      generic_name: standard_ec8es_v6
+      id: Standard_EC8es_v6
+      memory: 68719476736
+      name: Standard_EC8es_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardECADCCV5Family
+      generic_name: standard_ec96ads_cc_v5
+      id: Standard_EC96ads_cc_v5
+      memory: 721554505728
+      name: Standard_EC96ads_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardECADSv5Family
+      generic_name: standard_ec96ads_v5
+      id: Standard_EC96ads_v5
+      memory: 721554505728
+      name: Standard_EC96ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardECadsv6Family
+      generic_name: standard_ec96ads_v6
+      id: Standard_EC96ads_v6
+      memory: 721554505728
+      name: Standard_EC96ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardECACCV5Family
+      generic_name: standard_ec96as_cc_v5
+      id: Standard_EC96as_cc_v5
+      memory: 721554505728
+      name: Standard_EC96as_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardECASv5Family
+      generic_name: standard_ec96as_v5
+      id: Standard_EC96as_v5
+      memory: 721554505728
+      name: Standard_EC96as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardECasv6Family
+      generic_name: standard_ec96as_v6
+      id: Standard_EC96as_v6
+      memory: 721554505728
+      name: Standard_EC96as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardECIADSv5Family
+      generic_name: standard_ec96iads_v5
+      id: Standard_EC96iads_v5
+      memory: 721554505728
+      name: Standard_EC96iads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardECIASv5Family
+      generic_name: standard_ec96ias_v5
+      id: Standard_EC96ias_v5
+      memory: 721554505728
+      name: Standard_EC96ias_v5
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      family: standardFFamily
+      generic_name: standard_f1
+      id: Standard_F1
+      memory: 2147483648
+      name: Standard_F1
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardFFamily
+      generic_name: standard_f16
+      id: Standard_F16
+      memory: 34359738368
+      name: Standard_F16
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFamdsv7Family
+      generic_name: standard_f16-4amds_v7
+      id: Standard_F16-4amds_v7
+      memory: 137438953472
+      name: Standard_F16-4amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFamsv7Family
+      generic_name: standard_f16-4ams_v7
+      id: Standard_F16-4ams_v7
+      memory: 137438953472
+      name: Standard_F16-4ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFamdsv7Family
+      generic_name: standard_f16-8amds_v7
+      id: Standard_F16-8amds_v7
+      memory: 137438953472
+      name: Standard_F16-8amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFamsv7Family
+      generic_name: standard_f16-8ams_v7
+      id: Standard_F16-8ams_v7
+      memory: 137438953472
+      name: Standard_F16-8ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFadsv7Family
+      generic_name: standard_f16ads_v7
+      id: Standard_F16ads_v7
+      memory: 68719476736
+      name: Standard_F16ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFaldsv7Family
+      generic_name: standard_f16alds_v7
+      id: Standard_F16alds_v7
+      memory: 34359738368
+      name: Standard_F16alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFalsv6Family
+      generic_name: standard_f16als_v6
+      id: Standard_F16als_v6
+      memory: 34359738368
+      name: Standard_F16als_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFalsv7Family
+      generic_name: standard_f16als_v7
+      id: Standard_F16als_v7
+      memory: 34359738368
+      name: Standard_F16als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFamdsv7Family
+      generic_name: standard_f16amds_v7
+      id: Standard_F16amds_v7
+      memory: 137438953472
+      name: Standard_F16amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFamsv6Family
+      generic_name: standard_f16ams_v6
+      id: Standard_F16ams_v6
+      memory: 137438953472
+      name: Standard_F16ams_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFamsv7Family
+      generic_name: standard_f16ams_v7
+      id: Standard_F16ams_v7
+      memory: 137438953472
+      name: Standard_F16ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFasv6Family
+      generic_name: standard_f16as_v6
+      id: Standard_F16as_v6
+      memory: 68719476736
+      name: Standard_F16as_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFasv7Family
+      generic_name: standard_f16as_v7
+      id: Standard_F16as_v7
+      memory: 68719476736
+      name: Standard_F16as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardFSFamily
+      generic_name: standard_f16s
+      id: Standard_F16s
+      memory: 34359738368
+      name: Standard_F16s
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardFSv2Family
+      generic_name: standard_f16s_v2
+      id: Standard_F16s_v2
+      memory: 34359738368
+      name: Standard_F16s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      family: StandardFadsv7Family
+      generic_name: standard_f1ads_v7
+      id: Standard_F1ads_v7
+      memory: 4294967296
+      name: Standard_F1ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      family: StandardFaldsv7Family
+      generic_name: standard_f1alds_v7
+      id: Standard_F1alds_v7
+      memory: 2147483648
+      name: Standard_F1alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      family: StandardFalsv7Family
+      generic_name: standard_f1als_v7
+      id: Standard_F1als_v7
+      memory: 2147483648
+      name: Standard_F1als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      family: StandardFamdsv7Family
+      generic_name: standard_f1amds_v7
+      id: Standard_F1amds_v7
+      memory: 8589934592
+      name: Standard_F1amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      family: StandardFamsv7Family
+      generic_name: standard_f1ams_v7
+      id: Standard_F1ams_v7
+      memory: 8589934592
+      name: Standard_F1ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      family: StandardFasv7Family
+      generic_name: standard_f1as_v7
+      id: Standard_F1as_v7
+      memory: 4294967296
+      name: Standard_F1as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      family: standardFSFamily
+      generic_name: standard_f1s
+      id: Standard_F1s
+      memory: 2147483648
+      name: Standard_F1s
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardFFamily
+      generic_name: standard_f2
+      id: Standard_F2
+      memory: 4294967296
+      name: Standard_F2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFamdsv7Family
+      generic_name: standard_f2-1amds_v7
+      id: Standard_F2-1amds_v7
+      memory: 17179869184
+      name: Standard_F2-1amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFamsv7Family
+      generic_name: standard_f2-1ams_v7
+      id: Standard_F2-1ams_v7
+      memory: 17179869184
+      name: Standard_F2-1ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFadsv7Family
+      generic_name: standard_f2ads_v7
+      id: Standard_F2ads_v7
+      memory: 8589934592
+      name: Standard_F2ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFaldsv7Family
+      generic_name: standard_f2alds_v7
+      id: Standard_F2alds_v7
+      memory: 4294967296
+      name: Standard_F2alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFalsv6Family
+      generic_name: standard_f2als_v6
+      id: Standard_F2als_v6
+      memory: 4294967296
+      name: Standard_F2als_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFalsv7Family
+      generic_name: standard_f2als_v7
+      id: Standard_F2als_v7
+      memory: 4294967296
+      name: Standard_F2als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFamdsv7Family
+      generic_name: standard_f2amds_v7
+      id: Standard_F2amds_v7
+      memory: 17179869184
+      name: Standard_F2amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFamsv6Family
+      generic_name: standard_f2ams_v6
+      id: Standard_F2ams_v6
+      memory: 17179869184
+      name: Standard_F2ams_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFamsv7Family
+      generic_name: standard_f2ams_v7
+      id: Standard_F2ams_v7
+      memory: 17179869184
+      name: Standard_F2ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFasv6Family
+      generic_name: standard_f2as_v6
+      id: Standard_F2as_v6
+      memory: 8589934592
+      name: Standard_F2as_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFasv7Family
+      generic_name: standard_f2as_v7
+      id: Standard_F2as_v7
+      memory: 8589934592
+      name: Standard_F2as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardFSFamily
+      generic_name: standard_f2s
+      id: Standard_F2s
+      memory: 4294967296
+      name: Standard_F2s
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardFSv2Family
+      generic_name: standard_f2s_v2
+      id: Standard_F2s_v2
+      memory: 4294967296
+      name: Standard_F2s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFamdsv7Family
+      generic_name: standard_f32-16amds_v7
+      id: Standard_F32-16amds_v7
+      memory: 274877906944
+      name: Standard_F32-16amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFamsv7Family
+      generic_name: standard_f32-16ams_v7
+      id: Standard_F32-16ams_v7
+      memory: 274877906944
+      name: Standard_F32-16ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFamdsv7Family
+      generic_name: standard_f32-8amds_v7
+      id: Standard_F32-8amds_v7
+      memory: 274877906944
+      name: Standard_F32-8amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFamsv7Family
+      generic_name: standard_f32-8ams_v7
+      id: Standard_F32-8ams_v7
+      memory: 274877906944
+      name: Standard_F32-8ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFadsv7Family
+      generic_name: standard_f32ads_v7
+      id: Standard_F32ads_v7
+      memory: 137438953472
+      name: Standard_F32ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFaldsv7Family
+      generic_name: standard_f32alds_v7
+      id: Standard_F32alds_v7
+      memory: 68719476736
+      name: Standard_F32alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFalsv6Family
+      generic_name: standard_f32als_v6
+      id: Standard_F32als_v6
+      memory: 68719476736
+      name: Standard_F32als_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFalsv7Family
+      generic_name: standard_f32als_v7
+      id: Standard_F32als_v7
+      memory: 68719476736
+      name: Standard_F32als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFamdsv7Family
+      generic_name: standard_f32amds_v7
+      id: Standard_F32amds_v7
+      memory: 274877906944
+      name: Standard_F32amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFamsv6Family
+      generic_name: standard_f32ams_v6
+      id: Standard_F32ams_v6
+      memory: 274877906944
+      name: Standard_F32ams_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFamsv7Family
+      generic_name: standard_f32ams_v7
+      id: Standard_F32ams_v7
+      memory: 274877906944
+      name: Standard_F32ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFasv6Family
+      generic_name: standard_f32as_v6
+      id: Standard_F32as_v6
+      memory: 137438953472
+      name: Standard_F32as_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFasv7Family
+      generic_name: standard_f32as_v7
+      id: Standard_F32as_v7
+      memory: 137438953472
+      name: Standard_F32as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardFSv2Family
+      generic_name: standard_f32s_v2
+      id: Standard_F32s_v2
+      memory: 68719476736
+      name: Standard_F32s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardFFamily
+      generic_name: standard_f4
+      id: Standard_F4
+      memory: 8589934592
+      name: Standard_F4
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFamdsv7Family
+      generic_name: standard_f4-1amds_v7
+      id: Standard_F4-1amds_v7
+      memory: 34359738368
+      name: Standard_F4-1amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFamsv7Family
+      generic_name: standard_f4-1ams_v7
+      id: Standard_F4-1ams_v7
+      memory: 34359738368
+      name: Standard_F4-1ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFamdsv7Family
+      generic_name: standard_f4-2amds_v7
+      id: Standard_F4-2amds_v7
+      memory: 34359738368
+      name: Standard_F4-2amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFamsv7Family
+      generic_name: standard_f4-2ams_v7
+      id: Standard_F4-2ams_v7
+      memory: 34359738368
+      name: Standard_F4-2ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFadsv7Family
+      generic_name: standard_f48ads_v7
+      id: Standard_F48ads_v7
+      memory: 206158430208
+      name: Standard_F48ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFaldsv7Family
+      generic_name: standard_f48alds_v7
+      id: Standard_F48alds_v7
+      memory: 103079215104
+      name: Standard_F48alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFalsv6Family
+      generic_name: standard_f48als_v6
+      id: Standard_F48als_v6
+      memory: 103079215104
+      name: Standard_F48als_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFalsv7Family
+      generic_name: standard_f48als_v7
+      id: Standard_F48als_v7
+      memory: 103079215104
+      name: Standard_F48als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFamdsv7Family
+      generic_name: standard_f48amds_v7
+      id: Standard_F48amds_v7
+      memory: 412316860416
+      name: Standard_F48amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFamsv6Family
+      generic_name: standard_f48ams_v6
+      id: Standard_F48ams_v6
+      memory: 412316860416
+      name: Standard_F48ams_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFamsv7Family
+      generic_name: standard_f48ams_v7
+      id: Standard_F48ams_v7
+      memory: 412316860416
+      name: Standard_F48ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFasv6Family
+      generic_name: standard_f48as_v6
+      id: Standard_F48as_v6
+      memory: 206158430208
+      name: Standard_F48as_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFasv7Family
+      generic_name: standard_f48as_v7
+      id: Standard_F48as_v7
+      memory: 206158430208
+      name: Standard_F48as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardFSv2Family
+      generic_name: standard_f48s_v2
+      id: Standard_F48s_v2
+      memory: 103079215104
+      name: Standard_F48s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFadsv7Family
+      generic_name: standard_f4ads_v7
+      id: Standard_F4ads_v7
+      memory: 17179869184
+      name: Standard_F4ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFaldsv7Family
+      generic_name: standard_f4alds_v7
+      id: Standard_F4alds_v7
+      memory: 8589934592
+      name: Standard_F4alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFalsv6Family
+      generic_name: standard_f4als_v6
+      id: Standard_F4als_v6
+      memory: 8589934592
+      name: Standard_F4als_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFalsv7Family
+      generic_name: standard_f4als_v7
+      id: Standard_F4als_v7
+      memory: 8589934592
+      name: Standard_F4als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFamdsv7Family
+      generic_name: standard_f4amds_v7
+      id: Standard_F4amds_v7
+      memory: 34359738368
+      name: Standard_F4amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFamsv6Family
+      generic_name: standard_f4ams_v6
+      id: Standard_F4ams_v6
+      memory: 34359738368
+      name: Standard_F4ams_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFamsv7Family
+      generic_name: standard_f4ams_v7
+      id: Standard_F4ams_v7
+      memory: 34359738368
+      name: Standard_F4ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFasv6Family
+      generic_name: standard_f4as_v6
+      id: Standard_F4as_v6
+      memory: 17179869184
+      name: Standard_F4as_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFasv7Family
+      generic_name: standard_f4as_v7
+      id: Standard_F4as_v7
+      memory: 17179869184
+      name: Standard_F4as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardFSFamily
+      generic_name: standard_f4s
+      id: Standard_F4s
+      memory: 8589934592
+      name: Standard_F4s
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardFSv2Family
+      generic_name: standard_f4s_v2
+      id: Standard_F4s_v2
+      memory: 8589934592
+      name: Standard_F4s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFamdsv7Family
+      generic_name: standard_f64-16amds_v7
+      id: Standard_F64-16amds_v7
+      memory: 549755813888
+      name: Standard_F64-16amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: StandardFamsv7Family
+      generic_name: standard_f64-16ams_v7
+      id: Standard_F64-16ams_v7
+      memory: 549755813888
+      name: Standard_F64-16ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFamdsv7Family
+      generic_name: standard_f64-32amds_v7
+      id: Standard_F64-32amds_v7
+      memory: 549755813888
+      name: Standard_F64-32amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFamsv7Family
+      generic_name: standard_f64-32ams_v7
+      id: Standard_F64-32ams_v7
+      memory: 549755813888
+      name: Standard_F64-32ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFadsv7Family
+      generic_name: standard_f64ads_v7
+      id: Standard_F64ads_v7
+      memory: 274877906944
+      name: Standard_F64ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFaldsv7Family
+      generic_name: standard_f64alds_v7
+      id: Standard_F64alds_v7
+      memory: 137438953472
+      name: Standard_F64alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFalsv6Family
+      generic_name: standard_f64als_v6
+      id: Standard_F64als_v6
+      memory: 137438953472
+      name: Standard_F64als_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFalsv7Family
+      generic_name: standard_f64als_v7
+      id: Standard_F64als_v7
+      memory: 137438953472
+      name: Standard_F64als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFamdsv7Family
+      generic_name: standard_f64amds_v7
+      id: Standard_F64amds_v7
+      memory: 549755813888
+      name: Standard_F64amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFamsv6Family
+      generic_name: standard_f64ams_v6
+      id: Standard_F64ams_v6
+      memory: 549755813888
+      name: Standard_F64ams_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFamsv7Family
+      generic_name: standard_f64ams_v7
+      id: Standard_F64ams_v7
+      memory: 549755813888
+      name: Standard_F64ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFasv6Family
+      generic_name: standard_f64as_v6
+      id: Standard_F64as_v6
+      memory: 274877906944
+      name: Standard_F64as_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFasv7Family
+      generic_name: standard_f64as_v7
+      id: Standard_F64as_v7
+      memory: 274877906944
+      name: Standard_F64as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardFSv2Family
+      generic_name: standard_f64s_v2
+      id: Standard_F64s_v2
+      memory: 137438953472
+      name: Standard_F64s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 72
+      family: standardFSv2Family
+      generic_name: standard_f72s_v2
+      id: Standard_F72s_v2
+      memory: 154618822656
+      name: Standard_F72s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardFFamily
+      generic_name: standard_f8
+      id: Standard_F8
+      memory: 17179869184
+      name: Standard_F8
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFamdsv7Family
+      generic_name: standard_f8-2amds_v7
+      id: Standard_F8-2amds_v7
+      memory: 68719476736
+      name: Standard_F8-2amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFamsv7Family
+      generic_name: standard_f8-2ams_v7
+      id: Standard_F8-2ams_v7
+      memory: 68719476736
+      name: Standard_F8-2ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFamdsv7Family
+      generic_name: standard_f8-4amds_v7
+      id: Standard_F8-4amds_v7
+      memory: 68719476736
+      name: Standard_F8-4amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFamsv7Family
+      generic_name: standard_f8-4ams_v7
+      id: Standard_F8-4ams_v7
+      memory: 68719476736
+      name: Standard_F8-4ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: StandardFadsv7Family
+      generic_name: standard_f80ads_v7
+      id: Standard_F80ads_v7
+      memory: 343597383680
+      name: Standard_F80ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: StandardFaldsv7Family
+      generic_name: standard_f80alds_v7
+      id: Standard_F80alds_v7
+      memory: 171798691840
+      name: Standard_F80alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: StandardFalsv7Family
+      generic_name: standard_f80als_v7
+      id: Standard_F80als_v7
+      memory: 171798691840
+      name: Standard_F80als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: StandardFamdsv7Family
+      generic_name: standard_f80amds_v7
+      id: Standard_F80amds_v7
+      memory: 687194767360
+      name: Standard_F80amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: StandardFamsv7Family
+      generic_name: standard_f80ams_v7
+      id: Standard_F80ams_v7
+      memory: 687194767360
+      name: Standard_F80ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: StandardFasv7Family
+      generic_name: standard_f80as_v7
+      id: Standard_F80as_v7
+      memory: 343597383680
+      name: Standard_F80as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFadsv7Family
+      generic_name: standard_f8ads_v7
+      id: Standard_F8ads_v7
+      memory: 34359738368
+      name: Standard_F8ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFaldsv7Family
+      generic_name: standard_f8alds_v7
+      id: Standard_F8alds_v7
+      memory: 17179869184
+      name: Standard_F8alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFalsv6Family
+      generic_name: standard_f8als_v6
+      id: Standard_F8als_v6
+      memory: 17179869184
+      name: Standard_F8als_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFalsv7Family
+      generic_name: standard_f8als_v7
+      id: Standard_F8als_v7
+      memory: 17179869184
+      name: Standard_F8als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFamdsv7Family
+      generic_name: standard_f8amds_v7
+      id: Standard_F8amds_v7
+      memory: 68719476736
+      name: Standard_F8amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFamsv6Family
+      generic_name: standard_f8ams_v6
+      id: Standard_F8ams_v6
+      memory: 68719476736
+      name: Standard_F8ams_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFamsv7Family
+      generic_name: standard_f8ams_v7
+      id: Standard_F8ams_v7
+      memory: 68719476736
+      name: Standard_F8ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFasv6Family
+      generic_name: standard_f8as_v6
+      id: Standard_F8as_v6
+      memory: 34359738368
+      name: Standard_F8as_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFasv7Family
+      generic_name: standard_f8as_v7
+      id: Standard_F8as_v7
+      memory: 34359738368
+      name: Standard_F8as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardFSFamily
+      generic_name: standard_f8s
+      id: Standard_F8s
+      memory: 17179869184
+      name: Standard_F8s
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardFSv2Family
+      generic_name: standard_f8s_v2
+      id: Standard_F8s_v2
+      memory: 17179869184
+      name: Standard_F8s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 12
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx12-6mds_v2
+      id: Standard_FX12-6mds_v2
+      memory: 270582939648
+      name: Standard_FX12-6mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 12
+      family: StandardFXmsv2Family
+      generic_name: standard_fx12-6ms_v2
+      id: Standard_FX12-6ms_v2
+      memory: 270582939648
+      name: Standard_FX12-6ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 12
+      family: standardFXMDVSFamily
+      generic_name: standard_fx12mds
+      id: Standard_FX12mds
+      memory: 270582939648
+      name: Standard_FX12mds
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 12
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx12mds_v2
+      id: Standard_FX12mds_v2
+      memory: 270582939648
+      name: Standard_FX12mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 12
+      family: StandardFXmsv2Family
+      generic_name: standard_fx12ms_v2
+      id: Standard_FX12ms_v2
+      memory: 270582939648
+      name: Standard_FX12ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx16-4mds_v2
+      id: Standard_FX16-4mds_v2
+      memory: 360777252864
+      name: Standard_FX16-4mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFXmsv2Family
+      generic_name: standard_fx16-4ms_v2
+      id: Standard_FX16-4ms_v2
+      memory: 360777252864
+      name: Standard_FX16-4ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx16-8mds_v2
+      id: Standard_FX16-8mds_v2
+      memory: 360777252864
+      name: Standard_FX16-8mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFXmsv2Family
+      generic_name: standard_fx16-8ms_v2
+      id: Standard_FX16-8ms_v2
+      memory: 360777252864
+      name: Standard_FX16-8ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx16mds_v2
+      id: Standard_FX16mds_v2
+      memory: 360777252864
+      name: Standard_FX16mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFXmsv2Family
+      generic_name: standard_fx16ms_v2
+      id: Standard_FX16ms_v2
+      memory: 360777252864
+      name: Standard_FX16ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx24-12mds_v2
+      id: Standard_FX24-12mds_v2
+      memory: 541165879296
+      name: Standard_FX24-12mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      family: StandardFXmsv2Family
+      generic_name: standard_fx24-12ms_v2
+      id: Standard_FX24-12ms_v2
+      memory: 541165879296
+      name: Standard_FX24-12ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx24-6mds_v2
+      id: Standard_FX24-6mds_v2
+      memory: 541165879296
+      name: Standard_FX24-6mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      family: StandardFXmsv2Family
+      generic_name: standard_fx24-6ms_v2
+      id: Standard_FX24-6ms_v2
+      memory: 541165879296
+      name: Standard_FX24-6ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      family: standardFXMDVSFamily
+      generic_name: standard_fx24mds
+      id: Standard_FX24mds
+      memory: 541165879296
+      name: Standard_FX24mds
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx24mds_v2
+      id: Standard_FX24mds_v2
+      memory: 541165879296
+      name: Standard_FX24mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      family: StandardFXmsv2Family
+      generic_name: standard_fx24ms_v2
+      id: Standard_FX24ms_v2
+      memory: 541165879296
+      name: Standard_FX24ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx2mds_v2
+      id: Standard_FX2mds_v2
+      memory: 45097156608
+      name: Standard_FX2mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFXmsv2Family
+      generic_name: standard_fx2ms_v2
+      id: Standard_FX2ms_v2
+      memory: 45097156608
+      name: Standard_FX2ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx32-16mds_v2
+      id: Standard_FX32-16mds_v2
+      memory: 721554505728
+      name: Standard_FX32-16mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFXmsv2Family
+      generic_name: standard_fx32-16ms_v2
+      id: Standard_FX32-16ms_v2
+      memory: 721554505728
+      name: Standard_FX32-16ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx32-8mds_v2
+      id: Standard_FX32-8mds_v2
+      memory: 721554505728
+      name: Standard_FX32-8mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFXmsv2Family
+      generic_name: standard_fx32-8ms_v2
+      id: Standard_FX32-8ms_v2
+      memory: 721554505728
+      name: Standard_FX32-8ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx32mds_v2
+      id: Standard_FX32mds_v2
+      memory: 721554505728
+      name: Standard_FX32mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFXmsv2Family
+      generic_name: standard_fx32ms_v2
+      id: Standard_FX32ms_v2
+      memory: 721554505728
+      name: Standard_FX32ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 36
+      family: standardFXMDVSFamily
+      generic_name: standard_fx36mds
+      id: Standard_FX36mds
+      memory: 811748818944
+      name: Standard_FX36mds
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx4-2mds_v2
+      id: Standard_FX4-2mds_v2
+      memory: 90194313216
+      name: Standard_FX4-2mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFXmsv2Family
+      generic_name: standard_fx4-2ms_v2
+      id: Standard_FX4-2ms_v2
+      memory: 90194313216
+      name: Standard_FX4-2ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx48-12mds_v2
+      id: Standard_FX48-12mds_v2
+      memory: 1082331758592
+      name: Standard_FX48-12mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFXmsv2Family
+      generic_name: standard_fx48-12ms_v2
+      id: Standard_FX48-12ms_v2
+      memory: 1082331758592
+      name: Standard_FX48-12ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx48-24mds_v2
+      id: Standard_FX48-24mds_v2
+      memory: 1082331758592
+      name: Standard_FX48-24mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFXmsv2Family
+      generic_name: standard_fx48-24ms_v2
+      id: Standard_FX48-24ms_v2
+      memory: 1082331758592
+      name: Standard_FX48-24ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardFXMDVSFamily
+      generic_name: standard_fx48mds
+      id: Standard_FX48mds
+      memory: 1082331758592
+      name: Standard_FX48mds
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx48mds_v2
+      id: Standard_FX48mds_v2
+      memory: 1082331758592
+      name: Standard_FX48mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFXmsv2Family
+      generic_name: standard_fx48ms_v2
+      id: Standard_FX48ms_v2
+      memory: 1082331758592
+      name: Standard_FX48ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardFXMDVSFamily
+      generic_name: standard_fx4mds
+      id: Standard_FX4mds
+      memory: 90194313216
+      name: Standard_FX4mds
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx4mds_v2
+      id: Standard_FX4mds_v2
+      memory: 90194313216
+      name: Standard_FX4mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFXmsv2Family
+      generic_name: standard_fx4ms_v2
+      id: Standard_FX4ms_v2
+      memory: 90194313216
+      name: Standard_FX4ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx64-16mds_v2
+      id: Standard_FX64-16mds_v2
+      memory: 1443109011456
+      name: Standard_FX64-16mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFXmsv2Family
+      generic_name: standard_fx64-16ms_v2
+      id: Standard_FX64-16ms_v2
+      memory: 1443109011456
+      name: Standard_FX64-16ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx64-32mds_v2
+      id: Standard_FX64-32mds_v2
+      memory: 1443109011456
+      name: Standard_FX64-32mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFXmsv2Family
+      generic_name: standard_fx64-32ms_v2
+      id: Standard_FX64-32ms_v2
+      memory: 1443109011456
+      name: Standard_FX64-32ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx64mds_v2
+      id: Standard_FX64mds_v2
+      memory: 1443109011456
+      name: Standard_FX64mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFXmsv2Family
+      generic_name: standard_fx64ms_v2
+      id: Standard_FX64ms_v2
+      memory: 1443109011456
+      name: Standard_FX64ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx8-2mds_v2
+      id: Standard_FX8-2mds_v2
+      memory: 180388626432
+      name: Standard_FX8-2mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFXmsv2Family
+      generic_name: standard_fx8-2ms_v2
+      id: Standard_FX8-2ms_v2
+      memory: 180388626432
+      name: Standard_FX8-2ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx8-4mds_v2
+      id: Standard_FX8-4mds_v2
+      memory: 180388626432
+      name: Standard_FX8-4mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFXmsv2Family
+      generic_name: standard_fx8-4ms_v2
+      id: Standard_FX8-4ms_v2
+      memory: 180388626432
+      name: Standard_FX8-4ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx8mds_v2
+      id: Standard_FX8mds_v2
+      memory: 180388626432
+      name: Standard_FX8mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFXmsv2Family
+      generic_name: standard_fx8ms_v2
+      id: Standard_FX8ms_v2
+      memory: 180388626432
+      name: Standard_FX8ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx96-24mds_v2
+      id: Standard_FX96-24mds_v2
+      memory: 1967095021568
+      name: Standard_FX96-24mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardFXmsv2Family
+      generic_name: standard_fx96-24ms_v2
+      id: Standard_FX96-24ms_v2
+      memory: 1967095021568
+      name: Standard_FX96-24ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx96-48mds_v2
+      id: Standard_FX96-48mds_v2
+      memory: 1967095021568
+      name: Standard_FX96-48mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardFXmsv2Family
+      generic_name: standard_fx96-48ms_v2
+      id: Standard_FX96-48ms_v2
+      memory: 1967095021568
+      name: Standard_FX96-48ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx96mds_v2
+      id: Standard_FX96mds_v2
+      memory: 1967095021568
+      name: Standard_FX96mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardFXmsv2Family
+      generic_name: standard_fx96ms_v2
+      id: Standard_FX96ms_v2
+      memory: 1967095021568
+      name: Standard_FX96ms_v2
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 12
+      family: standardLaosv4Family
+      generic_name: standard_l12aos_v4
+      id: Standard_L12aos_v4
+      memory: 103079215104
+      name: Standard_L12aos_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardLaosv4Family
+      generic_name: standard_l16aos_v4
+      id: Standard_L16aos_v4
+      memory: 137438953472
+      name: Standard_L16aos_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardLASv3Family
+      generic_name: standard_l16as_v3
+      id: Standard_L16as_v3
+      memory: 137438953472
+      name: Standard_L16as_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardLasv4Family
+      generic_name: standard_l16as_v4
+      id: Standard_L16as_v4
+      memory: 137438953472
+      name: Standard_L16as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardLSv3Family
+      generic_name: standard_l16s_v3
+      id: Standard_L16s_v3
+      memory: 137438953472
+      name: Standard_L16s_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardLsv4Family
+      generic_name: standard_l16s_v4
+      id: Standard_L16s_v4
+      memory: 137438953472
+      name: Standard_L16s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      family: standardLaosv4Family
+      generic_name: standard_l24aos_v4
+      id: Standard_L24aos_v4
+      memory: 206158430208
+      name: Standard_L24aos_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardLaosv4Family
+      generic_name: standard_l2aos_v4
+      id: Standard_L2aos_v4
+      memory: 17179869184
+      name: Standard_L2aos_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardLasv4Family
+      generic_name: standard_l2as_v4
+      id: Standard_L2as_v4
+      memory: 17179869184
+      name: Standard_L2as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardLsv4Family
+      generic_name: standard_l2s_v4
+      id: Standard_L2s_v4
+      memory: 17179869184
+      name: Standard_L2s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardLaosv4Family
+      generic_name: standard_l32aos_v4
+      id: Standard_L32aos_v4
+      memory: 274877906944
+      name: Standard_L32aos_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardLASv3Family
+      generic_name: standard_l32as_v3
+      id: Standard_L32as_v3
+      memory: 274877906944
+      name: Standard_L32as_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardLasv4Family
+      generic_name: standard_l32as_v4
+      id: Standard_L32as_v4
+      memory: 274877906944
+      name: Standard_L32as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardLSv3Family
+      generic_name: standard_l32s_v3
+      id: Standard_L32s_v3
+      memory: 274877906944
+      name: Standard_L32s_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardLsv4Family
+      generic_name: standard_l32s_v4
+      id: Standard_L32s_v4
+      memory: 274877906944
+      name: Standard_L32s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardLASv3Family
+      generic_name: standard_l48as_v3
+      id: Standard_L48as_v3
+      memory: 412316860416
+      name: Standard_L48as_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardLasv4Family
+      generic_name: standard_l48as_v4
+      id: Standard_L48as_v4
+      memory: 412316860416
+      name: Standard_L48as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardLSv3Family
+      generic_name: standard_l48s_v3
+      id: Standard_L48s_v3
+      memory: 412316860416
+      name: Standard_L48s_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardLsv4Family
+      generic_name: standard_l48s_v4
+      id: Standard_L48s_v4
+      memory: 412316860416
+      name: Standard_L48s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardLaosv4Family
+      generic_name: standard_l4aos_v4
+      id: Standard_L4aos_v4
+      memory: 34359738368
+      name: Standard_L4aos_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardLasv4Family
+      generic_name: standard_l4as_v4
+      id: Standard_L4as_v4
+      memory: 34359738368
+      name: Standard_L4as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardLsv4Family
+      generic_name: standard_l4s_v4
+      id: Standard_L4s_v4
+      memory: 34359738368
+      name: Standard_L4s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardLASv3Family
+      generic_name: standard_l64as_v3
+      id: Standard_L64as_v3
+      memory: 549755813888
+      name: Standard_L64as_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardLasv4Family
+      generic_name: standard_l64as_v4
+      id: Standard_L64as_v4
+      memory: 549755813888
+      name: Standard_L64as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardLSv3Family
+      generic_name: standard_l64s_v3
+      id: Standard_L64s_v3
+      memory: 549755813888
+      name: Standard_L64s_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardLsv4Family
+      generic_name: standard_l64s_v4
+      id: Standard_L64s_v4
+      memory: 549755813888
+      name: Standard_L64s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: standardLASv3Family
+      generic_name: standard_l80as_v3
+      id: Standard_L80as_v3
+      memory: 687194767360
+      name: Standard_L80as_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: standardLasv4Family
+      generic_name: standard_l80as_v4
+      id: Standard_L80as_v4
+      memory: 687194767360
+      name: Standard_L80as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: standardLSv3Family
+      generic_name: standard_l80s_v3
+      id: Standard_L80s_v3
+      memory: 687194767360
+      name: Standard_L80s_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: standardLsv4Family
+      generic_name: standard_l80s_v4
+      id: Standard_L80s_v4
+      memory: 687194767360
+      name: Standard_L80s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardLaosv4Family
+      generic_name: standard_l8aos_v4
+      id: Standard_L8aos_v4
+      memory: 68719476736
+      name: Standard_L8aos_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardLASv3Family
+      generic_name: standard_l8as_v3
+      id: Standard_L8as_v3
+      memory: 68719476736
+      name: Standard_L8as_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardLasv4Family
+      generic_name: standard_l8as_v4
+      id: Standard_L8as_v4
+      memory: 68719476736
+      name: Standard_L8as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardLSv3Family
+      generic_name: standard_l8s_v3
+      id: Standard_L8s_v3
+      memory: 68719476736
+      name: Standard_L8s_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardLsv4Family
+      generic_name: standard_l8s_v4
+      id: Standard_L8s_v4
+      memory: 68719476736
+      name: Standard_L8s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardLasv4Family
+      generic_name: standard_l96as_v4
+      id: Standard_L96as_v4
+      memory: 824633720832
+      name: Standard_L96as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardLsv4Family
+      generic_name: standard_l96s_v4
+      id: Standard_L96s_v4
+      memory: 824633720832
+      name: Standard_L96s_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: Standard NCASv3_T4 Family
+      generic_name: standard_nc16as_t4_v3
+      id: Standard_NC16as_T4_v3
+      memory: 118111600640
+      name: Standard_NC16as_T4_v3
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 24
+      family: StandardNCADSA100v4Family
+      generic_name: standard_nc24ads_a100_v4
+      id: Standard_NC24ads_A100_v4
+      memory: 236223201280
+      name: Standard_NC24ads_A100_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 40
+      family: StandardNCadsH100v5Family
+      generic_name: standard_nc40ads_h100_v5
+      id: Standard_NC40ads_H100_v5
+      memory: 343597383680
+      name: Standard_NC40ads_H100_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardNCADSA100v4Family
+      generic_name: standard_nc48ads_a100_v4
+      id: Standard_NC48ads_A100_v4
+      memory: 472446402560
+      name: Standard_NC48ads_A100_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: Standard NCASv3_T4 Family
+      generic_name: standard_nc4as_t4_v3
+      id: Standard_NC4as_T4_v3
+      memory: 30064771072
+      name: Standard_NC4as_T4_v3
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: Standard NCASv3_T4 Family
+      generic_name: standard_nc64as_t4_v3
+      id: Standard_NC64as_T4_v3
+      memory: 472446402560
+      name: Standard_NC64as_T4_v3
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: StandardNCadsH100v5Family
+      generic_name: standard_nc80adis_h100_v5
+      id: Standard_NC80adis_H100_v5
+      memory: 687194767360
+      name: Standard_NC80adis_H100_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: Standard NCASv3_T4 Family
+      generic_name: standard_nc8as_t4_v3
+      id: Standard_NC8as_T4_v3
+      memory: 60129542144
+      name: Standard_NC8as_T4_v3
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardNCADSA100v4Family
+      generic_name: standard_nc96ads_a100_v4
+      id: Standard_NC96ads_A100_v4
+      memory: 944892805120
+      name: Standard_NC96ads_A100_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 12
+      family: StandardNVADSA10v5Family
+      generic_name: standard_nv12ads_a10_v5
+      id: Standard_NV12ads_A10_v5
+      memory: 118111600640
+      name: Standard_NV12ads_A10_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardNVSv4Family
+      generic_name: standard_nv16as_v4
+      id: Standard_NV16as_v4
+      memory: 60129542144
+      name: Standard_NV16as_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 18
+      family: StandardNVADSA10v5Family
+      generic_name: standard_nv18ads_a10_v5
+      id: Standard_NV18ads_A10_v5
+      memory: 236223201280
+      name: Standard_NV18ads_A10_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardNVSv4Family
+      generic_name: standard_nv32as_v4
+      id: Standard_NV32as_v4
+      memory: 120259084288
+      name: Standard_NV32as_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 36
+      family: StandardNVADSA10v5Family
+      generic_name: standard_nv36adms_a10_v5
+      id: Standard_NV36adms_A10_v5
+      memory: 944892805120
+      name: Standard_NV36adms_A10_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 36
+      family: StandardNVADSA10v5Family
+      generic_name: standard_nv36ads_a10_v5
+      id: Standard_NV36ads_A10_v5
+      memory: 472446402560
+      name: Standard_NV36ads_A10_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardNVSv4Family
+      generic_name: standard_nv4as_v4
+      id: Standard_NV4as_v4
+      memory: 15032385536
+      name: Standard_NV4as_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 6
+      family: StandardNVADSA10v5Family
+      generic_name: standard_nv6ads_a10_v5
+      id: Standard_NV6ads_A10_v5
+      memory: 59055800320
+      name: Standard_NV6ads_A10_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 72
+      family: StandardNVADSA10v5Family
+      generic_name: standard_nv72ads_a10_v5
+      id: Standard_NV72ads_A10_v5
+      memory: 944892805120
+      name: Standard_NV72ads_A10_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardNVSv4Family
+      generic_name: standard_nv8as_v4
+      id: Standard_NV8as_v4
+      memory: 30064771072
+      name: Standard_NV8as_v4
 kind: ConfigMap
 metadata:
   name: cloud-resources-config
@@ -7894,7 +9348,7 @@ spec:
         checksum/provisionshard: 'd2d4582f46da482e7a0c56f8a4372d95839bf6ced1d48a964d7030dc7e1b5b4b'
         checksum/cs: '7f91f7a8dc3a8b51073043defb13df2c3864a9c93f5a5588a2431f012bc2ae28'
         checksum/runtime: 'a59b6e4224066ebe7cb35d89a9e9c179f9e90942d3b4173c91c0609299a983ef'
-        checksum/cloudres: '6db050cd35a77e565d80d2ba2c028450a8758e3ab0a4e524ede12cf207c3a73a'
+        checksum/cloudres: '259ecb0074a7ea836f9f2eedd9769724a8c6feb37fade314157736ef2b4ceebd'
         checksum/sa: '0187a6f1019114e284fb5565a82e4e954460ac079f952f07b9602117c0d81e3f'
     spec:
       topologySpreadConstraints:

--- a/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_containerdb.yaml
+++ b/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_containerdb.yaml
@@ -751,639 +751,82 @@ data:
         supports_multi_az: true
   instance-types.yaml: |
     instance_types:
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_nc4as_t4_v3
-      id: Standard_NC4as_T4_v3
-      memory: 30064771072
-      name: Standard_NC4as_T4_v3
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_nc8as_t4_v3
-      id: Standard_NC8as_T4_v3
-      memory: 60129542144
-      name: Standard_NC8as_T4_v3
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_nc16as_t4_v3
-      id: Standard_NC16as_T4_v3
-      memory: 118111600640
-      name: Standard_NC16as_T4_v3
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_nc64as_t4_v3
-      id: Standard_NC64as_T4_v3
-      memory: 472446402560
-      name: Standard_NC64as_T4_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2_v4
-      id: Standard_E2_v4
-      memory: 17179869184
-      name: Standard_E2_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4_v4
-      id: Standard_E4_v4
-      memory: 34359738368
-      name: Standard_E4_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8_v4
-      id: Standard_E8_v4
-      memory: 68719476736
-      name: Standard_E8_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16_v4
-      id: Standard_E16_v4
-      memory: 137438953472
-      name: Standard_E16_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20_v4
-      id: Standard_E20_v4
-      memory: 171798691840
-      name: Standard_E20_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32_v4
-      id: Standard_E32_v4
-      memory: 274877906944
-      name: Standard_E32_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48_v4
-      id: Standard_E48_v4
-      memory: 412316860416
-      name: Standard_E48_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64_v4
-      id: Standard_E64_v4
-      memory: 541165879296
-      name: Standard_E64_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2d_v4
-      id: Standard_E2d_v4
-      memory: 17179869184
-      name: Standard_E2d_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4d_v4
-      id: Standard_E4d_v4
-      memory: 34359738368
-      name: Standard_E4d_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8d_v4
-      id: Standard_E8d_v4
-      memory: 68719476736
-      name: Standard_E8d_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16d_v4
-      id: Standard_E16d_v4
-      memory: 137438953472
-      name: Standard_E16d_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20d_v4
-      id: Standard_E20d_v4
-      memory: 171798691840
-      name: Standard_E20d_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32d_v4
-      id: Standard_E32d_v4
-      memory: 274877906944
-      name: Standard_E32d_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48d_v4
-      id: Standard_E48d_v4
-      memory: 412316860416
-      name: Standard_E48d_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64d_v4
-      id: Standard_E64d_v4
-      memory: 541165879296
-      name: Standard_E64d_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2s_v4
-      id: Standard_E2s_v4
-      memory: 17179869184
-      name: Standard_E2s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2s_v4
-      id: Standard_E4-2s_v4
-      memory: 34359738368
-      name: Standard_E4-2s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4s_v4
-      id: Standard_E4s_v4
-      memory: 34359738368
-      name: Standard_E4s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2s_v4
-      id: Standard_E8-2s_v4
-      memory: 68719476736
-      name: Standard_E8-2s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4s_v4
-      id: Standard_E8-4s_v4
-      memory: 68719476736
-      name: Standard_E8-4s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8s_v4
-      id: Standard_E8s_v4
-      memory: 68719476736
-      name: Standard_E8s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-4s_v4
-      id: Standard_E16-4s_v4
-      memory: 137438953472
-      name: Standard_E16-4s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8s_v4
-      id: Standard_E16-8s_v4
-      memory: 137438953472
-      name: Standard_E16-8s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16s_v4
-      id: Standard_E16s_v4
-      memory: 137438953472
-      name: Standard_E16s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20s_v4
-      id: Standard_E20s_v4
-      memory: 171798691840
-      name: Standard_E20s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8s_v4
-      id: Standard_E32-8s_v4
-      memory: 274877906944
-      name: Standard_E32-8s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16s_v4
-      id: Standard_E32-16s_v4
-      memory: 274877906944
-      name: Standard_E32-16s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32s_v4
-      id: Standard_E32s_v4
-      memory: 274877906944
-      name: Standard_E32s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48s_v4
-      id: Standard_E48s_v4
-      memory: 412316860416
-      name: Standard_E48s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16s_v4
-      id: Standard_E64-16s_v4
-      memory: 541165879296
-      name: Standard_E64-16s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32s_v4
-      id: Standard_E64-32s_v4
-      memory: 541165879296
-      name: Standard_E64-32s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64s_v4
-      id: Standard_E64s_v4
-      memory: 541165879296
-      name: Standard_E64s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_e80is_v4
-      id: Standard_E80is_v4
-      memory: 541165879296
-      name: Standard_E80is_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2ds_v4
-      id: Standard_E2ds_v4
-      memory: 17179869184
-      name: Standard_E2ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2ds_v4
-      id: Standard_E4-2ds_v4
-      memory: 34359738368
-      name: Standard_E4-2ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4ds_v4
-      id: Standard_E4ds_v4
-      memory: 34359738368
-      name: Standard_E4ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2ds_v4
-      id: Standard_E8-2ds_v4
-      memory: 68719476736
-      name: Standard_E8-2ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4ds_v4
-      id: Standard_E8-4ds_v4
-      memory: 68719476736
-      name: Standard_E8-4ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8ds_v4
-      id: Standard_E8ds_v4
-      memory: 68719476736
-      name: Standard_E8ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-4ds_v4
-      id: Standard_E16-4ds_v4
-      memory: 137438953472
-      name: Standard_E16-4ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8ds_v4
-      id: Standard_E16-8ds_v4
-      memory: 137438953472
-      name: Standard_E16-8ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16ds_v4
-      id: Standard_E16ds_v4
-      memory: 137438953472
-      name: Standard_E16ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20ds_v4
-      id: Standard_E20ds_v4
-      memory: 171798691840
-      name: Standard_E20ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8ds_v4
-      id: Standard_E32-8ds_v4
-      memory: 274877906944
-      name: Standard_E32-8ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16ds_v4
-      id: Standard_E32-16ds_v4
-      memory: 274877906944
-      name: Standard_E32-16ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32ds_v4
-      id: Standard_E32ds_v4
-      memory: 274877906944
-      name: Standard_E32ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48ds_v4
-      id: Standard_E48ds_v4
-      memory: 412316860416
-      name: Standard_E48ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16ds_v4
-      id: Standard_E64-16ds_v4
-      memory: 541165879296
-      name: Standard_E64-16ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32ds_v4
-      id: Standard_E64-32ds_v4
-      memory: 541165879296
-      name: Standard_E64-32ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64ds_v4
-      id: Standard_E64ds_v4
-      memory: 541165879296
-      name: Standard_E64ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_e80ids_v4
-      id: Standard_E80ids_v4
-      memory: 541165879296
-      name: Standard_E80ids_v4
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 2
-      generic_name: standard_d2d_v4
-      id: Standard_D2d_v4
-      memory: 8589934592
-      name: Standard_D2d_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4d_v4
-      id: Standard_D4d_v4
-      memory: 17179869184
-      name: Standard_D4d_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8d_v4
-      id: Standard_D8d_v4
-      memory: 34359738368
-      name: Standard_D8d_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16d_v4
-      id: Standard_D16d_v4
-      memory: 68719476736
-      name: Standard_D16d_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32d_v4
-      id: Standard_D32d_v4
-      memory: 137438953472
-      name: Standard_D32d_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48d_v4
-      id: Standard_D48d_v4
-      memory: 206158430208
-      name: Standard_D48d_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64d_v4
-      id: Standard_D64d_v4
-      memory: 274877906944
-      name: Standard_D64d_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2_v4
-      id: Standard_D2_v4
-      memory: 8589934592
-      name: Standard_D2_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4_v4
-      id: Standard_D4_v4
-      memory: 17179869184
-      name: Standard_D4_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8_v4
-      id: Standard_D8_v4
-      memory: 34359738368
-      name: Standard_D8_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16_v4
-      id: Standard_D16_v4
-      memory: 68719476736
-      name: Standard_D16_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32_v4
-      id: Standard_D32_v4
-      memory: 137438953472
-      name: Standard_D32_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48_v4
-      id: Standard_D48_v4
-      memory: 206158430208
-      name: Standard_D48_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64_v4
-      id: Standard_D64_v4
-      memory: 274877906944
-      name: Standard_D64_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2ds_v4
-      id: Standard_D2ds_v4
-      memory: 8589934592
-      name: Standard_D2ds_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4ds_v4
-      id: Standard_D4ds_v4
-      memory: 17179869184
-      name: Standard_D4ds_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8ds_v4
-      id: Standard_D8ds_v4
-      memory: 34359738368
-      name: Standard_D8ds_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16ds_v4
-      id: Standard_D16ds_v4
-      memory: 68719476736
-      name: Standard_D16ds_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32ds_v4
-      id: Standard_D32ds_v4
-      memory: 137438953472
-      name: Standard_D32ds_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48ds_v4
-      id: Standard_D48ds_v4
-      memory: 206158430208
-      name: Standard_D48ds_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64ds_v4
-      id: Standard_D64ds_v4
-      memory: 274877906944
-      name: Standard_D64ds_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2s_v4
-      id: Standard_D2s_v4
-      memory: 8589934592
-      name: Standard_D2s_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4s_v4
-      id: Standard_D4s_v4
-      memory: 17179869184
-      name: Standard_D4s_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8s_v4
-      id: Standard_D8s_v4
-      memory: 34359738368
-      name: Standard_D8s_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16s_v4
-      id: Standard_D16s_v4
-      memory: 68719476736
-      name: Standard_D16s_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32s_v4
-      id: Standard_D32s_v4
-      memory: 137438953472
-      name: Standard_D32s_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48s_v4
-      id: Standard_D48s_v4
-      memory: 206158430208
-      name: Standard_D48s_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64s_v4
-      id: Standard_D64s_v4
-      memory: 274877906944
-      name: Standard_D64s_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 1
-      generic_name: standard_d1_v2
-      id: Standard_D1_v2
-      memory: 3758096384
-      name: Standard_D1_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2_v2
-      id: Standard_D2_v2
-      memory: 7516192768
-      name: Standard_D2_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d3_v2
-      id: Standard_D3_v2
-      memory: 15032385536
-      name: Standard_D3_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d4_v2
-      id: Standard_D4_v2
-      memory: 30064771072
-      name: Standard_D4_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d5_v2
-      id: Standard_D5_v2
-      memory: 60129542144
-      name: Standard_D5_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
+      family: standardDv2Family
       generic_name: standard_d11_v2
       id: Standard_D11_v2
       memory: 15032385536
       name: Standard_D11_v2
     - category: general_purpose
       cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardDadsv7Family
+      generic_name: standard_d128ads_v7
+      id: Standard_D128ads_v7
+      memory: 549755813888
+      name: Standard_D128ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardDaldsv7Family
+      generic_name: standard_d128alds_v7
+      id: Standard_D128alds_v7
+      memory: 274877906944
+      name: Standard_D128alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardDalsv7Family
+      generic_name: standard_d128als_v7
+      id: Standard_D128als_v7
+      memory: 274877906944
+      name: Standard_D128als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardDasv7Family
+      generic_name: standard_d128as_v7
+      id: Standard_D128as_v7
+      memory: 549755813888
+      name: Standard_D128as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardDdsv6Family
+      generic_name: standard_d128ds_v6
+      id: Standard_D128ds_v6
+      memory: 549755813888
+      name: Standard_D128ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardDldsv6Family
+      generic_name: standard_d128lds_v6
+      id: Standard_D128lds_v6
+      memory: 274877906944
+      name: Standard_D128lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardDlsv6Family
+      generic_name: standard_d128ls_v6
+      id: Standard_D128ls_v6
+      memory: 274877906944
+      name: Standard_D128ls_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardDsv6Family
+      generic_name: standard_d128s_v6
+      id: Standard_D128s_v6
+      memory: 549755813888
+      name: Standard_D128s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
       cpu_cores: 4
+      family: standardDv2Family
       generic_name: standard_d12_v2
       id: Standard_D12_v2
       memory: 30064771072
@@ -1391,6 +834,7 @@ data:
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 8
+      family: standardDv2Family
       generic_name: standard_d13_v2
       id: Standard_D13_v2
       memory: 60129542144
@@ -1398,6 +842,7 @@ data:
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
+      family: standardDv2Family
       generic_name: standard_d14_v2
       id: Standard_D14_v2
       memory: 120259084288
@@ -1405,3559 +850,216 @@ data:
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 20
+      family: standardDv2Family
       generic_name: standard_d15_v2
       id: Standard_D15_v2
       memory: 150323855360
       name: Standard_D15_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 1
-      generic_name: standard_f1
-      id: Standard_F1
-      memory: 2147483648
-      name: Standard_F1
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2
-      id: Standard_F2
-      memory: 4294967296
-      name: Standard_F2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4
-      id: Standard_F4
-      memory: 8589934592
-      name: Standard_F4
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8
-      id: Standard_F8
-      memory: 17179869184
-      name: Standard_F8
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16
-      id: Standard_F16
-      memory: 34359738368
-      name: Standard_F16
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 1
-      generic_name: standard_ds1_v2
-      id: Standard_DS1_v2
-      memory: 3758096384
-      name: Standard_DS1_v2
+      cpu_cores: 160
+      family: StandardDadsv7Family
+      generic_name: standard_d160ads_v7
+      id: Standard_D160ads_v7
+      memory: 687194767360
+      name: Standard_D160ads_v7
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_ds2_v2
-      id: Standard_DS2_v2
-      memory: 7516192768
-      name: Standard_DS2_v2
+      cpu_cores: 160
+      family: StandardDaldsv7Family
+      generic_name: standard_d160alds_v7
+      id: Standard_D160alds_v7
+      memory: 343597383680
+      name: Standard_D160alds_v7
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_ds3_v2
-      id: Standard_DS3_v2
-      memory: 15032385536
-      name: Standard_DS3_v2
+      cpu_cores: 160
+      family: StandardDalsv7Family
+      generic_name: standard_d160als_v7
+      id: Standard_D160als_v7
+      memory: 343597383680
+      name: Standard_D160als_v7
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_ds4_v2
-      id: Standard_DS4_v2
-      memory: 30064771072
-      name: Standard_DS4_v2
+      cpu_cores: 160
+      family: StandardDasv7Family
+      generic_name: standard_d160as_v7
+      id: Standard_D160as_v7
+      memory: 687194767360
+      name: Standard_D160as_v7
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_ds5_v2
-      id: Standard_DS5_v2
-      memory: 60129542144
-      name: Standard_DS5_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_ds11-1_v2
-      id: Standard_DS11-1_v2
-      memory: 15032385536
-      name: Standard_DS11-1_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_ds11_v2
-      id: Standard_DS11_v2
-      memory: 15032385536
-      name: Standard_DS11_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_ds12-1_v2
-      id: Standard_DS12-1_v2
-      memory: 30064771072
-      name: Standard_DS12-1_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_ds12-2_v2
-      id: Standard_DS12-2_v2
-      memory: 30064771072
-      name: Standard_DS12-2_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_ds12_v2
-      id: Standard_DS12_v2
-      memory: 30064771072
-      name: Standard_DS12_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_ds13-2_v2
-      id: Standard_DS13-2_v2
-      memory: 60129542144
-      name: Standard_DS13-2_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_ds13-4_v2
-      id: Standard_DS13-4_v2
-      memory: 60129542144
-      name: Standard_DS13-4_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_ds13_v2
-      id: Standard_DS13_v2
-      memory: 60129542144
-      name: Standard_DS13_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_ds14-4_v2
-      id: Standard_DS14-4_v2
-      memory: 120259084288
-      name: Standard_DS14-4_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_ds14-8_v2
-      id: Standard_DS14-8_v2
-      memory: 120259084288
-      name: Standard_DS14-8_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_ds14_v2
-      id: Standard_DS14_v2
-      memory: 120259084288
-      name: Standard_DS14_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_ds15_v2
-      id: Standard_DS15_v2
-      memory: 150323855360
-      name: Standard_DS15_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 1
-      generic_name: standard_f1s
-      id: Standard_F1s
-      memory: 2147483648
-      name: Standard_F1s
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2s
-      id: Standard_F2s
-      memory: 4294967296
-      name: Standard_F2s
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4s
-      id: Standard_F4s
-      memory: 8589934592
-      name: Standard_F4s
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8s
-      id: Standard_F8s
-      memory: 17179869184
-      name: Standard_F8s
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16s
-      id: Standard_F16s
-      memory: 34359738368
-      name: Standard_F16s
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2_v3
-      id: Standard_D2_v3
-      memory: 8589934592
-      name: Standard_D2_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4_v3
-      id: Standard_D4_v3
-      memory: 17179869184
-      name: Standard_D4_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8_v3
-      id: Standard_D8_v3
-      memory: 34359738368
-      name: Standard_D8_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16_v3
-      id: Standard_D16_v3
-      memory: 68719476736
-      name: Standard_D16_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32_v3
-      id: Standard_D32_v3
-      memory: 137438953472
-      name: Standard_D32_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48_v3
-      id: Standard_D48_v3
-      memory: 206158430208
-      name: Standard_D48_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64_v3
-      id: Standard_D64_v3
-      memory: 274877906944
-      name: Standard_D64_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2s_v3
-      id: Standard_D2s_v3
-      memory: 8589934592
-      name: Standard_D2s_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4s_v3
-      id: Standard_D4s_v3
-      memory: 17179869184
-      name: Standard_D4s_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8s_v3
-      id: Standard_D8s_v3
-      memory: 34359738368
-      name: Standard_D8s_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16s_v3
-      id: Standard_D16s_v3
-      memory: 68719476736
-      name: Standard_D16s_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32s_v3
-      id: Standard_D32s_v3
-      memory: 137438953472
-      name: Standard_D32s_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48s_v3
-      id: Standard_D48s_v3
-      memory: 206158430208
-      name: Standard_D48s_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64s_v3
-      id: Standard_D64s_v3
-      memory: 274877906944
-      name: Standard_D64s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2_v3
-      id: Standard_E2_v3
-      memory: 17179869184
-      name: Standard_E2_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4_v3
-      id: Standard_E4_v3
-      memory: 34359738368
-      name: Standard_E4_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8_v3
-      id: Standard_E8_v3
-      memory: 68719476736
-      name: Standard_E8_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16_v3
-      id: Standard_E16_v3
-      memory: 137438953472
-      name: Standard_E16_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20_v3
-      id: Standard_E20_v3
-      memory: 171798691840
-      name: Standard_E20_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32_v3
-      id: Standard_E32_v3
-      memory: 274877906944
-      name: Standard_E32_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48_v3
-      id: Standard_E48_v3
-      memory: 412316860416
-      name: Standard_E48_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64_v3
-      id: Standard_E64_v3
-      memory: 463856467968
-      name: Standard_E64_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2s_v3
-      id: Standard_E2s_v3
-      memory: 17179869184
-      name: Standard_E2s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2s_v3
-      id: Standard_E4-2s_v3
-      memory: 34359738368
-      name: Standard_E4-2s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4s_v3
-      id: Standard_E4s_v3
-      memory: 34359738368
-      name: Standard_E4s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2s_v3
-      id: Standard_E8-2s_v3
-      memory: 68719476736
-      name: Standard_E8-2s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4s_v3
-      id: Standard_E8-4s_v3
-      memory: 68719476736
-      name: Standard_E8-4s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8s_v3
-      id: Standard_E8s_v3
-      memory: 68719476736
-      name: Standard_E8s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-4s_v3
-      id: Standard_E16-4s_v3
-      memory: 137438953472
-      name: Standard_E16-4s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8s_v3
-      id: Standard_E16-8s_v3
-      memory: 137438953472
-      name: Standard_E16-8s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16s_v3
-      id: Standard_E16s_v3
-      memory: 137438953472
-      name: Standard_E16s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20s_v3
-      id: Standard_E20s_v3
-      memory: 171798691840
-      name: Standard_E20s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8s_v3
-      id: Standard_E32-8s_v3
-      memory: 274877906944
-      name: Standard_E32-8s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16s_v3
-      id: Standard_E32-16s_v3
-      memory: 274877906944
-      name: Standard_E32-16s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32s_v3
-      id: Standard_E32s_v3
-      memory: 274877906944
-      name: Standard_E32s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48s_v3
-      id: Standard_E48s_v3
-      memory: 412316860416
-      name: Standard_E48s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16s_v3
-      id: Standard_E64-16s_v3
-      memory: 463856467968
-      name: Standard_E64-16s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32s_v3
-      id: Standard_E64-32s_v3
-      memory: 463856467968
-      name: Standard_E64-32s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64s_v3
-      id: Standard_E64s_v3
-      memory: 463856467968
-      name: Standard_E64s_v3
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2s_v2
-      id: Standard_F2s_v2
-      memory: 4294967296
-      name: Standard_F2s_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4s_v2
-      id: Standard_F4s_v2
-      memory: 8589934592
-      name: Standard_F4s_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8s_v2
-      id: Standard_F8s_v2
-      memory: 17179869184
-      name: Standard_F8s_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16s_v2
-      id: Standard_F16s_v2
-      memory: 34359738368
-      name: Standard_F16s_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32s_v2
-      id: Standard_F32s_v2
-      memory: 68719476736
-      name: Standard_F32s_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_f48s_v2
-      id: Standard_F48s_v2
-      memory: 103079215104
-      name: Standard_F48s_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64s_v2
-      id: Standard_F64s_v2
-      memory: 137438953472
-      name: Standard_F64s_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 72
-      generic_name: standard_f72s_v2
-      id: Standard_F72s_v2
-      memory: 154618822656
-      name: Standard_F72s_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2as_v5
-      id: Standard_D2as_v5
-      memory: 8589934592
-      name: Standard_D2as_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4as_v5
-      id: Standard_D4as_v5
-      memory: 17179869184
-      name: Standard_D4as_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8as_v5
-      id: Standard_D8as_v5
-      memory: 34359738368
-      name: Standard_D8as_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16as_v5
-      id: Standard_D16as_v5
-      memory: 68719476736
-      name: Standard_D16as_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32as_v5
-      id: Standard_D32as_v5
-      memory: 137438953472
-      name: Standard_D32as_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48as_v5
-      id: Standard_D48as_v5
-      memory: 206158430208
-      name: Standard_D48as_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64as_v5
-      id: Standard_D64as_v5
-      memory: 274877906944
-      name: Standard_D64as_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96as_v5
-      id: Standard_D96as_v5
-      memory: 412316860416
-      name: Standard_D96as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2as_v5
-      id: Standard_E2as_v5
-      memory: 17179869184
-      name: Standard_E2as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2as_v5
-      id: Standard_E4-2as_v5
-      memory: 34359738368
-      name: Standard_E4-2as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4as_v5
-      id: Standard_E4as_v5
-      memory: 34359738368
-      name: Standard_E4as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2as_v5
-      id: Standard_E8-2as_v5
-      memory: 68719476736
-      name: Standard_E8-2as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4as_v5
-      id: Standard_E8-4as_v5
-      memory: 68719476736
-      name: Standard_E8-4as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8as_v5
-      id: Standard_E8as_v5
-      memory: 68719476736
-      name: Standard_E8as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-4as_v5
-      id: Standard_E16-4as_v5
-      memory: 137438953472
-      name: Standard_E16-4as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8as_v5
-      id: Standard_E16-8as_v5
-      memory: 137438953472
-      name: Standard_E16-8as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16as_v5
-      id: Standard_E16as_v5
-      memory: 137438953472
-      name: Standard_E16as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20as_v5
-      id: Standard_E20as_v5
-      memory: 171798691840
-      name: Standard_E20as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8as_v5
-      id: Standard_E32-8as_v5
-      memory: 274877906944
-      name: Standard_E32-8as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16as_v5
-      id: Standard_E32-16as_v5
-      memory: 274877906944
-      name: Standard_E32-16as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32as_v5
-      id: Standard_E32as_v5
-      memory: 274877906944
-      name: Standard_E32as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48as_v5
-      id: Standard_E48as_v5
-      memory: 412316860416
-      name: Standard_E48as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16as_v5
-      id: Standard_E64-16as_v5
-      memory: 549755813888
-      name: Standard_E64-16as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32as_v5
-      id: Standard_E64-32as_v5
-      memory: 549755813888
-      name: Standard_E64-32as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64as_v5
-      id: Standard_E64as_v5
-      memory: 549755813888
-      name: Standard_E64as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-24as_v5
-      id: Standard_E96-24as_v5
-      memory: 721554505728
-      name: Standard_E96-24as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-48as_v5
-      id: Standard_E96-48as_v5
-      memory: 721554505728
-      name: Standard_E96-48as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96as_v5
-      id: Standard_E96as_v5
-      memory: 721554505728
-      name: Standard_E96as_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2ads_v5
-      id: Standard_D2ads_v5
-      memory: 8589934592
-      name: Standard_D2ads_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4ads_v5
-      id: Standard_D4ads_v5
-      memory: 17179869184
-      name: Standard_D4ads_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8ads_v5
-      id: Standard_D8ads_v5
-      memory: 34359738368
-      name: Standard_D8ads_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
+      family: standardDADSv5Family
       generic_name: standard_d16ads_v5
       id: Standard_D16ads_v5
       memory: 68719476736
       name: Standard_D16ads_v5
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32ads_v5
-      id: Standard_D32ads_v5
-      memory: 137438953472
-      name: Standard_D32ads_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48ads_v5
-      id: Standard_D48ads_v5
-      memory: 206158430208
-      name: Standard_D48ads_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64ads_v5
-      id: Standard_D64ads_v5
-      memory: 274877906944
-      name: Standard_D64ads_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96ads_v5
-      id: Standard_D96ads_v5
-      memory: 412316860416
-      name: Standard_D96ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2ads_v5
-      id: Standard_E2ads_v5
-      memory: 17179869184
-      name: Standard_E2ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2ads_v5
-      id: Standard_E4-2ads_v5
-      memory: 34359738368
-      name: Standard_E4-2ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4ads_v5
-      id: Standard_E4ads_v5
-      memory: 34359738368
-      name: Standard_E4ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2ads_v5
-      id: Standard_E8-2ads_v5
-      memory: 68719476736
-      name: Standard_E8-2ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4ads_v5
-      id: Standard_E8-4ads_v5
-      memory: 68719476736
-      name: Standard_E8-4ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8ads_v5
-      id: Standard_E8ads_v5
-      memory: 68719476736
-      name: Standard_E8ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_e16-4ads_v5
-      id: Standard_E16-4ads_v5
-      memory: 137438953472
-      name: Standard_E16-4ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8ads_v5
-      id: Standard_E16-8ads_v5
-      memory: 137438953472
-      name: Standard_E16-8ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16ads_v5
-      id: Standard_E16ads_v5
-      memory: 137438953472
-      name: Standard_E16ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20ads_v5
-      id: Standard_E20ads_v5
-      memory: 171798691840
-      name: Standard_E20ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8ads_v5
-      id: Standard_E32-8ads_v5
-      memory: 274877906944
-      name: Standard_E32-8ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16ads_v5
-      id: Standard_E32-16ads_v5
-      memory: 274877906944
-      name: Standard_E32-16ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32ads_v5
-      id: Standard_E32ads_v5
-      memory: 274877906944
-      name: Standard_E32ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48ads_v5
-      id: Standard_E48ads_v5
-      memory: 412316860416
-      name: Standard_E48ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16ads_v5
-      id: Standard_E64-16ads_v5
-      memory: 549755813888
-      name: Standard_E64-16ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32ads_v5
-      id: Standard_E64-32ads_v5
-      memory: 549755813888
-      name: Standard_E64-32ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64ads_v5
-      id: Standard_E64ads_v5
-      memory: 549755813888
-      name: Standard_E64ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-24ads_v5
-      id: Standard_E96-24ads_v5
-      memory: 721554505728
-      name: Standard_E96-24ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-48ads_v5
-      id: Standard_E96-48ads_v5
-      memory: 721554505728
-      name: Standard_E96-48ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96ads_v5
-      id: Standard_E96ads_v5
-      memory: 721554505728
-      name: Standard_E96ads_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2as_v6
-      id: Standard_D2as_v6
-      memory: 8589934592
-      name: Standard_D2as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4as_v6
-      id: Standard_D4as_v6
-      memory: 17179869184
-      name: Standard_D4as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8as_v6
-      id: Standard_D8as_v6
-      memory: 34359738368
-      name: Standard_D8as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16as_v6
-      id: Standard_D16as_v6
-      memory: 68719476736
-      name: Standard_D16as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32as_v6
-      id: Standard_D32as_v6
-      memory: 137438953472
-      name: Standard_D32as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48as_v6
-      id: Standard_D48as_v6
-      memory: 206158430208
-      name: Standard_D48as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64as_v6
-      id: Standard_D64as_v6
-      memory: 274877906944
-      name: Standard_D64as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96as_v6
-      id: Standard_D96as_v6
-      memory: 412316860416
-      name: Standard_D96as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2as_v6
-      id: Standard_E2as_v6
-      memory: 17179869184
-      name: Standard_E2as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4as_v6
-      id: Standard_E4as_v6
-      memory: 34359738368
-      name: Standard_E4as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8as_v6
-      id: Standard_E8as_v6
-      memory: 68719476736
-      name: Standard_E8as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16as_v6
-      id: Standard_E16as_v6
-      memory: 137438953472
-      name: Standard_E16as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20as_v6
-      id: Standard_E20as_v6
-      memory: 171798691840
-      name: Standard_E20as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32as_v6
-      id: Standard_E32as_v6
-      memory: 274877906944
-      name: Standard_E32as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48as_v6
-      id: Standard_E48as_v6
-      memory: 412316860416
-      name: Standard_E48as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64as_v6
-      id: Standard_E64as_v6
-      memory: 549755813888
-      name: Standard_E64as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96as_v6
-      id: Standard_E96as_v6
-      memory: 721554505728
-      name: Standard_E96as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2ads_v6
-      id: Standard_D2ads_v6
-      memory: 8589934592
-      name: Standard_D2ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4ads_v6
-      id: Standard_D4ads_v6
-      memory: 17179869184
-      name: Standard_D4ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8ads_v6
-      id: Standard_D8ads_v6
-      memory: 34359738368
-      name: Standard_D8ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
+      family: standardDadv6Family
       generic_name: standard_d16ads_v6
       id: Standard_D16ads_v6
       memory: 68719476736
       name: Standard_D16ads_v6
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32ads_v6
-      id: Standard_D32ads_v6
-      memory: 137438953472
-      name: Standard_D32ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48ads_v6
-      id: Standard_D48ads_v6
-      memory: 206158430208
-      name: Standard_D48ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64ads_v6
-      id: Standard_D64ads_v6
-      memory: 274877906944
-      name: Standard_D64ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96ads_v6
-      id: Standard_D96ads_v6
-      memory: 412316860416
-      name: Standard_D96ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2als_v6
-      id: Standard_D2als_v6
-      memory: 4294967296
-      name: Standard_D2als_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4als_v6
-      id: Standard_D4als_v6
-      memory: 8589934592
-      name: Standard_D4als_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8als_v6
-      id: Standard_D8als_v6
-      memory: 17179869184
-      name: Standard_D8als_v6
-    - category: general_purpose
-      cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_d16als_v6
-      id: Standard_D16als_v6
-      memory: 34359738368
-      name: Standard_D16als_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32als_v6
-      id: Standard_D32als_v6
+      family: StandardDadsv7Family
+      generic_name: standard_d16ads_v7
+      id: Standard_D16ads_v7
       memory: 68719476736
-      name: Standard_D32als_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48als_v6
-      id: Standard_D48als_v6
-      memory: 103079215104
-      name: Standard_D48als_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64als_v6
-      id: Standard_D64als_v6
-      memory: 137438953472
-      name: Standard_D64als_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96als_v6
-      id: Standard_D96als_v6
-      memory: 206158430208
-      name: Standard_D96als_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2alds_v6
-      id: Standard_D2alds_v6
-      memory: 4294967296
-      name: Standard_D2alds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4alds_v6
-      id: Standard_D4alds_v6
-      memory: 8589934592
-      name: Standard_D4alds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8alds_v6
-      id: Standard_D8alds_v6
-      memory: 17179869184
-      name: Standard_D8alds_v6
+      name: Standard_D16ads_v7
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
+      family: standardDaldv6Family
       generic_name: standard_d16alds_v6
       id: Standard_D16alds_v6
       memory: 34359738368
       name: Standard_D16alds_v6
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32alds_v6
-      id: Standard_D32alds_v6
-      memory: 68719476736
-      name: Standard_D32alds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48alds_v6
-      id: Standard_D48alds_v6
-      memory: 103079215104
-      name: Standard_D48alds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64alds_v6
-      id: Standard_D64alds_v6
-      memory: 137438953472
-      name: Standard_D64alds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96alds_v6
-      id: Standard_D96alds_v6
-      memory: 206158430208
-      name: Standard_D96alds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2ads_v6
-      id: Standard_E2ads_v6
-      memory: 17179869184
-      name: Standard_E2ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4ads_v6
-      id: Standard_E4ads_v6
+      cpu_cores: 16
+      family: StandardDaldsv7Family
+      generic_name: standard_d16alds_v7
+      id: Standard_D16alds_v7
       memory: 34359738368
-      name: Standard_E4ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8ads_v6
-      id: Standard_E8ads_v6
-      memory: 68719476736
-      name: Standard_E8ads_v6
-    - category: memory_optimized
+      name: Standard_D16alds_v7
+    - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_e16ads_v6
-      id: Standard_E16ads_v6
-      memory: 137438953472
-      name: Standard_E16ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20ads_v6
-      id: Standard_E20ads_v6
-      memory: 171798691840
-      name: Standard_E20ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32ads_v6
-      id: Standard_E32ads_v6
-      memory: 274877906944
-      name: Standard_E32ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48ads_v6
-      id: Standard_E48ads_v6
-      memory: 412316860416
-      name: Standard_E48ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64ads_v6
-      id: Standard_E64ads_v6
-      memory: 549755813888
-      name: Standard_E64ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-24ads_v6
-      id: Standard_E96-24ads_v6
-      memory: 721554505728
-      name: Standard_E96-24ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-48ads_v6
-      id: Standard_E96-48ads_v6
-      memory: 721554505728
-      name: Standard_E96-48ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96ads_v6
-      id: Standard_E96ads_v6
-      memory: 721554505728
-      name: Standard_E96ads_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2as_v6
-      id: Standard_F2as_v6
-      memory: 8589934592
-      name: Standard_F2as_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4as_v6
-      id: Standard_F4as_v6
-      memory: 17179869184
-      name: Standard_F4as_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8as_v6
-      id: Standard_F8as_v6
+      family: standardDalv6Family
+      generic_name: standard_d16als_v6
+      id: Standard_D16als_v6
       memory: 34359738368
-      name: Standard_F8as_v6
-    - category: compute_optimized
+      name: Standard_D16als_v6
+    - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_f16as_v6
-      id: Standard_F16as_v6
-      memory: 68719476736
-      name: Standard_F16as_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32as_v6
-      id: Standard_F32as_v6
-      memory: 137438953472
-      name: Standard_F32as_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_f48as_v6
-      id: Standard_F48as_v6
-      memory: 206158430208
-      name: Standard_F48as_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64as_v6
-      id: Standard_F64as_v6
-      memory: 274877906944
-      name: Standard_F64as_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2als_v6
-      id: Standard_F2als_v6
-      memory: 4294967296
-      name: Standard_F2als_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4als_v6
-      id: Standard_F4als_v6
-      memory: 8589934592
-      name: Standard_F4als_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8als_v6
-      id: Standard_F8als_v6
-      memory: 17179869184
-      name: Standard_F8als_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16als_v6
-      id: Standard_F16als_v6
+      family: StandardDalsv7Family
+      generic_name: standard_d16als_v7
+      id: Standard_D16als_v7
       memory: 34359738368
-      name: Standard_F16als_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32als_v6
-      id: Standard_F32als_v6
-      memory: 68719476736
-      name: Standard_F32als_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_f48als_v6
-      id: Standard_F48als_v6
-      memory: 103079215104
-      name: Standard_F48als_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64als_v6
-      id: Standard_F64als_v6
-      memory: 137438953472
-      name: Standard_F64als_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2ams_v6
-      id: Standard_F2ams_v6
-      memory: 17179869184
-      name: Standard_F2ams_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4ams_v6
-      id: Standard_F4ams_v6
-      memory: 34359738368
-      name: Standard_F4ams_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8ams_v6
-      id: Standard_F8ams_v6
-      memory: 68719476736
-      name: Standard_F8ams_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16ams_v6
-      id: Standard_F16ams_v6
-      memory: 137438953472
-      name: Standard_F16ams_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32ams_v6
-      id: Standard_F32ams_v6
-      memory: 274877906944
-      name: Standard_F32ams_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_f48ams_v6
-      id: Standard_F48ams_v6
-      memory: 412316860416
-      name: Standard_F48ams_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64ams_v6
-      id: Standard_F64ams_v6
-      memory: 549755813888
-      name: Standard_F64ams_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2ds_v5
-      id: Standard_D2ds_v5
-      memory: 8589934592
-      name: Standard_D2ds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4ds_v5
-      id: Standard_D4ds_v5
-      memory: 17179869184
-      name: Standard_D4ds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8ds_v5
-      id: Standard_D8ds_v5
-      memory: 34359738368
-      name: Standard_D8ds_v5
+      name: Standard_D16als_v7
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_d16ds_v5
-      id: Standard_D16ds_v5
-      memory: 68719476736
-      name: Standard_D16ds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32ds_v5
-      id: Standard_D32ds_v5
-      memory: 137438953472
-      name: Standard_D32ds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48ds_v5
-      id: Standard_D48ds_v5
-      memory: 206158430208
-      name: Standard_D48ds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64ds_v5
-      id: Standard_D64ds_v5
-      memory: 274877906944
-      name: Standard_D64ds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96ds_v5
-      id: Standard_D96ds_v5
-      memory: 412316860416
-      name: Standard_D96ds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2d_v5
-      id: Standard_D2d_v5
-      memory: 8589934592
-      name: Standard_D2d_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4d_v5
-      id: Standard_D4d_v5
-      memory: 17179869184
-      name: Standard_D4d_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8d_v5
-      id: Standard_D8d_v5
-      memory: 34359738368
-      name: Standard_D8d_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16d_v5
-      id: Standard_D16d_v5
-      memory: 68719476736
-      name: Standard_D16d_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32d_v5
-      id: Standard_D32d_v5
-      memory: 137438953472
-      name: Standard_D32d_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48d_v5
-      id: Standard_D48d_v5
-      memory: 206158430208
-      name: Standard_D48d_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64d_v5
-      id: Standard_D64d_v5
-      memory: 274877906944
-      name: Standard_D64d_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96d_v5
-      id: Standard_D96d_v5
-      memory: 412316860416
-      name: Standard_D96d_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2s_v5
-      id: Standard_D2s_v5
-      memory: 8589934592
-      name: Standard_D2s_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4s_v5
-      id: Standard_D4s_v5
-      memory: 17179869184
-      name: Standard_D4s_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8s_v5
-      id: Standard_D8s_v5
-      memory: 34359738368
-      name: Standard_D8s_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16s_v5
-      id: Standard_D16s_v5
-      memory: 68719476736
-      name: Standard_D16s_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32s_v5
-      id: Standard_D32s_v5
-      memory: 137438953472
-      name: Standard_D32s_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48s_v5
-      id: Standard_D48s_v5
-      memory: 206158430208
-      name: Standard_D48s_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64s_v5
-      id: Standard_D64s_v5
-      memory: 274877906944
-      name: Standard_D64s_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96s_v5
-      id: Standard_D96s_v5
-      memory: 412316860416
-      name: Standard_D96s_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2_v5
-      id: Standard_D2_v5
-      memory: 8589934592
-      name: Standard_D2_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4_v5
-      id: Standard_D4_v5
-      memory: 17179869184
-      name: Standard_D4_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8_v5
-      id: Standard_D8_v5
-      memory: 34359738368
-      name: Standard_D8_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16_v5
-      id: Standard_D16_v5
-      memory: 68719476736
-      name: Standard_D16_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32_v5
-      id: Standard_D32_v5
-      memory: 137438953472
-      name: Standard_D32_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48_v5
-      id: Standard_D48_v5
-      memory: 206158430208
-      name: Standard_D48_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64_v5
-      id: Standard_D64_v5
-      memory: 274877906944
-      name: Standard_D64_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96_v5
-      id: Standard_D96_v5
-      memory: 412316860416
-      name: Standard_D96_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2ds_v5
-      id: Standard_E2ds_v5
-      memory: 17179869184
-      name: Standard_E2ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2ds_v5
-      id: Standard_E4-2ds_v5
-      memory: 34359738368
-      name: Standard_E4-2ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4ds_v5
-      id: Standard_E4ds_v5
-      memory: 34359738368
-      name: Standard_E4ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2ds_v5
-      id: Standard_E8-2ds_v5
-      memory: 68719476736
-      name: Standard_E8-2ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4ds_v5
-      id: Standard_E8-4ds_v5
-      memory: 68719476736
-      name: Standard_E8-4ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8ds_v5
-      id: Standard_E8ds_v5
-      memory: 68719476736
-      name: Standard_E8ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-4ds_v5
-      id: Standard_E16-4ds_v5
-      memory: 137438953472
-      name: Standard_E16-4ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8ds_v5
-      id: Standard_E16-8ds_v5
-      memory: 137438953472
-      name: Standard_E16-8ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16ds_v5
-      id: Standard_E16ds_v5
-      memory: 137438953472
-      name: Standard_E16ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20ds_v5
-      id: Standard_E20ds_v5
-      memory: 171798691840
-      name: Standard_E20ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8ds_v5
-      id: Standard_E32-8ds_v5
-      memory: 274877906944
-      name: Standard_E32-8ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16ds_v5
-      id: Standard_E32-16ds_v5
-      memory: 274877906944
-      name: Standard_E32-16ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32ds_v5
-      id: Standard_E32ds_v5
-      memory: 274877906944
-      name: Standard_E32ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48ds_v5
-      id: Standard_E48ds_v5
-      memory: 412316860416
-      name: Standard_E48ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16ds_v5
-      id: Standard_E64-16ds_v5
-      memory: 549755813888
-      name: Standard_E64-16ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32ds_v5
-      id: Standard_E64-32ds_v5
-      memory: 549755813888
-      name: Standard_E64-32ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64ds_v5
-      id: Standard_E64ds_v5
-      memory: 549755813888
-      name: Standard_E64ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-24ds_v5
-      id: Standard_E96-24ds_v5
-      memory: 721554505728
-      name: Standard_E96-24ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-48ds_v5
-      id: Standard_E96-48ds_v5
-      memory: 721554505728
-      name: Standard_E96-48ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96ds_v5
-      id: Standard_E96ds_v5
-      memory: 721554505728
-      name: Standard_E96ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 104
-      generic_name: standard_e104ids_v5
-      id: Standard_E104ids_v5
-      memory: 721554505728
-      name: Standard_E104ids_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2d_v5
-      id: Standard_E2d_v5
-      memory: 17179869184
-      name: Standard_E2d_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4d_v5
-      id: Standard_E4d_v5
-      memory: 34359738368
-      name: Standard_E4d_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8d_v5
-      id: Standard_E8d_v5
-      memory: 68719476736
-      name: Standard_E8d_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16d_v5
-      id: Standard_E16d_v5
-      memory: 137438953472
-      name: Standard_E16d_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20d_v5
-      id: Standard_E20d_v5
-      memory: 171798691840
-      name: Standard_E20d_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32d_v5
-      id: Standard_E32d_v5
-      memory: 274877906944
-      name: Standard_E32d_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48d_v5
-      id: Standard_E48d_v5
-      memory: 412316860416
-      name: Standard_E48d_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64d_v5
-      id: Standard_E64d_v5
-      memory: 549755813888
-      name: Standard_E64d_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96d_v5
-      id: Standard_E96d_v5
-      memory: 721554505728
-      name: Standard_E96d_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 104
-      generic_name: standard_e104id_v5
-      id: Standard_E104id_v5
-      memory: 721554505728
-      name: Standard_E104id_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2s_v5
-      id: Standard_E2s_v5
-      memory: 17179869184
-      name: Standard_E2s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2s_v5
-      id: Standard_E4-2s_v5
-      memory: 34359738368
-      name: Standard_E4-2s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4s_v5
-      id: Standard_E4s_v5
-      memory: 34359738368
-      name: Standard_E4s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2s_v5
-      id: Standard_E8-2s_v5
-      memory: 68719476736
-      name: Standard_E8-2s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4s_v5
-      id: Standard_E8-4s_v5
-      memory: 68719476736
-      name: Standard_E8-4s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8s_v5
-      id: Standard_E8s_v5
-      memory: 68719476736
-      name: Standard_E8s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-4s_v5
-      id: Standard_E16-4s_v5
-      memory: 137438953472
-      name: Standard_E16-4s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8s_v5
-      id: Standard_E16-8s_v5
-      memory: 137438953472
-      name: Standard_E16-8s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16s_v5
-      id: Standard_E16s_v5
-      memory: 137438953472
-      name: Standard_E16s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20s_v5
-      id: Standard_E20s_v5
-      memory: 171798691840
-      name: Standard_E20s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8s_v5
-      id: Standard_E32-8s_v5
-      memory: 274877906944
-      name: Standard_E32-8s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16s_v5
-      id: Standard_E32-16s_v5
-      memory: 274877906944
-      name: Standard_E32-16s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32s_v5
-      id: Standard_E32s_v5
-      memory: 274877906944
-      name: Standard_E32s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48s_v5
-      id: Standard_E48s_v5
-      memory: 412316860416
-      name: Standard_E48s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16s_v5
-      id: Standard_E64-16s_v5
-      memory: 549755813888
-      name: Standard_E64-16s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32s_v5
-      id: Standard_E64-32s_v5
-      memory: 549755813888
-      name: Standard_E64-32s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64s_v5
-      id: Standard_E64s_v5
-      memory: 549755813888
-      name: Standard_E64s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-24s_v5
-      id: Standard_E96-24s_v5
-      memory: 721554505728
-      name: Standard_E96-24s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-48s_v5
-      id: Standard_E96-48s_v5
-      memory: 721554505728
-      name: Standard_E96-48s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96s_v5
-      id: Standard_E96s_v5
-      memory: 721554505728
-      name: Standard_E96s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 104
-      generic_name: standard_e104is_v5
-      id: Standard_E104is_v5
-      memory: 721554505728
-      name: Standard_E104is_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2_v5
-      id: Standard_E2_v5
-      memory: 17179869184
-      name: Standard_E2_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4_v5
-      id: Standard_E4_v5
-      memory: 34359738368
-      name: Standard_E4_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8_v5
-      id: Standard_E8_v5
-      memory: 68719476736
-      name: Standard_E8_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16_v5
-      id: Standard_E16_v5
-      memory: 137438953472
-      name: Standard_E16_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20_v5
-      id: Standard_E20_v5
-      memory: 171798691840
-      name: Standard_E20_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32_v5
-      id: Standard_E32_v5
-      memory: 274877906944
-      name: Standard_E32_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48_v5
-      id: Standard_E48_v5
-      memory: 412316860416
-      name: Standard_E48_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64_v5
-      id: Standard_E64_v5
-      memory: 549755813888
-      name: Standard_E64_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96_v5
-      id: Standard_E96_v5
-      memory: 721554505728
-      name: Standard_E96_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 104
-      generic_name: standard_e104i_v5
-      id: Standard_E104i_v5
-      memory: 721554505728
-      name: Standard_E104i_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2bs_v5
-      id: Standard_E2bs_v5
-      memory: 17179869184
-      name: Standard_E2bs_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4bs_v5
-      id: Standard_E4bs_v5
-      memory: 34359738368
-      name: Standard_E4bs_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8bs_v5
-      id: Standard_E8bs_v5
-      memory: 68719476736
-      name: Standard_E8bs_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16bs_v5
-      id: Standard_E16bs_v5
-      memory: 137438953472
-      name: Standard_E16bs_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32bs_v5
-      id: Standard_E32bs_v5
-      memory: 274877906944
-      name: Standard_E32bs_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48bs_v5
-      id: Standard_E48bs_v5
-      memory: 412316860416
-      name: Standard_E48bs_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64bs_v5
-      id: Standard_E64bs_v5
-      memory: 549755813888
-      name: Standard_E64bs_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96bs_v5
-      id: Standard_E96bs_v5
-      memory: 721554505728
-      name: Standard_E96bs_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 112
-      generic_name: standard_e112ibs_v5
-      id: Standard_E112ibs_v5
-      memory: 721554505728
-      name: Standard_E112ibs_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2bds_v5
-      id: Standard_E2bds_v5
-      memory: 17179869184
-      name: Standard_E2bds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4bds_v5
-      id: Standard_E4bds_v5
-      memory: 34359738368
-      name: Standard_E4bds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8bds_v5
-      id: Standard_E8bds_v5
-      memory: 68719476736
-      name: Standard_E8bds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16bds_v5
-      id: Standard_E16bds_v5
-      memory: 137438953472
-      name: Standard_E16bds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32bds_v5
-      id: Standard_E32bds_v5
-      memory: 274877906944
-      name: Standard_E32bds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48bds_v5
-      id: Standard_E48bds_v5
-      memory: 412316860416
-      name: Standard_E48bds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64bds_v5
-      id: Standard_E64bds_v5
-      memory: 549755813888
-      name: Standard_E64bds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96bds_v5
-      id: Standard_E96bds_v5
-      memory: 721554505728
-      name: Standard_E96bds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 112
-      generic_name: standard_e112ibds_v5
-      id: Standard_E112ibds_v5
-      memory: 721554505728
-      name: Standard_E112ibds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2ls_v5
-      id: Standard_D2ls_v5
-      memory: 4294967296
-      name: Standard_D2ls_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4ls_v5
-      id: Standard_D4ls_v5
-      memory: 8589934592
-      name: Standard_D4ls_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8ls_v5
-      id: Standard_D8ls_v5
-      memory: 17179869184
-      name: Standard_D8ls_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16ls_v5
-      id: Standard_D16ls_v5
-      memory: 34359738368
-      name: Standard_D16ls_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32ls_v5
-      id: Standard_D32ls_v5
-      memory: 68719476736
-      name: Standard_D32ls_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48ls_v5
-      id: Standard_D48ls_v5
-      memory: 103079215104
-      name: Standard_D48ls_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64ls_v5
-      id: Standard_D64ls_v5
-      memory: 137438953472
-      name: Standard_D64ls_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96ls_v5
-      id: Standard_D96ls_v5
-      memory: 206158430208
-      name: Standard_D96ls_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2lds_v5
-      id: Standard_D2lds_v5
-      memory: 4294967296
-      name: Standard_D2lds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4lds_v5
-      id: Standard_D4lds_v5
-      memory: 8589934592
-      name: Standard_D4lds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8lds_v5
-      id: Standard_D8lds_v5
-      memory: 17179869184
-      name: Standard_D8lds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16lds_v5
-      id: Standard_D16lds_v5
-      memory: 34359738368
-      name: Standard_D16lds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32lds_v5
-      id: Standard_D32lds_v5
-      memory: 68719476736
-      name: Standard_D32lds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48lds_v5
-      id: Standard_D48lds_v5
-      memory: 103079215104
-      name: Standard_D48lds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64lds_v5
-      id: Standard_D64lds_v5
-      memory: 137438953472
-      name: Standard_D64lds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96lds_v5
-      id: Standard_D96lds_v5
-      memory: 206158430208
-      name: Standard_D96lds_v5
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_nc8ads_a10_v4
-      id: Standard_NC8ads_A10_v4
-      memory: 107374182400
-      name: Standard_NC8ads_A10_v4
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_nc16ads_a10_v4
-      id: Standard_NC16ads_A10_v4
-      memory: 214748364800
-      name: Standard_NC16ads_A10_v4
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_nc32ads_a10_v4
-      id: Standard_NC32ads_A10_v4
-      memory: 429496729600
-      name: Standard_NC32ads_A10_v4
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 40
-      generic_name: standard_nc40ads_h100_v5
-      id: Standard_NC40ads_H100_v5
-      memory: 343597383680
-      name: Standard_NC40ads_H100_v5
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_nc80adis_h100_v5
-      id: Standard_NC80adis_H100_v5
-      memory: 687194767360
-      name: Standard_NC80adis_H100_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2ls_v6
-      id: Standard_D2ls_v6
-      memory: 4294967296
-      name: Standard_D2ls_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4ls_v6
-      id: Standard_D4ls_v6
-      memory: 8589934592
-      name: Standard_D4ls_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8ls_v6
-      id: Standard_D8ls_v6
-      memory: 17179869184
-      name: Standard_D8ls_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16ls_v6
-      id: Standard_D16ls_v6
-      memory: 34359738368
-      name: Standard_D16ls_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32ls_v6
-      id: Standard_D32ls_v6
-      memory: 68719476736
-      name: Standard_D32ls_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48ls_v6
-      id: Standard_D48ls_v6
-      memory: 103079215104
-      name: Standard_D48ls_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64ls_v6
-      id: Standard_D64ls_v6
-      memory: 137438953472
-      name: Standard_D64ls_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96ls_v6
-      id: Standard_D96ls_v6
-      memory: 206158430208
-      name: Standard_D96ls_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_d128ls_v6
-      id: Standard_D128ls_v6
-      memory: 274877906944
-      name: Standard_D128ls_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2lds_v6
-      id: Standard_D2lds_v6
-      memory: 4294967296
-      name: Standard_D2lds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4lds_v6
-      id: Standard_D4lds_v6
-      memory: 8589934592
-      name: Standard_D4lds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8lds_v6
-      id: Standard_D8lds_v6
-      memory: 17179869184
-      name: Standard_D8lds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16lds_v6
-      id: Standard_D16lds_v6
-      memory: 34359738368
-      name: Standard_D16lds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32lds_v6
-      id: Standard_D32lds_v6
-      memory: 68719476736
-      name: Standard_D32lds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48lds_v6
-      id: Standard_D48lds_v6
-      memory: 103079215104
-      name: Standard_D48lds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64lds_v6
-      id: Standard_D64lds_v6
-      memory: 137438953472
-      name: Standard_D64lds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96lds_v6
-      id: Standard_D96lds_v6
-      memory: 206158430208
-      name: Standard_D96lds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_d128lds_v6
-      id: Standard_D128lds_v6
-      memory: 274877906944
-      name: Standard_D128lds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2s_v6
-      id: Standard_D2s_v6
-      memory: 8589934592
-      name: Standard_D2s_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4s_v6
-      id: Standard_D4s_v6
-      memory: 17179869184
-      name: Standard_D4s_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8s_v6
-      id: Standard_D8s_v6
-      memory: 34359738368
-      name: Standard_D8s_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16s_v6
-      id: Standard_D16s_v6
-      memory: 68719476736
-      name: Standard_D16s_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32s_v6
-      id: Standard_D32s_v6
-      memory: 137438953472
-      name: Standard_D32s_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48s_v6
-      id: Standard_D48s_v6
-      memory: 206158430208
-      name: Standard_D48s_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64s_v6
-      id: Standard_D64s_v6
-      memory: 274877906944
-      name: Standard_D64s_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96s_v6
-      id: Standard_D96s_v6
-      memory: 412316860416
-      name: Standard_D96s_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_d128s_v6
-      id: Standard_D128s_v6
-      memory: 549755813888
-      name: Standard_D128s_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 192
-      generic_name: standard_d192s_v6
-      id: Standard_D192s_v6
-      memory: 824633720832
-      name: Standard_D192s_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2ds_v6
-      id: Standard_D2ds_v6
-      memory: 8589934592
-      name: Standard_D2ds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4ds_v6
-      id: Standard_D4ds_v6
-      memory: 17179869184
-      name: Standard_D4ds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8ds_v6
-      id: Standard_D8ds_v6
-      memory: 34359738368
-      name: Standard_D8ds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16ds_v6
-      id: Standard_D16ds_v6
-      memory: 68719476736
-      name: Standard_D16ds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32ds_v6
-      id: Standard_D32ds_v6
-      memory: 137438953472
-      name: Standard_D32ds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48ds_v6
-      id: Standard_D48ds_v6
-      memory: 206158430208
-      name: Standard_D48ds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64ds_v6
-      id: Standard_D64ds_v6
-      memory: 274877906944
-      name: Standard_D64ds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96ds_v6
-      id: Standard_D96ds_v6
-      memory: 412316860416
-      name: Standard_D96ds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_d128ds_v6
-      id: Standard_D128ds_v6
-      memory: 549755813888
-      name: Standard_D128ds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 192
-      generic_name: standard_d192ds_v6
-      id: Standard_D192ds_v6
-      memory: 824633720832
-      name: Standard_D192ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2s_v6
-      id: Standard_E2s_v6
-      memory: 17179869184
-      name: Standard_E2s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2s_v6
-      id: Standard_E4-2s_v6
-      memory: 34359738368
-      name: Standard_E4-2s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4s_v6
-      id: Standard_E4s_v6
-      memory: 34359738368
-      name: Standard_E4s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2s_v6
-      id: Standard_E8-2s_v6
-      memory: 68719476736
-      name: Standard_E8-2s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4s_v6
-      id: Standard_E8-4s_v6
-      memory: 68719476736
-      name: Standard_E8-4s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8s_v6
-      id: Standard_E8s_v6
-      memory: 68719476736
-      name: Standard_E8s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-4s_v6
-      id: Standard_E16-4s_v6
-      memory: 137438953472
-      name: Standard_E16-4s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8s_v6
-      id: Standard_E16-8s_v6
-      memory: 137438953472
-      name: Standard_E16-8s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16s_v6
-      id: Standard_E16s_v6
-      memory: 137438953472
-      name: Standard_E16s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20s_v6
-      id: Standard_E20s_v6
-      memory: 171798691840
-      name: Standard_E20s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8s_v6
-      id: Standard_E32-8s_v6
-      memory: 274877906944
-      name: Standard_E32-8s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16s_v6
-      id: Standard_E32-16s_v6
-      memory: 274877906944
-      name: Standard_E32-16s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32s_v6
-      id: Standard_E32s_v6
-      memory: 274877906944
-      name: Standard_E32s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48s_v6
-      id: Standard_E48s_v6
-      memory: 412316860416
-      name: Standard_E48s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16s_v6
-      id: Standard_E64-16s_v6
-      memory: 549755813888
-      name: Standard_E64-16s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32s_v6
-      id: Standard_E64-32s_v6
-      memory: 549755813888
-      name: Standard_E64-32s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64s_v6
-      id: Standard_E64s_v6
-      memory: 549755813888
-      name: Standard_E64s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-24s_v6
-      id: Standard_E96-24s_v6
-      memory: 824633720832
-      name: Standard_E96-24s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-48s_v6
-      id: Standard_E96-48s_v6
-      memory: 824633720832
-      name: Standard_E96-48s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96s_v6
-      id: Standard_E96s_v6
-      memory: 824633720832
-      name: Standard_E96s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2ds_v6
-      id: Standard_E2ds_v6
-      memory: 17179869184
-      name: Standard_E2ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2ds_v6
-      id: Standard_E4-2ds_v6
-      memory: 34359738368
-      name: Standard_E4-2ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4ds_v6
-      id: Standard_E4ds_v6
-      memory: 34359738368
-      name: Standard_E4ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2ds_v6
-      id: Standard_E8-2ds_v6
-      memory: 68719476736
-      name: Standard_E8-2ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4ds_v6
-      id: Standard_E8-4ds_v6
-      memory: 68719476736
-      name: Standard_E8-4ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8ds_v6
-      id: Standard_E8ds_v6
-      memory: 68719476736
-      name: Standard_E8ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-4ds_v6
-      id: Standard_E16-4ds_v6
-      memory: 137438953472
-      name: Standard_E16-4ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8ds_v6
-      id: Standard_E16-8ds_v6
-      memory: 137438953472
-      name: Standard_E16-8ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16ds_v6
-      id: Standard_E16ds_v6
-      memory: 137438953472
-      name: Standard_E16ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20ds_v6
-      id: Standard_E20ds_v6
-      memory: 171798691840
-      name: Standard_E20ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8ds_v6
-      id: Standard_E32-8ds_v6
-      memory: 274877906944
-      name: Standard_E32-8ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16ds_v6
-      id: Standard_E32-16ds_v6
-      memory: 274877906944
-      name: Standard_E32-16ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32ds_v6
-      id: Standard_E32ds_v6
-      memory: 274877906944
-      name: Standard_E32ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48ds_v6
-      id: Standard_E48ds_v6
-      memory: 412316860416
-      name: Standard_E48ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16ds_v6
-      id: Standard_E64-16ds_v6
-      memory: 549755813888
-      name: Standard_E64-16ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32ds_v6
-      id: Standard_E64-32ds_v6
-      memory: 549755813888
-      name: Standard_E64-32ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64ds_v6
-      id: Standard_E64ds_v6
-      memory: 549755813888
-      name: Standard_E64ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-24ds_v6
-      id: Standard_E96-24ds_v6
-      memory: 824633720832
-      name: Standard_E96-24ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-48ds_v6
-      id: Standard_E96-48ds_v6
-      memory: 824633720832
-      name: Standard_E96-48ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96ds_v6
-      id: Standard_E96ds_v6
-      memory: 824633720832
-      name: Standard_E96ds_v6
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_l8as_v3
-      id: Standard_L8as_v3
-      memory: 68719476736
-      name: Standard_L8as_v3
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_l16as_v3
-      id: Standard_L16as_v3
-      memory: 137438953472
-      name: Standard_L16as_v3
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_l32as_v3
-      id: Standard_L32as_v3
-      memory: 274877906944
-      name: Standard_L32as_v3
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_l48as_v3
-      id: Standard_L48as_v3
-      memory: 412316860416
-      name: Standard_L48as_v3
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_l64as_v3
-      id: Standard_L64as_v3
-      memory: 549755813888
-      name: Standard_L64as_v3
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_l80as_v3
-      id: Standard_L80as_v3
-      memory: 687194767360
-      name: Standard_L80as_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2a_v4
-      id: Standard_D2a_v4
-      memory: 8589934592
-      name: Standard_D2a_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4a_v4
-      id: Standard_D4a_v4
-      memory: 17179869184
-      name: Standard_D4a_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8a_v4
-      id: Standard_D8a_v4
-      memory: 34359738368
-      name: Standard_D8a_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16a_v4
-      id: Standard_D16a_v4
-      memory: 68719476736
-      name: Standard_D16a_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32a_v4
-      id: Standard_D32a_v4
-      memory: 137438953472
-      name: Standard_D32a_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48a_v4
-      id: Standard_D48a_v4
-      memory: 206158430208
-      name: Standard_D48a_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64a_v4
-      id: Standard_D64a_v4
-      memory: 274877906944
-      name: Standard_D64a_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96a_v4
-      id: Standard_D96a_v4
-      memory: 412316860416
-      name: Standard_D96a_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2as_v4
-      id: Standard_D2as_v4
-      memory: 8589934592
-      name: Standard_D2as_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4as_v4
-      id: Standard_D4as_v4
-      memory: 17179869184
-      name: Standard_D4as_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8as_v4
-      id: Standard_D8as_v4
-      memory: 34359738368
-      name: Standard_D8as_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
+      family: standardDASv4Family
       generic_name: standard_d16as_v4
       id: Standard_D16as_v4
       memory: 68719476736
       name: Standard_D16as_v4
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32as_v4
-      id: Standard_D32as_v4
-      memory: 137438953472
-      name: Standard_D32as_v4
+      cpu_cores: 16
+      family: standardDASv5Family
+      generic_name: standard_d16as_v5
+      id: Standard_D16as_v5
+      memory: 68719476736
+      name: Standard_D16as_v5
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48as_v4
-      id: Standard_D48as_v4
-      memory: 206158430208
-      name: Standard_D48as_v4
+      cpu_cores: 16
+      family: standardDav6Family
+      generic_name: standard_d16as_v6
+      id: Standard_D16as_v6
+      memory: 68719476736
+      name: Standard_D16as_v6
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64as_v4
-      id: Standard_D64as_v4
-      memory: 274877906944
-      name: Standard_D64as_v4
+      cpu_cores: 16
+      family: StandardDasv7Family
+      generic_name: standard_d16as_v7
+      id: Standard_D16as_v7
+      memory: 68719476736
+      name: Standard_D16as_v7
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96as_v4
-      id: Standard_D96as_v4
-      memory: 412316860416
-      name: Standard_D96as_v4
-    - category: memory_optimized
+      cpu_cores: 16
+      family: standardDAv4Family
+      generic_name: standard_d16a_v4
+      id: Standard_D16a_v4
+      memory: 68719476736
+      name: Standard_D16a_v4
+    - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2a_v4
-      id: Standard_E2a_v4
-      memory: 17179869184
-      name: Standard_E2a_v4
-    - category: memory_optimized
+      cpu_cores: 16
+      family: standardDDSv4Family
+      generic_name: standard_d16ds_v4
+      id: Standard_D16ds_v4
+      memory: 68719476736
+      name: Standard_D16ds_v4
+    - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4a_v4
-      id: Standard_E4a_v4
+      cpu_cores: 16
+      family: standardDDSv5Family
+      generic_name: standard_d16ds_v5
+      id: Standard_D16ds_v5
+      memory: 68719476736
+      name: Standard_D16ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardDdsv6Family
+      generic_name: standard_d16ds_v6
+      id: Standard_D16ds_v6
+      memory: 68719476736
+      name: Standard_D16ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDDv4Family
+      generic_name: standard_d16d_v4
+      id: Standard_D16d_v4
+      memory: 68719476736
+      name: Standard_D16d_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDDv5Family
+      generic_name: standard_d16d_v5
+      id: Standard_D16d_v5
+      memory: 68719476736
+      name: Standard_D16d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDLDSv5Family
+      generic_name: standard_d16lds_v5
+      id: Standard_D16lds_v5
       memory: 34359738368
-      name: Standard_E4a_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8a_v4
-      id: Standard_E8a_v4
-      memory: 68719476736
-      name: Standard_E8a_v4
-    - category: memory_optimized
+      name: Standard_D16lds_v5
+    - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_e16a_v4
-      id: Standard_E16a_v4
-      memory: 137438953472
-      name: Standard_E16a_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20a_v4
-      id: Standard_E20a_v4
-      memory: 171798691840
-      name: Standard_E20a_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32a_v4
-      id: Standard_E32a_v4
-      memory: 274877906944
-      name: Standard_E32a_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48a_v4
-      id: Standard_E48a_v4
-      memory: 412316860416
-      name: Standard_E48a_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64a_v4
-      id: Standard_E64a_v4
-      memory: 549755813888
-      name: Standard_E64a_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96a_v4
-      id: Standard_E96a_v4
-      memory: 721554505728
-      name: Standard_E96a_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2as_v4
-      id: Standard_E2as_v4
-      memory: 17179869184
-      name: Standard_E2as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2as_v4
-      id: Standard_E4-2as_v4
+      family: StandardDldsv6Family
+      generic_name: standard_d16lds_v6
+      id: Standard_D16lds_v6
       memory: 34359738368
-      name: Standard_E4-2as_v4
-    - category: memory_optimized
+      name: Standard_D16lds_v6
+    - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4as_v4
-      id: Standard_E4as_v4
+      cpu_cores: 16
+      family: standardDLSv5Family
+      generic_name: standard_d16ls_v5
+      id: Standard_D16ls_v5
       memory: 34359738368
-      name: Standard_E4as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2as_v4
-      id: Standard_E8-2as_v4
-      memory: 68719476736
-      name: Standard_E8-2as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4as_v4
-      id: Standard_E8-4as_v4
-      memory: 68719476736
-      name: Standard_E8-4as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8as_v4
-      id: Standard_E8as_v4
-      memory: 68719476736
-      name: Standard_E8as_v4
-    - category: memory_optimized
+      name: Standard_D16ls_v5
+    - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_e16-4as_v4
-      id: Standard_E16-4as_v4
-      memory: 137438953472
-      name: Standard_E16-4as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8as_v4
-      id: Standard_E16-8as_v4
-      memory: 137438953472
-      name: Standard_E16-8as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16as_v4
-      id: Standard_E16as_v4
-      memory: 137438953472
-      name: Standard_E16as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20as_v4
-      id: Standard_E20as_v4
-      memory: 171798691840
-      name: Standard_E20as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8as_v4
-      id: Standard_E32-8as_v4
-      memory: 274877906944
-      name: Standard_E32-8as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16as_v4
-      id: Standard_E32-16as_v4
-      memory: 274877906944
-      name: Standard_E32-16as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32as_v4
-      id: Standard_E32as_v4
-      memory: 274877906944
-      name: Standard_E32as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48as_v4
-      id: Standard_E48as_v4
-      memory: 412316860416
-      name: Standard_E48as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16as_v4
-      id: Standard_E64-16as_v4
-      memory: 549755813888
-      name: Standard_E64-16as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32as_v4
-      id: Standard_E64-32as_v4
-      memory: 549755813888
-      name: Standard_E64-32as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64as_v4
-      id: Standard_E64as_v4
-      memory: 549755813888
-      name: Standard_E64as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-24as_v4
-      id: Standard_E96-24as_v4
-      memory: 721554505728
-      name: Standard_E96-24as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-48as_v4
-      id: Standard_E96-48as_v4
-      memory: 721554505728
-      name: Standard_E96-48as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96as_v4
-      id: Standard_E96as_v4
-      memory: 721554505728
-      name: Standard_E96as_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_l8s_v3
-      id: Standard_L8s_v3
-      memory: 68719476736
-      name: Standard_L8s_v3
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_l16s_v3
-      id: Standard_L16s_v3
-      memory: 137438953472
-      name: Standard_L16s_v3
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_l32s_v3
-      id: Standard_L32s_v3
-      memory: 274877906944
-      name: Standard_L32s_v3
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_l48s_v3
-      id: Standard_L48s_v3
-      memory: 412316860416
-      name: Standard_L48s_v3
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_l64s_v3
-      id: Standard_L64s_v3
-      memory: 549755813888
-      name: Standard_L64s_v3
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_l80s_v3
-      id: Standard_L80s_v3
-      memory: 687194767360
-      name: Standard_L80s_v3
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_l2aos_v4
-      id: Standard_L2aos_v4
-      memory: 17179869184
-      name: Standard_L2aos_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_l4aos_v4
-      id: Standard_L4aos_v4
+      family: StandardDlsv6Family
+      generic_name: standard_d16ls_v6
+      id: Standard_D16ls_v6
       memory: 34359738368
-      name: Standard_L4aos_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_l8aos_v4
-      id: Standard_L8aos_v4
-      memory: 68719476736
-      name: Standard_L8aos_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 12
-      generic_name: standard_l12aos_v4
-      id: Standard_L12aos_v4
-      memory: 103079215104
-      name: Standard_L12aos_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_l16aos_v4
-      id: Standard_L16aos_v4
-      memory: 137438953472
-      name: Standard_L16aos_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 24
-      generic_name: standard_l24aos_v4
-      id: Standard_L24aos_v4
-      memory: 206158430208
-      name: Standard_L24aos_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_l32aos_v4
-      id: Standard_L32aos_v4
-      memory: 274877906944
-      name: Standard_L32aos_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_l2as_v4
-      id: Standard_L2as_v4
-      memory: 17179869184
-      name: Standard_L2as_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_l4as_v4
-      id: Standard_L4as_v4
-      memory: 34359738368
-      name: Standard_L4as_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_l8as_v4
-      id: Standard_L8as_v4
-      memory: 68719476736
-      name: Standard_L8as_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_l16as_v4
-      id: Standard_L16as_v4
-      memory: 137438953472
-      name: Standard_L16as_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_l32as_v4
-      id: Standard_L32as_v4
-      memory: 274877906944
-      name: Standard_L32as_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_l48as_v4
-      id: Standard_L48as_v4
-      memory: 412316860416
-      name: Standard_L48as_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_l64as_v4
-      id: Standard_L64as_v4
-      memory: 549755813888
-      name: Standard_L64as_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_l80as_v4
-      id: Standard_L80as_v4
-      memory: 687194767360
-      name: Standard_L80as_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_l96as_v4
-      id: Standard_L96as_v4
-      memory: 824633720832
-      name: Standard_L96as_v4
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2plds_v5
-      id: Standard_D2plds_v5
-      memory: 4294967296
-      name: Standard_D2plds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4plds_v5
-      id: Standard_D4plds_v5
-      memory: 8589934592
-      name: Standard_D4plds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8plds_v5
-      id: Standard_D8plds_v5
-      memory: 17179869184
-      name: Standard_D8plds_v5
+      name: Standard_D16ls_v6
     - architecture: arm64
       category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_d16plds_v5
-      id: Standard_D16plds_v5
-      memory: 34359738368
-      name: Standard_D16plds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32plds_v5
-      id: Standard_D32plds_v5
-      memory: 68719476736
-      name: Standard_D32plds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48plds_v5
-      id: Standard_D48plds_v5
-      memory: 103079215104
-      name: Standard_D48plds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64plds_v5
-      id: Standard_D64plds_v5
-      memory: 137438953472
-      name: Standard_D64plds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2pls_v5
-      id: Standard_D2pls_v5
-      memory: 4294967296
-      name: Standard_D2pls_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4pls_v5
-      id: Standard_D4pls_v5
-      memory: 8589934592
-      name: Standard_D4pls_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8pls_v5
-      id: Standard_D8pls_v5
-      memory: 17179869184
-      name: Standard_D8pls_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16pls_v5
-      id: Standard_D16pls_v5
-      memory: 34359738368
-      name: Standard_D16pls_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32pls_v5
-      id: Standard_D32pls_v5
-      memory: 68719476736
-      name: Standard_D32pls_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48pls_v5
-      id: Standard_D48pls_v5
-      memory: 103079215104
-      name: Standard_D48pls_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64pls_v5
-      id: Standard_D64pls_v5
-      memory: 137438953472
-      name: Standard_D64pls_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2pds_v5
-      id: Standard_D2pds_v5
-      memory: 8589934592
-      name: Standard_D2pds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4pds_v5
-      id: Standard_D4pds_v5
-      memory: 17179869184
-      name: Standard_D4pds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8pds_v5
-      id: Standard_D8pds_v5
-      memory: 34359738368
-      name: Standard_D8pds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
+      family: standardDPDSv5Family
       generic_name: standard_d16pds_v5
       id: Standard_D16pds_v5
       memory: 68719476736
@@ -4965,845 +1067,8 @@ data:
     - architecture: arm64
       category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32pds_v5
-      id: Standard_D32pds_v5
-      memory: 137438953472
-      name: Standard_D32pds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48pds_v5
-      id: Standard_D48pds_v5
-      memory: 206158430208
-      name: Standard_D48pds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64pds_v5
-      id: Standard_D64pds_v5
-      memory: 223338299392
-      name: Standard_D64pds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2ps_v5
-      id: Standard_D2ps_v5
-      memory: 8589934592
-      name: Standard_D2ps_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4ps_v5
-      id: Standard_D4ps_v5
-      memory: 17179869184
-      name: Standard_D4ps_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8ps_v5
-      id: Standard_D8ps_v5
-      memory: 34359738368
-      name: Standard_D8ps_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_d16ps_v5
-      id: Standard_D16ps_v5
-      memory: 68719476736
-      name: Standard_D16ps_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32ps_v5
-      id: Standard_D32ps_v5
-      memory: 137438953472
-      name: Standard_D32ps_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48ps_v5
-      id: Standard_D48ps_v5
-      memory: 206158430208
-      name: Standard_D48ps_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64ps_v5
-      id: Standard_D64ps_v5
-      memory: 223338299392
-      name: Standard_D64ps_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2pds_v5
-      id: Standard_E2pds_v5
-      memory: 17179869184
-      name: Standard_E2pds_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4pds_v5
-      id: Standard_E4pds_v5
-      memory: 34359738368
-      name: Standard_E4pds_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8pds_v5
-      id: Standard_E8pds_v5
-      memory: 68719476736
-      name: Standard_E8pds_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16pds_v5
-      id: Standard_E16pds_v5
-      memory: 137438953472
-      name: Standard_E16pds_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20pds_v5
-      id: Standard_E20pds_v5
-      memory: 171798691840
-      name: Standard_E20pds_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32pds_v5
-      id: Standard_E32pds_v5
-      memory: 223338299392
-      name: Standard_E32pds_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2ps_v5
-      id: Standard_E2ps_v5
-      memory: 17179869184
-      name: Standard_E2ps_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4ps_v5
-      id: Standard_E4ps_v5
-      memory: 34359738368
-      name: Standard_E4ps_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8ps_v5
-      id: Standard_E8ps_v5
-      memory: 68719476736
-      name: Standard_E8ps_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16ps_v5
-      id: Standard_E16ps_v5
-      memory: 137438953472
-      name: Standard_E16ps_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20ps_v5
-      id: Standard_E20ps_v5
-      memory: 171798691840
-      name: Standard_E20ps_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32ps_v5
-      id: Standard_E32ps_v5
-      memory: 223338299392
-      name: Standard_E32ps_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128-32s_v6
-      id: Standard_E128-32s_v6
-      memory: 1099511627776
-      name: Standard_E128-32s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128-64s_v6
-      id: Standard_E128-64s_v6
-      memory: 1099511627776
-      name: Standard_E128-64s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128s_v6
-      id: Standard_E128s_v6
-      memory: 1099511627776
-      name: Standard_E128s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 192
-      generic_name: standard_e192is_v6
-      id: Standard_E192is_v6
-      memory: 1967095021568
-      name: Standard_E192is_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128-32ds_v6
-      id: Standard_E128-32ds_v6
-      memory: 1099511627776
-      name: Standard_E128-32ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128-64ds_v6
-      id: Standard_E128-64ds_v6
-      memory: 1099511627776
-      name: Standard_E128-64ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128ds_v6
-      id: Standard_E128ds_v6
-      memory: 1099511627776
-      name: Standard_E128ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 192
-      generic_name: standard_e192ids_v6
-      id: Standard_E192ids_v6
-      memory: 1967095021568
-      name: Standard_E192ids_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_fx2ms_v2
-      id: Standard_FX2ms_v2
-      memory: 45097156608
-      name: Standard_FX2ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_fx4-2ms_v2
-      id: Standard_FX4-2ms_v2
-      memory: 90194313216
-      name: Standard_FX4-2ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_fx4ms_v2
-      id: Standard_FX4ms_v2
-      memory: 90194313216
-      name: Standard_FX4ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_fx8-2ms_v2
-      id: Standard_FX8-2ms_v2
-      memory: 180388626432
-      name: Standard_FX8-2ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_fx8-4ms_v2
-      id: Standard_FX8-4ms_v2
-      memory: 180388626432
-      name: Standard_FX8-4ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_fx8ms_v2
-      id: Standard_FX8ms_v2
-      memory: 180388626432
-      name: Standard_FX8ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 12
-      generic_name: standard_fx12-6ms_v2
-      id: Standard_FX12-6ms_v2
-      memory: 270582939648
-      name: Standard_FX12-6ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 12
-      generic_name: standard_fx12ms_v2
-      id: Standard_FX12ms_v2
-      memory: 270582939648
-      name: Standard_FX12ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_fx16-4ms_v2
-      id: Standard_FX16-4ms_v2
-      memory: 360777252864
-      name: Standard_FX16-4ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_fx16-8ms_v2
-      id: Standard_FX16-8ms_v2
-      memory: 360777252864
-      name: Standard_FX16-8ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_fx16ms_v2
-      id: Standard_FX16ms_v2
-      memory: 360777252864
-      name: Standard_FX16ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 24
-      generic_name: standard_fx24-6ms_v2
-      id: Standard_FX24-6ms_v2
-      memory: 541165879296
-      name: Standard_FX24-6ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 24
-      generic_name: standard_fx24-12ms_v2
-      id: Standard_FX24-12ms_v2
-      memory: 541165879296
-      name: Standard_FX24-12ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 24
-      generic_name: standard_fx24ms_v2
-      id: Standard_FX24ms_v2
-      memory: 541165879296
-      name: Standard_FX24ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_fx32-8ms_v2
-      id: Standard_FX32-8ms_v2
-      memory: 721554505728
-      name: Standard_FX32-8ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_fx32-16ms_v2
-      id: Standard_FX32-16ms_v2
-      memory: 721554505728
-      name: Standard_FX32-16ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_fx32ms_v2
-      id: Standard_FX32ms_v2
-      memory: 721554505728
-      name: Standard_FX32ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_fx48-12ms_v2
-      id: Standard_FX48-12ms_v2
-      memory: 1082331758592
-      name: Standard_FX48-12ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_fx48-24ms_v2
-      id: Standard_FX48-24ms_v2
-      memory: 1082331758592
-      name: Standard_FX48-24ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_fx48ms_v2
-      id: Standard_FX48ms_v2
-      memory: 1082331758592
-      name: Standard_FX48ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_fx64-16ms_v2
-      id: Standard_FX64-16ms_v2
-      memory: 1443109011456
-      name: Standard_FX64-16ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_fx64-32ms_v2
-      id: Standard_FX64-32ms_v2
-      memory: 1443109011456
-      name: Standard_FX64-32ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_fx64ms_v2
-      id: Standard_FX64ms_v2
-      memory: 1443109011456
-      name: Standard_FX64ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_fx96-24ms_v2
-      id: Standard_FX96-24ms_v2
-      memory: 1967095021568
-      name: Standard_FX96-24ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_fx96-48ms_v2
-      id: Standard_FX96-48ms_v2
-      memory: 1967095021568
-      name: Standard_FX96-48ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_fx96ms_v2
-      id: Standard_FX96ms_v2
-      memory: 1967095021568
-      name: Standard_FX96ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_fx2mds_v2
-      id: Standard_FX2mds_v2
-      memory: 45097156608
-      name: Standard_FX2mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_fx4-2mds_v2
-      id: Standard_FX4-2mds_v2
-      memory: 90194313216
-      name: Standard_FX4-2mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_fx4mds_v2
-      id: Standard_FX4mds_v2
-      memory: 90194313216
-      name: Standard_FX4mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_fx8-2mds_v2
-      id: Standard_FX8-2mds_v2
-      memory: 180388626432
-      name: Standard_FX8-2mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_fx8-4mds_v2
-      id: Standard_FX8-4mds_v2
-      memory: 180388626432
-      name: Standard_FX8-4mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_fx8mds_v2
-      id: Standard_FX8mds_v2
-      memory: 180388626432
-      name: Standard_FX8mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 12
-      generic_name: standard_fx12-6mds_v2
-      id: Standard_FX12-6mds_v2
-      memory: 270582939648
-      name: Standard_FX12-6mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 12
-      generic_name: standard_fx12mds_v2
-      id: Standard_FX12mds_v2
-      memory: 270582939648
-      name: Standard_FX12mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_fx16-4mds_v2
-      id: Standard_FX16-4mds_v2
-      memory: 360777252864
-      name: Standard_FX16-4mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_fx16-8mds_v2
-      id: Standard_FX16-8mds_v2
-      memory: 360777252864
-      name: Standard_FX16-8mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_fx16mds_v2
-      id: Standard_FX16mds_v2
-      memory: 360777252864
-      name: Standard_FX16mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 24
-      generic_name: standard_fx24-6mds_v2
-      id: Standard_FX24-6mds_v2
-      memory: 541165879296
-      name: Standard_FX24-6mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 24
-      generic_name: standard_fx24-12mds_v2
-      id: Standard_FX24-12mds_v2
-      memory: 541165879296
-      name: Standard_FX24-12mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 24
-      generic_name: standard_fx24mds_v2
-      id: Standard_FX24mds_v2
-      memory: 541165879296
-      name: Standard_FX24mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_fx32-8mds_v2
-      id: Standard_FX32-8mds_v2
-      memory: 721554505728
-      name: Standard_FX32-8mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_fx32-16mds_v2
-      id: Standard_FX32-16mds_v2
-      memory: 721554505728
-      name: Standard_FX32-16mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_fx32mds_v2
-      id: Standard_FX32mds_v2
-      memory: 721554505728
-      name: Standard_FX32mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_fx48-12mds_v2
-      id: Standard_FX48-12mds_v2
-      memory: 1082331758592
-      name: Standard_FX48-12mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_fx48-24mds_v2
-      id: Standard_FX48-24mds_v2
-      memory: 1082331758592
-      name: Standard_FX48-24mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_fx48mds_v2
-      id: Standard_FX48mds_v2
-      memory: 1082331758592
-      name: Standard_FX48mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_fx64-16mds_v2
-      id: Standard_FX64-16mds_v2
-      memory: 1443109011456
-      name: Standard_FX64-16mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_fx64-32mds_v2
-      id: Standard_FX64-32mds_v2
-      memory: 1443109011456
-      name: Standard_FX64-32mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_fx64mds_v2
-      id: Standard_FX64mds_v2
-      memory: 1443109011456
-      name: Standard_FX64mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_fx96-24mds_v2
-      id: Standard_FX96-24mds_v2
-      memory: 1967095021568
-      name: Standard_FX96-24mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_fx96-48mds_v2
-      id: Standard_FX96-48mds_v2
-      memory: 1967095021568
-      name: Standard_FX96-48mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_fx96mds_v2
-      id: Standard_FX96mds_v2
-      memory: 1967095021568
-      name: Standard_FX96mds_v2
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_l2s_v4
-      id: Standard_L2s_v4
-      memory: 17179869184
-      name: Standard_L2s_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_l4s_v4
-      id: Standard_L4s_v4
-      memory: 34359738368
-      name: Standard_L4s_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_l8s_v4
-      id: Standard_L8s_v4
-      memory: 68719476736
-      name: Standard_L8s_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_l16s_v4
-      id: Standard_L16s_v4
-      memory: 137438953472
-      name: Standard_L16s_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_l32s_v4
-      id: Standard_L32s_v4
-      memory: 274877906944
-      name: Standard_L32s_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_l48s_v4
-      id: Standard_L48s_v4
-      memory: 412316860416
-      name: Standard_L48s_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_l64s_v4
-      id: Standard_L64s_v4
-      memory: 549755813888
-      name: Standard_L64s_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_l80s_v4
-      id: Standard_L80s_v4
-      memory: 687194767360
-      name: Standard_L80s_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_l96s_v4
-      id: Standard_L96s_v4
-      memory: 824633720832
-      name: Standard_L96s_v4
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 6
-      generic_name: standard_nv6ads_a10_v5
-      id: Standard_NV6ads_A10_v5
-      memory: 59055800320
-      name: Standard_NV6ads_A10_v5
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 12
-      generic_name: standard_nv12ads_a10_v5
-      id: Standard_NV12ads_A10_v5
-      memory: 118111600640
-      name: Standard_NV12ads_A10_v5
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 18
-      generic_name: standard_nv18ads_a10_v5
-      id: Standard_NV18ads_A10_v5
-      memory: 236223201280
-      name: Standard_NV18ads_A10_v5
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 36
-      generic_name: standard_nv36adms_a10_v5
-      id: Standard_NV36adms_A10_v5
-      memory: 944892805120
-      name: Standard_NV36adms_A10_v5
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 36
-      generic_name: standard_nv36ads_a10_v5
-      id: Standard_NV36ads_A10_v5
-      memory: 472446402560
-      name: Standard_NV36ads_A10_v5
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 72
-      generic_name: standard_nv72ads_a10_v5
-      id: Standard_NV72ads_A10_v5
-      memory: 944892805120
-      name: Standard_NV72ads_A10_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 112
-      generic_name: standard_e112ias_v5
-      id: Standard_E112ias_v5
-      memory: 721554505728
-      name: Standard_E112ias_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 112
-      generic_name: standard_e112iads_v5
-      id: Standard_E112iads_v5
-      memory: 721554505728
-      name: Standard_E112iads_v5
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_fx4mds
-      id: Standard_FX4mds
-      memory: 90194313216
-      name: Standard_FX4mds
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 12
-      generic_name: standard_fx12mds
-      id: Standard_FX12mds
-      memory: 270582939648
-      name: Standard_FX12mds
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 24
-      generic_name: standard_fx24mds
-      id: Standard_FX24mds
-      memory: 541165879296
-      name: Standard_FX24mds
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 36
-      generic_name: standard_fx36mds
-      id: Standard_FX36mds
-      memory: 811748818944
-      name: Standard_FX36mds
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_fx48mds
-      id: Standard_FX48mds
-      memory: 1082331758592
-      name: Standard_FX48mds
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2pls_v6
-      id: Standard_D2pls_v6
-      memory: 4294967296
-      name: Standard_D2pls_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4pls_v6
-      id: Standard_D4pls_v6
-      memory: 8589934592
-      name: Standard_D4pls_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8pls_v6
-      id: Standard_D8pls_v6
-      memory: 17179869184
-      name: Standard_D8pls_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16pls_v6
-      id: Standard_D16pls_v6
-      memory: 34359738368
-      name: Standard_D16pls_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32pls_v6
-      id: Standard_D32pls_v6
-      memory: 68719476736
-      name: Standard_D32pls_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48pls_v6
-      id: Standard_D48pls_v6
-      memory: 103079215104
-      name: Standard_D48pls_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64pls_v6
-      id: Standard_D64pls_v6
-      memory: 137438953472
-      name: Standard_D64pls_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96pls_v6
-      id: Standard_D96pls_v6
-      memory: 206158430208
-      name: Standard_D96pls_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2pds_v6
-      id: Standard_D2pds_v6
-      memory: 8589934592
-      name: Standard_D2pds_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4pds_v6
-      id: Standard_D4pds_v6
-      memory: 17179869184
-      name: Standard_D4pds_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8pds_v6
-      id: Standard_D8pds_v6
-      memory: 34359738368
-      name: Standard_D8pds_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
+      family: StandardDpdsv6Family
       generic_name: standard_d16pds_v6
       id: Standard_D16pds_v6
       memory: 68719476736
@@ -5811,63 +1076,17 @@ data:
     - architecture: arm64
       category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32pds_v6
-      id: Standard_D32pds_v6
-      memory: 137438953472
-      name: Standard_D32pds_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48pds_v6
-      id: Standard_D48pds_v6
-      memory: 206158430208
-      name: Standard_D48pds_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64pds_v6
-      id: Standard_D64pds_v6
-      memory: 274877906944
-      name: Standard_D64pds_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96pds_v6
-      id: Standard_D96pds_v6
-      memory: 412316860416
-      name: Standard_D96pds_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2plds_v6
-      id: Standard_D2plds_v6
-      memory: 4294967296
-      name: Standard_D2plds_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4plds_v6
-      id: Standard_D4plds_v6
-      memory: 8589934592
-      name: Standard_D4plds_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8plds_v6
-      id: Standard_D8plds_v6
-      memory: 17179869184
-      name: Standard_D8plds_v6
+      cpu_cores: 16
+      family: standardDPLDSv5Family
+      generic_name: standard_d16plds_v5
+      id: Standard_D16plds_v5
+      memory: 34359738368
+      name: Standard_D16plds_v5
     - architecture: arm64
       category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
+      family: StandardDpldsv6Family
       generic_name: standard_d16plds_v6
       id: Standard_D16plds_v6
       memory: 34359738368
@@ -5875,7 +1094,623 @@ data:
     - architecture: arm64
       category: general_purpose
       cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDPLSv5Family
+      generic_name: standard_d16pls_v5
+      id: Standard_D16pls_v5
+      memory: 34359738368
+      name: Standard_D16pls_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardDplsv6Family
+      generic_name: standard_d16pls_v6
+      id: Standard_D16pls_v6
+      memory: 34359738368
+      name: Standard_D16pls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDPSv5Family
+      generic_name: standard_d16ps_v5
+      id: Standard_D16ps_v5
+      memory: 68719476736
+      name: Standard_D16ps_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardDpsv6Family
+      generic_name: standard_d16ps_v6
+      id: Standard_D16ps_v6
+      memory: 68719476736
+      name: Standard_D16ps_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDSv3Family
+      generic_name: standard_d16s_v3
+      id: Standard_D16s_v3
+      memory: 68719476736
+      name: Standard_D16s_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDSv4Family
+      generic_name: standard_d16s_v4
+      id: Standard_D16s_v4
+      memory: 68719476736
+      name: Standard_D16s_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDSv5Family
+      generic_name: standard_d16s_v5
+      id: Standard_D16s_v5
+      memory: 68719476736
+      name: Standard_D16s_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardDsv6Family
+      generic_name: standard_d16s_v6
+      id: Standard_D16s_v6
+      memory: 68719476736
+      name: Standard_D16s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDv3Family
+      generic_name: standard_d16_v3
+      id: Standard_D16_v3
+      memory: 68719476736
+      name: Standard_D16_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDv4Family
+      generic_name: standard_d16_v4
+      id: Standard_D16_v4
+      memory: 68719476736
+      name: Standard_D16_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDv5Family
+      generic_name: standard_d16_v5
+      id: Standard_D16_v5
+      memory: 68719476736
+      name: Standard_D16_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 192
+      family: StandardDdsv6Family
+      generic_name: standard_d192ds_v6
+      id: Standard_D192ds_v6
+      memory: 824633720832
+      name: Standard_D192ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 192
+      family: StandardDsv6Family
+      generic_name: standard_d192s_v6
+      id: Standard_D192s_v6
+      memory: 824633720832
+      name: Standard_D192s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 1
+      family: standardDv2Family
+      generic_name: standard_d1_v2
+      id: Standard_D1_v2
+      memory: 3221225472
+      name: Standard_D1_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDADSv5Family
+      generic_name: standard_d2ads_v5
+      id: Standard_D2ads_v5
+      memory: 8589934592
+      name: Standard_D2ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDadv6Family
+      generic_name: standard_d2ads_v6
+      id: Standard_D2ads_v6
+      memory: 8589934592
+      name: Standard_D2ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDadsv7Family
+      generic_name: standard_d2ads_v7
+      id: Standard_D2ads_v7
+      memory: 8589934592
+      name: Standard_D2ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDaldv6Family
+      generic_name: standard_d2alds_v6
+      id: Standard_D2alds_v6
+      memory: 4294967296
+      name: Standard_D2alds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDaldsv7Family
+      generic_name: standard_d2alds_v7
+      id: Standard_D2alds_v7
+      memory: 4294967296
+      name: Standard_D2alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDalv6Family
+      generic_name: standard_d2als_v6
+      id: Standard_D2als_v6
+      memory: 4294967296
+      name: Standard_D2als_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDalsv7Family
+      generic_name: standard_d2als_v7
+      id: Standard_D2als_v7
+      memory: 4294967296
+      name: Standard_D2als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDASv4Family
+      generic_name: standard_d2as_v4
+      id: Standard_D2as_v4
+      memory: 8589934592
+      name: Standard_D2as_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDASv5Family
+      generic_name: standard_d2as_v5
+      id: Standard_D2as_v5
+      memory: 8589934592
+      name: Standard_D2as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDav6Family
+      generic_name: standard_d2as_v6
+      id: Standard_D2as_v6
+      memory: 8589934592
+      name: Standard_D2as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDasv7Family
+      generic_name: standard_d2as_v7
+      id: Standard_D2as_v7
+      memory: 8589934592
+      name: Standard_D2as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDAv4Family
+      generic_name: standard_d2a_v4
+      id: Standard_D2a_v4
+      memory: 8589934592
+      name: Standard_D2a_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDDSv4Family
+      generic_name: standard_d2ds_v4
+      id: Standard_D2ds_v4
+      memory: 8589934592
+      name: Standard_D2ds_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDDSv5Family
+      generic_name: standard_d2ds_v5
+      id: Standard_D2ds_v5
+      memory: 8589934592
+      name: Standard_D2ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDdsv6Family
+      generic_name: standard_d2ds_v6
+      id: Standard_D2ds_v6
+      memory: 8589934592
+      name: Standard_D2ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDDv4Family
+      generic_name: standard_d2d_v4
+      id: Standard_D2d_v4
+      memory: 8589934592
+      name: Standard_D2d_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDDv5Family
+      generic_name: standard_d2d_v5
+      id: Standard_D2d_v5
+      memory: 8589934592
+      name: Standard_D2d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDLDSv5Family
+      generic_name: standard_d2lds_v5
+      id: Standard_D2lds_v5
+      memory: 4294967296
+      name: Standard_D2lds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDldsv6Family
+      generic_name: standard_d2lds_v6
+      id: Standard_D2lds_v6
+      memory: 4294967296
+      name: Standard_D2lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDLSv5Family
+      generic_name: standard_d2ls_v5
+      id: Standard_D2ls_v5
+      memory: 4294967296
+      name: Standard_D2ls_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDlsv6Family
+      generic_name: standard_d2ls_v6
+      id: Standard_D2ls_v6
+      memory: 4294967296
+      name: Standard_D2ls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDPDSv5Family
+      generic_name: standard_d2pds_v5
+      id: Standard_D2pds_v5
+      memory: 8589934592
+      name: Standard_D2pds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDpdsv6Family
+      generic_name: standard_d2pds_v6
+      id: Standard_D2pds_v6
+      memory: 8589934592
+      name: Standard_D2pds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDPLDSv5Family
+      generic_name: standard_d2plds_v5
+      id: Standard_D2plds_v5
+      memory: 4294967296
+      name: Standard_D2plds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDpldsv6Family
+      generic_name: standard_d2plds_v6
+      id: Standard_D2plds_v6
+      memory: 4294967296
+      name: Standard_D2plds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDPLSv5Family
+      generic_name: standard_d2pls_v5
+      id: Standard_D2pls_v5
+      memory: 4294967296
+      name: Standard_D2pls_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDplsv6Family
+      generic_name: standard_d2pls_v6
+      id: Standard_D2pls_v6
+      memory: 4294967296
+      name: Standard_D2pls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDPSv5Family
+      generic_name: standard_d2ps_v5
+      id: Standard_D2ps_v5
+      memory: 8589934592
+      name: Standard_D2ps_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDpsv6Family
+      generic_name: standard_d2ps_v6
+      id: Standard_D2ps_v6
+      memory: 8589934592
+      name: Standard_D2ps_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDSv3Family
+      generic_name: standard_d2s_v3
+      id: Standard_D2s_v3
+      memory: 8589934592
+      name: Standard_D2s_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDSv4Family
+      generic_name: standard_d2s_v4
+      id: Standard_D2s_v4
+      memory: 8589934592
+      name: Standard_D2s_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDSv5Family
+      generic_name: standard_d2s_v5
+      id: Standard_D2s_v5
+      memory: 8589934592
+      name: Standard_D2s_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDsv6Family
+      generic_name: standard_d2s_v6
+      id: Standard_D2s_v6
+      memory: 8589934592
+      name: Standard_D2s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDv2Family
+      generic_name: standard_d2_v2
+      id: Standard_D2_v2
+      memory: 7516192768
+      name: Standard_D2_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDv3Family
+      generic_name: standard_d2_v3
+      id: Standard_D2_v3
+      memory: 8589934592
+      name: Standard_D2_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDv4Family
+      generic_name: standard_d2_v4
+      id: Standard_D2_v4
+      memory: 8589934592
+      name: Standard_D2_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDv5Family
+      generic_name: standard_d2_v5
+      id: Standard_D2_v5
+      memory: 8589934592
+      name: Standard_D2_v5
+    - category: general_purpose
+      cloud_provider_id: azure
       cpu_cores: 32
+      family: standardDADSv5Family
+      generic_name: standard_d32ads_v5
+      id: Standard_D32ads_v5
+      memory: 137438953472
+      name: Standard_D32ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDadv6Family
+      generic_name: standard_d32ads_v6
+      id: Standard_D32ads_v6
+      memory: 137438953472
+      name: Standard_D32ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDadsv7Family
+      generic_name: standard_d32ads_v7
+      id: Standard_D32ads_v7
+      memory: 137438953472
+      name: Standard_D32ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDaldv6Family
+      generic_name: standard_d32alds_v6
+      id: Standard_D32alds_v6
+      memory: 68719476736
+      name: Standard_D32alds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDaldsv7Family
+      generic_name: standard_d32alds_v7
+      id: Standard_D32alds_v7
+      memory: 68719476736
+      name: Standard_D32alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDalv6Family
+      generic_name: standard_d32als_v6
+      id: Standard_D32als_v6
+      memory: 68719476736
+      name: Standard_D32als_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDalsv7Family
+      generic_name: standard_d32als_v7
+      id: Standard_D32als_v7
+      memory: 68719476736
+      name: Standard_D32als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDASv4Family
+      generic_name: standard_d32as_v4
+      id: Standard_D32as_v4
+      memory: 137438953472
+      name: Standard_D32as_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDASv5Family
+      generic_name: standard_d32as_v5
+      id: Standard_D32as_v5
+      memory: 137438953472
+      name: Standard_D32as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDav6Family
+      generic_name: standard_d32as_v6
+      id: Standard_D32as_v6
+      memory: 137438953472
+      name: Standard_D32as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDasv7Family
+      generic_name: standard_d32as_v7
+      id: Standard_D32as_v7
+      memory: 137438953472
+      name: Standard_D32as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDAv4Family
+      generic_name: standard_d32a_v4
+      id: Standard_D32a_v4
+      memory: 137438953472
+      name: Standard_D32a_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDDSv4Family
+      generic_name: standard_d32ds_v4
+      id: Standard_D32ds_v4
+      memory: 137438953472
+      name: Standard_D32ds_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDDSv5Family
+      generic_name: standard_d32ds_v5
+      id: Standard_D32ds_v5
+      memory: 137438953472
+      name: Standard_D32ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDdsv6Family
+      generic_name: standard_d32ds_v6
+      id: Standard_D32ds_v6
+      memory: 137438953472
+      name: Standard_D32ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDDv4Family
+      generic_name: standard_d32d_v4
+      id: Standard_D32d_v4
+      memory: 137438953472
+      name: Standard_D32d_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDDv5Family
+      generic_name: standard_d32d_v5
+      id: Standard_D32d_v5
+      memory: 137438953472
+      name: Standard_D32d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDLDSv5Family
+      generic_name: standard_d32lds_v5
+      id: Standard_D32lds_v5
+      memory: 68719476736
+      name: Standard_D32lds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDldsv6Family
+      generic_name: standard_d32lds_v6
+      id: Standard_D32lds_v6
+      memory: 68719476736
+      name: Standard_D32lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDLSv5Family
+      generic_name: standard_d32ls_v5
+      id: Standard_D32ls_v5
+      memory: 68719476736
+      name: Standard_D32ls_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDlsv6Family
+      generic_name: standard_d32ls_v6
+      id: Standard_D32ls_v6
+      memory: 68719476736
+      name: Standard_D32ls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDPDSv5Family
+      generic_name: standard_d32pds_v5
+      id: Standard_D32pds_v5
+      memory: 137438953472
+      name: Standard_D32pds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDpdsv6Family
+      generic_name: standard_d32pds_v6
+      id: Standard_D32pds_v6
+      memory: 137438953472
+      name: Standard_D32pds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDPLDSv5Family
+      generic_name: standard_d32plds_v5
+      id: Standard_D32plds_v5
+      memory: 68719476736
+      name: Standard_D32plds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDpldsv6Family
       generic_name: standard_d32plds_v6
       id: Standard_D32plds_v6
       memory: 68719476736
@@ -5883,7 +1718,303 @@ data:
     - architecture: arm64
       category: general_purpose
       cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDPLSv5Family
+      generic_name: standard_d32pls_v5
+      id: Standard_D32pls_v5
+      memory: 68719476736
+      name: Standard_D32pls_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDplsv6Family
+      generic_name: standard_d32pls_v6
+      id: Standard_D32pls_v6
+      memory: 68719476736
+      name: Standard_D32pls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDPSv5Family
+      generic_name: standard_d32ps_v5
+      id: Standard_D32ps_v5
+      memory: 137438953472
+      name: Standard_D32ps_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDpsv6Family
+      generic_name: standard_d32ps_v6
+      id: Standard_D32ps_v6
+      memory: 137438953472
+      name: Standard_D32ps_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDSv3Family
+      generic_name: standard_d32s_v3
+      id: Standard_D32s_v3
+      memory: 137438953472
+      name: Standard_D32s_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDSv4Family
+      generic_name: standard_d32s_v4
+      id: Standard_D32s_v4
+      memory: 137438953472
+      name: Standard_D32s_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDSv5Family
+      generic_name: standard_d32s_v5
+      id: Standard_D32s_v5
+      memory: 137438953472
+      name: Standard_D32s_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDsv6Family
+      generic_name: standard_d32s_v6
+      id: Standard_D32s_v6
+      memory: 137438953472
+      name: Standard_D32s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDv3Family
+      generic_name: standard_d32_v3
+      id: Standard_D32_v3
+      memory: 137438953472
+      name: Standard_D32_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDv4Family
+      generic_name: standard_d32_v4
+      id: Standard_D32_v4
+      memory: 137438953472
+      name: Standard_D32_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDv5Family
+      generic_name: standard_d32_v5
+      id: Standard_D32_v5
+      memory: 137438953472
+      name: Standard_D32_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDv2Family
+      generic_name: standard_d3_v2
+      id: Standard_D3_v2
+      memory: 15032385536
+      name: Standard_D3_v2
+    - category: general_purpose
+      cloud_provider_id: azure
       cpu_cores: 48
+      family: standardDADSv5Family
+      generic_name: standard_d48ads_v5
+      id: Standard_D48ads_v5
+      memory: 206158430208
+      name: Standard_D48ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDadv6Family
+      generic_name: standard_d48ads_v6
+      id: Standard_D48ads_v6
+      memory: 206158430208
+      name: Standard_D48ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDadsv7Family
+      generic_name: standard_d48ads_v7
+      id: Standard_D48ads_v7
+      memory: 206158430208
+      name: Standard_D48ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDaldv6Family
+      generic_name: standard_d48alds_v6
+      id: Standard_D48alds_v6
+      memory: 103079215104
+      name: Standard_D48alds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDaldsv7Family
+      generic_name: standard_d48alds_v7
+      id: Standard_D48alds_v7
+      memory: 103079215104
+      name: Standard_D48alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDalv6Family
+      generic_name: standard_d48als_v6
+      id: Standard_D48als_v6
+      memory: 103079215104
+      name: Standard_D48als_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDalsv7Family
+      generic_name: standard_d48als_v7
+      id: Standard_D48als_v7
+      memory: 103079215104
+      name: Standard_D48als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDASv4Family
+      generic_name: standard_d48as_v4
+      id: Standard_D48as_v4
+      memory: 206158430208
+      name: Standard_D48as_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDASv5Family
+      generic_name: standard_d48as_v5
+      id: Standard_D48as_v5
+      memory: 206158430208
+      name: Standard_D48as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDav6Family
+      generic_name: standard_d48as_v6
+      id: Standard_D48as_v6
+      memory: 206158430208
+      name: Standard_D48as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDasv7Family
+      generic_name: standard_d48as_v7
+      id: Standard_D48as_v7
+      memory: 206158430208
+      name: Standard_D48as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDAv4Family
+      generic_name: standard_d48a_v4
+      id: Standard_D48a_v4
+      memory: 206158430208
+      name: Standard_D48a_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDDSv4Family
+      generic_name: standard_d48ds_v4
+      id: Standard_D48ds_v4
+      memory: 206158430208
+      name: Standard_D48ds_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDDSv5Family
+      generic_name: standard_d48ds_v5
+      id: Standard_D48ds_v5
+      memory: 206158430208
+      name: Standard_D48ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDdsv6Family
+      generic_name: standard_d48ds_v6
+      id: Standard_D48ds_v6
+      memory: 206158430208
+      name: Standard_D48ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDDv4Family
+      generic_name: standard_d48d_v4
+      id: Standard_D48d_v4
+      memory: 206158430208
+      name: Standard_D48d_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDDv5Family
+      generic_name: standard_d48d_v5
+      id: Standard_D48d_v5
+      memory: 206158430208
+      name: Standard_D48d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDLDSv5Family
+      generic_name: standard_d48lds_v5
+      id: Standard_D48lds_v5
+      memory: 103079215104
+      name: Standard_D48lds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDldsv6Family
+      generic_name: standard_d48lds_v6
+      id: Standard_D48lds_v6
+      memory: 103079215104
+      name: Standard_D48lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDLSv5Family
+      generic_name: standard_d48ls_v5
+      id: Standard_D48ls_v5
+      memory: 103079215104
+      name: Standard_D48ls_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDlsv6Family
+      generic_name: standard_d48ls_v6
+      id: Standard_D48ls_v6
+      memory: 103079215104
+      name: Standard_D48ls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDPDSv5Family
+      generic_name: standard_d48pds_v5
+      id: Standard_D48pds_v5
+      memory: 206158430208
+      name: Standard_D48pds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDpdsv6Family
+      generic_name: standard_d48pds_v6
+      id: Standard_D48pds_v6
+      memory: 206158430208
+      name: Standard_D48pds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDPLDSv5Family
+      generic_name: standard_d48plds_v5
+      id: Standard_D48plds_v5
+      memory: 103079215104
+      name: Standard_D48plds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDpldsv6Family
       generic_name: standard_d48plds_v6
       id: Standard_D48plds_v6
       memory: 103079215104
@@ -5891,7 +2022,607 @@ data:
     - architecture: arm64
       category: general_purpose
       cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDPLSv5Family
+      generic_name: standard_d48pls_v5
+      id: Standard_D48pls_v5
+      memory: 103079215104
+      name: Standard_D48pls_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDplsv6Family
+      generic_name: standard_d48pls_v6
+      id: Standard_D48pls_v6
+      memory: 103079215104
+      name: Standard_D48pls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDPSv5Family
+      generic_name: standard_d48ps_v5
+      id: Standard_D48ps_v5
+      memory: 206158430208
+      name: Standard_D48ps_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDpsv6Family
+      generic_name: standard_d48ps_v6
+      id: Standard_D48ps_v6
+      memory: 206158430208
+      name: Standard_D48ps_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDSv3Family
+      generic_name: standard_d48s_v3
+      id: Standard_D48s_v3
+      memory: 206158430208
+      name: Standard_D48s_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDSv4Family
+      generic_name: standard_d48s_v4
+      id: Standard_D48s_v4
+      memory: 206158430208
+      name: Standard_D48s_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDSv5Family
+      generic_name: standard_d48s_v5
+      id: Standard_D48s_v5
+      memory: 206158430208
+      name: Standard_D48s_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDsv6Family
+      generic_name: standard_d48s_v6
+      id: Standard_D48s_v6
+      memory: 206158430208
+      name: Standard_D48s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDv3Family
+      generic_name: standard_d48_v3
+      id: Standard_D48_v3
+      memory: 206158430208
+      name: Standard_D48_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDv4Family
+      generic_name: standard_d48_v4
+      id: Standard_D48_v4
+      memory: 206158430208
+      name: Standard_D48_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDv5Family
+      generic_name: standard_d48_v5
+      id: Standard_D48_v5
+      memory: 206158430208
+      name: Standard_D48_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDADSv5Family
+      generic_name: standard_d4ads_v5
+      id: Standard_D4ads_v5
+      memory: 17179869184
+      name: Standard_D4ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDadv6Family
+      generic_name: standard_d4ads_v6
+      id: Standard_D4ads_v6
+      memory: 17179869184
+      name: Standard_D4ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDadsv7Family
+      generic_name: standard_d4ads_v7
+      id: Standard_D4ads_v7
+      memory: 17179869184
+      name: Standard_D4ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDaldv6Family
+      generic_name: standard_d4alds_v6
+      id: Standard_D4alds_v6
+      memory: 8589934592
+      name: Standard_D4alds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDaldsv7Family
+      generic_name: standard_d4alds_v7
+      id: Standard_D4alds_v7
+      memory: 8589934592
+      name: Standard_D4alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDalv6Family
+      generic_name: standard_d4als_v6
+      id: Standard_D4als_v6
+      memory: 8589934592
+      name: Standard_D4als_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDalsv7Family
+      generic_name: standard_d4als_v7
+      id: Standard_D4als_v7
+      memory: 8589934592
+      name: Standard_D4als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDASv4Family
+      generic_name: standard_d4as_v4
+      id: Standard_D4as_v4
+      memory: 17179869184
+      name: Standard_D4as_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDASv5Family
+      generic_name: standard_d4as_v5
+      id: Standard_D4as_v5
+      memory: 17179869184
+      name: Standard_D4as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDav6Family
+      generic_name: standard_d4as_v6
+      id: Standard_D4as_v6
+      memory: 17179869184
+      name: Standard_D4as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDasv7Family
+      generic_name: standard_d4as_v7
+      id: Standard_D4as_v7
+      memory: 17179869184
+      name: Standard_D4as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDAv4Family
+      generic_name: standard_d4a_v4
+      id: Standard_D4a_v4
+      memory: 17179869184
+      name: Standard_D4a_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDDSv4Family
+      generic_name: standard_d4ds_v4
+      id: Standard_D4ds_v4
+      memory: 17179869184
+      name: Standard_D4ds_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDDSv5Family
+      generic_name: standard_d4ds_v5
+      id: Standard_D4ds_v5
+      memory: 17179869184
+      name: Standard_D4ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDdsv6Family
+      generic_name: standard_d4ds_v6
+      id: Standard_D4ds_v6
+      memory: 17179869184
+      name: Standard_D4ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDDv4Family
+      generic_name: standard_d4d_v4
+      id: Standard_D4d_v4
+      memory: 17179869184
+      name: Standard_D4d_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDDv5Family
+      generic_name: standard_d4d_v5
+      id: Standard_D4d_v5
+      memory: 17179869184
+      name: Standard_D4d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDLDSv5Family
+      generic_name: standard_d4lds_v5
+      id: Standard_D4lds_v5
+      memory: 8589934592
+      name: Standard_D4lds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDldsv6Family
+      generic_name: standard_d4lds_v6
+      id: Standard_D4lds_v6
+      memory: 8589934592
+      name: Standard_D4lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDLSv5Family
+      generic_name: standard_d4ls_v5
+      id: Standard_D4ls_v5
+      memory: 8589934592
+      name: Standard_D4ls_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDlsv6Family
+      generic_name: standard_d4ls_v6
+      id: Standard_D4ls_v6
+      memory: 8589934592
+      name: Standard_D4ls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDPDSv5Family
+      generic_name: standard_d4pds_v5
+      id: Standard_D4pds_v5
+      memory: 17179869184
+      name: Standard_D4pds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDpdsv6Family
+      generic_name: standard_d4pds_v6
+      id: Standard_D4pds_v6
+      memory: 17179869184
+      name: Standard_D4pds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDPLDSv5Family
+      generic_name: standard_d4plds_v5
+      id: Standard_D4plds_v5
+      memory: 8589934592
+      name: Standard_D4plds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDpldsv6Family
+      generic_name: standard_d4plds_v6
+      id: Standard_D4plds_v6
+      memory: 8589934592
+      name: Standard_D4plds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDPLSv5Family
+      generic_name: standard_d4pls_v5
+      id: Standard_D4pls_v5
+      memory: 8589934592
+      name: Standard_D4pls_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDplsv6Family
+      generic_name: standard_d4pls_v6
+      id: Standard_D4pls_v6
+      memory: 8589934592
+      name: Standard_D4pls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDPSv5Family
+      generic_name: standard_d4ps_v5
+      id: Standard_D4ps_v5
+      memory: 17179869184
+      name: Standard_D4ps_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDpsv6Family
+      generic_name: standard_d4ps_v6
+      id: Standard_D4ps_v6
+      memory: 17179869184
+      name: Standard_D4ps_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDSv3Family
+      generic_name: standard_d4s_v3
+      id: Standard_D4s_v3
+      memory: 17179869184
+      name: Standard_D4s_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDSv4Family
+      generic_name: standard_d4s_v4
+      id: Standard_D4s_v4
+      memory: 17179869184
+      name: Standard_D4s_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDSv5Family
+      generic_name: standard_d4s_v5
+      id: Standard_D4s_v5
+      memory: 17179869184
+      name: Standard_D4s_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDsv6Family
+      generic_name: standard_d4s_v6
+      id: Standard_D4s_v6
+      memory: 17179869184
+      name: Standard_D4s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDv2Family
+      generic_name: standard_d4_v2
+      id: Standard_D4_v2
+      memory: 30064771072
+      name: Standard_D4_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDv3Family
+      generic_name: standard_d4_v3
+      id: Standard_D4_v3
+      memory: 17179869184
+      name: Standard_D4_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDv4Family
+      generic_name: standard_d4_v4
+      id: Standard_D4_v4
+      memory: 17179869184
+      name: Standard_D4_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDv5Family
+      generic_name: standard_d4_v5
+      id: Standard_D4_v5
+      memory: 17179869184
+      name: Standard_D4_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDv2Family
+      generic_name: standard_d5_v2
+      id: Standard_D5_v2
+      memory: 60129542144
+      name: Standard_D5_v2
+    - category: general_purpose
+      cloud_provider_id: azure
       cpu_cores: 64
+      family: standardDADSv5Family
+      generic_name: standard_d64ads_v5
+      id: Standard_D64ads_v5
+      memory: 274877906944
+      name: Standard_D64ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDadv6Family
+      generic_name: standard_d64ads_v6
+      id: Standard_D64ads_v6
+      memory: 274877906944
+      name: Standard_D64ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDadsv7Family
+      generic_name: standard_d64ads_v7
+      id: Standard_D64ads_v7
+      memory: 274877906944
+      name: Standard_D64ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDaldv6Family
+      generic_name: standard_d64alds_v6
+      id: Standard_D64alds_v6
+      memory: 137438953472
+      name: Standard_D64alds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDaldsv7Family
+      generic_name: standard_d64alds_v7
+      id: Standard_D64alds_v7
+      memory: 137438953472
+      name: Standard_D64alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDalv6Family
+      generic_name: standard_d64als_v6
+      id: Standard_D64als_v6
+      memory: 137438953472
+      name: Standard_D64als_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDalsv7Family
+      generic_name: standard_d64als_v7
+      id: Standard_D64als_v7
+      memory: 137438953472
+      name: Standard_D64als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDASv4Family
+      generic_name: standard_d64as_v4
+      id: Standard_D64as_v4
+      memory: 274877906944
+      name: Standard_D64as_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDASv5Family
+      generic_name: standard_d64as_v5
+      id: Standard_D64as_v5
+      memory: 274877906944
+      name: Standard_D64as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDav6Family
+      generic_name: standard_d64as_v6
+      id: Standard_D64as_v6
+      memory: 274877906944
+      name: Standard_D64as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDasv7Family
+      generic_name: standard_d64as_v7
+      id: Standard_D64as_v7
+      memory: 274877906944
+      name: Standard_D64as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDAv4Family
+      generic_name: standard_d64a_v4
+      id: Standard_D64a_v4
+      memory: 274877906944
+      name: Standard_D64a_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDDSv4Family
+      generic_name: standard_d64ds_v4
+      id: Standard_D64ds_v4
+      memory: 274877906944
+      name: Standard_D64ds_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDDSv5Family
+      generic_name: standard_d64ds_v5
+      id: Standard_D64ds_v5
+      memory: 274877906944
+      name: Standard_D64ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDdsv6Family
+      generic_name: standard_d64ds_v6
+      id: Standard_D64ds_v6
+      memory: 274877906944
+      name: Standard_D64ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDDv4Family
+      generic_name: standard_d64d_v4
+      id: Standard_D64d_v4
+      memory: 274877906944
+      name: Standard_D64d_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDDv5Family
+      generic_name: standard_d64d_v5
+      id: Standard_D64d_v5
+      memory: 274877906944
+      name: Standard_D64d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDLDSv5Family
+      generic_name: standard_d64lds_v5
+      id: Standard_D64lds_v5
+      memory: 137438953472
+      name: Standard_D64lds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDldsv6Family
+      generic_name: standard_d64lds_v6
+      id: Standard_D64lds_v6
+      memory: 137438953472
+      name: Standard_D64lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDLSv5Family
+      generic_name: standard_d64ls_v5
+      id: Standard_D64ls_v5
+      memory: 137438953472
+      name: Standard_D64ls_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDlsv6Family
+      generic_name: standard_d64ls_v6
+      id: Standard_D64ls_v6
+      memory: 137438953472
+      name: Standard_D64ls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDPDSv5Family
+      generic_name: standard_d64pds_v5
+      id: Standard_D64pds_v5
+      memory: 223338299392
+      name: Standard_D64pds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDpdsv6Family
+      generic_name: standard_d64pds_v6
+      id: Standard_D64pds_v6
+      memory: 274877906944
+      name: Standard_D64pds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDPLDSv5Family
+      generic_name: standard_d64plds_v5
+      id: Standard_D64plds_v5
+      memory: 137438953472
+      name: Standard_D64plds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDpldsv6Family
       generic_name: standard_d64plds_v6
       id: Standard_D64plds_v6
       memory: 137438953472
@@ -5899,7 +2630,557 @@ data:
     - architecture: arm64
       category: general_purpose
       cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDPLSv5Family
+      generic_name: standard_d64pls_v5
+      id: Standard_D64pls_v5
+      memory: 137438953472
+      name: Standard_D64pls_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDplsv6Family
+      generic_name: standard_d64pls_v6
+      id: Standard_D64pls_v6
+      memory: 137438953472
+      name: Standard_D64pls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDPSv5Family
+      generic_name: standard_d64ps_v5
+      id: Standard_D64ps_v5
+      memory: 223338299392
+      name: Standard_D64ps_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDpsv6Family
+      generic_name: standard_d64ps_v6
+      id: Standard_D64ps_v6
+      memory: 274877906944
+      name: Standard_D64ps_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDSv3Family
+      generic_name: standard_d64s_v3
+      id: Standard_D64s_v3
+      memory: 274877906944
+      name: Standard_D64s_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDSv4Family
+      generic_name: standard_d64s_v4
+      id: Standard_D64s_v4
+      memory: 274877906944
+      name: Standard_D64s_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDSv5Family
+      generic_name: standard_d64s_v5
+      id: Standard_D64s_v5
+      memory: 274877906944
+      name: Standard_D64s_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDsv6Family
+      generic_name: standard_d64s_v6
+      id: Standard_D64s_v6
+      memory: 274877906944
+      name: Standard_D64s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDv3Family
+      generic_name: standard_d64_v3
+      id: Standard_D64_v3
+      memory: 274877906944
+      name: Standard_D64_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDv4Family
+      generic_name: standard_d64_v4
+      id: Standard_D64_v4
+      memory: 274877906944
+      name: Standard_D64_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDv5Family
+      generic_name: standard_d64_v5
+      id: Standard_D64_v5
+      memory: 274877906944
+      name: Standard_D64_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDADSv5Family
+      generic_name: standard_d8ads_v5
+      id: Standard_D8ads_v5
+      memory: 34359738368
+      name: Standard_D8ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDadv6Family
+      generic_name: standard_d8ads_v6
+      id: Standard_D8ads_v6
+      memory: 34359738368
+      name: Standard_D8ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDadsv7Family
+      generic_name: standard_d8ads_v7
+      id: Standard_D8ads_v7
+      memory: 34359738368
+      name: Standard_D8ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDaldv6Family
+      generic_name: standard_d8alds_v6
+      id: Standard_D8alds_v6
+      memory: 17179869184
+      name: Standard_D8alds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDaldsv7Family
+      generic_name: standard_d8alds_v7
+      id: Standard_D8alds_v7
+      memory: 17179869184
+      name: Standard_D8alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDalv6Family
+      generic_name: standard_d8als_v6
+      id: Standard_D8als_v6
+      memory: 17179869184
+      name: Standard_D8als_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDalsv7Family
+      generic_name: standard_d8als_v7
+      id: Standard_D8als_v7
+      memory: 17179869184
+      name: Standard_D8als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDASv4Family
+      generic_name: standard_d8as_v4
+      id: Standard_D8as_v4
+      memory: 34359738368
+      name: Standard_D8as_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDASv5Family
+      generic_name: standard_d8as_v5
+      id: Standard_D8as_v5
+      memory: 34359738368
+      name: Standard_D8as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDav6Family
+      generic_name: standard_d8as_v6
+      id: Standard_D8as_v6
+      memory: 34359738368
+      name: Standard_D8as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDasv7Family
+      generic_name: standard_d8as_v7
+      id: Standard_D8as_v7
+      memory: 34359738368
+      name: Standard_D8as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDAv4Family
+      generic_name: standard_d8a_v4
+      id: Standard_D8a_v4
+      memory: 34359738368
+      name: Standard_D8a_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDDSv4Family
+      generic_name: standard_d8ds_v4
+      id: Standard_D8ds_v4
+      memory: 34359738368
+      name: Standard_D8ds_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDDSv5Family
+      generic_name: standard_d8ds_v5
+      id: Standard_D8ds_v5
+      memory: 34359738368
+      name: Standard_D8ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDdsv6Family
+      generic_name: standard_d8ds_v6
+      id: Standard_D8ds_v6
+      memory: 34359738368
+      name: Standard_D8ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDDv4Family
+      generic_name: standard_d8d_v4
+      id: Standard_D8d_v4
+      memory: 34359738368
+      name: Standard_D8d_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDDv5Family
+      generic_name: standard_d8d_v5
+      id: Standard_D8d_v5
+      memory: 34359738368
+      name: Standard_D8d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDLDSv5Family
+      generic_name: standard_d8lds_v5
+      id: Standard_D8lds_v5
+      memory: 17179869184
+      name: Standard_D8lds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDldsv6Family
+      generic_name: standard_d8lds_v6
+      id: Standard_D8lds_v6
+      memory: 17179869184
+      name: Standard_D8lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDLSv5Family
+      generic_name: standard_d8ls_v5
+      id: Standard_D8ls_v5
+      memory: 17179869184
+      name: Standard_D8ls_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDlsv6Family
+      generic_name: standard_d8ls_v6
+      id: Standard_D8ls_v6
+      memory: 17179869184
+      name: Standard_D8ls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDPDSv5Family
+      generic_name: standard_d8pds_v5
+      id: Standard_D8pds_v5
+      memory: 34359738368
+      name: Standard_D8pds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDpdsv6Family
+      generic_name: standard_d8pds_v6
+      id: Standard_D8pds_v6
+      memory: 34359738368
+      name: Standard_D8pds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDPLDSv5Family
+      generic_name: standard_d8plds_v5
+      id: Standard_D8plds_v5
+      memory: 17179869184
+      name: Standard_D8plds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDpldsv6Family
+      generic_name: standard_d8plds_v6
+      id: Standard_D8plds_v6
+      memory: 17179869184
+      name: Standard_D8plds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDPLSv5Family
+      generic_name: standard_d8pls_v5
+      id: Standard_D8pls_v5
+      memory: 17179869184
+      name: Standard_D8pls_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDplsv6Family
+      generic_name: standard_d8pls_v6
+      id: Standard_D8pls_v6
+      memory: 17179869184
+      name: Standard_D8pls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDPSv5Family
+      generic_name: standard_d8ps_v5
+      id: Standard_D8ps_v5
+      memory: 34359738368
+      name: Standard_D8ps_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDpsv6Family
+      generic_name: standard_d8ps_v6
+      id: Standard_D8ps_v6
+      memory: 34359738368
+      name: Standard_D8ps_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDSv3Family
+      generic_name: standard_d8s_v3
+      id: Standard_D8s_v3
+      memory: 34359738368
+      name: Standard_D8s_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDSv4Family
+      generic_name: standard_d8s_v4
+      id: Standard_D8s_v4
+      memory: 34359738368
+      name: Standard_D8s_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDSv5Family
+      generic_name: standard_d8s_v5
+      id: Standard_D8s_v5
+      memory: 34359738368
+      name: Standard_D8s_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDsv6Family
+      generic_name: standard_d8s_v6
+      id: Standard_D8s_v6
+      memory: 34359738368
+      name: Standard_D8s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDv3Family
+      generic_name: standard_d8_v3
+      id: Standard_D8_v3
+      memory: 34359738368
+      name: Standard_D8_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDv4Family
+      generic_name: standard_d8_v4
+      id: Standard_D8_v4
+      memory: 34359738368
+      name: Standard_D8_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDv5Family
+      generic_name: standard_d8_v5
+      id: Standard_D8_v5
+      memory: 34359738368
+      name: Standard_D8_v5
+    - category: general_purpose
+      cloud_provider_id: azure
       cpu_cores: 96
+      family: standardDADSv5Family
+      generic_name: standard_d96ads_v5
+      id: Standard_D96ads_v5
+      memory: 412316860416
+      name: Standard_D96ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDadv6Family
+      generic_name: standard_d96ads_v6
+      id: Standard_D96ads_v6
+      memory: 412316860416
+      name: Standard_D96ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardDadsv7Family
+      generic_name: standard_d96ads_v7
+      id: Standard_D96ads_v7
+      memory: 412316860416
+      name: Standard_D96ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDaldv6Family
+      generic_name: standard_d96alds_v6
+      id: Standard_D96alds_v6
+      memory: 206158430208
+      name: Standard_D96alds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardDaldsv7Family
+      generic_name: standard_d96alds_v7
+      id: Standard_D96alds_v7
+      memory: 206158430208
+      name: Standard_D96alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDalv6Family
+      generic_name: standard_d96als_v6
+      id: Standard_D96als_v6
+      memory: 206158430208
+      name: Standard_D96als_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardDalsv7Family
+      generic_name: standard_d96als_v7
+      id: Standard_D96als_v7
+      memory: 206158430208
+      name: Standard_D96als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDASv4Family
+      generic_name: standard_d96as_v4
+      id: Standard_D96as_v4
+      memory: 412316860416
+      name: Standard_D96as_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDASv5Family
+      generic_name: standard_d96as_v5
+      id: Standard_D96as_v5
+      memory: 412316860416
+      name: Standard_D96as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDav6Family
+      generic_name: standard_d96as_v6
+      id: Standard_D96as_v6
+      memory: 412316860416
+      name: Standard_D96as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardDasv7Family
+      generic_name: standard_d96as_v7
+      id: Standard_D96as_v7
+      memory: 412316860416
+      name: Standard_D96as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDAv4Family
+      generic_name: standard_d96a_v4
+      id: Standard_D96a_v4
+      memory: 412316860416
+      name: Standard_D96a_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDDSv5Family
+      generic_name: standard_d96ds_v5
+      id: Standard_D96ds_v5
+      memory: 412316860416
+      name: Standard_D96ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardDdsv6Family
+      generic_name: standard_d96ds_v6
+      id: Standard_D96ds_v6
+      memory: 412316860416
+      name: Standard_D96ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDDv5Family
+      generic_name: standard_d96d_v5
+      id: Standard_D96d_v5
+      memory: 412316860416
+      name: Standard_D96d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDLDSv5Family
+      generic_name: standard_d96lds_v5
+      id: Standard_D96lds_v5
+      memory: 206158430208
+      name: Standard_D96lds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardDldsv6Family
+      generic_name: standard_d96lds_v6
+      id: Standard_D96lds_v6
+      memory: 206158430208
+      name: Standard_D96lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDLSv5Family
+      generic_name: standard_d96ls_v5
+      id: Standard_D96ls_v5
+      memory: 206158430208
+      name: Standard_D96ls_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardDlsv6Family
+      generic_name: standard_d96ls_v6
+      id: Standard_D96ls_v6
+      memory: 206158430208
+      name: Standard_D96ls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardDpdsv6Family
+      generic_name: standard_d96pds_v6
+      id: Standard_D96pds_v6
+      memory: 412316860416
+      name: Standard_D96pds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardDpldsv6Family
       generic_name: standard_d96plds_v6
       id: Standard_D96plds_v6
       memory: 206158430208
@@ -5907,1675 +3188,233 @@ data:
     - architecture: arm64
       category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2ps_v6
-      id: Standard_D2ps_v6
-      memory: 8589934592
-      name: Standard_D2ps_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4ps_v6
-      id: Standard_D4ps_v6
-      memory: 17179869184
-      name: Standard_D4ps_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8ps_v6
-      id: Standard_D8ps_v6
-      memory: 34359738368
-      name: Standard_D8ps_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16ps_v6
-      id: Standard_D16ps_v6
-      memory: 68719476736
-      name: Standard_D16ps_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32ps_v6
-      id: Standard_D32ps_v6
-      memory: 137438953472
-      name: Standard_D32ps_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48ps_v6
-      id: Standard_D48ps_v6
+      cpu_cores: 96
+      family: StandardDplsv6Family
+      generic_name: standard_d96pls_v6
+      id: Standard_D96pls_v6
       memory: 206158430208
-      name: Standard_D48ps_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64ps_v6
-      id: Standard_D64ps_v6
-      memory: 274877906944
-      name: Standard_D64ps_v6
+      name: Standard_D96pls_v6
     - architecture: arm64
       category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 96
+      family: StandardDpsv6Family
       generic_name: standard_d96ps_v6
       id: Standard_D96ps_v6
       memory: 412316860416
       name: Standard_D96ps_v6
-    - architecture: arm64
-      category: memory_optimized
+    - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2ps_v6
-      id: Standard_E2ps_v6
-      memory: 17179869184
-      name: Standard_E2ps_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4ps_v6
-      id: Standard_E4ps_v6
-      memory: 34359738368
-      name: Standard_E4ps_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8ps_v6
-      id: Standard_E8ps_v6
-      memory: 68719476736
-      name: Standard_E8ps_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16ps_v6
-      id: Standard_E16ps_v6
-      memory: 137438953472
-      name: Standard_E16ps_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32ps_v6
-      id: Standard_E32ps_v6
-      memory: 274877906944
-      name: Standard_E32ps_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48ps_v6
-      id: Standard_E48ps_v6
+      cpu_cores: 96
+      family: standardDSv5Family
+      generic_name: standard_d96s_v5
+      id: Standard_D96s_v5
       memory: 412316860416
-      name: Standard_E48ps_v6
-    - architecture: arm64
-      category: memory_optimized
+      name: Standard_D96s_v5
+    - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64ps_v6
-      id: Standard_E64ps_v6
+      cpu_cores: 96
+      family: StandardDsv6Family
+      generic_name: standard_d96s_v6
+      id: Standard_D96s_v6
+      memory: 412316860416
+      name: Standard_D96s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDv5Family
+      generic_name: standard_d96_v5
+      id: Standard_D96_v5
+      memory: 412316860416
+      name: Standard_D96_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: standardDCEDV6Family
+      generic_name: standard_dc128eds_v6
+      id: Standard_DC128eds_v6
       memory: 549755813888
-      name: Standard_E64ps_v6
-    - architecture: arm64
-      category: memory_optimized
+      name: Standard_DC128eds_v6
+    - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96ps_v6
-      id: Standard_E96ps_v6
-      memory: 721554505728
-      name: Standard_E96ps_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2pds_v6
-      id: Standard_E2pds_v6
-      memory: 17179869184
-      name: Standard_E2pds_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4pds_v6
-      id: Standard_E4pds_v6
-      memory: 34359738368
-      name: Standard_E4pds_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8pds_v6
-      id: Standard_E8pds_v6
-      memory: 68719476736
-      name: Standard_E8pds_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16pds_v6
-      id: Standard_E16pds_v6
-      memory: 137438953472
-      name: Standard_E16pds_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32pds_v6
-      id: Standard_E32pds_v6
-      memory: 274877906944
-      name: Standard_E32pds_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48pds_v6
-      id: Standard_E48pds_v6
-      memory: 412316860416
-      name: Standard_E48pds_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64pds_v6
-      id: Standard_E64pds_v6
+      cpu_cores: 128
+      family: standardDCEV6Family
+      generic_name: standard_dc128es_v6
+      id: Standard_DC128es_v6
       memory: 549755813888
-      name: Standard_E64pds_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96pds_v6
-      id: Standard_E96pds_v6
-      memory: 721554505728
-      name: Standard_E96pds_v6
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 24
-      generic_name: standard_nc24ads_a100_v4
-      id: Standard_NC24ads_A100_v4
-      memory: 236223201280
-      name: Standard_NC24ads_A100_v4
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_nc48ads_a100_v4
-      id: Standard_NC48ads_A100_v4
-      memory: 472446402560
-      name: Standard_NC48ads_A100_v4
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_nc96ads_a100_v4
-      id: Standard_NC96ads_A100_v4
-      memory: 944892805120
-      name: Standard_NC96ads_A100_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_dc2as_v6
-      id: Standard_DC2as_v6
-      memory: 8589934592
-      name: Standard_DC2as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_dc4as_v6
-      id: Standard_DC4as_v6
-      memory: 17179869184
-      name: Standard_DC4as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_dc8as_v6
-      id: Standard_DC8as_v6
-      memory: 34359738368
-      name: Standard_DC8as_v6
+      name: Standard_DC128es_v6
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_dc16as_v6
-      id: Standard_DC16as_v6
+      family: standardDCADCCV5Family
+      generic_name: standard_dc16ads_cc_v5
+      id: Standard_DC16ads_cc_v5
       memory: 68719476736
-      name: Standard_DC16as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_dc32as_v6
-      id: Standard_DC32as_v6
-      memory: 137438953472
-      name: Standard_DC32as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_dc48as_v6
-      id: Standard_DC48as_v6
-      memory: 206158430208
-      name: Standard_DC48as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_dc64as_v6
-      id: Standard_DC64as_v6
-      memory: 274877906944
-      name: Standard_DC64as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_dc96as_v6
-      id: Standard_DC96as_v6
-      memory: 412316860416
-      name: Standard_DC96as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_dc2ads_v6
-      id: Standard_DC2ads_v6
-      memory: 8589934592
-      name: Standard_DC2ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_dc4ads_v6
-      id: Standard_DC4ads_v6
-      memory: 17179869184
-      name: Standard_DC4ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_dc8ads_v6
-      id: Standard_DC8ads_v6
-      memory: 34359738368
-      name: Standard_DC8ads_v6
+      name: Standard_DC16ads_cc_v5
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
+      family: standardDCADSv5Family
+      generic_name: standard_dc16ads_v5
+      id: Standard_DC16ads_v5
+      memory: 68719476736
+      name: Standard_DC16ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDCadsv6Family
       generic_name: standard_dc16ads_v6
       id: Standard_DC16ads_v6
       memory: 68719476736
       name: Standard_DC16ads_v6
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_dc32ads_v6
-      id: Standard_DC32ads_v6
-      memory: 137438953472
-      name: Standard_DC32ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_dc48ads_v6
-      id: Standard_DC48ads_v6
-      memory: 206158430208
-      name: Standard_DC48ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_dc64ads_v6
-      id: Standard_DC64ads_v6
-      memory: 274877906944
-      name: Standard_DC64ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_dc96ads_v6
-      id: Standard_DC96ads_v6
-      memory: 412316860416
-      name: Standard_DC96ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_ec2as_v6
-      id: Standard_EC2as_v6
-      memory: 17179869184
-      name: Standard_EC2as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_ec4as_v6
-      id: Standard_EC4as_v6
-      memory: 34359738368
-      name: Standard_EC4as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_ec8as_v6
-      id: Standard_EC8as_v6
+      cpu_cores: 16
+      family: standardDCACCV5Family
+      generic_name: standard_dc16as_cc_v5
+      id: Standard_DC16as_cc_v5
       memory: 68719476736
-      name: Standard_EC8as_v6
-    - category: memory_optimized
+      name: Standard_DC16as_cc_v5
+    - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_ec16as_v6
-      id: Standard_EC16as_v6
-      memory: 137438953472
-      name: Standard_EC16as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_ec32as_v6
-      id: Standard_EC32as_v6
-      memory: 274877906944
-      name: Standard_EC32as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_ec48as_v6
-      id: Standard_EC48as_v6
-      memory: 412316860416
-      name: Standard_EC48as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_ec64as_v6
-      id: Standard_EC64as_v6
-      memory: 549755813888
-      name: Standard_EC64as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_ec96as_v6
-      id: Standard_EC96as_v6
-      memory: 721554505728
-      name: Standard_EC96as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_ec2ads_v6
-      id: Standard_EC2ads_v6
-      memory: 17179869184
-      name: Standard_EC2ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_ec4ads_v6
-      id: Standard_EC4ads_v6
-      memory: 34359738368
-      name: Standard_EC4ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_ec8ads_v6
-      id: Standard_EC8ads_v6
+      family: standardDCASv5Family
+      generic_name: standard_dc16as_v5
+      id: Standard_DC16as_v5
       memory: 68719476736
-      name: Standard_EC8ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_ec16ads_v6
-      id: Standard_EC16ads_v6
-      memory: 137438953472
-      name: Standard_EC16ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_ec32ads_v6
-      id: Standard_EC32ads_v6
-      memory: 274877906944
-      name: Standard_EC32ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_ec48ads_v6
-      id: Standard_EC48ads_v6
-      memory: 412316860416
-      name: Standard_EC48ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_ec64ads_v6
-      id: Standard_EC64ads_v6
-      memory: 549755813888
-      name: Standard_EC64ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_ec96ads_v6
-      id: Standard_EC96ads_v6
-      memory: 721554505728
-      name: Standard_EC96ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2als_v7
-      id: Standard_D2als_v7
-      memory: 4294967296
-      name: Standard_D2als_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4als_v7
-      id: Standard_D4als_v7
-      memory: 8589934592
-      name: Standard_D4als_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8als_v7
-      id: Standard_D8als_v7
-      memory: 17179869184
-      name: Standard_D8als_v7
+      name: Standard_DC16as_v5
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_d16als_v7
-      id: Standard_D16als_v7
-      memory: 34359738368
-      name: Standard_D16als_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32als_v7
-      id: Standard_D32als_v7
+      family: standardDCasv6Family
+      generic_name: standard_dc16as_v6
+      id: Standard_DC16as_v6
       memory: 68719476736
-      name: Standard_D32als_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48als_v7
-      id: Standard_D48als_v7
-      memory: 103079215104
-      name: Standard_D48als_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64als_v7
-      id: Standard_D64als_v7
-      memory: 137438953472
-      name: Standard_D64als_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96als_v7
-      id: Standard_D96als_v7
-      memory: 206158430208
-      name: Standard_D96als_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_d128als_v7
-      id: Standard_D128als_v7
-      memory: 274877906944
-      name: Standard_D128als_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 160
-      generic_name: standard_d160als_v7
-      id: Standard_D160als_v7
-      memory: 343597383680
-      name: Standard_D160als_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2alds_v7
-      id: Standard_D2alds_v7
-      memory: 4294967296
-      name: Standard_D2alds_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4alds_v7
-      id: Standard_D4alds_v7
-      memory: 8589934592
-      name: Standard_D4alds_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8alds_v7
-      id: Standard_D8alds_v7
-      memory: 17179869184
-      name: Standard_D8alds_v7
+      name: Standard_DC16as_v6
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_d16alds_v7
-      id: Standard_D16alds_v7
-      memory: 34359738368
-      name: Standard_D16alds_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32alds_v7
-      id: Standard_D32alds_v7
+      family: standardDCEDV6Family
+      generic_name: standard_dc16eds_v6
+      id: Standard_DC16eds_v6
       memory: 68719476736
-      name: Standard_D32alds_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48alds_v7
-      id: Standard_D48alds_v7
-      memory: 103079215104
-      name: Standard_D48alds_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64alds_v7
-      id: Standard_D64alds_v7
-      memory: 137438953472
-      name: Standard_D64alds_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96alds_v7
-      id: Standard_D96alds_v7
-      memory: 206158430208
-      name: Standard_D96alds_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_d128alds_v7
-      id: Standard_D128alds_v7
-      memory: 274877906944
-      name: Standard_D128alds_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 160
-      generic_name: standard_d160alds_v7
-      id: Standard_D160alds_v7
-      memory: 343597383680
-      name: Standard_D160alds_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2as_v7
-      id: Standard_D2as_v7
-      memory: 8589934592
-      name: Standard_D2as_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4as_v7
-      id: Standard_D4as_v7
-      memory: 17179869184
-      name: Standard_D4as_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8as_v7
-      id: Standard_D8as_v7
-      memory: 34359738368
-      name: Standard_D8as_v7
+      name: Standard_DC16eds_v6
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_d16as_v7
-      id: Standard_D16as_v7
-      memory: 68719476736
-      name: Standard_D16as_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32as_v7
-      id: Standard_D32as_v7
-      memory: 137438953472
-      name: Standard_D32as_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48as_v7
-      id: Standard_D48as_v7
-      memory: 206158430208
-      name: Standard_D48as_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64as_v7
-      id: Standard_D64as_v7
-      memory: 274877906944
-      name: Standard_D64as_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96as_v7
-      id: Standard_D96as_v7
-      memory: 412316860416
-      name: Standard_D96as_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_d128as_v7
-      id: Standard_D128as_v7
-      memory: 549755813888
-      name: Standard_D128as_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 160
-      generic_name: standard_d160as_v7
-      id: Standard_D160as_v7
-      memory: 687194767360
-      name: Standard_D160as_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2ads_v7
-      id: Standard_D2ads_v7
-      memory: 8589934592
-      name: Standard_D2ads_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4ads_v7
-      id: Standard_D4ads_v7
-      memory: 17179869184
-      name: Standard_D4ads_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8ads_v7
-      id: Standard_D8ads_v7
-      memory: 34359738368
-      name: Standard_D8ads_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16ads_v7
-      id: Standard_D16ads_v7
-      memory: 68719476736
-      name: Standard_D16ads_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32ads_v7
-      id: Standard_D32ads_v7
-      memory: 137438953472
-      name: Standard_D32ads_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48ads_v7
-      id: Standard_D48ads_v7
-      memory: 206158430208
-      name: Standard_D48ads_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64ads_v7
-      id: Standard_D64ads_v7
-      memory: 274877906944
-      name: Standard_D64ads_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96ads_v7
-      id: Standard_D96ads_v7
-      memory: 412316860416
-      name: Standard_D96ads_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_d128ads_v7
-      id: Standard_D128ads_v7
-      memory: 549755813888
-      name: Standard_D128ads_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 160
-      generic_name: standard_d160ads_v7
-      id: Standard_D160ads_v7
-      memory: 687194767360
-      name: Standard_D160ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2as_v7
-      id: Standard_E2as_v7
-      memory: 17179869184
-      name: Standard_E2as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2as_v7
-      id: Standard_E4-2as_v7
-      memory: 34359738368
-      name: Standard_E4-2as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4as_v7
-      id: Standard_E4as_v7
-      memory: 34359738368
-      name: Standard_E4as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2as_v7
-      id: Standard_E8-2as_v7
-      memory: 68719476736
-      name: Standard_E8-2as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4as_v7
-      id: Standard_E8-4as_v7
-      memory: 68719476736
-      name: Standard_E8-4as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8as_v7
-      id: Standard_E8as_v7
-      memory: 68719476736
-      name: Standard_E8as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-4as_v7
-      id: Standard_E16-4as_v7
-      memory: 137438953472
-      name: Standard_E16-4as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8as_v7
-      id: Standard_E16-8as_v7
-      memory: 137438953472
-      name: Standard_E16-8as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16as_v7
-      id: Standard_E16as_v7
-      memory: 137438953472
-      name: Standard_E16as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8as_v7
-      id: Standard_E32-8as_v7
-      memory: 274877906944
-      name: Standard_E32-8as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16as_v7
-      id: Standard_E32-16as_v7
-      memory: 274877906944
-      name: Standard_E32-16as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32as_v7
-      id: Standard_E32as_v7
-      memory: 274877906944
-      name: Standard_E32as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48as_v7
-      id: Standard_E48as_v7
-      memory: 412316860416
-      name: Standard_E48as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16as_v7
-      id: Standard_E64-16as_v7
-      memory: 549755813888
-      name: Standard_E64-16as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32as_v7
-      id: Standard_E64-32as_v7
-      memory: 549755813888
-      name: Standard_E64-32as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64as_v7
-      id: Standard_E64as_v7
-      memory: 549755813888
-      name: Standard_E64as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-24as_v7
-      id: Standard_E96-24as_v7
-      memory: 824633720832
-      name: Standard_E96-24as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-48as_v7
-      id: Standard_E96-48as_v7
-      memory: 824633720832
-      name: Standard_E96-48as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96as_v7
-      id: Standard_E96as_v7
-      memory: 824633720832
-      name: Standard_E96as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128-32as_v7
-      id: Standard_E128-32as_v7
-      memory: 1099511627776
-      name: Standard_E128-32as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128-64as_v7
-      id: Standard_E128-64as_v7
-      memory: 1099511627776
-      name: Standard_E128-64as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128as_v7
-      id: Standard_E128as_v7
-      memory: 1099511627776
-      name: Standard_E128as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2ads_v7
-      id: Standard_E2ads_v7
-      memory: 17179869184
-      name: Standard_E2ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2ads_v7
-      id: Standard_E4-2ads_v7
-      memory: 34359738368
-      name: Standard_E4-2ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4ads_v7
-      id: Standard_E4ads_v7
-      memory: 34359738368
-      name: Standard_E4ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2ads_v7
-      id: Standard_E8-2ads_v7
-      memory: 68719476736
-      name: Standard_E8-2ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4ads_v7
-      id: Standard_E8-4ads_v7
-      memory: 68719476736
-      name: Standard_E8-4ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8ads_v7
-      id: Standard_E8ads_v7
-      memory: 68719476736
-      name: Standard_E8ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-4ads_v7
-      id: Standard_E16-4ads_v7
-      memory: 137438953472
-      name: Standard_E16-4ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8ads_v7
-      id: Standard_E16-8ads_v7
-      memory: 137438953472
-      name: Standard_E16-8ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16ads_v7
-      id: Standard_E16ads_v7
-      memory: 137438953472
-      name: Standard_E16ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8ads_v7
-      id: Standard_E32-8ads_v7
-      memory: 274877906944
-      name: Standard_E32-8ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16ads_v7
-      id: Standard_E32-16ads_v7
-      memory: 274877906944
-      name: Standard_E32-16ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32ads_v7
-      id: Standard_E32ads_v7
-      memory: 274877906944
-      name: Standard_E32ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48ads_v7
-      id: Standard_E48ads_v7
-      memory: 412316860416
-      name: Standard_E48ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16ads_v7
-      id: Standard_E64-16ads_v7
-      memory: 549755813888
-      name: Standard_E64-16ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32ads_v7
-      id: Standard_E64-32ads_v7
-      memory: 549755813888
-      name: Standard_E64-32ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64ads_v7
-      id: Standard_E64ads_v7
-      memory: 549755813888
-      name: Standard_E64ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-24ads_v7
-      id: Standard_E96-24ads_v7
-      memory: 824633720832
-      name: Standard_E96-24ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-48ads_v7
-      id: Standard_E96-48ads_v7
-      memory: 824633720832
-      name: Standard_E96-48ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96ads_v7
-      id: Standard_E96ads_v7
-      memory: 824633720832
-      name: Standard_E96ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128-32ads_v7
-      id: Standard_E128-32ads_v7
-      memory: 1099511627776
-      name: Standard_E128-32ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128-64ads_v7
-      id: Standard_E128-64ads_v7
-      memory: 1099511627776
-      name: Standard_E128-64ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128ads_v7
-      id: Standard_E128ads_v7
-      memory: 1099511627776
-      name: Standard_E128ads_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 1
-      generic_name: standard_f1als_v7
-      id: Standard_F1als_v7
-      memory: 2147483648
-      name: Standard_F1als_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2als_v7
-      id: Standard_F2als_v7
-      memory: 4294967296
-      name: Standard_F2als_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4als_v7
-      id: Standard_F4als_v7
-      memory: 8589934592
-      name: Standard_F4als_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8als_v7
-      id: Standard_F8als_v7
-      memory: 17179869184
-      name: Standard_F8als_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16als_v7
-      id: Standard_F16als_v7
-      memory: 34359738368
-      name: Standard_F16als_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32als_v7
-      id: Standard_F32als_v7
-      memory: 68719476736
-      name: Standard_F32als_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_f48als_v7
-      id: Standard_F48als_v7
-      memory: 103079215104
-      name: Standard_F48als_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64als_v7
-      id: Standard_F64als_v7
-      memory: 137438953472
-      name: Standard_F64als_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_f80als_v7
-      id: Standard_F80als_v7
-      memory: 171798691840
-      name: Standard_F80als_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 1
-      generic_name: standard_f1alds_v7
-      id: Standard_F1alds_v7
-      memory: 2147483648
-      name: Standard_F1alds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2alds_v7
-      id: Standard_F2alds_v7
-      memory: 4294967296
-      name: Standard_F2alds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4alds_v7
-      id: Standard_F4alds_v7
-      memory: 8589934592
-      name: Standard_F4alds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8alds_v7
-      id: Standard_F8alds_v7
-      memory: 17179869184
-      name: Standard_F8alds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16alds_v7
-      id: Standard_F16alds_v7
-      memory: 34359738368
-      name: Standard_F16alds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32alds_v7
-      id: Standard_F32alds_v7
-      memory: 68719476736
-      name: Standard_F32alds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_f48alds_v7
-      id: Standard_F48alds_v7
-      memory: 103079215104
-      name: Standard_F48alds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64alds_v7
-      id: Standard_F64alds_v7
-      memory: 137438953472
-      name: Standard_F64alds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_f80alds_v7
-      id: Standard_F80alds_v7
-      memory: 171798691840
-      name: Standard_F80alds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 1
-      generic_name: standard_f1as_v7
-      id: Standard_F1as_v7
-      memory: 4294967296
-      name: Standard_F1as_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2as_v7
-      id: Standard_F2as_v7
-      memory: 8589934592
-      name: Standard_F2as_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4as_v7
-      id: Standard_F4as_v7
-      memory: 17179869184
-      name: Standard_F4as_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8as_v7
-      id: Standard_F8as_v7
-      memory: 34359738368
-      name: Standard_F8as_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16as_v7
-      id: Standard_F16as_v7
-      memory: 68719476736
-      name: Standard_F16as_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32as_v7
-      id: Standard_F32as_v7
-      memory: 137438953472
-      name: Standard_F32as_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_f48as_v7
-      id: Standard_F48as_v7
-      memory: 206158430208
-      name: Standard_F48as_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64as_v7
-      id: Standard_F64as_v7
-      memory: 274877906944
-      name: Standard_F64as_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_f80as_v7
-      id: Standard_F80as_v7
-      memory: 343597383680
-      name: Standard_F80as_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 1
-      generic_name: standard_f1ads_v7
-      id: Standard_F1ads_v7
-      memory: 4294967296
-      name: Standard_F1ads_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2ads_v7
-      id: Standard_F2ads_v7
-      memory: 8589934592
-      name: Standard_F2ads_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4ads_v7
-      id: Standard_F4ads_v7
-      memory: 17179869184
-      name: Standard_F4ads_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8ads_v7
-      id: Standard_F8ads_v7
-      memory: 34359738368
-      name: Standard_F8ads_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16ads_v7
-      id: Standard_F16ads_v7
-      memory: 68719476736
-      name: Standard_F16ads_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32ads_v7
-      id: Standard_F32ads_v7
-      memory: 137438953472
-      name: Standard_F32ads_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_f48ads_v7
-      id: Standard_F48ads_v7
-      memory: 206158430208
-      name: Standard_F48ads_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64ads_v7
-      id: Standard_F64ads_v7
-      memory: 274877906944
-      name: Standard_F64ads_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_f80ads_v7
-      id: Standard_F80ads_v7
-      memory: 343597383680
-      name: Standard_F80ads_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 1
-      generic_name: standard_f1ams_v7
-      id: Standard_F1ams_v7
-      memory: 8589934592
-      name: Standard_F1ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2-1ams_v7
-      id: Standard_F2-1ams_v7
-      memory: 17179869184
-      name: Standard_F2-1ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2ams_v7
-      id: Standard_F2ams_v7
-      memory: 17179869184
-      name: Standard_F2ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4-1ams_v7
-      id: Standard_F4-1ams_v7
-      memory: 34359738368
-      name: Standard_F4-1ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4-2ams_v7
-      id: Standard_F4-2ams_v7
-      memory: 34359738368
-      name: Standard_F4-2ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4ams_v7
-      id: Standard_F4ams_v7
-      memory: 34359738368
-      name: Standard_F4ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8-2ams_v7
-      id: Standard_F8-2ams_v7
-      memory: 68719476736
-      name: Standard_F8-2ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8-4ams_v7
-      id: Standard_F8-4ams_v7
-      memory: 68719476736
-      name: Standard_F8-4ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8ams_v7
-      id: Standard_F8ams_v7
-      memory: 68719476736
-      name: Standard_F8ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16-4ams_v7
-      id: Standard_F16-4ams_v7
-      memory: 137438953472
-      name: Standard_F16-4ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16-8ams_v7
-      id: Standard_F16-8ams_v7
-      memory: 137438953472
-      name: Standard_F16-8ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16ams_v7
-      id: Standard_F16ams_v7
-      memory: 137438953472
-      name: Standard_F16ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32-8ams_v7
-      id: Standard_F32-8ams_v7
-      memory: 274877906944
-      name: Standard_F32-8ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32-16ams_v7
-      id: Standard_F32-16ams_v7
-      memory: 274877906944
-      name: Standard_F32-16ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32ams_v7
-      id: Standard_F32ams_v7
-      memory: 274877906944
-      name: Standard_F32ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_f48ams_v7
-      id: Standard_F48ams_v7
-      memory: 412316860416
-      name: Standard_F48ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_f64-16ams_v7
-      id: Standard_F64-16ams_v7
-      memory: 549755813888
-      name: Standard_F64-16ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64-32ams_v7
-      id: Standard_F64-32ams_v7
-      memory: 549755813888
-      name: Standard_F64-32ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64ams_v7
-      id: Standard_F64ams_v7
-      memory: 549755813888
-      name: Standard_F64ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_f80ams_v7
-      id: Standard_F80ams_v7
-      memory: 687194767360
-      name: Standard_F80ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 1
-      generic_name: standard_f1amds_v7
-      id: Standard_F1amds_v7
-      memory: 8589934592
-      name: Standard_F1amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2-1amds_v7
-      id: Standard_F2-1amds_v7
-      memory: 17179869184
-      name: Standard_F2-1amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2amds_v7
-      id: Standard_F2amds_v7
-      memory: 17179869184
-      name: Standard_F2amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4-1amds_v7
-      id: Standard_F4-1amds_v7
-      memory: 34359738368
-      name: Standard_F4-1amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4-2amds_v7
-      id: Standard_F4-2amds_v7
-      memory: 34359738368
-      name: Standard_F4-2amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4amds_v7
-      id: Standard_F4amds_v7
-      memory: 34359738368
-      name: Standard_F4amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8-2amds_v7
-      id: Standard_F8-2amds_v7
-      memory: 68719476736
-      name: Standard_F8-2amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8-4amds_v7
-      id: Standard_F8-4amds_v7
-      memory: 68719476736
-      name: Standard_F8-4amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8amds_v7
-      id: Standard_F8amds_v7
-      memory: 68719476736
-      name: Standard_F8amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16-4amds_v7
-      id: Standard_F16-4amds_v7
-      memory: 137438953472
-      name: Standard_F16-4amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16-8amds_v7
-      id: Standard_F16-8amds_v7
-      memory: 137438953472
-      name: Standard_F16-8amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16amds_v7
-      id: Standard_F16amds_v7
-      memory: 137438953472
-      name: Standard_F16amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32-8amds_v7
-      id: Standard_F32-8amds_v7
-      memory: 274877906944
-      name: Standard_F32-8amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32-16amds_v7
-      id: Standard_F32-16amds_v7
-      memory: 274877906944
-      name: Standard_F32-16amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32amds_v7
-      id: Standard_F32amds_v7
-      memory: 274877906944
-      name: Standard_F32amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_f48amds_v7
-      id: Standard_F48amds_v7
-      memory: 412316860416
-      name: Standard_F48amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64-16amds_v7
-      id: Standard_F64-16amds_v7
-      memory: 549755813888
-      name: Standard_F64-16amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64-32amds_v7
-      id: Standard_F64-32amds_v7
-      memory: 549755813888
-      name: Standard_F64-32amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64amds_v7
-      id: Standard_F64amds_v7
-      memory: 549755813888
-      name: Standard_F64amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_f80amds_v7
-      id: Standard_F80amds_v7
-      memory: 687194767360
-      name: Standard_F80amds_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96ias_v4
-      id: Standard_E96ias_v4
-      memory: 721554505728
-      name: Standard_E96ias_v4
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_nd96isr_h200_v5
-      id: Standard_ND96isr_H200_v5
-      memory: 1986422374400
-      name: Standard_ND96isr_H200_v5
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_nv4as_v4
-      id: Standard_NV4as_v4
-      memory: 15032385536
-      name: Standard_NV4as_v4
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_nv8as_v4
-      id: Standard_NV8as_v4
-      memory: 30064771072
-      name: Standard_NV8as_v4
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_nv16as_v4
-      id: Standard_NV16as_v4
-      memory: 60129542144
-      name: Standard_NV16as_v4
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_nv32as_v4
-      id: Standard_NV32as_v4
-      memory: 120259084288
-      name: Standard_NV32as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 160
-      generic_name: standard_e160as_v7
-      id: Standard_E160as_v7
-      memory: 1374389534720
-      name: Standard_E160as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 160
-      generic_name: standard_e160ads_v7
-      id: Standard_E160ads_v7
-      memory: 1374389534720
-      name: Standard_E160ads_v7
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 6
-      generic_name: standard_nc6s_v3
-      id: Standard_NC6s_v3
-      memory: 120259084288
-      name: Standard_NC6s_v3
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 12
-      generic_name: standard_nc12s_v3
-      id: Standard_NC12s_v3
-      memory: 240518168576
-      name: Standard_NC12s_v3
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 24
-      generic_name: standard_nc24rs_v3
-      id: Standard_NC24rs_v3
-      memory: 481036337152
-      name: Standard_NC24rs_v3
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 24
-      generic_name: standard_nc24s_v3
-      id: Standard_NC24s_v3
-      memory: 481036337152
-      name: Standard_NC24s_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_dc2es_v6
-      id: Standard_DC2es_v6
-      memory: 8589934592
-      name: Standard_DC2es_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_dc4es_v6
-      id: Standard_DC4es_v6
-      memory: 17179869184
-      name: Standard_DC4es_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_dc8es_v6
-      id: Standard_DC8es_v6
-      memory: 34359738368
-      name: Standard_DC8es_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
+      family: standardDCEV6Family
       generic_name: standard_dc16es_v6
       id: Standard_DC16es_v6
       memory: 68719476736
       name: Standard_DC16es_v6
     - category: general_purpose
       cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDCADSv5Family
+      generic_name: standard_dc2ads_v5
+      id: Standard_DC2ads_v5
+      memory: 8589934592
+      name: Standard_DC2ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDCadsv6Family
+      generic_name: standard_dc2ads_v6
+      id: Standard_DC2ads_v6
+      memory: 8589934592
+      name: Standard_DC2ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDCASv5Family
+      generic_name: standard_dc2as_v5
+      id: Standard_DC2as_v5
+      memory: 8589934592
+      name: Standard_DC2as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDCasv6Family
+      generic_name: standard_dc2as_v6
+      id: Standard_DC2as_v6
+      memory: 8589934592
+      name: Standard_DC2as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDCEDV6Family
+      generic_name: standard_dc2eds_v6
+      id: Standard_DC2eds_v6
+      memory: 8589934592
+      name: Standard_DC2eds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDCEV6Family
+      generic_name: standard_dc2es_v6
+      id: Standard_DC2es_v6
+      memory: 8589934592
+      name: Standard_DC2es_v6
+    - category: general_purpose
+      cloud_provider_id: azure
       cpu_cores: 32
+      family: standardDCADCCV5Family
+      generic_name: standard_dc32ads_cc_v5
+      id: Standard_DC32ads_cc_v5
+      memory: 137438953472
+      name: Standard_DC32ads_cc_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDCADSv5Family
+      generic_name: standard_dc32ads_v5
+      id: Standard_DC32ads_v5
+      memory: 137438953472
+      name: Standard_DC32ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDCadsv6Family
+      generic_name: standard_dc32ads_v6
+      id: Standard_DC32ads_v6
+      memory: 137438953472
+      name: Standard_DC32ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDCACCV5Family
+      generic_name: standard_dc32as_cc_v5
+      id: Standard_DC32as_cc_v5
+      memory: 137438953472
+      name: Standard_DC32as_cc_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDCASv5Family
+      generic_name: standard_dc32as_v5
+      id: Standard_DC32as_v5
+      memory: 137438953472
+      name: Standard_DC32as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDCasv6Family
+      generic_name: standard_dc32as_v6
+      id: Standard_DC32as_v6
+      memory: 137438953472
+      name: Standard_DC32as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDCEDV6Family
+      generic_name: standard_dc32eds_v6
+      id: Standard_DC32eds_v6
+      memory: 137438953472
+      name: Standard_DC32eds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDCEV6Family
       generic_name: standard_dc32es_v6
       id: Standard_DC32es_v6
       memory: 137438953472
@@ -7583,125 +3422,3659 @@ data:
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 48
-      generic_name: standard_dc48es_v6
-      id: Standard_DC48es_v6
+      family: standardDCADCCV5Family
+      generic_name: standard_dc48ads_cc_v5
+      id: Standard_DC48ads_cc_v5
       memory: 206158430208
-      name: Standard_DC48es_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_dc64es_v6
-      id: Standard_DC64es_v6
-      memory: 274877906944
-      name: Standard_DC64es_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_dc96es_v6
-      id: Standard_DC96es_v6
-      memory: 412316860416
-      name: Standard_DC96es_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_dc128es_v6
-      id: Standard_DC128es_v6
-      memory: 549755813888
-      name: Standard_DC128es_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_dc2eds_v6
-      id: Standard_DC2eds_v6
-      memory: 8589934592
-      name: Standard_DC2eds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_dc4eds_v6
-      id: Standard_DC4eds_v6
-      memory: 17179869184
-      name: Standard_DC4eds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_dc8eds_v6
-      id: Standard_DC8eds_v6
-      memory: 34359738368
-      name: Standard_DC8eds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_dc16eds_v6
-      id: Standard_DC16eds_v6
-      memory: 68719476736
-      name: Standard_DC16eds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_dc32eds_v6
-      id: Standard_DC32eds_v6
-      memory: 137438953472
-      name: Standard_DC32eds_v6
+      name: Standard_DC48ads_cc_v5
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 48
+      family: standardDCADSv5Family
+      generic_name: standard_dc48ads_v5
+      id: Standard_DC48ads_v5
+      memory: 206158430208
+      name: Standard_DC48ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDCadsv6Family
+      generic_name: standard_dc48ads_v6
+      id: Standard_DC48ads_v6
+      memory: 206158430208
+      name: Standard_DC48ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDCACCV5Family
+      generic_name: standard_dc48as_cc_v5
+      id: Standard_DC48as_cc_v5
+      memory: 206158430208
+      name: Standard_DC48as_cc_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDCASv5Family
+      generic_name: standard_dc48as_v5
+      id: Standard_DC48as_v5
+      memory: 206158430208
+      name: Standard_DC48as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDCasv6Family
+      generic_name: standard_dc48as_v6
+      id: Standard_DC48as_v6
+      memory: 206158430208
+      name: Standard_DC48as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDCEDV6Family
       generic_name: standard_dc48eds_v6
       id: Standard_DC48eds_v6
       memory: 206158430208
       name: Standard_DC48eds_v6
     - category: general_purpose
       cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDCEV6Family
+      generic_name: standard_dc48es_v6
+      id: Standard_DC48es_v6
+      memory: 206158430208
+      name: Standard_DC48es_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDCADCCV5Family
+      generic_name: standard_dc4ads_cc_v5
+      id: Standard_DC4ads_cc_v5
+      memory: 17179869184
+      name: Standard_DC4ads_cc_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDCADSv5Family
+      generic_name: standard_dc4ads_v5
+      id: Standard_DC4ads_v5
+      memory: 17179869184
+      name: Standard_DC4ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDCadsv6Family
+      generic_name: standard_dc4ads_v6
+      id: Standard_DC4ads_v6
+      memory: 17179869184
+      name: Standard_DC4ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDCACCV5Family
+      generic_name: standard_dc4as_cc_v5
+      id: Standard_DC4as_cc_v5
+      memory: 17179869184
+      name: Standard_DC4as_cc_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDCASv5Family
+      generic_name: standard_dc4as_v5
+      id: Standard_DC4as_v5
+      memory: 17179869184
+      name: Standard_DC4as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDCasv6Family
+      generic_name: standard_dc4as_v6
+      id: Standard_DC4as_v6
+      memory: 17179869184
+      name: Standard_DC4as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDCEDV6Family
+      generic_name: standard_dc4eds_v6
+      id: Standard_DC4eds_v6
+      memory: 17179869184
+      name: Standard_DC4eds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDCEV6Family
+      generic_name: standard_dc4es_v6
+      id: Standard_DC4es_v6
+      memory: 17179869184
+      name: Standard_DC4es_v6
+    - category: general_purpose
+      cloud_provider_id: azure
       cpu_cores: 64
+      family: standardDCADCCV5Family
+      generic_name: standard_dc64ads_cc_v5
+      id: Standard_DC64ads_cc_v5
+      memory: 274877906944
+      name: Standard_DC64ads_cc_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDCADSv5Family
+      generic_name: standard_dc64ads_v5
+      id: Standard_DC64ads_v5
+      memory: 274877906944
+      name: Standard_DC64ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDCadsv6Family
+      generic_name: standard_dc64ads_v6
+      id: Standard_DC64ads_v6
+      memory: 274877906944
+      name: Standard_DC64ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDCACCV5Family
+      generic_name: standard_dc64as_cc_v5
+      id: Standard_DC64as_cc_v5
+      memory: 274877906944
+      name: Standard_DC64as_cc_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDCASv5Family
+      generic_name: standard_dc64as_v5
+      id: Standard_DC64as_v5
+      memory: 274877906944
+      name: Standard_DC64as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDCasv6Family
+      generic_name: standard_dc64as_v6
+      id: Standard_DC64as_v6
+      memory: 274877906944
+      name: Standard_DC64as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDCEDV6Family
       generic_name: standard_dc64eds_v6
       id: Standard_DC64eds_v6
       memory: 274877906944
       name: Standard_DC64eds_v6
     - category: general_purpose
       cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDCEV6Family
+      generic_name: standard_dc64es_v6
+      id: Standard_DC64es_v6
+      memory: 274877906944
+      name: Standard_DC64es_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDCADCCV5Family
+      generic_name: standard_dc8ads_cc_v5
+      id: Standard_DC8ads_cc_v5
+      memory: 34359738368
+      name: Standard_DC8ads_cc_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDCADSv5Family
+      generic_name: standard_dc8ads_v5
+      id: Standard_DC8ads_v5
+      memory: 34359738368
+      name: Standard_DC8ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDCadsv6Family
+      generic_name: standard_dc8ads_v6
+      id: Standard_DC8ads_v6
+      memory: 34359738368
+      name: Standard_DC8ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDCACCV5Family
+      generic_name: standard_dc8as_cc_v5
+      id: Standard_DC8as_cc_v5
+      memory: 34359738368
+      name: Standard_DC8as_cc_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDCASv5Family
+      generic_name: standard_dc8as_v5
+      id: Standard_DC8as_v5
+      memory: 34359738368
+      name: Standard_DC8as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDCasv6Family
+      generic_name: standard_dc8as_v6
+      id: Standard_DC8as_v6
+      memory: 34359738368
+      name: Standard_DC8as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDCEDV6Family
+      generic_name: standard_dc8eds_v6
+      id: Standard_DC8eds_v6
+      memory: 34359738368
+      name: Standard_DC8eds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDCEV6Family
+      generic_name: standard_dc8es_v6
+      id: Standard_DC8es_v6
+      memory: 34359738368
+      name: Standard_DC8es_v6
+    - category: general_purpose
+      cloud_provider_id: azure
       cpu_cores: 96
+      family: standardDCADCCV5Family
+      generic_name: standard_dc96ads_cc_v5
+      id: Standard_DC96ads_cc_v5
+      memory: 412316860416
+      name: Standard_DC96ads_cc_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDCADSv5Family
+      generic_name: standard_dc96ads_v5
+      id: Standard_DC96ads_v5
+      memory: 412316860416
+      name: Standard_DC96ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDCadsv6Family
+      generic_name: standard_dc96ads_v6
+      id: Standard_DC96ads_v6
+      memory: 412316860416
+      name: Standard_DC96ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDCACCV5Family
+      generic_name: standard_dc96as_cc_v5
+      id: Standard_DC96as_cc_v5
+      memory: 412316860416
+      name: Standard_DC96as_cc_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDCASv5Family
+      generic_name: standard_dc96as_v5
+      id: Standard_DC96as_v5
+      memory: 412316860416
+      name: Standard_DC96as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDCasv6Family
+      generic_name: standard_dc96as_v6
+      id: Standard_DC96as_v6
+      memory: 412316860416
+      name: Standard_DC96as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDCEDV6Family
       generic_name: standard_dc96eds_v6
       id: Standard_DC96eds_v6
       memory: 412316860416
       name: Standard_DC96eds_v6
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_dc128eds_v6
-      id: Standard_DC128eds_v6
-      memory: 549755813888
-      name: Standard_DC128eds_v6
-    - category: memory_optimized
+      cpu_cores: 96
+      family: standardDCEV6Family
+      generic_name: standard_dc96es_v6
+      id: Standard_DC96es_v6
+      memory: 412316860416
+      name: Standard_DC96es_v6
+    - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 2
-      generic_name: standard_ec2es_v6
-      id: Standard_EC2es_v6
-      memory: 17179869184
-      name: Standard_EC2es_v6
-    - category: memory_optimized
+      family: standardDSv2Family
+      generic_name: standard_ds11-1_v2
+      id: Standard_DS11-1_v2
+      memory: 15032385536
+      name: Standard_DS11-1_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDSv2Family
+      generic_name: standard_ds11_v2
+      id: Standard_DS11_v2
+      memory: 15032385536
+      name: Standard_DS11_v2
+    - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 4
-      generic_name: standard_ec4es_v6
-      id: Standard_EC4es_v6
-      memory: 34359738368
-      name: Standard_EC4es_v6
-    - category: memory_optimized
+      family: standardDSv2Family
+      generic_name: standard_ds12-1_v2
+      id: Standard_DS12-1_v2
+      memory: 30064771072
+      name: Standard_DS12-1_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDSv2Family
+      generic_name: standard_ds12-2_v2
+      id: Standard_DS12-2_v2
+      memory: 30064771072
+      name: Standard_DS12-2_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDSv2Family
+      generic_name: standard_ds12_v2
+      id: Standard_DS12_v2
+      memory: 30064771072
+      name: Standard_DS12_v2
+    - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 8
-      generic_name: standard_ec8es_v6
-      id: Standard_EC8es_v6
-      memory: 68719476736
-      name: Standard_EC8es_v6
+      family: standardDSv2Family
+      generic_name: standard_ds13-2_v2
+      id: Standard_DS13-2_v2
+      memory: 60129542144
+      name: Standard_DS13-2_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDSv2Family
+      generic_name: standard_ds13-4_v2
+      id: Standard_DS13-4_v2
+      memory: 60129542144
+      name: Standard_DS13-4_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDSv2Family
+      generic_name: standard_ds13_v2
+      id: Standard_DS13_v2
+      memory: 60129542144
+      name: Standard_DS13_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDSv2Family
+      generic_name: standard_ds14-4_v2
+      id: Standard_DS14-4_v2
+      memory: 120259084288
+      name: Standard_DS14-4_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDSv2Family
+      generic_name: standard_ds14-8_v2
+      id: Standard_DS14-8_v2
+      memory: 120259084288
+      name: Standard_DS14-8_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDSv2Family
+      generic_name: standard_ds14_v2
+      id: Standard_DS14_v2
+      memory: 120259084288
+      name: Standard_DS14_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardDSv2Family
+      generic_name: standard_ds15_v2
+      id: Standard_DS15_v2
+      memory: 150323855360
+      name: Standard_DS15_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 1
+      family: standardDSv2Family
+      generic_name: standard_ds1_v2
+      id: Standard_DS1_v2
+      memory: 3221225472
+      name: Standard_DS1_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDSv2Family
+      generic_name: standard_ds2_v2
+      id: Standard_DS2_v2
+      memory: 7516192768
+      name: Standard_DS2_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDSv2Family
+      generic_name: standard_ds3_v2
+      id: Standard_DS3_v2
+      memory: 15032385536
+      name: Standard_DS3_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDSv2Family
+      generic_name: standard_ds4_v2
+      id: Standard_DS4_v2
+      memory: 30064771072
+      name: Standard_DS4_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDSv2Family
+      generic_name: standard_ds5_v2
+      id: Standard_DS5_v2
+      memory: 60129542144
+      name: Standard_DS5_v2
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 104
+      family: standardEIDSv5Family
+      generic_name: standard_e104ids_v5
+      id: Standard_E104ids_v5
+      memory: 721554505728
+      name: Standard_E104ids_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 104
+      family: standardEIDv5Family
+      generic_name: standard_e104id_v5
+      id: Standard_E104id_v5
+      memory: 721554505728
+      name: Standard_E104id_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 104
+      family: standardEISv5Family
+      generic_name: standard_e104is_v5
+      id: Standard_E104is_v5
+      memory: 721554505728
+      name: Standard_E104is_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 104
+      family: standardEIv5Family
+      generic_name: standard_e104i_v5
+      id: Standard_E104i_v5
+      memory: 721554505728
+      name: Standard_E104i_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 112
+      family: standardEIADSv5Family
+      generic_name: standard_e112iads_v5
+      id: Standard_E112iads_v5
+      memory: 721554505728
+      name: Standard_E112iads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 112
+      family: standardEIASv5Family
+      generic_name: standard_e112ias_v5
+      id: Standard_E112ias_v5
+      memory: 721554505728
+      name: Standard_E112ias_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 112
+      family: standardEIBDSv5Family
+      generic_name: standard_e112ibds_v5
+      id: Standard_E112ibds_v5
+      memory: 721554505728
+      name: Standard_E112ibds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 112
+      family: standardEIBSv5Family
+      generic_name: standard_e112ibs_v5
+      id: Standard_E112ibs_v5
+      memory: 721554505728
+      name: Standard_E112ibs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEadsv7Family
+      generic_name: standard_e128-32ads_v7
+      id: Standard_E128-32ads_v7
+      memory: 1099511627776
+      name: Standard_E128-32ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEasv7Family
+      generic_name: standard_e128-32as_v7
+      id: Standard_E128-32as_v7
+      memory: 1099511627776
+      name: Standard_E128-32as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEdsv6Family
+      generic_name: standard_e128-32ds_v6
+      id: Standard_E128-32ds_v6
+      memory: 1099511627776
+      name: Standard_E128-32ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEsv6Family
+      generic_name: standard_e128-32s_v6
+      id: Standard_E128-32s_v6
+      memory: 1099511627776
+      name: Standard_E128-32s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEadsv7Family
+      generic_name: standard_e128-64ads_v7
+      id: Standard_E128-64ads_v7
+      memory: 1099511627776
+      name: Standard_E128-64ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEasv7Family
+      generic_name: standard_e128-64as_v7
+      id: Standard_E128-64as_v7
+      memory: 1099511627776
+      name: Standard_E128-64as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEdsv6Family
+      generic_name: standard_e128-64ds_v6
+      id: Standard_E128-64ds_v6
+      memory: 1099511627776
+      name: Standard_E128-64ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEsv6Family
+      generic_name: standard_e128-64s_v6
+      id: Standard_E128-64s_v6
+      memory: 1099511627776
+      name: Standard_E128-64s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEadsv7Family
+      generic_name: standard_e128ads_v7
+      id: Standard_E128ads_v7
+      memory: 1099511627776
+      name: Standard_E128ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEasv7Family
+      generic_name: standard_e128as_v7
+      id: Standard_E128as_v7
+      memory: 1099511627776
+      name: Standard_E128as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEdsv6Family
+      generic_name: standard_e128ds_v6
+      id: Standard_E128ds_v6
+      memory: 1099511627776
+      name: Standard_E128ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEsv6Family
+      generic_name: standard_e128s_v6
+      id: Standard_E128s_v6
+      memory: 1099511627776
+      name: Standard_E128s_v6
     - category: memory_optimized
       cloud_provider_id: azure
       cpu_cores: 16
+      family: standardEADSv5Family
+      generic_name: standard_e16-4ads_v5
+      id: Standard_E16-4ads_v5
+      memory: 137438953472
+      name: Standard_E16-4ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEadsv7Family
+      generic_name: standard_e16-4ads_v7
+      id: Standard_E16-4ads_v7
+      memory: 137438953472
+      name: Standard_E16-4ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEASv4Family
+      generic_name: standard_e16-4as_v4
+      id: Standard_E16-4as_v4
+      memory: 137438953472
+      name: Standard_E16-4as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEASv5Family
+      generic_name: standard_e16-4as_v5
+      id: Standard_E16-4as_v5
+      memory: 137438953472
+      name: Standard_E16-4as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEasv7Family
+      generic_name: standard_e16-4as_v7
+      id: Standard_E16-4as_v7
+      memory: 137438953472
+      name: Standard_E16-4as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEDSv4Family
+      generic_name: standard_e16-4ds_v4
+      id: Standard_E16-4ds_v4
+      memory: 137438953472
+      name: Standard_E16-4ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEDSv5Family
+      generic_name: standard_e16-4ds_v5
+      id: Standard_E16-4ds_v5
+      memory: 137438953472
+      name: Standard_E16-4ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEdsv6Family
+      generic_name: standard_e16-4ds_v6
+      id: Standard_E16-4ds_v6
+      memory: 137438953472
+      name: Standard_E16-4ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardESv3Family
+      generic_name: standard_e16-4s_v3
+      id: Standard_E16-4s_v3
+      memory: 137438953472
+      name: Standard_E16-4s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardESv4Family
+      generic_name: standard_e16-4s_v4
+      id: Standard_E16-4s_v4
+      memory: 137438953472
+      name: Standard_E16-4s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardESv5Family
+      generic_name: standard_e16-4s_v5
+      id: Standard_E16-4s_v5
+      memory: 137438953472
+      name: Standard_E16-4s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEsv6Family
+      generic_name: standard_e16-4s_v6
+      id: Standard_E16-4s_v6
+      memory: 137438953472
+      name: Standard_E16-4s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEADSv5Family
+      generic_name: standard_e16-8ads_v5
+      id: Standard_E16-8ads_v5
+      memory: 137438953472
+      name: Standard_E16-8ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEadsv7Family
+      generic_name: standard_e16-8ads_v7
+      id: Standard_E16-8ads_v7
+      memory: 137438953472
+      name: Standard_E16-8ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEASv4Family
+      generic_name: standard_e16-8as_v4
+      id: Standard_E16-8as_v4
+      memory: 137438953472
+      name: Standard_E16-8as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEASv5Family
+      generic_name: standard_e16-8as_v5
+      id: Standard_E16-8as_v5
+      memory: 137438953472
+      name: Standard_E16-8as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEasv7Family
+      generic_name: standard_e16-8as_v7
+      id: Standard_E16-8as_v7
+      memory: 137438953472
+      name: Standard_E16-8as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEDSv4Family
+      generic_name: standard_e16-8ds_v4
+      id: Standard_E16-8ds_v4
+      memory: 137438953472
+      name: Standard_E16-8ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEDSv5Family
+      generic_name: standard_e16-8ds_v5
+      id: Standard_E16-8ds_v5
+      memory: 137438953472
+      name: Standard_E16-8ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEdsv6Family
+      generic_name: standard_e16-8ds_v6
+      id: Standard_E16-8ds_v6
+      memory: 137438953472
+      name: Standard_E16-8ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardESv3Family
+      generic_name: standard_e16-8s_v3
+      id: Standard_E16-8s_v3
+      memory: 137438953472
+      name: Standard_E16-8s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardESv4Family
+      generic_name: standard_e16-8s_v4
+      id: Standard_E16-8s_v4
+      memory: 137438953472
+      name: Standard_E16-8s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardESv5Family
+      generic_name: standard_e16-8s_v5
+      id: Standard_E16-8s_v5
+      memory: 137438953472
+      name: Standard_E16-8s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEsv6Family
+      generic_name: standard_e16-8s_v6
+      id: Standard_E16-8s_v6
+      memory: 137438953472
+      name: Standard_E16-8s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 160
+      family: StandardEadsv7Family
+      generic_name: standard_e160ads_v7
+      id: Standard_E160ads_v7
+      memory: 1374389534720
+      name: Standard_E160ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 160
+      family: StandardEasv7Family
+      generic_name: standard_e160as_v7
+      id: Standard_E160as_v7
+      memory: 1374389534720
+      name: Standard_E160as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEADSv5Family
+      generic_name: standard_e16ads_v5
+      id: Standard_E16ads_v5
+      memory: 137438953472
+      name: Standard_E16ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEadv6Family
+      generic_name: standard_e16ads_v6
+      id: Standard_E16ads_v6
+      memory: 137438953472
+      name: Standard_E16ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEadsv7Family
+      generic_name: standard_e16ads_v7
+      id: Standard_E16ads_v7
+      memory: 137438953472
+      name: Standard_E16ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEASv4Family
+      generic_name: standard_e16as_v4
+      id: Standard_E16as_v4
+      memory: 137438953472
+      name: Standard_E16as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEASv5Family
+      generic_name: standard_e16as_v5
+      id: Standard_E16as_v5
+      memory: 137438953472
+      name: Standard_E16as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEav6Family
+      generic_name: standard_e16as_v6
+      id: Standard_E16as_v6
+      memory: 137438953472
+      name: Standard_E16as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEasv7Family
+      generic_name: standard_e16as_v7
+      id: Standard_E16as_v7
+      memory: 137438953472
+      name: Standard_E16as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEAv4Family
+      generic_name: standard_e16a_v4
+      id: Standard_E16a_v4
+      memory: 137438953472
+      name: Standard_E16a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEBDSv5Family
+      generic_name: standard_e16bds_v5
+      id: Standard_E16bds_v5
+      memory: 137438953472
+      name: Standard_E16bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEBSv5Family
+      generic_name: standard_e16bs_v5
+      id: Standard_E16bs_v5
+      memory: 137438953472
+      name: Standard_E16bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEDSv4Family
+      generic_name: standard_e16ds_v4
+      id: Standard_E16ds_v4
+      memory: 137438953472
+      name: Standard_E16ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEDSv5Family
+      generic_name: standard_e16ds_v5
+      id: Standard_E16ds_v5
+      memory: 137438953472
+      name: Standard_E16ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEdsv6Family
+      generic_name: standard_e16ds_v6
+      id: Standard_E16ds_v6
+      memory: 137438953472
+      name: Standard_E16ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEDv4Family
+      generic_name: standard_e16d_v4
+      id: Standard_E16d_v4
+      memory: 137438953472
+      name: Standard_E16d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEDv5Family
+      generic_name: standard_e16d_v5
+      id: Standard_E16d_v5
+      memory: 137438953472
+      name: Standard_E16d_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEPDSv5Family
+      generic_name: standard_e16pds_v5
+      id: Standard_E16pds_v5
+      memory: 137438953472
+      name: Standard_E16pds_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEpdsv6Family
+      generic_name: standard_e16pds_v6
+      id: Standard_E16pds_v6
+      memory: 137438953472
+      name: Standard_E16pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEPSv5Family
+      generic_name: standard_e16ps_v5
+      id: Standard_E16ps_v5
+      memory: 137438953472
+      name: Standard_E16ps_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEpsv6Family
+      generic_name: standard_e16ps_v6
+      id: Standard_E16ps_v6
+      memory: 137438953472
+      name: Standard_E16ps_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardESv3Family
+      generic_name: standard_e16s_v3
+      id: Standard_E16s_v3
+      memory: 137438953472
+      name: Standard_E16s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardESv4Family
+      generic_name: standard_e16s_v4
+      id: Standard_E16s_v4
+      memory: 137438953472
+      name: Standard_E16s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardESv5Family
+      generic_name: standard_e16s_v5
+      id: Standard_E16s_v5
+      memory: 137438953472
+      name: Standard_E16s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEsv6Family
+      generic_name: standard_e16s_v6
+      id: Standard_E16s_v6
+      memory: 137438953472
+      name: Standard_E16s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEv3Family
+      generic_name: standard_e16_v3
+      id: Standard_E16_v3
+      memory: 137438953472
+      name: Standard_E16_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEv4Family
+      generic_name: standard_e16_v4
+      id: Standard_E16_v4
+      memory: 137438953472
+      name: Standard_E16_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEv5Family
+      generic_name: standard_e16_v5
+      id: Standard_E16_v5
+      memory: 137438953472
+      name: Standard_E16_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 192
+      family: StandardEdsv6Family
+      generic_name: standard_e192ids_v6
+      id: Standard_E192ids_v6
+      memory: 1967095021568
+      name: Standard_E192ids_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 192
+      family: StandardEsv6Family
+      generic_name: standard_e192is_v6
+      id: Standard_E192is_v6
+      memory: 1967095021568
+      name: Standard_E192is_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEADSv5Family
+      generic_name: standard_e20ads_v5
+      id: Standard_E20ads_v5
+      memory: 171798691840
+      name: Standard_E20ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEadv6Family
+      generic_name: standard_e20ads_v6
+      id: Standard_E20ads_v6
+      memory: 171798691840
+      name: Standard_E20ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEASv4Family
+      generic_name: standard_e20as_v4
+      id: Standard_E20as_v4
+      memory: 171798691840
+      name: Standard_E20as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEASv5Family
+      generic_name: standard_e20as_v5
+      id: Standard_E20as_v5
+      memory: 171798691840
+      name: Standard_E20as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEav6Family
+      generic_name: standard_e20as_v6
+      id: Standard_E20as_v6
+      memory: 171798691840
+      name: Standard_E20as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEAv4Family
+      generic_name: standard_e20a_v4
+      id: Standard_E20a_v4
+      memory: 171798691840
+      name: Standard_E20a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEDSv4Family
+      generic_name: standard_e20ds_v4
+      id: Standard_E20ds_v4
+      memory: 171798691840
+      name: Standard_E20ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEDSv5Family
+      generic_name: standard_e20ds_v5
+      id: Standard_E20ds_v5
+      memory: 171798691840
+      name: Standard_E20ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: StandardEdsv6Family
+      generic_name: standard_e20ds_v6
+      id: Standard_E20ds_v6
+      memory: 171798691840
+      name: Standard_E20ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEDv4Family
+      generic_name: standard_e20d_v4
+      id: Standard_E20d_v4
+      memory: 171798691840
+      name: Standard_E20d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEDv5Family
+      generic_name: standard_e20d_v5
+      id: Standard_E20d_v5
+      memory: 171798691840
+      name: Standard_E20d_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEPDSv5Family
+      generic_name: standard_e20pds_v5
+      id: Standard_E20pds_v5
+      memory: 171798691840
+      name: Standard_E20pds_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEPSv5Family
+      generic_name: standard_e20ps_v5
+      id: Standard_E20ps_v5
+      memory: 171798691840
+      name: Standard_E20ps_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardESv3Family
+      generic_name: standard_e20s_v3
+      id: Standard_E20s_v3
+      memory: 171798691840
+      name: Standard_E20s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardESv4Family
+      generic_name: standard_e20s_v4
+      id: Standard_E20s_v4
+      memory: 171798691840
+      name: Standard_E20s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardESv5Family
+      generic_name: standard_e20s_v5
+      id: Standard_E20s_v5
+      memory: 171798691840
+      name: Standard_E20s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: StandardEsv6Family
+      generic_name: standard_e20s_v6
+      id: Standard_E20s_v6
+      memory: 171798691840
+      name: Standard_E20s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEv3Family
+      generic_name: standard_e20_v3
+      id: Standard_E20_v3
+      memory: 171798691840
+      name: Standard_E20_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEv4Family
+      generic_name: standard_e20_v4
+      id: Standard_E20_v4
+      memory: 171798691840
+      name: Standard_E20_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEv5Family
+      generic_name: standard_e20_v5
+      id: Standard_E20_v5
+      memory: 171798691840
+      name: Standard_E20_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEADSv5Family
+      generic_name: standard_e2ads_v5
+      id: Standard_E2ads_v5
+      memory: 17179869184
+      name: Standard_E2ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEadv6Family
+      generic_name: standard_e2ads_v6
+      id: Standard_E2ads_v6
+      memory: 17179869184
+      name: Standard_E2ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardEadsv7Family
+      generic_name: standard_e2ads_v7
+      id: Standard_E2ads_v7
+      memory: 17179869184
+      name: Standard_E2ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEASv4Family
+      generic_name: standard_e2as_v4
+      id: Standard_E2as_v4
+      memory: 17179869184
+      name: Standard_E2as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEASv5Family
+      generic_name: standard_e2as_v5
+      id: Standard_E2as_v5
+      memory: 17179869184
+      name: Standard_E2as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEav6Family
+      generic_name: standard_e2as_v6
+      id: Standard_E2as_v6
+      memory: 17179869184
+      name: Standard_E2as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardEasv7Family
+      generic_name: standard_e2as_v7
+      id: Standard_E2as_v7
+      memory: 17179869184
+      name: Standard_E2as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEAv4Family
+      generic_name: standard_e2a_v4
+      id: Standard_E2a_v4
+      memory: 17179869184
+      name: Standard_E2a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEBDSv5Family
+      generic_name: standard_e2bds_v5
+      id: Standard_E2bds_v5
+      memory: 17179869184
+      name: Standard_E2bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEBSv5Family
+      generic_name: standard_e2bs_v5
+      id: Standard_E2bs_v5
+      memory: 17179869184
+      name: Standard_E2bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEDSv4Family
+      generic_name: standard_e2ds_v4
+      id: Standard_E2ds_v4
+      memory: 17179869184
+      name: Standard_E2ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEDSv5Family
+      generic_name: standard_e2ds_v5
+      id: Standard_E2ds_v5
+      memory: 17179869184
+      name: Standard_E2ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardEdsv6Family
+      generic_name: standard_e2ds_v6
+      id: Standard_E2ds_v6
+      memory: 17179869184
+      name: Standard_E2ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEDv4Family
+      generic_name: standard_e2d_v4
+      id: Standard_E2d_v4
+      memory: 17179869184
+      name: Standard_E2d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEDv5Family
+      generic_name: standard_e2d_v5
+      id: Standard_E2d_v5
+      memory: 17179869184
+      name: Standard_E2d_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEPDSv5Family
+      generic_name: standard_e2pds_v5
+      id: Standard_E2pds_v5
+      memory: 17179869184
+      name: Standard_E2pds_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardEpdsv6Family
+      generic_name: standard_e2pds_v6
+      id: Standard_E2pds_v6
+      memory: 17179869184
+      name: Standard_E2pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEPSv5Family
+      generic_name: standard_e2ps_v5
+      id: Standard_E2ps_v5
+      memory: 17179869184
+      name: Standard_E2ps_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardEpsv6Family
+      generic_name: standard_e2ps_v6
+      id: Standard_E2ps_v6
+      memory: 17179869184
+      name: Standard_E2ps_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardESv3Family
+      generic_name: standard_e2s_v3
+      id: Standard_E2s_v3
+      memory: 17179869184
+      name: Standard_E2s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardESv4Family
+      generic_name: standard_e2s_v4
+      id: Standard_E2s_v4
+      memory: 17179869184
+      name: Standard_E2s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardESv5Family
+      generic_name: standard_e2s_v5
+      id: Standard_E2s_v5
+      memory: 17179869184
+      name: Standard_E2s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardEsv6Family
+      generic_name: standard_e2s_v6
+      id: Standard_E2s_v6
+      memory: 17179869184
+      name: Standard_E2s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEv3Family
+      generic_name: standard_e2_v3
+      id: Standard_E2_v3
+      memory: 17179869184
+      name: Standard_E2_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEv4Family
+      generic_name: standard_e2_v4
+      id: Standard_E2_v4
+      memory: 17179869184
+      name: Standard_E2_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEv5Family
+      generic_name: standard_e2_v5
+      id: Standard_E2_v5
+      memory: 17179869184
+      name: Standard_E2_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEADSv5Family
+      generic_name: standard_e32-16ads_v5
+      id: Standard_E32-16ads_v5
+      memory: 274877906944
+      name: Standard_E32-16ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEadsv7Family
+      generic_name: standard_e32-16ads_v7
+      id: Standard_E32-16ads_v7
+      memory: 274877906944
+      name: Standard_E32-16ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEASv4Family
+      generic_name: standard_e32-16as_v4
+      id: Standard_E32-16as_v4
+      memory: 274877906944
+      name: Standard_E32-16as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEASv5Family
+      generic_name: standard_e32-16as_v5
+      id: Standard_E32-16as_v5
+      memory: 274877906944
+      name: Standard_E32-16as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEasv7Family
+      generic_name: standard_e32-16as_v7
+      id: Standard_E32-16as_v7
+      memory: 274877906944
+      name: Standard_E32-16as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEDSv4Family
+      generic_name: standard_e32-16ds_v4
+      id: Standard_E32-16ds_v4
+      memory: 274877906944
+      name: Standard_E32-16ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEDSv5Family
+      generic_name: standard_e32-16ds_v5
+      id: Standard_E32-16ds_v5
+      memory: 274877906944
+      name: Standard_E32-16ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEdsv6Family
+      generic_name: standard_e32-16ds_v6
+      id: Standard_E32-16ds_v6
+      memory: 274877906944
+      name: Standard_E32-16ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardESv3Family
+      generic_name: standard_e32-16s_v3
+      id: Standard_E32-16s_v3
+      memory: 274877906944
+      name: Standard_E32-16s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardESv4Family
+      generic_name: standard_e32-16s_v4
+      id: Standard_E32-16s_v4
+      memory: 274877906944
+      name: Standard_E32-16s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardESv5Family
+      generic_name: standard_e32-16s_v5
+      id: Standard_E32-16s_v5
+      memory: 274877906944
+      name: Standard_E32-16s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEsv6Family
+      generic_name: standard_e32-16s_v6
+      id: Standard_E32-16s_v6
+      memory: 274877906944
+      name: Standard_E32-16s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEADSv5Family
+      generic_name: standard_e32-8ads_v5
+      id: Standard_E32-8ads_v5
+      memory: 274877906944
+      name: Standard_E32-8ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEadsv7Family
+      generic_name: standard_e32-8ads_v7
+      id: Standard_E32-8ads_v7
+      memory: 274877906944
+      name: Standard_E32-8ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEASv4Family
+      generic_name: standard_e32-8as_v4
+      id: Standard_E32-8as_v4
+      memory: 274877906944
+      name: Standard_E32-8as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEASv5Family
+      generic_name: standard_e32-8as_v5
+      id: Standard_E32-8as_v5
+      memory: 274877906944
+      name: Standard_E32-8as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEasv7Family
+      generic_name: standard_e32-8as_v7
+      id: Standard_E32-8as_v7
+      memory: 274877906944
+      name: Standard_E32-8as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEDSv4Family
+      generic_name: standard_e32-8ds_v4
+      id: Standard_E32-8ds_v4
+      memory: 274877906944
+      name: Standard_E32-8ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEDSv5Family
+      generic_name: standard_e32-8ds_v5
+      id: Standard_E32-8ds_v5
+      memory: 274877906944
+      name: Standard_E32-8ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEdsv6Family
+      generic_name: standard_e32-8ds_v6
+      id: Standard_E32-8ds_v6
+      memory: 274877906944
+      name: Standard_E32-8ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardESv3Family
+      generic_name: standard_e32-8s_v3
+      id: Standard_E32-8s_v3
+      memory: 274877906944
+      name: Standard_E32-8s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardESv4Family
+      generic_name: standard_e32-8s_v4
+      id: Standard_E32-8s_v4
+      memory: 274877906944
+      name: Standard_E32-8s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardESv5Family
+      generic_name: standard_e32-8s_v5
+      id: Standard_E32-8s_v5
+      memory: 274877906944
+      name: Standard_E32-8s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEsv6Family
+      generic_name: standard_e32-8s_v6
+      id: Standard_E32-8s_v6
+      memory: 274877906944
+      name: Standard_E32-8s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEADSv5Family
+      generic_name: standard_e32ads_v5
+      id: Standard_E32ads_v5
+      memory: 274877906944
+      name: Standard_E32ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEadv6Family
+      generic_name: standard_e32ads_v6
+      id: Standard_E32ads_v6
+      memory: 274877906944
+      name: Standard_E32ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEadsv7Family
+      generic_name: standard_e32ads_v7
+      id: Standard_E32ads_v7
+      memory: 274877906944
+      name: Standard_E32ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEASv4Family
+      generic_name: standard_e32as_v4
+      id: Standard_E32as_v4
+      memory: 274877906944
+      name: Standard_E32as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEASv5Family
+      generic_name: standard_e32as_v5
+      id: Standard_E32as_v5
+      memory: 274877906944
+      name: Standard_E32as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEav6Family
+      generic_name: standard_e32as_v6
+      id: Standard_E32as_v6
+      memory: 274877906944
+      name: Standard_E32as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEasv7Family
+      generic_name: standard_e32as_v7
+      id: Standard_E32as_v7
+      memory: 274877906944
+      name: Standard_E32as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEAv4Family
+      generic_name: standard_e32a_v4
+      id: Standard_E32a_v4
+      memory: 274877906944
+      name: Standard_E32a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEBDSv5Family
+      generic_name: standard_e32bds_v5
+      id: Standard_E32bds_v5
+      memory: 274877906944
+      name: Standard_E32bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEBSv5Family
+      generic_name: standard_e32bs_v5
+      id: Standard_E32bs_v5
+      memory: 274877906944
+      name: Standard_E32bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEDSv4Family
+      generic_name: standard_e32ds_v4
+      id: Standard_E32ds_v4
+      memory: 274877906944
+      name: Standard_E32ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEDSv5Family
+      generic_name: standard_e32ds_v5
+      id: Standard_E32ds_v5
+      memory: 274877906944
+      name: Standard_E32ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEdsv6Family
+      generic_name: standard_e32ds_v6
+      id: Standard_E32ds_v6
+      memory: 274877906944
+      name: Standard_E32ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEDv4Family
+      generic_name: standard_e32d_v4
+      id: Standard_E32d_v4
+      memory: 274877906944
+      name: Standard_E32d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEDv5Family
+      generic_name: standard_e32d_v5
+      id: Standard_E32d_v5
+      memory: 274877906944
+      name: Standard_E32d_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEPDSv5Family
+      generic_name: standard_e32pds_v5
+      id: Standard_E32pds_v5
+      memory: 223338299392
+      name: Standard_E32pds_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEpdsv6Family
+      generic_name: standard_e32pds_v6
+      id: Standard_E32pds_v6
+      memory: 274877906944
+      name: Standard_E32pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEPSv5Family
+      generic_name: standard_e32ps_v5
+      id: Standard_E32ps_v5
+      memory: 223338299392
+      name: Standard_E32ps_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEpsv6Family
+      generic_name: standard_e32ps_v6
+      id: Standard_E32ps_v6
+      memory: 274877906944
+      name: Standard_E32ps_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardESv3Family
+      generic_name: standard_e32s_v3
+      id: Standard_E32s_v3
+      memory: 274877906944
+      name: Standard_E32s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardESv4Family
+      generic_name: standard_e32s_v4
+      id: Standard_E32s_v4
+      memory: 274877906944
+      name: Standard_E32s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardESv5Family
+      generic_name: standard_e32s_v5
+      id: Standard_E32s_v5
+      memory: 274877906944
+      name: Standard_E32s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEsv6Family
+      generic_name: standard_e32s_v6
+      id: Standard_E32s_v6
+      memory: 274877906944
+      name: Standard_E32s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEv3Family
+      generic_name: standard_e32_v3
+      id: Standard_E32_v3
+      memory: 274877906944
+      name: Standard_E32_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEv4Family
+      generic_name: standard_e32_v4
+      id: Standard_E32_v4
+      memory: 274877906944
+      name: Standard_E32_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEv5Family
+      generic_name: standard_e32_v5
+      id: Standard_E32_v5
+      memory: 274877906944
+      name: Standard_E32_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEADSv5Family
+      generic_name: standard_e4-2ads_v5
+      id: Standard_E4-2ads_v5
+      memory: 34359738368
+      name: Standard_E4-2ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardEadsv7Family
+      generic_name: standard_e4-2ads_v7
+      id: Standard_E4-2ads_v7
+      memory: 34359738368
+      name: Standard_E4-2ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEASv4Family
+      generic_name: standard_e4-2as_v4
+      id: Standard_E4-2as_v4
+      memory: 34359738368
+      name: Standard_E4-2as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEASv5Family
+      generic_name: standard_e4-2as_v5
+      id: Standard_E4-2as_v5
+      memory: 34359738368
+      name: Standard_E4-2as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardEasv7Family
+      generic_name: standard_e4-2as_v7
+      id: Standard_E4-2as_v7
+      memory: 34359738368
+      name: Standard_E4-2as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEDSv4Family
+      generic_name: standard_e4-2ds_v4
+      id: Standard_E4-2ds_v4
+      memory: 34359738368
+      name: Standard_E4-2ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEDSv5Family
+      generic_name: standard_e4-2ds_v5
+      id: Standard_E4-2ds_v5
+      memory: 34359738368
+      name: Standard_E4-2ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardEdsv6Family
+      generic_name: standard_e4-2ds_v6
+      id: Standard_E4-2ds_v6
+      memory: 34359738368
+      name: Standard_E4-2ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardESv3Family
+      generic_name: standard_e4-2s_v3
+      id: Standard_E4-2s_v3
+      memory: 34359738368
+      name: Standard_E4-2s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardESv4Family
+      generic_name: standard_e4-2s_v4
+      id: Standard_E4-2s_v4
+      memory: 34359738368
+      name: Standard_E4-2s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardESv5Family
+      generic_name: standard_e4-2s_v5
+      id: Standard_E4-2s_v5
+      memory: 34359738368
+      name: Standard_E4-2s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardEsv6Family
+      generic_name: standard_e4-2s_v6
+      id: Standard_E4-2s_v6
+      memory: 34359738368
+      name: Standard_E4-2s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEADSv5Family
+      generic_name: standard_e48ads_v5
+      id: Standard_E48ads_v5
+      memory: 412316860416
+      name: Standard_E48ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEadv6Family
+      generic_name: standard_e48ads_v6
+      id: Standard_E48ads_v6
+      memory: 412316860416
+      name: Standard_E48ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardEadsv7Family
+      generic_name: standard_e48ads_v7
+      id: Standard_E48ads_v7
+      memory: 412316860416
+      name: Standard_E48ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEASv4Family
+      generic_name: standard_e48as_v4
+      id: Standard_E48as_v4
+      memory: 412316860416
+      name: Standard_E48as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEASv5Family
+      generic_name: standard_e48as_v5
+      id: Standard_E48as_v5
+      memory: 412316860416
+      name: Standard_E48as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEav6Family
+      generic_name: standard_e48as_v6
+      id: Standard_E48as_v6
+      memory: 412316860416
+      name: Standard_E48as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardEasv7Family
+      generic_name: standard_e48as_v7
+      id: Standard_E48as_v7
+      memory: 412316860416
+      name: Standard_E48as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEAv4Family
+      generic_name: standard_e48a_v4
+      id: Standard_E48a_v4
+      memory: 412316860416
+      name: Standard_E48a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEBDSv5Family
+      generic_name: standard_e48bds_v5
+      id: Standard_E48bds_v5
+      memory: 412316860416
+      name: Standard_E48bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEBSv5Family
+      generic_name: standard_e48bs_v5
+      id: Standard_E48bs_v5
+      memory: 412316860416
+      name: Standard_E48bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEDSv4Family
+      generic_name: standard_e48ds_v4
+      id: Standard_E48ds_v4
+      memory: 412316860416
+      name: Standard_E48ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEDSv5Family
+      generic_name: standard_e48ds_v5
+      id: Standard_E48ds_v5
+      memory: 412316860416
+      name: Standard_E48ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardEdsv6Family
+      generic_name: standard_e48ds_v6
+      id: Standard_E48ds_v6
+      memory: 412316860416
+      name: Standard_E48ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEDv4Family
+      generic_name: standard_e48d_v4
+      id: Standard_E48d_v4
+      memory: 412316860416
+      name: Standard_E48d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEDv5Family
+      generic_name: standard_e48d_v5
+      id: Standard_E48d_v5
+      memory: 412316860416
+      name: Standard_E48d_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardEpdsv6Family
+      generic_name: standard_e48pds_v6
+      id: Standard_E48pds_v6
+      memory: 412316860416
+      name: Standard_E48pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardEpsv6Family
+      generic_name: standard_e48ps_v6
+      id: Standard_E48ps_v6
+      memory: 412316860416
+      name: Standard_E48ps_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardESv3Family
+      generic_name: standard_e48s_v3
+      id: Standard_E48s_v3
+      memory: 412316860416
+      name: Standard_E48s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardESv4Family
+      generic_name: standard_e48s_v4
+      id: Standard_E48s_v4
+      memory: 412316860416
+      name: Standard_E48s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardESv5Family
+      generic_name: standard_e48s_v5
+      id: Standard_E48s_v5
+      memory: 412316860416
+      name: Standard_E48s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardEsv6Family
+      generic_name: standard_e48s_v6
+      id: Standard_E48s_v6
+      memory: 412316860416
+      name: Standard_E48s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEv3Family
+      generic_name: standard_e48_v3
+      id: Standard_E48_v3
+      memory: 412316860416
+      name: Standard_E48_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEv4Family
+      generic_name: standard_e48_v4
+      id: Standard_E48_v4
+      memory: 412316860416
+      name: Standard_E48_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEv5Family
+      generic_name: standard_e48_v5
+      id: Standard_E48_v5
+      memory: 412316860416
+      name: Standard_E48_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEADSv5Family
+      generic_name: standard_e4ads_v5
+      id: Standard_E4ads_v5
+      memory: 34359738368
+      name: Standard_E4ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEadv6Family
+      generic_name: standard_e4ads_v6
+      id: Standard_E4ads_v6
+      memory: 34359738368
+      name: Standard_E4ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardEadsv7Family
+      generic_name: standard_e4ads_v7
+      id: Standard_E4ads_v7
+      memory: 34359738368
+      name: Standard_E4ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEASv4Family
+      generic_name: standard_e4as_v4
+      id: Standard_E4as_v4
+      memory: 34359738368
+      name: Standard_E4as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEASv5Family
+      generic_name: standard_e4as_v5
+      id: Standard_E4as_v5
+      memory: 34359738368
+      name: Standard_E4as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEav6Family
+      generic_name: standard_e4as_v6
+      id: Standard_E4as_v6
+      memory: 34359738368
+      name: Standard_E4as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardEasv7Family
+      generic_name: standard_e4as_v7
+      id: Standard_E4as_v7
+      memory: 34359738368
+      name: Standard_E4as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEAv4Family
+      generic_name: standard_e4a_v4
+      id: Standard_E4a_v4
+      memory: 34359738368
+      name: Standard_E4a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEBDSv5Family
+      generic_name: standard_e4bds_v5
+      id: Standard_E4bds_v5
+      memory: 34359738368
+      name: Standard_E4bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEBSv5Family
+      generic_name: standard_e4bs_v5
+      id: Standard_E4bs_v5
+      memory: 34359738368
+      name: Standard_E4bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEDSv4Family
+      generic_name: standard_e4ds_v4
+      id: Standard_E4ds_v4
+      memory: 34359738368
+      name: Standard_E4ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEDSv5Family
+      generic_name: standard_e4ds_v5
+      id: Standard_E4ds_v5
+      memory: 34359738368
+      name: Standard_E4ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardEdsv6Family
+      generic_name: standard_e4ds_v6
+      id: Standard_E4ds_v6
+      memory: 34359738368
+      name: Standard_E4ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEDv4Family
+      generic_name: standard_e4d_v4
+      id: Standard_E4d_v4
+      memory: 34359738368
+      name: Standard_E4d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEDv5Family
+      generic_name: standard_e4d_v5
+      id: Standard_E4d_v5
+      memory: 34359738368
+      name: Standard_E4d_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEPDSv5Family
+      generic_name: standard_e4pds_v5
+      id: Standard_E4pds_v5
+      memory: 34359738368
+      name: Standard_E4pds_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardEpdsv6Family
+      generic_name: standard_e4pds_v6
+      id: Standard_E4pds_v6
+      memory: 34359738368
+      name: Standard_E4pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEPSv5Family
+      generic_name: standard_e4ps_v5
+      id: Standard_E4ps_v5
+      memory: 34359738368
+      name: Standard_E4ps_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardEpsv6Family
+      generic_name: standard_e4ps_v6
+      id: Standard_E4ps_v6
+      memory: 34359738368
+      name: Standard_E4ps_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardESv3Family
+      generic_name: standard_e4s_v3
+      id: Standard_E4s_v3
+      memory: 34359738368
+      name: Standard_E4s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardESv4Family
+      generic_name: standard_e4s_v4
+      id: Standard_E4s_v4
+      memory: 34359738368
+      name: Standard_E4s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardESv5Family
+      generic_name: standard_e4s_v5
+      id: Standard_E4s_v5
+      memory: 34359738368
+      name: Standard_E4s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardEsv6Family
+      generic_name: standard_e4s_v6
+      id: Standard_E4s_v6
+      memory: 34359738368
+      name: Standard_E4s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEv3Family
+      generic_name: standard_e4_v3
+      id: Standard_E4_v3
+      memory: 34359738368
+      name: Standard_E4_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEv4Family
+      generic_name: standard_e4_v4
+      id: Standard_E4_v4
+      memory: 34359738368
+      name: Standard_E4_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEv5Family
+      generic_name: standard_e4_v5
+      id: Standard_E4_v5
+      memory: 34359738368
+      name: Standard_E4_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEADSv5Family
+      generic_name: standard_e64-16ads_v5
+      id: Standard_E64-16ads_v5
+      memory: 549755813888
+      name: Standard_E64-16ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEadsv7Family
+      generic_name: standard_e64-16ads_v7
+      id: Standard_E64-16ads_v7
+      memory: 549755813888
+      name: Standard_E64-16ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEASv4Family
+      generic_name: standard_e64-16as_v4
+      id: Standard_E64-16as_v4
+      memory: 549755813888
+      name: Standard_E64-16as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEASv5Family
+      generic_name: standard_e64-16as_v5
+      id: Standard_E64-16as_v5
+      memory: 549755813888
+      name: Standard_E64-16as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEasv7Family
+      generic_name: standard_e64-16as_v7
+      id: Standard_E64-16as_v7
+      memory: 549755813888
+      name: Standard_E64-16as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEDSv4Family
+      generic_name: standard_e64-16ds_v4
+      id: Standard_E64-16ds_v4
+      memory: 541165879296
+      name: Standard_E64-16ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEDSv5Family
+      generic_name: standard_e64-16ds_v5
+      id: Standard_E64-16ds_v5
+      memory: 549755813888
+      name: Standard_E64-16ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEdsv6Family
+      generic_name: standard_e64-16ds_v6
+      id: Standard_E64-16ds_v6
+      memory: 549755813888
+      name: Standard_E64-16ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardESv3Family
+      generic_name: standard_e64-16s_v3
+      id: Standard_E64-16s_v3
+      memory: 463856467968
+      name: Standard_E64-16s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardESv4Family
+      generic_name: standard_e64-16s_v4
+      id: Standard_E64-16s_v4
+      memory: 541165879296
+      name: Standard_E64-16s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardESv5Family
+      generic_name: standard_e64-16s_v5
+      id: Standard_E64-16s_v5
+      memory: 549755813888
+      name: Standard_E64-16s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEsv6Family
+      generic_name: standard_e64-16s_v6
+      id: Standard_E64-16s_v6
+      memory: 549755813888
+      name: Standard_E64-16s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEADSv5Family
+      generic_name: standard_e64-32ads_v5
+      id: Standard_E64-32ads_v5
+      memory: 549755813888
+      name: Standard_E64-32ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEadsv7Family
+      generic_name: standard_e64-32ads_v7
+      id: Standard_E64-32ads_v7
+      memory: 549755813888
+      name: Standard_E64-32ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEASv4Family
+      generic_name: standard_e64-32as_v4
+      id: Standard_E64-32as_v4
+      memory: 549755813888
+      name: Standard_E64-32as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEASv5Family
+      generic_name: standard_e64-32as_v5
+      id: Standard_E64-32as_v5
+      memory: 549755813888
+      name: Standard_E64-32as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEasv7Family
+      generic_name: standard_e64-32as_v7
+      id: Standard_E64-32as_v7
+      memory: 549755813888
+      name: Standard_E64-32as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEDSv4Family
+      generic_name: standard_e64-32ds_v4
+      id: Standard_E64-32ds_v4
+      memory: 541165879296
+      name: Standard_E64-32ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEDSv5Family
+      generic_name: standard_e64-32ds_v5
+      id: Standard_E64-32ds_v5
+      memory: 549755813888
+      name: Standard_E64-32ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEdsv6Family
+      generic_name: standard_e64-32ds_v6
+      id: Standard_E64-32ds_v6
+      memory: 549755813888
+      name: Standard_E64-32ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardESv3Family
+      generic_name: standard_e64-32s_v3
+      id: Standard_E64-32s_v3
+      memory: 463856467968
+      name: Standard_E64-32s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardESv4Family
+      generic_name: standard_e64-32s_v4
+      id: Standard_E64-32s_v4
+      memory: 541165879296
+      name: Standard_E64-32s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardESv5Family
+      generic_name: standard_e64-32s_v5
+      id: Standard_E64-32s_v5
+      memory: 549755813888
+      name: Standard_E64-32s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEsv6Family
+      generic_name: standard_e64-32s_v6
+      id: Standard_E64-32s_v6
+      memory: 549755813888
+      name: Standard_E64-32s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEADSv5Family
+      generic_name: standard_e64ads_v5
+      id: Standard_E64ads_v5
+      memory: 549755813888
+      name: Standard_E64ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEadv6Family
+      generic_name: standard_e64ads_v6
+      id: Standard_E64ads_v6
+      memory: 549755813888
+      name: Standard_E64ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEadsv7Family
+      generic_name: standard_e64ads_v7
+      id: Standard_E64ads_v7
+      memory: 549755813888
+      name: Standard_E64ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEASv4Family
+      generic_name: standard_e64as_v4
+      id: Standard_E64as_v4
+      memory: 549755813888
+      name: Standard_E64as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEASv5Family
+      generic_name: standard_e64as_v5
+      id: Standard_E64as_v5
+      memory: 549755813888
+      name: Standard_E64as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEav6Family
+      generic_name: standard_e64as_v6
+      id: Standard_E64as_v6
+      memory: 549755813888
+      name: Standard_E64as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEasv7Family
+      generic_name: standard_e64as_v7
+      id: Standard_E64as_v7
+      memory: 549755813888
+      name: Standard_E64as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEAv4Family
+      generic_name: standard_e64a_v4
+      id: Standard_E64a_v4
+      memory: 549755813888
+      name: Standard_E64a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEBDSv5Family
+      generic_name: standard_e64bds_v5
+      id: Standard_E64bds_v5
+      memory: 549755813888
+      name: Standard_E64bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEBSv5Family
+      generic_name: standard_e64bs_v5
+      id: Standard_E64bs_v5
+      memory: 549755813888
+      name: Standard_E64bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEDSv4Family
+      generic_name: standard_e64ds_v4
+      id: Standard_E64ds_v4
+      memory: 541165879296
+      name: Standard_E64ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEDSv5Family
+      generic_name: standard_e64ds_v5
+      id: Standard_E64ds_v5
+      memory: 549755813888
+      name: Standard_E64ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEdsv6Family
+      generic_name: standard_e64ds_v6
+      id: Standard_E64ds_v6
+      memory: 549755813888
+      name: Standard_E64ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEDv4Family
+      generic_name: standard_e64d_v4
+      id: Standard_E64d_v4
+      memory: 541165879296
+      name: Standard_E64d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEDv5Family
+      generic_name: standard_e64d_v5
+      id: Standard_E64d_v5
+      memory: 549755813888
+      name: Standard_E64d_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEpdsv6Family
+      generic_name: standard_e64pds_v6
+      id: Standard_E64pds_v6
+      memory: 549755813888
+      name: Standard_E64pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEpsv6Family
+      generic_name: standard_e64ps_v6
+      id: Standard_E64ps_v6
+      memory: 549755813888
+      name: Standard_E64ps_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardESv3Family
+      generic_name: standard_e64s_v3
+      id: Standard_E64s_v3
+      memory: 463856467968
+      name: Standard_E64s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardESv4Family
+      generic_name: standard_e64s_v4
+      id: Standard_E64s_v4
+      memory: 541165879296
+      name: Standard_E64s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardESv5Family
+      generic_name: standard_e64s_v5
+      id: Standard_E64s_v5
+      memory: 549755813888
+      name: Standard_E64s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEsv6Family
+      generic_name: standard_e64s_v6
+      id: Standard_E64s_v6
+      memory: 549755813888
+      name: Standard_E64s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEv3Family
+      generic_name: standard_e64_v3
+      id: Standard_E64_v3
+      memory: 463856467968
+      name: Standard_E64_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEv4Family
+      generic_name: standard_e64_v4
+      id: Standard_E64_v4
+      memory: 541165879296
+      name: Standard_E64_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEv5Family
+      generic_name: standard_e64_v5
+      id: Standard_E64_v5
+      memory: 549755813888
+      name: Standard_E64_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEADSv5Family
+      generic_name: standard_e8-2ads_v5
+      id: Standard_E8-2ads_v5
+      memory: 68719476736
+      name: Standard_E8-2ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEadsv7Family
+      generic_name: standard_e8-2ads_v7
+      id: Standard_E8-2ads_v7
+      memory: 68719476736
+      name: Standard_E8-2ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEASv4Family
+      generic_name: standard_e8-2as_v4
+      id: Standard_E8-2as_v4
+      memory: 68719476736
+      name: Standard_E8-2as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEASv5Family
+      generic_name: standard_e8-2as_v5
+      id: Standard_E8-2as_v5
+      memory: 68719476736
+      name: Standard_E8-2as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEasv7Family
+      generic_name: standard_e8-2as_v7
+      id: Standard_E8-2as_v7
+      memory: 68719476736
+      name: Standard_E8-2as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEDSv4Family
+      generic_name: standard_e8-2ds_v4
+      id: Standard_E8-2ds_v4
+      memory: 68719476736
+      name: Standard_E8-2ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEDSv5Family
+      generic_name: standard_e8-2ds_v5
+      id: Standard_E8-2ds_v5
+      memory: 68719476736
+      name: Standard_E8-2ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEdsv6Family
+      generic_name: standard_e8-2ds_v6
+      id: Standard_E8-2ds_v6
+      memory: 68719476736
+      name: Standard_E8-2ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardESv3Family
+      generic_name: standard_e8-2s_v3
+      id: Standard_E8-2s_v3
+      memory: 68719476736
+      name: Standard_E8-2s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardESv4Family
+      generic_name: standard_e8-2s_v4
+      id: Standard_E8-2s_v4
+      memory: 68719476736
+      name: Standard_E8-2s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardESv5Family
+      generic_name: standard_e8-2s_v5
+      id: Standard_E8-2s_v5
+      memory: 68719476736
+      name: Standard_E8-2s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEsv6Family
+      generic_name: standard_e8-2s_v6
+      id: Standard_E8-2s_v6
+      memory: 68719476736
+      name: Standard_E8-2s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEADSv5Family
+      generic_name: standard_e8-4ads_v5
+      id: Standard_E8-4ads_v5
+      memory: 68719476736
+      name: Standard_E8-4ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEadsv7Family
+      generic_name: standard_e8-4ads_v7
+      id: Standard_E8-4ads_v7
+      memory: 68719476736
+      name: Standard_E8-4ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEASv4Family
+      generic_name: standard_e8-4as_v4
+      id: Standard_E8-4as_v4
+      memory: 68719476736
+      name: Standard_E8-4as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEASv5Family
+      generic_name: standard_e8-4as_v5
+      id: Standard_E8-4as_v5
+      memory: 68719476736
+      name: Standard_E8-4as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEasv7Family
+      generic_name: standard_e8-4as_v7
+      id: Standard_E8-4as_v7
+      memory: 68719476736
+      name: Standard_E8-4as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEDSv4Family
+      generic_name: standard_e8-4ds_v4
+      id: Standard_E8-4ds_v4
+      memory: 68719476736
+      name: Standard_E8-4ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEDSv5Family
+      generic_name: standard_e8-4ds_v5
+      id: Standard_E8-4ds_v5
+      memory: 68719476736
+      name: Standard_E8-4ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEdsv6Family
+      generic_name: standard_e8-4ds_v6
+      id: Standard_E8-4ds_v6
+      memory: 68719476736
+      name: Standard_E8-4ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardESv3Family
+      generic_name: standard_e8-4s_v3
+      id: Standard_E8-4s_v3
+      memory: 68719476736
+      name: Standard_E8-4s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardESv4Family
+      generic_name: standard_e8-4s_v4
+      id: Standard_E8-4s_v4
+      memory: 68719476736
+      name: Standard_E8-4s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardESv5Family
+      generic_name: standard_e8-4s_v5
+      id: Standard_E8-4s_v5
+      memory: 68719476736
+      name: Standard_E8-4s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEsv6Family
+      generic_name: standard_e8-4s_v6
+      id: Standard_E8-4s_v6
+      memory: 68719476736
+      name: Standard_E8-4s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: standardXEIDSv4Family
+      generic_name: standard_e80ids_v4
+      id: Standard_E80ids_v4
+      memory: 541165879296
+      name: Standard_E80ids_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: standardXEISv4Family
+      generic_name: standard_e80is_v4
+      id: Standard_E80is_v4
+      memory: 541165879296
+      name: Standard_E80is_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEADSv5Family
+      generic_name: standard_e8ads_v5
+      id: Standard_E8ads_v5
+      memory: 68719476736
+      name: Standard_E8ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEadv6Family
+      generic_name: standard_e8ads_v6
+      id: Standard_E8ads_v6
+      memory: 68719476736
+      name: Standard_E8ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEadsv7Family
+      generic_name: standard_e8ads_v7
+      id: Standard_E8ads_v7
+      memory: 68719476736
+      name: Standard_E8ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEASv4Family
+      generic_name: standard_e8as_v4
+      id: Standard_E8as_v4
+      memory: 68719476736
+      name: Standard_E8as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEASv5Family
+      generic_name: standard_e8as_v5
+      id: Standard_E8as_v5
+      memory: 68719476736
+      name: Standard_E8as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEav6Family
+      generic_name: standard_e8as_v6
+      id: Standard_E8as_v6
+      memory: 68719476736
+      name: Standard_E8as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEasv7Family
+      generic_name: standard_e8as_v7
+      id: Standard_E8as_v7
+      memory: 68719476736
+      name: Standard_E8as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEAv4Family
+      generic_name: standard_e8a_v4
+      id: Standard_E8a_v4
+      memory: 68719476736
+      name: Standard_E8a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEBDSv5Family
+      generic_name: standard_e8bds_v5
+      id: Standard_E8bds_v5
+      memory: 68719476736
+      name: Standard_E8bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEBSv5Family
+      generic_name: standard_e8bs_v5
+      id: Standard_E8bs_v5
+      memory: 68719476736
+      name: Standard_E8bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEDSv4Family
+      generic_name: standard_e8ds_v4
+      id: Standard_E8ds_v4
+      memory: 68719476736
+      name: Standard_E8ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEDSv5Family
+      generic_name: standard_e8ds_v5
+      id: Standard_E8ds_v5
+      memory: 68719476736
+      name: Standard_E8ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEdsv6Family
+      generic_name: standard_e8ds_v6
+      id: Standard_E8ds_v6
+      memory: 68719476736
+      name: Standard_E8ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEDv4Family
+      generic_name: standard_e8d_v4
+      id: Standard_E8d_v4
+      memory: 68719476736
+      name: Standard_E8d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEDv5Family
+      generic_name: standard_e8d_v5
+      id: Standard_E8d_v5
+      memory: 68719476736
+      name: Standard_E8d_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEPDSv5Family
+      generic_name: standard_e8pds_v5
+      id: Standard_E8pds_v5
+      memory: 68719476736
+      name: Standard_E8pds_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEpdsv6Family
+      generic_name: standard_e8pds_v6
+      id: Standard_E8pds_v6
+      memory: 68719476736
+      name: Standard_E8pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEPSv5Family
+      generic_name: standard_e8ps_v5
+      id: Standard_E8ps_v5
+      memory: 68719476736
+      name: Standard_E8ps_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEpsv6Family
+      generic_name: standard_e8ps_v6
+      id: Standard_E8ps_v6
+      memory: 68719476736
+      name: Standard_E8ps_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardESv3Family
+      generic_name: standard_e8s_v3
+      id: Standard_E8s_v3
+      memory: 68719476736
+      name: Standard_E8s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardESv4Family
+      generic_name: standard_e8s_v4
+      id: Standard_E8s_v4
+      memory: 68719476736
+      name: Standard_E8s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardESv5Family
+      generic_name: standard_e8s_v5
+      id: Standard_E8s_v5
+      memory: 68719476736
+      name: Standard_E8s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEsv6Family
+      generic_name: standard_e8s_v6
+      id: Standard_E8s_v6
+      memory: 68719476736
+      name: Standard_E8s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEv3Family
+      generic_name: standard_e8_v3
+      id: Standard_E8_v3
+      memory: 68719476736
+      name: Standard_E8_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEv4Family
+      generic_name: standard_e8_v4
+      id: Standard_E8_v4
+      memory: 68719476736
+      name: Standard_E8_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEv5Family
+      generic_name: standard_e8_v5
+      id: Standard_E8_v5
+      memory: 68719476736
+      name: Standard_E8_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEADSv5Family
+      generic_name: standard_e96-24ads_v5
+      id: Standard_E96-24ads_v5
+      memory: 721554505728
+      name: Standard_E96-24ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEadv6Family
+      generic_name: standard_e96-24ads_v6
+      id: Standard_E96-24ads_v6
+      memory: 721554505728
+      name: Standard_E96-24ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEadsv7Family
+      generic_name: standard_e96-24ads_v7
+      id: Standard_E96-24ads_v7
+      memory: 824633720832
+      name: Standard_E96-24ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEASv4Family
+      generic_name: standard_e96-24as_v4
+      id: Standard_E96-24as_v4
+      memory: 721554505728
+      name: Standard_E96-24as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEASv5Family
+      generic_name: standard_e96-24as_v5
+      id: Standard_E96-24as_v5
+      memory: 721554505728
+      name: Standard_E96-24as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEasv7Family
+      generic_name: standard_e96-24as_v7
+      id: Standard_E96-24as_v7
+      memory: 824633720832
+      name: Standard_E96-24as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEDSv5Family
+      generic_name: standard_e96-24ds_v5
+      id: Standard_E96-24ds_v5
+      memory: 721554505728
+      name: Standard_E96-24ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEdsv6Family
+      generic_name: standard_e96-24ds_v6
+      id: Standard_E96-24ds_v6
+      memory: 824633720832
+      name: Standard_E96-24ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardESv5Family
+      generic_name: standard_e96-24s_v5
+      id: Standard_E96-24s_v5
+      memory: 721554505728
+      name: Standard_E96-24s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEsv6Family
+      generic_name: standard_e96-24s_v6
+      id: Standard_E96-24s_v6
+      memory: 824633720832
+      name: Standard_E96-24s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEADSv5Family
+      generic_name: standard_e96-48ads_v5
+      id: Standard_E96-48ads_v5
+      memory: 721554505728
+      name: Standard_E96-48ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEadv6Family
+      generic_name: standard_e96-48ads_v6
+      id: Standard_E96-48ads_v6
+      memory: 721554505728
+      name: Standard_E96-48ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEadsv7Family
+      generic_name: standard_e96-48ads_v7
+      id: Standard_E96-48ads_v7
+      memory: 824633720832
+      name: Standard_E96-48ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEASv4Family
+      generic_name: standard_e96-48as_v4
+      id: Standard_E96-48as_v4
+      memory: 721554505728
+      name: Standard_E96-48as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEASv5Family
+      generic_name: standard_e96-48as_v5
+      id: Standard_E96-48as_v5
+      memory: 721554505728
+      name: Standard_E96-48as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEasv7Family
+      generic_name: standard_e96-48as_v7
+      id: Standard_E96-48as_v7
+      memory: 824633720832
+      name: Standard_E96-48as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEDSv5Family
+      generic_name: standard_e96-48ds_v5
+      id: Standard_E96-48ds_v5
+      memory: 721554505728
+      name: Standard_E96-48ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEdsv6Family
+      generic_name: standard_e96-48ds_v6
+      id: Standard_E96-48ds_v6
+      memory: 824633720832
+      name: Standard_E96-48ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardESv5Family
+      generic_name: standard_e96-48s_v5
+      id: Standard_E96-48s_v5
+      memory: 721554505728
+      name: Standard_E96-48s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEsv6Family
+      generic_name: standard_e96-48s_v6
+      id: Standard_E96-48s_v6
+      memory: 824633720832
+      name: Standard_E96-48s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEADSv5Family
+      generic_name: standard_e96ads_v5
+      id: Standard_E96ads_v5
+      memory: 721554505728
+      name: Standard_E96ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEadv6Family
+      generic_name: standard_e96ads_v6
+      id: Standard_E96ads_v6
+      memory: 721554505728
+      name: Standard_E96ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEadsv7Family
+      generic_name: standard_e96ads_v7
+      id: Standard_E96ads_v7
+      memory: 824633720832
+      name: Standard_E96ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEASv4Family
+      generic_name: standard_e96as_v4
+      id: Standard_E96as_v4
+      memory: 721554505728
+      name: Standard_E96as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEASv5Family
+      generic_name: standard_e96as_v5
+      id: Standard_E96as_v5
+      memory: 721554505728
+      name: Standard_E96as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEav6Family
+      generic_name: standard_e96as_v6
+      id: Standard_E96as_v6
+      memory: 721554505728
+      name: Standard_E96as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEasv7Family
+      generic_name: standard_e96as_v7
+      id: Standard_E96as_v7
+      memory: 824633720832
+      name: Standard_E96as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEAv4Family
+      generic_name: standard_e96a_v4
+      id: Standard_E96a_v4
+      memory: 721554505728
+      name: Standard_E96a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEBDSv5Family
+      generic_name: standard_e96bds_v5
+      id: Standard_E96bds_v5
+      memory: 721554505728
+      name: Standard_E96bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEBSv5Family
+      generic_name: standard_e96bs_v5
+      id: Standard_E96bs_v5
+      memory: 721554505728
+      name: Standard_E96bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEDSv5Family
+      generic_name: standard_e96ds_v5
+      id: Standard_E96ds_v5
+      memory: 721554505728
+      name: Standard_E96ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEdsv6Family
+      generic_name: standard_e96ds_v6
+      id: Standard_E96ds_v6
+      memory: 824633720832
+      name: Standard_E96ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEDv5Family
+      generic_name: standard_e96d_v5
+      id: Standard_E96d_v5
+      memory: 721554505728
+      name: Standard_E96d_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEIASv4Family
+      generic_name: standard_e96ias_v4
+      id: Standard_E96ias_v4
+      memory: 721554505728
+      name: Standard_E96ias_v4
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEpdsv6Family
+      generic_name: standard_e96pds_v6
+      id: Standard_E96pds_v6
+      memory: 721554505728
+      name: Standard_E96pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEpsv6Family
+      generic_name: standard_e96ps_v6
+      id: Standard_E96ps_v6
+      memory: 721554505728
+      name: Standard_E96ps_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardESv5Family
+      generic_name: standard_e96s_v5
+      id: Standard_E96s_v5
+      memory: 721554505728
+      name: Standard_E96s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEsv6Family
+      generic_name: standard_e96s_v6
+      id: Standard_E96s_v6
+      memory: 824633720832
+      name: Standard_E96s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEv5Family
+      generic_name: standard_e96_v5
+      id: Standard_E96_v5
+      memory: 721554505728
+      name: Standard_E96_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardECADCCV5Family
+      generic_name: standard_ec16ads_cc_v5
+      id: Standard_EC16ads_cc_v5
+      memory: 137438953472
+      name: Standard_EC16ads_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardECADSv5Family
+      generic_name: standard_ec16ads_v5
+      id: Standard_EC16ads_v5
+      memory: 137438953472
+      name: Standard_EC16ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardECadsv6Family
+      generic_name: standard_ec16ads_v6
+      id: Standard_EC16ads_v6
+      memory: 137438953472
+      name: Standard_EC16ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardECACCV5Family
+      generic_name: standard_ec16as_cc_v5
+      id: Standard_EC16as_cc_v5
+      memory: 137438953472
+      name: Standard_EC16as_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardECASv5Family
+      generic_name: standard_ec16as_v5
+      id: Standard_EC16as_v5
+      memory: 137438953472
+      name: Standard_EC16as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardECasv6Family
+      generic_name: standard_ec16as_v6
+      id: Standard_EC16as_v6
+      memory: 137438953472
+      name: Standard_EC16as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardECEDV6Family
+      generic_name: standard_ec16eds_v6
+      id: Standard_EC16eds_v6
+      memory: 137438953472
+      name: Standard_EC16eds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardECEV6Family
       generic_name: standard_ec16es_v6
       id: Standard_EC16es_v6
       memory: 137438953472
       name: Standard_EC16es_v6
     - category: memory_optimized
       cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardECADCCV5Family
+      generic_name: standard_ec20ads_cc_v5
+      id: Standard_EC20ads_cc_v5
+      memory: 171798691840
+      name: Standard_EC20ads_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardECADSv5Family
+      generic_name: standard_ec20ads_v5
+      id: Standard_EC20ads_v5
+      memory: 171798691840
+      name: Standard_EC20ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardECACCV5Family
+      generic_name: standard_ec20as_cc_v5
+      id: Standard_EC20as_cc_v5
+      memory: 171798691840
+      name: Standard_EC20as_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardECASv5Family
+      generic_name: standard_ec20as_v5
+      id: Standard_EC20as_v5
+      memory: 171798691840
+      name: Standard_EC20as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardECADSv5Family
+      generic_name: standard_ec2ads_v5
+      id: Standard_EC2ads_v5
+      memory: 17179869184
+      name: Standard_EC2ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardECadsv6Family
+      generic_name: standard_ec2ads_v6
+      id: Standard_EC2ads_v6
+      memory: 17179869184
+      name: Standard_EC2ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardECASv5Family
+      generic_name: standard_ec2as_v5
+      id: Standard_EC2as_v5
+      memory: 17179869184
+      name: Standard_EC2as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardECasv6Family
+      generic_name: standard_ec2as_v6
+      id: Standard_EC2as_v6
+      memory: 17179869184
+      name: Standard_EC2as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardECEDV6Family
+      generic_name: standard_ec2eds_v6
+      id: Standard_EC2eds_v6
+      memory: 17179869184
+      name: Standard_EC2eds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardECEV6Family
+      generic_name: standard_ec2es_v6
+      id: Standard_EC2es_v6
+      memory: 17179869184
+      name: Standard_EC2es_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
       cpu_cores: 32
+      family: standardECADCCV5Family
+      generic_name: standard_ec32ads_cc_v5
+      id: Standard_EC32ads_cc_v5
+      memory: 206158430208
+      name: Standard_EC32ads_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardECADSv5Family
+      generic_name: standard_ec32ads_v5
+      id: Standard_EC32ads_v5
+      memory: 206158430208
+      name: Standard_EC32ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardECadsv6Family
+      generic_name: standard_ec32ads_v6
+      id: Standard_EC32ads_v6
+      memory: 274877906944
+      name: Standard_EC32ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardECACCV5Family
+      generic_name: standard_ec32as_cc_v5
+      id: Standard_EC32as_cc_v5
+      memory: 206158430208
+      name: Standard_EC32as_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardECASv5Family
+      generic_name: standard_ec32as_v5
+      id: Standard_EC32as_v5
+      memory: 206158430208
+      name: Standard_EC32as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardECasv6Family
+      generic_name: standard_ec32as_v6
+      id: Standard_EC32as_v6
+      memory: 274877906944
+      name: Standard_EC32as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardECEDV6Family
+      generic_name: standard_ec32eds_v6
+      id: Standard_EC32eds_v6
+      memory: 274877906944
+      name: Standard_EC32eds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardECEV6Family
       generic_name: standard_ec32es_v6
       id: Standard_EC32es_v6
       memory: 274877906944
@@ -7709,66 +7082,2147 @@ data:
     - category: memory_optimized
       cloud_provider_id: azure
       cpu_cores: 48
-      generic_name: standard_ec48es_v6
-      id: Standard_EC48es_v6
+      family: standardECADCCV5Family
+      generic_name: standard_ec48ads_cc_v5
+      id: Standard_EC48ads_cc_v5
       memory: 412316860416
-      name: Standard_EC48es_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_ec64es_v6
-      id: Standard_EC64es_v6
-      memory: 549755813888
-      name: Standard_EC64es_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_ec2eds_v6
-      id: Standard_EC2eds_v6
-      memory: 17179869184
-      name: Standard_EC2eds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_ec4eds_v6
-      id: Standard_EC4eds_v6
-      memory: 34359738368
-      name: Standard_EC4eds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_ec8eds_v6
-      id: Standard_EC8eds_v6
-      memory: 68719476736
-      name: Standard_EC8eds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_ec16eds_v6
-      id: Standard_EC16eds_v6
-      memory: 137438953472
-      name: Standard_EC16eds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_ec32eds_v6
-      id: Standard_EC32eds_v6
-      memory: 274877906944
-      name: Standard_EC32eds_v6
+      name: Standard_EC48ads_cc_v5
     - category: memory_optimized
       cloud_provider_id: azure
       cpu_cores: 48
+      family: standardECADSv5Family
+      generic_name: standard_ec48ads_v5
+      id: Standard_EC48ads_v5
+      memory: 412316860416
+      name: Standard_EC48ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardECadsv6Family
+      generic_name: standard_ec48ads_v6
+      id: Standard_EC48ads_v6
+      memory: 412316860416
+      name: Standard_EC48ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardECACCV5Family
+      generic_name: standard_ec48as_cc_v5
+      id: Standard_EC48as_cc_v5
+      memory: 412316860416
+      name: Standard_EC48as_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardECASv5Family
+      generic_name: standard_ec48as_v5
+      id: Standard_EC48as_v5
+      memory: 412316860416
+      name: Standard_EC48as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardECasv6Family
+      generic_name: standard_ec48as_v6
+      id: Standard_EC48as_v6
+      memory: 412316860416
+      name: Standard_EC48as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardECEDV6Family
       generic_name: standard_ec48eds_v6
       id: Standard_EC48eds_v6
       memory: 412316860416
       name: Standard_EC48eds_v6
     - category: memory_optimized
       cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardECEV6Family
+      generic_name: standard_ec48es_v6
+      id: Standard_EC48es_v6
+      memory: 412316860416
+      name: Standard_EC48es_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardECADCCV5Family
+      generic_name: standard_ec4ads_cc_v5
+      id: Standard_EC4ads_cc_v5
+      memory: 34359738368
+      name: Standard_EC4ads_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardECADSv5Family
+      generic_name: standard_ec4ads_v5
+      id: Standard_EC4ads_v5
+      memory: 34359738368
+      name: Standard_EC4ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardECadsv6Family
+      generic_name: standard_ec4ads_v6
+      id: Standard_EC4ads_v6
+      memory: 34359738368
+      name: Standard_EC4ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardECACCV5Family
+      generic_name: standard_ec4as_cc_v5
+      id: Standard_EC4as_cc_v5
+      memory: 34359738368
+      name: Standard_EC4as_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardECASv5Family
+      generic_name: standard_ec4as_v5
+      id: Standard_EC4as_v5
+      memory: 34359738368
+      name: Standard_EC4as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardECasv6Family
+      generic_name: standard_ec4as_v6
+      id: Standard_EC4as_v6
+      memory: 34359738368
+      name: Standard_EC4as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardECEDV6Family
+      generic_name: standard_ec4eds_v6
+      id: Standard_EC4eds_v6
+      memory: 34359738368
+      name: Standard_EC4eds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardECEV6Family
+      generic_name: standard_ec4es_v6
+      id: Standard_EC4es_v6
+      memory: 34359738368
+      name: Standard_EC4es_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
       cpu_cores: 64
+      family: standardECADCCV5Family
+      generic_name: standard_ec64ads_cc_v5
+      id: Standard_EC64ads_cc_v5
+      memory: 549755813888
+      name: Standard_EC64ads_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardECADSv5Family
+      generic_name: standard_ec64ads_v5
+      id: Standard_EC64ads_v5
+      memory: 549755813888
+      name: Standard_EC64ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardECadsv6Family
+      generic_name: standard_ec64ads_v6
+      id: Standard_EC64ads_v6
+      memory: 549755813888
+      name: Standard_EC64ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardECACCV5Family
+      generic_name: standard_ec64as_cc_v5
+      id: Standard_EC64as_cc_v5
+      memory: 549755813888
+      name: Standard_EC64as_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardECASv5Family
+      generic_name: standard_ec64as_v5
+      id: Standard_EC64as_v5
+      memory: 549755813888
+      name: Standard_EC64as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardECasv6Family
+      generic_name: standard_ec64as_v6
+      id: Standard_EC64as_v6
+      memory: 549755813888
+      name: Standard_EC64as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardECEDV6Family
       generic_name: standard_ec64eds_v6
       id: Standard_EC64eds_v6
       memory: 549755813888
       name: Standard_EC64eds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardECEV6Family
+      generic_name: standard_ec64es_v6
+      id: Standard_EC64es_v6
+      memory: 549755813888
+      name: Standard_EC64es_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardECADCCV5Family
+      generic_name: standard_ec8ads_cc_v5
+      id: Standard_EC8ads_cc_v5
+      memory: 68719476736
+      name: Standard_EC8ads_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardECADSv5Family
+      generic_name: standard_ec8ads_v5
+      id: Standard_EC8ads_v5
+      memory: 68719476736
+      name: Standard_EC8ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardECadsv6Family
+      generic_name: standard_ec8ads_v6
+      id: Standard_EC8ads_v6
+      memory: 68719476736
+      name: Standard_EC8ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardECACCV5Family
+      generic_name: standard_ec8as_cc_v5
+      id: Standard_EC8as_cc_v5
+      memory: 68719476736
+      name: Standard_EC8as_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardECASv5Family
+      generic_name: standard_ec8as_v5
+      id: Standard_EC8as_v5
+      memory: 68719476736
+      name: Standard_EC8as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardECasv6Family
+      generic_name: standard_ec8as_v6
+      id: Standard_EC8as_v6
+      memory: 68719476736
+      name: Standard_EC8as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardECEDV6Family
+      generic_name: standard_ec8eds_v6
+      id: Standard_EC8eds_v6
+      memory: 68719476736
+      name: Standard_EC8eds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardECEV6Family
+      generic_name: standard_ec8es_v6
+      id: Standard_EC8es_v6
+      memory: 68719476736
+      name: Standard_EC8es_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardECADCCV5Family
+      generic_name: standard_ec96ads_cc_v5
+      id: Standard_EC96ads_cc_v5
+      memory: 721554505728
+      name: Standard_EC96ads_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardECADSv5Family
+      generic_name: standard_ec96ads_v5
+      id: Standard_EC96ads_v5
+      memory: 721554505728
+      name: Standard_EC96ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardECadsv6Family
+      generic_name: standard_ec96ads_v6
+      id: Standard_EC96ads_v6
+      memory: 721554505728
+      name: Standard_EC96ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardECACCV5Family
+      generic_name: standard_ec96as_cc_v5
+      id: Standard_EC96as_cc_v5
+      memory: 721554505728
+      name: Standard_EC96as_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardECASv5Family
+      generic_name: standard_ec96as_v5
+      id: Standard_EC96as_v5
+      memory: 721554505728
+      name: Standard_EC96as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardECasv6Family
+      generic_name: standard_ec96as_v6
+      id: Standard_EC96as_v6
+      memory: 721554505728
+      name: Standard_EC96as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardECIADSv5Family
+      generic_name: standard_ec96iads_v5
+      id: Standard_EC96iads_v5
+      memory: 721554505728
+      name: Standard_EC96iads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardECIASv5Family
+      generic_name: standard_ec96ias_v5
+      id: Standard_EC96ias_v5
+      memory: 721554505728
+      name: Standard_EC96ias_v5
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      family: standardFFamily
+      generic_name: standard_f1
+      id: Standard_F1
+      memory: 2147483648
+      name: Standard_F1
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardFFamily
+      generic_name: standard_f16
+      id: Standard_F16
+      memory: 34359738368
+      name: Standard_F16
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFamdsv7Family
+      generic_name: standard_f16-4amds_v7
+      id: Standard_F16-4amds_v7
+      memory: 137438953472
+      name: Standard_F16-4amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFamsv7Family
+      generic_name: standard_f16-4ams_v7
+      id: Standard_F16-4ams_v7
+      memory: 137438953472
+      name: Standard_F16-4ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFamdsv7Family
+      generic_name: standard_f16-8amds_v7
+      id: Standard_F16-8amds_v7
+      memory: 137438953472
+      name: Standard_F16-8amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFamsv7Family
+      generic_name: standard_f16-8ams_v7
+      id: Standard_F16-8ams_v7
+      memory: 137438953472
+      name: Standard_F16-8ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFadsv7Family
+      generic_name: standard_f16ads_v7
+      id: Standard_F16ads_v7
+      memory: 68719476736
+      name: Standard_F16ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFaldsv7Family
+      generic_name: standard_f16alds_v7
+      id: Standard_F16alds_v7
+      memory: 34359738368
+      name: Standard_F16alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFalsv6Family
+      generic_name: standard_f16als_v6
+      id: Standard_F16als_v6
+      memory: 34359738368
+      name: Standard_F16als_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFalsv7Family
+      generic_name: standard_f16als_v7
+      id: Standard_F16als_v7
+      memory: 34359738368
+      name: Standard_F16als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFamdsv7Family
+      generic_name: standard_f16amds_v7
+      id: Standard_F16amds_v7
+      memory: 137438953472
+      name: Standard_F16amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFamsv6Family
+      generic_name: standard_f16ams_v6
+      id: Standard_F16ams_v6
+      memory: 137438953472
+      name: Standard_F16ams_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFamsv7Family
+      generic_name: standard_f16ams_v7
+      id: Standard_F16ams_v7
+      memory: 137438953472
+      name: Standard_F16ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFasv6Family
+      generic_name: standard_f16as_v6
+      id: Standard_F16as_v6
+      memory: 68719476736
+      name: Standard_F16as_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFasv7Family
+      generic_name: standard_f16as_v7
+      id: Standard_F16as_v7
+      memory: 68719476736
+      name: Standard_F16as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardFSFamily
+      generic_name: standard_f16s
+      id: Standard_F16s
+      memory: 34359738368
+      name: Standard_F16s
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardFSv2Family
+      generic_name: standard_f16s_v2
+      id: Standard_F16s_v2
+      memory: 34359738368
+      name: Standard_F16s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      family: StandardFadsv7Family
+      generic_name: standard_f1ads_v7
+      id: Standard_F1ads_v7
+      memory: 4294967296
+      name: Standard_F1ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      family: StandardFaldsv7Family
+      generic_name: standard_f1alds_v7
+      id: Standard_F1alds_v7
+      memory: 2147483648
+      name: Standard_F1alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      family: StandardFalsv7Family
+      generic_name: standard_f1als_v7
+      id: Standard_F1als_v7
+      memory: 2147483648
+      name: Standard_F1als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      family: StandardFamdsv7Family
+      generic_name: standard_f1amds_v7
+      id: Standard_F1amds_v7
+      memory: 8589934592
+      name: Standard_F1amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      family: StandardFamsv7Family
+      generic_name: standard_f1ams_v7
+      id: Standard_F1ams_v7
+      memory: 8589934592
+      name: Standard_F1ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      family: StandardFasv7Family
+      generic_name: standard_f1as_v7
+      id: Standard_F1as_v7
+      memory: 4294967296
+      name: Standard_F1as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      family: standardFSFamily
+      generic_name: standard_f1s
+      id: Standard_F1s
+      memory: 2147483648
+      name: Standard_F1s
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardFFamily
+      generic_name: standard_f2
+      id: Standard_F2
+      memory: 4294967296
+      name: Standard_F2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFamdsv7Family
+      generic_name: standard_f2-1amds_v7
+      id: Standard_F2-1amds_v7
+      memory: 17179869184
+      name: Standard_F2-1amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFamsv7Family
+      generic_name: standard_f2-1ams_v7
+      id: Standard_F2-1ams_v7
+      memory: 17179869184
+      name: Standard_F2-1ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFadsv7Family
+      generic_name: standard_f2ads_v7
+      id: Standard_F2ads_v7
+      memory: 8589934592
+      name: Standard_F2ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFaldsv7Family
+      generic_name: standard_f2alds_v7
+      id: Standard_F2alds_v7
+      memory: 4294967296
+      name: Standard_F2alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFalsv6Family
+      generic_name: standard_f2als_v6
+      id: Standard_F2als_v6
+      memory: 4294967296
+      name: Standard_F2als_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFalsv7Family
+      generic_name: standard_f2als_v7
+      id: Standard_F2als_v7
+      memory: 4294967296
+      name: Standard_F2als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFamdsv7Family
+      generic_name: standard_f2amds_v7
+      id: Standard_F2amds_v7
+      memory: 17179869184
+      name: Standard_F2amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFamsv6Family
+      generic_name: standard_f2ams_v6
+      id: Standard_F2ams_v6
+      memory: 17179869184
+      name: Standard_F2ams_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFamsv7Family
+      generic_name: standard_f2ams_v7
+      id: Standard_F2ams_v7
+      memory: 17179869184
+      name: Standard_F2ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFasv6Family
+      generic_name: standard_f2as_v6
+      id: Standard_F2as_v6
+      memory: 8589934592
+      name: Standard_F2as_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFasv7Family
+      generic_name: standard_f2as_v7
+      id: Standard_F2as_v7
+      memory: 8589934592
+      name: Standard_F2as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardFSFamily
+      generic_name: standard_f2s
+      id: Standard_F2s
+      memory: 4294967296
+      name: Standard_F2s
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardFSv2Family
+      generic_name: standard_f2s_v2
+      id: Standard_F2s_v2
+      memory: 4294967296
+      name: Standard_F2s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFamdsv7Family
+      generic_name: standard_f32-16amds_v7
+      id: Standard_F32-16amds_v7
+      memory: 274877906944
+      name: Standard_F32-16amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFamsv7Family
+      generic_name: standard_f32-16ams_v7
+      id: Standard_F32-16ams_v7
+      memory: 274877906944
+      name: Standard_F32-16ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFamdsv7Family
+      generic_name: standard_f32-8amds_v7
+      id: Standard_F32-8amds_v7
+      memory: 274877906944
+      name: Standard_F32-8amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFamsv7Family
+      generic_name: standard_f32-8ams_v7
+      id: Standard_F32-8ams_v7
+      memory: 274877906944
+      name: Standard_F32-8ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFadsv7Family
+      generic_name: standard_f32ads_v7
+      id: Standard_F32ads_v7
+      memory: 137438953472
+      name: Standard_F32ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFaldsv7Family
+      generic_name: standard_f32alds_v7
+      id: Standard_F32alds_v7
+      memory: 68719476736
+      name: Standard_F32alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFalsv6Family
+      generic_name: standard_f32als_v6
+      id: Standard_F32als_v6
+      memory: 68719476736
+      name: Standard_F32als_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFalsv7Family
+      generic_name: standard_f32als_v7
+      id: Standard_F32als_v7
+      memory: 68719476736
+      name: Standard_F32als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFamdsv7Family
+      generic_name: standard_f32amds_v7
+      id: Standard_F32amds_v7
+      memory: 274877906944
+      name: Standard_F32amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFamsv6Family
+      generic_name: standard_f32ams_v6
+      id: Standard_F32ams_v6
+      memory: 274877906944
+      name: Standard_F32ams_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFamsv7Family
+      generic_name: standard_f32ams_v7
+      id: Standard_F32ams_v7
+      memory: 274877906944
+      name: Standard_F32ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFasv6Family
+      generic_name: standard_f32as_v6
+      id: Standard_F32as_v6
+      memory: 137438953472
+      name: Standard_F32as_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFasv7Family
+      generic_name: standard_f32as_v7
+      id: Standard_F32as_v7
+      memory: 137438953472
+      name: Standard_F32as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardFSv2Family
+      generic_name: standard_f32s_v2
+      id: Standard_F32s_v2
+      memory: 68719476736
+      name: Standard_F32s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardFFamily
+      generic_name: standard_f4
+      id: Standard_F4
+      memory: 8589934592
+      name: Standard_F4
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFamdsv7Family
+      generic_name: standard_f4-1amds_v7
+      id: Standard_F4-1amds_v7
+      memory: 34359738368
+      name: Standard_F4-1amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFamsv7Family
+      generic_name: standard_f4-1ams_v7
+      id: Standard_F4-1ams_v7
+      memory: 34359738368
+      name: Standard_F4-1ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFamdsv7Family
+      generic_name: standard_f4-2amds_v7
+      id: Standard_F4-2amds_v7
+      memory: 34359738368
+      name: Standard_F4-2amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFamsv7Family
+      generic_name: standard_f4-2ams_v7
+      id: Standard_F4-2ams_v7
+      memory: 34359738368
+      name: Standard_F4-2ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFadsv7Family
+      generic_name: standard_f48ads_v7
+      id: Standard_F48ads_v7
+      memory: 206158430208
+      name: Standard_F48ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFaldsv7Family
+      generic_name: standard_f48alds_v7
+      id: Standard_F48alds_v7
+      memory: 103079215104
+      name: Standard_F48alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFalsv6Family
+      generic_name: standard_f48als_v6
+      id: Standard_F48als_v6
+      memory: 103079215104
+      name: Standard_F48als_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFalsv7Family
+      generic_name: standard_f48als_v7
+      id: Standard_F48als_v7
+      memory: 103079215104
+      name: Standard_F48als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFamdsv7Family
+      generic_name: standard_f48amds_v7
+      id: Standard_F48amds_v7
+      memory: 412316860416
+      name: Standard_F48amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFamsv6Family
+      generic_name: standard_f48ams_v6
+      id: Standard_F48ams_v6
+      memory: 412316860416
+      name: Standard_F48ams_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFamsv7Family
+      generic_name: standard_f48ams_v7
+      id: Standard_F48ams_v7
+      memory: 412316860416
+      name: Standard_F48ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFasv6Family
+      generic_name: standard_f48as_v6
+      id: Standard_F48as_v6
+      memory: 206158430208
+      name: Standard_F48as_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFasv7Family
+      generic_name: standard_f48as_v7
+      id: Standard_F48as_v7
+      memory: 206158430208
+      name: Standard_F48as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardFSv2Family
+      generic_name: standard_f48s_v2
+      id: Standard_F48s_v2
+      memory: 103079215104
+      name: Standard_F48s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFadsv7Family
+      generic_name: standard_f4ads_v7
+      id: Standard_F4ads_v7
+      memory: 17179869184
+      name: Standard_F4ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFaldsv7Family
+      generic_name: standard_f4alds_v7
+      id: Standard_F4alds_v7
+      memory: 8589934592
+      name: Standard_F4alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFalsv6Family
+      generic_name: standard_f4als_v6
+      id: Standard_F4als_v6
+      memory: 8589934592
+      name: Standard_F4als_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFalsv7Family
+      generic_name: standard_f4als_v7
+      id: Standard_F4als_v7
+      memory: 8589934592
+      name: Standard_F4als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFamdsv7Family
+      generic_name: standard_f4amds_v7
+      id: Standard_F4amds_v7
+      memory: 34359738368
+      name: Standard_F4amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFamsv6Family
+      generic_name: standard_f4ams_v6
+      id: Standard_F4ams_v6
+      memory: 34359738368
+      name: Standard_F4ams_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFamsv7Family
+      generic_name: standard_f4ams_v7
+      id: Standard_F4ams_v7
+      memory: 34359738368
+      name: Standard_F4ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFasv6Family
+      generic_name: standard_f4as_v6
+      id: Standard_F4as_v6
+      memory: 17179869184
+      name: Standard_F4as_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFasv7Family
+      generic_name: standard_f4as_v7
+      id: Standard_F4as_v7
+      memory: 17179869184
+      name: Standard_F4as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardFSFamily
+      generic_name: standard_f4s
+      id: Standard_F4s
+      memory: 8589934592
+      name: Standard_F4s
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardFSv2Family
+      generic_name: standard_f4s_v2
+      id: Standard_F4s_v2
+      memory: 8589934592
+      name: Standard_F4s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFamdsv7Family
+      generic_name: standard_f64-16amds_v7
+      id: Standard_F64-16amds_v7
+      memory: 549755813888
+      name: Standard_F64-16amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: StandardFamsv7Family
+      generic_name: standard_f64-16ams_v7
+      id: Standard_F64-16ams_v7
+      memory: 549755813888
+      name: Standard_F64-16ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFamdsv7Family
+      generic_name: standard_f64-32amds_v7
+      id: Standard_F64-32amds_v7
+      memory: 549755813888
+      name: Standard_F64-32amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFamsv7Family
+      generic_name: standard_f64-32ams_v7
+      id: Standard_F64-32ams_v7
+      memory: 549755813888
+      name: Standard_F64-32ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFadsv7Family
+      generic_name: standard_f64ads_v7
+      id: Standard_F64ads_v7
+      memory: 274877906944
+      name: Standard_F64ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFaldsv7Family
+      generic_name: standard_f64alds_v7
+      id: Standard_F64alds_v7
+      memory: 137438953472
+      name: Standard_F64alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFalsv6Family
+      generic_name: standard_f64als_v6
+      id: Standard_F64als_v6
+      memory: 137438953472
+      name: Standard_F64als_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFalsv7Family
+      generic_name: standard_f64als_v7
+      id: Standard_F64als_v7
+      memory: 137438953472
+      name: Standard_F64als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFamdsv7Family
+      generic_name: standard_f64amds_v7
+      id: Standard_F64amds_v7
+      memory: 549755813888
+      name: Standard_F64amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFamsv6Family
+      generic_name: standard_f64ams_v6
+      id: Standard_F64ams_v6
+      memory: 549755813888
+      name: Standard_F64ams_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFamsv7Family
+      generic_name: standard_f64ams_v7
+      id: Standard_F64ams_v7
+      memory: 549755813888
+      name: Standard_F64ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFasv6Family
+      generic_name: standard_f64as_v6
+      id: Standard_F64as_v6
+      memory: 274877906944
+      name: Standard_F64as_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFasv7Family
+      generic_name: standard_f64as_v7
+      id: Standard_F64as_v7
+      memory: 274877906944
+      name: Standard_F64as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardFSv2Family
+      generic_name: standard_f64s_v2
+      id: Standard_F64s_v2
+      memory: 137438953472
+      name: Standard_F64s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 72
+      family: standardFSv2Family
+      generic_name: standard_f72s_v2
+      id: Standard_F72s_v2
+      memory: 154618822656
+      name: Standard_F72s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardFFamily
+      generic_name: standard_f8
+      id: Standard_F8
+      memory: 17179869184
+      name: Standard_F8
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFamdsv7Family
+      generic_name: standard_f8-2amds_v7
+      id: Standard_F8-2amds_v7
+      memory: 68719476736
+      name: Standard_F8-2amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFamsv7Family
+      generic_name: standard_f8-2ams_v7
+      id: Standard_F8-2ams_v7
+      memory: 68719476736
+      name: Standard_F8-2ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFamdsv7Family
+      generic_name: standard_f8-4amds_v7
+      id: Standard_F8-4amds_v7
+      memory: 68719476736
+      name: Standard_F8-4amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFamsv7Family
+      generic_name: standard_f8-4ams_v7
+      id: Standard_F8-4ams_v7
+      memory: 68719476736
+      name: Standard_F8-4ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: StandardFadsv7Family
+      generic_name: standard_f80ads_v7
+      id: Standard_F80ads_v7
+      memory: 343597383680
+      name: Standard_F80ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: StandardFaldsv7Family
+      generic_name: standard_f80alds_v7
+      id: Standard_F80alds_v7
+      memory: 171798691840
+      name: Standard_F80alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: StandardFalsv7Family
+      generic_name: standard_f80als_v7
+      id: Standard_F80als_v7
+      memory: 171798691840
+      name: Standard_F80als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: StandardFamdsv7Family
+      generic_name: standard_f80amds_v7
+      id: Standard_F80amds_v7
+      memory: 687194767360
+      name: Standard_F80amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: StandardFamsv7Family
+      generic_name: standard_f80ams_v7
+      id: Standard_F80ams_v7
+      memory: 687194767360
+      name: Standard_F80ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: StandardFasv7Family
+      generic_name: standard_f80as_v7
+      id: Standard_F80as_v7
+      memory: 343597383680
+      name: Standard_F80as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFadsv7Family
+      generic_name: standard_f8ads_v7
+      id: Standard_F8ads_v7
+      memory: 34359738368
+      name: Standard_F8ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFaldsv7Family
+      generic_name: standard_f8alds_v7
+      id: Standard_F8alds_v7
+      memory: 17179869184
+      name: Standard_F8alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFalsv6Family
+      generic_name: standard_f8als_v6
+      id: Standard_F8als_v6
+      memory: 17179869184
+      name: Standard_F8als_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFalsv7Family
+      generic_name: standard_f8als_v7
+      id: Standard_F8als_v7
+      memory: 17179869184
+      name: Standard_F8als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFamdsv7Family
+      generic_name: standard_f8amds_v7
+      id: Standard_F8amds_v7
+      memory: 68719476736
+      name: Standard_F8amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFamsv6Family
+      generic_name: standard_f8ams_v6
+      id: Standard_F8ams_v6
+      memory: 68719476736
+      name: Standard_F8ams_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFamsv7Family
+      generic_name: standard_f8ams_v7
+      id: Standard_F8ams_v7
+      memory: 68719476736
+      name: Standard_F8ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFasv6Family
+      generic_name: standard_f8as_v6
+      id: Standard_F8as_v6
+      memory: 34359738368
+      name: Standard_F8as_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFasv7Family
+      generic_name: standard_f8as_v7
+      id: Standard_F8as_v7
+      memory: 34359738368
+      name: Standard_F8as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardFSFamily
+      generic_name: standard_f8s
+      id: Standard_F8s
+      memory: 17179869184
+      name: Standard_F8s
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardFSv2Family
+      generic_name: standard_f8s_v2
+      id: Standard_F8s_v2
+      memory: 17179869184
+      name: Standard_F8s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 12
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx12-6mds_v2
+      id: Standard_FX12-6mds_v2
+      memory: 270582939648
+      name: Standard_FX12-6mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 12
+      family: StandardFXmsv2Family
+      generic_name: standard_fx12-6ms_v2
+      id: Standard_FX12-6ms_v2
+      memory: 270582939648
+      name: Standard_FX12-6ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 12
+      family: standardFXMDVSFamily
+      generic_name: standard_fx12mds
+      id: Standard_FX12mds
+      memory: 270582939648
+      name: Standard_FX12mds
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 12
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx12mds_v2
+      id: Standard_FX12mds_v2
+      memory: 270582939648
+      name: Standard_FX12mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 12
+      family: StandardFXmsv2Family
+      generic_name: standard_fx12ms_v2
+      id: Standard_FX12ms_v2
+      memory: 270582939648
+      name: Standard_FX12ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx16-4mds_v2
+      id: Standard_FX16-4mds_v2
+      memory: 360777252864
+      name: Standard_FX16-4mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFXmsv2Family
+      generic_name: standard_fx16-4ms_v2
+      id: Standard_FX16-4ms_v2
+      memory: 360777252864
+      name: Standard_FX16-4ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx16-8mds_v2
+      id: Standard_FX16-8mds_v2
+      memory: 360777252864
+      name: Standard_FX16-8mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFXmsv2Family
+      generic_name: standard_fx16-8ms_v2
+      id: Standard_FX16-8ms_v2
+      memory: 360777252864
+      name: Standard_FX16-8ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx16mds_v2
+      id: Standard_FX16mds_v2
+      memory: 360777252864
+      name: Standard_FX16mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFXmsv2Family
+      generic_name: standard_fx16ms_v2
+      id: Standard_FX16ms_v2
+      memory: 360777252864
+      name: Standard_FX16ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx24-12mds_v2
+      id: Standard_FX24-12mds_v2
+      memory: 541165879296
+      name: Standard_FX24-12mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      family: StandardFXmsv2Family
+      generic_name: standard_fx24-12ms_v2
+      id: Standard_FX24-12ms_v2
+      memory: 541165879296
+      name: Standard_FX24-12ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx24-6mds_v2
+      id: Standard_FX24-6mds_v2
+      memory: 541165879296
+      name: Standard_FX24-6mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      family: StandardFXmsv2Family
+      generic_name: standard_fx24-6ms_v2
+      id: Standard_FX24-6ms_v2
+      memory: 541165879296
+      name: Standard_FX24-6ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      family: standardFXMDVSFamily
+      generic_name: standard_fx24mds
+      id: Standard_FX24mds
+      memory: 541165879296
+      name: Standard_FX24mds
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx24mds_v2
+      id: Standard_FX24mds_v2
+      memory: 541165879296
+      name: Standard_FX24mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      family: StandardFXmsv2Family
+      generic_name: standard_fx24ms_v2
+      id: Standard_FX24ms_v2
+      memory: 541165879296
+      name: Standard_FX24ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx2mds_v2
+      id: Standard_FX2mds_v2
+      memory: 45097156608
+      name: Standard_FX2mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFXmsv2Family
+      generic_name: standard_fx2ms_v2
+      id: Standard_FX2ms_v2
+      memory: 45097156608
+      name: Standard_FX2ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx32-16mds_v2
+      id: Standard_FX32-16mds_v2
+      memory: 721554505728
+      name: Standard_FX32-16mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFXmsv2Family
+      generic_name: standard_fx32-16ms_v2
+      id: Standard_FX32-16ms_v2
+      memory: 721554505728
+      name: Standard_FX32-16ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx32-8mds_v2
+      id: Standard_FX32-8mds_v2
+      memory: 721554505728
+      name: Standard_FX32-8mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFXmsv2Family
+      generic_name: standard_fx32-8ms_v2
+      id: Standard_FX32-8ms_v2
+      memory: 721554505728
+      name: Standard_FX32-8ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx32mds_v2
+      id: Standard_FX32mds_v2
+      memory: 721554505728
+      name: Standard_FX32mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFXmsv2Family
+      generic_name: standard_fx32ms_v2
+      id: Standard_FX32ms_v2
+      memory: 721554505728
+      name: Standard_FX32ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 36
+      family: standardFXMDVSFamily
+      generic_name: standard_fx36mds
+      id: Standard_FX36mds
+      memory: 811748818944
+      name: Standard_FX36mds
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx4-2mds_v2
+      id: Standard_FX4-2mds_v2
+      memory: 90194313216
+      name: Standard_FX4-2mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFXmsv2Family
+      generic_name: standard_fx4-2ms_v2
+      id: Standard_FX4-2ms_v2
+      memory: 90194313216
+      name: Standard_FX4-2ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx48-12mds_v2
+      id: Standard_FX48-12mds_v2
+      memory: 1082331758592
+      name: Standard_FX48-12mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFXmsv2Family
+      generic_name: standard_fx48-12ms_v2
+      id: Standard_FX48-12ms_v2
+      memory: 1082331758592
+      name: Standard_FX48-12ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx48-24mds_v2
+      id: Standard_FX48-24mds_v2
+      memory: 1082331758592
+      name: Standard_FX48-24mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFXmsv2Family
+      generic_name: standard_fx48-24ms_v2
+      id: Standard_FX48-24ms_v2
+      memory: 1082331758592
+      name: Standard_FX48-24ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardFXMDVSFamily
+      generic_name: standard_fx48mds
+      id: Standard_FX48mds
+      memory: 1082331758592
+      name: Standard_FX48mds
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx48mds_v2
+      id: Standard_FX48mds_v2
+      memory: 1082331758592
+      name: Standard_FX48mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFXmsv2Family
+      generic_name: standard_fx48ms_v2
+      id: Standard_FX48ms_v2
+      memory: 1082331758592
+      name: Standard_FX48ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardFXMDVSFamily
+      generic_name: standard_fx4mds
+      id: Standard_FX4mds
+      memory: 90194313216
+      name: Standard_FX4mds
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx4mds_v2
+      id: Standard_FX4mds_v2
+      memory: 90194313216
+      name: Standard_FX4mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFXmsv2Family
+      generic_name: standard_fx4ms_v2
+      id: Standard_FX4ms_v2
+      memory: 90194313216
+      name: Standard_FX4ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx64-16mds_v2
+      id: Standard_FX64-16mds_v2
+      memory: 1443109011456
+      name: Standard_FX64-16mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFXmsv2Family
+      generic_name: standard_fx64-16ms_v2
+      id: Standard_FX64-16ms_v2
+      memory: 1443109011456
+      name: Standard_FX64-16ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx64-32mds_v2
+      id: Standard_FX64-32mds_v2
+      memory: 1443109011456
+      name: Standard_FX64-32mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFXmsv2Family
+      generic_name: standard_fx64-32ms_v2
+      id: Standard_FX64-32ms_v2
+      memory: 1443109011456
+      name: Standard_FX64-32ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx64mds_v2
+      id: Standard_FX64mds_v2
+      memory: 1443109011456
+      name: Standard_FX64mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFXmsv2Family
+      generic_name: standard_fx64ms_v2
+      id: Standard_FX64ms_v2
+      memory: 1443109011456
+      name: Standard_FX64ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx8-2mds_v2
+      id: Standard_FX8-2mds_v2
+      memory: 180388626432
+      name: Standard_FX8-2mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFXmsv2Family
+      generic_name: standard_fx8-2ms_v2
+      id: Standard_FX8-2ms_v2
+      memory: 180388626432
+      name: Standard_FX8-2ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx8-4mds_v2
+      id: Standard_FX8-4mds_v2
+      memory: 180388626432
+      name: Standard_FX8-4mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFXmsv2Family
+      generic_name: standard_fx8-4ms_v2
+      id: Standard_FX8-4ms_v2
+      memory: 180388626432
+      name: Standard_FX8-4ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx8mds_v2
+      id: Standard_FX8mds_v2
+      memory: 180388626432
+      name: Standard_FX8mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFXmsv2Family
+      generic_name: standard_fx8ms_v2
+      id: Standard_FX8ms_v2
+      memory: 180388626432
+      name: Standard_FX8ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx96-24mds_v2
+      id: Standard_FX96-24mds_v2
+      memory: 1967095021568
+      name: Standard_FX96-24mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardFXmsv2Family
+      generic_name: standard_fx96-24ms_v2
+      id: Standard_FX96-24ms_v2
+      memory: 1967095021568
+      name: Standard_FX96-24ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx96-48mds_v2
+      id: Standard_FX96-48mds_v2
+      memory: 1967095021568
+      name: Standard_FX96-48mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardFXmsv2Family
+      generic_name: standard_fx96-48ms_v2
+      id: Standard_FX96-48ms_v2
+      memory: 1967095021568
+      name: Standard_FX96-48ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx96mds_v2
+      id: Standard_FX96mds_v2
+      memory: 1967095021568
+      name: Standard_FX96mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardFXmsv2Family
+      generic_name: standard_fx96ms_v2
+      id: Standard_FX96ms_v2
+      memory: 1967095021568
+      name: Standard_FX96ms_v2
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 12
+      family: standardLaosv4Family
+      generic_name: standard_l12aos_v4
+      id: Standard_L12aos_v4
+      memory: 103079215104
+      name: Standard_L12aos_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardLaosv4Family
+      generic_name: standard_l16aos_v4
+      id: Standard_L16aos_v4
+      memory: 137438953472
+      name: Standard_L16aos_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardLASv3Family
+      generic_name: standard_l16as_v3
+      id: Standard_L16as_v3
+      memory: 137438953472
+      name: Standard_L16as_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardLasv4Family
+      generic_name: standard_l16as_v4
+      id: Standard_L16as_v4
+      memory: 137438953472
+      name: Standard_L16as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardLSv3Family
+      generic_name: standard_l16s_v3
+      id: Standard_L16s_v3
+      memory: 137438953472
+      name: Standard_L16s_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardLsv4Family
+      generic_name: standard_l16s_v4
+      id: Standard_L16s_v4
+      memory: 137438953472
+      name: Standard_L16s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      family: standardLaosv4Family
+      generic_name: standard_l24aos_v4
+      id: Standard_L24aos_v4
+      memory: 206158430208
+      name: Standard_L24aos_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardLaosv4Family
+      generic_name: standard_l2aos_v4
+      id: Standard_L2aos_v4
+      memory: 17179869184
+      name: Standard_L2aos_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardLasv4Family
+      generic_name: standard_l2as_v4
+      id: Standard_L2as_v4
+      memory: 17179869184
+      name: Standard_L2as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardLsv4Family
+      generic_name: standard_l2s_v4
+      id: Standard_L2s_v4
+      memory: 17179869184
+      name: Standard_L2s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardLaosv4Family
+      generic_name: standard_l32aos_v4
+      id: Standard_L32aos_v4
+      memory: 274877906944
+      name: Standard_L32aos_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardLASv3Family
+      generic_name: standard_l32as_v3
+      id: Standard_L32as_v3
+      memory: 274877906944
+      name: Standard_L32as_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardLasv4Family
+      generic_name: standard_l32as_v4
+      id: Standard_L32as_v4
+      memory: 274877906944
+      name: Standard_L32as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardLSv3Family
+      generic_name: standard_l32s_v3
+      id: Standard_L32s_v3
+      memory: 274877906944
+      name: Standard_L32s_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardLsv4Family
+      generic_name: standard_l32s_v4
+      id: Standard_L32s_v4
+      memory: 274877906944
+      name: Standard_L32s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardLASv3Family
+      generic_name: standard_l48as_v3
+      id: Standard_L48as_v3
+      memory: 412316860416
+      name: Standard_L48as_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardLasv4Family
+      generic_name: standard_l48as_v4
+      id: Standard_L48as_v4
+      memory: 412316860416
+      name: Standard_L48as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardLSv3Family
+      generic_name: standard_l48s_v3
+      id: Standard_L48s_v3
+      memory: 412316860416
+      name: Standard_L48s_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardLsv4Family
+      generic_name: standard_l48s_v4
+      id: Standard_L48s_v4
+      memory: 412316860416
+      name: Standard_L48s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardLaosv4Family
+      generic_name: standard_l4aos_v4
+      id: Standard_L4aos_v4
+      memory: 34359738368
+      name: Standard_L4aos_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardLasv4Family
+      generic_name: standard_l4as_v4
+      id: Standard_L4as_v4
+      memory: 34359738368
+      name: Standard_L4as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardLsv4Family
+      generic_name: standard_l4s_v4
+      id: Standard_L4s_v4
+      memory: 34359738368
+      name: Standard_L4s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardLASv3Family
+      generic_name: standard_l64as_v3
+      id: Standard_L64as_v3
+      memory: 549755813888
+      name: Standard_L64as_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardLasv4Family
+      generic_name: standard_l64as_v4
+      id: Standard_L64as_v4
+      memory: 549755813888
+      name: Standard_L64as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardLSv3Family
+      generic_name: standard_l64s_v3
+      id: Standard_L64s_v3
+      memory: 549755813888
+      name: Standard_L64s_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardLsv4Family
+      generic_name: standard_l64s_v4
+      id: Standard_L64s_v4
+      memory: 549755813888
+      name: Standard_L64s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: standardLASv3Family
+      generic_name: standard_l80as_v3
+      id: Standard_L80as_v3
+      memory: 687194767360
+      name: Standard_L80as_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: standardLasv4Family
+      generic_name: standard_l80as_v4
+      id: Standard_L80as_v4
+      memory: 687194767360
+      name: Standard_L80as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: standardLSv3Family
+      generic_name: standard_l80s_v3
+      id: Standard_L80s_v3
+      memory: 687194767360
+      name: Standard_L80s_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: standardLsv4Family
+      generic_name: standard_l80s_v4
+      id: Standard_L80s_v4
+      memory: 687194767360
+      name: Standard_L80s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardLaosv4Family
+      generic_name: standard_l8aos_v4
+      id: Standard_L8aos_v4
+      memory: 68719476736
+      name: Standard_L8aos_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardLASv3Family
+      generic_name: standard_l8as_v3
+      id: Standard_L8as_v3
+      memory: 68719476736
+      name: Standard_L8as_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardLasv4Family
+      generic_name: standard_l8as_v4
+      id: Standard_L8as_v4
+      memory: 68719476736
+      name: Standard_L8as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardLSv3Family
+      generic_name: standard_l8s_v3
+      id: Standard_L8s_v3
+      memory: 68719476736
+      name: Standard_L8s_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardLsv4Family
+      generic_name: standard_l8s_v4
+      id: Standard_L8s_v4
+      memory: 68719476736
+      name: Standard_L8s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardLasv4Family
+      generic_name: standard_l96as_v4
+      id: Standard_L96as_v4
+      memory: 824633720832
+      name: Standard_L96as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardLsv4Family
+      generic_name: standard_l96s_v4
+      id: Standard_L96s_v4
+      memory: 824633720832
+      name: Standard_L96s_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: Standard NCASv3_T4 Family
+      generic_name: standard_nc16as_t4_v3
+      id: Standard_NC16as_T4_v3
+      memory: 118111600640
+      name: Standard_NC16as_T4_v3
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 24
+      family: StandardNCADSA100v4Family
+      generic_name: standard_nc24ads_a100_v4
+      id: Standard_NC24ads_A100_v4
+      memory: 236223201280
+      name: Standard_NC24ads_A100_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 40
+      family: StandardNCadsH100v5Family
+      generic_name: standard_nc40ads_h100_v5
+      id: Standard_NC40ads_H100_v5
+      memory: 343597383680
+      name: Standard_NC40ads_H100_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardNCADSA100v4Family
+      generic_name: standard_nc48ads_a100_v4
+      id: Standard_NC48ads_A100_v4
+      memory: 472446402560
+      name: Standard_NC48ads_A100_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: Standard NCASv3_T4 Family
+      generic_name: standard_nc4as_t4_v3
+      id: Standard_NC4as_T4_v3
+      memory: 30064771072
+      name: Standard_NC4as_T4_v3
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: Standard NCASv3_T4 Family
+      generic_name: standard_nc64as_t4_v3
+      id: Standard_NC64as_T4_v3
+      memory: 472446402560
+      name: Standard_NC64as_T4_v3
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: StandardNCadsH100v5Family
+      generic_name: standard_nc80adis_h100_v5
+      id: Standard_NC80adis_H100_v5
+      memory: 687194767360
+      name: Standard_NC80adis_H100_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: Standard NCASv3_T4 Family
+      generic_name: standard_nc8as_t4_v3
+      id: Standard_NC8as_T4_v3
+      memory: 60129542144
+      name: Standard_NC8as_T4_v3
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardNCADSA100v4Family
+      generic_name: standard_nc96ads_a100_v4
+      id: Standard_NC96ads_A100_v4
+      memory: 944892805120
+      name: Standard_NC96ads_A100_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 12
+      family: StandardNVADSA10v5Family
+      generic_name: standard_nv12ads_a10_v5
+      id: Standard_NV12ads_A10_v5
+      memory: 118111600640
+      name: Standard_NV12ads_A10_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardNVSv4Family
+      generic_name: standard_nv16as_v4
+      id: Standard_NV16as_v4
+      memory: 60129542144
+      name: Standard_NV16as_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 18
+      family: StandardNVADSA10v5Family
+      generic_name: standard_nv18ads_a10_v5
+      id: Standard_NV18ads_A10_v5
+      memory: 236223201280
+      name: Standard_NV18ads_A10_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardNVSv4Family
+      generic_name: standard_nv32as_v4
+      id: Standard_NV32as_v4
+      memory: 120259084288
+      name: Standard_NV32as_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 36
+      family: StandardNVADSA10v5Family
+      generic_name: standard_nv36adms_a10_v5
+      id: Standard_NV36adms_A10_v5
+      memory: 944892805120
+      name: Standard_NV36adms_A10_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 36
+      family: StandardNVADSA10v5Family
+      generic_name: standard_nv36ads_a10_v5
+      id: Standard_NV36ads_A10_v5
+      memory: 472446402560
+      name: Standard_NV36ads_A10_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardNVSv4Family
+      generic_name: standard_nv4as_v4
+      id: Standard_NV4as_v4
+      memory: 15032385536
+      name: Standard_NV4as_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 6
+      family: StandardNVADSA10v5Family
+      generic_name: standard_nv6ads_a10_v5
+      id: Standard_NV6ads_A10_v5
+      memory: 59055800320
+      name: Standard_NV6ads_A10_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 72
+      family: StandardNVADSA10v5Family
+      generic_name: standard_nv72ads_a10_v5
+      id: Standard_NV72ads_A10_v5
+      memory: 944892805120
+      name: Standard_NV72ads_A10_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardNVSv4Family
+      generic_name: standard_nv8as_v4
+      id: Standard_NV8as_v4
+      memory: 30064771072
+      name: Standard_NV8as_v4
 kind: ConfigMap
 metadata:
   name: cloud-resources-config
@@ -7995,7 +9449,7 @@ spec:
         checksum/provisionshard: 'd2d4582f46da482e7a0c56f8a4372d95839bf6ced1d48a964d7030dc7e1b5b4b'
         checksum/cs: '7f91f7a8dc3a8b51073043defb13df2c3864a9c93f5a5588a2431f012bc2ae28'
         checksum/runtime: 'a59b6e4224066ebe7cb35d89a9e9c179f9e90942d3b4173c91c0609299a983ef'
-        checksum/cloudres: '6db050cd35a77e565d80d2ba2c028450a8758e3ab0a4e524ede12cf207c3a73a'
+        checksum/cloudres: '259ecb0074a7ea836f9f2eedd9769724a8c6feb37fade314157736ef2b4ceebd'
         checksum/sa: '0187a6f1019114e284fb5565a82e4e954460ac079f952f07b9602117c0d81e3f'
     spec:
       topologySpreadConstraints:

--- a/cluster-service/update_instance_types.py
+++ b/cluster-service/update_instance_types.py
@@ -16,7 +16,7 @@ from yaml.resolver import BaseResolver
 # $ python update_instance_types.py --region eastus --output cloud-resources-config.yaml
 
 parser = argparse.ArgumentParser(description='Generates a list of available instance types in the given region. '
-                                             'Requires an active az session to run "az vm list-sizes" on the shell.')
+                                             'Requires an active az session to run "az vm list-skus" on the shell.')
 parser.add_argument('--region', default="westus3", help='the azure region, by default westus3')
 parser.add_argument('--input', default="deploy/templates/cloud-resources-config.configmap.yaml",
                     help='the input configmap, by default the cloud resources-config in the helm template directory')
@@ -45,24 +45,43 @@ with open(args.input) as f:
         raise RuntimeError(f"Error parsing input YAML file {args.input}: {e}")
 
 # shelling out here to avoid importing all kinds of Azure libraries via pip
-json_out = os.popen(f"az vm list-sizes --location \"{args.region}\"").read()
+json_out = os.popen(f"az vm list-skus --location \"{args.region}\"").read()
 if not json_out.strip():
-    raise RuntimeError("Unable to list vm sizes. Please check that an azure session is active and is able to run az commands.")
+    raise RuntimeError("Unable to list vm skus. Please check that an azure session is active and is able to run az commands.")
 types = json.loads(json_out)
+
+def capability_value(capabilities, name):
+    for capability in capabilities:
+        if capability.get("name") == name:
+            return capability.get("value")
+    return None
 
 instance_types_set = {}
 instance_types_list = []
 for i in range(len(types)):
     vm_type = types[i]
+    if vm_type.get("resourceType") != "virtualMachines":
+        continue
+
     type_name = vm_type['name']
     print(f"processing {vm_type['name']}")
+
+    capabilities = vm_type.get("capabilities") or []
+    vcpus = capability_value(capabilities, "vCPUs")
+    memory_gb = capability_value(capabilities, "MemoryGB")
+    family = vm_type.get("family")
+    if vcpus is None or memory_gb is None or not family:
+        print(f"skipping {type_name}")
+        continue
+
     instance_type = {
         "cloud_provider_id": "azure",
         "id": type_name,
         "name": type_name,
         "generic_name": type_name.lower(),
-        "cpu_cores": int(vm_type["numberOfCores"]),
-        "memory": int(vm_type["memoryInMB"]) * 1024 * 1024,
+        "cpu_cores": int(vcpus),
+        "family": family,
+        "memory": int(float(memory_gb)) * 1024 * 1024 * 1024,
     }
 
     if "L" in type_name:

--- a/cluster-service/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_cluster_service.yaml
+++ b/cluster-service/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_cluster_service.yaml
@@ -751,639 +751,82 @@ data:
         supports_multi_az: true
   instance-types.yaml: |
     instance_types:
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_nc4as_t4_v3
-      id: Standard_NC4as_T4_v3
-      memory: 30064771072
-      name: Standard_NC4as_T4_v3
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_nc8as_t4_v3
-      id: Standard_NC8as_T4_v3
-      memory: 60129542144
-      name: Standard_NC8as_T4_v3
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_nc16as_t4_v3
-      id: Standard_NC16as_T4_v3
-      memory: 118111600640
-      name: Standard_NC16as_T4_v3
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_nc64as_t4_v3
-      id: Standard_NC64as_T4_v3
-      memory: 472446402560
-      name: Standard_NC64as_T4_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2_v4
-      id: Standard_E2_v4
-      memory: 17179869184
-      name: Standard_E2_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4_v4
-      id: Standard_E4_v4
-      memory: 34359738368
-      name: Standard_E4_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8_v4
-      id: Standard_E8_v4
-      memory: 68719476736
-      name: Standard_E8_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16_v4
-      id: Standard_E16_v4
-      memory: 137438953472
-      name: Standard_E16_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20_v4
-      id: Standard_E20_v4
-      memory: 171798691840
-      name: Standard_E20_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32_v4
-      id: Standard_E32_v4
-      memory: 274877906944
-      name: Standard_E32_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48_v4
-      id: Standard_E48_v4
-      memory: 412316860416
-      name: Standard_E48_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64_v4
-      id: Standard_E64_v4
-      memory: 541165879296
-      name: Standard_E64_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2d_v4
-      id: Standard_E2d_v4
-      memory: 17179869184
-      name: Standard_E2d_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4d_v4
-      id: Standard_E4d_v4
-      memory: 34359738368
-      name: Standard_E4d_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8d_v4
-      id: Standard_E8d_v4
-      memory: 68719476736
-      name: Standard_E8d_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16d_v4
-      id: Standard_E16d_v4
-      memory: 137438953472
-      name: Standard_E16d_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20d_v4
-      id: Standard_E20d_v4
-      memory: 171798691840
-      name: Standard_E20d_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32d_v4
-      id: Standard_E32d_v4
-      memory: 274877906944
-      name: Standard_E32d_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48d_v4
-      id: Standard_E48d_v4
-      memory: 412316860416
-      name: Standard_E48d_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64d_v4
-      id: Standard_E64d_v4
-      memory: 541165879296
-      name: Standard_E64d_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2s_v4
-      id: Standard_E2s_v4
-      memory: 17179869184
-      name: Standard_E2s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2s_v4
-      id: Standard_E4-2s_v4
-      memory: 34359738368
-      name: Standard_E4-2s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4s_v4
-      id: Standard_E4s_v4
-      memory: 34359738368
-      name: Standard_E4s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2s_v4
-      id: Standard_E8-2s_v4
-      memory: 68719476736
-      name: Standard_E8-2s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4s_v4
-      id: Standard_E8-4s_v4
-      memory: 68719476736
-      name: Standard_E8-4s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8s_v4
-      id: Standard_E8s_v4
-      memory: 68719476736
-      name: Standard_E8s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-4s_v4
-      id: Standard_E16-4s_v4
-      memory: 137438953472
-      name: Standard_E16-4s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8s_v4
-      id: Standard_E16-8s_v4
-      memory: 137438953472
-      name: Standard_E16-8s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16s_v4
-      id: Standard_E16s_v4
-      memory: 137438953472
-      name: Standard_E16s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20s_v4
-      id: Standard_E20s_v4
-      memory: 171798691840
-      name: Standard_E20s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8s_v4
-      id: Standard_E32-8s_v4
-      memory: 274877906944
-      name: Standard_E32-8s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16s_v4
-      id: Standard_E32-16s_v4
-      memory: 274877906944
-      name: Standard_E32-16s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32s_v4
-      id: Standard_E32s_v4
-      memory: 274877906944
-      name: Standard_E32s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48s_v4
-      id: Standard_E48s_v4
-      memory: 412316860416
-      name: Standard_E48s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16s_v4
-      id: Standard_E64-16s_v4
-      memory: 541165879296
-      name: Standard_E64-16s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32s_v4
-      id: Standard_E64-32s_v4
-      memory: 541165879296
-      name: Standard_E64-32s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64s_v4
-      id: Standard_E64s_v4
-      memory: 541165879296
-      name: Standard_E64s_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_e80is_v4
-      id: Standard_E80is_v4
-      memory: 541165879296
-      name: Standard_E80is_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2ds_v4
-      id: Standard_E2ds_v4
-      memory: 17179869184
-      name: Standard_E2ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2ds_v4
-      id: Standard_E4-2ds_v4
-      memory: 34359738368
-      name: Standard_E4-2ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4ds_v4
-      id: Standard_E4ds_v4
-      memory: 34359738368
-      name: Standard_E4ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2ds_v4
-      id: Standard_E8-2ds_v4
-      memory: 68719476736
-      name: Standard_E8-2ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4ds_v4
-      id: Standard_E8-4ds_v4
-      memory: 68719476736
-      name: Standard_E8-4ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8ds_v4
-      id: Standard_E8ds_v4
-      memory: 68719476736
-      name: Standard_E8ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-4ds_v4
-      id: Standard_E16-4ds_v4
-      memory: 137438953472
-      name: Standard_E16-4ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8ds_v4
-      id: Standard_E16-8ds_v4
-      memory: 137438953472
-      name: Standard_E16-8ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16ds_v4
-      id: Standard_E16ds_v4
-      memory: 137438953472
-      name: Standard_E16ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20ds_v4
-      id: Standard_E20ds_v4
-      memory: 171798691840
-      name: Standard_E20ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8ds_v4
-      id: Standard_E32-8ds_v4
-      memory: 274877906944
-      name: Standard_E32-8ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16ds_v4
-      id: Standard_E32-16ds_v4
-      memory: 274877906944
-      name: Standard_E32-16ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32ds_v4
-      id: Standard_E32ds_v4
-      memory: 274877906944
-      name: Standard_E32ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48ds_v4
-      id: Standard_E48ds_v4
-      memory: 412316860416
-      name: Standard_E48ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16ds_v4
-      id: Standard_E64-16ds_v4
-      memory: 541165879296
-      name: Standard_E64-16ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32ds_v4
-      id: Standard_E64-32ds_v4
-      memory: 541165879296
-      name: Standard_E64-32ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64ds_v4
-      id: Standard_E64ds_v4
-      memory: 541165879296
-      name: Standard_E64ds_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_e80ids_v4
-      id: Standard_E80ids_v4
-      memory: 541165879296
-      name: Standard_E80ids_v4
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 2
-      generic_name: standard_d2d_v4
-      id: Standard_D2d_v4
-      memory: 8589934592
-      name: Standard_D2d_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4d_v4
-      id: Standard_D4d_v4
-      memory: 17179869184
-      name: Standard_D4d_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8d_v4
-      id: Standard_D8d_v4
-      memory: 34359738368
-      name: Standard_D8d_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16d_v4
-      id: Standard_D16d_v4
-      memory: 68719476736
-      name: Standard_D16d_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32d_v4
-      id: Standard_D32d_v4
-      memory: 137438953472
-      name: Standard_D32d_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48d_v4
-      id: Standard_D48d_v4
-      memory: 206158430208
-      name: Standard_D48d_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64d_v4
-      id: Standard_D64d_v4
-      memory: 274877906944
-      name: Standard_D64d_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2_v4
-      id: Standard_D2_v4
-      memory: 8589934592
-      name: Standard_D2_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4_v4
-      id: Standard_D4_v4
-      memory: 17179869184
-      name: Standard_D4_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8_v4
-      id: Standard_D8_v4
-      memory: 34359738368
-      name: Standard_D8_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16_v4
-      id: Standard_D16_v4
-      memory: 68719476736
-      name: Standard_D16_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32_v4
-      id: Standard_D32_v4
-      memory: 137438953472
-      name: Standard_D32_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48_v4
-      id: Standard_D48_v4
-      memory: 206158430208
-      name: Standard_D48_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64_v4
-      id: Standard_D64_v4
-      memory: 274877906944
-      name: Standard_D64_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2ds_v4
-      id: Standard_D2ds_v4
-      memory: 8589934592
-      name: Standard_D2ds_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4ds_v4
-      id: Standard_D4ds_v4
-      memory: 17179869184
-      name: Standard_D4ds_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8ds_v4
-      id: Standard_D8ds_v4
-      memory: 34359738368
-      name: Standard_D8ds_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16ds_v4
-      id: Standard_D16ds_v4
-      memory: 68719476736
-      name: Standard_D16ds_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32ds_v4
-      id: Standard_D32ds_v4
-      memory: 137438953472
-      name: Standard_D32ds_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48ds_v4
-      id: Standard_D48ds_v4
-      memory: 206158430208
-      name: Standard_D48ds_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64ds_v4
-      id: Standard_D64ds_v4
-      memory: 274877906944
-      name: Standard_D64ds_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2s_v4
-      id: Standard_D2s_v4
-      memory: 8589934592
-      name: Standard_D2s_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4s_v4
-      id: Standard_D4s_v4
-      memory: 17179869184
-      name: Standard_D4s_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8s_v4
-      id: Standard_D8s_v4
-      memory: 34359738368
-      name: Standard_D8s_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16s_v4
-      id: Standard_D16s_v4
-      memory: 68719476736
-      name: Standard_D16s_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32s_v4
-      id: Standard_D32s_v4
-      memory: 137438953472
-      name: Standard_D32s_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48s_v4
-      id: Standard_D48s_v4
-      memory: 206158430208
-      name: Standard_D48s_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64s_v4
-      id: Standard_D64s_v4
-      memory: 274877906944
-      name: Standard_D64s_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 1
-      generic_name: standard_d1_v2
-      id: Standard_D1_v2
-      memory: 3758096384
-      name: Standard_D1_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2_v2
-      id: Standard_D2_v2
-      memory: 7516192768
-      name: Standard_D2_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d3_v2
-      id: Standard_D3_v2
-      memory: 15032385536
-      name: Standard_D3_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d4_v2
-      id: Standard_D4_v2
-      memory: 30064771072
-      name: Standard_D4_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d5_v2
-      id: Standard_D5_v2
-      memory: 60129542144
-      name: Standard_D5_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
+      family: standardDv2Family
       generic_name: standard_d11_v2
       id: Standard_D11_v2
       memory: 15032385536
       name: Standard_D11_v2
     - category: general_purpose
       cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardDadsv7Family
+      generic_name: standard_d128ads_v7
+      id: Standard_D128ads_v7
+      memory: 549755813888
+      name: Standard_D128ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardDaldsv7Family
+      generic_name: standard_d128alds_v7
+      id: Standard_D128alds_v7
+      memory: 274877906944
+      name: Standard_D128alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardDalsv7Family
+      generic_name: standard_d128als_v7
+      id: Standard_D128als_v7
+      memory: 274877906944
+      name: Standard_D128als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardDasv7Family
+      generic_name: standard_d128as_v7
+      id: Standard_D128as_v7
+      memory: 549755813888
+      name: Standard_D128as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardDdsv6Family
+      generic_name: standard_d128ds_v6
+      id: Standard_D128ds_v6
+      memory: 549755813888
+      name: Standard_D128ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardDldsv6Family
+      generic_name: standard_d128lds_v6
+      id: Standard_D128lds_v6
+      memory: 274877906944
+      name: Standard_D128lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardDlsv6Family
+      generic_name: standard_d128ls_v6
+      id: Standard_D128ls_v6
+      memory: 274877906944
+      name: Standard_D128ls_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardDsv6Family
+      generic_name: standard_d128s_v6
+      id: Standard_D128s_v6
+      memory: 549755813888
+      name: Standard_D128s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
       cpu_cores: 4
+      family: standardDv2Family
       generic_name: standard_d12_v2
       id: Standard_D12_v2
       memory: 30064771072
@@ -1391,6 +834,7 @@ data:
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 8
+      family: standardDv2Family
       generic_name: standard_d13_v2
       id: Standard_D13_v2
       memory: 60129542144
@@ -1398,6 +842,7 @@ data:
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
+      family: standardDv2Family
       generic_name: standard_d14_v2
       id: Standard_D14_v2
       memory: 120259084288
@@ -1405,3559 +850,216 @@ data:
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 20
+      family: standardDv2Family
       generic_name: standard_d15_v2
       id: Standard_D15_v2
       memory: 150323855360
       name: Standard_D15_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 1
-      generic_name: standard_f1
-      id: Standard_F1
-      memory: 2147483648
-      name: Standard_F1
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2
-      id: Standard_F2
-      memory: 4294967296
-      name: Standard_F2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4
-      id: Standard_F4
-      memory: 8589934592
-      name: Standard_F4
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8
-      id: Standard_F8
-      memory: 17179869184
-      name: Standard_F8
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16
-      id: Standard_F16
-      memory: 34359738368
-      name: Standard_F16
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 1
-      generic_name: standard_ds1_v2
-      id: Standard_DS1_v2
-      memory: 3758096384
-      name: Standard_DS1_v2
+      cpu_cores: 160
+      family: StandardDadsv7Family
+      generic_name: standard_d160ads_v7
+      id: Standard_D160ads_v7
+      memory: 687194767360
+      name: Standard_D160ads_v7
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_ds2_v2
-      id: Standard_DS2_v2
-      memory: 7516192768
-      name: Standard_DS2_v2
+      cpu_cores: 160
+      family: StandardDaldsv7Family
+      generic_name: standard_d160alds_v7
+      id: Standard_D160alds_v7
+      memory: 343597383680
+      name: Standard_D160alds_v7
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_ds3_v2
-      id: Standard_DS3_v2
-      memory: 15032385536
-      name: Standard_DS3_v2
+      cpu_cores: 160
+      family: StandardDalsv7Family
+      generic_name: standard_d160als_v7
+      id: Standard_D160als_v7
+      memory: 343597383680
+      name: Standard_D160als_v7
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_ds4_v2
-      id: Standard_DS4_v2
-      memory: 30064771072
-      name: Standard_DS4_v2
+      cpu_cores: 160
+      family: StandardDasv7Family
+      generic_name: standard_d160as_v7
+      id: Standard_D160as_v7
+      memory: 687194767360
+      name: Standard_D160as_v7
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_ds5_v2
-      id: Standard_DS5_v2
-      memory: 60129542144
-      name: Standard_DS5_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_ds11-1_v2
-      id: Standard_DS11-1_v2
-      memory: 15032385536
-      name: Standard_DS11-1_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_ds11_v2
-      id: Standard_DS11_v2
-      memory: 15032385536
-      name: Standard_DS11_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_ds12-1_v2
-      id: Standard_DS12-1_v2
-      memory: 30064771072
-      name: Standard_DS12-1_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_ds12-2_v2
-      id: Standard_DS12-2_v2
-      memory: 30064771072
-      name: Standard_DS12-2_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_ds12_v2
-      id: Standard_DS12_v2
-      memory: 30064771072
-      name: Standard_DS12_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_ds13-2_v2
-      id: Standard_DS13-2_v2
-      memory: 60129542144
-      name: Standard_DS13-2_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_ds13-4_v2
-      id: Standard_DS13-4_v2
-      memory: 60129542144
-      name: Standard_DS13-4_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_ds13_v2
-      id: Standard_DS13_v2
-      memory: 60129542144
-      name: Standard_DS13_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_ds14-4_v2
-      id: Standard_DS14-4_v2
-      memory: 120259084288
-      name: Standard_DS14-4_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_ds14-8_v2
-      id: Standard_DS14-8_v2
-      memory: 120259084288
-      name: Standard_DS14-8_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_ds14_v2
-      id: Standard_DS14_v2
-      memory: 120259084288
-      name: Standard_DS14_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_ds15_v2
-      id: Standard_DS15_v2
-      memory: 150323855360
-      name: Standard_DS15_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 1
-      generic_name: standard_f1s
-      id: Standard_F1s
-      memory: 2147483648
-      name: Standard_F1s
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2s
-      id: Standard_F2s
-      memory: 4294967296
-      name: Standard_F2s
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4s
-      id: Standard_F4s
-      memory: 8589934592
-      name: Standard_F4s
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8s
-      id: Standard_F8s
-      memory: 17179869184
-      name: Standard_F8s
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16s
-      id: Standard_F16s
-      memory: 34359738368
-      name: Standard_F16s
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2_v3
-      id: Standard_D2_v3
-      memory: 8589934592
-      name: Standard_D2_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4_v3
-      id: Standard_D4_v3
-      memory: 17179869184
-      name: Standard_D4_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8_v3
-      id: Standard_D8_v3
-      memory: 34359738368
-      name: Standard_D8_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16_v3
-      id: Standard_D16_v3
-      memory: 68719476736
-      name: Standard_D16_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32_v3
-      id: Standard_D32_v3
-      memory: 137438953472
-      name: Standard_D32_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48_v3
-      id: Standard_D48_v3
-      memory: 206158430208
-      name: Standard_D48_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64_v3
-      id: Standard_D64_v3
-      memory: 274877906944
-      name: Standard_D64_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2s_v3
-      id: Standard_D2s_v3
-      memory: 8589934592
-      name: Standard_D2s_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4s_v3
-      id: Standard_D4s_v3
-      memory: 17179869184
-      name: Standard_D4s_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8s_v3
-      id: Standard_D8s_v3
-      memory: 34359738368
-      name: Standard_D8s_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16s_v3
-      id: Standard_D16s_v3
-      memory: 68719476736
-      name: Standard_D16s_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32s_v3
-      id: Standard_D32s_v3
-      memory: 137438953472
-      name: Standard_D32s_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48s_v3
-      id: Standard_D48s_v3
-      memory: 206158430208
-      name: Standard_D48s_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64s_v3
-      id: Standard_D64s_v3
-      memory: 274877906944
-      name: Standard_D64s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2_v3
-      id: Standard_E2_v3
-      memory: 17179869184
-      name: Standard_E2_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4_v3
-      id: Standard_E4_v3
-      memory: 34359738368
-      name: Standard_E4_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8_v3
-      id: Standard_E8_v3
-      memory: 68719476736
-      name: Standard_E8_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16_v3
-      id: Standard_E16_v3
-      memory: 137438953472
-      name: Standard_E16_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20_v3
-      id: Standard_E20_v3
-      memory: 171798691840
-      name: Standard_E20_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32_v3
-      id: Standard_E32_v3
-      memory: 274877906944
-      name: Standard_E32_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48_v3
-      id: Standard_E48_v3
-      memory: 412316860416
-      name: Standard_E48_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64_v3
-      id: Standard_E64_v3
-      memory: 463856467968
-      name: Standard_E64_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2s_v3
-      id: Standard_E2s_v3
-      memory: 17179869184
-      name: Standard_E2s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2s_v3
-      id: Standard_E4-2s_v3
-      memory: 34359738368
-      name: Standard_E4-2s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4s_v3
-      id: Standard_E4s_v3
-      memory: 34359738368
-      name: Standard_E4s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2s_v3
-      id: Standard_E8-2s_v3
-      memory: 68719476736
-      name: Standard_E8-2s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4s_v3
-      id: Standard_E8-4s_v3
-      memory: 68719476736
-      name: Standard_E8-4s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8s_v3
-      id: Standard_E8s_v3
-      memory: 68719476736
-      name: Standard_E8s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-4s_v3
-      id: Standard_E16-4s_v3
-      memory: 137438953472
-      name: Standard_E16-4s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8s_v3
-      id: Standard_E16-8s_v3
-      memory: 137438953472
-      name: Standard_E16-8s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16s_v3
-      id: Standard_E16s_v3
-      memory: 137438953472
-      name: Standard_E16s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20s_v3
-      id: Standard_E20s_v3
-      memory: 171798691840
-      name: Standard_E20s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8s_v3
-      id: Standard_E32-8s_v3
-      memory: 274877906944
-      name: Standard_E32-8s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16s_v3
-      id: Standard_E32-16s_v3
-      memory: 274877906944
-      name: Standard_E32-16s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32s_v3
-      id: Standard_E32s_v3
-      memory: 274877906944
-      name: Standard_E32s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48s_v3
-      id: Standard_E48s_v3
-      memory: 412316860416
-      name: Standard_E48s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16s_v3
-      id: Standard_E64-16s_v3
-      memory: 463856467968
-      name: Standard_E64-16s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32s_v3
-      id: Standard_E64-32s_v3
-      memory: 463856467968
-      name: Standard_E64-32s_v3
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64s_v3
-      id: Standard_E64s_v3
-      memory: 463856467968
-      name: Standard_E64s_v3
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2s_v2
-      id: Standard_F2s_v2
-      memory: 4294967296
-      name: Standard_F2s_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4s_v2
-      id: Standard_F4s_v2
-      memory: 8589934592
-      name: Standard_F4s_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8s_v2
-      id: Standard_F8s_v2
-      memory: 17179869184
-      name: Standard_F8s_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16s_v2
-      id: Standard_F16s_v2
-      memory: 34359738368
-      name: Standard_F16s_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32s_v2
-      id: Standard_F32s_v2
-      memory: 68719476736
-      name: Standard_F32s_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_f48s_v2
-      id: Standard_F48s_v2
-      memory: 103079215104
-      name: Standard_F48s_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64s_v2
-      id: Standard_F64s_v2
-      memory: 137438953472
-      name: Standard_F64s_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 72
-      generic_name: standard_f72s_v2
-      id: Standard_F72s_v2
-      memory: 154618822656
-      name: Standard_F72s_v2
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2as_v5
-      id: Standard_D2as_v5
-      memory: 8589934592
-      name: Standard_D2as_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4as_v5
-      id: Standard_D4as_v5
-      memory: 17179869184
-      name: Standard_D4as_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8as_v5
-      id: Standard_D8as_v5
-      memory: 34359738368
-      name: Standard_D8as_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16as_v5
-      id: Standard_D16as_v5
-      memory: 68719476736
-      name: Standard_D16as_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32as_v5
-      id: Standard_D32as_v5
-      memory: 137438953472
-      name: Standard_D32as_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48as_v5
-      id: Standard_D48as_v5
-      memory: 206158430208
-      name: Standard_D48as_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64as_v5
-      id: Standard_D64as_v5
-      memory: 274877906944
-      name: Standard_D64as_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96as_v5
-      id: Standard_D96as_v5
-      memory: 412316860416
-      name: Standard_D96as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2as_v5
-      id: Standard_E2as_v5
-      memory: 17179869184
-      name: Standard_E2as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2as_v5
-      id: Standard_E4-2as_v5
-      memory: 34359738368
-      name: Standard_E4-2as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4as_v5
-      id: Standard_E4as_v5
-      memory: 34359738368
-      name: Standard_E4as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2as_v5
-      id: Standard_E8-2as_v5
-      memory: 68719476736
-      name: Standard_E8-2as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4as_v5
-      id: Standard_E8-4as_v5
-      memory: 68719476736
-      name: Standard_E8-4as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8as_v5
-      id: Standard_E8as_v5
-      memory: 68719476736
-      name: Standard_E8as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-4as_v5
-      id: Standard_E16-4as_v5
-      memory: 137438953472
-      name: Standard_E16-4as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8as_v5
-      id: Standard_E16-8as_v5
-      memory: 137438953472
-      name: Standard_E16-8as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16as_v5
-      id: Standard_E16as_v5
-      memory: 137438953472
-      name: Standard_E16as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20as_v5
-      id: Standard_E20as_v5
-      memory: 171798691840
-      name: Standard_E20as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8as_v5
-      id: Standard_E32-8as_v5
-      memory: 274877906944
-      name: Standard_E32-8as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16as_v5
-      id: Standard_E32-16as_v5
-      memory: 274877906944
-      name: Standard_E32-16as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32as_v5
-      id: Standard_E32as_v5
-      memory: 274877906944
-      name: Standard_E32as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48as_v5
-      id: Standard_E48as_v5
-      memory: 412316860416
-      name: Standard_E48as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16as_v5
-      id: Standard_E64-16as_v5
-      memory: 549755813888
-      name: Standard_E64-16as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32as_v5
-      id: Standard_E64-32as_v5
-      memory: 549755813888
-      name: Standard_E64-32as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64as_v5
-      id: Standard_E64as_v5
-      memory: 549755813888
-      name: Standard_E64as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-24as_v5
-      id: Standard_E96-24as_v5
-      memory: 721554505728
-      name: Standard_E96-24as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-48as_v5
-      id: Standard_E96-48as_v5
-      memory: 721554505728
-      name: Standard_E96-48as_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96as_v5
-      id: Standard_E96as_v5
-      memory: 721554505728
-      name: Standard_E96as_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2ads_v5
-      id: Standard_D2ads_v5
-      memory: 8589934592
-      name: Standard_D2ads_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4ads_v5
-      id: Standard_D4ads_v5
-      memory: 17179869184
-      name: Standard_D4ads_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8ads_v5
-      id: Standard_D8ads_v5
-      memory: 34359738368
-      name: Standard_D8ads_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
+      family: standardDADSv5Family
       generic_name: standard_d16ads_v5
       id: Standard_D16ads_v5
       memory: 68719476736
       name: Standard_D16ads_v5
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32ads_v5
-      id: Standard_D32ads_v5
-      memory: 137438953472
-      name: Standard_D32ads_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48ads_v5
-      id: Standard_D48ads_v5
-      memory: 206158430208
-      name: Standard_D48ads_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64ads_v5
-      id: Standard_D64ads_v5
-      memory: 274877906944
-      name: Standard_D64ads_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96ads_v5
-      id: Standard_D96ads_v5
-      memory: 412316860416
-      name: Standard_D96ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2ads_v5
-      id: Standard_E2ads_v5
-      memory: 17179869184
-      name: Standard_E2ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2ads_v5
-      id: Standard_E4-2ads_v5
-      memory: 34359738368
-      name: Standard_E4-2ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4ads_v5
-      id: Standard_E4ads_v5
-      memory: 34359738368
-      name: Standard_E4ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2ads_v5
-      id: Standard_E8-2ads_v5
-      memory: 68719476736
-      name: Standard_E8-2ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4ads_v5
-      id: Standard_E8-4ads_v5
-      memory: 68719476736
-      name: Standard_E8-4ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8ads_v5
-      id: Standard_E8ads_v5
-      memory: 68719476736
-      name: Standard_E8ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_e16-4ads_v5
-      id: Standard_E16-4ads_v5
-      memory: 137438953472
-      name: Standard_E16-4ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8ads_v5
-      id: Standard_E16-8ads_v5
-      memory: 137438953472
-      name: Standard_E16-8ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16ads_v5
-      id: Standard_E16ads_v5
-      memory: 137438953472
-      name: Standard_E16ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20ads_v5
-      id: Standard_E20ads_v5
-      memory: 171798691840
-      name: Standard_E20ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8ads_v5
-      id: Standard_E32-8ads_v5
-      memory: 274877906944
-      name: Standard_E32-8ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16ads_v5
-      id: Standard_E32-16ads_v5
-      memory: 274877906944
-      name: Standard_E32-16ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32ads_v5
-      id: Standard_E32ads_v5
-      memory: 274877906944
-      name: Standard_E32ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48ads_v5
-      id: Standard_E48ads_v5
-      memory: 412316860416
-      name: Standard_E48ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16ads_v5
-      id: Standard_E64-16ads_v5
-      memory: 549755813888
-      name: Standard_E64-16ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32ads_v5
-      id: Standard_E64-32ads_v5
-      memory: 549755813888
-      name: Standard_E64-32ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64ads_v5
-      id: Standard_E64ads_v5
-      memory: 549755813888
-      name: Standard_E64ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-24ads_v5
-      id: Standard_E96-24ads_v5
-      memory: 721554505728
-      name: Standard_E96-24ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-48ads_v5
-      id: Standard_E96-48ads_v5
-      memory: 721554505728
-      name: Standard_E96-48ads_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96ads_v5
-      id: Standard_E96ads_v5
-      memory: 721554505728
-      name: Standard_E96ads_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2as_v6
-      id: Standard_D2as_v6
-      memory: 8589934592
-      name: Standard_D2as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4as_v6
-      id: Standard_D4as_v6
-      memory: 17179869184
-      name: Standard_D4as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8as_v6
-      id: Standard_D8as_v6
-      memory: 34359738368
-      name: Standard_D8as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16as_v6
-      id: Standard_D16as_v6
-      memory: 68719476736
-      name: Standard_D16as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32as_v6
-      id: Standard_D32as_v6
-      memory: 137438953472
-      name: Standard_D32as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48as_v6
-      id: Standard_D48as_v6
-      memory: 206158430208
-      name: Standard_D48as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64as_v6
-      id: Standard_D64as_v6
-      memory: 274877906944
-      name: Standard_D64as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96as_v6
-      id: Standard_D96as_v6
-      memory: 412316860416
-      name: Standard_D96as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2as_v6
-      id: Standard_E2as_v6
-      memory: 17179869184
-      name: Standard_E2as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4as_v6
-      id: Standard_E4as_v6
-      memory: 34359738368
-      name: Standard_E4as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8as_v6
-      id: Standard_E8as_v6
-      memory: 68719476736
-      name: Standard_E8as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16as_v6
-      id: Standard_E16as_v6
-      memory: 137438953472
-      name: Standard_E16as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20as_v6
-      id: Standard_E20as_v6
-      memory: 171798691840
-      name: Standard_E20as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32as_v6
-      id: Standard_E32as_v6
-      memory: 274877906944
-      name: Standard_E32as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48as_v6
-      id: Standard_E48as_v6
-      memory: 412316860416
-      name: Standard_E48as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64as_v6
-      id: Standard_E64as_v6
-      memory: 549755813888
-      name: Standard_E64as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96as_v6
-      id: Standard_E96as_v6
-      memory: 721554505728
-      name: Standard_E96as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2ads_v6
-      id: Standard_D2ads_v6
-      memory: 8589934592
-      name: Standard_D2ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4ads_v6
-      id: Standard_D4ads_v6
-      memory: 17179869184
-      name: Standard_D4ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8ads_v6
-      id: Standard_D8ads_v6
-      memory: 34359738368
-      name: Standard_D8ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
+      family: standardDadv6Family
       generic_name: standard_d16ads_v6
       id: Standard_D16ads_v6
       memory: 68719476736
       name: Standard_D16ads_v6
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32ads_v6
-      id: Standard_D32ads_v6
-      memory: 137438953472
-      name: Standard_D32ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48ads_v6
-      id: Standard_D48ads_v6
-      memory: 206158430208
-      name: Standard_D48ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64ads_v6
-      id: Standard_D64ads_v6
-      memory: 274877906944
-      name: Standard_D64ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96ads_v6
-      id: Standard_D96ads_v6
-      memory: 412316860416
-      name: Standard_D96ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2als_v6
-      id: Standard_D2als_v6
-      memory: 4294967296
-      name: Standard_D2als_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4als_v6
-      id: Standard_D4als_v6
-      memory: 8589934592
-      name: Standard_D4als_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8als_v6
-      id: Standard_D8als_v6
-      memory: 17179869184
-      name: Standard_D8als_v6
-    - category: general_purpose
-      cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_d16als_v6
-      id: Standard_D16als_v6
-      memory: 34359738368
-      name: Standard_D16als_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32als_v6
-      id: Standard_D32als_v6
+      family: StandardDadsv7Family
+      generic_name: standard_d16ads_v7
+      id: Standard_D16ads_v7
       memory: 68719476736
-      name: Standard_D32als_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48als_v6
-      id: Standard_D48als_v6
-      memory: 103079215104
-      name: Standard_D48als_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64als_v6
-      id: Standard_D64als_v6
-      memory: 137438953472
-      name: Standard_D64als_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96als_v6
-      id: Standard_D96als_v6
-      memory: 206158430208
-      name: Standard_D96als_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2alds_v6
-      id: Standard_D2alds_v6
-      memory: 4294967296
-      name: Standard_D2alds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4alds_v6
-      id: Standard_D4alds_v6
-      memory: 8589934592
-      name: Standard_D4alds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8alds_v6
-      id: Standard_D8alds_v6
-      memory: 17179869184
-      name: Standard_D8alds_v6
+      name: Standard_D16ads_v7
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
+      family: standardDaldv6Family
       generic_name: standard_d16alds_v6
       id: Standard_D16alds_v6
       memory: 34359738368
       name: Standard_D16alds_v6
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32alds_v6
-      id: Standard_D32alds_v6
-      memory: 68719476736
-      name: Standard_D32alds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48alds_v6
-      id: Standard_D48alds_v6
-      memory: 103079215104
-      name: Standard_D48alds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64alds_v6
-      id: Standard_D64alds_v6
-      memory: 137438953472
-      name: Standard_D64alds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96alds_v6
-      id: Standard_D96alds_v6
-      memory: 206158430208
-      name: Standard_D96alds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2ads_v6
-      id: Standard_E2ads_v6
-      memory: 17179869184
-      name: Standard_E2ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4ads_v6
-      id: Standard_E4ads_v6
+      cpu_cores: 16
+      family: StandardDaldsv7Family
+      generic_name: standard_d16alds_v7
+      id: Standard_D16alds_v7
       memory: 34359738368
-      name: Standard_E4ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8ads_v6
-      id: Standard_E8ads_v6
-      memory: 68719476736
-      name: Standard_E8ads_v6
-    - category: memory_optimized
+      name: Standard_D16alds_v7
+    - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_e16ads_v6
-      id: Standard_E16ads_v6
-      memory: 137438953472
-      name: Standard_E16ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20ads_v6
-      id: Standard_E20ads_v6
-      memory: 171798691840
-      name: Standard_E20ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32ads_v6
-      id: Standard_E32ads_v6
-      memory: 274877906944
-      name: Standard_E32ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48ads_v6
-      id: Standard_E48ads_v6
-      memory: 412316860416
-      name: Standard_E48ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64ads_v6
-      id: Standard_E64ads_v6
-      memory: 549755813888
-      name: Standard_E64ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-24ads_v6
-      id: Standard_E96-24ads_v6
-      memory: 721554505728
-      name: Standard_E96-24ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-48ads_v6
-      id: Standard_E96-48ads_v6
-      memory: 721554505728
-      name: Standard_E96-48ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96ads_v6
-      id: Standard_E96ads_v6
-      memory: 721554505728
-      name: Standard_E96ads_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2as_v6
-      id: Standard_F2as_v6
-      memory: 8589934592
-      name: Standard_F2as_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4as_v6
-      id: Standard_F4as_v6
-      memory: 17179869184
-      name: Standard_F4as_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8as_v6
-      id: Standard_F8as_v6
+      family: standardDalv6Family
+      generic_name: standard_d16als_v6
+      id: Standard_D16als_v6
       memory: 34359738368
-      name: Standard_F8as_v6
-    - category: compute_optimized
+      name: Standard_D16als_v6
+    - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_f16as_v6
-      id: Standard_F16as_v6
-      memory: 68719476736
-      name: Standard_F16as_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32as_v6
-      id: Standard_F32as_v6
-      memory: 137438953472
-      name: Standard_F32as_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_f48as_v6
-      id: Standard_F48as_v6
-      memory: 206158430208
-      name: Standard_F48as_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64as_v6
-      id: Standard_F64as_v6
-      memory: 274877906944
-      name: Standard_F64as_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2als_v6
-      id: Standard_F2als_v6
-      memory: 4294967296
-      name: Standard_F2als_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4als_v6
-      id: Standard_F4als_v6
-      memory: 8589934592
-      name: Standard_F4als_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8als_v6
-      id: Standard_F8als_v6
-      memory: 17179869184
-      name: Standard_F8als_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16als_v6
-      id: Standard_F16als_v6
+      family: StandardDalsv7Family
+      generic_name: standard_d16als_v7
+      id: Standard_D16als_v7
       memory: 34359738368
-      name: Standard_F16als_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32als_v6
-      id: Standard_F32als_v6
-      memory: 68719476736
-      name: Standard_F32als_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_f48als_v6
-      id: Standard_F48als_v6
-      memory: 103079215104
-      name: Standard_F48als_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64als_v6
-      id: Standard_F64als_v6
-      memory: 137438953472
-      name: Standard_F64als_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2ams_v6
-      id: Standard_F2ams_v6
-      memory: 17179869184
-      name: Standard_F2ams_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4ams_v6
-      id: Standard_F4ams_v6
-      memory: 34359738368
-      name: Standard_F4ams_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8ams_v6
-      id: Standard_F8ams_v6
-      memory: 68719476736
-      name: Standard_F8ams_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16ams_v6
-      id: Standard_F16ams_v6
-      memory: 137438953472
-      name: Standard_F16ams_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32ams_v6
-      id: Standard_F32ams_v6
-      memory: 274877906944
-      name: Standard_F32ams_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_f48ams_v6
-      id: Standard_F48ams_v6
-      memory: 412316860416
-      name: Standard_F48ams_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64ams_v6
-      id: Standard_F64ams_v6
-      memory: 549755813888
-      name: Standard_F64ams_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2ds_v5
-      id: Standard_D2ds_v5
-      memory: 8589934592
-      name: Standard_D2ds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4ds_v5
-      id: Standard_D4ds_v5
-      memory: 17179869184
-      name: Standard_D4ds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8ds_v5
-      id: Standard_D8ds_v5
-      memory: 34359738368
-      name: Standard_D8ds_v5
+      name: Standard_D16als_v7
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_d16ds_v5
-      id: Standard_D16ds_v5
-      memory: 68719476736
-      name: Standard_D16ds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32ds_v5
-      id: Standard_D32ds_v5
-      memory: 137438953472
-      name: Standard_D32ds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48ds_v5
-      id: Standard_D48ds_v5
-      memory: 206158430208
-      name: Standard_D48ds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64ds_v5
-      id: Standard_D64ds_v5
-      memory: 274877906944
-      name: Standard_D64ds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96ds_v5
-      id: Standard_D96ds_v5
-      memory: 412316860416
-      name: Standard_D96ds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2d_v5
-      id: Standard_D2d_v5
-      memory: 8589934592
-      name: Standard_D2d_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4d_v5
-      id: Standard_D4d_v5
-      memory: 17179869184
-      name: Standard_D4d_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8d_v5
-      id: Standard_D8d_v5
-      memory: 34359738368
-      name: Standard_D8d_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16d_v5
-      id: Standard_D16d_v5
-      memory: 68719476736
-      name: Standard_D16d_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32d_v5
-      id: Standard_D32d_v5
-      memory: 137438953472
-      name: Standard_D32d_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48d_v5
-      id: Standard_D48d_v5
-      memory: 206158430208
-      name: Standard_D48d_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64d_v5
-      id: Standard_D64d_v5
-      memory: 274877906944
-      name: Standard_D64d_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96d_v5
-      id: Standard_D96d_v5
-      memory: 412316860416
-      name: Standard_D96d_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2s_v5
-      id: Standard_D2s_v5
-      memory: 8589934592
-      name: Standard_D2s_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4s_v5
-      id: Standard_D4s_v5
-      memory: 17179869184
-      name: Standard_D4s_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8s_v5
-      id: Standard_D8s_v5
-      memory: 34359738368
-      name: Standard_D8s_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16s_v5
-      id: Standard_D16s_v5
-      memory: 68719476736
-      name: Standard_D16s_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32s_v5
-      id: Standard_D32s_v5
-      memory: 137438953472
-      name: Standard_D32s_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48s_v5
-      id: Standard_D48s_v5
-      memory: 206158430208
-      name: Standard_D48s_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64s_v5
-      id: Standard_D64s_v5
-      memory: 274877906944
-      name: Standard_D64s_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96s_v5
-      id: Standard_D96s_v5
-      memory: 412316860416
-      name: Standard_D96s_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2_v5
-      id: Standard_D2_v5
-      memory: 8589934592
-      name: Standard_D2_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4_v5
-      id: Standard_D4_v5
-      memory: 17179869184
-      name: Standard_D4_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8_v5
-      id: Standard_D8_v5
-      memory: 34359738368
-      name: Standard_D8_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16_v5
-      id: Standard_D16_v5
-      memory: 68719476736
-      name: Standard_D16_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32_v5
-      id: Standard_D32_v5
-      memory: 137438953472
-      name: Standard_D32_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48_v5
-      id: Standard_D48_v5
-      memory: 206158430208
-      name: Standard_D48_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64_v5
-      id: Standard_D64_v5
-      memory: 274877906944
-      name: Standard_D64_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96_v5
-      id: Standard_D96_v5
-      memory: 412316860416
-      name: Standard_D96_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2ds_v5
-      id: Standard_E2ds_v5
-      memory: 17179869184
-      name: Standard_E2ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2ds_v5
-      id: Standard_E4-2ds_v5
-      memory: 34359738368
-      name: Standard_E4-2ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4ds_v5
-      id: Standard_E4ds_v5
-      memory: 34359738368
-      name: Standard_E4ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2ds_v5
-      id: Standard_E8-2ds_v5
-      memory: 68719476736
-      name: Standard_E8-2ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4ds_v5
-      id: Standard_E8-4ds_v5
-      memory: 68719476736
-      name: Standard_E8-4ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8ds_v5
-      id: Standard_E8ds_v5
-      memory: 68719476736
-      name: Standard_E8ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-4ds_v5
-      id: Standard_E16-4ds_v5
-      memory: 137438953472
-      name: Standard_E16-4ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8ds_v5
-      id: Standard_E16-8ds_v5
-      memory: 137438953472
-      name: Standard_E16-8ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16ds_v5
-      id: Standard_E16ds_v5
-      memory: 137438953472
-      name: Standard_E16ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20ds_v5
-      id: Standard_E20ds_v5
-      memory: 171798691840
-      name: Standard_E20ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8ds_v5
-      id: Standard_E32-8ds_v5
-      memory: 274877906944
-      name: Standard_E32-8ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16ds_v5
-      id: Standard_E32-16ds_v5
-      memory: 274877906944
-      name: Standard_E32-16ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32ds_v5
-      id: Standard_E32ds_v5
-      memory: 274877906944
-      name: Standard_E32ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48ds_v5
-      id: Standard_E48ds_v5
-      memory: 412316860416
-      name: Standard_E48ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16ds_v5
-      id: Standard_E64-16ds_v5
-      memory: 549755813888
-      name: Standard_E64-16ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32ds_v5
-      id: Standard_E64-32ds_v5
-      memory: 549755813888
-      name: Standard_E64-32ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64ds_v5
-      id: Standard_E64ds_v5
-      memory: 549755813888
-      name: Standard_E64ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-24ds_v5
-      id: Standard_E96-24ds_v5
-      memory: 721554505728
-      name: Standard_E96-24ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-48ds_v5
-      id: Standard_E96-48ds_v5
-      memory: 721554505728
-      name: Standard_E96-48ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96ds_v5
-      id: Standard_E96ds_v5
-      memory: 721554505728
-      name: Standard_E96ds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 104
-      generic_name: standard_e104ids_v5
-      id: Standard_E104ids_v5
-      memory: 721554505728
-      name: Standard_E104ids_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2d_v5
-      id: Standard_E2d_v5
-      memory: 17179869184
-      name: Standard_E2d_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4d_v5
-      id: Standard_E4d_v5
-      memory: 34359738368
-      name: Standard_E4d_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8d_v5
-      id: Standard_E8d_v5
-      memory: 68719476736
-      name: Standard_E8d_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16d_v5
-      id: Standard_E16d_v5
-      memory: 137438953472
-      name: Standard_E16d_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20d_v5
-      id: Standard_E20d_v5
-      memory: 171798691840
-      name: Standard_E20d_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32d_v5
-      id: Standard_E32d_v5
-      memory: 274877906944
-      name: Standard_E32d_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48d_v5
-      id: Standard_E48d_v5
-      memory: 412316860416
-      name: Standard_E48d_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64d_v5
-      id: Standard_E64d_v5
-      memory: 549755813888
-      name: Standard_E64d_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96d_v5
-      id: Standard_E96d_v5
-      memory: 721554505728
-      name: Standard_E96d_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 104
-      generic_name: standard_e104id_v5
-      id: Standard_E104id_v5
-      memory: 721554505728
-      name: Standard_E104id_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2s_v5
-      id: Standard_E2s_v5
-      memory: 17179869184
-      name: Standard_E2s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2s_v5
-      id: Standard_E4-2s_v5
-      memory: 34359738368
-      name: Standard_E4-2s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4s_v5
-      id: Standard_E4s_v5
-      memory: 34359738368
-      name: Standard_E4s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2s_v5
-      id: Standard_E8-2s_v5
-      memory: 68719476736
-      name: Standard_E8-2s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4s_v5
-      id: Standard_E8-4s_v5
-      memory: 68719476736
-      name: Standard_E8-4s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8s_v5
-      id: Standard_E8s_v5
-      memory: 68719476736
-      name: Standard_E8s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-4s_v5
-      id: Standard_E16-4s_v5
-      memory: 137438953472
-      name: Standard_E16-4s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8s_v5
-      id: Standard_E16-8s_v5
-      memory: 137438953472
-      name: Standard_E16-8s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16s_v5
-      id: Standard_E16s_v5
-      memory: 137438953472
-      name: Standard_E16s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20s_v5
-      id: Standard_E20s_v5
-      memory: 171798691840
-      name: Standard_E20s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8s_v5
-      id: Standard_E32-8s_v5
-      memory: 274877906944
-      name: Standard_E32-8s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16s_v5
-      id: Standard_E32-16s_v5
-      memory: 274877906944
-      name: Standard_E32-16s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32s_v5
-      id: Standard_E32s_v5
-      memory: 274877906944
-      name: Standard_E32s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48s_v5
-      id: Standard_E48s_v5
-      memory: 412316860416
-      name: Standard_E48s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16s_v5
-      id: Standard_E64-16s_v5
-      memory: 549755813888
-      name: Standard_E64-16s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32s_v5
-      id: Standard_E64-32s_v5
-      memory: 549755813888
-      name: Standard_E64-32s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64s_v5
-      id: Standard_E64s_v5
-      memory: 549755813888
-      name: Standard_E64s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-24s_v5
-      id: Standard_E96-24s_v5
-      memory: 721554505728
-      name: Standard_E96-24s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-48s_v5
-      id: Standard_E96-48s_v5
-      memory: 721554505728
-      name: Standard_E96-48s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96s_v5
-      id: Standard_E96s_v5
-      memory: 721554505728
-      name: Standard_E96s_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 104
-      generic_name: standard_e104is_v5
-      id: Standard_E104is_v5
-      memory: 721554505728
-      name: Standard_E104is_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2_v5
-      id: Standard_E2_v5
-      memory: 17179869184
-      name: Standard_E2_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4_v5
-      id: Standard_E4_v5
-      memory: 34359738368
-      name: Standard_E4_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8_v5
-      id: Standard_E8_v5
-      memory: 68719476736
-      name: Standard_E8_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16_v5
-      id: Standard_E16_v5
-      memory: 137438953472
-      name: Standard_E16_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20_v5
-      id: Standard_E20_v5
-      memory: 171798691840
-      name: Standard_E20_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32_v5
-      id: Standard_E32_v5
-      memory: 274877906944
-      name: Standard_E32_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48_v5
-      id: Standard_E48_v5
-      memory: 412316860416
-      name: Standard_E48_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64_v5
-      id: Standard_E64_v5
-      memory: 549755813888
-      name: Standard_E64_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96_v5
-      id: Standard_E96_v5
-      memory: 721554505728
-      name: Standard_E96_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 104
-      generic_name: standard_e104i_v5
-      id: Standard_E104i_v5
-      memory: 721554505728
-      name: Standard_E104i_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2bs_v5
-      id: Standard_E2bs_v5
-      memory: 17179869184
-      name: Standard_E2bs_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4bs_v5
-      id: Standard_E4bs_v5
-      memory: 34359738368
-      name: Standard_E4bs_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8bs_v5
-      id: Standard_E8bs_v5
-      memory: 68719476736
-      name: Standard_E8bs_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16bs_v5
-      id: Standard_E16bs_v5
-      memory: 137438953472
-      name: Standard_E16bs_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32bs_v5
-      id: Standard_E32bs_v5
-      memory: 274877906944
-      name: Standard_E32bs_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48bs_v5
-      id: Standard_E48bs_v5
-      memory: 412316860416
-      name: Standard_E48bs_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64bs_v5
-      id: Standard_E64bs_v5
-      memory: 549755813888
-      name: Standard_E64bs_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96bs_v5
-      id: Standard_E96bs_v5
-      memory: 721554505728
-      name: Standard_E96bs_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 112
-      generic_name: standard_e112ibs_v5
-      id: Standard_E112ibs_v5
-      memory: 721554505728
-      name: Standard_E112ibs_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2bds_v5
-      id: Standard_E2bds_v5
-      memory: 17179869184
-      name: Standard_E2bds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4bds_v5
-      id: Standard_E4bds_v5
-      memory: 34359738368
-      name: Standard_E4bds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8bds_v5
-      id: Standard_E8bds_v5
-      memory: 68719476736
-      name: Standard_E8bds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16bds_v5
-      id: Standard_E16bds_v5
-      memory: 137438953472
-      name: Standard_E16bds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32bds_v5
-      id: Standard_E32bds_v5
-      memory: 274877906944
-      name: Standard_E32bds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48bds_v5
-      id: Standard_E48bds_v5
-      memory: 412316860416
-      name: Standard_E48bds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64bds_v5
-      id: Standard_E64bds_v5
-      memory: 549755813888
-      name: Standard_E64bds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96bds_v5
-      id: Standard_E96bds_v5
-      memory: 721554505728
-      name: Standard_E96bds_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 112
-      generic_name: standard_e112ibds_v5
-      id: Standard_E112ibds_v5
-      memory: 721554505728
-      name: Standard_E112ibds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2ls_v5
-      id: Standard_D2ls_v5
-      memory: 4294967296
-      name: Standard_D2ls_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4ls_v5
-      id: Standard_D4ls_v5
-      memory: 8589934592
-      name: Standard_D4ls_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8ls_v5
-      id: Standard_D8ls_v5
-      memory: 17179869184
-      name: Standard_D8ls_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16ls_v5
-      id: Standard_D16ls_v5
-      memory: 34359738368
-      name: Standard_D16ls_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32ls_v5
-      id: Standard_D32ls_v5
-      memory: 68719476736
-      name: Standard_D32ls_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48ls_v5
-      id: Standard_D48ls_v5
-      memory: 103079215104
-      name: Standard_D48ls_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64ls_v5
-      id: Standard_D64ls_v5
-      memory: 137438953472
-      name: Standard_D64ls_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96ls_v5
-      id: Standard_D96ls_v5
-      memory: 206158430208
-      name: Standard_D96ls_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2lds_v5
-      id: Standard_D2lds_v5
-      memory: 4294967296
-      name: Standard_D2lds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4lds_v5
-      id: Standard_D4lds_v5
-      memory: 8589934592
-      name: Standard_D4lds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8lds_v5
-      id: Standard_D8lds_v5
-      memory: 17179869184
-      name: Standard_D8lds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16lds_v5
-      id: Standard_D16lds_v5
-      memory: 34359738368
-      name: Standard_D16lds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32lds_v5
-      id: Standard_D32lds_v5
-      memory: 68719476736
-      name: Standard_D32lds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48lds_v5
-      id: Standard_D48lds_v5
-      memory: 103079215104
-      name: Standard_D48lds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64lds_v5
-      id: Standard_D64lds_v5
-      memory: 137438953472
-      name: Standard_D64lds_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96lds_v5
-      id: Standard_D96lds_v5
-      memory: 206158430208
-      name: Standard_D96lds_v5
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_nc8ads_a10_v4
-      id: Standard_NC8ads_A10_v4
-      memory: 107374182400
-      name: Standard_NC8ads_A10_v4
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_nc16ads_a10_v4
-      id: Standard_NC16ads_A10_v4
-      memory: 214748364800
-      name: Standard_NC16ads_A10_v4
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_nc32ads_a10_v4
-      id: Standard_NC32ads_A10_v4
-      memory: 429496729600
-      name: Standard_NC32ads_A10_v4
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 40
-      generic_name: standard_nc40ads_h100_v5
-      id: Standard_NC40ads_H100_v5
-      memory: 343597383680
-      name: Standard_NC40ads_H100_v5
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_nc80adis_h100_v5
-      id: Standard_NC80adis_H100_v5
-      memory: 687194767360
-      name: Standard_NC80adis_H100_v5
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2ls_v6
-      id: Standard_D2ls_v6
-      memory: 4294967296
-      name: Standard_D2ls_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4ls_v6
-      id: Standard_D4ls_v6
-      memory: 8589934592
-      name: Standard_D4ls_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8ls_v6
-      id: Standard_D8ls_v6
-      memory: 17179869184
-      name: Standard_D8ls_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16ls_v6
-      id: Standard_D16ls_v6
-      memory: 34359738368
-      name: Standard_D16ls_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32ls_v6
-      id: Standard_D32ls_v6
-      memory: 68719476736
-      name: Standard_D32ls_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48ls_v6
-      id: Standard_D48ls_v6
-      memory: 103079215104
-      name: Standard_D48ls_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64ls_v6
-      id: Standard_D64ls_v6
-      memory: 137438953472
-      name: Standard_D64ls_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96ls_v6
-      id: Standard_D96ls_v6
-      memory: 206158430208
-      name: Standard_D96ls_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_d128ls_v6
-      id: Standard_D128ls_v6
-      memory: 274877906944
-      name: Standard_D128ls_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2lds_v6
-      id: Standard_D2lds_v6
-      memory: 4294967296
-      name: Standard_D2lds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4lds_v6
-      id: Standard_D4lds_v6
-      memory: 8589934592
-      name: Standard_D4lds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8lds_v6
-      id: Standard_D8lds_v6
-      memory: 17179869184
-      name: Standard_D8lds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16lds_v6
-      id: Standard_D16lds_v6
-      memory: 34359738368
-      name: Standard_D16lds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32lds_v6
-      id: Standard_D32lds_v6
-      memory: 68719476736
-      name: Standard_D32lds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48lds_v6
-      id: Standard_D48lds_v6
-      memory: 103079215104
-      name: Standard_D48lds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64lds_v6
-      id: Standard_D64lds_v6
-      memory: 137438953472
-      name: Standard_D64lds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96lds_v6
-      id: Standard_D96lds_v6
-      memory: 206158430208
-      name: Standard_D96lds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_d128lds_v6
-      id: Standard_D128lds_v6
-      memory: 274877906944
-      name: Standard_D128lds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2s_v6
-      id: Standard_D2s_v6
-      memory: 8589934592
-      name: Standard_D2s_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4s_v6
-      id: Standard_D4s_v6
-      memory: 17179869184
-      name: Standard_D4s_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8s_v6
-      id: Standard_D8s_v6
-      memory: 34359738368
-      name: Standard_D8s_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16s_v6
-      id: Standard_D16s_v6
-      memory: 68719476736
-      name: Standard_D16s_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32s_v6
-      id: Standard_D32s_v6
-      memory: 137438953472
-      name: Standard_D32s_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48s_v6
-      id: Standard_D48s_v6
-      memory: 206158430208
-      name: Standard_D48s_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64s_v6
-      id: Standard_D64s_v6
-      memory: 274877906944
-      name: Standard_D64s_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96s_v6
-      id: Standard_D96s_v6
-      memory: 412316860416
-      name: Standard_D96s_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_d128s_v6
-      id: Standard_D128s_v6
-      memory: 549755813888
-      name: Standard_D128s_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 192
-      generic_name: standard_d192s_v6
-      id: Standard_D192s_v6
-      memory: 824633720832
-      name: Standard_D192s_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2ds_v6
-      id: Standard_D2ds_v6
-      memory: 8589934592
-      name: Standard_D2ds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4ds_v6
-      id: Standard_D4ds_v6
-      memory: 17179869184
-      name: Standard_D4ds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8ds_v6
-      id: Standard_D8ds_v6
-      memory: 34359738368
-      name: Standard_D8ds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16ds_v6
-      id: Standard_D16ds_v6
-      memory: 68719476736
-      name: Standard_D16ds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32ds_v6
-      id: Standard_D32ds_v6
-      memory: 137438953472
-      name: Standard_D32ds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48ds_v6
-      id: Standard_D48ds_v6
-      memory: 206158430208
-      name: Standard_D48ds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64ds_v6
-      id: Standard_D64ds_v6
-      memory: 274877906944
-      name: Standard_D64ds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96ds_v6
-      id: Standard_D96ds_v6
-      memory: 412316860416
-      name: Standard_D96ds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_d128ds_v6
-      id: Standard_D128ds_v6
-      memory: 549755813888
-      name: Standard_D128ds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 192
-      generic_name: standard_d192ds_v6
-      id: Standard_D192ds_v6
-      memory: 824633720832
-      name: Standard_D192ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2s_v6
-      id: Standard_E2s_v6
-      memory: 17179869184
-      name: Standard_E2s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2s_v6
-      id: Standard_E4-2s_v6
-      memory: 34359738368
-      name: Standard_E4-2s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4s_v6
-      id: Standard_E4s_v6
-      memory: 34359738368
-      name: Standard_E4s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2s_v6
-      id: Standard_E8-2s_v6
-      memory: 68719476736
-      name: Standard_E8-2s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4s_v6
-      id: Standard_E8-4s_v6
-      memory: 68719476736
-      name: Standard_E8-4s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8s_v6
-      id: Standard_E8s_v6
-      memory: 68719476736
-      name: Standard_E8s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-4s_v6
-      id: Standard_E16-4s_v6
-      memory: 137438953472
-      name: Standard_E16-4s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8s_v6
-      id: Standard_E16-8s_v6
-      memory: 137438953472
-      name: Standard_E16-8s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16s_v6
-      id: Standard_E16s_v6
-      memory: 137438953472
-      name: Standard_E16s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20s_v6
-      id: Standard_E20s_v6
-      memory: 171798691840
-      name: Standard_E20s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8s_v6
-      id: Standard_E32-8s_v6
-      memory: 274877906944
-      name: Standard_E32-8s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16s_v6
-      id: Standard_E32-16s_v6
-      memory: 274877906944
-      name: Standard_E32-16s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32s_v6
-      id: Standard_E32s_v6
-      memory: 274877906944
-      name: Standard_E32s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48s_v6
-      id: Standard_E48s_v6
-      memory: 412316860416
-      name: Standard_E48s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16s_v6
-      id: Standard_E64-16s_v6
-      memory: 549755813888
-      name: Standard_E64-16s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32s_v6
-      id: Standard_E64-32s_v6
-      memory: 549755813888
-      name: Standard_E64-32s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64s_v6
-      id: Standard_E64s_v6
-      memory: 549755813888
-      name: Standard_E64s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-24s_v6
-      id: Standard_E96-24s_v6
-      memory: 824633720832
-      name: Standard_E96-24s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-48s_v6
-      id: Standard_E96-48s_v6
-      memory: 824633720832
-      name: Standard_E96-48s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96s_v6
-      id: Standard_E96s_v6
-      memory: 824633720832
-      name: Standard_E96s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2ds_v6
-      id: Standard_E2ds_v6
-      memory: 17179869184
-      name: Standard_E2ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2ds_v6
-      id: Standard_E4-2ds_v6
-      memory: 34359738368
-      name: Standard_E4-2ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4ds_v6
-      id: Standard_E4ds_v6
-      memory: 34359738368
-      name: Standard_E4ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2ds_v6
-      id: Standard_E8-2ds_v6
-      memory: 68719476736
-      name: Standard_E8-2ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4ds_v6
-      id: Standard_E8-4ds_v6
-      memory: 68719476736
-      name: Standard_E8-4ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8ds_v6
-      id: Standard_E8ds_v6
-      memory: 68719476736
-      name: Standard_E8ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-4ds_v6
-      id: Standard_E16-4ds_v6
-      memory: 137438953472
-      name: Standard_E16-4ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8ds_v6
-      id: Standard_E16-8ds_v6
-      memory: 137438953472
-      name: Standard_E16-8ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16ds_v6
-      id: Standard_E16ds_v6
-      memory: 137438953472
-      name: Standard_E16ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20ds_v6
-      id: Standard_E20ds_v6
-      memory: 171798691840
-      name: Standard_E20ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8ds_v6
-      id: Standard_E32-8ds_v6
-      memory: 274877906944
-      name: Standard_E32-8ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16ds_v6
-      id: Standard_E32-16ds_v6
-      memory: 274877906944
-      name: Standard_E32-16ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32ds_v6
-      id: Standard_E32ds_v6
-      memory: 274877906944
-      name: Standard_E32ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48ds_v6
-      id: Standard_E48ds_v6
-      memory: 412316860416
-      name: Standard_E48ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16ds_v6
-      id: Standard_E64-16ds_v6
-      memory: 549755813888
-      name: Standard_E64-16ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32ds_v6
-      id: Standard_E64-32ds_v6
-      memory: 549755813888
-      name: Standard_E64-32ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64ds_v6
-      id: Standard_E64ds_v6
-      memory: 549755813888
-      name: Standard_E64ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-24ds_v6
-      id: Standard_E96-24ds_v6
-      memory: 824633720832
-      name: Standard_E96-24ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-48ds_v6
-      id: Standard_E96-48ds_v6
-      memory: 824633720832
-      name: Standard_E96-48ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96ds_v6
-      id: Standard_E96ds_v6
-      memory: 824633720832
-      name: Standard_E96ds_v6
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_l8as_v3
-      id: Standard_L8as_v3
-      memory: 68719476736
-      name: Standard_L8as_v3
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_l16as_v3
-      id: Standard_L16as_v3
-      memory: 137438953472
-      name: Standard_L16as_v3
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_l32as_v3
-      id: Standard_L32as_v3
-      memory: 274877906944
-      name: Standard_L32as_v3
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_l48as_v3
-      id: Standard_L48as_v3
-      memory: 412316860416
-      name: Standard_L48as_v3
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_l64as_v3
-      id: Standard_L64as_v3
-      memory: 549755813888
-      name: Standard_L64as_v3
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_l80as_v3
-      id: Standard_L80as_v3
-      memory: 687194767360
-      name: Standard_L80as_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2a_v4
-      id: Standard_D2a_v4
-      memory: 8589934592
-      name: Standard_D2a_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4a_v4
-      id: Standard_D4a_v4
-      memory: 17179869184
-      name: Standard_D4a_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8a_v4
-      id: Standard_D8a_v4
-      memory: 34359738368
-      name: Standard_D8a_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16a_v4
-      id: Standard_D16a_v4
-      memory: 68719476736
-      name: Standard_D16a_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32a_v4
-      id: Standard_D32a_v4
-      memory: 137438953472
-      name: Standard_D32a_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48a_v4
-      id: Standard_D48a_v4
-      memory: 206158430208
-      name: Standard_D48a_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64a_v4
-      id: Standard_D64a_v4
-      memory: 274877906944
-      name: Standard_D64a_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96a_v4
-      id: Standard_D96a_v4
-      memory: 412316860416
-      name: Standard_D96a_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2as_v4
-      id: Standard_D2as_v4
-      memory: 8589934592
-      name: Standard_D2as_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4as_v4
-      id: Standard_D4as_v4
-      memory: 17179869184
-      name: Standard_D4as_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8as_v4
-      id: Standard_D8as_v4
-      memory: 34359738368
-      name: Standard_D8as_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
+      family: standardDASv4Family
       generic_name: standard_d16as_v4
       id: Standard_D16as_v4
       memory: 68719476736
       name: Standard_D16as_v4
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32as_v4
-      id: Standard_D32as_v4
-      memory: 137438953472
-      name: Standard_D32as_v4
+      cpu_cores: 16
+      family: standardDASv5Family
+      generic_name: standard_d16as_v5
+      id: Standard_D16as_v5
+      memory: 68719476736
+      name: Standard_D16as_v5
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48as_v4
-      id: Standard_D48as_v4
-      memory: 206158430208
-      name: Standard_D48as_v4
+      cpu_cores: 16
+      family: standardDav6Family
+      generic_name: standard_d16as_v6
+      id: Standard_D16as_v6
+      memory: 68719476736
+      name: Standard_D16as_v6
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64as_v4
-      id: Standard_D64as_v4
-      memory: 274877906944
-      name: Standard_D64as_v4
+      cpu_cores: 16
+      family: StandardDasv7Family
+      generic_name: standard_d16as_v7
+      id: Standard_D16as_v7
+      memory: 68719476736
+      name: Standard_D16as_v7
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96as_v4
-      id: Standard_D96as_v4
-      memory: 412316860416
-      name: Standard_D96as_v4
-    - category: memory_optimized
+      cpu_cores: 16
+      family: standardDAv4Family
+      generic_name: standard_d16a_v4
+      id: Standard_D16a_v4
+      memory: 68719476736
+      name: Standard_D16a_v4
+    - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2a_v4
-      id: Standard_E2a_v4
-      memory: 17179869184
-      name: Standard_E2a_v4
-    - category: memory_optimized
+      cpu_cores: 16
+      family: standardDDSv4Family
+      generic_name: standard_d16ds_v4
+      id: Standard_D16ds_v4
+      memory: 68719476736
+      name: Standard_D16ds_v4
+    - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4a_v4
-      id: Standard_E4a_v4
+      cpu_cores: 16
+      family: standardDDSv5Family
+      generic_name: standard_d16ds_v5
+      id: Standard_D16ds_v5
+      memory: 68719476736
+      name: Standard_D16ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardDdsv6Family
+      generic_name: standard_d16ds_v6
+      id: Standard_D16ds_v6
+      memory: 68719476736
+      name: Standard_D16ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDDv4Family
+      generic_name: standard_d16d_v4
+      id: Standard_D16d_v4
+      memory: 68719476736
+      name: Standard_D16d_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDDv5Family
+      generic_name: standard_d16d_v5
+      id: Standard_D16d_v5
+      memory: 68719476736
+      name: Standard_D16d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDLDSv5Family
+      generic_name: standard_d16lds_v5
+      id: Standard_D16lds_v5
       memory: 34359738368
-      name: Standard_E4a_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8a_v4
-      id: Standard_E8a_v4
-      memory: 68719476736
-      name: Standard_E8a_v4
-    - category: memory_optimized
+      name: Standard_D16lds_v5
+    - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_e16a_v4
-      id: Standard_E16a_v4
-      memory: 137438953472
-      name: Standard_E16a_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20a_v4
-      id: Standard_E20a_v4
-      memory: 171798691840
-      name: Standard_E20a_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32a_v4
-      id: Standard_E32a_v4
-      memory: 274877906944
-      name: Standard_E32a_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48a_v4
-      id: Standard_E48a_v4
-      memory: 412316860416
-      name: Standard_E48a_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64a_v4
-      id: Standard_E64a_v4
-      memory: 549755813888
-      name: Standard_E64a_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96a_v4
-      id: Standard_E96a_v4
-      memory: 721554505728
-      name: Standard_E96a_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2as_v4
-      id: Standard_E2as_v4
-      memory: 17179869184
-      name: Standard_E2as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2as_v4
-      id: Standard_E4-2as_v4
+      family: StandardDldsv6Family
+      generic_name: standard_d16lds_v6
+      id: Standard_D16lds_v6
       memory: 34359738368
-      name: Standard_E4-2as_v4
-    - category: memory_optimized
+      name: Standard_D16lds_v6
+    - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4as_v4
-      id: Standard_E4as_v4
+      cpu_cores: 16
+      family: standardDLSv5Family
+      generic_name: standard_d16ls_v5
+      id: Standard_D16ls_v5
       memory: 34359738368
-      name: Standard_E4as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2as_v4
-      id: Standard_E8-2as_v4
-      memory: 68719476736
-      name: Standard_E8-2as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4as_v4
-      id: Standard_E8-4as_v4
-      memory: 68719476736
-      name: Standard_E8-4as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8as_v4
-      id: Standard_E8as_v4
-      memory: 68719476736
-      name: Standard_E8as_v4
-    - category: memory_optimized
+      name: Standard_D16ls_v5
+    - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_e16-4as_v4
-      id: Standard_E16-4as_v4
-      memory: 137438953472
-      name: Standard_E16-4as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8as_v4
-      id: Standard_E16-8as_v4
-      memory: 137438953472
-      name: Standard_E16-8as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16as_v4
-      id: Standard_E16as_v4
-      memory: 137438953472
-      name: Standard_E16as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20as_v4
-      id: Standard_E20as_v4
-      memory: 171798691840
-      name: Standard_E20as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8as_v4
-      id: Standard_E32-8as_v4
-      memory: 274877906944
-      name: Standard_E32-8as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16as_v4
-      id: Standard_E32-16as_v4
-      memory: 274877906944
-      name: Standard_E32-16as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32as_v4
-      id: Standard_E32as_v4
-      memory: 274877906944
-      name: Standard_E32as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48as_v4
-      id: Standard_E48as_v4
-      memory: 412316860416
-      name: Standard_E48as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16as_v4
-      id: Standard_E64-16as_v4
-      memory: 549755813888
-      name: Standard_E64-16as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32as_v4
-      id: Standard_E64-32as_v4
-      memory: 549755813888
-      name: Standard_E64-32as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64as_v4
-      id: Standard_E64as_v4
-      memory: 549755813888
-      name: Standard_E64as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-24as_v4
-      id: Standard_E96-24as_v4
-      memory: 721554505728
-      name: Standard_E96-24as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-48as_v4
-      id: Standard_E96-48as_v4
-      memory: 721554505728
-      name: Standard_E96-48as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96as_v4
-      id: Standard_E96as_v4
-      memory: 721554505728
-      name: Standard_E96as_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_l8s_v3
-      id: Standard_L8s_v3
-      memory: 68719476736
-      name: Standard_L8s_v3
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_l16s_v3
-      id: Standard_L16s_v3
-      memory: 137438953472
-      name: Standard_L16s_v3
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_l32s_v3
-      id: Standard_L32s_v3
-      memory: 274877906944
-      name: Standard_L32s_v3
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_l48s_v3
-      id: Standard_L48s_v3
-      memory: 412316860416
-      name: Standard_L48s_v3
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_l64s_v3
-      id: Standard_L64s_v3
-      memory: 549755813888
-      name: Standard_L64s_v3
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_l80s_v3
-      id: Standard_L80s_v3
-      memory: 687194767360
-      name: Standard_L80s_v3
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_l2aos_v4
-      id: Standard_L2aos_v4
-      memory: 17179869184
-      name: Standard_L2aos_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_l4aos_v4
-      id: Standard_L4aos_v4
+      family: StandardDlsv6Family
+      generic_name: standard_d16ls_v6
+      id: Standard_D16ls_v6
       memory: 34359738368
-      name: Standard_L4aos_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_l8aos_v4
-      id: Standard_L8aos_v4
-      memory: 68719476736
-      name: Standard_L8aos_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 12
-      generic_name: standard_l12aos_v4
-      id: Standard_L12aos_v4
-      memory: 103079215104
-      name: Standard_L12aos_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_l16aos_v4
-      id: Standard_L16aos_v4
-      memory: 137438953472
-      name: Standard_L16aos_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 24
-      generic_name: standard_l24aos_v4
-      id: Standard_L24aos_v4
-      memory: 206158430208
-      name: Standard_L24aos_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_l32aos_v4
-      id: Standard_L32aos_v4
-      memory: 274877906944
-      name: Standard_L32aos_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_l2as_v4
-      id: Standard_L2as_v4
-      memory: 17179869184
-      name: Standard_L2as_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_l4as_v4
-      id: Standard_L4as_v4
-      memory: 34359738368
-      name: Standard_L4as_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_l8as_v4
-      id: Standard_L8as_v4
-      memory: 68719476736
-      name: Standard_L8as_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_l16as_v4
-      id: Standard_L16as_v4
-      memory: 137438953472
-      name: Standard_L16as_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_l32as_v4
-      id: Standard_L32as_v4
-      memory: 274877906944
-      name: Standard_L32as_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_l48as_v4
-      id: Standard_L48as_v4
-      memory: 412316860416
-      name: Standard_L48as_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_l64as_v4
-      id: Standard_L64as_v4
-      memory: 549755813888
-      name: Standard_L64as_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_l80as_v4
-      id: Standard_L80as_v4
-      memory: 687194767360
-      name: Standard_L80as_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_l96as_v4
-      id: Standard_L96as_v4
-      memory: 824633720832
-      name: Standard_L96as_v4
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2plds_v5
-      id: Standard_D2plds_v5
-      memory: 4294967296
-      name: Standard_D2plds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4plds_v5
-      id: Standard_D4plds_v5
-      memory: 8589934592
-      name: Standard_D4plds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8plds_v5
-      id: Standard_D8plds_v5
-      memory: 17179869184
-      name: Standard_D8plds_v5
+      name: Standard_D16ls_v6
     - architecture: arm64
       category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_d16plds_v5
-      id: Standard_D16plds_v5
-      memory: 34359738368
-      name: Standard_D16plds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32plds_v5
-      id: Standard_D32plds_v5
-      memory: 68719476736
-      name: Standard_D32plds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48plds_v5
-      id: Standard_D48plds_v5
-      memory: 103079215104
-      name: Standard_D48plds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64plds_v5
-      id: Standard_D64plds_v5
-      memory: 137438953472
-      name: Standard_D64plds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2pls_v5
-      id: Standard_D2pls_v5
-      memory: 4294967296
-      name: Standard_D2pls_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4pls_v5
-      id: Standard_D4pls_v5
-      memory: 8589934592
-      name: Standard_D4pls_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8pls_v5
-      id: Standard_D8pls_v5
-      memory: 17179869184
-      name: Standard_D8pls_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16pls_v5
-      id: Standard_D16pls_v5
-      memory: 34359738368
-      name: Standard_D16pls_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32pls_v5
-      id: Standard_D32pls_v5
-      memory: 68719476736
-      name: Standard_D32pls_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48pls_v5
-      id: Standard_D48pls_v5
-      memory: 103079215104
-      name: Standard_D48pls_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64pls_v5
-      id: Standard_D64pls_v5
-      memory: 137438953472
-      name: Standard_D64pls_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2pds_v5
-      id: Standard_D2pds_v5
-      memory: 8589934592
-      name: Standard_D2pds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4pds_v5
-      id: Standard_D4pds_v5
-      memory: 17179869184
-      name: Standard_D4pds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8pds_v5
-      id: Standard_D8pds_v5
-      memory: 34359738368
-      name: Standard_D8pds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
+      family: standardDPDSv5Family
       generic_name: standard_d16pds_v5
       id: Standard_D16pds_v5
       memory: 68719476736
@@ -4965,845 +1067,8 @@ data:
     - architecture: arm64
       category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32pds_v5
-      id: Standard_D32pds_v5
-      memory: 137438953472
-      name: Standard_D32pds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48pds_v5
-      id: Standard_D48pds_v5
-      memory: 206158430208
-      name: Standard_D48pds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64pds_v5
-      id: Standard_D64pds_v5
-      memory: 223338299392
-      name: Standard_D64pds_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2ps_v5
-      id: Standard_D2ps_v5
-      memory: 8589934592
-      name: Standard_D2ps_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4ps_v5
-      id: Standard_D4ps_v5
-      memory: 17179869184
-      name: Standard_D4ps_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8ps_v5
-      id: Standard_D8ps_v5
-      memory: 34359738368
-      name: Standard_D8ps_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_d16ps_v5
-      id: Standard_D16ps_v5
-      memory: 68719476736
-      name: Standard_D16ps_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32ps_v5
-      id: Standard_D32ps_v5
-      memory: 137438953472
-      name: Standard_D32ps_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48ps_v5
-      id: Standard_D48ps_v5
-      memory: 206158430208
-      name: Standard_D48ps_v5
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64ps_v5
-      id: Standard_D64ps_v5
-      memory: 223338299392
-      name: Standard_D64ps_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2pds_v5
-      id: Standard_E2pds_v5
-      memory: 17179869184
-      name: Standard_E2pds_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4pds_v5
-      id: Standard_E4pds_v5
-      memory: 34359738368
-      name: Standard_E4pds_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8pds_v5
-      id: Standard_E8pds_v5
-      memory: 68719476736
-      name: Standard_E8pds_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16pds_v5
-      id: Standard_E16pds_v5
-      memory: 137438953472
-      name: Standard_E16pds_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20pds_v5
-      id: Standard_E20pds_v5
-      memory: 171798691840
-      name: Standard_E20pds_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32pds_v5
-      id: Standard_E32pds_v5
-      memory: 223338299392
-      name: Standard_E32pds_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2ps_v5
-      id: Standard_E2ps_v5
-      memory: 17179869184
-      name: Standard_E2ps_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4ps_v5
-      id: Standard_E4ps_v5
-      memory: 34359738368
-      name: Standard_E4ps_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8ps_v5
-      id: Standard_E8ps_v5
-      memory: 68719476736
-      name: Standard_E8ps_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16ps_v5
-      id: Standard_E16ps_v5
-      memory: 137438953472
-      name: Standard_E16ps_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 20
-      generic_name: standard_e20ps_v5
-      id: Standard_E20ps_v5
-      memory: 171798691840
-      name: Standard_E20ps_v5
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32ps_v5
-      id: Standard_E32ps_v5
-      memory: 223338299392
-      name: Standard_E32ps_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128-32s_v6
-      id: Standard_E128-32s_v6
-      memory: 1099511627776
-      name: Standard_E128-32s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128-64s_v6
-      id: Standard_E128-64s_v6
-      memory: 1099511627776
-      name: Standard_E128-64s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128s_v6
-      id: Standard_E128s_v6
-      memory: 1099511627776
-      name: Standard_E128s_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 192
-      generic_name: standard_e192is_v6
-      id: Standard_E192is_v6
-      memory: 1967095021568
-      name: Standard_E192is_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128-32ds_v6
-      id: Standard_E128-32ds_v6
-      memory: 1099511627776
-      name: Standard_E128-32ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128-64ds_v6
-      id: Standard_E128-64ds_v6
-      memory: 1099511627776
-      name: Standard_E128-64ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128ds_v6
-      id: Standard_E128ds_v6
-      memory: 1099511627776
-      name: Standard_E128ds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 192
-      generic_name: standard_e192ids_v6
-      id: Standard_E192ids_v6
-      memory: 1967095021568
-      name: Standard_E192ids_v6
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_fx2ms_v2
-      id: Standard_FX2ms_v2
-      memory: 45097156608
-      name: Standard_FX2ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_fx4-2ms_v2
-      id: Standard_FX4-2ms_v2
-      memory: 90194313216
-      name: Standard_FX4-2ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_fx4ms_v2
-      id: Standard_FX4ms_v2
-      memory: 90194313216
-      name: Standard_FX4ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_fx8-2ms_v2
-      id: Standard_FX8-2ms_v2
-      memory: 180388626432
-      name: Standard_FX8-2ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_fx8-4ms_v2
-      id: Standard_FX8-4ms_v2
-      memory: 180388626432
-      name: Standard_FX8-4ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_fx8ms_v2
-      id: Standard_FX8ms_v2
-      memory: 180388626432
-      name: Standard_FX8ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 12
-      generic_name: standard_fx12-6ms_v2
-      id: Standard_FX12-6ms_v2
-      memory: 270582939648
-      name: Standard_FX12-6ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 12
-      generic_name: standard_fx12ms_v2
-      id: Standard_FX12ms_v2
-      memory: 270582939648
-      name: Standard_FX12ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_fx16-4ms_v2
-      id: Standard_FX16-4ms_v2
-      memory: 360777252864
-      name: Standard_FX16-4ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_fx16-8ms_v2
-      id: Standard_FX16-8ms_v2
-      memory: 360777252864
-      name: Standard_FX16-8ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_fx16ms_v2
-      id: Standard_FX16ms_v2
-      memory: 360777252864
-      name: Standard_FX16ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 24
-      generic_name: standard_fx24-6ms_v2
-      id: Standard_FX24-6ms_v2
-      memory: 541165879296
-      name: Standard_FX24-6ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 24
-      generic_name: standard_fx24-12ms_v2
-      id: Standard_FX24-12ms_v2
-      memory: 541165879296
-      name: Standard_FX24-12ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 24
-      generic_name: standard_fx24ms_v2
-      id: Standard_FX24ms_v2
-      memory: 541165879296
-      name: Standard_FX24ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_fx32-8ms_v2
-      id: Standard_FX32-8ms_v2
-      memory: 721554505728
-      name: Standard_FX32-8ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_fx32-16ms_v2
-      id: Standard_FX32-16ms_v2
-      memory: 721554505728
-      name: Standard_FX32-16ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_fx32ms_v2
-      id: Standard_FX32ms_v2
-      memory: 721554505728
-      name: Standard_FX32ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_fx48-12ms_v2
-      id: Standard_FX48-12ms_v2
-      memory: 1082331758592
-      name: Standard_FX48-12ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_fx48-24ms_v2
-      id: Standard_FX48-24ms_v2
-      memory: 1082331758592
-      name: Standard_FX48-24ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_fx48ms_v2
-      id: Standard_FX48ms_v2
-      memory: 1082331758592
-      name: Standard_FX48ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_fx64-16ms_v2
-      id: Standard_FX64-16ms_v2
-      memory: 1443109011456
-      name: Standard_FX64-16ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_fx64-32ms_v2
-      id: Standard_FX64-32ms_v2
-      memory: 1443109011456
-      name: Standard_FX64-32ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_fx64ms_v2
-      id: Standard_FX64ms_v2
-      memory: 1443109011456
-      name: Standard_FX64ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_fx96-24ms_v2
-      id: Standard_FX96-24ms_v2
-      memory: 1967095021568
-      name: Standard_FX96-24ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_fx96-48ms_v2
-      id: Standard_FX96-48ms_v2
-      memory: 1967095021568
-      name: Standard_FX96-48ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_fx96ms_v2
-      id: Standard_FX96ms_v2
-      memory: 1967095021568
-      name: Standard_FX96ms_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_fx2mds_v2
-      id: Standard_FX2mds_v2
-      memory: 45097156608
-      name: Standard_FX2mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_fx4-2mds_v2
-      id: Standard_FX4-2mds_v2
-      memory: 90194313216
-      name: Standard_FX4-2mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_fx4mds_v2
-      id: Standard_FX4mds_v2
-      memory: 90194313216
-      name: Standard_FX4mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_fx8-2mds_v2
-      id: Standard_FX8-2mds_v2
-      memory: 180388626432
-      name: Standard_FX8-2mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_fx8-4mds_v2
-      id: Standard_FX8-4mds_v2
-      memory: 180388626432
-      name: Standard_FX8-4mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_fx8mds_v2
-      id: Standard_FX8mds_v2
-      memory: 180388626432
-      name: Standard_FX8mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 12
-      generic_name: standard_fx12-6mds_v2
-      id: Standard_FX12-6mds_v2
-      memory: 270582939648
-      name: Standard_FX12-6mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 12
-      generic_name: standard_fx12mds_v2
-      id: Standard_FX12mds_v2
-      memory: 270582939648
-      name: Standard_FX12mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_fx16-4mds_v2
-      id: Standard_FX16-4mds_v2
-      memory: 360777252864
-      name: Standard_FX16-4mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_fx16-8mds_v2
-      id: Standard_FX16-8mds_v2
-      memory: 360777252864
-      name: Standard_FX16-8mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_fx16mds_v2
-      id: Standard_FX16mds_v2
-      memory: 360777252864
-      name: Standard_FX16mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 24
-      generic_name: standard_fx24-6mds_v2
-      id: Standard_FX24-6mds_v2
-      memory: 541165879296
-      name: Standard_FX24-6mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 24
-      generic_name: standard_fx24-12mds_v2
-      id: Standard_FX24-12mds_v2
-      memory: 541165879296
-      name: Standard_FX24-12mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 24
-      generic_name: standard_fx24mds_v2
-      id: Standard_FX24mds_v2
-      memory: 541165879296
-      name: Standard_FX24mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_fx32-8mds_v2
-      id: Standard_FX32-8mds_v2
-      memory: 721554505728
-      name: Standard_FX32-8mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_fx32-16mds_v2
-      id: Standard_FX32-16mds_v2
-      memory: 721554505728
-      name: Standard_FX32-16mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_fx32mds_v2
-      id: Standard_FX32mds_v2
-      memory: 721554505728
-      name: Standard_FX32mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_fx48-12mds_v2
-      id: Standard_FX48-12mds_v2
-      memory: 1082331758592
-      name: Standard_FX48-12mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_fx48-24mds_v2
-      id: Standard_FX48-24mds_v2
-      memory: 1082331758592
-      name: Standard_FX48-24mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_fx48mds_v2
-      id: Standard_FX48mds_v2
-      memory: 1082331758592
-      name: Standard_FX48mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_fx64-16mds_v2
-      id: Standard_FX64-16mds_v2
-      memory: 1443109011456
-      name: Standard_FX64-16mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_fx64-32mds_v2
-      id: Standard_FX64-32mds_v2
-      memory: 1443109011456
-      name: Standard_FX64-32mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_fx64mds_v2
-      id: Standard_FX64mds_v2
-      memory: 1443109011456
-      name: Standard_FX64mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_fx96-24mds_v2
-      id: Standard_FX96-24mds_v2
-      memory: 1967095021568
-      name: Standard_FX96-24mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_fx96-48mds_v2
-      id: Standard_FX96-48mds_v2
-      memory: 1967095021568
-      name: Standard_FX96-48mds_v2
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_fx96mds_v2
-      id: Standard_FX96mds_v2
-      memory: 1967095021568
-      name: Standard_FX96mds_v2
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_l2s_v4
-      id: Standard_L2s_v4
-      memory: 17179869184
-      name: Standard_L2s_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_l4s_v4
-      id: Standard_L4s_v4
-      memory: 34359738368
-      name: Standard_L4s_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_l8s_v4
-      id: Standard_L8s_v4
-      memory: 68719476736
-      name: Standard_L8s_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_l16s_v4
-      id: Standard_L16s_v4
-      memory: 137438953472
-      name: Standard_L16s_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_l32s_v4
-      id: Standard_L32s_v4
-      memory: 274877906944
-      name: Standard_L32s_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_l48s_v4
-      id: Standard_L48s_v4
-      memory: 412316860416
-      name: Standard_L48s_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_l64s_v4
-      id: Standard_L64s_v4
-      memory: 549755813888
-      name: Standard_L64s_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_l80s_v4
-      id: Standard_L80s_v4
-      memory: 687194767360
-      name: Standard_L80s_v4
-    - category: storage_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_l96s_v4
-      id: Standard_L96s_v4
-      memory: 824633720832
-      name: Standard_L96s_v4
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 6
-      generic_name: standard_nv6ads_a10_v5
-      id: Standard_NV6ads_A10_v5
-      memory: 59055800320
-      name: Standard_NV6ads_A10_v5
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 12
-      generic_name: standard_nv12ads_a10_v5
-      id: Standard_NV12ads_A10_v5
-      memory: 118111600640
-      name: Standard_NV12ads_A10_v5
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 18
-      generic_name: standard_nv18ads_a10_v5
-      id: Standard_NV18ads_A10_v5
-      memory: 236223201280
-      name: Standard_NV18ads_A10_v5
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 36
-      generic_name: standard_nv36adms_a10_v5
-      id: Standard_NV36adms_A10_v5
-      memory: 944892805120
-      name: Standard_NV36adms_A10_v5
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 36
-      generic_name: standard_nv36ads_a10_v5
-      id: Standard_NV36ads_A10_v5
-      memory: 472446402560
-      name: Standard_NV36ads_A10_v5
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 72
-      generic_name: standard_nv72ads_a10_v5
-      id: Standard_NV72ads_A10_v5
-      memory: 944892805120
-      name: Standard_NV72ads_A10_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 112
-      generic_name: standard_e112ias_v5
-      id: Standard_E112ias_v5
-      memory: 721554505728
-      name: Standard_E112ias_v5
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 112
-      generic_name: standard_e112iads_v5
-      id: Standard_E112iads_v5
-      memory: 721554505728
-      name: Standard_E112iads_v5
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_fx4mds
-      id: Standard_FX4mds
-      memory: 90194313216
-      name: Standard_FX4mds
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 12
-      generic_name: standard_fx12mds
-      id: Standard_FX12mds
-      memory: 270582939648
-      name: Standard_FX12mds
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 24
-      generic_name: standard_fx24mds
-      id: Standard_FX24mds
-      memory: 541165879296
-      name: Standard_FX24mds
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 36
-      generic_name: standard_fx36mds
-      id: Standard_FX36mds
-      memory: 811748818944
-      name: Standard_FX36mds
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_fx48mds
-      id: Standard_FX48mds
-      memory: 1082331758592
-      name: Standard_FX48mds
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2pls_v6
-      id: Standard_D2pls_v6
-      memory: 4294967296
-      name: Standard_D2pls_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4pls_v6
-      id: Standard_D4pls_v6
-      memory: 8589934592
-      name: Standard_D4pls_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8pls_v6
-      id: Standard_D8pls_v6
-      memory: 17179869184
-      name: Standard_D8pls_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16pls_v6
-      id: Standard_D16pls_v6
-      memory: 34359738368
-      name: Standard_D16pls_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32pls_v6
-      id: Standard_D32pls_v6
-      memory: 68719476736
-      name: Standard_D32pls_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48pls_v6
-      id: Standard_D48pls_v6
-      memory: 103079215104
-      name: Standard_D48pls_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64pls_v6
-      id: Standard_D64pls_v6
-      memory: 137438953472
-      name: Standard_D64pls_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96pls_v6
-      id: Standard_D96pls_v6
-      memory: 206158430208
-      name: Standard_D96pls_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2pds_v6
-      id: Standard_D2pds_v6
-      memory: 8589934592
-      name: Standard_D2pds_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4pds_v6
-      id: Standard_D4pds_v6
-      memory: 17179869184
-      name: Standard_D4pds_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8pds_v6
-      id: Standard_D8pds_v6
-      memory: 34359738368
-      name: Standard_D8pds_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
+      family: StandardDpdsv6Family
       generic_name: standard_d16pds_v6
       id: Standard_D16pds_v6
       memory: 68719476736
@@ -5811,63 +1076,17 @@ data:
     - architecture: arm64
       category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32pds_v6
-      id: Standard_D32pds_v6
-      memory: 137438953472
-      name: Standard_D32pds_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48pds_v6
-      id: Standard_D48pds_v6
-      memory: 206158430208
-      name: Standard_D48pds_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64pds_v6
-      id: Standard_D64pds_v6
-      memory: 274877906944
-      name: Standard_D64pds_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96pds_v6
-      id: Standard_D96pds_v6
-      memory: 412316860416
-      name: Standard_D96pds_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2plds_v6
-      id: Standard_D2plds_v6
-      memory: 4294967296
-      name: Standard_D2plds_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4plds_v6
-      id: Standard_D4plds_v6
-      memory: 8589934592
-      name: Standard_D4plds_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8plds_v6
-      id: Standard_D8plds_v6
-      memory: 17179869184
-      name: Standard_D8plds_v6
+      cpu_cores: 16
+      family: standardDPLDSv5Family
+      generic_name: standard_d16plds_v5
+      id: Standard_D16plds_v5
+      memory: 34359738368
+      name: Standard_D16plds_v5
     - architecture: arm64
       category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
+      family: StandardDpldsv6Family
       generic_name: standard_d16plds_v6
       id: Standard_D16plds_v6
       memory: 34359738368
@@ -5875,7 +1094,623 @@ data:
     - architecture: arm64
       category: general_purpose
       cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDPLSv5Family
+      generic_name: standard_d16pls_v5
+      id: Standard_D16pls_v5
+      memory: 34359738368
+      name: Standard_D16pls_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardDplsv6Family
+      generic_name: standard_d16pls_v6
+      id: Standard_D16pls_v6
+      memory: 34359738368
+      name: Standard_D16pls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDPSv5Family
+      generic_name: standard_d16ps_v5
+      id: Standard_D16ps_v5
+      memory: 68719476736
+      name: Standard_D16ps_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardDpsv6Family
+      generic_name: standard_d16ps_v6
+      id: Standard_D16ps_v6
+      memory: 68719476736
+      name: Standard_D16ps_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDSv3Family
+      generic_name: standard_d16s_v3
+      id: Standard_D16s_v3
+      memory: 68719476736
+      name: Standard_D16s_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDSv4Family
+      generic_name: standard_d16s_v4
+      id: Standard_D16s_v4
+      memory: 68719476736
+      name: Standard_D16s_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDSv5Family
+      generic_name: standard_d16s_v5
+      id: Standard_D16s_v5
+      memory: 68719476736
+      name: Standard_D16s_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardDsv6Family
+      generic_name: standard_d16s_v6
+      id: Standard_D16s_v6
+      memory: 68719476736
+      name: Standard_D16s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDv3Family
+      generic_name: standard_d16_v3
+      id: Standard_D16_v3
+      memory: 68719476736
+      name: Standard_D16_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDv4Family
+      generic_name: standard_d16_v4
+      id: Standard_D16_v4
+      memory: 68719476736
+      name: Standard_D16_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDv5Family
+      generic_name: standard_d16_v5
+      id: Standard_D16_v5
+      memory: 68719476736
+      name: Standard_D16_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 192
+      family: StandardDdsv6Family
+      generic_name: standard_d192ds_v6
+      id: Standard_D192ds_v6
+      memory: 824633720832
+      name: Standard_D192ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 192
+      family: StandardDsv6Family
+      generic_name: standard_d192s_v6
+      id: Standard_D192s_v6
+      memory: 824633720832
+      name: Standard_D192s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 1
+      family: standardDv2Family
+      generic_name: standard_d1_v2
+      id: Standard_D1_v2
+      memory: 3221225472
+      name: Standard_D1_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDADSv5Family
+      generic_name: standard_d2ads_v5
+      id: Standard_D2ads_v5
+      memory: 8589934592
+      name: Standard_D2ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDadv6Family
+      generic_name: standard_d2ads_v6
+      id: Standard_D2ads_v6
+      memory: 8589934592
+      name: Standard_D2ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDadsv7Family
+      generic_name: standard_d2ads_v7
+      id: Standard_D2ads_v7
+      memory: 8589934592
+      name: Standard_D2ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDaldv6Family
+      generic_name: standard_d2alds_v6
+      id: Standard_D2alds_v6
+      memory: 4294967296
+      name: Standard_D2alds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDaldsv7Family
+      generic_name: standard_d2alds_v7
+      id: Standard_D2alds_v7
+      memory: 4294967296
+      name: Standard_D2alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDalv6Family
+      generic_name: standard_d2als_v6
+      id: Standard_D2als_v6
+      memory: 4294967296
+      name: Standard_D2als_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDalsv7Family
+      generic_name: standard_d2als_v7
+      id: Standard_D2als_v7
+      memory: 4294967296
+      name: Standard_D2als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDASv4Family
+      generic_name: standard_d2as_v4
+      id: Standard_D2as_v4
+      memory: 8589934592
+      name: Standard_D2as_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDASv5Family
+      generic_name: standard_d2as_v5
+      id: Standard_D2as_v5
+      memory: 8589934592
+      name: Standard_D2as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDav6Family
+      generic_name: standard_d2as_v6
+      id: Standard_D2as_v6
+      memory: 8589934592
+      name: Standard_D2as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDasv7Family
+      generic_name: standard_d2as_v7
+      id: Standard_D2as_v7
+      memory: 8589934592
+      name: Standard_D2as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDAv4Family
+      generic_name: standard_d2a_v4
+      id: Standard_D2a_v4
+      memory: 8589934592
+      name: Standard_D2a_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDDSv4Family
+      generic_name: standard_d2ds_v4
+      id: Standard_D2ds_v4
+      memory: 8589934592
+      name: Standard_D2ds_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDDSv5Family
+      generic_name: standard_d2ds_v5
+      id: Standard_D2ds_v5
+      memory: 8589934592
+      name: Standard_D2ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDdsv6Family
+      generic_name: standard_d2ds_v6
+      id: Standard_D2ds_v6
+      memory: 8589934592
+      name: Standard_D2ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDDv4Family
+      generic_name: standard_d2d_v4
+      id: Standard_D2d_v4
+      memory: 8589934592
+      name: Standard_D2d_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDDv5Family
+      generic_name: standard_d2d_v5
+      id: Standard_D2d_v5
+      memory: 8589934592
+      name: Standard_D2d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDLDSv5Family
+      generic_name: standard_d2lds_v5
+      id: Standard_D2lds_v5
+      memory: 4294967296
+      name: Standard_D2lds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDldsv6Family
+      generic_name: standard_d2lds_v6
+      id: Standard_D2lds_v6
+      memory: 4294967296
+      name: Standard_D2lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDLSv5Family
+      generic_name: standard_d2ls_v5
+      id: Standard_D2ls_v5
+      memory: 4294967296
+      name: Standard_D2ls_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDlsv6Family
+      generic_name: standard_d2ls_v6
+      id: Standard_D2ls_v6
+      memory: 4294967296
+      name: Standard_D2ls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDPDSv5Family
+      generic_name: standard_d2pds_v5
+      id: Standard_D2pds_v5
+      memory: 8589934592
+      name: Standard_D2pds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDpdsv6Family
+      generic_name: standard_d2pds_v6
+      id: Standard_D2pds_v6
+      memory: 8589934592
+      name: Standard_D2pds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDPLDSv5Family
+      generic_name: standard_d2plds_v5
+      id: Standard_D2plds_v5
+      memory: 4294967296
+      name: Standard_D2plds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDpldsv6Family
+      generic_name: standard_d2plds_v6
+      id: Standard_D2plds_v6
+      memory: 4294967296
+      name: Standard_D2plds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDPLSv5Family
+      generic_name: standard_d2pls_v5
+      id: Standard_D2pls_v5
+      memory: 4294967296
+      name: Standard_D2pls_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDplsv6Family
+      generic_name: standard_d2pls_v6
+      id: Standard_D2pls_v6
+      memory: 4294967296
+      name: Standard_D2pls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDPSv5Family
+      generic_name: standard_d2ps_v5
+      id: Standard_D2ps_v5
+      memory: 8589934592
+      name: Standard_D2ps_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDpsv6Family
+      generic_name: standard_d2ps_v6
+      id: Standard_D2ps_v6
+      memory: 8589934592
+      name: Standard_D2ps_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDSv3Family
+      generic_name: standard_d2s_v3
+      id: Standard_D2s_v3
+      memory: 8589934592
+      name: Standard_D2s_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDSv4Family
+      generic_name: standard_d2s_v4
+      id: Standard_D2s_v4
+      memory: 8589934592
+      name: Standard_D2s_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDSv5Family
+      generic_name: standard_d2s_v5
+      id: Standard_D2s_v5
+      memory: 8589934592
+      name: Standard_D2s_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardDsv6Family
+      generic_name: standard_d2s_v6
+      id: Standard_D2s_v6
+      memory: 8589934592
+      name: Standard_D2s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDv2Family
+      generic_name: standard_d2_v2
+      id: Standard_D2_v2
+      memory: 7516192768
+      name: Standard_D2_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDv3Family
+      generic_name: standard_d2_v3
+      id: Standard_D2_v3
+      memory: 8589934592
+      name: Standard_D2_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDv4Family
+      generic_name: standard_d2_v4
+      id: Standard_D2_v4
+      memory: 8589934592
+      name: Standard_D2_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDv5Family
+      generic_name: standard_d2_v5
+      id: Standard_D2_v5
+      memory: 8589934592
+      name: Standard_D2_v5
+    - category: general_purpose
+      cloud_provider_id: azure
       cpu_cores: 32
+      family: standardDADSv5Family
+      generic_name: standard_d32ads_v5
+      id: Standard_D32ads_v5
+      memory: 137438953472
+      name: Standard_D32ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDadv6Family
+      generic_name: standard_d32ads_v6
+      id: Standard_D32ads_v6
+      memory: 137438953472
+      name: Standard_D32ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDadsv7Family
+      generic_name: standard_d32ads_v7
+      id: Standard_D32ads_v7
+      memory: 137438953472
+      name: Standard_D32ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDaldv6Family
+      generic_name: standard_d32alds_v6
+      id: Standard_D32alds_v6
+      memory: 68719476736
+      name: Standard_D32alds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDaldsv7Family
+      generic_name: standard_d32alds_v7
+      id: Standard_D32alds_v7
+      memory: 68719476736
+      name: Standard_D32alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDalv6Family
+      generic_name: standard_d32als_v6
+      id: Standard_D32als_v6
+      memory: 68719476736
+      name: Standard_D32als_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDalsv7Family
+      generic_name: standard_d32als_v7
+      id: Standard_D32als_v7
+      memory: 68719476736
+      name: Standard_D32als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDASv4Family
+      generic_name: standard_d32as_v4
+      id: Standard_D32as_v4
+      memory: 137438953472
+      name: Standard_D32as_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDASv5Family
+      generic_name: standard_d32as_v5
+      id: Standard_D32as_v5
+      memory: 137438953472
+      name: Standard_D32as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDav6Family
+      generic_name: standard_d32as_v6
+      id: Standard_D32as_v6
+      memory: 137438953472
+      name: Standard_D32as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDasv7Family
+      generic_name: standard_d32as_v7
+      id: Standard_D32as_v7
+      memory: 137438953472
+      name: Standard_D32as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDAv4Family
+      generic_name: standard_d32a_v4
+      id: Standard_D32a_v4
+      memory: 137438953472
+      name: Standard_D32a_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDDSv4Family
+      generic_name: standard_d32ds_v4
+      id: Standard_D32ds_v4
+      memory: 137438953472
+      name: Standard_D32ds_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDDSv5Family
+      generic_name: standard_d32ds_v5
+      id: Standard_D32ds_v5
+      memory: 137438953472
+      name: Standard_D32ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDdsv6Family
+      generic_name: standard_d32ds_v6
+      id: Standard_D32ds_v6
+      memory: 137438953472
+      name: Standard_D32ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDDv4Family
+      generic_name: standard_d32d_v4
+      id: Standard_D32d_v4
+      memory: 137438953472
+      name: Standard_D32d_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDDv5Family
+      generic_name: standard_d32d_v5
+      id: Standard_D32d_v5
+      memory: 137438953472
+      name: Standard_D32d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDLDSv5Family
+      generic_name: standard_d32lds_v5
+      id: Standard_D32lds_v5
+      memory: 68719476736
+      name: Standard_D32lds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDldsv6Family
+      generic_name: standard_d32lds_v6
+      id: Standard_D32lds_v6
+      memory: 68719476736
+      name: Standard_D32lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDLSv5Family
+      generic_name: standard_d32ls_v5
+      id: Standard_D32ls_v5
+      memory: 68719476736
+      name: Standard_D32ls_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDlsv6Family
+      generic_name: standard_d32ls_v6
+      id: Standard_D32ls_v6
+      memory: 68719476736
+      name: Standard_D32ls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDPDSv5Family
+      generic_name: standard_d32pds_v5
+      id: Standard_D32pds_v5
+      memory: 137438953472
+      name: Standard_D32pds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDpdsv6Family
+      generic_name: standard_d32pds_v6
+      id: Standard_D32pds_v6
+      memory: 137438953472
+      name: Standard_D32pds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDPLDSv5Family
+      generic_name: standard_d32plds_v5
+      id: Standard_D32plds_v5
+      memory: 68719476736
+      name: Standard_D32plds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDpldsv6Family
       generic_name: standard_d32plds_v6
       id: Standard_D32plds_v6
       memory: 68719476736
@@ -5883,7 +1718,303 @@ data:
     - architecture: arm64
       category: general_purpose
       cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDPLSv5Family
+      generic_name: standard_d32pls_v5
+      id: Standard_D32pls_v5
+      memory: 68719476736
+      name: Standard_D32pls_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDplsv6Family
+      generic_name: standard_d32pls_v6
+      id: Standard_D32pls_v6
+      memory: 68719476736
+      name: Standard_D32pls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDPSv5Family
+      generic_name: standard_d32ps_v5
+      id: Standard_D32ps_v5
+      memory: 137438953472
+      name: Standard_D32ps_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDpsv6Family
+      generic_name: standard_d32ps_v6
+      id: Standard_D32ps_v6
+      memory: 137438953472
+      name: Standard_D32ps_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDSv3Family
+      generic_name: standard_d32s_v3
+      id: Standard_D32s_v3
+      memory: 137438953472
+      name: Standard_D32s_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDSv4Family
+      generic_name: standard_d32s_v4
+      id: Standard_D32s_v4
+      memory: 137438953472
+      name: Standard_D32s_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDSv5Family
+      generic_name: standard_d32s_v5
+      id: Standard_D32s_v5
+      memory: 137438953472
+      name: Standard_D32s_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardDsv6Family
+      generic_name: standard_d32s_v6
+      id: Standard_D32s_v6
+      memory: 137438953472
+      name: Standard_D32s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDv3Family
+      generic_name: standard_d32_v3
+      id: Standard_D32_v3
+      memory: 137438953472
+      name: Standard_D32_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDv4Family
+      generic_name: standard_d32_v4
+      id: Standard_D32_v4
+      memory: 137438953472
+      name: Standard_D32_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDv5Family
+      generic_name: standard_d32_v5
+      id: Standard_D32_v5
+      memory: 137438953472
+      name: Standard_D32_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDv2Family
+      generic_name: standard_d3_v2
+      id: Standard_D3_v2
+      memory: 15032385536
+      name: Standard_D3_v2
+    - category: general_purpose
+      cloud_provider_id: azure
       cpu_cores: 48
+      family: standardDADSv5Family
+      generic_name: standard_d48ads_v5
+      id: Standard_D48ads_v5
+      memory: 206158430208
+      name: Standard_D48ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDadv6Family
+      generic_name: standard_d48ads_v6
+      id: Standard_D48ads_v6
+      memory: 206158430208
+      name: Standard_D48ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDadsv7Family
+      generic_name: standard_d48ads_v7
+      id: Standard_D48ads_v7
+      memory: 206158430208
+      name: Standard_D48ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDaldv6Family
+      generic_name: standard_d48alds_v6
+      id: Standard_D48alds_v6
+      memory: 103079215104
+      name: Standard_D48alds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDaldsv7Family
+      generic_name: standard_d48alds_v7
+      id: Standard_D48alds_v7
+      memory: 103079215104
+      name: Standard_D48alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDalv6Family
+      generic_name: standard_d48als_v6
+      id: Standard_D48als_v6
+      memory: 103079215104
+      name: Standard_D48als_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDalsv7Family
+      generic_name: standard_d48als_v7
+      id: Standard_D48als_v7
+      memory: 103079215104
+      name: Standard_D48als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDASv4Family
+      generic_name: standard_d48as_v4
+      id: Standard_D48as_v4
+      memory: 206158430208
+      name: Standard_D48as_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDASv5Family
+      generic_name: standard_d48as_v5
+      id: Standard_D48as_v5
+      memory: 206158430208
+      name: Standard_D48as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDav6Family
+      generic_name: standard_d48as_v6
+      id: Standard_D48as_v6
+      memory: 206158430208
+      name: Standard_D48as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDasv7Family
+      generic_name: standard_d48as_v7
+      id: Standard_D48as_v7
+      memory: 206158430208
+      name: Standard_D48as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDAv4Family
+      generic_name: standard_d48a_v4
+      id: Standard_D48a_v4
+      memory: 206158430208
+      name: Standard_D48a_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDDSv4Family
+      generic_name: standard_d48ds_v4
+      id: Standard_D48ds_v4
+      memory: 206158430208
+      name: Standard_D48ds_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDDSv5Family
+      generic_name: standard_d48ds_v5
+      id: Standard_D48ds_v5
+      memory: 206158430208
+      name: Standard_D48ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDdsv6Family
+      generic_name: standard_d48ds_v6
+      id: Standard_D48ds_v6
+      memory: 206158430208
+      name: Standard_D48ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDDv4Family
+      generic_name: standard_d48d_v4
+      id: Standard_D48d_v4
+      memory: 206158430208
+      name: Standard_D48d_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDDv5Family
+      generic_name: standard_d48d_v5
+      id: Standard_D48d_v5
+      memory: 206158430208
+      name: Standard_D48d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDLDSv5Family
+      generic_name: standard_d48lds_v5
+      id: Standard_D48lds_v5
+      memory: 103079215104
+      name: Standard_D48lds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDldsv6Family
+      generic_name: standard_d48lds_v6
+      id: Standard_D48lds_v6
+      memory: 103079215104
+      name: Standard_D48lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDLSv5Family
+      generic_name: standard_d48ls_v5
+      id: Standard_D48ls_v5
+      memory: 103079215104
+      name: Standard_D48ls_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDlsv6Family
+      generic_name: standard_d48ls_v6
+      id: Standard_D48ls_v6
+      memory: 103079215104
+      name: Standard_D48ls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDPDSv5Family
+      generic_name: standard_d48pds_v5
+      id: Standard_D48pds_v5
+      memory: 206158430208
+      name: Standard_D48pds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDpdsv6Family
+      generic_name: standard_d48pds_v6
+      id: Standard_D48pds_v6
+      memory: 206158430208
+      name: Standard_D48pds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDPLDSv5Family
+      generic_name: standard_d48plds_v5
+      id: Standard_D48plds_v5
+      memory: 103079215104
+      name: Standard_D48plds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDpldsv6Family
       generic_name: standard_d48plds_v6
       id: Standard_D48plds_v6
       memory: 103079215104
@@ -5891,7 +2022,607 @@ data:
     - architecture: arm64
       category: general_purpose
       cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDPLSv5Family
+      generic_name: standard_d48pls_v5
+      id: Standard_D48pls_v5
+      memory: 103079215104
+      name: Standard_D48pls_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDplsv6Family
+      generic_name: standard_d48pls_v6
+      id: Standard_D48pls_v6
+      memory: 103079215104
+      name: Standard_D48pls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDPSv5Family
+      generic_name: standard_d48ps_v5
+      id: Standard_D48ps_v5
+      memory: 206158430208
+      name: Standard_D48ps_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDpsv6Family
+      generic_name: standard_d48ps_v6
+      id: Standard_D48ps_v6
+      memory: 206158430208
+      name: Standard_D48ps_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDSv3Family
+      generic_name: standard_d48s_v3
+      id: Standard_D48s_v3
+      memory: 206158430208
+      name: Standard_D48s_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDSv4Family
+      generic_name: standard_d48s_v4
+      id: Standard_D48s_v4
+      memory: 206158430208
+      name: Standard_D48s_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDSv5Family
+      generic_name: standard_d48s_v5
+      id: Standard_D48s_v5
+      memory: 206158430208
+      name: Standard_D48s_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardDsv6Family
+      generic_name: standard_d48s_v6
+      id: Standard_D48s_v6
+      memory: 206158430208
+      name: Standard_D48s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDv3Family
+      generic_name: standard_d48_v3
+      id: Standard_D48_v3
+      memory: 206158430208
+      name: Standard_D48_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDv4Family
+      generic_name: standard_d48_v4
+      id: Standard_D48_v4
+      memory: 206158430208
+      name: Standard_D48_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDv5Family
+      generic_name: standard_d48_v5
+      id: Standard_D48_v5
+      memory: 206158430208
+      name: Standard_D48_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDADSv5Family
+      generic_name: standard_d4ads_v5
+      id: Standard_D4ads_v5
+      memory: 17179869184
+      name: Standard_D4ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDadv6Family
+      generic_name: standard_d4ads_v6
+      id: Standard_D4ads_v6
+      memory: 17179869184
+      name: Standard_D4ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDadsv7Family
+      generic_name: standard_d4ads_v7
+      id: Standard_D4ads_v7
+      memory: 17179869184
+      name: Standard_D4ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDaldv6Family
+      generic_name: standard_d4alds_v6
+      id: Standard_D4alds_v6
+      memory: 8589934592
+      name: Standard_D4alds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDaldsv7Family
+      generic_name: standard_d4alds_v7
+      id: Standard_D4alds_v7
+      memory: 8589934592
+      name: Standard_D4alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDalv6Family
+      generic_name: standard_d4als_v6
+      id: Standard_D4als_v6
+      memory: 8589934592
+      name: Standard_D4als_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDalsv7Family
+      generic_name: standard_d4als_v7
+      id: Standard_D4als_v7
+      memory: 8589934592
+      name: Standard_D4als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDASv4Family
+      generic_name: standard_d4as_v4
+      id: Standard_D4as_v4
+      memory: 17179869184
+      name: Standard_D4as_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDASv5Family
+      generic_name: standard_d4as_v5
+      id: Standard_D4as_v5
+      memory: 17179869184
+      name: Standard_D4as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDav6Family
+      generic_name: standard_d4as_v6
+      id: Standard_D4as_v6
+      memory: 17179869184
+      name: Standard_D4as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDasv7Family
+      generic_name: standard_d4as_v7
+      id: Standard_D4as_v7
+      memory: 17179869184
+      name: Standard_D4as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDAv4Family
+      generic_name: standard_d4a_v4
+      id: Standard_D4a_v4
+      memory: 17179869184
+      name: Standard_D4a_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDDSv4Family
+      generic_name: standard_d4ds_v4
+      id: Standard_D4ds_v4
+      memory: 17179869184
+      name: Standard_D4ds_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDDSv5Family
+      generic_name: standard_d4ds_v5
+      id: Standard_D4ds_v5
+      memory: 17179869184
+      name: Standard_D4ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDdsv6Family
+      generic_name: standard_d4ds_v6
+      id: Standard_D4ds_v6
+      memory: 17179869184
+      name: Standard_D4ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDDv4Family
+      generic_name: standard_d4d_v4
+      id: Standard_D4d_v4
+      memory: 17179869184
+      name: Standard_D4d_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDDv5Family
+      generic_name: standard_d4d_v5
+      id: Standard_D4d_v5
+      memory: 17179869184
+      name: Standard_D4d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDLDSv5Family
+      generic_name: standard_d4lds_v5
+      id: Standard_D4lds_v5
+      memory: 8589934592
+      name: Standard_D4lds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDldsv6Family
+      generic_name: standard_d4lds_v6
+      id: Standard_D4lds_v6
+      memory: 8589934592
+      name: Standard_D4lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDLSv5Family
+      generic_name: standard_d4ls_v5
+      id: Standard_D4ls_v5
+      memory: 8589934592
+      name: Standard_D4ls_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDlsv6Family
+      generic_name: standard_d4ls_v6
+      id: Standard_D4ls_v6
+      memory: 8589934592
+      name: Standard_D4ls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDPDSv5Family
+      generic_name: standard_d4pds_v5
+      id: Standard_D4pds_v5
+      memory: 17179869184
+      name: Standard_D4pds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDpdsv6Family
+      generic_name: standard_d4pds_v6
+      id: Standard_D4pds_v6
+      memory: 17179869184
+      name: Standard_D4pds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDPLDSv5Family
+      generic_name: standard_d4plds_v5
+      id: Standard_D4plds_v5
+      memory: 8589934592
+      name: Standard_D4plds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDpldsv6Family
+      generic_name: standard_d4plds_v6
+      id: Standard_D4plds_v6
+      memory: 8589934592
+      name: Standard_D4plds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDPLSv5Family
+      generic_name: standard_d4pls_v5
+      id: Standard_D4pls_v5
+      memory: 8589934592
+      name: Standard_D4pls_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDplsv6Family
+      generic_name: standard_d4pls_v6
+      id: Standard_D4pls_v6
+      memory: 8589934592
+      name: Standard_D4pls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDPSv5Family
+      generic_name: standard_d4ps_v5
+      id: Standard_D4ps_v5
+      memory: 17179869184
+      name: Standard_D4ps_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDpsv6Family
+      generic_name: standard_d4ps_v6
+      id: Standard_D4ps_v6
+      memory: 17179869184
+      name: Standard_D4ps_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDSv3Family
+      generic_name: standard_d4s_v3
+      id: Standard_D4s_v3
+      memory: 17179869184
+      name: Standard_D4s_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDSv4Family
+      generic_name: standard_d4s_v4
+      id: Standard_D4s_v4
+      memory: 17179869184
+      name: Standard_D4s_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDSv5Family
+      generic_name: standard_d4s_v5
+      id: Standard_D4s_v5
+      memory: 17179869184
+      name: Standard_D4s_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardDsv6Family
+      generic_name: standard_d4s_v6
+      id: Standard_D4s_v6
+      memory: 17179869184
+      name: Standard_D4s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDv2Family
+      generic_name: standard_d4_v2
+      id: Standard_D4_v2
+      memory: 30064771072
+      name: Standard_D4_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDv3Family
+      generic_name: standard_d4_v3
+      id: Standard_D4_v3
+      memory: 17179869184
+      name: Standard_D4_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDv4Family
+      generic_name: standard_d4_v4
+      id: Standard_D4_v4
+      memory: 17179869184
+      name: Standard_D4_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDv5Family
+      generic_name: standard_d4_v5
+      id: Standard_D4_v5
+      memory: 17179869184
+      name: Standard_D4_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDv2Family
+      generic_name: standard_d5_v2
+      id: Standard_D5_v2
+      memory: 60129542144
+      name: Standard_D5_v2
+    - category: general_purpose
+      cloud_provider_id: azure
       cpu_cores: 64
+      family: standardDADSv5Family
+      generic_name: standard_d64ads_v5
+      id: Standard_D64ads_v5
+      memory: 274877906944
+      name: Standard_D64ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDadv6Family
+      generic_name: standard_d64ads_v6
+      id: Standard_D64ads_v6
+      memory: 274877906944
+      name: Standard_D64ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDadsv7Family
+      generic_name: standard_d64ads_v7
+      id: Standard_D64ads_v7
+      memory: 274877906944
+      name: Standard_D64ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDaldv6Family
+      generic_name: standard_d64alds_v6
+      id: Standard_D64alds_v6
+      memory: 137438953472
+      name: Standard_D64alds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDaldsv7Family
+      generic_name: standard_d64alds_v7
+      id: Standard_D64alds_v7
+      memory: 137438953472
+      name: Standard_D64alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDalv6Family
+      generic_name: standard_d64als_v6
+      id: Standard_D64als_v6
+      memory: 137438953472
+      name: Standard_D64als_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDalsv7Family
+      generic_name: standard_d64als_v7
+      id: Standard_D64als_v7
+      memory: 137438953472
+      name: Standard_D64als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDASv4Family
+      generic_name: standard_d64as_v4
+      id: Standard_D64as_v4
+      memory: 274877906944
+      name: Standard_D64as_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDASv5Family
+      generic_name: standard_d64as_v5
+      id: Standard_D64as_v5
+      memory: 274877906944
+      name: Standard_D64as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDav6Family
+      generic_name: standard_d64as_v6
+      id: Standard_D64as_v6
+      memory: 274877906944
+      name: Standard_D64as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDasv7Family
+      generic_name: standard_d64as_v7
+      id: Standard_D64as_v7
+      memory: 274877906944
+      name: Standard_D64as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDAv4Family
+      generic_name: standard_d64a_v4
+      id: Standard_D64a_v4
+      memory: 274877906944
+      name: Standard_D64a_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDDSv4Family
+      generic_name: standard_d64ds_v4
+      id: Standard_D64ds_v4
+      memory: 274877906944
+      name: Standard_D64ds_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDDSv5Family
+      generic_name: standard_d64ds_v5
+      id: Standard_D64ds_v5
+      memory: 274877906944
+      name: Standard_D64ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDdsv6Family
+      generic_name: standard_d64ds_v6
+      id: Standard_D64ds_v6
+      memory: 274877906944
+      name: Standard_D64ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDDv4Family
+      generic_name: standard_d64d_v4
+      id: Standard_D64d_v4
+      memory: 274877906944
+      name: Standard_D64d_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDDv5Family
+      generic_name: standard_d64d_v5
+      id: Standard_D64d_v5
+      memory: 274877906944
+      name: Standard_D64d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDLDSv5Family
+      generic_name: standard_d64lds_v5
+      id: Standard_D64lds_v5
+      memory: 137438953472
+      name: Standard_D64lds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDldsv6Family
+      generic_name: standard_d64lds_v6
+      id: Standard_D64lds_v6
+      memory: 137438953472
+      name: Standard_D64lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDLSv5Family
+      generic_name: standard_d64ls_v5
+      id: Standard_D64ls_v5
+      memory: 137438953472
+      name: Standard_D64ls_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDlsv6Family
+      generic_name: standard_d64ls_v6
+      id: Standard_D64ls_v6
+      memory: 137438953472
+      name: Standard_D64ls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDPDSv5Family
+      generic_name: standard_d64pds_v5
+      id: Standard_D64pds_v5
+      memory: 223338299392
+      name: Standard_D64pds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDpdsv6Family
+      generic_name: standard_d64pds_v6
+      id: Standard_D64pds_v6
+      memory: 274877906944
+      name: Standard_D64pds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDPLDSv5Family
+      generic_name: standard_d64plds_v5
+      id: Standard_D64plds_v5
+      memory: 137438953472
+      name: Standard_D64plds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDpldsv6Family
       generic_name: standard_d64plds_v6
       id: Standard_D64plds_v6
       memory: 137438953472
@@ -5899,7 +2630,557 @@ data:
     - architecture: arm64
       category: general_purpose
       cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDPLSv5Family
+      generic_name: standard_d64pls_v5
+      id: Standard_D64pls_v5
+      memory: 137438953472
+      name: Standard_D64pls_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDplsv6Family
+      generic_name: standard_d64pls_v6
+      id: Standard_D64pls_v6
+      memory: 137438953472
+      name: Standard_D64pls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDPSv5Family
+      generic_name: standard_d64ps_v5
+      id: Standard_D64ps_v5
+      memory: 223338299392
+      name: Standard_D64ps_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDpsv6Family
+      generic_name: standard_d64ps_v6
+      id: Standard_D64ps_v6
+      memory: 274877906944
+      name: Standard_D64ps_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDSv3Family
+      generic_name: standard_d64s_v3
+      id: Standard_D64s_v3
+      memory: 274877906944
+      name: Standard_D64s_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDSv4Family
+      generic_name: standard_d64s_v4
+      id: Standard_D64s_v4
+      memory: 274877906944
+      name: Standard_D64s_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDSv5Family
+      generic_name: standard_d64s_v5
+      id: Standard_D64s_v5
+      memory: 274877906944
+      name: Standard_D64s_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardDsv6Family
+      generic_name: standard_d64s_v6
+      id: Standard_D64s_v6
+      memory: 274877906944
+      name: Standard_D64s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDv3Family
+      generic_name: standard_d64_v3
+      id: Standard_D64_v3
+      memory: 274877906944
+      name: Standard_D64_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDv4Family
+      generic_name: standard_d64_v4
+      id: Standard_D64_v4
+      memory: 274877906944
+      name: Standard_D64_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDv5Family
+      generic_name: standard_d64_v5
+      id: Standard_D64_v5
+      memory: 274877906944
+      name: Standard_D64_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDADSv5Family
+      generic_name: standard_d8ads_v5
+      id: Standard_D8ads_v5
+      memory: 34359738368
+      name: Standard_D8ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDadv6Family
+      generic_name: standard_d8ads_v6
+      id: Standard_D8ads_v6
+      memory: 34359738368
+      name: Standard_D8ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDadsv7Family
+      generic_name: standard_d8ads_v7
+      id: Standard_D8ads_v7
+      memory: 34359738368
+      name: Standard_D8ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDaldv6Family
+      generic_name: standard_d8alds_v6
+      id: Standard_D8alds_v6
+      memory: 17179869184
+      name: Standard_D8alds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDaldsv7Family
+      generic_name: standard_d8alds_v7
+      id: Standard_D8alds_v7
+      memory: 17179869184
+      name: Standard_D8alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDalv6Family
+      generic_name: standard_d8als_v6
+      id: Standard_D8als_v6
+      memory: 17179869184
+      name: Standard_D8als_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDalsv7Family
+      generic_name: standard_d8als_v7
+      id: Standard_D8als_v7
+      memory: 17179869184
+      name: Standard_D8als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDASv4Family
+      generic_name: standard_d8as_v4
+      id: Standard_D8as_v4
+      memory: 34359738368
+      name: Standard_D8as_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDASv5Family
+      generic_name: standard_d8as_v5
+      id: Standard_D8as_v5
+      memory: 34359738368
+      name: Standard_D8as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDav6Family
+      generic_name: standard_d8as_v6
+      id: Standard_D8as_v6
+      memory: 34359738368
+      name: Standard_D8as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDasv7Family
+      generic_name: standard_d8as_v7
+      id: Standard_D8as_v7
+      memory: 34359738368
+      name: Standard_D8as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDAv4Family
+      generic_name: standard_d8a_v4
+      id: Standard_D8a_v4
+      memory: 34359738368
+      name: Standard_D8a_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDDSv4Family
+      generic_name: standard_d8ds_v4
+      id: Standard_D8ds_v4
+      memory: 34359738368
+      name: Standard_D8ds_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDDSv5Family
+      generic_name: standard_d8ds_v5
+      id: Standard_D8ds_v5
+      memory: 34359738368
+      name: Standard_D8ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDdsv6Family
+      generic_name: standard_d8ds_v6
+      id: Standard_D8ds_v6
+      memory: 34359738368
+      name: Standard_D8ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDDv4Family
+      generic_name: standard_d8d_v4
+      id: Standard_D8d_v4
+      memory: 34359738368
+      name: Standard_D8d_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDDv5Family
+      generic_name: standard_d8d_v5
+      id: Standard_D8d_v5
+      memory: 34359738368
+      name: Standard_D8d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDLDSv5Family
+      generic_name: standard_d8lds_v5
+      id: Standard_D8lds_v5
+      memory: 17179869184
+      name: Standard_D8lds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDldsv6Family
+      generic_name: standard_d8lds_v6
+      id: Standard_D8lds_v6
+      memory: 17179869184
+      name: Standard_D8lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDLSv5Family
+      generic_name: standard_d8ls_v5
+      id: Standard_D8ls_v5
+      memory: 17179869184
+      name: Standard_D8ls_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDlsv6Family
+      generic_name: standard_d8ls_v6
+      id: Standard_D8ls_v6
+      memory: 17179869184
+      name: Standard_D8ls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDPDSv5Family
+      generic_name: standard_d8pds_v5
+      id: Standard_D8pds_v5
+      memory: 34359738368
+      name: Standard_D8pds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDpdsv6Family
+      generic_name: standard_d8pds_v6
+      id: Standard_D8pds_v6
+      memory: 34359738368
+      name: Standard_D8pds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDPLDSv5Family
+      generic_name: standard_d8plds_v5
+      id: Standard_D8plds_v5
+      memory: 17179869184
+      name: Standard_D8plds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDpldsv6Family
+      generic_name: standard_d8plds_v6
+      id: Standard_D8plds_v6
+      memory: 17179869184
+      name: Standard_D8plds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDPLSv5Family
+      generic_name: standard_d8pls_v5
+      id: Standard_D8pls_v5
+      memory: 17179869184
+      name: Standard_D8pls_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDplsv6Family
+      generic_name: standard_d8pls_v6
+      id: Standard_D8pls_v6
+      memory: 17179869184
+      name: Standard_D8pls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDPSv5Family
+      generic_name: standard_d8ps_v5
+      id: Standard_D8ps_v5
+      memory: 34359738368
+      name: Standard_D8ps_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDpsv6Family
+      generic_name: standard_d8ps_v6
+      id: Standard_D8ps_v6
+      memory: 34359738368
+      name: Standard_D8ps_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDSv3Family
+      generic_name: standard_d8s_v3
+      id: Standard_D8s_v3
+      memory: 34359738368
+      name: Standard_D8s_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDSv4Family
+      generic_name: standard_d8s_v4
+      id: Standard_D8s_v4
+      memory: 34359738368
+      name: Standard_D8s_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDSv5Family
+      generic_name: standard_d8s_v5
+      id: Standard_D8s_v5
+      memory: 34359738368
+      name: Standard_D8s_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardDsv6Family
+      generic_name: standard_d8s_v6
+      id: Standard_D8s_v6
+      memory: 34359738368
+      name: Standard_D8s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDv3Family
+      generic_name: standard_d8_v3
+      id: Standard_D8_v3
+      memory: 34359738368
+      name: Standard_D8_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDv4Family
+      generic_name: standard_d8_v4
+      id: Standard_D8_v4
+      memory: 34359738368
+      name: Standard_D8_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDv5Family
+      generic_name: standard_d8_v5
+      id: Standard_D8_v5
+      memory: 34359738368
+      name: Standard_D8_v5
+    - category: general_purpose
+      cloud_provider_id: azure
       cpu_cores: 96
+      family: standardDADSv5Family
+      generic_name: standard_d96ads_v5
+      id: Standard_D96ads_v5
+      memory: 412316860416
+      name: Standard_D96ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDadv6Family
+      generic_name: standard_d96ads_v6
+      id: Standard_D96ads_v6
+      memory: 412316860416
+      name: Standard_D96ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardDadsv7Family
+      generic_name: standard_d96ads_v7
+      id: Standard_D96ads_v7
+      memory: 412316860416
+      name: Standard_D96ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDaldv6Family
+      generic_name: standard_d96alds_v6
+      id: Standard_D96alds_v6
+      memory: 206158430208
+      name: Standard_D96alds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardDaldsv7Family
+      generic_name: standard_d96alds_v7
+      id: Standard_D96alds_v7
+      memory: 206158430208
+      name: Standard_D96alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDalv6Family
+      generic_name: standard_d96als_v6
+      id: Standard_D96als_v6
+      memory: 206158430208
+      name: Standard_D96als_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardDalsv7Family
+      generic_name: standard_d96als_v7
+      id: Standard_D96als_v7
+      memory: 206158430208
+      name: Standard_D96als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDASv4Family
+      generic_name: standard_d96as_v4
+      id: Standard_D96as_v4
+      memory: 412316860416
+      name: Standard_D96as_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDASv5Family
+      generic_name: standard_d96as_v5
+      id: Standard_D96as_v5
+      memory: 412316860416
+      name: Standard_D96as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDav6Family
+      generic_name: standard_d96as_v6
+      id: Standard_D96as_v6
+      memory: 412316860416
+      name: Standard_D96as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardDasv7Family
+      generic_name: standard_d96as_v7
+      id: Standard_D96as_v7
+      memory: 412316860416
+      name: Standard_D96as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDAv4Family
+      generic_name: standard_d96a_v4
+      id: Standard_D96a_v4
+      memory: 412316860416
+      name: Standard_D96a_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDDSv5Family
+      generic_name: standard_d96ds_v5
+      id: Standard_D96ds_v5
+      memory: 412316860416
+      name: Standard_D96ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardDdsv6Family
+      generic_name: standard_d96ds_v6
+      id: Standard_D96ds_v6
+      memory: 412316860416
+      name: Standard_D96ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDDv5Family
+      generic_name: standard_d96d_v5
+      id: Standard_D96d_v5
+      memory: 412316860416
+      name: Standard_D96d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDLDSv5Family
+      generic_name: standard_d96lds_v5
+      id: Standard_D96lds_v5
+      memory: 206158430208
+      name: Standard_D96lds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardDldsv6Family
+      generic_name: standard_d96lds_v6
+      id: Standard_D96lds_v6
+      memory: 206158430208
+      name: Standard_D96lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDLSv5Family
+      generic_name: standard_d96ls_v5
+      id: Standard_D96ls_v5
+      memory: 206158430208
+      name: Standard_D96ls_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardDlsv6Family
+      generic_name: standard_d96ls_v6
+      id: Standard_D96ls_v6
+      memory: 206158430208
+      name: Standard_D96ls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardDpdsv6Family
+      generic_name: standard_d96pds_v6
+      id: Standard_D96pds_v6
+      memory: 412316860416
+      name: Standard_D96pds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardDpldsv6Family
       generic_name: standard_d96plds_v6
       id: Standard_D96plds_v6
       memory: 206158430208
@@ -5907,1675 +3188,233 @@ data:
     - architecture: arm64
       category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2ps_v6
-      id: Standard_D2ps_v6
-      memory: 8589934592
-      name: Standard_D2ps_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4ps_v6
-      id: Standard_D4ps_v6
-      memory: 17179869184
-      name: Standard_D4ps_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8ps_v6
-      id: Standard_D8ps_v6
-      memory: 34359738368
-      name: Standard_D8ps_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16ps_v6
-      id: Standard_D16ps_v6
-      memory: 68719476736
-      name: Standard_D16ps_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32ps_v6
-      id: Standard_D32ps_v6
-      memory: 137438953472
-      name: Standard_D32ps_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48ps_v6
-      id: Standard_D48ps_v6
+      cpu_cores: 96
+      family: StandardDplsv6Family
+      generic_name: standard_d96pls_v6
+      id: Standard_D96pls_v6
       memory: 206158430208
-      name: Standard_D48ps_v6
-    - architecture: arm64
-      category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64ps_v6
-      id: Standard_D64ps_v6
-      memory: 274877906944
-      name: Standard_D64ps_v6
+      name: Standard_D96pls_v6
     - architecture: arm64
       category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 96
+      family: StandardDpsv6Family
       generic_name: standard_d96ps_v6
       id: Standard_D96ps_v6
       memory: 412316860416
       name: Standard_D96ps_v6
-    - architecture: arm64
-      category: memory_optimized
+    - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2ps_v6
-      id: Standard_E2ps_v6
-      memory: 17179869184
-      name: Standard_E2ps_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4ps_v6
-      id: Standard_E4ps_v6
-      memory: 34359738368
-      name: Standard_E4ps_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8ps_v6
-      id: Standard_E8ps_v6
-      memory: 68719476736
-      name: Standard_E8ps_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16ps_v6
-      id: Standard_E16ps_v6
-      memory: 137438953472
-      name: Standard_E16ps_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32ps_v6
-      id: Standard_E32ps_v6
-      memory: 274877906944
-      name: Standard_E32ps_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48ps_v6
-      id: Standard_E48ps_v6
+      cpu_cores: 96
+      family: standardDSv5Family
+      generic_name: standard_d96s_v5
+      id: Standard_D96s_v5
       memory: 412316860416
-      name: Standard_E48ps_v6
-    - architecture: arm64
-      category: memory_optimized
+      name: Standard_D96s_v5
+    - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64ps_v6
-      id: Standard_E64ps_v6
+      cpu_cores: 96
+      family: StandardDsv6Family
+      generic_name: standard_d96s_v6
+      id: Standard_D96s_v6
+      memory: 412316860416
+      name: Standard_D96s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDv5Family
+      generic_name: standard_d96_v5
+      id: Standard_D96_v5
+      memory: 412316860416
+      name: Standard_D96_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: standardDCEDV6Family
+      generic_name: standard_dc128eds_v6
+      id: Standard_DC128eds_v6
       memory: 549755813888
-      name: Standard_E64ps_v6
-    - architecture: arm64
-      category: memory_optimized
+      name: Standard_DC128eds_v6
+    - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96ps_v6
-      id: Standard_E96ps_v6
-      memory: 721554505728
-      name: Standard_E96ps_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2pds_v6
-      id: Standard_E2pds_v6
-      memory: 17179869184
-      name: Standard_E2pds_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4pds_v6
-      id: Standard_E4pds_v6
-      memory: 34359738368
-      name: Standard_E4pds_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8pds_v6
-      id: Standard_E8pds_v6
-      memory: 68719476736
-      name: Standard_E8pds_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16pds_v6
-      id: Standard_E16pds_v6
-      memory: 137438953472
-      name: Standard_E16pds_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32pds_v6
-      id: Standard_E32pds_v6
-      memory: 274877906944
-      name: Standard_E32pds_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48pds_v6
-      id: Standard_E48pds_v6
-      memory: 412316860416
-      name: Standard_E48pds_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64pds_v6
-      id: Standard_E64pds_v6
+      cpu_cores: 128
+      family: standardDCEV6Family
+      generic_name: standard_dc128es_v6
+      id: Standard_DC128es_v6
       memory: 549755813888
-      name: Standard_E64pds_v6
-    - architecture: arm64
-      category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96pds_v6
-      id: Standard_E96pds_v6
-      memory: 721554505728
-      name: Standard_E96pds_v6
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 24
-      generic_name: standard_nc24ads_a100_v4
-      id: Standard_NC24ads_A100_v4
-      memory: 236223201280
-      name: Standard_NC24ads_A100_v4
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_nc48ads_a100_v4
-      id: Standard_NC48ads_A100_v4
-      memory: 472446402560
-      name: Standard_NC48ads_A100_v4
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_nc96ads_a100_v4
-      id: Standard_NC96ads_A100_v4
-      memory: 944892805120
-      name: Standard_NC96ads_A100_v4
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_dc2as_v6
-      id: Standard_DC2as_v6
-      memory: 8589934592
-      name: Standard_DC2as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_dc4as_v6
-      id: Standard_DC4as_v6
-      memory: 17179869184
-      name: Standard_DC4as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_dc8as_v6
-      id: Standard_DC8as_v6
-      memory: 34359738368
-      name: Standard_DC8as_v6
+      name: Standard_DC128es_v6
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_dc16as_v6
-      id: Standard_DC16as_v6
+      family: standardDCADCCV5Family
+      generic_name: standard_dc16ads_cc_v5
+      id: Standard_DC16ads_cc_v5
       memory: 68719476736
-      name: Standard_DC16as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_dc32as_v6
-      id: Standard_DC32as_v6
-      memory: 137438953472
-      name: Standard_DC32as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_dc48as_v6
-      id: Standard_DC48as_v6
-      memory: 206158430208
-      name: Standard_DC48as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_dc64as_v6
-      id: Standard_DC64as_v6
-      memory: 274877906944
-      name: Standard_DC64as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_dc96as_v6
-      id: Standard_DC96as_v6
-      memory: 412316860416
-      name: Standard_DC96as_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_dc2ads_v6
-      id: Standard_DC2ads_v6
-      memory: 8589934592
-      name: Standard_DC2ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_dc4ads_v6
-      id: Standard_DC4ads_v6
-      memory: 17179869184
-      name: Standard_DC4ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_dc8ads_v6
-      id: Standard_DC8ads_v6
-      memory: 34359738368
-      name: Standard_DC8ads_v6
+      name: Standard_DC16ads_cc_v5
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
+      family: standardDCADSv5Family
+      generic_name: standard_dc16ads_v5
+      id: Standard_DC16ads_v5
+      memory: 68719476736
+      name: Standard_DC16ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDCadsv6Family
       generic_name: standard_dc16ads_v6
       id: Standard_DC16ads_v6
       memory: 68719476736
       name: Standard_DC16ads_v6
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_dc32ads_v6
-      id: Standard_DC32ads_v6
-      memory: 137438953472
-      name: Standard_DC32ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_dc48ads_v6
-      id: Standard_DC48ads_v6
-      memory: 206158430208
-      name: Standard_DC48ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_dc64ads_v6
-      id: Standard_DC64ads_v6
-      memory: 274877906944
-      name: Standard_DC64ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_dc96ads_v6
-      id: Standard_DC96ads_v6
-      memory: 412316860416
-      name: Standard_DC96ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_ec2as_v6
-      id: Standard_EC2as_v6
-      memory: 17179869184
-      name: Standard_EC2as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_ec4as_v6
-      id: Standard_EC4as_v6
-      memory: 34359738368
-      name: Standard_EC4as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_ec8as_v6
-      id: Standard_EC8as_v6
+      cpu_cores: 16
+      family: standardDCACCV5Family
+      generic_name: standard_dc16as_cc_v5
+      id: Standard_DC16as_cc_v5
       memory: 68719476736
-      name: Standard_EC8as_v6
-    - category: memory_optimized
+      name: Standard_DC16as_cc_v5
+    - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_ec16as_v6
-      id: Standard_EC16as_v6
-      memory: 137438953472
-      name: Standard_EC16as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_ec32as_v6
-      id: Standard_EC32as_v6
-      memory: 274877906944
-      name: Standard_EC32as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_ec48as_v6
-      id: Standard_EC48as_v6
-      memory: 412316860416
-      name: Standard_EC48as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_ec64as_v6
-      id: Standard_EC64as_v6
-      memory: 549755813888
-      name: Standard_EC64as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_ec96as_v6
-      id: Standard_EC96as_v6
-      memory: 721554505728
-      name: Standard_EC96as_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_ec2ads_v6
-      id: Standard_EC2ads_v6
-      memory: 17179869184
-      name: Standard_EC2ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_ec4ads_v6
-      id: Standard_EC4ads_v6
-      memory: 34359738368
-      name: Standard_EC4ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_ec8ads_v6
-      id: Standard_EC8ads_v6
+      family: standardDCASv5Family
+      generic_name: standard_dc16as_v5
+      id: Standard_DC16as_v5
       memory: 68719476736
-      name: Standard_EC8ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_ec16ads_v6
-      id: Standard_EC16ads_v6
-      memory: 137438953472
-      name: Standard_EC16ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_ec32ads_v6
-      id: Standard_EC32ads_v6
-      memory: 274877906944
-      name: Standard_EC32ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_ec48ads_v6
-      id: Standard_EC48ads_v6
-      memory: 412316860416
-      name: Standard_EC48ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_ec64ads_v6
-      id: Standard_EC64ads_v6
-      memory: 549755813888
-      name: Standard_EC64ads_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_ec96ads_v6
-      id: Standard_EC96ads_v6
-      memory: 721554505728
-      name: Standard_EC96ads_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2als_v7
-      id: Standard_D2als_v7
-      memory: 4294967296
-      name: Standard_D2als_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4als_v7
-      id: Standard_D4als_v7
-      memory: 8589934592
-      name: Standard_D4als_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8als_v7
-      id: Standard_D8als_v7
-      memory: 17179869184
-      name: Standard_D8als_v7
+      name: Standard_DC16as_v5
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_d16als_v7
-      id: Standard_D16als_v7
-      memory: 34359738368
-      name: Standard_D16als_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32als_v7
-      id: Standard_D32als_v7
+      family: standardDCasv6Family
+      generic_name: standard_dc16as_v6
+      id: Standard_DC16as_v6
       memory: 68719476736
-      name: Standard_D32als_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48als_v7
-      id: Standard_D48als_v7
-      memory: 103079215104
-      name: Standard_D48als_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64als_v7
-      id: Standard_D64als_v7
-      memory: 137438953472
-      name: Standard_D64als_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96als_v7
-      id: Standard_D96als_v7
-      memory: 206158430208
-      name: Standard_D96als_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_d128als_v7
-      id: Standard_D128als_v7
-      memory: 274877906944
-      name: Standard_D128als_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 160
-      generic_name: standard_d160als_v7
-      id: Standard_D160als_v7
-      memory: 343597383680
-      name: Standard_D160als_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2alds_v7
-      id: Standard_D2alds_v7
-      memory: 4294967296
-      name: Standard_D2alds_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4alds_v7
-      id: Standard_D4alds_v7
-      memory: 8589934592
-      name: Standard_D4alds_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8alds_v7
-      id: Standard_D8alds_v7
-      memory: 17179869184
-      name: Standard_D8alds_v7
+      name: Standard_DC16as_v6
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_d16alds_v7
-      id: Standard_D16alds_v7
-      memory: 34359738368
-      name: Standard_D16alds_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32alds_v7
-      id: Standard_D32alds_v7
+      family: standardDCEDV6Family
+      generic_name: standard_dc16eds_v6
+      id: Standard_DC16eds_v6
       memory: 68719476736
-      name: Standard_D32alds_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48alds_v7
-      id: Standard_D48alds_v7
-      memory: 103079215104
-      name: Standard_D48alds_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64alds_v7
-      id: Standard_D64alds_v7
-      memory: 137438953472
-      name: Standard_D64alds_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96alds_v7
-      id: Standard_D96alds_v7
-      memory: 206158430208
-      name: Standard_D96alds_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_d128alds_v7
-      id: Standard_D128alds_v7
-      memory: 274877906944
-      name: Standard_D128alds_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 160
-      generic_name: standard_d160alds_v7
-      id: Standard_D160alds_v7
-      memory: 343597383680
-      name: Standard_D160alds_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2as_v7
-      id: Standard_D2as_v7
-      memory: 8589934592
-      name: Standard_D2as_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4as_v7
-      id: Standard_D4as_v7
-      memory: 17179869184
-      name: Standard_D4as_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8as_v7
-      id: Standard_D8as_v7
-      memory: 34359738368
-      name: Standard_D8as_v7
+      name: Standard_DC16eds_v6
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 16
-      generic_name: standard_d16as_v7
-      id: Standard_D16as_v7
-      memory: 68719476736
-      name: Standard_D16as_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32as_v7
-      id: Standard_D32as_v7
-      memory: 137438953472
-      name: Standard_D32as_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48as_v7
-      id: Standard_D48as_v7
-      memory: 206158430208
-      name: Standard_D48as_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64as_v7
-      id: Standard_D64as_v7
-      memory: 274877906944
-      name: Standard_D64as_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96as_v7
-      id: Standard_D96as_v7
-      memory: 412316860416
-      name: Standard_D96as_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_d128as_v7
-      id: Standard_D128as_v7
-      memory: 549755813888
-      name: Standard_D128as_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 160
-      generic_name: standard_d160as_v7
-      id: Standard_D160as_v7
-      memory: 687194767360
-      name: Standard_D160as_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_d2ads_v7
-      id: Standard_D2ads_v7
-      memory: 8589934592
-      name: Standard_D2ads_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_d4ads_v7
-      id: Standard_D4ads_v7
-      memory: 17179869184
-      name: Standard_D4ads_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_d8ads_v7
-      id: Standard_D8ads_v7
-      memory: 34359738368
-      name: Standard_D8ads_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_d16ads_v7
-      id: Standard_D16ads_v7
-      memory: 68719476736
-      name: Standard_D16ads_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_d32ads_v7
-      id: Standard_D32ads_v7
-      memory: 137438953472
-      name: Standard_D32ads_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_d48ads_v7
-      id: Standard_D48ads_v7
-      memory: 206158430208
-      name: Standard_D48ads_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_d64ads_v7
-      id: Standard_D64ads_v7
-      memory: 274877906944
-      name: Standard_D64ads_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_d96ads_v7
-      id: Standard_D96ads_v7
-      memory: 412316860416
-      name: Standard_D96ads_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_d128ads_v7
-      id: Standard_D128ads_v7
-      memory: 549755813888
-      name: Standard_D128ads_v7
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 160
-      generic_name: standard_d160ads_v7
-      id: Standard_D160ads_v7
-      memory: 687194767360
-      name: Standard_D160ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2as_v7
-      id: Standard_E2as_v7
-      memory: 17179869184
-      name: Standard_E2as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2as_v7
-      id: Standard_E4-2as_v7
-      memory: 34359738368
-      name: Standard_E4-2as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4as_v7
-      id: Standard_E4as_v7
-      memory: 34359738368
-      name: Standard_E4as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2as_v7
-      id: Standard_E8-2as_v7
-      memory: 68719476736
-      name: Standard_E8-2as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4as_v7
-      id: Standard_E8-4as_v7
-      memory: 68719476736
-      name: Standard_E8-4as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8as_v7
-      id: Standard_E8as_v7
-      memory: 68719476736
-      name: Standard_E8as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-4as_v7
-      id: Standard_E16-4as_v7
-      memory: 137438953472
-      name: Standard_E16-4as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8as_v7
-      id: Standard_E16-8as_v7
-      memory: 137438953472
-      name: Standard_E16-8as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16as_v7
-      id: Standard_E16as_v7
-      memory: 137438953472
-      name: Standard_E16as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8as_v7
-      id: Standard_E32-8as_v7
-      memory: 274877906944
-      name: Standard_E32-8as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16as_v7
-      id: Standard_E32-16as_v7
-      memory: 274877906944
-      name: Standard_E32-16as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32as_v7
-      id: Standard_E32as_v7
-      memory: 274877906944
-      name: Standard_E32as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48as_v7
-      id: Standard_E48as_v7
-      memory: 412316860416
-      name: Standard_E48as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16as_v7
-      id: Standard_E64-16as_v7
-      memory: 549755813888
-      name: Standard_E64-16as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32as_v7
-      id: Standard_E64-32as_v7
-      memory: 549755813888
-      name: Standard_E64-32as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64as_v7
-      id: Standard_E64as_v7
-      memory: 549755813888
-      name: Standard_E64as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-24as_v7
-      id: Standard_E96-24as_v7
-      memory: 824633720832
-      name: Standard_E96-24as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-48as_v7
-      id: Standard_E96-48as_v7
-      memory: 824633720832
-      name: Standard_E96-48as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96as_v7
-      id: Standard_E96as_v7
-      memory: 824633720832
-      name: Standard_E96as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128-32as_v7
-      id: Standard_E128-32as_v7
-      memory: 1099511627776
-      name: Standard_E128-32as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128-64as_v7
-      id: Standard_E128-64as_v7
-      memory: 1099511627776
-      name: Standard_E128-64as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128as_v7
-      id: Standard_E128as_v7
-      memory: 1099511627776
-      name: Standard_E128as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_e2ads_v7
-      id: Standard_E2ads_v7
-      memory: 17179869184
-      name: Standard_E2ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4-2ads_v7
-      id: Standard_E4-2ads_v7
-      memory: 34359738368
-      name: Standard_E4-2ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_e4ads_v7
-      id: Standard_E4ads_v7
-      memory: 34359738368
-      name: Standard_E4ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-2ads_v7
-      id: Standard_E8-2ads_v7
-      memory: 68719476736
-      name: Standard_E8-2ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8-4ads_v7
-      id: Standard_E8-4ads_v7
-      memory: 68719476736
-      name: Standard_E8-4ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_e8ads_v7
-      id: Standard_E8ads_v7
-      memory: 68719476736
-      name: Standard_E8ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-4ads_v7
-      id: Standard_E16-4ads_v7
-      memory: 137438953472
-      name: Standard_E16-4ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16-8ads_v7
-      id: Standard_E16-8ads_v7
-      memory: 137438953472
-      name: Standard_E16-8ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_e16ads_v7
-      id: Standard_E16ads_v7
-      memory: 137438953472
-      name: Standard_E16ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-8ads_v7
-      id: Standard_E32-8ads_v7
-      memory: 274877906944
-      name: Standard_E32-8ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32-16ads_v7
-      id: Standard_E32-16ads_v7
-      memory: 274877906944
-      name: Standard_E32-16ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_e32ads_v7
-      id: Standard_E32ads_v7
-      memory: 274877906944
-      name: Standard_E32ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_e48ads_v7
-      id: Standard_E48ads_v7
-      memory: 412316860416
-      name: Standard_E48ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-16ads_v7
-      id: Standard_E64-16ads_v7
-      memory: 549755813888
-      name: Standard_E64-16ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64-32ads_v7
-      id: Standard_E64-32ads_v7
-      memory: 549755813888
-      name: Standard_E64-32ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_e64ads_v7
-      id: Standard_E64ads_v7
-      memory: 549755813888
-      name: Standard_E64ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-24ads_v7
-      id: Standard_E96-24ads_v7
-      memory: 824633720832
-      name: Standard_E96-24ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96-48ads_v7
-      id: Standard_E96-48ads_v7
-      memory: 824633720832
-      name: Standard_E96-48ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96ads_v7
-      id: Standard_E96ads_v7
-      memory: 824633720832
-      name: Standard_E96ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128-32ads_v7
-      id: Standard_E128-32ads_v7
-      memory: 1099511627776
-      name: Standard_E128-32ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128-64ads_v7
-      id: Standard_E128-64ads_v7
-      memory: 1099511627776
-      name: Standard_E128-64ads_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_e128ads_v7
-      id: Standard_E128ads_v7
-      memory: 1099511627776
-      name: Standard_E128ads_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 1
-      generic_name: standard_f1als_v7
-      id: Standard_F1als_v7
-      memory: 2147483648
-      name: Standard_F1als_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2als_v7
-      id: Standard_F2als_v7
-      memory: 4294967296
-      name: Standard_F2als_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4als_v7
-      id: Standard_F4als_v7
-      memory: 8589934592
-      name: Standard_F4als_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8als_v7
-      id: Standard_F8als_v7
-      memory: 17179869184
-      name: Standard_F8als_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16als_v7
-      id: Standard_F16als_v7
-      memory: 34359738368
-      name: Standard_F16als_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32als_v7
-      id: Standard_F32als_v7
-      memory: 68719476736
-      name: Standard_F32als_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_f48als_v7
-      id: Standard_F48als_v7
-      memory: 103079215104
-      name: Standard_F48als_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64als_v7
-      id: Standard_F64als_v7
-      memory: 137438953472
-      name: Standard_F64als_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_f80als_v7
-      id: Standard_F80als_v7
-      memory: 171798691840
-      name: Standard_F80als_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 1
-      generic_name: standard_f1alds_v7
-      id: Standard_F1alds_v7
-      memory: 2147483648
-      name: Standard_F1alds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2alds_v7
-      id: Standard_F2alds_v7
-      memory: 4294967296
-      name: Standard_F2alds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4alds_v7
-      id: Standard_F4alds_v7
-      memory: 8589934592
-      name: Standard_F4alds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8alds_v7
-      id: Standard_F8alds_v7
-      memory: 17179869184
-      name: Standard_F8alds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16alds_v7
-      id: Standard_F16alds_v7
-      memory: 34359738368
-      name: Standard_F16alds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32alds_v7
-      id: Standard_F32alds_v7
-      memory: 68719476736
-      name: Standard_F32alds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_f48alds_v7
-      id: Standard_F48alds_v7
-      memory: 103079215104
-      name: Standard_F48alds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64alds_v7
-      id: Standard_F64alds_v7
-      memory: 137438953472
-      name: Standard_F64alds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_f80alds_v7
-      id: Standard_F80alds_v7
-      memory: 171798691840
-      name: Standard_F80alds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 1
-      generic_name: standard_f1as_v7
-      id: Standard_F1as_v7
-      memory: 4294967296
-      name: Standard_F1as_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2as_v7
-      id: Standard_F2as_v7
-      memory: 8589934592
-      name: Standard_F2as_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4as_v7
-      id: Standard_F4as_v7
-      memory: 17179869184
-      name: Standard_F4as_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8as_v7
-      id: Standard_F8as_v7
-      memory: 34359738368
-      name: Standard_F8as_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16as_v7
-      id: Standard_F16as_v7
-      memory: 68719476736
-      name: Standard_F16as_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32as_v7
-      id: Standard_F32as_v7
-      memory: 137438953472
-      name: Standard_F32as_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_f48as_v7
-      id: Standard_F48as_v7
-      memory: 206158430208
-      name: Standard_F48as_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64as_v7
-      id: Standard_F64as_v7
-      memory: 274877906944
-      name: Standard_F64as_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_f80as_v7
-      id: Standard_F80as_v7
-      memory: 343597383680
-      name: Standard_F80as_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 1
-      generic_name: standard_f1ads_v7
-      id: Standard_F1ads_v7
-      memory: 4294967296
-      name: Standard_F1ads_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2ads_v7
-      id: Standard_F2ads_v7
-      memory: 8589934592
-      name: Standard_F2ads_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4ads_v7
-      id: Standard_F4ads_v7
-      memory: 17179869184
-      name: Standard_F4ads_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8ads_v7
-      id: Standard_F8ads_v7
-      memory: 34359738368
-      name: Standard_F8ads_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16ads_v7
-      id: Standard_F16ads_v7
-      memory: 68719476736
-      name: Standard_F16ads_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32ads_v7
-      id: Standard_F32ads_v7
-      memory: 137438953472
-      name: Standard_F32ads_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_f48ads_v7
-      id: Standard_F48ads_v7
-      memory: 206158430208
-      name: Standard_F48ads_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64ads_v7
-      id: Standard_F64ads_v7
-      memory: 274877906944
-      name: Standard_F64ads_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_f80ads_v7
-      id: Standard_F80ads_v7
-      memory: 343597383680
-      name: Standard_F80ads_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 1
-      generic_name: standard_f1ams_v7
-      id: Standard_F1ams_v7
-      memory: 8589934592
-      name: Standard_F1ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2-1ams_v7
-      id: Standard_F2-1ams_v7
-      memory: 17179869184
-      name: Standard_F2-1ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2ams_v7
-      id: Standard_F2ams_v7
-      memory: 17179869184
-      name: Standard_F2ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4-1ams_v7
-      id: Standard_F4-1ams_v7
-      memory: 34359738368
-      name: Standard_F4-1ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4-2ams_v7
-      id: Standard_F4-2ams_v7
-      memory: 34359738368
-      name: Standard_F4-2ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4ams_v7
-      id: Standard_F4ams_v7
-      memory: 34359738368
-      name: Standard_F4ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8-2ams_v7
-      id: Standard_F8-2ams_v7
-      memory: 68719476736
-      name: Standard_F8-2ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8-4ams_v7
-      id: Standard_F8-4ams_v7
-      memory: 68719476736
-      name: Standard_F8-4ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8ams_v7
-      id: Standard_F8ams_v7
-      memory: 68719476736
-      name: Standard_F8ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16-4ams_v7
-      id: Standard_F16-4ams_v7
-      memory: 137438953472
-      name: Standard_F16-4ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16-8ams_v7
-      id: Standard_F16-8ams_v7
-      memory: 137438953472
-      name: Standard_F16-8ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16ams_v7
-      id: Standard_F16ams_v7
-      memory: 137438953472
-      name: Standard_F16ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32-8ams_v7
-      id: Standard_F32-8ams_v7
-      memory: 274877906944
-      name: Standard_F32-8ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32-16ams_v7
-      id: Standard_F32-16ams_v7
-      memory: 274877906944
-      name: Standard_F32-16ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32ams_v7
-      id: Standard_F32ams_v7
-      memory: 274877906944
-      name: Standard_F32ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_f48ams_v7
-      id: Standard_F48ams_v7
-      memory: 412316860416
-      name: Standard_F48ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_f64-16ams_v7
-      id: Standard_F64-16ams_v7
-      memory: 549755813888
-      name: Standard_F64-16ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64-32ams_v7
-      id: Standard_F64-32ams_v7
-      memory: 549755813888
-      name: Standard_F64-32ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64ams_v7
-      id: Standard_F64ams_v7
-      memory: 549755813888
-      name: Standard_F64ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_f80ams_v7
-      id: Standard_F80ams_v7
-      memory: 687194767360
-      name: Standard_F80ams_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 1
-      generic_name: standard_f1amds_v7
-      id: Standard_F1amds_v7
-      memory: 8589934592
-      name: Standard_F1amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2-1amds_v7
-      id: Standard_F2-1amds_v7
-      memory: 17179869184
-      name: Standard_F2-1amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_f2amds_v7
-      id: Standard_F2amds_v7
-      memory: 17179869184
-      name: Standard_F2amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4-1amds_v7
-      id: Standard_F4-1amds_v7
-      memory: 34359738368
-      name: Standard_F4-1amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4-2amds_v7
-      id: Standard_F4-2amds_v7
-      memory: 34359738368
-      name: Standard_F4-2amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_f4amds_v7
-      id: Standard_F4amds_v7
-      memory: 34359738368
-      name: Standard_F4amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8-2amds_v7
-      id: Standard_F8-2amds_v7
-      memory: 68719476736
-      name: Standard_F8-2amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8-4amds_v7
-      id: Standard_F8-4amds_v7
-      memory: 68719476736
-      name: Standard_F8-4amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_f8amds_v7
-      id: Standard_F8amds_v7
-      memory: 68719476736
-      name: Standard_F8amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16-4amds_v7
-      id: Standard_F16-4amds_v7
-      memory: 137438953472
-      name: Standard_F16-4amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16-8amds_v7
-      id: Standard_F16-8amds_v7
-      memory: 137438953472
-      name: Standard_F16-8amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_f16amds_v7
-      id: Standard_F16amds_v7
-      memory: 137438953472
-      name: Standard_F16amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32-8amds_v7
-      id: Standard_F32-8amds_v7
-      memory: 274877906944
-      name: Standard_F32-8amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32-16amds_v7
-      id: Standard_F32-16amds_v7
-      memory: 274877906944
-      name: Standard_F32-16amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_f32amds_v7
-      id: Standard_F32amds_v7
-      memory: 274877906944
-      name: Standard_F32amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 48
-      generic_name: standard_f48amds_v7
-      id: Standard_F48amds_v7
-      memory: 412316860416
-      name: Standard_F48amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64-16amds_v7
-      id: Standard_F64-16amds_v7
-      memory: 549755813888
-      name: Standard_F64-16amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64-32amds_v7
-      id: Standard_F64-32amds_v7
-      memory: 549755813888
-      name: Standard_F64-32amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_f64amds_v7
-      id: Standard_F64amds_v7
-      memory: 549755813888
-      name: Standard_F64amds_v7
-    - category: compute_optimized
-      cloud_provider_id: azure
-      cpu_cores: 80
-      generic_name: standard_f80amds_v7
-      id: Standard_F80amds_v7
-      memory: 687194767360
-      name: Standard_F80amds_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_e96ias_v4
-      id: Standard_E96ias_v4
-      memory: 721554505728
-      name: Standard_E96ias_v4
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_nd96isr_h200_v5
-      id: Standard_ND96isr_H200_v5
-      memory: 1986422374400
-      name: Standard_ND96isr_H200_v5
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_nv4as_v4
-      id: Standard_NV4as_v4
-      memory: 15032385536
-      name: Standard_NV4as_v4
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_nv8as_v4
-      id: Standard_NV8as_v4
-      memory: 30064771072
-      name: Standard_NV8as_v4
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_nv16as_v4
-      id: Standard_NV16as_v4
-      memory: 60129542144
-      name: Standard_NV16as_v4
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_nv32as_v4
-      id: Standard_NV32as_v4
-      memory: 120259084288
-      name: Standard_NV32as_v4
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 160
-      generic_name: standard_e160as_v7
-      id: Standard_E160as_v7
-      memory: 1374389534720
-      name: Standard_E160as_v7
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 160
-      generic_name: standard_e160ads_v7
-      id: Standard_E160ads_v7
-      memory: 1374389534720
-      name: Standard_E160ads_v7
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 6
-      generic_name: standard_nc6s_v3
-      id: Standard_NC6s_v3
-      memory: 120259084288
-      name: Standard_NC6s_v3
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 12
-      generic_name: standard_nc12s_v3
-      id: Standard_NC12s_v3
-      memory: 240518168576
-      name: Standard_NC12s_v3
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 24
-      generic_name: standard_nc24rs_v3
-      id: Standard_NC24rs_v3
-      memory: 481036337152
-      name: Standard_NC24rs_v3
-    - category: gpu_workload
-      cloud_provider_id: azure
-      cpu_cores: 24
-      generic_name: standard_nc24s_v3
-      id: Standard_NC24s_v3
-      memory: 481036337152
-      name: Standard_NC24s_v3
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_dc2es_v6
-      id: Standard_DC2es_v6
-      memory: 8589934592
-      name: Standard_DC2es_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_dc4es_v6
-      id: Standard_DC4es_v6
-      memory: 17179869184
-      name: Standard_DC4es_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_dc8es_v6
-      id: Standard_DC8es_v6
-      memory: 34359738368
-      name: Standard_DC8es_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
+      family: standardDCEV6Family
       generic_name: standard_dc16es_v6
       id: Standard_DC16es_v6
       memory: 68719476736
       name: Standard_DC16es_v6
     - category: general_purpose
       cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDCADSv5Family
+      generic_name: standard_dc2ads_v5
+      id: Standard_DC2ads_v5
+      memory: 8589934592
+      name: Standard_DC2ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDCadsv6Family
+      generic_name: standard_dc2ads_v6
+      id: Standard_DC2ads_v6
+      memory: 8589934592
+      name: Standard_DC2ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDCASv5Family
+      generic_name: standard_dc2as_v5
+      id: Standard_DC2as_v5
+      memory: 8589934592
+      name: Standard_DC2as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDCasv6Family
+      generic_name: standard_dc2as_v6
+      id: Standard_DC2as_v6
+      memory: 8589934592
+      name: Standard_DC2as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDCEDV6Family
+      generic_name: standard_dc2eds_v6
+      id: Standard_DC2eds_v6
+      memory: 8589934592
+      name: Standard_DC2eds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDCEV6Family
+      generic_name: standard_dc2es_v6
+      id: Standard_DC2es_v6
+      memory: 8589934592
+      name: Standard_DC2es_v6
+    - category: general_purpose
+      cloud_provider_id: azure
       cpu_cores: 32
+      family: standardDCADCCV5Family
+      generic_name: standard_dc32ads_cc_v5
+      id: Standard_DC32ads_cc_v5
+      memory: 137438953472
+      name: Standard_DC32ads_cc_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDCADSv5Family
+      generic_name: standard_dc32ads_v5
+      id: Standard_DC32ads_v5
+      memory: 137438953472
+      name: Standard_DC32ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDCadsv6Family
+      generic_name: standard_dc32ads_v6
+      id: Standard_DC32ads_v6
+      memory: 137438953472
+      name: Standard_DC32ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDCACCV5Family
+      generic_name: standard_dc32as_cc_v5
+      id: Standard_DC32as_cc_v5
+      memory: 137438953472
+      name: Standard_DC32as_cc_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDCASv5Family
+      generic_name: standard_dc32as_v5
+      id: Standard_DC32as_v5
+      memory: 137438953472
+      name: Standard_DC32as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDCasv6Family
+      generic_name: standard_dc32as_v6
+      id: Standard_DC32as_v6
+      memory: 137438953472
+      name: Standard_DC32as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDCEDV6Family
+      generic_name: standard_dc32eds_v6
+      id: Standard_DC32eds_v6
+      memory: 137438953472
+      name: Standard_DC32eds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardDCEV6Family
       generic_name: standard_dc32es_v6
       id: Standard_DC32es_v6
       memory: 137438953472
@@ -7583,125 +3422,3659 @@ data:
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 48
-      generic_name: standard_dc48es_v6
-      id: Standard_DC48es_v6
+      family: standardDCADCCV5Family
+      generic_name: standard_dc48ads_cc_v5
+      id: Standard_DC48ads_cc_v5
       memory: 206158430208
-      name: Standard_DC48es_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_dc64es_v6
-      id: Standard_DC64es_v6
-      memory: 274877906944
-      name: Standard_DC64es_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 96
-      generic_name: standard_dc96es_v6
-      id: Standard_DC96es_v6
-      memory: 412316860416
-      name: Standard_DC96es_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_dc128es_v6
-      id: Standard_DC128es_v6
-      memory: 549755813888
-      name: Standard_DC128es_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_dc2eds_v6
-      id: Standard_DC2eds_v6
-      memory: 8589934592
-      name: Standard_DC2eds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_dc4eds_v6
-      id: Standard_DC4eds_v6
-      memory: 17179869184
-      name: Standard_DC4eds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_dc8eds_v6
-      id: Standard_DC8eds_v6
-      memory: 34359738368
-      name: Standard_DC8eds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_dc16eds_v6
-      id: Standard_DC16eds_v6
-      memory: 68719476736
-      name: Standard_DC16eds_v6
-    - category: general_purpose
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_dc32eds_v6
-      id: Standard_DC32eds_v6
-      memory: 137438953472
-      name: Standard_DC32eds_v6
+      name: Standard_DC48ads_cc_v5
     - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 48
+      family: standardDCADSv5Family
+      generic_name: standard_dc48ads_v5
+      id: Standard_DC48ads_v5
+      memory: 206158430208
+      name: Standard_DC48ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDCadsv6Family
+      generic_name: standard_dc48ads_v6
+      id: Standard_DC48ads_v6
+      memory: 206158430208
+      name: Standard_DC48ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDCACCV5Family
+      generic_name: standard_dc48as_cc_v5
+      id: Standard_DC48as_cc_v5
+      memory: 206158430208
+      name: Standard_DC48as_cc_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDCASv5Family
+      generic_name: standard_dc48as_v5
+      id: Standard_DC48as_v5
+      memory: 206158430208
+      name: Standard_DC48as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDCasv6Family
+      generic_name: standard_dc48as_v6
+      id: Standard_DC48as_v6
+      memory: 206158430208
+      name: Standard_DC48as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDCEDV6Family
       generic_name: standard_dc48eds_v6
       id: Standard_DC48eds_v6
       memory: 206158430208
       name: Standard_DC48eds_v6
     - category: general_purpose
       cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardDCEV6Family
+      generic_name: standard_dc48es_v6
+      id: Standard_DC48es_v6
+      memory: 206158430208
+      name: Standard_DC48es_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDCADCCV5Family
+      generic_name: standard_dc4ads_cc_v5
+      id: Standard_DC4ads_cc_v5
+      memory: 17179869184
+      name: Standard_DC4ads_cc_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDCADSv5Family
+      generic_name: standard_dc4ads_v5
+      id: Standard_DC4ads_v5
+      memory: 17179869184
+      name: Standard_DC4ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDCadsv6Family
+      generic_name: standard_dc4ads_v6
+      id: Standard_DC4ads_v6
+      memory: 17179869184
+      name: Standard_DC4ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDCACCV5Family
+      generic_name: standard_dc4as_cc_v5
+      id: Standard_DC4as_cc_v5
+      memory: 17179869184
+      name: Standard_DC4as_cc_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDCASv5Family
+      generic_name: standard_dc4as_v5
+      id: Standard_DC4as_v5
+      memory: 17179869184
+      name: Standard_DC4as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDCasv6Family
+      generic_name: standard_dc4as_v6
+      id: Standard_DC4as_v6
+      memory: 17179869184
+      name: Standard_DC4as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDCEDV6Family
+      generic_name: standard_dc4eds_v6
+      id: Standard_DC4eds_v6
+      memory: 17179869184
+      name: Standard_DC4eds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDCEV6Family
+      generic_name: standard_dc4es_v6
+      id: Standard_DC4es_v6
+      memory: 17179869184
+      name: Standard_DC4es_v6
+    - category: general_purpose
+      cloud_provider_id: azure
       cpu_cores: 64
+      family: standardDCADCCV5Family
+      generic_name: standard_dc64ads_cc_v5
+      id: Standard_DC64ads_cc_v5
+      memory: 274877906944
+      name: Standard_DC64ads_cc_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDCADSv5Family
+      generic_name: standard_dc64ads_v5
+      id: Standard_DC64ads_v5
+      memory: 274877906944
+      name: Standard_DC64ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDCadsv6Family
+      generic_name: standard_dc64ads_v6
+      id: Standard_DC64ads_v6
+      memory: 274877906944
+      name: Standard_DC64ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDCACCV5Family
+      generic_name: standard_dc64as_cc_v5
+      id: Standard_DC64as_cc_v5
+      memory: 274877906944
+      name: Standard_DC64as_cc_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDCASv5Family
+      generic_name: standard_dc64as_v5
+      id: Standard_DC64as_v5
+      memory: 274877906944
+      name: Standard_DC64as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDCasv6Family
+      generic_name: standard_dc64as_v6
+      id: Standard_DC64as_v6
+      memory: 274877906944
+      name: Standard_DC64as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDCEDV6Family
       generic_name: standard_dc64eds_v6
       id: Standard_DC64eds_v6
       memory: 274877906944
       name: Standard_DC64eds_v6
     - category: general_purpose
       cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardDCEV6Family
+      generic_name: standard_dc64es_v6
+      id: Standard_DC64es_v6
+      memory: 274877906944
+      name: Standard_DC64es_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDCADCCV5Family
+      generic_name: standard_dc8ads_cc_v5
+      id: Standard_DC8ads_cc_v5
+      memory: 34359738368
+      name: Standard_DC8ads_cc_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDCADSv5Family
+      generic_name: standard_dc8ads_v5
+      id: Standard_DC8ads_v5
+      memory: 34359738368
+      name: Standard_DC8ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDCadsv6Family
+      generic_name: standard_dc8ads_v6
+      id: Standard_DC8ads_v6
+      memory: 34359738368
+      name: Standard_DC8ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDCACCV5Family
+      generic_name: standard_dc8as_cc_v5
+      id: Standard_DC8as_cc_v5
+      memory: 34359738368
+      name: Standard_DC8as_cc_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDCASv5Family
+      generic_name: standard_dc8as_v5
+      id: Standard_DC8as_v5
+      memory: 34359738368
+      name: Standard_DC8as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDCasv6Family
+      generic_name: standard_dc8as_v6
+      id: Standard_DC8as_v6
+      memory: 34359738368
+      name: Standard_DC8as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDCEDV6Family
+      generic_name: standard_dc8eds_v6
+      id: Standard_DC8eds_v6
+      memory: 34359738368
+      name: Standard_DC8eds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDCEV6Family
+      generic_name: standard_dc8es_v6
+      id: Standard_DC8es_v6
+      memory: 34359738368
+      name: Standard_DC8es_v6
+    - category: general_purpose
+      cloud_provider_id: azure
       cpu_cores: 96
+      family: standardDCADCCV5Family
+      generic_name: standard_dc96ads_cc_v5
+      id: Standard_DC96ads_cc_v5
+      memory: 412316860416
+      name: Standard_DC96ads_cc_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDCADSv5Family
+      generic_name: standard_dc96ads_v5
+      id: Standard_DC96ads_v5
+      memory: 412316860416
+      name: Standard_DC96ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDCadsv6Family
+      generic_name: standard_dc96ads_v6
+      id: Standard_DC96ads_v6
+      memory: 412316860416
+      name: Standard_DC96ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDCACCV5Family
+      generic_name: standard_dc96as_cc_v5
+      id: Standard_DC96as_cc_v5
+      memory: 412316860416
+      name: Standard_DC96as_cc_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDCASv5Family
+      generic_name: standard_dc96as_v5
+      id: Standard_DC96as_v5
+      memory: 412316860416
+      name: Standard_DC96as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDCasv6Family
+      generic_name: standard_dc96as_v6
+      id: Standard_DC96as_v6
+      memory: 412316860416
+      name: Standard_DC96as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardDCEDV6Family
       generic_name: standard_dc96eds_v6
       id: Standard_DC96eds_v6
       memory: 412316860416
       name: Standard_DC96eds_v6
     - category: general_purpose
       cloud_provider_id: azure
-      cpu_cores: 128
-      generic_name: standard_dc128eds_v6
-      id: Standard_DC128eds_v6
-      memory: 549755813888
-      name: Standard_DC128eds_v6
-    - category: memory_optimized
+      cpu_cores: 96
+      family: standardDCEV6Family
+      generic_name: standard_dc96es_v6
+      id: Standard_DC96es_v6
+      memory: 412316860416
+      name: Standard_DC96es_v6
+    - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 2
-      generic_name: standard_ec2es_v6
-      id: Standard_EC2es_v6
-      memory: 17179869184
-      name: Standard_EC2es_v6
-    - category: memory_optimized
+      family: standardDSv2Family
+      generic_name: standard_ds11-1_v2
+      id: Standard_DS11-1_v2
+      memory: 15032385536
+      name: Standard_DS11-1_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDSv2Family
+      generic_name: standard_ds11_v2
+      id: Standard_DS11_v2
+      memory: 15032385536
+      name: Standard_DS11_v2
+    - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 4
-      generic_name: standard_ec4es_v6
-      id: Standard_EC4es_v6
-      memory: 34359738368
-      name: Standard_EC4es_v6
-    - category: memory_optimized
+      family: standardDSv2Family
+      generic_name: standard_ds12-1_v2
+      id: Standard_DS12-1_v2
+      memory: 30064771072
+      name: Standard_DS12-1_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDSv2Family
+      generic_name: standard_ds12-2_v2
+      id: Standard_DS12-2_v2
+      memory: 30064771072
+      name: Standard_DS12-2_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDSv2Family
+      generic_name: standard_ds12_v2
+      id: Standard_DS12_v2
+      memory: 30064771072
+      name: Standard_DS12_v2
+    - category: general_purpose
       cloud_provider_id: azure
       cpu_cores: 8
-      generic_name: standard_ec8es_v6
-      id: Standard_EC8es_v6
-      memory: 68719476736
-      name: Standard_EC8es_v6
+      family: standardDSv2Family
+      generic_name: standard_ds13-2_v2
+      id: Standard_DS13-2_v2
+      memory: 60129542144
+      name: Standard_DS13-2_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDSv2Family
+      generic_name: standard_ds13-4_v2
+      id: Standard_DS13-4_v2
+      memory: 60129542144
+      name: Standard_DS13-4_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDSv2Family
+      generic_name: standard_ds13_v2
+      id: Standard_DS13_v2
+      memory: 60129542144
+      name: Standard_DS13_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDSv2Family
+      generic_name: standard_ds14-4_v2
+      id: Standard_DS14-4_v2
+      memory: 120259084288
+      name: Standard_DS14-4_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDSv2Family
+      generic_name: standard_ds14-8_v2
+      id: Standard_DS14-8_v2
+      memory: 120259084288
+      name: Standard_DS14-8_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDSv2Family
+      generic_name: standard_ds14_v2
+      id: Standard_DS14_v2
+      memory: 120259084288
+      name: Standard_DS14_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardDSv2Family
+      generic_name: standard_ds15_v2
+      id: Standard_DS15_v2
+      memory: 150323855360
+      name: Standard_DS15_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 1
+      family: standardDSv2Family
+      generic_name: standard_ds1_v2
+      id: Standard_DS1_v2
+      memory: 3221225472
+      name: Standard_DS1_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardDSv2Family
+      generic_name: standard_ds2_v2
+      id: Standard_DS2_v2
+      memory: 7516192768
+      name: Standard_DS2_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardDSv2Family
+      generic_name: standard_ds3_v2
+      id: Standard_DS3_v2
+      memory: 15032385536
+      name: Standard_DS3_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardDSv2Family
+      generic_name: standard_ds4_v2
+      id: Standard_DS4_v2
+      memory: 30064771072
+      name: Standard_DS4_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardDSv2Family
+      generic_name: standard_ds5_v2
+      id: Standard_DS5_v2
+      memory: 60129542144
+      name: Standard_DS5_v2
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 104
+      family: standardEIDSv5Family
+      generic_name: standard_e104ids_v5
+      id: Standard_E104ids_v5
+      memory: 721554505728
+      name: Standard_E104ids_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 104
+      family: standardEIDv5Family
+      generic_name: standard_e104id_v5
+      id: Standard_E104id_v5
+      memory: 721554505728
+      name: Standard_E104id_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 104
+      family: standardEISv5Family
+      generic_name: standard_e104is_v5
+      id: Standard_E104is_v5
+      memory: 721554505728
+      name: Standard_E104is_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 104
+      family: standardEIv5Family
+      generic_name: standard_e104i_v5
+      id: Standard_E104i_v5
+      memory: 721554505728
+      name: Standard_E104i_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 112
+      family: standardEIADSv5Family
+      generic_name: standard_e112iads_v5
+      id: Standard_E112iads_v5
+      memory: 721554505728
+      name: Standard_E112iads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 112
+      family: standardEIASv5Family
+      generic_name: standard_e112ias_v5
+      id: Standard_E112ias_v5
+      memory: 721554505728
+      name: Standard_E112ias_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 112
+      family: standardEIBDSv5Family
+      generic_name: standard_e112ibds_v5
+      id: Standard_E112ibds_v5
+      memory: 721554505728
+      name: Standard_E112ibds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 112
+      family: standardEIBSv5Family
+      generic_name: standard_e112ibs_v5
+      id: Standard_E112ibs_v5
+      memory: 721554505728
+      name: Standard_E112ibs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEadsv7Family
+      generic_name: standard_e128-32ads_v7
+      id: Standard_E128-32ads_v7
+      memory: 1099511627776
+      name: Standard_E128-32ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEasv7Family
+      generic_name: standard_e128-32as_v7
+      id: Standard_E128-32as_v7
+      memory: 1099511627776
+      name: Standard_E128-32as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEdsv6Family
+      generic_name: standard_e128-32ds_v6
+      id: Standard_E128-32ds_v6
+      memory: 1099511627776
+      name: Standard_E128-32ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEsv6Family
+      generic_name: standard_e128-32s_v6
+      id: Standard_E128-32s_v6
+      memory: 1099511627776
+      name: Standard_E128-32s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEadsv7Family
+      generic_name: standard_e128-64ads_v7
+      id: Standard_E128-64ads_v7
+      memory: 1099511627776
+      name: Standard_E128-64ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEasv7Family
+      generic_name: standard_e128-64as_v7
+      id: Standard_E128-64as_v7
+      memory: 1099511627776
+      name: Standard_E128-64as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEdsv6Family
+      generic_name: standard_e128-64ds_v6
+      id: Standard_E128-64ds_v6
+      memory: 1099511627776
+      name: Standard_E128-64ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEsv6Family
+      generic_name: standard_e128-64s_v6
+      id: Standard_E128-64s_v6
+      memory: 1099511627776
+      name: Standard_E128-64s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEadsv7Family
+      generic_name: standard_e128ads_v7
+      id: Standard_E128ads_v7
+      memory: 1099511627776
+      name: Standard_E128ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEasv7Family
+      generic_name: standard_e128as_v7
+      id: Standard_E128as_v7
+      memory: 1099511627776
+      name: Standard_E128as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEdsv6Family
+      generic_name: standard_e128ds_v6
+      id: Standard_E128ds_v6
+      memory: 1099511627776
+      name: Standard_E128ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      family: StandardEsv6Family
+      generic_name: standard_e128s_v6
+      id: Standard_E128s_v6
+      memory: 1099511627776
+      name: Standard_E128s_v6
     - category: memory_optimized
       cloud_provider_id: azure
       cpu_cores: 16
+      family: standardEADSv5Family
+      generic_name: standard_e16-4ads_v5
+      id: Standard_E16-4ads_v5
+      memory: 137438953472
+      name: Standard_E16-4ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEadsv7Family
+      generic_name: standard_e16-4ads_v7
+      id: Standard_E16-4ads_v7
+      memory: 137438953472
+      name: Standard_E16-4ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEASv4Family
+      generic_name: standard_e16-4as_v4
+      id: Standard_E16-4as_v4
+      memory: 137438953472
+      name: Standard_E16-4as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEASv5Family
+      generic_name: standard_e16-4as_v5
+      id: Standard_E16-4as_v5
+      memory: 137438953472
+      name: Standard_E16-4as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEasv7Family
+      generic_name: standard_e16-4as_v7
+      id: Standard_E16-4as_v7
+      memory: 137438953472
+      name: Standard_E16-4as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEDSv4Family
+      generic_name: standard_e16-4ds_v4
+      id: Standard_E16-4ds_v4
+      memory: 137438953472
+      name: Standard_E16-4ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEDSv5Family
+      generic_name: standard_e16-4ds_v5
+      id: Standard_E16-4ds_v5
+      memory: 137438953472
+      name: Standard_E16-4ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEdsv6Family
+      generic_name: standard_e16-4ds_v6
+      id: Standard_E16-4ds_v6
+      memory: 137438953472
+      name: Standard_E16-4ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardESv3Family
+      generic_name: standard_e16-4s_v3
+      id: Standard_E16-4s_v3
+      memory: 137438953472
+      name: Standard_E16-4s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardESv4Family
+      generic_name: standard_e16-4s_v4
+      id: Standard_E16-4s_v4
+      memory: 137438953472
+      name: Standard_E16-4s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardESv5Family
+      generic_name: standard_e16-4s_v5
+      id: Standard_E16-4s_v5
+      memory: 137438953472
+      name: Standard_E16-4s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEsv6Family
+      generic_name: standard_e16-4s_v6
+      id: Standard_E16-4s_v6
+      memory: 137438953472
+      name: Standard_E16-4s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEADSv5Family
+      generic_name: standard_e16-8ads_v5
+      id: Standard_E16-8ads_v5
+      memory: 137438953472
+      name: Standard_E16-8ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEadsv7Family
+      generic_name: standard_e16-8ads_v7
+      id: Standard_E16-8ads_v7
+      memory: 137438953472
+      name: Standard_E16-8ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEASv4Family
+      generic_name: standard_e16-8as_v4
+      id: Standard_E16-8as_v4
+      memory: 137438953472
+      name: Standard_E16-8as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEASv5Family
+      generic_name: standard_e16-8as_v5
+      id: Standard_E16-8as_v5
+      memory: 137438953472
+      name: Standard_E16-8as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEasv7Family
+      generic_name: standard_e16-8as_v7
+      id: Standard_E16-8as_v7
+      memory: 137438953472
+      name: Standard_E16-8as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEDSv4Family
+      generic_name: standard_e16-8ds_v4
+      id: Standard_E16-8ds_v4
+      memory: 137438953472
+      name: Standard_E16-8ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEDSv5Family
+      generic_name: standard_e16-8ds_v5
+      id: Standard_E16-8ds_v5
+      memory: 137438953472
+      name: Standard_E16-8ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEdsv6Family
+      generic_name: standard_e16-8ds_v6
+      id: Standard_E16-8ds_v6
+      memory: 137438953472
+      name: Standard_E16-8ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardESv3Family
+      generic_name: standard_e16-8s_v3
+      id: Standard_E16-8s_v3
+      memory: 137438953472
+      name: Standard_E16-8s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardESv4Family
+      generic_name: standard_e16-8s_v4
+      id: Standard_E16-8s_v4
+      memory: 137438953472
+      name: Standard_E16-8s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardESv5Family
+      generic_name: standard_e16-8s_v5
+      id: Standard_E16-8s_v5
+      memory: 137438953472
+      name: Standard_E16-8s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEsv6Family
+      generic_name: standard_e16-8s_v6
+      id: Standard_E16-8s_v6
+      memory: 137438953472
+      name: Standard_E16-8s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 160
+      family: StandardEadsv7Family
+      generic_name: standard_e160ads_v7
+      id: Standard_E160ads_v7
+      memory: 1374389534720
+      name: Standard_E160ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 160
+      family: StandardEasv7Family
+      generic_name: standard_e160as_v7
+      id: Standard_E160as_v7
+      memory: 1374389534720
+      name: Standard_E160as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEADSv5Family
+      generic_name: standard_e16ads_v5
+      id: Standard_E16ads_v5
+      memory: 137438953472
+      name: Standard_E16ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEadv6Family
+      generic_name: standard_e16ads_v6
+      id: Standard_E16ads_v6
+      memory: 137438953472
+      name: Standard_E16ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEadsv7Family
+      generic_name: standard_e16ads_v7
+      id: Standard_E16ads_v7
+      memory: 137438953472
+      name: Standard_E16ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEASv4Family
+      generic_name: standard_e16as_v4
+      id: Standard_E16as_v4
+      memory: 137438953472
+      name: Standard_E16as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEASv5Family
+      generic_name: standard_e16as_v5
+      id: Standard_E16as_v5
+      memory: 137438953472
+      name: Standard_E16as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEav6Family
+      generic_name: standard_e16as_v6
+      id: Standard_E16as_v6
+      memory: 137438953472
+      name: Standard_E16as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEasv7Family
+      generic_name: standard_e16as_v7
+      id: Standard_E16as_v7
+      memory: 137438953472
+      name: Standard_E16as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEAv4Family
+      generic_name: standard_e16a_v4
+      id: Standard_E16a_v4
+      memory: 137438953472
+      name: Standard_E16a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEBDSv5Family
+      generic_name: standard_e16bds_v5
+      id: Standard_E16bds_v5
+      memory: 137438953472
+      name: Standard_E16bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEBSv5Family
+      generic_name: standard_e16bs_v5
+      id: Standard_E16bs_v5
+      memory: 137438953472
+      name: Standard_E16bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEDSv4Family
+      generic_name: standard_e16ds_v4
+      id: Standard_E16ds_v4
+      memory: 137438953472
+      name: Standard_E16ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEDSv5Family
+      generic_name: standard_e16ds_v5
+      id: Standard_E16ds_v5
+      memory: 137438953472
+      name: Standard_E16ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEdsv6Family
+      generic_name: standard_e16ds_v6
+      id: Standard_E16ds_v6
+      memory: 137438953472
+      name: Standard_E16ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEDv4Family
+      generic_name: standard_e16d_v4
+      id: Standard_E16d_v4
+      memory: 137438953472
+      name: Standard_E16d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEDv5Family
+      generic_name: standard_e16d_v5
+      id: Standard_E16d_v5
+      memory: 137438953472
+      name: Standard_E16d_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEPDSv5Family
+      generic_name: standard_e16pds_v5
+      id: Standard_E16pds_v5
+      memory: 137438953472
+      name: Standard_E16pds_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEpdsv6Family
+      generic_name: standard_e16pds_v6
+      id: Standard_E16pds_v6
+      memory: 137438953472
+      name: Standard_E16pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEPSv5Family
+      generic_name: standard_e16ps_v5
+      id: Standard_E16ps_v5
+      memory: 137438953472
+      name: Standard_E16ps_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEpsv6Family
+      generic_name: standard_e16ps_v6
+      id: Standard_E16ps_v6
+      memory: 137438953472
+      name: Standard_E16ps_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardESv3Family
+      generic_name: standard_e16s_v3
+      id: Standard_E16s_v3
+      memory: 137438953472
+      name: Standard_E16s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardESv4Family
+      generic_name: standard_e16s_v4
+      id: Standard_E16s_v4
+      memory: 137438953472
+      name: Standard_E16s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardESv5Family
+      generic_name: standard_e16s_v5
+      id: Standard_E16s_v5
+      memory: 137438953472
+      name: Standard_E16s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardEsv6Family
+      generic_name: standard_e16s_v6
+      id: Standard_E16s_v6
+      memory: 137438953472
+      name: Standard_E16s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEv3Family
+      generic_name: standard_e16_v3
+      id: Standard_E16_v3
+      memory: 137438953472
+      name: Standard_E16_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEv4Family
+      generic_name: standard_e16_v4
+      id: Standard_E16_v4
+      memory: 137438953472
+      name: Standard_E16_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardEv5Family
+      generic_name: standard_e16_v5
+      id: Standard_E16_v5
+      memory: 137438953472
+      name: Standard_E16_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 192
+      family: StandardEdsv6Family
+      generic_name: standard_e192ids_v6
+      id: Standard_E192ids_v6
+      memory: 1967095021568
+      name: Standard_E192ids_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 192
+      family: StandardEsv6Family
+      generic_name: standard_e192is_v6
+      id: Standard_E192is_v6
+      memory: 1967095021568
+      name: Standard_E192is_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEADSv5Family
+      generic_name: standard_e20ads_v5
+      id: Standard_E20ads_v5
+      memory: 171798691840
+      name: Standard_E20ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEadv6Family
+      generic_name: standard_e20ads_v6
+      id: Standard_E20ads_v6
+      memory: 171798691840
+      name: Standard_E20ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEASv4Family
+      generic_name: standard_e20as_v4
+      id: Standard_E20as_v4
+      memory: 171798691840
+      name: Standard_E20as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEASv5Family
+      generic_name: standard_e20as_v5
+      id: Standard_E20as_v5
+      memory: 171798691840
+      name: Standard_E20as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEav6Family
+      generic_name: standard_e20as_v6
+      id: Standard_E20as_v6
+      memory: 171798691840
+      name: Standard_E20as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEAv4Family
+      generic_name: standard_e20a_v4
+      id: Standard_E20a_v4
+      memory: 171798691840
+      name: Standard_E20a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEDSv4Family
+      generic_name: standard_e20ds_v4
+      id: Standard_E20ds_v4
+      memory: 171798691840
+      name: Standard_E20ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEDSv5Family
+      generic_name: standard_e20ds_v5
+      id: Standard_E20ds_v5
+      memory: 171798691840
+      name: Standard_E20ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: StandardEdsv6Family
+      generic_name: standard_e20ds_v6
+      id: Standard_E20ds_v6
+      memory: 171798691840
+      name: Standard_E20ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEDv4Family
+      generic_name: standard_e20d_v4
+      id: Standard_E20d_v4
+      memory: 171798691840
+      name: Standard_E20d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEDv5Family
+      generic_name: standard_e20d_v5
+      id: Standard_E20d_v5
+      memory: 171798691840
+      name: Standard_E20d_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEPDSv5Family
+      generic_name: standard_e20pds_v5
+      id: Standard_E20pds_v5
+      memory: 171798691840
+      name: Standard_E20pds_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEPSv5Family
+      generic_name: standard_e20ps_v5
+      id: Standard_E20ps_v5
+      memory: 171798691840
+      name: Standard_E20ps_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardESv3Family
+      generic_name: standard_e20s_v3
+      id: Standard_E20s_v3
+      memory: 171798691840
+      name: Standard_E20s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardESv4Family
+      generic_name: standard_e20s_v4
+      id: Standard_E20s_v4
+      memory: 171798691840
+      name: Standard_E20s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardESv5Family
+      generic_name: standard_e20s_v5
+      id: Standard_E20s_v5
+      memory: 171798691840
+      name: Standard_E20s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: StandardEsv6Family
+      generic_name: standard_e20s_v6
+      id: Standard_E20s_v6
+      memory: 171798691840
+      name: Standard_E20s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEv3Family
+      generic_name: standard_e20_v3
+      id: Standard_E20_v3
+      memory: 171798691840
+      name: Standard_E20_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEv4Family
+      generic_name: standard_e20_v4
+      id: Standard_E20_v4
+      memory: 171798691840
+      name: Standard_E20_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardEv5Family
+      generic_name: standard_e20_v5
+      id: Standard_E20_v5
+      memory: 171798691840
+      name: Standard_E20_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEADSv5Family
+      generic_name: standard_e2ads_v5
+      id: Standard_E2ads_v5
+      memory: 17179869184
+      name: Standard_E2ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEadv6Family
+      generic_name: standard_e2ads_v6
+      id: Standard_E2ads_v6
+      memory: 17179869184
+      name: Standard_E2ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardEadsv7Family
+      generic_name: standard_e2ads_v7
+      id: Standard_E2ads_v7
+      memory: 17179869184
+      name: Standard_E2ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEASv4Family
+      generic_name: standard_e2as_v4
+      id: Standard_E2as_v4
+      memory: 17179869184
+      name: Standard_E2as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEASv5Family
+      generic_name: standard_e2as_v5
+      id: Standard_E2as_v5
+      memory: 17179869184
+      name: Standard_E2as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEav6Family
+      generic_name: standard_e2as_v6
+      id: Standard_E2as_v6
+      memory: 17179869184
+      name: Standard_E2as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardEasv7Family
+      generic_name: standard_e2as_v7
+      id: Standard_E2as_v7
+      memory: 17179869184
+      name: Standard_E2as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEAv4Family
+      generic_name: standard_e2a_v4
+      id: Standard_E2a_v4
+      memory: 17179869184
+      name: Standard_E2a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEBDSv5Family
+      generic_name: standard_e2bds_v5
+      id: Standard_E2bds_v5
+      memory: 17179869184
+      name: Standard_E2bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEBSv5Family
+      generic_name: standard_e2bs_v5
+      id: Standard_E2bs_v5
+      memory: 17179869184
+      name: Standard_E2bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEDSv4Family
+      generic_name: standard_e2ds_v4
+      id: Standard_E2ds_v4
+      memory: 17179869184
+      name: Standard_E2ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEDSv5Family
+      generic_name: standard_e2ds_v5
+      id: Standard_E2ds_v5
+      memory: 17179869184
+      name: Standard_E2ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardEdsv6Family
+      generic_name: standard_e2ds_v6
+      id: Standard_E2ds_v6
+      memory: 17179869184
+      name: Standard_E2ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEDv4Family
+      generic_name: standard_e2d_v4
+      id: Standard_E2d_v4
+      memory: 17179869184
+      name: Standard_E2d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEDv5Family
+      generic_name: standard_e2d_v5
+      id: Standard_E2d_v5
+      memory: 17179869184
+      name: Standard_E2d_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEPDSv5Family
+      generic_name: standard_e2pds_v5
+      id: Standard_E2pds_v5
+      memory: 17179869184
+      name: Standard_E2pds_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardEpdsv6Family
+      generic_name: standard_e2pds_v6
+      id: Standard_E2pds_v6
+      memory: 17179869184
+      name: Standard_E2pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEPSv5Family
+      generic_name: standard_e2ps_v5
+      id: Standard_E2ps_v5
+      memory: 17179869184
+      name: Standard_E2ps_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardEpsv6Family
+      generic_name: standard_e2ps_v6
+      id: Standard_E2ps_v6
+      memory: 17179869184
+      name: Standard_E2ps_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardESv3Family
+      generic_name: standard_e2s_v3
+      id: Standard_E2s_v3
+      memory: 17179869184
+      name: Standard_E2s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardESv4Family
+      generic_name: standard_e2s_v4
+      id: Standard_E2s_v4
+      memory: 17179869184
+      name: Standard_E2s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardESv5Family
+      generic_name: standard_e2s_v5
+      id: Standard_E2s_v5
+      memory: 17179869184
+      name: Standard_E2s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardEsv6Family
+      generic_name: standard_e2s_v6
+      id: Standard_E2s_v6
+      memory: 17179869184
+      name: Standard_E2s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEv3Family
+      generic_name: standard_e2_v3
+      id: Standard_E2_v3
+      memory: 17179869184
+      name: Standard_E2_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEv4Family
+      generic_name: standard_e2_v4
+      id: Standard_E2_v4
+      memory: 17179869184
+      name: Standard_E2_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardEv5Family
+      generic_name: standard_e2_v5
+      id: Standard_E2_v5
+      memory: 17179869184
+      name: Standard_E2_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEADSv5Family
+      generic_name: standard_e32-16ads_v5
+      id: Standard_E32-16ads_v5
+      memory: 274877906944
+      name: Standard_E32-16ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEadsv7Family
+      generic_name: standard_e32-16ads_v7
+      id: Standard_E32-16ads_v7
+      memory: 274877906944
+      name: Standard_E32-16ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEASv4Family
+      generic_name: standard_e32-16as_v4
+      id: Standard_E32-16as_v4
+      memory: 274877906944
+      name: Standard_E32-16as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEASv5Family
+      generic_name: standard_e32-16as_v5
+      id: Standard_E32-16as_v5
+      memory: 274877906944
+      name: Standard_E32-16as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEasv7Family
+      generic_name: standard_e32-16as_v7
+      id: Standard_E32-16as_v7
+      memory: 274877906944
+      name: Standard_E32-16as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEDSv4Family
+      generic_name: standard_e32-16ds_v4
+      id: Standard_E32-16ds_v4
+      memory: 274877906944
+      name: Standard_E32-16ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEDSv5Family
+      generic_name: standard_e32-16ds_v5
+      id: Standard_E32-16ds_v5
+      memory: 274877906944
+      name: Standard_E32-16ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEdsv6Family
+      generic_name: standard_e32-16ds_v6
+      id: Standard_E32-16ds_v6
+      memory: 274877906944
+      name: Standard_E32-16ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardESv3Family
+      generic_name: standard_e32-16s_v3
+      id: Standard_E32-16s_v3
+      memory: 274877906944
+      name: Standard_E32-16s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardESv4Family
+      generic_name: standard_e32-16s_v4
+      id: Standard_E32-16s_v4
+      memory: 274877906944
+      name: Standard_E32-16s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardESv5Family
+      generic_name: standard_e32-16s_v5
+      id: Standard_E32-16s_v5
+      memory: 274877906944
+      name: Standard_E32-16s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEsv6Family
+      generic_name: standard_e32-16s_v6
+      id: Standard_E32-16s_v6
+      memory: 274877906944
+      name: Standard_E32-16s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEADSv5Family
+      generic_name: standard_e32-8ads_v5
+      id: Standard_E32-8ads_v5
+      memory: 274877906944
+      name: Standard_E32-8ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEadsv7Family
+      generic_name: standard_e32-8ads_v7
+      id: Standard_E32-8ads_v7
+      memory: 274877906944
+      name: Standard_E32-8ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEASv4Family
+      generic_name: standard_e32-8as_v4
+      id: Standard_E32-8as_v4
+      memory: 274877906944
+      name: Standard_E32-8as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEASv5Family
+      generic_name: standard_e32-8as_v5
+      id: Standard_E32-8as_v5
+      memory: 274877906944
+      name: Standard_E32-8as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEasv7Family
+      generic_name: standard_e32-8as_v7
+      id: Standard_E32-8as_v7
+      memory: 274877906944
+      name: Standard_E32-8as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEDSv4Family
+      generic_name: standard_e32-8ds_v4
+      id: Standard_E32-8ds_v4
+      memory: 274877906944
+      name: Standard_E32-8ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEDSv5Family
+      generic_name: standard_e32-8ds_v5
+      id: Standard_E32-8ds_v5
+      memory: 274877906944
+      name: Standard_E32-8ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEdsv6Family
+      generic_name: standard_e32-8ds_v6
+      id: Standard_E32-8ds_v6
+      memory: 274877906944
+      name: Standard_E32-8ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardESv3Family
+      generic_name: standard_e32-8s_v3
+      id: Standard_E32-8s_v3
+      memory: 274877906944
+      name: Standard_E32-8s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardESv4Family
+      generic_name: standard_e32-8s_v4
+      id: Standard_E32-8s_v4
+      memory: 274877906944
+      name: Standard_E32-8s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardESv5Family
+      generic_name: standard_e32-8s_v5
+      id: Standard_E32-8s_v5
+      memory: 274877906944
+      name: Standard_E32-8s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEsv6Family
+      generic_name: standard_e32-8s_v6
+      id: Standard_E32-8s_v6
+      memory: 274877906944
+      name: Standard_E32-8s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEADSv5Family
+      generic_name: standard_e32ads_v5
+      id: Standard_E32ads_v5
+      memory: 274877906944
+      name: Standard_E32ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEadv6Family
+      generic_name: standard_e32ads_v6
+      id: Standard_E32ads_v6
+      memory: 274877906944
+      name: Standard_E32ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEadsv7Family
+      generic_name: standard_e32ads_v7
+      id: Standard_E32ads_v7
+      memory: 274877906944
+      name: Standard_E32ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEASv4Family
+      generic_name: standard_e32as_v4
+      id: Standard_E32as_v4
+      memory: 274877906944
+      name: Standard_E32as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEASv5Family
+      generic_name: standard_e32as_v5
+      id: Standard_E32as_v5
+      memory: 274877906944
+      name: Standard_E32as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEav6Family
+      generic_name: standard_e32as_v6
+      id: Standard_E32as_v6
+      memory: 274877906944
+      name: Standard_E32as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEasv7Family
+      generic_name: standard_e32as_v7
+      id: Standard_E32as_v7
+      memory: 274877906944
+      name: Standard_E32as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEAv4Family
+      generic_name: standard_e32a_v4
+      id: Standard_E32a_v4
+      memory: 274877906944
+      name: Standard_E32a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEBDSv5Family
+      generic_name: standard_e32bds_v5
+      id: Standard_E32bds_v5
+      memory: 274877906944
+      name: Standard_E32bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEBSv5Family
+      generic_name: standard_e32bs_v5
+      id: Standard_E32bs_v5
+      memory: 274877906944
+      name: Standard_E32bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEDSv4Family
+      generic_name: standard_e32ds_v4
+      id: Standard_E32ds_v4
+      memory: 274877906944
+      name: Standard_E32ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEDSv5Family
+      generic_name: standard_e32ds_v5
+      id: Standard_E32ds_v5
+      memory: 274877906944
+      name: Standard_E32ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEdsv6Family
+      generic_name: standard_e32ds_v6
+      id: Standard_E32ds_v6
+      memory: 274877906944
+      name: Standard_E32ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEDv4Family
+      generic_name: standard_e32d_v4
+      id: Standard_E32d_v4
+      memory: 274877906944
+      name: Standard_E32d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEDv5Family
+      generic_name: standard_e32d_v5
+      id: Standard_E32d_v5
+      memory: 274877906944
+      name: Standard_E32d_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEPDSv5Family
+      generic_name: standard_e32pds_v5
+      id: Standard_E32pds_v5
+      memory: 223338299392
+      name: Standard_E32pds_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEpdsv6Family
+      generic_name: standard_e32pds_v6
+      id: Standard_E32pds_v6
+      memory: 274877906944
+      name: Standard_E32pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEPSv5Family
+      generic_name: standard_e32ps_v5
+      id: Standard_E32ps_v5
+      memory: 223338299392
+      name: Standard_E32ps_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEpsv6Family
+      generic_name: standard_e32ps_v6
+      id: Standard_E32ps_v6
+      memory: 274877906944
+      name: Standard_E32ps_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardESv3Family
+      generic_name: standard_e32s_v3
+      id: Standard_E32s_v3
+      memory: 274877906944
+      name: Standard_E32s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardESv4Family
+      generic_name: standard_e32s_v4
+      id: Standard_E32s_v4
+      memory: 274877906944
+      name: Standard_E32s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardESv5Family
+      generic_name: standard_e32s_v5
+      id: Standard_E32s_v5
+      memory: 274877906944
+      name: Standard_E32s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardEsv6Family
+      generic_name: standard_e32s_v6
+      id: Standard_E32s_v6
+      memory: 274877906944
+      name: Standard_E32s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEv3Family
+      generic_name: standard_e32_v3
+      id: Standard_E32_v3
+      memory: 274877906944
+      name: Standard_E32_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEv4Family
+      generic_name: standard_e32_v4
+      id: Standard_E32_v4
+      memory: 274877906944
+      name: Standard_E32_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardEv5Family
+      generic_name: standard_e32_v5
+      id: Standard_E32_v5
+      memory: 274877906944
+      name: Standard_E32_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEADSv5Family
+      generic_name: standard_e4-2ads_v5
+      id: Standard_E4-2ads_v5
+      memory: 34359738368
+      name: Standard_E4-2ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardEadsv7Family
+      generic_name: standard_e4-2ads_v7
+      id: Standard_E4-2ads_v7
+      memory: 34359738368
+      name: Standard_E4-2ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEASv4Family
+      generic_name: standard_e4-2as_v4
+      id: Standard_E4-2as_v4
+      memory: 34359738368
+      name: Standard_E4-2as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEASv5Family
+      generic_name: standard_e4-2as_v5
+      id: Standard_E4-2as_v5
+      memory: 34359738368
+      name: Standard_E4-2as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardEasv7Family
+      generic_name: standard_e4-2as_v7
+      id: Standard_E4-2as_v7
+      memory: 34359738368
+      name: Standard_E4-2as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEDSv4Family
+      generic_name: standard_e4-2ds_v4
+      id: Standard_E4-2ds_v4
+      memory: 34359738368
+      name: Standard_E4-2ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEDSv5Family
+      generic_name: standard_e4-2ds_v5
+      id: Standard_E4-2ds_v5
+      memory: 34359738368
+      name: Standard_E4-2ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardEdsv6Family
+      generic_name: standard_e4-2ds_v6
+      id: Standard_E4-2ds_v6
+      memory: 34359738368
+      name: Standard_E4-2ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardESv3Family
+      generic_name: standard_e4-2s_v3
+      id: Standard_E4-2s_v3
+      memory: 34359738368
+      name: Standard_E4-2s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardESv4Family
+      generic_name: standard_e4-2s_v4
+      id: Standard_E4-2s_v4
+      memory: 34359738368
+      name: Standard_E4-2s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardESv5Family
+      generic_name: standard_e4-2s_v5
+      id: Standard_E4-2s_v5
+      memory: 34359738368
+      name: Standard_E4-2s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardEsv6Family
+      generic_name: standard_e4-2s_v6
+      id: Standard_E4-2s_v6
+      memory: 34359738368
+      name: Standard_E4-2s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEADSv5Family
+      generic_name: standard_e48ads_v5
+      id: Standard_E48ads_v5
+      memory: 412316860416
+      name: Standard_E48ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEadv6Family
+      generic_name: standard_e48ads_v6
+      id: Standard_E48ads_v6
+      memory: 412316860416
+      name: Standard_E48ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardEadsv7Family
+      generic_name: standard_e48ads_v7
+      id: Standard_E48ads_v7
+      memory: 412316860416
+      name: Standard_E48ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEASv4Family
+      generic_name: standard_e48as_v4
+      id: Standard_E48as_v4
+      memory: 412316860416
+      name: Standard_E48as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEASv5Family
+      generic_name: standard_e48as_v5
+      id: Standard_E48as_v5
+      memory: 412316860416
+      name: Standard_E48as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEav6Family
+      generic_name: standard_e48as_v6
+      id: Standard_E48as_v6
+      memory: 412316860416
+      name: Standard_E48as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardEasv7Family
+      generic_name: standard_e48as_v7
+      id: Standard_E48as_v7
+      memory: 412316860416
+      name: Standard_E48as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEAv4Family
+      generic_name: standard_e48a_v4
+      id: Standard_E48a_v4
+      memory: 412316860416
+      name: Standard_E48a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEBDSv5Family
+      generic_name: standard_e48bds_v5
+      id: Standard_E48bds_v5
+      memory: 412316860416
+      name: Standard_E48bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEBSv5Family
+      generic_name: standard_e48bs_v5
+      id: Standard_E48bs_v5
+      memory: 412316860416
+      name: Standard_E48bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEDSv4Family
+      generic_name: standard_e48ds_v4
+      id: Standard_E48ds_v4
+      memory: 412316860416
+      name: Standard_E48ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEDSv5Family
+      generic_name: standard_e48ds_v5
+      id: Standard_E48ds_v5
+      memory: 412316860416
+      name: Standard_E48ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardEdsv6Family
+      generic_name: standard_e48ds_v6
+      id: Standard_E48ds_v6
+      memory: 412316860416
+      name: Standard_E48ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEDv4Family
+      generic_name: standard_e48d_v4
+      id: Standard_E48d_v4
+      memory: 412316860416
+      name: Standard_E48d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEDv5Family
+      generic_name: standard_e48d_v5
+      id: Standard_E48d_v5
+      memory: 412316860416
+      name: Standard_E48d_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardEpdsv6Family
+      generic_name: standard_e48pds_v6
+      id: Standard_E48pds_v6
+      memory: 412316860416
+      name: Standard_E48pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardEpsv6Family
+      generic_name: standard_e48ps_v6
+      id: Standard_E48ps_v6
+      memory: 412316860416
+      name: Standard_E48ps_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardESv3Family
+      generic_name: standard_e48s_v3
+      id: Standard_E48s_v3
+      memory: 412316860416
+      name: Standard_E48s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardESv4Family
+      generic_name: standard_e48s_v4
+      id: Standard_E48s_v4
+      memory: 412316860416
+      name: Standard_E48s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardESv5Family
+      generic_name: standard_e48s_v5
+      id: Standard_E48s_v5
+      memory: 412316860416
+      name: Standard_E48s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardEsv6Family
+      generic_name: standard_e48s_v6
+      id: Standard_E48s_v6
+      memory: 412316860416
+      name: Standard_E48s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEv3Family
+      generic_name: standard_e48_v3
+      id: Standard_E48_v3
+      memory: 412316860416
+      name: Standard_E48_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEv4Family
+      generic_name: standard_e48_v4
+      id: Standard_E48_v4
+      memory: 412316860416
+      name: Standard_E48_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardEv5Family
+      generic_name: standard_e48_v5
+      id: Standard_E48_v5
+      memory: 412316860416
+      name: Standard_E48_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEADSv5Family
+      generic_name: standard_e4ads_v5
+      id: Standard_E4ads_v5
+      memory: 34359738368
+      name: Standard_E4ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEadv6Family
+      generic_name: standard_e4ads_v6
+      id: Standard_E4ads_v6
+      memory: 34359738368
+      name: Standard_E4ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardEadsv7Family
+      generic_name: standard_e4ads_v7
+      id: Standard_E4ads_v7
+      memory: 34359738368
+      name: Standard_E4ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEASv4Family
+      generic_name: standard_e4as_v4
+      id: Standard_E4as_v4
+      memory: 34359738368
+      name: Standard_E4as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEASv5Family
+      generic_name: standard_e4as_v5
+      id: Standard_E4as_v5
+      memory: 34359738368
+      name: Standard_E4as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEav6Family
+      generic_name: standard_e4as_v6
+      id: Standard_E4as_v6
+      memory: 34359738368
+      name: Standard_E4as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardEasv7Family
+      generic_name: standard_e4as_v7
+      id: Standard_E4as_v7
+      memory: 34359738368
+      name: Standard_E4as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEAv4Family
+      generic_name: standard_e4a_v4
+      id: Standard_E4a_v4
+      memory: 34359738368
+      name: Standard_E4a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEBDSv5Family
+      generic_name: standard_e4bds_v5
+      id: Standard_E4bds_v5
+      memory: 34359738368
+      name: Standard_E4bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEBSv5Family
+      generic_name: standard_e4bs_v5
+      id: Standard_E4bs_v5
+      memory: 34359738368
+      name: Standard_E4bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEDSv4Family
+      generic_name: standard_e4ds_v4
+      id: Standard_E4ds_v4
+      memory: 34359738368
+      name: Standard_E4ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEDSv5Family
+      generic_name: standard_e4ds_v5
+      id: Standard_E4ds_v5
+      memory: 34359738368
+      name: Standard_E4ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardEdsv6Family
+      generic_name: standard_e4ds_v6
+      id: Standard_E4ds_v6
+      memory: 34359738368
+      name: Standard_E4ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEDv4Family
+      generic_name: standard_e4d_v4
+      id: Standard_E4d_v4
+      memory: 34359738368
+      name: Standard_E4d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEDv5Family
+      generic_name: standard_e4d_v5
+      id: Standard_E4d_v5
+      memory: 34359738368
+      name: Standard_E4d_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEPDSv5Family
+      generic_name: standard_e4pds_v5
+      id: Standard_E4pds_v5
+      memory: 34359738368
+      name: Standard_E4pds_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardEpdsv6Family
+      generic_name: standard_e4pds_v6
+      id: Standard_E4pds_v6
+      memory: 34359738368
+      name: Standard_E4pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEPSv5Family
+      generic_name: standard_e4ps_v5
+      id: Standard_E4ps_v5
+      memory: 34359738368
+      name: Standard_E4ps_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardEpsv6Family
+      generic_name: standard_e4ps_v6
+      id: Standard_E4ps_v6
+      memory: 34359738368
+      name: Standard_E4ps_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardESv3Family
+      generic_name: standard_e4s_v3
+      id: Standard_E4s_v3
+      memory: 34359738368
+      name: Standard_E4s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardESv4Family
+      generic_name: standard_e4s_v4
+      id: Standard_E4s_v4
+      memory: 34359738368
+      name: Standard_E4s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardESv5Family
+      generic_name: standard_e4s_v5
+      id: Standard_E4s_v5
+      memory: 34359738368
+      name: Standard_E4s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardEsv6Family
+      generic_name: standard_e4s_v6
+      id: Standard_E4s_v6
+      memory: 34359738368
+      name: Standard_E4s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEv3Family
+      generic_name: standard_e4_v3
+      id: Standard_E4_v3
+      memory: 34359738368
+      name: Standard_E4_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEv4Family
+      generic_name: standard_e4_v4
+      id: Standard_E4_v4
+      memory: 34359738368
+      name: Standard_E4_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardEv5Family
+      generic_name: standard_e4_v5
+      id: Standard_E4_v5
+      memory: 34359738368
+      name: Standard_E4_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEADSv5Family
+      generic_name: standard_e64-16ads_v5
+      id: Standard_E64-16ads_v5
+      memory: 549755813888
+      name: Standard_E64-16ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEadsv7Family
+      generic_name: standard_e64-16ads_v7
+      id: Standard_E64-16ads_v7
+      memory: 549755813888
+      name: Standard_E64-16ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEASv4Family
+      generic_name: standard_e64-16as_v4
+      id: Standard_E64-16as_v4
+      memory: 549755813888
+      name: Standard_E64-16as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEASv5Family
+      generic_name: standard_e64-16as_v5
+      id: Standard_E64-16as_v5
+      memory: 549755813888
+      name: Standard_E64-16as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEasv7Family
+      generic_name: standard_e64-16as_v7
+      id: Standard_E64-16as_v7
+      memory: 549755813888
+      name: Standard_E64-16as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEDSv4Family
+      generic_name: standard_e64-16ds_v4
+      id: Standard_E64-16ds_v4
+      memory: 541165879296
+      name: Standard_E64-16ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEDSv5Family
+      generic_name: standard_e64-16ds_v5
+      id: Standard_E64-16ds_v5
+      memory: 549755813888
+      name: Standard_E64-16ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEdsv6Family
+      generic_name: standard_e64-16ds_v6
+      id: Standard_E64-16ds_v6
+      memory: 549755813888
+      name: Standard_E64-16ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardESv3Family
+      generic_name: standard_e64-16s_v3
+      id: Standard_E64-16s_v3
+      memory: 463856467968
+      name: Standard_E64-16s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardESv4Family
+      generic_name: standard_e64-16s_v4
+      id: Standard_E64-16s_v4
+      memory: 541165879296
+      name: Standard_E64-16s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardESv5Family
+      generic_name: standard_e64-16s_v5
+      id: Standard_E64-16s_v5
+      memory: 549755813888
+      name: Standard_E64-16s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEsv6Family
+      generic_name: standard_e64-16s_v6
+      id: Standard_E64-16s_v6
+      memory: 549755813888
+      name: Standard_E64-16s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEADSv5Family
+      generic_name: standard_e64-32ads_v5
+      id: Standard_E64-32ads_v5
+      memory: 549755813888
+      name: Standard_E64-32ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEadsv7Family
+      generic_name: standard_e64-32ads_v7
+      id: Standard_E64-32ads_v7
+      memory: 549755813888
+      name: Standard_E64-32ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEASv4Family
+      generic_name: standard_e64-32as_v4
+      id: Standard_E64-32as_v4
+      memory: 549755813888
+      name: Standard_E64-32as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEASv5Family
+      generic_name: standard_e64-32as_v5
+      id: Standard_E64-32as_v5
+      memory: 549755813888
+      name: Standard_E64-32as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEasv7Family
+      generic_name: standard_e64-32as_v7
+      id: Standard_E64-32as_v7
+      memory: 549755813888
+      name: Standard_E64-32as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEDSv4Family
+      generic_name: standard_e64-32ds_v4
+      id: Standard_E64-32ds_v4
+      memory: 541165879296
+      name: Standard_E64-32ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEDSv5Family
+      generic_name: standard_e64-32ds_v5
+      id: Standard_E64-32ds_v5
+      memory: 549755813888
+      name: Standard_E64-32ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEdsv6Family
+      generic_name: standard_e64-32ds_v6
+      id: Standard_E64-32ds_v6
+      memory: 549755813888
+      name: Standard_E64-32ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardESv3Family
+      generic_name: standard_e64-32s_v3
+      id: Standard_E64-32s_v3
+      memory: 463856467968
+      name: Standard_E64-32s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardESv4Family
+      generic_name: standard_e64-32s_v4
+      id: Standard_E64-32s_v4
+      memory: 541165879296
+      name: Standard_E64-32s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardESv5Family
+      generic_name: standard_e64-32s_v5
+      id: Standard_E64-32s_v5
+      memory: 549755813888
+      name: Standard_E64-32s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEsv6Family
+      generic_name: standard_e64-32s_v6
+      id: Standard_E64-32s_v6
+      memory: 549755813888
+      name: Standard_E64-32s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEADSv5Family
+      generic_name: standard_e64ads_v5
+      id: Standard_E64ads_v5
+      memory: 549755813888
+      name: Standard_E64ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEadv6Family
+      generic_name: standard_e64ads_v6
+      id: Standard_E64ads_v6
+      memory: 549755813888
+      name: Standard_E64ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEadsv7Family
+      generic_name: standard_e64ads_v7
+      id: Standard_E64ads_v7
+      memory: 549755813888
+      name: Standard_E64ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEASv4Family
+      generic_name: standard_e64as_v4
+      id: Standard_E64as_v4
+      memory: 549755813888
+      name: Standard_E64as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEASv5Family
+      generic_name: standard_e64as_v5
+      id: Standard_E64as_v5
+      memory: 549755813888
+      name: Standard_E64as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEav6Family
+      generic_name: standard_e64as_v6
+      id: Standard_E64as_v6
+      memory: 549755813888
+      name: Standard_E64as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEasv7Family
+      generic_name: standard_e64as_v7
+      id: Standard_E64as_v7
+      memory: 549755813888
+      name: Standard_E64as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEAv4Family
+      generic_name: standard_e64a_v4
+      id: Standard_E64a_v4
+      memory: 549755813888
+      name: Standard_E64a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEBDSv5Family
+      generic_name: standard_e64bds_v5
+      id: Standard_E64bds_v5
+      memory: 549755813888
+      name: Standard_E64bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEBSv5Family
+      generic_name: standard_e64bs_v5
+      id: Standard_E64bs_v5
+      memory: 549755813888
+      name: Standard_E64bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEDSv4Family
+      generic_name: standard_e64ds_v4
+      id: Standard_E64ds_v4
+      memory: 541165879296
+      name: Standard_E64ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEDSv5Family
+      generic_name: standard_e64ds_v5
+      id: Standard_E64ds_v5
+      memory: 549755813888
+      name: Standard_E64ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEdsv6Family
+      generic_name: standard_e64ds_v6
+      id: Standard_E64ds_v6
+      memory: 549755813888
+      name: Standard_E64ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEDv4Family
+      generic_name: standard_e64d_v4
+      id: Standard_E64d_v4
+      memory: 541165879296
+      name: Standard_E64d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEDv5Family
+      generic_name: standard_e64d_v5
+      id: Standard_E64d_v5
+      memory: 549755813888
+      name: Standard_E64d_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEpdsv6Family
+      generic_name: standard_e64pds_v6
+      id: Standard_E64pds_v6
+      memory: 549755813888
+      name: Standard_E64pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEpsv6Family
+      generic_name: standard_e64ps_v6
+      id: Standard_E64ps_v6
+      memory: 549755813888
+      name: Standard_E64ps_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardESv3Family
+      generic_name: standard_e64s_v3
+      id: Standard_E64s_v3
+      memory: 463856467968
+      name: Standard_E64s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardESv4Family
+      generic_name: standard_e64s_v4
+      id: Standard_E64s_v4
+      memory: 541165879296
+      name: Standard_E64s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardESv5Family
+      generic_name: standard_e64s_v5
+      id: Standard_E64s_v5
+      memory: 549755813888
+      name: Standard_E64s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardEsv6Family
+      generic_name: standard_e64s_v6
+      id: Standard_E64s_v6
+      memory: 549755813888
+      name: Standard_E64s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEv3Family
+      generic_name: standard_e64_v3
+      id: Standard_E64_v3
+      memory: 463856467968
+      name: Standard_E64_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEv4Family
+      generic_name: standard_e64_v4
+      id: Standard_E64_v4
+      memory: 541165879296
+      name: Standard_E64_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardEv5Family
+      generic_name: standard_e64_v5
+      id: Standard_E64_v5
+      memory: 549755813888
+      name: Standard_E64_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEADSv5Family
+      generic_name: standard_e8-2ads_v5
+      id: Standard_E8-2ads_v5
+      memory: 68719476736
+      name: Standard_E8-2ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEadsv7Family
+      generic_name: standard_e8-2ads_v7
+      id: Standard_E8-2ads_v7
+      memory: 68719476736
+      name: Standard_E8-2ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEASv4Family
+      generic_name: standard_e8-2as_v4
+      id: Standard_E8-2as_v4
+      memory: 68719476736
+      name: Standard_E8-2as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEASv5Family
+      generic_name: standard_e8-2as_v5
+      id: Standard_E8-2as_v5
+      memory: 68719476736
+      name: Standard_E8-2as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEasv7Family
+      generic_name: standard_e8-2as_v7
+      id: Standard_E8-2as_v7
+      memory: 68719476736
+      name: Standard_E8-2as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEDSv4Family
+      generic_name: standard_e8-2ds_v4
+      id: Standard_E8-2ds_v4
+      memory: 68719476736
+      name: Standard_E8-2ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEDSv5Family
+      generic_name: standard_e8-2ds_v5
+      id: Standard_E8-2ds_v5
+      memory: 68719476736
+      name: Standard_E8-2ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEdsv6Family
+      generic_name: standard_e8-2ds_v6
+      id: Standard_E8-2ds_v6
+      memory: 68719476736
+      name: Standard_E8-2ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardESv3Family
+      generic_name: standard_e8-2s_v3
+      id: Standard_E8-2s_v3
+      memory: 68719476736
+      name: Standard_E8-2s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardESv4Family
+      generic_name: standard_e8-2s_v4
+      id: Standard_E8-2s_v4
+      memory: 68719476736
+      name: Standard_E8-2s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardESv5Family
+      generic_name: standard_e8-2s_v5
+      id: Standard_E8-2s_v5
+      memory: 68719476736
+      name: Standard_E8-2s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEsv6Family
+      generic_name: standard_e8-2s_v6
+      id: Standard_E8-2s_v6
+      memory: 68719476736
+      name: Standard_E8-2s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEADSv5Family
+      generic_name: standard_e8-4ads_v5
+      id: Standard_E8-4ads_v5
+      memory: 68719476736
+      name: Standard_E8-4ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEadsv7Family
+      generic_name: standard_e8-4ads_v7
+      id: Standard_E8-4ads_v7
+      memory: 68719476736
+      name: Standard_E8-4ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEASv4Family
+      generic_name: standard_e8-4as_v4
+      id: Standard_E8-4as_v4
+      memory: 68719476736
+      name: Standard_E8-4as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEASv5Family
+      generic_name: standard_e8-4as_v5
+      id: Standard_E8-4as_v5
+      memory: 68719476736
+      name: Standard_E8-4as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEasv7Family
+      generic_name: standard_e8-4as_v7
+      id: Standard_E8-4as_v7
+      memory: 68719476736
+      name: Standard_E8-4as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEDSv4Family
+      generic_name: standard_e8-4ds_v4
+      id: Standard_E8-4ds_v4
+      memory: 68719476736
+      name: Standard_E8-4ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEDSv5Family
+      generic_name: standard_e8-4ds_v5
+      id: Standard_E8-4ds_v5
+      memory: 68719476736
+      name: Standard_E8-4ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEdsv6Family
+      generic_name: standard_e8-4ds_v6
+      id: Standard_E8-4ds_v6
+      memory: 68719476736
+      name: Standard_E8-4ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardESv3Family
+      generic_name: standard_e8-4s_v3
+      id: Standard_E8-4s_v3
+      memory: 68719476736
+      name: Standard_E8-4s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardESv4Family
+      generic_name: standard_e8-4s_v4
+      id: Standard_E8-4s_v4
+      memory: 68719476736
+      name: Standard_E8-4s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardESv5Family
+      generic_name: standard_e8-4s_v5
+      id: Standard_E8-4s_v5
+      memory: 68719476736
+      name: Standard_E8-4s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEsv6Family
+      generic_name: standard_e8-4s_v6
+      id: Standard_E8-4s_v6
+      memory: 68719476736
+      name: Standard_E8-4s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: standardXEIDSv4Family
+      generic_name: standard_e80ids_v4
+      id: Standard_E80ids_v4
+      memory: 541165879296
+      name: Standard_E80ids_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: standardXEISv4Family
+      generic_name: standard_e80is_v4
+      id: Standard_E80is_v4
+      memory: 541165879296
+      name: Standard_E80is_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEADSv5Family
+      generic_name: standard_e8ads_v5
+      id: Standard_E8ads_v5
+      memory: 68719476736
+      name: Standard_E8ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEadv6Family
+      generic_name: standard_e8ads_v6
+      id: Standard_E8ads_v6
+      memory: 68719476736
+      name: Standard_E8ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEadsv7Family
+      generic_name: standard_e8ads_v7
+      id: Standard_E8ads_v7
+      memory: 68719476736
+      name: Standard_E8ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEASv4Family
+      generic_name: standard_e8as_v4
+      id: Standard_E8as_v4
+      memory: 68719476736
+      name: Standard_E8as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEASv5Family
+      generic_name: standard_e8as_v5
+      id: Standard_E8as_v5
+      memory: 68719476736
+      name: Standard_E8as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEav6Family
+      generic_name: standard_e8as_v6
+      id: Standard_E8as_v6
+      memory: 68719476736
+      name: Standard_E8as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEasv7Family
+      generic_name: standard_e8as_v7
+      id: Standard_E8as_v7
+      memory: 68719476736
+      name: Standard_E8as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEAv4Family
+      generic_name: standard_e8a_v4
+      id: Standard_E8a_v4
+      memory: 68719476736
+      name: Standard_E8a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEBDSv5Family
+      generic_name: standard_e8bds_v5
+      id: Standard_E8bds_v5
+      memory: 68719476736
+      name: Standard_E8bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEBSv5Family
+      generic_name: standard_e8bs_v5
+      id: Standard_E8bs_v5
+      memory: 68719476736
+      name: Standard_E8bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEDSv4Family
+      generic_name: standard_e8ds_v4
+      id: Standard_E8ds_v4
+      memory: 68719476736
+      name: Standard_E8ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEDSv5Family
+      generic_name: standard_e8ds_v5
+      id: Standard_E8ds_v5
+      memory: 68719476736
+      name: Standard_E8ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEdsv6Family
+      generic_name: standard_e8ds_v6
+      id: Standard_E8ds_v6
+      memory: 68719476736
+      name: Standard_E8ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEDv4Family
+      generic_name: standard_e8d_v4
+      id: Standard_E8d_v4
+      memory: 68719476736
+      name: Standard_E8d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEDv5Family
+      generic_name: standard_e8d_v5
+      id: Standard_E8d_v5
+      memory: 68719476736
+      name: Standard_E8d_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEPDSv5Family
+      generic_name: standard_e8pds_v5
+      id: Standard_E8pds_v5
+      memory: 68719476736
+      name: Standard_E8pds_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEpdsv6Family
+      generic_name: standard_e8pds_v6
+      id: Standard_E8pds_v6
+      memory: 68719476736
+      name: Standard_E8pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEPSv5Family
+      generic_name: standard_e8ps_v5
+      id: Standard_E8ps_v5
+      memory: 68719476736
+      name: Standard_E8ps_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEpsv6Family
+      generic_name: standard_e8ps_v6
+      id: Standard_E8ps_v6
+      memory: 68719476736
+      name: Standard_E8ps_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardESv3Family
+      generic_name: standard_e8s_v3
+      id: Standard_E8s_v3
+      memory: 68719476736
+      name: Standard_E8s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardESv4Family
+      generic_name: standard_e8s_v4
+      id: Standard_E8s_v4
+      memory: 68719476736
+      name: Standard_E8s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardESv5Family
+      generic_name: standard_e8s_v5
+      id: Standard_E8s_v5
+      memory: 68719476736
+      name: Standard_E8s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardEsv6Family
+      generic_name: standard_e8s_v6
+      id: Standard_E8s_v6
+      memory: 68719476736
+      name: Standard_E8s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEv3Family
+      generic_name: standard_e8_v3
+      id: Standard_E8_v3
+      memory: 68719476736
+      name: Standard_E8_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEv4Family
+      generic_name: standard_e8_v4
+      id: Standard_E8_v4
+      memory: 68719476736
+      name: Standard_E8_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardEv5Family
+      generic_name: standard_e8_v5
+      id: Standard_E8_v5
+      memory: 68719476736
+      name: Standard_E8_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEADSv5Family
+      generic_name: standard_e96-24ads_v5
+      id: Standard_E96-24ads_v5
+      memory: 721554505728
+      name: Standard_E96-24ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEadv6Family
+      generic_name: standard_e96-24ads_v6
+      id: Standard_E96-24ads_v6
+      memory: 721554505728
+      name: Standard_E96-24ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEadsv7Family
+      generic_name: standard_e96-24ads_v7
+      id: Standard_E96-24ads_v7
+      memory: 824633720832
+      name: Standard_E96-24ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEASv4Family
+      generic_name: standard_e96-24as_v4
+      id: Standard_E96-24as_v4
+      memory: 721554505728
+      name: Standard_E96-24as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEASv5Family
+      generic_name: standard_e96-24as_v5
+      id: Standard_E96-24as_v5
+      memory: 721554505728
+      name: Standard_E96-24as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEasv7Family
+      generic_name: standard_e96-24as_v7
+      id: Standard_E96-24as_v7
+      memory: 824633720832
+      name: Standard_E96-24as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEDSv5Family
+      generic_name: standard_e96-24ds_v5
+      id: Standard_E96-24ds_v5
+      memory: 721554505728
+      name: Standard_E96-24ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEdsv6Family
+      generic_name: standard_e96-24ds_v6
+      id: Standard_E96-24ds_v6
+      memory: 824633720832
+      name: Standard_E96-24ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardESv5Family
+      generic_name: standard_e96-24s_v5
+      id: Standard_E96-24s_v5
+      memory: 721554505728
+      name: Standard_E96-24s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEsv6Family
+      generic_name: standard_e96-24s_v6
+      id: Standard_E96-24s_v6
+      memory: 824633720832
+      name: Standard_E96-24s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEADSv5Family
+      generic_name: standard_e96-48ads_v5
+      id: Standard_E96-48ads_v5
+      memory: 721554505728
+      name: Standard_E96-48ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEadv6Family
+      generic_name: standard_e96-48ads_v6
+      id: Standard_E96-48ads_v6
+      memory: 721554505728
+      name: Standard_E96-48ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEadsv7Family
+      generic_name: standard_e96-48ads_v7
+      id: Standard_E96-48ads_v7
+      memory: 824633720832
+      name: Standard_E96-48ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEASv4Family
+      generic_name: standard_e96-48as_v4
+      id: Standard_E96-48as_v4
+      memory: 721554505728
+      name: Standard_E96-48as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEASv5Family
+      generic_name: standard_e96-48as_v5
+      id: Standard_E96-48as_v5
+      memory: 721554505728
+      name: Standard_E96-48as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEasv7Family
+      generic_name: standard_e96-48as_v7
+      id: Standard_E96-48as_v7
+      memory: 824633720832
+      name: Standard_E96-48as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEDSv5Family
+      generic_name: standard_e96-48ds_v5
+      id: Standard_E96-48ds_v5
+      memory: 721554505728
+      name: Standard_E96-48ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEdsv6Family
+      generic_name: standard_e96-48ds_v6
+      id: Standard_E96-48ds_v6
+      memory: 824633720832
+      name: Standard_E96-48ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardESv5Family
+      generic_name: standard_e96-48s_v5
+      id: Standard_E96-48s_v5
+      memory: 721554505728
+      name: Standard_E96-48s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEsv6Family
+      generic_name: standard_e96-48s_v6
+      id: Standard_E96-48s_v6
+      memory: 824633720832
+      name: Standard_E96-48s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEADSv5Family
+      generic_name: standard_e96ads_v5
+      id: Standard_E96ads_v5
+      memory: 721554505728
+      name: Standard_E96ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEadv6Family
+      generic_name: standard_e96ads_v6
+      id: Standard_E96ads_v6
+      memory: 721554505728
+      name: Standard_E96ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEadsv7Family
+      generic_name: standard_e96ads_v7
+      id: Standard_E96ads_v7
+      memory: 824633720832
+      name: Standard_E96ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEASv4Family
+      generic_name: standard_e96as_v4
+      id: Standard_E96as_v4
+      memory: 721554505728
+      name: Standard_E96as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEASv5Family
+      generic_name: standard_e96as_v5
+      id: Standard_E96as_v5
+      memory: 721554505728
+      name: Standard_E96as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEav6Family
+      generic_name: standard_e96as_v6
+      id: Standard_E96as_v6
+      memory: 721554505728
+      name: Standard_E96as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEasv7Family
+      generic_name: standard_e96as_v7
+      id: Standard_E96as_v7
+      memory: 824633720832
+      name: Standard_E96as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEAv4Family
+      generic_name: standard_e96a_v4
+      id: Standard_E96a_v4
+      memory: 721554505728
+      name: Standard_E96a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEBDSv5Family
+      generic_name: standard_e96bds_v5
+      id: Standard_E96bds_v5
+      memory: 721554505728
+      name: Standard_E96bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEBSv5Family
+      generic_name: standard_e96bs_v5
+      id: Standard_E96bs_v5
+      memory: 721554505728
+      name: Standard_E96bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEDSv5Family
+      generic_name: standard_e96ds_v5
+      id: Standard_E96ds_v5
+      memory: 721554505728
+      name: Standard_E96ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEdsv6Family
+      generic_name: standard_e96ds_v6
+      id: Standard_E96ds_v6
+      memory: 824633720832
+      name: Standard_E96ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEDv5Family
+      generic_name: standard_e96d_v5
+      id: Standard_E96d_v5
+      memory: 721554505728
+      name: Standard_E96d_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEIASv4Family
+      generic_name: standard_e96ias_v4
+      id: Standard_E96ias_v4
+      memory: 721554505728
+      name: Standard_E96ias_v4
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEpdsv6Family
+      generic_name: standard_e96pds_v6
+      id: Standard_E96pds_v6
+      memory: 721554505728
+      name: Standard_E96pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEpsv6Family
+      generic_name: standard_e96ps_v6
+      id: Standard_E96ps_v6
+      memory: 721554505728
+      name: Standard_E96ps_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardESv5Family
+      generic_name: standard_e96s_v5
+      id: Standard_E96s_v5
+      memory: 721554505728
+      name: Standard_E96s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardEsv6Family
+      generic_name: standard_e96s_v6
+      id: Standard_E96s_v6
+      memory: 824633720832
+      name: Standard_E96s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardEv5Family
+      generic_name: standard_e96_v5
+      id: Standard_E96_v5
+      memory: 721554505728
+      name: Standard_E96_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardECADCCV5Family
+      generic_name: standard_ec16ads_cc_v5
+      id: Standard_EC16ads_cc_v5
+      memory: 137438953472
+      name: Standard_EC16ads_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardECADSv5Family
+      generic_name: standard_ec16ads_v5
+      id: Standard_EC16ads_v5
+      memory: 137438953472
+      name: Standard_EC16ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardECadsv6Family
+      generic_name: standard_ec16ads_v6
+      id: Standard_EC16ads_v6
+      memory: 137438953472
+      name: Standard_EC16ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardECACCV5Family
+      generic_name: standard_ec16as_cc_v5
+      id: Standard_EC16as_cc_v5
+      memory: 137438953472
+      name: Standard_EC16as_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardECASv5Family
+      generic_name: standard_ec16as_v5
+      id: Standard_EC16as_v5
+      memory: 137438953472
+      name: Standard_EC16as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardECasv6Family
+      generic_name: standard_ec16as_v6
+      id: Standard_EC16as_v6
+      memory: 137438953472
+      name: Standard_EC16as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardECEDV6Family
+      generic_name: standard_ec16eds_v6
+      id: Standard_EC16eds_v6
+      memory: 137438953472
+      name: Standard_EC16eds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardECEV6Family
       generic_name: standard_ec16es_v6
       id: Standard_EC16es_v6
       memory: 137438953472
       name: Standard_EC16es_v6
     - category: memory_optimized
       cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardECADCCV5Family
+      generic_name: standard_ec20ads_cc_v5
+      id: Standard_EC20ads_cc_v5
+      memory: 171798691840
+      name: Standard_EC20ads_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardECADSv5Family
+      generic_name: standard_ec20ads_v5
+      id: Standard_EC20ads_v5
+      memory: 171798691840
+      name: Standard_EC20ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardECACCV5Family
+      generic_name: standard_ec20as_cc_v5
+      id: Standard_EC20as_cc_v5
+      memory: 171798691840
+      name: Standard_EC20as_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      family: standardECASv5Family
+      generic_name: standard_ec20as_v5
+      id: Standard_EC20as_v5
+      memory: 171798691840
+      name: Standard_EC20as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardECADSv5Family
+      generic_name: standard_ec2ads_v5
+      id: Standard_EC2ads_v5
+      memory: 17179869184
+      name: Standard_EC2ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardECadsv6Family
+      generic_name: standard_ec2ads_v6
+      id: Standard_EC2ads_v6
+      memory: 17179869184
+      name: Standard_EC2ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardECASv5Family
+      generic_name: standard_ec2as_v5
+      id: Standard_EC2as_v5
+      memory: 17179869184
+      name: Standard_EC2as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardECasv6Family
+      generic_name: standard_ec2as_v6
+      id: Standard_EC2as_v6
+      memory: 17179869184
+      name: Standard_EC2as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardECEDV6Family
+      generic_name: standard_ec2eds_v6
+      id: Standard_EC2eds_v6
+      memory: 17179869184
+      name: Standard_EC2eds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardECEV6Family
+      generic_name: standard_ec2es_v6
+      id: Standard_EC2es_v6
+      memory: 17179869184
+      name: Standard_EC2es_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
       cpu_cores: 32
+      family: standardECADCCV5Family
+      generic_name: standard_ec32ads_cc_v5
+      id: Standard_EC32ads_cc_v5
+      memory: 206158430208
+      name: Standard_EC32ads_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardECADSv5Family
+      generic_name: standard_ec32ads_v5
+      id: Standard_EC32ads_v5
+      memory: 206158430208
+      name: Standard_EC32ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardECadsv6Family
+      generic_name: standard_ec32ads_v6
+      id: Standard_EC32ads_v6
+      memory: 274877906944
+      name: Standard_EC32ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardECACCV5Family
+      generic_name: standard_ec32as_cc_v5
+      id: Standard_EC32as_cc_v5
+      memory: 206158430208
+      name: Standard_EC32as_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardECASv5Family
+      generic_name: standard_ec32as_v5
+      id: Standard_EC32as_v5
+      memory: 206158430208
+      name: Standard_EC32as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardECasv6Family
+      generic_name: standard_ec32as_v6
+      id: Standard_EC32as_v6
+      memory: 274877906944
+      name: Standard_EC32as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardECEDV6Family
+      generic_name: standard_ec32eds_v6
+      id: Standard_EC32eds_v6
+      memory: 274877906944
+      name: Standard_EC32eds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardECEV6Family
       generic_name: standard_ec32es_v6
       id: Standard_EC32es_v6
       memory: 274877906944
@@ -7709,66 +7082,2147 @@ data:
     - category: memory_optimized
       cloud_provider_id: azure
       cpu_cores: 48
-      generic_name: standard_ec48es_v6
-      id: Standard_EC48es_v6
+      family: standardECADCCV5Family
+      generic_name: standard_ec48ads_cc_v5
+      id: Standard_EC48ads_cc_v5
       memory: 412316860416
-      name: Standard_EC48es_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 64
-      generic_name: standard_ec64es_v6
-      id: Standard_EC64es_v6
-      memory: 549755813888
-      name: Standard_EC64es_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 2
-      generic_name: standard_ec2eds_v6
-      id: Standard_EC2eds_v6
-      memory: 17179869184
-      name: Standard_EC2eds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 4
-      generic_name: standard_ec4eds_v6
-      id: Standard_EC4eds_v6
-      memory: 34359738368
-      name: Standard_EC4eds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 8
-      generic_name: standard_ec8eds_v6
-      id: Standard_EC8eds_v6
-      memory: 68719476736
-      name: Standard_EC8eds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 16
-      generic_name: standard_ec16eds_v6
-      id: Standard_EC16eds_v6
-      memory: 137438953472
-      name: Standard_EC16eds_v6
-    - category: memory_optimized
-      cloud_provider_id: azure
-      cpu_cores: 32
-      generic_name: standard_ec32eds_v6
-      id: Standard_EC32eds_v6
-      memory: 274877906944
-      name: Standard_EC32eds_v6
+      name: Standard_EC48ads_cc_v5
     - category: memory_optimized
       cloud_provider_id: azure
       cpu_cores: 48
+      family: standardECADSv5Family
+      generic_name: standard_ec48ads_v5
+      id: Standard_EC48ads_v5
+      memory: 412316860416
+      name: Standard_EC48ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardECadsv6Family
+      generic_name: standard_ec48ads_v6
+      id: Standard_EC48ads_v6
+      memory: 412316860416
+      name: Standard_EC48ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardECACCV5Family
+      generic_name: standard_ec48as_cc_v5
+      id: Standard_EC48as_cc_v5
+      memory: 412316860416
+      name: Standard_EC48as_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardECASv5Family
+      generic_name: standard_ec48as_v5
+      id: Standard_EC48as_v5
+      memory: 412316860416
+      name: Standard_EC48as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardECasv6Family
+      generic_name: standard_ec48as_v6
+      id: Standard_EC48as_v6
+      memory: 412316860416
+      name: Standard_EC48as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardECEDV6Family
       generic_name: standard_ec48eds_v6
       id: Standard_EC48eds_v6
       memory: 412316860416
       name: Standard_EC48eds_v6
     - category: memory_optimized
       cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardECEV6Family
+      generic_name: standard_ec48es_v6
+      id: Standard_EC48es_v6
+      memory: 412316860416
+      name: Standard_EC48es_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardECADCCV5Family
+      generic_name: standard_ec4ads_cc_v5
+      id: Standard_EC4ads_cc_v5
+      memory: 34359738368
+      name: Standard_EC4ads_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardECADSv5Family
+      generic_name: standard_ec4ads_v5
+      id: Standard_EC4ads_v5
+      memory: 34359738368
+      name: Standard_EC4ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardECadsv6Family
+      generic_name: standard_ec4ads_v6
+      id: Standard_EC4ads_v6
+      memory: 34359738368
+      name: Standard_EC4ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardECACCV5Family
+      generic_name: standard_ec4as_cc_v5
+      id: Standard_EC4as_cc_v5
+      memory: 34359738368
+      name: Standard_EC4as_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardECASv5Family
+      generic_name: standard_ec4as_v5
+      id: Standard_EC4as_v5
+      memory: 34359738368
+      name: Standard_EC4as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardECasv6Family
+      generic_name: standard_ec4as_v6
+      id: Standard_EC4as_v6
+      memory: 34359738368
+      name: Standard_EC4as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardECEDV6Family
+      generic_name: standard_ec4eds_v6
+      id: Standard_EC4eds_v6
+      memory: 34359738368
+      name: Standard_EC4eds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardECEV6Family
+      generic_name: standard_ec4es_v6
+      id: Standard_EC4es_v6
+      memory: 34359738368
+      name: Standard_EC4es_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
       cpu_cores: 64
+      family: standardECADCCV5Family
+      generic_name: standard_ec64ads_cc_v5
+      id: Standard_EC64ads_cc_v5
+      memory: 549755813888
+      name: Standard_EC64ads_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardECADSv5Family
+      generic_name: standard_ec64ads_v5
+      id: Standard_EC64ads_v5
+      memory: 549755813888
+      name: Standard_EC64ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardECadsv6Family
+      generic_name: standard_ec64ads_v6
+      id: Standard_EC64ads_v6
+      memory: 549755813888
+      name: Standard_EC64ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardECACCV5Family
+      generic_name: standard_ec64as_cc_v5
+      id: Standard_EC64as_cc_v5
+      memory: 549755813888
+      name: Standard_EC64as_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardECASv5Family
+      generic_name: standard_ec64as_v5
+      id: Standard_EC64as_v5
+      memory: 549755813888
+      name: Standard_EC64as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardECasv6Family
+      generic_name: standard_ec64as_v6
+      id: Standard_EC64as_v6
+      memory: 549755813888
+      name: Standard_EC64as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardECEDV6Family
       generic_name: standard_ec64eds_v6
       id: Standard_EC64eds_v6
       memory: 549755813888
       name: Standard_EC64eds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardECEV6Family
+      generic_name: standard_ec64es_v6
+      id: Standard_EC64es_v6
+      memory: 549755813888
+      name: Standard_EC64es_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardECADCCV5Family
+      generic_name: standard_ec8ads_cc_v5
+      id: Standard_EC8ads_cc_v5
+      memory: 68719476736
+      name: Standard_EC8ads_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardECADSv5Family
+      generic_name: standard_ec8ads_v5
+      id: Standard_EC8ads_v5
+      memory: 68719476736
+      name: Standard_EC8ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardECadsv6Family
+      generic_name: standard_ec8ads_v6
+      id: Standard_EC8ads_v6
+      memory: 68719476736
+      name: Standard_EC8ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardECACCV5Family
+      generic_name: standard_ec8as_cc_v5
+      id: Standard_EC8as_cc_v5
+      memory: 68719476736
+      name: Standard_EC8as_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardECASv5Family
+      generic_name: standard_ec8as_v5
+      id: Standard_EC8as_v5
+      memory: 68719476736
+      name: Standard_EC8as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardECasv6Family
+      generic_name: standard_ec8as_v6
+      id: Standard_EC8as_v6
+      memory: 68719476736
+      name: Standard_EC8as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardECEDV6Family
+      generic_name: standard_ec8eds_v6
+      id: Standard_EC8eds_v6
+      memory: 68719476736
+      name: Standard_EC8eds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardECEV6Family
+      generic_name: standard_ec8es_v6
+      id: Standard_EC8es_v6
+      memory: 68719476736
+      name: Standard_EC8es_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardECADCCV5Family
+      generic_name: standard_ec96ads_cc_v5
+      id: Standard_EC96ads_cc_v5
+      memory: 721554505728
+      name: Standard_EC96ads_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardECADSv5Family
+      generic_name: standard_ec96ads_v5
+      id: Standard_EC96ads_v5
+      memory: 721554505728
+      name: Standard_EC96ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardECadsv6Family
+      generic_name: standard_ec96ads_v6
+      id: Standard_EC96ads_v6
+      memory: 721554505728
+      name: Standard_EC96ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardECACCV5Family
+      generic_name: standard_ec96as_cc_v5
+      id: Standard_EC96as_cc_v5
+      memory: 721554505728
+      name: Standard_EC96as_cc_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardECASv5Family
+      generic_name: standard_ec96as_v5
+      id: Standard_EC96as_v5
+      memory: 721554505728
+      name: Standard_EC96as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardECasv6Family
+      generic_name: standard_ec96as_v6
+      id: Standard_EC96as_v6
+      memory: 721554505728
+      name: Standard_EC96as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardECIADSv5Family
+      generic_name: standard_ec96iads_v5
+      id: Standard_EC96iads_v5
+      memory: 721554505728
+      name: Standard_EC96iads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardECIASv5Family
+      generic_name: standard_ec96ias_v5
+      id: Standard_EC96ias_v5
+      memory: 721554505728
+      name: Standard_EC96ias_v5
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      family: standardFFamily
+      generic_name: standard_f1
+      id: Standard_F1
+      memory: 2147483648
+      name: Standard_F1
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardFFamily
+      generic_name: standard_f16
+      id: Standard_F16
+      memory: 34359738368
+      name: Standard_F16
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFamdsv7Family
+      generic_name: standard_f16-4amds_v7
+      id: Standard_F16-4amds_v7
+      memory: 137438953472
+      name: Standard_F16-4amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFamsv7Family
+      generic_name: standard_f16-4ams_v7
+      id: Standard_F16-4ams_v7
+      memory: 137438953472
+      name: Standard_F16-4ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFamdsv7Family
+      generic_name: standard_f16-8amds_v7
+      id: Standard_F16-8amds_v7
+      memory: 137438953472
+      name: Standard_F16-8amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFamsv7Family
+      generic_name: standard_f16-8ams_v7
+      id: Standard_F16-8ams_v7
+      memory: 137438953472
+      name: Standard_F16-8ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFadsv7Family
+      generic_name: standard_f16ads_v7
+      id: Standard_F16ads_v7
+      memory: 68719476736
+      name: Standard_F16ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFaldsv7Family
+      generic_name: standard_f16alds_v7
+      id: Standard_F16alds_v7
+      memory: 34359738368
+      name: Standard_F16alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFalsv6Family
+      generic_name: standard_f16als_v6
+      id: Standard_F16als_v6
+      memory: 34359738368
+      name: Standard_F16als_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFalsv7Family
+      generic_name: standard_f16als_v7
+      id: Standard_F16als_v7
+      memory: 34359738368
+      name: Standard_F16als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFamdsv7Family
+      generic_name: standard_f16amds_v7
+      id: Standard_F16amds_v7
+      memory: 137438953472
+      name: Standard_F16amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFamsv6Family
+      generic_name: standard_f16ams_v6
+      id: Standard_F16ams_v6
+      memory: 137438953472
+      name: Standard_F16ams_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFamsv7Family
+      generic_name: standard_f16ams_v7
+      id: Standard_F16ams_v7
+      memory: 137438953472
+      name: Standard_F16ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFasv6Family
+      generic_name: standard_f16as_v6
+      id: Standard_F16as_v6
+      memory: 68719476736
+      name: Standard_F16as_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFasv7Family
+      generic_name: standard_f16as_v7
+      id: Standard_F16as_v7
+      memory: 68719476736
+      name: Standard_F16as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardFSFamily
+      generic_name: standard_f16s
+      id: Standard_F16s
+      memory: 34359738368
+      name: Standard_F16s
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardFSv2Family
+      generic_name: standard_f16s_v2
+      id: Standard_F16s_v2
+      memory: 34359738368
+      name: Standard_F16s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      family: StandardFadsv7Family
+      generic_name: standard_f1ads_v7
+      id: Standard_F1ads_v7
+      memory: 4294967296
+      name: Standard_F1ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      family: StandardFaldsv7Family
+      generic_name: standard_f1alds_v7
+      id: Standard_F1alds_v7
+      memory: 2147483648
+      name: Standard_F1alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      family: StandardFalsv7Family
+      generic_name: standard_f1als_v7
+      id: Standard_F1als_v7
+      memory: 2147483648
+      name: Standard_F1als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      family: StandardFamdsv7Family
+      generic_name: standard_f1amds_v7
+      id: Standard_F1amds_v7
+      memory: 8589934592
+      name: Standard_F1amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      family: StandardFamsv7Family
+      generic_name: standard_f1ams_v7
+      id: Standard_F1ams_v7
+      memory: 8589934592
+      name: Standard_F1ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      family: StandardFasv7Family
+      generic_name: standard_f1as_v7
+      id: Standard_F1as_v7
+      memory: 4294967296
+      name: Standard_F1as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      family: standardFSFamily
+      generic_name: standard_f1s
+      id: Standard_F1s
+      memory: 2147483648
+      name: Standard_F1s
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardFFamily
+      generic_name: standard_f2
+      id: Standard_F2
+      memory: 4294967296
+      name: Standard_F2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFamdsv7Family
+      generic_name: standard_f2-1amds_v7
+      id: Standard_F2-1amds_v7
+      memory: 17179869184
+      name: Standard_F2-1amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFamsv7Family
+      generic_name: standard_f2-1ams_v7
+      id: Standard_F2-1ams_v7
+      memory: 17179869184
+      name: Standard_F2-1ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFadsv7Family
+      generic_name: standard_f2ads_v7
+      id: Standard_F2ads_v7
+      memory: 8589934592
+      name: Standard_F2ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFaldsv7Family
+      generic_name: standard_f2alds_v7
+      id: Standard_F2alds_v7
+      memory: 4294967296
+      name: Standard_F2alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFalsv6Family
+      generic_name: standard_f2als_v6
+      id: Standard_F2als_v6
+      memory: 4294967296
+      name: Standard_F2als_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFalsv7Family
+      generic_name: standard_f2als_v7
+      id: Standard_F2als_v7
+      memory: 4294967296
+      name: Standard_F2als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFamdsv7Family
+      generic_name: standard_f2amds_v7
+      id: Standard_F2amds_v7
+      memory: 17179869184
+      name: Standard_F2amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFamsv6Family
+      generic_name: standard_f2ams_v6
+      id: Standard_F2ams_v6
+      memory: 17179869184
+      name: Standard_F2ams_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFamsv7Family
+      generic_name: standard_f2ams_v7
+      id: Standard_F2ams_v7
+      memory: 17179869184
+      name: Standard_F2ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFasv6Family
+      generic_name: standard_f2as_v6
+      id: Standard_F2as_v6
+      memory: 8589934592
+      name: Standard_F2as_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFasv7Family
+      generic_name: standard_f2as_v7
+      id: Standard_F2as_v7
+      memory: 8589934592
+      name: Standard_F2as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardFSFamily
+      generic_name: standard_f2s
+      id: Standard_F2s
+      memory: 4294967296
+      name: Standard_F2s
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardFSv2Family
+      generic_name: standard_f2s_v2
+      id: Standard_F2s_v2
+      memory: 4294967296
+      name: Standard_F2s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFamdsv7Family
+      generic_name: standard_f32-16amds_v7
+      id: Standard_F32-16amds_v7
+      memory: 274877906944
+      name: Standard_F32-16amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFamsv7Family
+      generic_name: standard_f32-16ams_v7
+      id: Standard_F32-16ams_v7
+      memory: 274877906944
+      name: Standard_F32-16ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFamdsv7Family
+      generic_name: standard_f32-8amds_v7
+      id: Standard_F32-8amds_v7
+      memory: 274877906944
+      name: Standard_F32-8amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFamsv7Family
+      generic_name: standard_f32-8ams_v7
+      id: Standard_F32-8ams_v7
+      memory: 274877906944
+      name: Standard_F32-8ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFadsv7Family
+      generic_name: standard_f32ads_v7
+      id: Standard_F32ads_v7
+      memory: 137438953472
+      name: Standard_F32ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFaldsv7Family
+      generic_name: standard_f32alds_v7
+      id: Standard_F32alds_v7
+      memory: 68719476736
+      name: Standard_F32alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFalsv6Family
+      generic_name: standard_f32als_v6
+      id: Standard_F32als_v6
+      memory: 68719476736
+      name: Standard_F32als_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFalsv7Family
+      generic_name: standard_f32als_v7
+      id: Standard_F32als_v7
+      memory: 68719476736
+      name: Standard_F32als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFamdsv7Family
+      generic_name: standard_f32amds_v7
+      id: Standard_F32amds_v7
+      memory: 274877906944
+      name: Standard_F32amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFamsv6Family
+      generic_name: standard_f32ams_v6
+      id: Standard_F32ams_v6
+      memory: 274877906944
+      name: Standard_F32ams_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFamsv7Family
+      generic_name: standard_f32ams_v7
+      id: Standard_F32ams_v7
+      memory: 274877906944
+      name: Standard_F32ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFasv6Family
+      generic_name: standard_f32as_v6
+      id: Standard_F32as_v6
+      memory: 137438953472
+      name: Standard_F32as_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFasv7Family
+      generic_name: standard_f32as_v7
+      id: Standard_F32as_v7
+      memory: 137438953472
+      name: Standard_F32as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardFSv2Family
+      generic_name: standard_f32s_v2
+      id: Standard_F32s_v2
+      memory: 68719476736
+      name: Standard_F32s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardFFamily
+      generic_name: standard_f4
+      id: Standard_F4
+      memory: 8589934592
+      name: Standard_F4
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFamdsv7Family
+      generic_name: standard_f4-1amds_v7
+      id: Standard_F4-1amds_v7
+      memory: 34359738368
+      name: Standard_F4-1amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFamsv7Family
+      generic_name: standard_f4-1ams_v7
+      id: Standard_F4-1ams_v7
+      memory: 34359738368
+      name: Standard_F4-1ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFamdsv7Family
+      generic_name: standard_f4-2amds_v7
+      id: Standard_F4-2amds_v7
+      memory: 34359738368
+      name: Standard_F4-2amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFamsv7Family
+      generic_name: standard_f4-2ams_v7
+      id: Standard_F4-2ams_v7
+      memory: 34359738368
+      name: Standard_F4-2ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFadsv7Family
+      generic_name: standard_f48ads_v7
+      id: Standard_F48ads_v7
+      memory: 206158430208
+      name: Standard_F48ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFaldsv7Family
+      generic_name: standard_f48alds_v7
+      id: Standard_F48alds_v7
+      memory: 103079215104
+      name: Standard_F48alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFalsv6Family
+      generic_name: standard_f48als_v6
+      id: Standard_F48als_v6
+      memory: 103079215104
+      name: Standard_F48als_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFalsv7Family
+      generic_name: standard_f48als_v7
+      id: Standard_F48als_v7
+      memory: 103079215104
+      name: Standard_F48als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFamdsv7Family
+      generic_name: standard_f48amds_v7
+      id: Standard_F48amds_v7
+      memory: 412316860416
+      name: Standard_F48amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFamsv6Family
+      generic_name: standard_f48ams_v6
+      id: Standard_F48ams_v6
+      memory: 412316860416
+      name: Standard_F48ams_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFamsv7Family
+      generic_name: standard_f48ams_v7
+      id: Standard_F48ams_v7
+      memory: 412316860416
+      name: Standard_F48ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFasv6Family
+      generic_name: standard_f48as_v6
+      id: Standard_F48as_v6
+      memory: 206158430208
+      name: Standard_F48as_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFasv7Family
+      generic_name: standard_f48as_v7
+      id: Standard_F48as_v7
+      memory: 206158430208
+      name: Standard_F48as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardFSv2Family
+      generic_name: standard_f48s_v2
+      id: Standard_F48s_v2
+      memory: 103079215104
+      name: Standard_F48s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFadsv7Family
+      generic_name: standard_f4ads_v7
+      id: Standard_F4ads_v7
+      memory: 17179869184
+      name: Standard_F4ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFaldsv7Family
+      generic_name: standard_f4alds_v7
+      id: Standard_F4alds_v7
+      memory: 8589934592
+      name: Standard_F4alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFalsv6Family
+      generic_name: standard_f4als_v6
+      id: Standard_F4als_v6
+      memory: 8589934592
+      name: Standard_F4als_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFalsv7Family
+      generic_name: standard_f4als_v7
+      id: Standard_F4als_v7
+      memory: 8589934592
+      name: Standard_F4als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFamdsv7Family
+      generic_name: standard_f4amds_v7
+      id: Standard_F4amds_v7
+      memory: 34359738368
+      name: Standard_F4amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFamsv6Family
+      generic_name: standard_f4ams_v6
+      id: Standard_F4ams_v6
+      memory: 34359738368
+      name: Standard_F4ams_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFamsv7Family
+      generic_name: standard_f4ams_v7
+      id: Standard_F4ams_v7
+      memory: 34359738368
+      name: Standard_F4ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFasv6Family
+      generic_name: standard_f4as_v6
+      id: Standard_F4as_v6
+      memory: 17179869184
+      name: Standard_F4as_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFasv7Family
+      generic_name: standard_f4as_v7
+      id: Standard_F4as_v7
+      memory: 17179869184
+      name: Standard_F4as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardFSFamily
+      generic_name: standard_f4s
+      id: Standard_F4s
+      memory: 8589934592
+      name: Standard_F4s
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardFSv2Family
+      generic_name: standard_f4s_v2
+      id: Standard_F4s_v2
+      memory: 8589934592
+      name: Standard_F4s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFamdsv7Family
+      generic_name: standard_f64-16amds_v7
+      id: Standard_F64-16amds_v7
+      memory: 549755813888
+      name: Standard_F64-16amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: StandardFamsv7Family
+      generic_name: standard_f64-16ams_v7
+      id: Standard_F64-16ams_v7
+      memory: 549755813888
+      name: Standard_F64-16ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFamdsv7Family
+      generic_name: standard_f64-32amds_v7
+      id: Standard_F64-32amds_v7
+      memory: 549755813888
+      name: Standard_F64-32amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFamsv7Family
+      generic_name: standard_f64-32ams_v7
+      id: Standard_F64-32ams_v7
+      memory: 549755813888
+      name: Standard_F64-32ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFadsv7Family
+      generic_name: standard_f64ads_v7
+      id: Standard_F64ads_v7
+      memory: 274877906944
+      name: Standard_F64ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFaldsv7Family
+      generic_name: standard_f64alds_v7
+      id: Standard_F64alds_v7
+      memory: 137438953472
+      name: Standard_F64alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFalsv6Family
+      generic_name: standard_f64als_v6
+      id: Standard_F64als_v6
+      memory: 137438953472
+      name: Standard_F64als_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFalsv7Family
+      generic_name: standard_f64als_v7
+      id: Standard_F64als_v7
+      memory: 137438953472
+      name: Standard_F64als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFamdsv7Family
+      generic_name: standard_f64amds_v7
+      id: Standard_F64amds_v7
+      memory: 549755813888
+      name: Standard_F64amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFamsv6Family
+      generic_name: standard_f64ams_v6
+      id: Standard_F64ams_v6
+      memory: 549755813888
+      name: Standard_F64ams_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFamsv7Family
+      generic_name: standard_f64ams_v7
+      id: Standard_F64ams_v7
+      memory: 549755813888
+      name: Standard_F64ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFasv6Family
+      generic_name: standard_f64as_v6
+      id: Standard_F64as_v6
+      memory: 274877906944
+      name: Standard_F64as_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFasv7Family
+      generic_name: standard_f64as_v7
+      id: Standard_F64as_v7
+      memory: 274877906944
+      name: Standard_F64as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardFSv2Family
+      generic_name: standard_f64s_v2
+      id: Standard_F64s_v2
+      memory: 137438953472
+      name: Standard_F64s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 72
+      family: standardFSv2Family
+      generic_name: standard_f72s_v2
+      id: Standard_F72s_v2
+      memory: 154618822656
+      name: Standard_F72s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardFFamily
+      generic_name: standard_f8
+      id: Standard_F8
+      memory: 17179869184
+      name: Standard_F8
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFamdsv7Family
+      generic_name: standard_f8-2amds_v7
+      id: Standard_F8-2amds_v7
+      memory: 68719476736
+      name: Standard_F8-2amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFamsv7Family
+      generic_name: standard_f8-2ams_v7
+      id: Standard_F8-2ams_v7
+      memory: 68719476736
+      name: Standard_F8-2ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFamdsv7Family
+      generic_name: standard_f8-4amds_v7
+      id: Standard_F8-4amds_v7
+      memory: 68719476736
+      name: Standard_F8-4amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFamsv7Family
+      generic_name: standard_f8-4ams_v7
+      id: Standard_F8-4ams_v7
+      memory: 68719476736
+      name: Standard_F8-4ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: StandardFadsv7Family
+      generic_name: standard_f80ads_v7
+      id: Standard_F80ads_v7
+      memory: 343597383680
+      name: Standard_F80ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: StandardFaldsv7Family
+      generic_name: standard_f80alds_v7
+      id: Standard_F80alds_v7
+      memory: 171798691840
+      name: Standard_F80alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: StandardFalsv7Family
+      generic_name: standard_f80als_v7
+      id: Standard_F80als_v7
+      memory: 171798691840
+      name: Standard_F80als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: StandardFamdsv7Family
+      generic_name: standard_f80amds_v7
+      id: Standard_F80amds_v7
+      memory: 687194767360
+      name: Standard_F80amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: StandardFamsv7Family
+      generic_name: standard_f80ams_v7
+      id: Standard_F80ams_v7
+      memory: 687194767360
+      name: Standard_F80ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: StandardFasv7Family
+      generic_name: standard_f80as_v7
+      id: Standard_F80as_v7
+      memory: 343597383680
+      name: Standard_F80as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFadsv7Family
+      generic_name: standard_f8ads_v7
+      id: Standard_F8ads_v7
+      memory: 34359738368
+      name: Standard_F8ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFaldsv7Family
+      generic_name: standard_f8alds_v7
+      id: Standard_F8alds_v7
+      memory: 17179869184
+      name: Standard_F8alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFalsv6Family
+      generic_name: standard_f8als_v6
+      id: Standard_F8als_v6
+      memory: 17179869184
+      name: Standard_F8als_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFalsv7Family
+      generic_name: standard_f8als_v7
+      id: Standard_F8als_v7
+      memory: 17179869184
+      name: Standard_F8als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFamdsv7Family
+      generic_name: standard_f8amds_v7
+      id: Standard_F8amds_v7
+      memory: 68719476736
+      name: Standard_F8amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFamsv6Family
+      generic_name: standard_f8ams_v6
+      id: Standard_F8ams_v6
+      memory: 68719476736
+      name: Standard_F8ams_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFamsv7Family
+      generic_name: standard_f8ams_v7
+      id: Standard_F8ams_v7
+      memory: 68719476736
+      name: Standard_F8ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFasv6Family
+      generic_name: standard_f8as_v6
+      id: Standard_F8as_v6
+      memory: 34359738368
+      name: Standard_F8as_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFasv7Family
+      generic_name: standard_f8as_v7
+      id: Standard_F8as_v7
+      memory: 34359738368
+      name: Standard_F8as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardFSFamily
+      generic_name: standard_f8s
+      id: Standard_F8s
+      memory: 17179869184
+      name: Standard_F8s
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardFSv2Family
+      generic_name: standard_f8s_v2
+      id: Standard_F8s_v2
+      memory: 17179869184
+      name: Standard_F8s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 12
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx12-6mds_v2
+      id: Standard_FX12-6mds_v2
+      memory: 270582939648
+      name: Standard_FX12-6mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 12
+      family: StandardFXmsv2Family
+      generic_name: standard_fx12-6ms_v2
+      id: Standard_FX12-6ms_v2
+      memory: 270582939648
+      name: Standard_FX12-6ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 12
+      family: standardFXMDVSFamily
+      generic_name: standard_fx12mds
+      id: Standard_FX12mds
+      memory: 270582939648
+      name: Standard_FX12mds
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 12
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx12mds_v2
+      id: Standard_FX12mds_v2
+      memory: 270582939648
+      name: Standard_FX12mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 12
+      family: StandardFXmsv2Family
+      generic_name: standard_fx12ms_v2
+      id: Standard_FX12ms_v2
+      memory: 270582939648
+      name: Standard_FX12ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx16-4mds_v2
+      id: Standard_FX16-4mds_v2
+      memory: 360777252864
+      name: Standard_FX16-4mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFXmsv2Family
+      generic_name: standard_fx16-4ms_v2
+      id: Standard_FX16-4ms_v2
+      memory: 360777252864
+      name: Standard_FX16-4ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx16-8mds_v2
+      id: Standard_FX16-8mds_v2
+      memory: 360777252864
+      name: Standard_FX16-8mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFXmsv2Family
+      generic_name: standard_fx16-8ms_v2
+      id: Standard_FX16-8ms_v2
+      memory: 360777252864
+      name: Standard_FX16-8ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx16mds_v2
+      id: Standard_FX16mds_v2
+      memory: 360777252864
+      name: Standard_FX16mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: StandardFXmsv2Family
+      generic_name: standard_fx16ms_v2
+      id: Standard_FX16ms_v2
+      memory: 360777252864
+      name: Standard_FX16ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx24-12mds_v2
+      id: Standard_FX24-12mds_v2
+      memory: 541165879296
+      name: Standard_FX24-12mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      family: StandardFXmsv2Family
+      generic_name: standard_fx24-12ms_v2
+      id: Standard_FX24-12ms_v2
+      memory: 541165879296
+      name: Standard_FX24-12ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx24-6mds_v2
+      id: Standard_FX24-6mds_v2
+      memory: 541165879296
+      name: Standard_FX24-6mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      family: StandardFXmsv2Family
+      generic_name: standard_fx24-6ms_v2
+      id: Standard_FX24-6ms_v2
+      memory: 541165879296
+      name: Standard_FX24-6ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      family: standardFXMDVSFamily
+      generic_name: standard_fx24mds
+      id: Standard_FX24mds
+      memory: 541165879296
+      name: Standard_FX24mds
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx24mds_v2
+      id: Standard_FX24mds_v2
+      memory: 541165879296
+      name: Standard_FX24mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      family: StandardFXmsv2Family
+      generic_name: standard_fx24ms_v2
+      id: Standard_FX24ms_v2
+      memory: 541165879296
+      name: Standard_FX24ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx2mds_v2
+      id: Standard_FX2mds_v2
+      memory: 45097156608
+      name: Standard_FX2mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: StandardFXmsv2Family
+      generic_name: standard_fx2ms_v2
+      id: Standard_FX2ms_v2
+      memory: 45097156608
+      name: Standard_FX2ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx32-16mds_v2
+      id: Standard_FX32-16mds_v2
+      memory: 721554505728
+      name: Standard_FX32-16mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFXmsv2Family
+      generic_name: standard_fx32-16ms_v2
+      id: Standard_FX32-16ms_v2
+      memory: 721554505728
+      name: Standard_FX32-16ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx32-8mds_v2
+      id: Standard_FX32-8mds_v2
+      memory: 721554505728
+      name: Standard_FX32-8mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFXmsv2Family
+      generic_name: standard_fx32-8ms_v2
+      id: Standard_FX32-8ms_v2
+      memory: 721554505728
+      name: Standard_FX32-8ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx32mds_v2
+      id: Standard_FX32mds_v2
+      memory: 721554505728
+      name: Standard_FX32mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: StandardFXmsv2Family
+      generic_name: standard_fx32ms_v2
+      id: Standard_FX32ms_v2
+      memory: 721554505728
+      name: Standard_FX32ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 36
+      family: standardFXMDVSFamily
+      generic_name: standard_fx36mds
+      id: Standard_FX36mds
+      memory: 811748818944
+      name: Standard_FX36mds
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx4-2mds_v2
+      id: Standard_FX4-2mds_v2
+      memory: 90194313216
+      name: Standard_FX4-2mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFXmsv2Family
+      generic_name: standard_fx4-2ms_v2
+      id: Standard_FX4-2ms_v2
+      memory: 90194313216
+      name: Standard_FX4-2ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx48-12mds_v2
+      id: Standard_FX48-12mds_v2
+      memory: 1082331758592
+      name: Standard_FX48-12mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFXmsv2Family
+      generic_name: standard_fx48-12ms_v2
+      id: Standard_FX48-12ms_v2
+      memory: 1082331758592
+      name: Standard_FX48-12ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx48-24mds_v2
+      id: Standard_FX48-24mds_v2
+      memory: 1082331758592
+      name: Standard_FX48-24mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFXmsv2Family
+      generic_name: standard_fx48-24ms_v2
+      id: Standard_FX48-24ms_v2
+      memory: 1082331758592
+      name: Standard_FX48-24ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardFXMDVSFamily
+      generic_name: standard_fx48mds
+      id: Standard_FX48mds
+      memory: 1082331758592
+      name: Standard_FX48mds
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx48mds_v2
+      id: Standard_FX48mds_v2
+      memory: 1082331758592
+      name: Standard_FX48mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardFXmsv2Family
+      generic_name: standard_fx48ms_v2
+      id: Standard_FX48ms_v2
+      memory: 1082331758592
+      name: Standard_FX48ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardFXMDVSFamily
+      generic_name: standard_fx4mds
+      id: Standard_FX4mds
+      memory: 90194313216
+      name: Standard_FX4mds
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx4mds_v2
+      id: Standard_FX4mds_v2
+      memory: 90194313216
+      name: Standard_FX4mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: StandardFXmsv2Family
+      generic_name: standard_fx4ms_v2
+      id: Standard_FX4ms_v2
+      memory: 90194313216
+      name: Standard_FX4ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx64-16mds_v2
+      id: Standard_FX64-16mds_v2
+      memory: 1443109011456
+      name: Standard_FX64-16mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFXmsv2Family
+      generic_name: standard_fx64-16ms_v2
+      id: Standard_FX64-16ms_v2
+      memory: 1443109011456
+      name: Standard_FX64-16ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx64-32mds_v2
+      id: Standard_FX64-32mds_v2
+      memory: 1443109011456
+      name: Standard_FX64-32mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFXmsv2Family
+      generic_name: standard_fx64-32ms_v2
+      id: Standard_FX64-32ms_v2
+      memory: 1443109011456
+      name: Standard_FX64-32ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx64mds_v2
+      id: Standard_FX64mds_v2
+      memory: 1443109011456
+      name: Standard_FX64mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: StandardFXmsv2Family
+      generic_name: standard_fx64ms_v2
+      id: Standard_FX64ms_v2
+      memory: 1443109011456
+      name: Standard_FX64ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx8-2mds_v2
+      id: Standard_FX8-2mds_v2
+      memory: 180388626432
+      name: Standard_FX8-2mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFXmsv2Family
+      generic_name: standard_fx8-2ms_v2
+      id: Standard_FX8-2ms_v2
+      memory: 180388626432
+      name: Standard_FX8-2ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx8-4mds_v2
+      id: Standard_FX8-4mds_v2
+      memory: 180388626432
+      name: Standard_FX8-4mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFXmsv2Family
+      generic_name: standard_fx8-4ms_v2
+      id: Standard_FX8-4ms_v2
+      memory: 180388626432
+      name: Standard_FX8-4ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx8mds_v2
+      id: Standard_FX8mds_v2
+      memory: 180388626432
+      name: Standard_FX8mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: StandardFXmsv2Family
+      generic_name: standard_fx8ms_v2
+      id: Standard_FX8ms_v2
+      memory: 180388626432
+      name: Standard_FX8ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx96-24mds_v2
+      id: Standard_FX96-24mds_v2
+      memory: 1967095021568
+      name: Standard_FX96-24mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardFXmsv2Family
+      generic_name: standard_fx96-24ms_v2
+      id: Standard_FX96-24ms_v2
+      memory: 1967095021568
+      name: Standard_FX96-24ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx96-48mds_v2
+      id: Standard_FX96-48mds_v2
+      memory: 1967095021568
+      name: Standard_FX96-48mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardFXmsv2Family
+      generic_name: standard_fx96-48ms_v2
+      id: Standard_FX96-48ms_v2
+      memory: 1967095021568
+      name: Standard_FX96-48ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardFXmdsv2Family
+      generic_name: standard_fx96mds_v2
+      id: Standard_FX96mds_v2
+      memory: 1967095021568
+      name: Standard_FX96mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardFXmsv2Family
+      generic_name: standard_fx96ms_v2
+      id: Standard_FX96ms_v2
+      memory: 1967095021568
+      name: Standard_FX96ms_v2
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 12
+      family: standardLaosv4Family
+      generic_name: standard_l12aos_v4
+      id: Standard_L12aos_v4
+      memory: 103079215104
+      name: Standard_L12aos_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardLaosv4Family
+      generic_name: standard_l16aos_v4
+      id: Standard_L16aos_v4
+      memory: 137438953472
+      name: Standard_L16aos_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardLASv3Family
+      generic_name: standard_l16as_v3
+      id: Standard_L16as_v3
+      memory: 137438953472
+      name: Standard_L16as_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardLasv4Family
+      generic_name: standard_l16as_v4
+      id: Standard_L16as_v4
+      memory: 137438953472
+      name: Standard_L16as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardLSv3Family
+      generic_name: standard_l16s_v3
+      id: Standard_L16s_v3
+      memory: 137438953472
+      name: Standard_L16s_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardLsv4Family
+      generic_name: standard_l16s_v4
+      id: Standard_L16s_v4
+      memory: 137438953472
+      name: Standard_L16s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      family: standardLaosv4Family
+      generic_name: standard_l24aos_v4
+      id: Standard_L24aos_v4
+      memory: 206158430208
+      name: Standard_L24aos_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardLaosv4Family
+      generic_name: standard_l2aos_v4
+      id: Standard_L2aos_v4
+      memory: 17179869184
+      name: Standard_L2aos_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardLasv4Family
+      generic_name: standard_l2as_v4
+      id: Standard_L2as_v4
+      memory: 17179869184
+      name: Standard_L2as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      family: standardLsv4Family
+      generic_name: standard_l2s_v4
+      id: Standard_L2s_v4
+      memory: 17179869184
+      name: Standard_L2s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardLaosv4Family
+      generic_name: standard_l32aos_v4
+      id: Standard_L32aos_v4
+      memory: 274877906944
+      name: Standard_L32aos_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardLASv3Family
+      generic_name: standard_l32as_v3
+      id: Standard_L32as_v3
+      memory: 274877906944
+      name: Standard_L32as_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardLasv4Family
+      generic_name: standard_l32as_v4
+      id: Standard_L32as_v4
+      memory: 274877906944
+      name: Standard_L32as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardLSv3Family
+      generic_name: standard_l32s_v3
+      id: Standard_L32s_v3
+      memory: 274877906944
+      name: Standard_L32s_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardLsv4Family
+      generic_name: standard_l32s_v4
+      id: Standard_L32s_v4
+      memory: 274877906944
+      name: Standard_L32s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardLASv3Family
+      generic_name: standard_l48as_v3
+      id: Standard_L48as_v3
+      memory: 412316860416
+      name: Standard_L48as_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardLasv4Family
+      generic_name: standard_l48as_v4
+      id: Standard_L48as_v4
+      memory: 412316860416
+      name: Standard_L48as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardLSv3Family
+      generic_name: standard_l48s_v3
+      id: Standard_L48s_v3
+      memory: 412316860416
+      name: Standard_L48s_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: standardLsv4Family
+      generic_name: standard_l48s_v4
+      id: Standard_L48s_v4
+      memory: 412316860416
+      name: Standard_L48s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardLaosv4Family
+      generic_name: standard_l4aos_v4
+      id: Standard_L4aos_v4
+      memory: 34359738368
+      name: Standard_L4aos_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardLasv4Family
+      generic_name: standard_l4as_v4
+      id: Standard_L4as_v4
+      memory: 34359738368
+      name: Standard_L4as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardLsv4Family
+      generic_name: standard_l4s_v4
+      id: Standard_L4s_v4
+      memory: 34359738368
+      name: Standard_L4s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardLASv3Family
+      generic_name: standard_l64as_v3
+      id: Standard_L64as_v3
+      memory: 549755813888
+      name: Standard_L64as_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardLasv4Family
+      generic_name: standard_l64as_v4
+      id: Standard_L64as_v4
+      memory: 549755813888
+      name: Standard_L64as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardLSv3Family
+      generic_name: standard_l64s_v3
+      id: Standard_L64s_v3
+      memory: 549755813888
+      name: Standard_L64s_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: standardLsv4Family
+      generic_name: standard_l64s_v4
+      id: Standard_L64s_v4
+      memory: 549755813888
+      name: Standard_L64s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: standardLASv3Family
+      generic_name: standard_l80as_v3
+      id: Standard_L80as_v3
+      memory: 687194767360
+      name: Standard_L80as_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: standardLasv4Family
+      generic_name: standard_l80as_v4
+      id: Standard_L80as_v4
+      memory: 687194767360
+      name: Standard_L80as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: standardLSv3Family
+      generic_name: standard_l80s_v3
+      id: Standard_L80s_v3
+      memory: 687194767360
+      name: Standard_L80s_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: standardLsv4Family
+      generic_name: standard_l80s_v4
+      id: Standard_L80s_v4
+      memory: 687194767360
+      name: Standard_L80s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardLaosv4Family
+      generic_name: standard_l8aos_v4
+      id: Standard_L8aos_v4
+      memory: 68719476736
+      name: Standard_L8aos_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardLASv3Family
+      generic_name: standard_l8as_v3
+      id: Standard_L8as_v3
+      memory: 68719476736
+      name: Standard_L8as_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardLasv4Family
+      generic_name: standard_l8as_v4
+      id: Standard_L8as_v4
+      memory: 68719476736
+      name: Standard_L8as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardLSv3Family
+      generic_name: standard_l8s_v3
+      id: Standard_L8s_v3
+      memory: 68719476736
+      name: Standard_L8s_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardLsv4Family
+      generic_name: standard_l8s_v4
+      id: Standard_L8s_v4
+      memory: 68719476736
+      name: Standard_L8s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardLasv4Family
+      generic_name: standard_l96as_v4
+      id: Standard_L96as_v4
+      memory: 824633720832
+      name: Standard_L96as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: standardLsv4Family
+      generic_name: standard_l96s_v4
+      id: Standard_L96s_v4
+      memory: 824633720832
+      name: Standard_L96s_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: Standard NCASv3_T4 Family
+      generic_name: standard_nc16as_t4_v3
+      id: Standard_NC16as_T4_v3
+      memory: 118111600640
+      name: Standard_NC16as_T4_v3
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 24
+      family: StandardNCADSA100v4Family
+      generic_name: standard_nc24ads_a100_v4
+      id: Standard_NC24ads_A100_v4
+      memory: 236223201280
+      name: Standard_NC24ads_A100_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 40
+      family: StandardNCadsH100v5Family
+      generic_name: standard_nc40ads_h100_v5
+      id: Standard_NC40ads_H100_v5
+      memory: 343597383680
+      name: Standard_NC40ads_H100_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 48
+      family: StandardNCADSA100v4Family
+      generic_name: standard_nc48ads_a100_v4
+      id: Standard_NC48ads_A100_v4
+      memory: 472446402560
+      name: Standard_NC48ads_A100_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: Standard NCASv3_T4 Family
+      generic_name: standard_nc4as_t4_v3
+      id: Standard_NC4as_T4_v3
+      memory: 30064771072
+      name: Standard_NC4as_T4_v3
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 64
+      family: Standard NCASv3_T4 Family
+      generic_name: standard_nc64as_t4_v3
+      id: Standard_NC64as_T4_v3
+      memory: 472446402560
+      name: Standard_NC64as_T4_v3
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 80
+      family: StandardNCadsH100v5Family
+      generic_name: standard_nc80adis_h100_v5
+      id: Standard_NC80adis_H100_v5
+      memory: 687194767360
+      name: Standard_NC80adis_H100_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: Standard NCASv3_T4 Family
+      generic_name: standard_nc8as_t4_v3
+      id: Standard_NC8as_T4_v3
+      memory: 60129542144
+      name: Standard_NC8as_T4_v3
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 96
+      family: StandardNCADSA100v4Family
+      generic_name: standard_nc96ads_a100_v4
+      id: Standard_NC96ads_A100_v4
+      memory: 944892805120
+      name: Standard_NC96ads_A100_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 12
+      family: StandardNVADSA10v5Family
+      generic_name: standard_nv12ads_a10_v5
+      id: Standard_NV12ads_A10_v5
+      memory: 118111600640
+      name: Standard_NV12ads_A10_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 16
+      family: standardNVSv4Family
+      generic_name: standard_nv16as_v4
+      id: Standard_NV16as_v4
+      memory: 60129542144
+      name: Standard_NV16as_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 18
+      family: StandardNVADSA10v5Family
+      generic_name: standard_nv18ads_a10_v5
+      id: Standard_NV18ads_A10_v5
+      memory: 236223201280
+      name: Standard_NV18ads_A10_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 32
+      family: standardNVSv4Family
+      generic_name: standard_nv32as_v4
+      id: Standard_NV32as_v4
+      memory: 120259084288
+      name: Standard_NV32as_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 36
+      family: StandardNVADSA10v5Family
+      generic_name: standard_nv36adms_a10_v5
+      id: Standard_NV36adms_A10_v5
+      memory: 944892805120
+      name: Standard_NV36adms_A10_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 36
+      family: StandardNVADSA10v5Family
+      generic_name: standard_nv36ads_a10_v5
+      id: Standard_NV36ads_A10_v5
+      memory: 472446402560
+      name: Standard_NV36ads_A10_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 4
+      family: standardNVSv4Family
+      generic_name: standard_nv4as_v4
+      id: Standard_NV4as_v4
+      memory: 15032385536
+      name: Standard_NV4as_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 6
+      family: StandardNVADSA10v5Family
+      generic_name: standard_nv6ads_a10_v5
+      id: Standard_NV6ads_A10_v5
+      memory: 59055800320
+      name: Standard_NV6ads_A10_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 72
+      family: StandardNVADSA10v5Family
+      generic_name: standard_nv72ads_a10_v5
+      id: Standard_NV72ads_A10_v5
+      memory: 944892805120
+      name: Standard_NV72ads_A10_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 8
+      family: standardNVSv4Family
+      generic_name: standard_nv8as_v4
+      id: Standard_NV8as_v4
+      memory: 30064771072
+      name: Standard_NV8as_v4
 kind: ConfigMap
 metadata:
   name: cloud-resources-config
@@ -7894,7 +9348,7 @@ spec:
         checksum/provisionshard: 'd2d4582f46da482e7a0c56f8a4372d95839bf6ced1d48a964d7030dc7e1b5b4b'
         checksum/cs: '7f91f7a8dc3a8b51073043defb13df2c3864a9c93f5a5588a2431f012bc2ae28'
         checksum/runtime: 'a59b6e4224066ebe7cb35d89a9e9c179f9e90942d3b4173c91c0609299a983ef'
-        checksum/cloudres: '6db050cd35a77e565d80d2ba2c028450a8758e3ab0a4e524ede12cf207c3a73a'
+        checksum/cloudres: '259ecb0074a7ea836f9f2eedd9769724a8c6feb37fade314157736ef2b4ceebd'
         checksum/sa: '0187a6f1019114e284fb5565a82e4e954460ac079f952f07b9602117c0d81e3f'
     spec:
       topologySpreadConstraints:


### PR DESCRIPTION
<!-- Link to Jira issue -->
Jira issue: https://redhat.atlassian.net/browse/ARO-9982

Adds Azure **quota family** metadata to the Cluster Service instance type catalog, as the first step toward backend **inflight VM quota validation** for node pools ([ARO-9982](https://redhat.atlassian.net/browse/ARO-9982)).
- Switch `update_instance_types.py` from `az vm list-sizes` to `az vm list-skus` so each SKU includes its Azure quota `family` (e.g. `standardDSv3Family`) alongside existing `cpu_cores`.
- Regenerate `cloud-resources-config.configmap.yaml` for **westus3**.
- Refresh cluster-service Helm golden fixtures so `make test-helm-fixtures` passes.

### Why

Backend node pool quota validation needs two pieces of SKU metadata from the catalog:
| Field | Source | Used for |
|-------|--------|----------|
| `cpu_cores` | catalog (existing) | `required vCPUs = cpu_cores × max_nodes` |
| `family` | catalog (**new**) | match against `az vm list-usage` quota `name.value` |

`family` cannot come from `list-usage` alone — that API returns quota buckets, not per-SKU mapping. Azure exposes the mapping on **Resource SKUs** (`list-skus`), so the generator now uses that API.
This MR is **data-only** (catalog + generator). Backend validation controller, Usage API wiring, and configmap mount in backend land in a **follow-up MR**.


### What

### `update_instance_types.py`
- `az vm list-sizes` → `az vm list-skus`
- Filter `resourceType == virtualMachines`
- Read `vCPUs` / `MemoryGB` from SKU capabilities
- Add `family` from SKU `.family`
- Skip SKUs missing vCPUs, memory, or family

### `cloud-resources-config.configmap.yaml`
- Regenerated for westus3 (~1048 instance types)
- Every catalog entry now has `family:` in addition to `cpu_cores`

### Helm fixtures
- Updated `zz_fixture_TestHelmTemplate_cs_azuredb.yaml`
- Updated `zz_fixture_TestHelmTemplate_cs_containerdb.yaml`
- Updated `zz_fixture_TestHelmTemplate_dev_westus3_svc_1_cluster_service.yaml`

## Known gap: 4 enabled NC v3 GPU SKUs missing from catalog

After switching to `list-skus`, **4 SKUs that are still enabled in `instance-type-constraints.yaml` are no longer in the westus3 catalog**:
- `Standard_NC6s_v3`
- `Standard_NC12s_v3`
- `Standard_NC24s_v3`
- `Standard_NC24rs_v3`

These **were present** in the old catalog  but are **not returned** by `az vm list-skus` for westus3 (retired/unavailable in that region - source: https://learn.microsoft.com/en-us/azure/virtual-machines/ncv3-retirement).

**Impact if left unresolved:**
- No impact on running clusters or CS startup
- **New** node pool creates using those SKUs may fail (enabled in constraints, missing from catalog metadata)
- MR2 quota validation cannot check those SKUs

This MR does **not** change constraints — documenting the gap for reviewers.

### Testing

- [x] Verified `family` present on sample SKUs (e.g. `Standard_D8s_v3` → `standardDSv3Family`)
- [x] Checked enabled SKUs vs catalog (82/86 present; 4 NC v3 gap documented above)
- [x] `make update-helm-fixtures` (from repo root)
- [x] `make test-helm-fixtures` (from repo root)


### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
