### PR TITLE
ARO-24037: add assign/action to MSI mock role for ACR pull MI support

### DIFF
--- a/dev-infrastructure/templates/e2e-subscription-rbac-assignment-subscription.bicep
+++ b/dev-infrastructure/templates/e2e-subscription-rbac-assignment-subscription.bicep
@@ -82,6 +82,7 @@ resource msiMockRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
           'Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials/read'
           'Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials/write'
           'Microsoft.ManagedIdentity/userAssignedIdentities/read'
+          'Microsoft.ManagedIdentity/userAssignedIdentities/assign/action'
           'Microsoft.Network/loadBalancers/backendAddressPools/read'
           'Microsoft.Network/loadBalancers/backendAddressPools/write'
           'Microsoft.Network/loadBalancers/read'

--- a/dev-infrastructure/templates/mock-identities.bicep
+++ b/dev-infrastructure/templates/mock-identities.bicep
@@ -169,6 +169,7 @@ resource msiCustomRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
           'Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials/read'
           'Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials/write'
           'Microsoft.ManagedIdentity/userAssignedIdentities/read'
+          'Microsoft.ManagedIdentity/userAssignedIdentities/assign/action' // attach customer-provided MIs (e.g. ACR pull) to VMs via CAPZ
           'Microsoft.Network/loadBalancers/backendAddressPools/read' // read backend address pools of LB to check if the backend address pool already exists
           'Microsoft.Network/loadBalancers/backendAddressPools/write' // write backend address pools to LB
           'Microsoft.Network/loadBalancers/read' // to check if LB exists or not before writing to it

--- a/dev-infrastructure/templates/mock-identity-roles.bicep
+++ b/dev-infrastructure/templates/mock-identity-roles.bicep
@@ -57,6 +57,7 @@ resource msiCustomRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
           'Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials/read'
           'Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials/write'
           'Microsoft.ManagedIdentity/userAssignedIdentities/read'
+          'Microsoft.ManagedIdentity/userAssignedIdentities/assign/action'
           'Microsoft.Network/loadBalancers/backendAddressPools/read'
           'Microsoft.Network/loadBalancers/backendAddressPools/write'
           'Microsoft.Network/loadBalancers/read'


### PR DESCRIPTION
[ARO-24037](https://redhat.atlassian.net/browse/ARO-24037)

### What

Add `Microsoft.ManagedIdentity/userAssignedIdentities/assign/action` to the `dev-msi-mock` custom role in both `mock-identities.bicep` (personal dev) and `e2e-subscription-rbac-assignment-subscription.bicep` (CI e2e subscriptions).

### Why

[ARO-24037](https://redhat.atlassian.net/browse/ARO-24037) adds customer-provided managed identities for ACR image pulls. CAPZ needs `assign/action` to attach these MIs to worker VMs. A backend validation controller verifies this permission via CheckAccess. Without this role update, that check fails in dev/test because the mock MSI role doesn't include the permission.

This is the same permission granted by the `Managed Identity Operator` built-in role in production.

### Testing

No tests — this is a role definition change in bicep. Verified by deploying the mock role update and confirming the backend validation controller's CheckAccess passes.

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [x] All comment threads resolved before merge
