### PR TITLE
fix: downgrading credential refresher alerts from sev2 -> sev3

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedMsftPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedMsftPrometheusAlertingRules.bicep
@@ -755,7 +755,7 @@ resource msftMsiCredentialRefresher 'Microsoft.AlertsManagement/prometheusRuleGr
         alert: 'ClusterCredentialExpiringSoon'
         enabled: true
         labels: {
-          severity: 'critical'
+          severity: 'warning'
         }
         annotations: {
           correlationId: 'ClusterCredentialExpiringSoon/{{ $labels.cluster }}'
@@ -767,7 +767,7 @@ resource msftMsiCredentialRefresher 'Microsoft.AlertsManagement/prometheusRuleGr
         }
         expression: 'sum by (cluster) (increase(credential_refresher_days_until_msi_credential_expiration_bucket{le=~"^30([.]0)?$"}[30m])) - sum by (cluster) (increase(credential_refresher_days_until_msi_credential_expiration_bucket{le=~"^0([.]0)?$"}[30m])) > 0'
         for: 'PT5M'
-        severity: severityCeiling > 0 ? max(2, severityCeiling) : 2
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
         actions: [
@@ -782,7 +782,7 @@ resource msftMsiCredentialRefresher 'Microsoft.AlertsManagement/prometheusRuleGr
         alert: 'ClusterCredentialExpired'
         enabled: true
         labels: {
-          severity: 'critical'
+          severity: 'warning'
         }
         annotations: {
           correlationId: 'ClusterCredentialExpired/{{ $labels.cluster }}'
@@ -794,7 +794,7 @@ resource msftMsiCredentialRefresher 'Microsoft.AlertsManagement/prometheusRuleGr
         }
         expression: 'sum by (cluster) (increase(credential_refresher_days_until_msi_credential_expiration_bucket{le=~"^0([.]0)?$"}[30m])) - sum by (cluster) (increase(credential_refresher_days_until_msi_credential_expiration_bucket{le=~"^-90([.]0)?$"}[30m])) > 0'
         for: 'PT5M'
-        severity: severityCeiling > 0 ? max(2, severityCeiling) : 2
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
         actions: [
@@ -809,7 +809,7 @@ resource msftMsiCredentialRefresher 'Microsoft.AlertsManagement/prometheusRuleGr
         alert: 'ClusterCredentialNotRenewable'
         enabled: true
         labels: {
-          severity: 'critical'
+          severity: 'warning'
         }
         annotations: {
           correlationId: 'ClusterCredentialNotRenewable/{{ $labels.cluster }}'
@@ -821,7 +821,7 @@ resource msftMsiCredentialRefresher 'Microsoft.AlertsManagement/prometheusRuleGr
         }
         expression: 'sum by (cluster) (increase(credential_refresher_days_until_msi_credential_expiration_bucket{le=~"^-90([.]0)?$"}[30m])) > 0'
         for: 'PT5M'
-        severity: severityCeiling > 0 ? max(2, severityCeiling) : 2
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
     ]
     scopes: [

--- a/observability/alerts/msi-credential-refresher-prometheusRule.yaml
+++ b/observability/alerts/msi-credential-refresher-prometheusRule.yaml
@@ -12,7 +12,7 @@ spec:
       expr: sum by (cluster) (increase(credential_refresher_days_until_msi_credential_expiration_bucket{le=~"^30([.]0)?$"}[30m])) - sum by (cluster) (increase(credential_refresher_days_until_msi_credential_expiration_bucket{le=~"^0([.]0)?$"}[30m])) > 0
       for: 5m
       labels:
-        severity: critical
+        severity: warning
       annotations:
         description: 'Credential(s) for customer cluster monitored by {{ $labels.cluster }} are expiring in less than 30 days.'
         summary: 'Customer cluster credential expiring in less than 30 days'
@@ -22,7 +22,7 @@ spec:
       expr: sum by (cluster) (increase(credential_refresher_days_until_msi_credential_expiration_bucket{le=~"^0([.]0)?$"}[30m])) - sum by (cluster) (increase(credential_refresher_days_until_msi_credential_expiration_bucket{le=~"^-90([.]0)?$"}[30m])) > 0
       for: 5m
       labels:
-        severity: critical
+        severity: warning
       annotations:
         description: 'Credential(s) for customer cluster monitored by {{ $labels.cluster }} expired.'
         summary: 'Customer cluster credential expired'
@@ -32,7 +32,7 @@ spec:
       expr: sum by (cluster) (increase(credential_refresher_days_until_msi_credential_expiration_bucket{le=~"^-90([.]0)?$"}[30m])) > 0
       for: 5m
       labels:
-        severity: critical
+        severity: warning
       annotations:
         description: 'Credential(s) for customer cluster monitored by {{ $labels.cluster }} are no longer renewable.'
         summary: 'Customer cluster credential is no longer renewable'

--- a/observability/alerts/msi-credential-refresher-prometheusRule_test.yaml
+++ b/observability/alerts/msi-credential-refresher-prometheusRule_test.yaml
@@ -16,7 +16,7 @@ tests:
     alertname: ClusterCredentialExpiringSoon
     exp_alerts:
     - exp_labels:
-        severity: critical
+        severity: warning
         cluster: test-cluster
       exp_annotations:
         description: 'Credential(s) for customer cluster monitored by test-cluster are expiring in less than 30 days.'
@@ -45,7 +45,7 @@ tests:
     alertname: ClusterCredentialNotRenewable
     exp_alerts:
     - exp_labels:
-        severity: critical
+        severity: warning
         cluster: test-cluster
       exp_annotations:
         description: 'Credential(s) for customer cluster monitored by test-cluster are no longer renewable.'
@@ -74,7 +74,7 @@ tests:
     alertname: ClusterCredentialExpired
     exp_alerts:
     - exp_labels:
-        severity: critical
+        severity: warning
         cluster: test-cluster
       exp_annotations:
         description: 'Credential(s) for customer cluster monitored by test-cluster expired.'
@@ -115,7 +115,7 @@ tests:
     alertname: ClusterCredentialExpiringSoon
     exp_alerts:
     - exp_labels:
-        severity: critical
+        severity: warning
         cluster: test-cluster
       exp_annotations:
         description: 'Credential(s) for customer cluster monitored by test-cluster are expiring in less than 30 days.'
@@ -132,7 +132,7 @@ tests:
     alertname: ClusterCredentialNotRenewable
     exp_alerts:
     - exp_labels:
-        severity: critical
+        severity: warning
         cluster: test-cluster
       exp_annotations:
         description: 'Credential(s) for customer cluster monitored by test-cluster are no longer renewable.'
@@ -152,7 +152,7 @@ tests:
     alertname: ClusterCredentialExpired
     exp_alerts:
     - exp_labels:
-        severity: critical
+        severity: warning
         cluster: test-cluster
       exp_annotations:
         description: 'Credential(s) for customer cluster monitored by test-cluster expired.'


### PR DESCRIPTION
[ARO-28257](https://redhat.atlassian.net/browse/ARO-28257)

### What

Downgrading credential refresher alerts from sev2 -> sev3

### Why

These are quite noisy at the moment because there are some deleted clusters that have secrets that aren't cleaned up. I never really intended for this to be a sev2

### Testing

Updated the alert unit tests

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [x] All comment threads resolved before merge

If E2E tests are included:

- [x] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [x] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
