### PR TITLE
feat: add maestro server queue alerts and panels

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
@@ -990,6 +990,60 @@ resource maestro 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
         for: 'PT15M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'MaestroPostgresNotificationQueueUsageHigh'
+        enabled: true
+        labels: {
+          severity: 'warning'
+        }
+        annotations: {
+          correlationId: 'MaestroPostgresNotificationQueueUsageHigh/{{ $labels.cluster }}'
+          description: 'Maestro PostgreSQL notification queue usage is above 50% for the last 5 minutes. Current value: {{ $value | humanizePercentage }}. If the queue fills up, NOTIFY calls will block and event processing will stall.'
+          info: 'Maestro PostgreSQL notification queue usage is above 50% for the last 5 minutes. Current value: {{ $value | humanizePercentage }}. If the queue fills up, NOTIFY calls will block and event processing will stall.'
+          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/maestro/index.html'
+          summary: 'Maestro PostgreSQL notification queue usage is high'
+          title: 'Maestro PostgreSQL notification queue usage is high'
+        }
+        expression: 'max(postgres_notification_queue_usage{namespace="maestro"}) > 0.5'
+        for: 'PT5M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'MaestroWorkqueueDepthHigh'
+        enabled: true
+        labels: {
+          severity: 'warning'
+        }
+        annotations: {
+          correlationId: 'MaestroWorkqueueDepthHigh/{{ $labels.cluster }}/{{ $labels.queue_name }}'
+          description: 'Maestro workqueue {{ $labels.queue_name }} depth is {{ $value }}, sustained above 100 for 10 minutes. Events are not being processed fast enough.'
+          info: 'Maestro workqueue {{ $labels.queue_name }} depth is {{ $value }}, sustained above 100 for 10 minutes. Events are not being processed fast enough.'
+          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/maestro/index.html'
+          summary: 'Maestro workqueue depth is high'
+          title: 'Maestro workqueue depth is high queue_name:{{ $labels.queue_name }}'
+        }
+        expression: 'max by (queue_name) (workqueue_depth{namespace="maestro",queue_name!=""}) > 100'
+        for: 'PT10M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
     ]
     scopes: [
       azureMonitoring

--- a/maestro/alerts/maestro-prometheusRule.yaml
+++ b/maestro/alerts/maestro-prometheusRule.yaml
@@ -116,3 +116,35 @@ spec:
         description: 'At least one maestro-server replica has been NotReady for 15 minutes (available {{ $value }} below desired). Readiness is gated on Postgres connectivity, so a persistently NotReady replica usually indicates database connectivity problems.'
         runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/maestro/index.html'
         summary: 'A maestro-server replica is not Ready'
+    - alert: MaestroPostgresNotificationQueueUsageHigh
+      # Fires when the PostgreSQL notification queue usage exceeds 50%.
+      # The notification queue is a fixed-size 8GB buffer shared across
+      # all connections. If it fills up, NOTIFY calls block, stalling
+      # event processing for both spec and status controllers. A
+      # sustained high usage indicates listeners are not draining
+      # notifications fast enough.
+      expr: |
+        max(postgres_notification_queue_usage{namespace="maestro"}) > 0.5
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        description: 'Maestro PostgreSQL notification queue usage is above 50% for the last 5 minutes. Current value: {{ $value | humanizePercentage }}. If the queue fills up, NOTIFY calls will block and event processing will stall.'
+        runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/maestro/index.html'
+        summary: 'Maestro PostgreSQL notification queue usage is high'
+    - alert: MaestroWorkqueueDepthHigh
+      # Fires when a maestro workqueue depth stays above 100 for 10
+      # minutes. The workqueues buffer events between NOTIFY receipt
+      # and controller reconciliation. A sustained high depth means
+      # the controller is not keeping up — possibly due to a burst
+      # of resynced events after a lost NOTIFY, slow reconciliation,
+      # or database contention.
+      expr: |
+        max by(queue_name) (workqueue_depth{namespace="maestro", queue_name!=""}) > 100
+      for: 10m
+      labels:
+        severity: warning
+      annotations:
+        description: 'Maestro workqueue {{ $labels.queue_name }} depth is {{ $value }}, sustained above 100 for 10 minutes. Events are not being processed fast enough.'
+        runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/maestro/index.html'
+        summary: 'Maestro workqueue depth is high'

--- a/maestro/alerts/maestro-prometheusRule_test.yaml
+++ b/maestro/alerts/maestro-prometheusRule_test.yaml
@@ -180,4 +180,52 @@ tests:
   alert_rule_test:
   - eval_time: 16m
     alertname: MaestroServerReplicaNotReady
+# Test: MaestroPostgresNotificationQueueUsageHigh fires when usage > 50%
+- interval: 1m
+  input_series:
+  - series: 'postgres_notification_queue_usage{namespace="maestro"}'
+    values: "0.6x10" # 60% usage sustained for 10 minutes
+  alert_rule_test:
+  - eval_time: 6m
+    alertname: MaestroPostgresNotificationQueueUsageHigh
+    exp_alerts:
+    - exp_labels:
+        severity: warning
+      exp_annotations:
+        description: 'Maestro PostgreSQL notification queue usage is above 50% for the last 5 minutes. Current value: 60%. If the queue fills up, NOTIFY calls will block and event processing will stall.'
+        runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/maestro/index.html'
+        summary: 'Maestro PostgreSQL notification queue usage is high'
+# Test: MaestroPostgresNotificationQueueUsageHigh does not fire when usage <= 50%
+- interval: 1m
+  input_series:
+  - series: 'postgres_notification_queue_usage{namespace="maestro"}'
+    values: "0.3x10" # 30% usage (within normal range)
+  alert_rule_test:
+  - eval_time: 6m
+    alertname: MaestroPostgresNotificationQueueUsageHigh
+    exp_alerts: []
+# Test: MaestroWorkqueueDepthHigh fires when depth > 100 for 10m
+- interval: 1m
+  input_series:
+  - series: 'workqueue_depth{namespace="maestro", queue_name="event-controller"}'
+    values: "150x15" # 150 items sustained for 15 minutes
+  alert_rule_test:
+  - eval_time: 11m
+    alertname: MaestroWorkqueueDepthHigh
+    exp_alerts:
+    - exp_labels:
+        severity: warning
+        queue_name: event-controller
+      exp_annotations:
+        description: 'Maestro workqueue event-controller depth is 150, sustained above 100 for 10 minutes. Events are not being processed fast enough.'
+        runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/maestro/index.html'
+        summary: 'Maestro workqueue depth is high'
+# Test: MaestroWorkqueueDepthHigh does not fire when depth <= 100
+- interval: 1m
+  input_series:
+  - series: 'workqueue_depth{namespace="maestro", queue_name="event-controller"}'
+    values: "50x15" # 50 items (within normal range)
+  alert_rule_test:
+  - eval_time: 11m
+    alertname: MaestroWorkqueueDepthHigh
     exp_alerts: []

--- a/observability/grafana-dashboards/maestro/maestro-server.json
+++ b/observability/grafana-dashboards/maestro/maestro-server.json
@@ -978,6 +978,220 @@
       ],
       "title": "REST API Inbound Request Duration",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line+area"
+            }
+          },
+          "max": 1,
+          "min": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.5
+              },
+              {
+                "color": "red",
+                "value": 0.9
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 23
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "max(postgres_notification_queue_usage{namespace=\"maestro\"})",
+          "instant": false,
+          "legendFormat": "queue usage",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "PostgreSQL Notification Queue Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line+area"
+            }
+          },
+          "min": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 100
+              },
+              {
+                "color": "red",
+                "value": 1000
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 23
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "max by(queue_name) (workqueue_depth{namespace=\"maestro\", queue_name!=\"\"})",
+          "instant": false,
+          "legendFormat": "{{queue_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Work Queue Depth",
+      "type": "timeseries"
     }
   ],
   "preload": false,


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-26755

### What

This PR adds two alerts and alerts and two new panels to the maestro dashboard related to queue length metrics.

1. postgres_notification_queue_usage - A gauge for reporting queue usage of the postegres NOTIFY queue.  This metric should be at or very near 0 during normal operation, and a value of > 0.5 (1 being the max) will produce a warning alert.
2. workqueue_depth - A gauge reporting the depth of the in-memory work queue used by maestro to process spec and status events.

PostgresSQL Notification Queue Usage and Work Queue Depth panels were also added to the maestro server dashboard:
<img width="974" height="835" alt="image" src="https://github.com/user-attachments/assets/9d2812fb-d0a1-490e-befe-14050424ba19" />

### Why

Issues have been observed with maestro's processing of spec and status events, and it is hoped that these metrics will aide in diagnosing these issues.

### Testing

Unit tests were added for the alerts.  Integration tests were also added to maestro for the postgres_notification_queue_usage metric.

Manual testing was performed in a personal dev environment to test the dashboards.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [x] All comment threads resolved before merge
