### PR TITLE
fix: use underlay inventory for service alerts

### DIFF
--- a/docs/alerts/underlay_clusters.md
+++ b/docs/alerts/underlay_clusters.md
@@ -1,0 +1,42 @@
+# underlay_clusters alerts
+
+The `underlay_clusters` metric is emitted by the static recording rule defined in
+`dev-infrastructure/modules/metrics/underlay-clusters-metric.bicep`.
+Each service and management cluster deployment instantiates that module with its
+AKS cluster name, producing:
+
+```promql
+underlay_clusters{cluster="<cluster-name>", source="bicep"} = 1
+```
+
+This metric is the source of truth for which underlay service and management
+clusters should exist. It is static deployment-time inventory, so it should
+always be present for every service cluster and every management cluster, and
+entries should not disappear while those clusters still exist.
+
+If an `underlay_clusters` entry disappears, or the inventory becomes too small,
+multiple other alerts lose their desired-cluster source of truth and may stop
+detecting cluster-specific failures. Treat these alerts as requiring immediate
+attention.
+
+## Alerts
+
+### UnderlayClusterInventoryEntryMissing
+
+This alert fires when a `cluster` label existed in `underlay_clusters` within
+the last 7 days but is no longer present.
+
+Check whether the affected service or management cluster was intentionally
+removed. If it still exists, investigate the cluster deployment and the
+`underlay-clusters-metric-<cluster>` recording rule in the services Azure
+Monitor Workspace.
+
+### UnderlayClusterInventoryTooSmall
+
+This alert fires when `underlay_clusters` has two or fewer distinct `cluster`
+label values, or when the `underlay_clusters` metric itself is absent.
+
+The inventory should never be this small in a healthy environment. Confirm the
+underlay-clusters metric rule groups exist for the service cluster and all
+management cluster stamps, then restore the missing recording rules before
+dependent alerts lose coverage.

--- a/frontend/alerts/mise-prometheusRule.yaml
+++ b/frontend/alerts/mise-prometheusRule.yaml
@@ -13,10 +13,10 @@ spec:
   - name: mise
     rules:
     - alert: MiseEnvoyScrapeDown
-      # Get list of all `svc` clusters (returns 1 for each)
+      # Get list of all declared `svc` clusters (returns 1 for each)
       # Remove clusters that have the istio-proxy metric UP
       expr: |
-        group by (cluster) (up{job="kube-state-metrics", cluster=~".*-svc(-[0-9]+)?$"})
+        group by (cluster) (underlay_clusters{cluster=~".*-svc(-[0-9]+)?$"})
         unless on(cluster)
         group by (cluster) (up{endpoint="http-envoy-prom", container="istio-proxy", namespace="mise"} == 1)
       for: 5m

--- a/frontend/alerts/mise-prometheusRule_test.yaml
+++ b/frontend/alerts/mise-prometheusRule_test.yaml
@@ -5,7 +5,7 @@ tests:
 # Test: Service cluster exists but mise metric is missing - alert should fire
 - interval: 1s
   input_series:
-  - series: 'up{job="kube-state-metrics", cluster="test-svc-1"}'
+  - series: 'underlay_clusters{cluster="test-svc-1", source="bicep"}'
     values: '1x600'
   alert_rule_test:
   - eval_time: 301s # alert should fire after 5m
@@ -22,7 +22,7 @@ tests:
 # Test: Service cluster exists and mise metric is present - no alert
 - interval: 1s
   input_series:
-  - series: 'up{job="kube-state-metrics", cluster="test-svc-1"}'
+  - series: 'underlay_clusters{cluster="test-svc-1", source="bicep"}'
     values: '1x600'
   - series: 'up{endpoint="http-envoy-prom", container="istio-proxy", namespace="mise", cluster="test-svc-1"}'
     values: '1x600'
@@ -33,7 +33,7 @@ tests:
 # Test: Service cluster exists, mise metric was present but goes down - alert should fire
 - interval: 1s
   input_series:
-  - series: 'up{job="kube-state-metrics", cluster="test-svc-2"}'
+  - series: 'underlay_clusters{cluster="test-svc-2", source="bicep"}'
     values: '1x600'
   - series: 'up{endpoint="http-envoy-prom", container="istio-proxy", namespace="mise", cluster="test-svc-2"}'
     values: '1x100 0x500' # 100s healthy, then down

--- a/observability/alerts/arobit-prometheusRule.yaml
+++ b/observability/alerts/arobit-prometheusRule.yaml
@@ -8,7 +8,7 @@ spec:
   - name: arobit-rules
     rules:
     - alert: ArobitForwarderJobUp
-      expr: group by (cluster) (up{job="kube-state-metrics"}) unless on(cluster) group by (cluster) (up{job="arobit-forwarder",namespace="arobit"} == 1)
+      expr: group by (cluster) (underlay_clusters) unless on(cluster) group by (cluster) (up{job="arobit-forwarder",namespace="arobit"} == 1)
       for: 15m
       labels:
         severity: warning

--- a/observability/alerts/arobit-prometheusRule_test.yaml
+++ b/observability/alerts/arobit-prometheusRule_test.yaml
@@ -5,7 +5,7 @@ tests:
 # ArobitForwarderJobUp - alert fires
 - interval: 1m
   input_series:
-  - series: 'up{job="kube-state-metrics",cluster="test"}'
+  - series: 'underlay_clusters{cluster="test",source="bicep"}'
     values: "1+0x15"
   - series: 'up{job="arobit-forwarder",namespace="arobit",cluster="test"}'
     values: "0+0x15"

--- a/observability/alerts/prometheus-prometheusRule.yaml
+++ b/observability/alerts/prometheus-prometheusRule.yaml
@@ -13,9 +13,7 @@ spec:
   - name: prometheus-wip-rules
     rules:
     - alert: PrometheusJobUp
-      # TODO: once PR #5732 (underlay_clusters source-of-truth metric) is merged and confirmed
-      # working in production, replace up{job="kubelet"} with underlay_clusters.
-      expr: group by (cluster) (up{job="kubelet"}) unless on(cluster) group by (cluster) (up{job="prometheus/prometheus",namespace="prometheus"} == 1)
+      expr: group by (cluster) (underlay_clusters) unless on(cluster) group by (cluster) (up{job="prometheus/prometheus",namespace="prometheus"} == 1)
       for: 10m
       labels:
         severity: critical
@@ -62,13 +60,13 @@ spec:
         runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md
         summary: Prometheus sample count below 95% SLO threshold for 24 hours.
     - alert: PrometheusMetricsAbsentPerCluster
-      expr: count by (cluster) (count_over_time(up{job="prometheus/prometheus",namespace="prometheus"}[7d])) unless count by (cluster) (count_over_time(up{job="prometheus/prometheus",namespace="prometheus"}[10m]))
+      expr: group by (cluster) (underlay_clusters) unless on(cluster) count by (cluster) (count_over_time(up{job="prometheus/prometheus",namespace="prometheus"}[10m]))
       for: 10m
       labels:
         severity: critical
       annotations:
         description: |
-          Prometheus on cluster {{ $labels.cluster }} has not reported any up metrics in the last 10 minutes, but was reporting within the last 7 days.
+          Prometheus on cluster {{ $labels.cluster }} has not reported any up metrics in the last 10 minutes, but is declared in the underlay cluster inventory.
           This indicates the Prometheus agent on this specific cluster is dead or its remote write pipeline is broken.
           Check the PrometheusAgent pod status and remote write configuration on the affected cluster.
         runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md

--- a/observability/alerts/prometheus-prometheusRule.yaml
+++ b/observability/alerts/prometheus-prometheusRule.yaml
@@ -71,6 +71,30 @@ spec:
           Check the PrometheusAgent pod status and remote write configuration on the affected cluster.
         runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md
         summary: Prometheus metrics absent for cluster {{ $labels.cluster }}.
+    - alert: UnderlayClusterInventoryEntryMissing
+      expr: group by (cluster) (count_over_time(underlay_clusters[7d])) unless on(cluster) group by (cluster) (underlay_clusters)
+      for: 10m
+      labels:
+        severity: warning
+      annotations:
+        description: |
+          Underlay cluster {{ $labels.cluster }} was present in the underlay cluster inventory within the last 7 days, but is no longer present.
+          The underlay cluster inventory is static deployment-time data and entries should not disappear while their service or management clusters still exist.
+          Investigate the underlay_clusters recording rule and the cluster's deployment state.
+        runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/underlay_clusters.md
+        summary: Underlay cluster inventory entry disappeared for {{ $labels.cluster }}.
+    - alert: UnderlayClusterInventoryTooSmall
+      expr: count(count by (cluster) (underlay_clusters)) <= 2 or absent(underlay_clusters)
+      for: 10m
+      labels:
+        severity: warning
+      annotations:
+        description: |
+          The underlay cluster inventory has two or fewer cluster labels, or the underlay_clusters metric is completely absent.
+          The inventory should include all service and management clusters and should never be this small.
+          Investigate the underlay_clusters recording rules before dependent alerts lose their source of truth.
+        runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/underlay_clusters.md
+        summary: Underlay cluster inventory has too few entries.
     - alert: PrometheusPendingRate
       expr: |
         (

--- a/observability/alerts/prometheus-prometheusRule_test.yaml
+++ b/observability/alerts/prometheus-prometheusRule_test.yaml
@@ -5,7 +5,7 @@ tests:
 # prometheus-slo-rules group tests
 - interval: 1m
   input_series:
-  - series: 'up{job="kubelet",cluster="test"}'
+  - series: 'underlay_clusters{cluster="test",source="bicep"}'
     values: "1+0x15"
   - series: 'up{job="prometheus/prometheus",namespace="prometheus",cluster="test"}'
     values: "0+0x15"
@@ -188,7 +188,7 @@ tests:
 # Additional test scenarios with multiple instances
 - interval: 1m
   input_series:
-  - series: 'up{job="kubelet",cluster="test"}'
+  - series: 'underlay_clusters{cluster="test",source="bicep"}'
     values: "1+0x15"
   - series: 'up{job="prometheus/prometheus",namespace="prometheus",instance="prometheus-0",cluster="test"}'
     values: "0+0x15"
@@ -211,7 +211,7 @@ tests:
 # Test no alert scenario for PrometheusJobUp
 - interval: 1m
   input_series:
-  - series: 'up{job="kubelet",cluster="test"}'
+  - series: 'underlay_clusters{cluster="test",source="bicep"}'
     values: "1+0x15"
   - series: 'up{job="prometheus/prometheus",namespace="prometheus",cluster="test"}'
     values: "1+0x15"
@@ -419,7 +419,7 @@ tests:
 # Test PrometheusJobUp with sustained outage
 - interval: 1m
   input_series:
-  - series: 'up{job="kubelet",cluster="test"}'
+  - series: 'underlay_clusters{cluster="test",source="bicep"}'
     values: "1+0x15"
   - series: 'up{job="prometheus/prometheus",namespace="prometheus",cluster="test"}'
     values: "0+0x15" # Continuously down
@@ -664,7 +664,7 @@ tests:
 # Test that alert does not fire before for: 10m is reached
 - interval: 1m
   input_series:
-  - series: 'up{job="kubelet",cluster="test"}'
+  - series: 'underlay_clusters{cluster="test",source="bicep"}'
     values: "1+0x10"
   - series: 'up{job="prometheus/prometheus",namespace="prometheus",cluster="test"}'
     values: "0+0x10"
@@ -675,7 +675,7 @@ tests:
 # Test that alert fires once for: 10m is reached
 - interval: 1m
   input_series:
-  - series: 'up{job="kubelet",cluster="test"}'
+  - series: 'underlay_clusters{cluster="test",source="bicep"}'
     values: "1+0x15"
   - series: 'up{job="prometheus/prometheus",namespace="prometheus",cluster="test"}'
     values: "0+0x15"
@@ -766,7 +766,7 @@ tests:
 # Test recovery after alert condition
 - interval: 1m
   input_series:
-  - series: 'up{job="kubelet",cluster="test"}'
+  - series: 'underlay_clusters{cluster="test",source="bicep"}'
     values: "1+0x25"
   - series: 'up{job="prometheus/prometheus",namespace="prometheus",cluster="test"}'
     values: "0+0x12 1+0x13" # Down for 12 minutes, then up
@@ -846,10 +846,12 @@ tests:
     alertname: PrometheusUptimeSampleCount
     exp_alerts: []
 # Test PrometheusMetricsAbsentPerCluster - cluster went dead
-# 20 samples at 1m interval (t=0 to t=19m), then nothing.
-# At eval_time=40m: [7d] window has 20 samples, [10m] window (t=30m-40m) has 0 → fires.
+# The underlay inventory declares the cluster, and Prometheus reports for 20m before going absent.
+# At eval_time=40m, the [10m] window (t=30m-40m) has 0 samples → fires.
 - interval: 1m
   input_series:
+  - series: 'underlay_clusters{cluster="dead-cluster",source="bicep"}'
+    values: "1+0x50"
   - series: 'up{job="prometheus/prometheus",namespace="prometheus",cluster="dead-cluster"}'
     values: "1+0x20"
   alert_rule_test:
@@ -862,13 +864,15 @@ tests:
       exp_annotations:
         summary: Prometheus metrics absent for cluster dead-cluster.
         description: |
-          Prometheus on cluster dead-cluster has not reported any up metrics in the last 10 minutes, but was reporting within the last 7 days.
+          Prometheus on cluster dead-cluster has not reported any up metrics in the last 10 minutes, but is declared in the underlay cluster inventory.
           This indicates the Prometheus agent on this specific cluster is dead or its remote write pipeline is broken.
           Check the PrometheusAgent pod status and remote write configuration on the affected cluster.
         runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md
 # Test PrometheusMetricsAbsentPerCluster - healthy cluster (continuous data)
 - interval: 1m
   input_series:
+  - series: 'underlay_clusters{cluster="healthy-cluster",source="bicep"}'
+    values: "1+0x50"
   - series: 'up{job="prometheus/prometheus",namespace="prometheus",cluster="healthy-cluster"}'
     values: "1+0x50"
   alert_rule_test:
@@ -879,6 +883,10 @@ tests:
 # Only the dead cluster should fire.
 - interval: 1m
   input_series:
+  - series: 'underlay_clusters{cluster="alive",source="bicep"}'
+    values: "1+0x50"
+  - series: 'underlay_clusters{cluster="dead",source="bicep"}'
+    values: "1+0x50"
   - series: 'up{job="prometheus/prometheus",namespace="prometheus",cluster="alive"}'
     values: "1+0x50"
   - series: 'up{job="prometheus/prometheus",namespace="prometheus",cluster="dead"}'
@@ -893,14 +901,14 @@ tests:
       exp_annotations:
         summary: Prometheus metrics absent for cluster dead.
         description: |
-          Prometheus on cluster dead has not reported any up metrics in the last 10 minutes, but was reporting within the last 7 days.
+          Prometheus on cluster dead has not reported any up metrics in the last 10 minutes, but is declared in the underlay cluster inventory.
           This indicates the Prometheus agent on this specific cluster is dead or its remote write pipeline is broken.
           Check the PrometheusAgent pod status and remote write configuration on the affected cluster.
         runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md
 # Test multiple namespaces and jobs
 - interval: 1m
   input_series:
-  - series: 'up{job="kubelet",cluster="test"}'
+  - series: 'underlay_clusters{cluster="test",source="bicep"}'
     values: "1+0x15"
   - series: 'up{job="prometheus/prometheus",namespace="monitoring",cluster="test"}'
     values: "0+0x15"

--- a/observability/alerts/prometheus-prometheusRule_test.yaml
+++ b/observability/alerts/prometheus-prometheusRule_test.yaml
@@ -905,6 +905,83 @@ tests:
           This indicates the Prometheus agent on this specific cluster is dead or its remote write pipeline is broken.
           Check the PrometheusAgent pod status and remote write configuration on the affected cluster.
         runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md
+# Test UnderlayClusterInventoryEntryMissing - inventory entry disappeared
+- interval: 1m
+  input_series:
+  - series: 'underlay_clusters{cluster="missing-cluster",source="bicep"}'
+    values: "1+0x20"
+  alert_rule_test:
+  - eval_time: 40m
+    alertname: UnderlayClusterInventoryEntryMissing
+    exp_alerts:
+    - exp_labels:
+        severity: warning
+        cluster: missing-cluster
+      exp_annotations:
+        summary: Underlay cluster inventory entry disappeared for missing-cluster.
+        description: |
+          Underlay cluster missing-cluster was present in the underlay cluster inventory within the last 7 days, but is no longer present.
+          The underlay cluster inventory is static deployment-time data and entries should not disappear while their service or management clusters still exist.
+          Investigate the underlay_clusters recording rule and the cluster's deployment state.
+        runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/underlay_clusters.md
+# Test UnderlayClusterInventoryEntryMissing - inventory entry still present
+- interval: 1m
+  input_series:
+  - series: 'underlay_clusters{cluster="present-cluster",source="bicep"}'
+    values: "1+0x50"
+  alert_rule_test:
+  - eval_time: 40m
+    alertname: UnderlayClusterInventoryEntryMissing
+    exp_alerts: []
+# Test UnderlayClusterInventoryTooSmall - fewer than expected cluster labels
+- interval: 1m
+  input_series:
+  - series: 'underlay_clusters{cluster="svc-1",source="bicep"}'
+    values: "1+0x15"
+  - series: 'underlay_clusters{cluster="mgmt-1",source="bicep"}'
+    values: "1+0x15"
+  alert_rule_test:
+  - eval_time: 10m
+    alertname: UnderlayClusterInventoryTooSmall
+    exp_alerts:
+    - exp_labels:
+        severity: warning
+      exp_annotations:
+        summary: Underlay cluster inventory has too few entries.
+        description: |
+          The underlay cluster inventory has two or fewer cluster labels, or the underlay_clusters metric is completely absent.
+          The inventory should include all service and management clusters and should never be this small.
+          Investigate the underlay_clusters recording rules before dependent alerts lose their source of truth.
+        runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/underlay_clusters.md
+# Test UnderlayClusterInventoryTooSmall - metric is absent
+- interval: 1m
+  input_series: []
+  alert_rule_test:
+  - eval_time: 10m
+    alertname: UnderlayClusterInventoryTooSmall
+    exp_alerts:
+    - exp_labels:
+        severity: warning
+      exp_annotations:
+        summary: Underlay cluster inventory has too few entries.
+        description: |
+          The underlay cluster inventory has two or fewer cluster labels, or the underlay_clusters metric is completely absent.
+          The inventory should include all service and management clusters and should never be this small.
+          Investigate the underlay_clusters recording rules before dependent alerts lose their source of truth.
+        runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/underlay_clusters.md
+# Test UnderlayClusterInventoryTooSmall - inventory has enough cluster labels
+- interval: 1m
+  input_series:
+  - series: 'underlay_clusters{cluster="svc-1",source="bicep"}'
+    values: "1+0x15"
+  - series: 'underlay_clusters{cluster="mgmt-1",source="bicep"}'
+    values: "1+0x15"
+  - series: 'underlay_clusters{cluster="mgmt-2",source="bicep"}'
+    values: "1+0x15"
+  alert_rule_test:
+  - eval_time: 10m
+    alertname: UnderlayClusterInventoryTooSmall
+    exp_alerts: []
 # Test multiple namespaces and jobs
 - interval: 1m
   input_series:


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-1444

## Summary
- Switch services-only Prometheus, Arobit, and MISE absence alerts to use `underlay_clusters` as the desired-cluster source of truth.
- Add Sev 3 underlay inventory integrity alerts for disappeared entries and too-small or absent inventory in the SL services queue.
- Add `docs/alerts/underlay_clusters.md` as the runbook for the new inventory alerts.
- Update the corresponding YAML rule tests.
- Leave generated Bicep unchanged for now.

## Testing
- Validated touched observability alert tests with the prometheus-rules generator using temporary output outside the repo.
- Validated touched MISE alert test with the prometheus-rules generator using temporary output outside the repo.