### PR TITLE
chore: grant chai-bot app registration AllDatabasesViewer on dev Kusto

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1147,6 +1147,8 @@ clouds:
         enableAutoScale: true
         adminGroups: ""
         viewerGroups: "64dc69e4-d083-49fc-9569-ebece1dd1408/6b6d3adf-8476-4727-9812-20ffdef2b85c"
+        # app registration associated with chai-bot
+        viewerIdentities: "64dc69e4-d083-49fc-9569-ebece1dd1408/5990dc26-1b73-4547-9bba-9a5bd64a0165"
         rg: "hcp-kusto-us"
       auditLogsEventHub:
         # Turning off audit log eventhubs for most dev environments due to the difficulty of

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -524,7 +524,7 @@ kusto:
   sku: Standard_E8ads_v5
   tier: Standard
   viewerGroups: 64dc69e4-d083-49fc-9569-ebece1dd1408/6b6d3adf-8476-4727-9812-20ffdef2b85c
-  viewerIdentities: ""
+  viewerIdentities: 64dc69e4-d083-49fc-9569-ebece1dd1408/5990dc26-1b73-4547-9bba-9a5bd64a0165
 kvCertAccessPrincipalId: c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb
 kvCertAccessRoleId: ""
 kvCertOfficerPrincipalId: c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -524,7 +524,7 @@ kusto:
   sku: Standard_E8ads_v5
   tier: Standard
   viewerGroups: 64dc69e4-d083-49fc-9569-ebece1dd1408/6b6d3adf-8476-4727-9812-20ffdef2b85c
-  viewerIdentities: ""
+  viewerIdentities: 64dc69e4-d083-49fc-9569-ebece1dd1408/5990dc26-1b73-4547-9bba-9a5bd64a0165
 kvCertAccessPrincipalId: c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb
 kvCertAccessRoleId: ""
 kvCertOfficerPrincipalId: c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -524,7 +524,7 @@ kusto:
   sku: Standard_E8ads_v5
   tier: Standard
   viewerGroups: 64dc69e4-d083-49fc-9569-ebece1dd1408/6b6d3adf-8476-4727-9812-20ffdef2b85c
-  viewerIdentities: ""
+  viewerIdentities: 64dc69e4-d083-49fc-9569-ebece1dd1408/5990dc26-1b73-4547-9bba-9a5bd64a0165
 kvCertAccessPrincipalId: c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb
 kvCertAccessRoleId: ""
 kvCertOfficerPrincipalId: c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -524,7 +524,7 @@ kusto:
   sku: Standard_E8ads_v5
   tier: Standard
   viewerGroups: 64dc69e4-d083-49fc-9569-ebece1dd1408/6b6d3adf-8476-4727-9812-20ffdef2b85c
-  viewerIdentities: ""
+  viewerIdentities: 64dc69e4-d083-49fc-9569-ebece1dd1408/5990dc26-1b73-4547-9bba-9a5bd64a0165
 kvCertAccessPrincipalId: c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb
 kvCertAccessRoleId: ""
 kvCertOfficerPrincipalId: c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -524,7 +524,7 @@ kusto:
   sku: Standard_E8ads_v5
   tier: Standard
   viewerGroups: 64dc69e4-d083-49fc-9569-ebece1dd1408/6b6d3adf-8476-4727-9812-20ffdef2b85c
-  viewerIdentities: ""
+  viewerIdentities: 64dc69e4-d083-49fc-9569-ebece1dd1408/5990dc26-1b73-4547-9bba-9a5bd64a0165
 kvCertAccessPrincipalId: c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb
 kvCertAccessRoleId: ""
 kvCertOfficerPrincipalId: c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -524,7 +524,7 @@ kusto:
   sku: Standard_E8ads_v5
   tier: Standard
   viewerGroups: 64dc69e4-d083-49fc-9569-ebece1dd1408/6b6d3adf-8476-4727-9812-20ffdef2b85c
-  viewerIdentities: ""
+  viewerIdentities: 64dc69e4-d083-49fc-9569-ebece1dd1408/5990dc26-1b73-4547-9bba-9a5bd64a0165
 kvCertAccessPrincipalId: c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb
 kvCertAccessRoleId: ""
 kvCertOfficerPrincipalId: c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb


### PR DESCRIPTION
## Summary
- Adds the chai-bot app registration (`5990dc26-1b73-4547-9bba-9a5bd64a0165`) as a `viewerIdentity` on the dev Kusto cluster (`hcp-dev-us-2`)
- This grants `AllDatabasesViewer` role via the existing `clusterViewPermissionsForIdentities` principal assignment in `cluster.bicep`
- Change applies to all dev environments (cspr, ci00, ci01, dev, perf, pers)

## Test plan
- [x] `cd config && make materialize` passes with no unexpected changes
- [x] All helm fixture tests pass
- [ ] After merge, verify the geography pipeline deploys the principal assignment to `hcp-dev-us-2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)