### PR TITLE
fix: weight PrometheusUptime by sample count

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
@@ -66,19 +66,21 @@ Check the status of the Prometheus pods, service endpoints, and network connecti
         }
         annotations: {
           correlationId: 'PrometheusUptime/{{ $labels.cluster }}'
-          description: '''Prometheus has been unreachable for more than 5% of the time over the past 24 hours.
+          description: '''Fewer than 95% of present Prometheus self-up samples were healthy over the past 24 hours.
 This may indicate that the Prometheus server is down, experiencing network issues, or stuck in a crash loop.
+Missing samples are covered separately by PrometheusUptimeSampleCount.
 Please check the status of the Prometheus pods, service endpoints, and network connectivity.
 '''
-          info: '''Prometheus has been unreachable for more than 5% of the time over the past 24 hours.
+          info: '''Fewer than 95% of present Prometheus self-up samples were healthy over the past 24 hours.
 This may indicate that the Prometheus server is down, experiencing network issues, or stuck in a crash loop.
+Missing samples are covered separately by PrometheusUptimeSampleCount.
 Please check the status of the Prometheus pods, service endpoints, and network connectivity.
 '''
           runbook_url: 'https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md'
-          summary: 'Prometheus is unreachable for 1 day.'
-          title: 'Prometheus is unreachable for 1 day.'
+          summary: 'Prometheus uptime below 95% over 24 hours.'
+          title: 'Prometheus uptime below 95% over 24 hours.'
         }
-        expression: 'avg by (job, namespace, cluster) (avg_over_time(up{job="prometheus/prometheus",namespace="prometheus"}[1d])) < 0.95'
+        expression: '(sum by (job, namespace, cluster) (sum_over_time(up{job="prometheus/prometheus",namespace="prometheus"}[1d])) / sum by (job, namespace, cluster) (count_over_time(up{job="prometheus/prometheus",namespace="prometheus"}[1d]))) < 0.95'
         for: 'PT10M'
         severity: severityCeiling > 0 ? max(2, severityCeiling) : 2
       }
@@ -100,12 +102,12 @@ Please check the status of the Prometheus pods, service endpoints, and network c
         annotations: {
           correlationId: 'PrometheusUptimeSampleCount/{{ $labels.cluster }}'
           description: '''Prometheus has delivered fewer than 95% of expected samples in the past 24 hours (expected 2880 at 30s interval, threshold 2736).
-Unlike PrometheusUptime which averages existing samples, this alert treats data gaps as downtime.
+Unlike PrometheusUptime which evaluates the health of present samples, this alert treats data gaps as downtime.
 Complete metric absence (no samples) will also trigger PrometheusMetricsAbsentPerCluster.
 Check the PrometheusAgent pod status, remote write pipeline, and PodMonitor configuration.
 '''
           info: '''Prometheus has delivered fewer than 95% of expected samples in the past 24 hours (expected 2880 at 30s interval, threshold 2736).
-Unlike PrometheusUptime which averages existing samples, this alert treats data gaps as downtime.
+Unlike PrometheusUptime which evaluates the health of present samples, this alert treats data gaps as downtime.
 Complete metric absence (no samples) will also trigger PrometheusMetricsAbsentPerCluster.
 Check the PrometheusAgent pod status, remote write pipeline, and PodMonitor configuration.
 '''

--- a/docs/alerts/Prometheus.md
+++ b/docs/alerts/Prometheus.md
@@ -11,7 +11,7 @@ The timings below are approximate and exclude Azure Monitor evaluation jitter, I
 | `PrometheusJobUp` | 10m | critical | The cluster exists according to the external anchor, but `up{job="prometheus/prometheus", namespace="prometheus"} == 1` is not present. This catches Prometheus down, unreachable, or reporting `up=0`. |
 | `PrometheusMetricsAbsentPerCluster` | 10m | critical | No Prometheus self-`up` samples have arrived for a cluster that should be reporting. With `underlay_clusters`, this means a declared underlay cluster has no Prometheus self-metrics in the recent window. |
 | `PrometheusUptimeSampleCount` | 10m | warning | Fewer than 95% of expected Prometheus self-`up` samples arrived over 24h. This treats missing samples as downtime. |
-| `PrometheusUptime` | 10m | critical | More than 5% of present Prometheus self-`up` samples over 24h were `0`. This does not count missing samples as downtime. |
+| `PrometheusUptime` | 10m | critical | More than 5% of present Prometheus self-`up` samples over 24h were `0`, weighted by sample count across all observed series. This does not count missing samples as downtime. |
 | `PrometheusPendingRate` | 15m | critical | Prometheus remote-write queue pressure is high: too many samples are pending relative to in-flight samples. |
 | `PrometheusFailedRate` | 15m | critical | More than 10% of remote-write samples are failing over the short rate window. |
 | `PrometheusRemoteStorageFailures` | 15m | critical | Upstream Prometheus Operator alert: more than 1% of samples failed to send to remote storage. Metrics and alerts may be missing or inaccurate. |
@@ -30,7 +30,7 @@ This table assumes the worst useful "Prometheus is down" shape for each alert: P
 | `PrometheusJobUp` | 10m | critical | ~10-15m | It can fire as soon as the latest good `up == 1` sample is no longer selected, then the `for: 10m` timer completes. The upper bound accounts for PromQL lookback of the last good sample. |
 | `PrometheusMetricsAbsentPerCluster` | 10m | critical | ~20m | `count_over_time(...[10m])` remains non-empty until the last sample is older than 10m, then the `for: 10m` timer completes. |
 | `PrometheusUptimeSampleCount` | 10m | warning | ~82m | It fires once more than 5% of the expected 24h samples are missing: 72m of missing samples plus `for: 10m`. |
-| `PrometheusUptime` | 10m | critical | Never for pure absence; ~82m if `up=0` samples continue | `avg_over_time(up[1d])` averages only samples that exist. Missing samples do not lower the average. |
+| `PrometheusUptime` | 10m | critical | Never for pure absence; ~82m if `up=0` samples continue | It compares successful present `up` samples with total present `up` samples. Missing samples do not lower the average. |
 | `PrometheusPendingRate` | 15m | critical | Never | Needs Prometheus to emit remote-write queue metrics. |
 | `PrometheusFailedRate` | 15m | critical | Never | Needs Prometheus to emit remote-write failure counters. |
 | `PrometheusRemoteStorageFailures` | 15m | critical | Never | Needs Prometheus to emit remote storage success/failure counters. |
@@ -61,7 +61,7 @@ Primary alerts:
 | Alert | Signal |
 |---|---|
 | `PrometheusJobUp` | Fires after 10m because the expected healthy `up == 1` series is absent. |
-| `PrometheusUptime` | Fires after more than 5% of the 24h window contains present `up=0` samples, plus `for: 10m`. |
+| `PrometheusUptime` | Fires after more than 5% of the present Prometheus self-`up` samples in the 24h window are `0`, plus `for: 10m`. Short-lived target identities are weighted only by their actual sample count. |
 
 `PrometheusUptimeSampleCount` does not detect this by itself because the samples are present. It only counts how many samples arrived, not whether they were `0` or `1`.
 

--- a/observability/alerts/prometheus-prometheusRule.yaml
+++ b/observability/alerts/prometheus-prometheusRule.yaml
@@ -62,7 +62,7 @@ spec:
       annotations:
         description: |
           Prometheus has delivered fewer than 95% of expected samples in the past 24 hours (expected 2880 at 30s interval, threshold 2736).
-          Unlike PrometheusUptime which averages existing samples, this alert treats data gaps as downtime.
+          Unlike PrometheusUptime which evaluates the health of present samples, this alert treats data gaps as downtime.
           Complete metric absence (no samples) will also trigger PrometheusMetricsAbsentPerCluster.
           Check the PrometheusAgent pod status, remote write pipeline, and PodMonitor configuration.
         runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md

--- a/observability/alerts/prometheus-prometheusRule.yaml
+++ b/observability/alerts/prometheus-prometheusRule.yaml
@@ -27,17 +27,23 @@ spec:
         runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md
         summary: Prometheus is unreachable for 10 minutes.
     - alert: PrometheusUptime
-      expr: avg by (job, namespace, cluster) (avg_over_time(up{job="prometheus/prometheus",namespace="prometheus"}[1d])) < 0.95
+      expr: |
+        (
+          sum by (job, namespace, cluster) (sum_over_time(up{job="prometheus/prometheus",namespace="prometheus"}[1d]))
+          /
+          sum by (job, namespace, cluster) (count_over_time(up{job="prometheus/prometheus",namespace="prometheus"}[1d]))
+        ) < 0.95
       for: 10m
       labels:
         severity: critical
       annotations:
         description: |
-          Prometheus has been unreachable for more than 5% of the time over the past 24 hours.
+          Fewer than 95% of present Prometheus self-up samples were healthy over the past 24 hours.
           This may indicate that the Prometheus server is down, experiencing network issues, or stuck in a crash loop.
+          Missing samples are covered separately by PrometheusUptimeSampleCount.
           Please check the status of the Prometheus pods, service endpoints, and network connectivity.
         runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md
-        summary: Prometheus is unreachable for 1 day.
+        summary: Prometheus uptime below 95% over 24 hours.
     - alert: PrometheusUptimeSampleCount
       # The divisor 30 matches spec.scrapeInterval (30s) in prometheus.yaml. Update both together if the interval changes.
       # sum (not min) so pod restarts don't false-fire: old + new instance samples cover the full day.

--- a/observability/alerts/prometheus-prometheusRule_test.yaml
+++ b/observability/alerts/prometheus-prometheusRule_test.yaml
@@ -36,12 +36,23 @@ tests:
         job: prometheus/prometheus
         namespace: prometheus
       exp_annotations:
-        summary: Prometheus is unreachable for 1 day.
+        summary: Prometheus uptime below 95% over 24 hours.
         description: |
-          Prometheus has been unreachable for more than 5% of the time over the past 24 hours.
+          Fewer than 95% of present Prometheus self-up samples were healthy over the past 24 hours.
           This may indicate that the Prometheus server is down, experiencing network issues, or stuck in a crash loop.
+          Missing samples are covered separately by PrometheusUptimeSampleCount.
           Please check the status of the Prometheus pods, service endpoints, and network connectivity.
         runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md
+- interval: 1m
+  input_series:
+  - series: 'up{job="prometheus/prometheus",namespace="prometheus",cluster="test",instance="healthy"}'
+    values: "1+0x1440"
+  - series: 'up{job="prometheus/prometheus",namespace="prometheus",cluster="test",instance="stale-failed"}'
+    values: "0+0x5 stale"
+  alert_rule_test:
+  - eval_time: 1d
+    alertname: PrometheusUptime
+    exp_alerts: []
 - interval: 1m
   input_series:
   - series: 'prometheus_remote_storage_samples_pending{cluster="test"}'
@@ -451,10 +462,11 @@ tests:
         job: prometheus/prometheus
         namespace: prometheus
       exp_annotations:
-        summary: Prometheus is unreachable for 1 day.
+        summary: Prometheus uptime below 95% over 24 hours.
         description: |
-          Prometheus has been unreachable for more than 5% of the time over the past 24 hours.
+          Fewer than 95% of present Prometheus self-up samples were healthy over the past 24 hours.
           This may indicate that the Prometheus server is down, experiencing network issues, or stuck in a crash loop.
+          Missing samples are covered separately by PrometheusUptimeSampleCount.
           Please check the status of the Prometheus pods, service endpoints, and network connectivity.
         runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md
 # Test PrometheusPendingRate with low pending rate

--- a/observability/alerts/prometheus-prometheusRule_test.yaml
+++ b/observability/alerts/prometheus-prometheusRule_test.yaml
@@ -830,7 +830,7 @@ tests:
         summary: Prometheus sample count below 95% SLO threshold for 24 hours.
         description: |
           Prometheus has delivered fewer than 95% of expected samples in the past 24 hours (expected 2880 at 30s interval, threshold 2736).
-          Unlike PrometheusUptime which averages existing samples, this alert treats data gaps as downtime.
+          Unlike PrometheusUptime which evaluates the health of present samples, this alert treats data gaps as downtime.
           Complete metric absence (no samples) will also trigger PrometheusMetricsAbsentPerCluster.
           Check the PrometheusAgent pod status, remote write pipeline, and PodMonitor configuration.
         runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md


### PR DESCRIPTION
Jira: https://redhat.atlassian.net/browse/AROSLSRE-1446

## Why

`PrometheusUptime` is intended to measure whether Prometheus self-`up` samples are healthy for at least 95% of the last 24h, while `PrometheusUptimeSampleCount` separately covers missing samples / ingestion gaps.

The current expression calculates `avg_over_time(up[1d])` independently for each target series and then averages those per-series results equally:

```promql
avg by (job, namespace, cluster) (
  avg_over_time(up{job="prometheus/prometheus",namespace="prometheus"}[1d])
) < 0.95
```

That means each target identity gets equal weight regardless of how many samples it contributed. **For example, one series with 5 minutes of `up=0` and another series with 24 hours of `up=1` are averaged as `(0 + 1) / 2 = 50%` availability, even though the failed series only contributed 5 minutes of data.**

## What

This changes `PrometheusUptime` to weight by actual present sample count:

```promql
sum_over_time(up[1d]) / count_over_time(up[1d]) < 0.95
```

aggregated by `job`, `namespace`, and `cluster`.

With this shape:
- `up=0` samples still count as unhealthy.
- Missing samples do not count here; `PrometheusUptimeSampleCount` owns that signal.
- Short-lived stale target identities only contribute their actual sample count instead of getting equal weight with full-day series.

Also updates the Prometheus alert runbook wording and adds a regression test for a stale short-lived failed target series.

## Verification

- Corrected alert doesn't go below 99.95% across all regions in the past 30 days.
- Current alert is firing in multiple regions due to the short timeseries of only 0s having the same weight as 24h series of ones.