### PR TITLE
fix(swift-vnet): gate on DNS readiness and widen retry budget to absorb ACI cold-start (ARO-28244)

### DIFF
--- a/dev-infrastructure/scripts/swift-vnet.sh
+++ b/dev-infrastructure/scripts/swift-vnet.sh
@@ -32,8 +32,9 @@ fi
 
 CONTAINER_IMAGE="mcr.microsoft.com/azure-cli:2.53.1"
 CONTAINER_GROUP_NAME="swift-vnet-${VNET_NAME}"
-TIMEOUT=600
+TIMEOUT=900
 POLL_INTERVAL=10
+HEARTBEAT_INTERVAL=60
 
 az account set --subscription "${SUBSCRIPTION_ID}"
 
@@ -46,40 +47,71 @@ az container delete \
 
 # Script executed inside the container, AS globalMSI. Values are baked in here (none are
 # secret) and the whole script is base64-encoded below so container command-line quoting
-# cannot mangle it. The managed identity's Network/Tag Contributor role assignments are
-# created by the preceding swift-vnet-permissions step; Azure RBAC is eventually consistent,
-# so the first write can fail with AuthorizationFailed until the assignment propagates - the
-# retry helper absorbs that lag.
+# cannot mangle it.
+#
+# Two independent transient failure modes are handled with a bounded, fixed-interval retry
+# (see retry()). Both are "wait until ready" conditions, so we poll at a short fixed interval
+# to detect recovery promptly rather than backing off:
+#   1. Container DNS cold-start: a freshly-created ACI in a delegated VNet subnet can come up
+#      before its resolver is ready, so name resolution fails with [Errno -3] Try again
+#      (EAI_AGAIN) for the first minutes. A DNS readiness gate waits on the real dependency
+#      (resolving the Azure control-plane endpoints) before running any az command.
+#   2. RBAC propagation: the managed identity's Network/Tag Contributor role assignments are
+#      created by the preceding swift-vnet-permissions step and Azure RBAC is eventually
+#      consistent, so the first reads/writes can fail with AuthorizationFailed until the
+#      assignment propagates.
 read -r -d '' CONTAINER_SCRIPT <<EOF || true
 set -euo pipefail
 
-MAX_WAIT=180
+MAX_WAIT=300
 POLL_INTERVAL=5
 
+# retry <description> <command...>: run the command, polling at a fixed POLL_INTERVAL until it
+# succeeds or MAX_WAIT is exceeded. Each attempt is logged with elapsed time so the container
+# log makes clear what is being waited on and for how long. A fixed short interval (not a
+# backoff) is deliberate: these are readiness waits (DNS/RBAC), so we want to catch recovery
+# promptly, and a single serial caller polling its own resource poses no throttling risk.
 retry() {
-  local start=\${SECONDS}
+  local desc=\$1; shift
+  local start=\${SECONDS} attempt=1 elapsed
   until "\$@"; do
-    if [ \$((SECONDS - start)) -ge "\${MAX_WAIT}" ]; then
-      echo "'\$*' still failing after \$((SECONDS - start))s" >&2
+    elapsed=\$((SECONDS - start))
+    if [ "\${elapsed}" -ge "\${MAX_WAIT}" ]; then
+      echo "[swift-vnet] \${desc}: giving up after \${attempt} attempt(s) / \${elapsed}s (limit \${MAX_WAIT}s)" >&2
       return 1
     fi
-    echo "Command failed (likely RBAC propagation or network cold-start); retrying in \${POLL_INTERVAL}s..." >&2
+    echo "[swift-vnet] \${desc}: attempt \${attempt} failed (elapsed \${elapsed}s/\${MAX_WAIT}s; likely container DNS cold-start or RBAC propagation); retrying in \${POLL_INTERVAL}s..." >&2
     sleep "\${POLL_INTERVAL}"
+    attempt=\$((attempt + 1))
   done
+  if [ "\${attempt}" -gt 1 ]; then
+    echo "[swift-vnet] \${desc}: succeeded on attempt \${attempt} (\$((SECONDS - start))s)" >&2
+  fi
 }
 
-# Log in as globalMSI. The container's network/DNS stack may not be ready the instant it
-# starts, so az login can fail with a transient DNS error ([Errno -3] Try again) on a cold
-# start. Wrap login and account-set in retry so that self-heals instead of killing the step.
-echo "Logging in with the Swift-registered managed identity..."
-retry az login --identity --username "${DEPLOYMENT_MSI_ID}" --output none
-retry az account set --subscription "${SUBSCRIPTION_ID}"
+# Resolver check via python3 (bundled with the azure-cli image, unlike getent which is not
+# guaranteed present) — this also exercises the exact getaddrinfo() path that fails with
+# EAI_AGAIN during the DNS cold-start we are gating on.
+resolves() { python3 -c "import socket,sys; socket.getaddrinfo(sys.argv[1], None)" "\$1" >/dev/null 2>&1; }
+
+# DNS readiness gate: wait until the container's resolver can actually resolve the Azure
+# control-plane endpoints before running any az command (see mode 1 above). This turns the
+# cold-start into an explicit, well-logged wait on the real dependency instead of a noisy
+# az login stack trace.
+echo "[swift-vnet] Waiting for DNS readiness (Azure control-plane endpoints)..."
+retry "dns readiness (login.microsoftonline.com)" resolves login.microsoftonline.com
+retry "dns readiness (management.azure.com)" resolves management.azure.com
+
+# Log in as globalMSI. Wrapped in retry as cheap insurance against a residual transient
+# (TLS/outbound blip or IMDS not ready) even after DNS is up.
+echo "[swift-vnet] Logging in with the Swift-registered managed identity..."
+retry "az login (globalMSI)" az login --identity --username "${DEPLOYMENT_MSI_ID}" --output none
+retry "az account set" az account set --subscription "${SUBSCRIPTION_ID}"
 
 # Wait until the managed identity can actually read the resource group before deciding whether
-# the VNet exists. The Network/Tag Contributor assignments are created in a preceding step and
-# Azure RBAC is eventually consistent, so without this gate a transient auth failure on the
-# existence check could misroute a re-run (existing VNet) into the create path.
-retry az group show --name "${RESOURCE_GROUP}" --output none
+# the VNet exists (see mode 2 above: RBAC is eventually consistent, so without this gate a
+# transient auth failure on the existence check could misroute a re-run into the create path).
+retry "az group show" az group show --name "${RESOURCE_GROUP}" --output none
 
 # Decide whether the VNet already exists, distinguishing a genuine NotFound (create path) from
 # a transient/AuthorizationFailed error (retry the read). The az group show gate above already
@@ -87,6 +119,7 @@ retry az group show --name "${RESOURCE_GROUP}" --output none
 # existing VNet into the create path - only a real NotFound should reach create.
 vnet_exists=""
 show_start=\${SECONDS}
+show_attempt=1
 while true; do
   if show_err=\$(az network vnet show --resource-group "${RESOURCE_GROUP}" --name "${VNET_NAME}" --output none 2>&1); then
     vnet_exists="yes"
@@ -96,17 +129,19 @@ while true; do
     vnet_exists="no"
     break
   fi
-  if [ \$((SECONDS - show_start)) -ge "\${MAX_WAIT}" ]; then
-    echo "VNet existence check still failing after \$((SECONDS - show_start))s: \${show_err}" >&2
+  show_elapsed=\$((SECONDS - show_start))
+  if [ "\${show_elapsed}" -ge "\${MAX_WAIT}" ]; then
+    echo "[swift-vnet] vnet existence check: giving up after \${show_attempt} attempt(s) / \${show_elapsed}s: \${show_err}" >&2
     exit 1
   fi
-  echo "VNet show failed (non-NotFound, likely transient/RBAC propagation); retrying in \${POLL_INTERVAL}s..." >&2
+  echo "[swift-vnet] vnet existence check: attempt \${show_attempt} non-NotFound failure (elapsed \${show_elapsed}s/\${MAX_WAIT}s; likely transient/RBAC propagation); retrying in \${POLL_INTERVAL}s..." >&2
   sleep "\${POLL_INTERVAL}"
+  show_attempt=\$((show_attempt + 1))
 done
 
 if [ "\${vnet_exists}" = "yes" ]; then
-  echo "VNet ${VNET_NAME} exists. Updating Swift tag..."
-  retry az resource tag \
+  echo "[swift-vnet] VNet ${VNET_NAME} exists. Updating Swift tag..."
+  retry "az resource tag" az resource tag \
     --is-incremental \
     --tags stampcreatorserviceinfo=true \
     --resource-group "${RESOURCE_GROUP}" \
@@ -114,15 +149,15 @@ if [ "\${vnet_exists}" = "yes" ]; then
     --resource-type Microsoft.Network/virtualNetworks \
     --api-version 2024-05-01
 else
-  echo "VNet ${VNET_NAME} does not exist. Creating..."
-  retry az network vnet create \
+  echo "[swift-vnet] VNet ${VNET_NAME} does not exist. Creating..."
+  retry "az network vnet create" az network vnet create \
     --resource-group "${RESOURCE_GROUP}" \
     --name "${VNET_NAME}" \
     --address-prefixes "${VNET_ADDRESS_PREFIX}" \
     --tags stampcreatorserviceinfo=true
 fi
 
-echo "Swift VNet ${VNET_NAME} is ready and tagged."
+echo "[swift-vnet] Swift VNet ${VNET_NAME} is ready and tagged."
 EOF
 
 CONTAINER_SCRIPT_B64=$(printf '%s' "${CONTAINER_SCRIPT}" | base64 | tr -d '\n')
@@ -157,6 +192,8 @@ group_provisioning_state() {
 }
 
 start=${SECONDS}
+last_state="__init__"
+last_log=0
 while true; do
   state=$(container_state)
   if [ "${state}" = "Terminated" ]; then
@@ -178,7 +215,15 @@ while true; do
     az container delete --resource-group "${RESOURCE_GROUP}" --name "${CONTAINER_GROUP_NAME}" --yes >/dev/null 2>&1 || true
     exit 1
   fi
-  echo "Waiting for ${CONTAINER_GROUP_NAME} to finish (state: ${state:-pending})..."
+  # Log on state transitions (plus the initial state) and emit a periodic heartbeat so long
+  # stretches in "Running" still produce output — this avoids CI/EV2 inactivity/no-output
+  # timeouts during multi-minute cold starts without flooding the step with identical lines.
+  now=$((SECONDS - start))
+  if [ "${state}" != "${last_state}" ] || [ $((now - last_log)) -ge "${HEARTBEAT_INTERVAL}" ]; then
+    echo "Waiting for ${CONTAINER_GROUP_NAME} to finish (state: ${state:-pending}, elapsed ${now}s)..."
+    last_state="${state}"
+    last_log=${now}
+  fi
   sleep "${POLL_INTERVAL}"
 done
 


### PR DESCRIPTION
<!-- https://redhat.atlassian.net/browse/ARO-28244 -->

### What

Harden the migrated Swift VNet Shell step (`scripts/swift-vnet.sh`) against ACI container network/DNS cold-start:

- **DNS readiness gate** — before any `az` call, wait until the container's resolver can actually resolve the Azure control-plane endpoints (`login.microsoftonline.com`, `management.azure.com`).
- **Wider budget** — `MAX_WAIT` 180→300s to cover a multi-minute cold-start, keeping the RBAC-propagation retries `retry()` already guarded.
- **Fixed short poll, no backoff** — these are readiness waits (DNS/RBAC come up as a step-function), so a short fixed poll catches recovery promptly; a single serial caller polling its own resource poses no throttling risk that would justify backing off.
- **Clearer logs** — each attempt logs description + elapsed/limit; the outer container-wait loop only logs on state transitions instead of a wall of identical `Running` lines. Container `TIMEOUT` raised to 900s.

### Why

The step launches an ACI container that runs `az` as globalMSI. On a freshly-created container the resolver isn't ready, so the first call (`az login --identity`) fails with `[Errno -3] Try again` (getaddrinfo `EAI_AGAIN`) for the first minutes. The existing retry with `MAX_WAIT=180` could exhaust its budget before DNS came up and fail provisioning — a common e2e flake:

```
Logging in with the Swift-registered managed identity...
ERROR: <urllib3...>: Failed to establish a new connection: [Errno -3] Try again
Command failed (...); retrying in 5s...   (x6)
'az login --identity ...' still failing after 191s
✗ swift-vnet-aks-net exited with code 1
```

This gates on the real dependency (DNS) and gives it enough time to settle.

### Flow

```mermaid
flowchart TD
    A([EV2 Shell step: swift-vnet.sh]) --> B{ENABLE_SWIFT == true?}
    B -- no --> Z0([Skip: exit 0])
    B -- yes --> C[az account set + delete stale container group]
    C --> D["Launch ACI container group as globalMSI<br/>(az container create --no-wait)"]

    D --> E{Poll container state<br/>&le; TIMEOUT 900s}
    E -- "provisioningState = Failed" --> XF([Dump logs, delete, exit 1])
    E -- "timeout" --> XT([Dump logs, delete, exit 1])
    E -- "Terminated" --> R[Fetch logs + exitCode, cleanup]

    subgraph INNER["Inside container (AS globalMSI) — retry(): fixed 5s poll, MAX_WAIT 300s"]
        direction TB
        G1["DNS readiness gate<br/>resolve login.microsoftonline.com + management.azure.com"] --> G2[az login --identity + az account set]
        G2 --> G3["az group show<br/>(wait for RBAC propagation)"]
        G3 --> G4{VNet exists?}
        G4 -- "yes" --> G5[az resource tag<br/>stampcreatorserviceinfo=true]
        G4 -- "no / NotFound" --> G6[az network vnet create + tag]
        G4 -- "transient / AuthorizationFailed" --> G4
        G5 --> G7([VNet ready & tagged])
        G6 --> G7
        G1 -. "still failing after MAX_WAIT" .-> GF([exit 1])
        G3 -. "still failing after MAX_WAIT" .-> GF
    end

    D -.runs.-> INNER

    R --> S{exitCode == 0?}
    S -- yes --> Z1([Success: VNet created/tagged])
    S -- no --> Z2([exit 1])
```

### Testing

- `bash -n` clean on the outer script and on the decoded inner container script.
- Unit-checked `retry()`: success-after-N-failures logs `succeeded on attempt N`; budget exhaustion logs `giving up after … (limit …s)` and returns non-zero.

### Special notes for your reviewer

- This is the immediate, low-risk mitigation and fully absorbs the cold-start regardless of its root cause. Pinning a fixed resolver (`dnsConfig.nameServers=168.63.129.16`) is a *candidate* follow-up on [ARO-28244](https://redhat.atlassian.net/browse/ARO-28244), not a guaranteed fix — `EAI_AGAIN` is also consistent with the container's network data path not being ready yet, in which case pinning wouldn't help. Plan is to measure the gate's wait times post-merge and only pursue pinning if it proves out.
- The retry is still required after DNS is up: Azure RBAC for the globalMSI role assignments (from the preceding `swift-vnet-permissions` step) is eventually consistent.

### PR Checklist

- [x] Does not introduce new deployment scripts (stays a Shell step)
- [x] No secrets added
- [x] Behavior unchanged when `ENABLE_SWIFT != true`
