### PR TITLE
fix(dev-ci): upgrade opstool AKS node pools, not just control plane (AROSLSRE-1414)

### DIFF
--- a/dev-infrastructure/dev-ci/cluster/opstool-aks-pipeline.yaml
+++ b/dev-infrastructure/dev-ci/cluster/opstool-aks-pipeline.yaml
@@ -58,7 +58,7 @@ resourceGroups:
     outputOnly: true
     dependsOn:
     - resourceGroup: opstool
-      step: cluster
+      step: upgrade-aks-cluster
   # Placeholder kusto output for schema compatibility (opstool doesn't use kusto - a breaking fix)
   - name: kusto-placeholder
     action: ARM
@@ -76,7 +76,7 @@ resourceGroups:
     deploymentLevel: ResourceGroup
     dependsOn:
     - resourceGroup: opstool
-      step: cluster
+      step: upgrade-aks-cluster
   - name: prometheus
     aksCluster: '{{ .opstool.aks.name }}'
     action: Helm

--- a/dev-infrastructure/dev-ci/cluster/opstool-aks-pipeline.yaml
+++ b/dev-infrastructure/dev-ci/cluster/opstool-aks-pipeline.yaml
@@ -25,6 +25,31 @@ resourceGroups:
     dependsOn:
     - resourceGroup: opstool
       step: network
+  # Upgrade the AKS control plane and node pools to the configured Kubernetes
+  # version. The `cluster` ARM step only moves the control plane; node pools
+  # keep their orchestrator version on a managedCluster PUT, so an explicit
+  # `az aks upgrade` (mirroring svc/mgmt) is required to roll the node pools.
+  - name: upgrade-aks-cluster
+    action: Shell
+    command: ./upgrade-aks-cluster.sh
+    workingDir: ../../scripts
+    shellIdentity:
+      input:
+        resourceGroup: global
+        step: global-identity
+        name: globalMSIId
+    variables:
+    - name: CLUSTER_NAME
+      configRef: opstool.aks.name
+    - name: RESOURCE_GROUP
+      configRef: svc.rg
+    - name: KUBERNETES_VERSION
+      configRef: opstool.aks.kubernetesVersion
+    dependsOn:
+    - resourceGroup: opstool
+      step: cluster
+    - resourceGroup: global
+      step: global-identity
   - name: cluster-output
     action: ARM
     template: ../../templates/output-opstool-cluster.bicep
@@ -83,3 +108,15 @@ resourceGroups:
       resourceGroup: opstool
       step: cluster-output
       name: prometheusUAMIId
+- name: global
+  resourceGroup: '{{ .global.rg }}'
+  subscription: '{{ .global.subscription.key }}'
+  steps:
+  # Expose the shared global rollout identity so the upgrade-aks-cluster Shell
+  # step can assume it (same identity used by svc/mgmt upgrade steps).
+  - name: global-identity
+    action: ARM
+    template: ../../templates/output-opstool-global-identity.bicep
+    parameters: ../../configurations/output-opstool-global-identity.tmpl.bicepparam
+    deploymentLevel: ResourceGroup
+    outputOnly: true


### PR DESCRIPTION
[AROSLSRE-1414](https://redhat.atlassian.net/browse/AROSLSRE-1414)

### What

Adds an `upgrade-aks-cluster` Shell step to the opstool dev-ci pipeline so that a Kubernetes version bump in `config-dev-ci.yaml` rolls the **node pools**, not just the control plane. The step runs the same `dev-infrastructure/scripts/upgrade-aks-cluster.sh` used by the svc/mgmt pipelines and assumes the shared `global-rollout-identity`, exposed via a new `global-identity` output step (mirroring the dev-ci `e2e-subscription-rbac` pipeline).

### Why

The opstool pipeline previously ran only the `cluster` ARM step. That step sets the managedCluster `kubernetesVersion` (control plane) but the `agentPoolProfiles` / `aks/pool.bicep` pools carry **no `orchestratorVersion`** — on a managedCluster PUT an omitted `orchestratorVersion` means "no change", so existing node pools stay on their current version.

Observed after deploying the `1.33` bump to opstool: control plane went to `1.33.12` but all three node pools stayed on `1.32` orchestrator. svc/mgmt don't hit this because their pipelines already run `upgrade-aks-cluster.sh` (`az aks upgrade`, which rolls control plane **and** node pools). opstool was the outlier. This is also the root cause of the opstool version drift behind AROSLSRE-863.

```text
config kubernetesVersion bump
  -> cluster ARM step        => control plane upgraded, pools unchanged  (before)
  -> upgrade-aks-cluster.sh  => `az aks upgrade` rolls control plane + node pools  (after)
```

### Testing

- `templatize pipeline validate --topology-config-file topology-dev-ci.yaml --service-config-file config/config-dev-ci.yaml --dev-mode --dev-region westus3` → passes.
- `yamlfmt` → no changes.
- Reuses the already-proven `upgrade-aks-cluster.sh` and the `global-identity` output pattern from the sibling `e2e-subscription-rbac` pipeline; the script is idempotent (no-op when the cluster is already at the target version).

### Special notes for your reviewer

dev-ci infra is rolled out manually (`make dev-ci-local-run`), so this takes effect on the next opstool rollout. Scope is dev-ci only (`topology-dev-ci.yaml`); int/stg/prod are unaffected.
