### PR TITLE
fix: add region to AMW incident titles

### DIFF
--- a/dev-infrastructure/configurations/monitoring.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/monitoring.tmpl.bicepparam
@@ -2,6 +2,7 @@ using '../templates/monitoring.bicep'
 
 param azureMonitoringWorkspaceId = '__azureMonitoringWorkspaceId__'
 param hcpAzureMonitoringWorkspaceId = '__hcpAzureMonitoringWorkspaceId__'
+param region = '{{ .region }}'
 
 param manageConnection = {{ .monitoring.icm.manageConnection }}
 param alertsEnabled = {{ .monitoring.alertsEnabled }}

--- a/dev-infrastructure/modules/metrics/amw-ingestion-alerts.bicep
+++ b/dev-infrastructure/modules/metrics/amw-ingestion-alerts.bicep
@@ -4,6 +4,9 @@ param actionGroups array
 @description('Whether alerts are enabled')
 param enabled bool
 
+@description('ARO HCP region name')
+param region string
+
 @description('Workspace configurations to monitor')
 param workspaces array
 
@@ -41,6 +44,7 @@ resource approachingActiveTimeSeries 'Microsoft.Insights/metricAlerts@2018-03-01
         for g in actionGroups: {
           actionGroupId: g
           webHookProperties: {
+            'IcM.Title': '${region}: AMW Approaching Active TimeSeries Limit - ${ws.label}'
             'IcM.CorrelationId': 'AMWActiveTimeSeriesLimit/${ws.label}/${last(split(ws.id, '/'))}'
           }
         }
@@ -80,6 +84,7 @@ resource highRiskActiveTimeSeries 'Microsoft.Insights/metricAlerts@2018-03-01' =
         for g in actionGroups: {
           actionGroupId: g
           webHookProperties: {
+            'IcM.Title': '${region}: AMW High Risk Active TimeSeries Limit - ${ws.label}'
             'IcM.CorrelationId': 'AMWActiveTimeSeriesLimit/${ws.label}/${last(split(ws.id, '/'))}'
           }
         }
@@ -119,6 +124,7 @@ resource approachingEventIngestion 'Microsoft.Insights/metricAlerts@2018-03-01' 
         for g in actionGroups: {
           actionGroupId: g
           webHookProperties: {
+            'IcM.Title': '${region}: AMW Approaching Event Ingestion Limit - ${ws.label}'
             'IcM.CorrelationId': 'AMWEventIngestionLimit/${ws.label}/${last(split(ws.id, '/'))}'
           }
         }
@@ -158,6 +164,7 @@ resource highRiskEventIngestion 'Microsoft.Insights/metricAlerts@2018-03-01' = [
         for g in actionGroups: {
           actionGroupId: g
           webHookProperties: {
+            'IcM.Title': '${region}: AMW High Risk Event Ingestion Limit - ${ws.label}'
             'IcM.CorrelationId': 'AMWEventIngestionLimit/${ws.label}/${last(split(ws.id, '/'))}'
           }
         }
@@ -197,6 +204,7 @@ resource lowEventIngestion 'Microsoft.Insights/metricAlerts@2018-03-01' = [
         for g in actionGroups: {
           actionGroupId: g
           webHookProperties: {
+            'IcM.Title': '${region}: AMW Low Event Ingestion Utilization - ${ws.label}'
             'IcM.CorrelationId': 'AMWEventIngestionLimit/${ws.label}/${last(split(ws.id, '/'))}'
           }
         }

--- a/dev-infrastructure/templates/monitoring.bicep
+++ b/dev-infrastructure/templates/monitoring.bicep
@@ -4,6 +4,9 @@ param azureMonitoringWorkspaceId string
 @description('ID of the Azure Monitor Workspace for hosted control planes')
 param hcpAzureMonitoringWorkspaceId string
 
+@description('ARO HCP region name')
+param region string
+
 @description('The ICM environment')
 param icmEnvironment string
 
@@ -198,6 +201,7 @@ module ingestionAlerts '../modules/metrics/amw-ingestion-alerts.bicep' = {
   params: {
     actionGroups: slActionGroups
     enabled: alertsEnabled
+    region: region
     workspaces: [
       {
         id: azureMonitoringWorkspaceId


### PR DESCRIPTION
## Why

Direct AMW metric alerts currently rely on the Azure Monitor/IcM default incident title format, which does not include the ARO HCP region. This makes incidents like AMW ingestion alerts harder to triage when the same alert exists in multiple regions and is not in line with how prom incidents look like.

## What

- Pass the required ARO HCP `region` value into the monitoring deployment.
- Set `IcM.Title` for all direct AMW metric alerts to `<region>: <alert name>`.
- Keep existing Azure metric alert resource names unchanged to avoid replacing alert resources just for title formatting.

## Validation

- `bicep build dev-infrastructure/templates/monitoring.bicep --stdout`
