### PR TITLE
feat: add generic memory drift and trend alerts for ARO-HCP services

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedKustoOnlyServicePrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedKustoOnlyServicePrometheusAlertingRules.bicep
@@ -1737,3 +1737,86 @@ resource svcFrontendPathLatency 'Microsoft.AlertsManagement/prometheusRuleGroups
     ]
   }
 }
+
+resource svcServiceMemoryResourcesRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'svc-service-memory-resources-rules'
+  location: location
+  properties: {
+    interval: 'PT1M'
+    rules: [
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'ServiceMemoryDrift'
+        enabled: true
+        labels: {
+          component: 'service-memory'
+          severity: 'warning'
+          team: 'hcp-sl'
+        }
+        annotations: {
+          correlationId: 'ServiceMemoryDrift/{{ $labels.cluster }}/{{ $labels.container }}/{{ $labels.pod }}/{{ $labels.namespace }}'
+          description: '''Container {{ $labels.container }} in pod {{ $labels.pod }} (namespace {{ $labels.namespace }}) on cluster {{ $labels.cluster }} is using {{ $value | humanizePercentage }} of its memory request for more than 15 minutes.
+This may indicate a memory leak or workload growth that requires right-sizing the request in config.yaml.
+'''
+          info: '''Container {{ $labels.container }} in pod {{ $labels.pod }} (namespace {{ $labels.namespace }}) on cluster {{ $labels.cluster }} is using {{ $value | humanizePercentage }} of its memory request for more than 15 minutes.
+This may indicate a memory leak or workload growth that requires right-sizing the request in config.yaml.
+'''
+          owning_team: 'hcp-sl'
+          runbook_url: 'https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/service-memory-resources.md'
+          summary: '{{ $labels.container }} in {{ $labels.namespace }} exceeds 1.5x its memory request on cluster {{ $labels.cluster }}. pod:{{ $labels.pod }}'
+          title: '{{ $labels.container }} in {{ $labels.namespace }} exceeds 1.5x its memory request on cluster {{ $labels.cluster }}. pod:{{ $labels.pod }}'
+        }
+        expression: '(container_memory_working_set_bytes{container!="",namespace=~"aro-hcp|aro-hcp-admin-api|aro-hcp-exporter|clusters-service|fleet|kube-applier|maestro|mgmt-agent|prometheus|secret-sync-controller|sessiongate"} / on (namespace, pod, container, cluster) group_left () max by (namespace, pod, container, cluster) (kube_pod_container_resource_requests{job="kube-state-metrics",namespace=~"aro-hcp|aro-hcp-admin-api|aro-hcp-exporter|clusters-service|fleet|kube-applier|maestro|mgmt-agent|prometheus|secret-sync-controller|sessiongate",resource="memory"})) > 1.5'
+        for: 'PT15M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'ServiceMemoryTrend'
+        enabled: true
+        labels: {
+          component: 'service-memory'
+          severity: 'info'
+          team: 'hcp-sl'
+        }
+        annotations: {
+          correlationId: 'ServiceMemoryTrend/{{ $labels.cluster }}/{{ $labels.container }}/{{ $labels.pod }}/{{ $labels.namespace }}'
+          description: '''Container {{ $labels.container }} in pod {{ $labels.pod }} (namespace {{ $labels.namespace }}) on cluster {{ $labels.cluster }} memory is growing steadily.
+At the current rate over the past 6 hours, it will exceed 2x its memory request within 4 hours.
+Investigate for potential memory leaks or increased workload.
+'''
+          info: '''Container {{ $labels.container }} in pod {{ $labels.pod }} (namespace {{ $labels.namespace }}) on cluster {{ $labels.cluster }} memory is growing steadily.
+At the current rate over the past 6 hours, it will exceed 2x its memory request within 4 hours.
+Investigate for potential memory leaks or increased workload.
+'''
+          owning_team: 'hcp-sl'
+          runbook_url: 'https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/service-memory-resources.md'
+          summary: '{{ $labels.container }} in {{ $labels.namespace }} memory trending toward 2x its request on cluster {{ $labels.cluster }}. pod:{{ $labels.pod }}'
+          title: '{{ $labels.container }} in {{ $labels.namespace }} memory trending toward 2x its request on cluster {{ $labels.cluster }}. pod:{{ $labels.pod }}'
+        }
+        expression: '(predict_linear(container_memory_working_set_bytes{container!="",namespace=~"aro-hcp|aro-hcp-admin-api|aro-hcp-exporter|clusters-service|fleet|kube-applier|maestro|mgmt-agent|prometheus|secret-sync-controller|sessiongate"}[6h], 4 * 3600) / on (namespace, pod, container, cluster) group_left () max by (namespace, pod, container, cluster) (kube_pod_container_resource_requests{job="kube-state-metrics",namespace=~"aro-hcp|aro-hcp-admin-api|aro-hcp-exporter|clusters-service|fleet|kube-applier|maestro|mgmt-agent|prometheus|secret-sync-controller|sessiongate",resource="memory"})) > 2'
+        for: 'PT30M'
+        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
+      }
+    ]
+    scopes: [
+      azureMonitoring
+    ]
+  }
+}

--- a/docs/alerts/service-memory-resources.md
+++ b/docs/alerts/service-memory-resources.md
@@ -1,0 +1,73 @@
+# Service Memory Resource Alerts
+
+These alerts detect when any ARO-HCP service's actual memory usage drifts above
+its configured request, catching growth before it leads to OOM kills or
+evictions. Memory requests are configured per-service in `config/config.yaml`
+under each service's `resources.requests.memory` field.
+
+## The alerts at a glance
+
+- **`ServiceMemoryDrift`** (warning / SEV 3, `for: 15m`) — fires when a
+  container's working set exceeds 1.5× its memory request for 15 minutes.
+- **`ServiceMemoryTrend`** (info / SEV 4, `for: 30m`) — fires when
+  `predict_linear` over a 6-hour window projects a container's memory will
+  exceed 2× its request within 4 hours.
+
+## Scope
+
+These alerts cover all ARO-HCP service namespaces:
+`aro-hcp`, `aro-hcp-admin-api`, `aro-hcp-exporter`, `clusters-service`,
+`fleet`, `kube-applier`, `maestro`, `mgmt-agent`, `secret-sync-controller`,
+`sessiongate`.
+
+Only containers with a configured memory request will fire (the PromQL join
+against `kube_pod_container_resource_requests` naturally excludes untuned
+services).
+
+## What causes these alerts to fire
+
+- **Memory leak** in the service or one of its dependencies.
+- **Workload growth** — more traffic, more clusters, larger payloads.
+- **Request set too low** — the initial sizing was based on a lighter workload
+  than production now runs.
+
+## Investigation steps
+
+1. **Confirm the alert is genuine** — open the Ad-hoc Explorer dashboard in
+   Grafana and query:
+   ```promql
+   container_memory_working_set_bytes{container="<container>", namespace="<namespace>"}
+   ```
+   Compare to the configured request value from `config/config.yaml`.
+
+2. **Check for recent changes** — query Kusto for recent deployments or version
+   changes of the affected service on the affected cluster. Check whether
+   traffic or workload volume has recently increased.
+
+3. **Check pod restarts via Kusto** — query `KubePodInventory` for the service
+   namespace on the affected cluster to check restart counts and OOMKill events.
+   Frequent restarts combined with this alert suggest a memory leak.
+
+4. **Look at the growth pattern**:
+   - Sudden jump → likely a new workload or config change.
+   - Steady linear growth → likely a memory leak.
+   - Stepped increases over days → workload growth.
+
+## Remediation
+
+- **Right-size the request**: If usage has legitimately grown, update the memory
+  request in `config/config.yaml` for the affected service and roll out. The
+  request should be set to observed peak usage × 1.25 safety margin.
+- **Investigate a leak**: If growth is unbounded and linear, file a bug against
+  the affected service and consider adding a memory limit as a short-term
+  guardrail.
+- **Scale out**: If the growth is proportional to workload volume, this is
+  expected — consider horizontal scaling or workload rebalancing.
+
+## Related
+
+- Parent epic: [AROSLSRE-1027](https://redhat.atlassian.net/browse/AROSLSRE-1027) —
+  Resource management for ARO-HCP components
+- Ticket: [AROSLSRE-1564](https://redhat.atlassian.net/browse/AROSLSRE-1564) —
+  Generic memory drift/trend alerting for all ARO-HCP services
+- Alert source: `observability/alerts/serviceMemoryResources-prometheusRule.yaml`

--- a/observability/alerts-kusto-services.yaml
+++ b/observability/alerts-kusto-services.yaml
@@ -1,6 +1,7 @@
 prometheusRules:
   rulesFolders:
   - ../frontend/alerts/frontend-path-latency-prometheusRule.yaml
+  - alerts/serviceMemoryResources-prometheusRule.yaml
   untestedRules:
   - alerts/kubernetesControlPlane-prometheusRule.yaml
   outputBicep: ../dev-infrastructure/modules/metrics/rules/generatedKustoOnlyServicePrometheusAlertingRules.bicep

--- a/observability/alerts/serviceMemoryResources-prometheusRule.yaml
+++ b/observability/alerts/serviceMemoryResources-prometheusRule.yaml
@@ -1,0 +1,63 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app.kubernetes.io/name: kube-prometheus
+    app.kubernetes.io/part-of: kube-prometheus
+    prometheus: k8s
+    role: alert-rules
+  name: service-memory-resources-rules
+  namespace: monitoring
+spec:
+  groups:
+  - name: service-memory-resources-rules
+    labels:
+      component: service-memory
+    rules:
+    # Owner: Service Lifecycle team (hcp-sl)
+    # AROSLSRE-1564: Generic memory drift/trend alerting for all ARO-HCP services
+    # Only containers with a configured memory request will match the join;
+    # services without a request are naturally excluded.
+    - alert: ServiceMemoryDrift
+      expr: |
+        (
+          container_memory_working_set_bytes{container!="", namespace=~"aro-hcp|aro-hcp-admin-api|aro-hcp-exporter|clusters-service|fleet|kube-applier|maestro|mgmt-agent|prometheus|secret-sync-controller|sessiongate"}
+          / on(namespace, pod, container, cluster) group_left()
+          max by(namespace, pod, container, cluster) (
+            kube_pod_container_resource_requests{resource="memory", job="kube-state-metrics", namespace=~"aro-hcp|aro-hcp-admin-api|aro-hcp-exporter|clusters-service|fleet|kube-applier|maestro|mgmt-agent|prometheus|secret-sync-controller|sessiongate"}
+          )
+        ) > 1.5
+      for: 15m
+      labels:
+        severity: warning
+        team: hcp-sl
+      annotations:
+        summary: '{{ $labels.container }} in {{ $labels.namespace }} exceeds 1.5x its memory request on cluster {{ $labels.cluster }}. pod:{{ $labels.pod }}'
+        description: |
+          Container {{ $labels.container }} in pod {{ $labels.pod }} (namespace {{ $labels.namespace }}) on cluster {{ $labels.cluster }} is using {{ $value | humanizePercentage }} of its memory request for more than 15 minutes.
+          This may indicate a memory leak or workload growth that requires right-sizing the request in config.yaml.
+        runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/service-memory-resources.md
+        owning_team: hcp-sl
+    - alert: ServiceMemoryTrend
+      expr: |
+        (
+          predict_linear(
+            container_memory_working_set_bytes{container!="", namespace=~"aro-hcp|aro-hcp-admin-api|aro-hcp-exporter|clusters-service|fleet|kube-applier|maestro|mgmt-agent|prometheus|secret-sync-controller|sessiongate"}[6h], 4 * 3600
+          )
+          / on(namespace, pod, container, cluster) group_left()
+          max by(namespace, pod, container, cluster) (
+            kube_pod_container_resource_requests{resource="memory", job="kube-state-metrics", namespace=~"aro-hcp|aro-hcp-admin-api|aro-hcp-exporter|clusters-service|fleet|kube-applier|maestro|mgmt-agent|prometheus|secret-sync-controller|sessiongate"}
+          )
+        ) > 2.0
+      for: 30m
+      labels:
+        severity: info
+        team: hcp-sl
+      annotations:
+        summary: '{{ $labels.container }} in {{ $labels.namespace }} memory trending toward 2x its request on cluster {{ $labels.cluster }}. pod:{{ $labels.pod }}'
+        description: |
+          Container {{ $labels.container }} in pod {{ $labels.pod }} (namespace {{ $labels.namespace }}) on cluster {{ $labels.cluster }} memory is growing steadily.
+          At the current rate over the past 6 hours, it will exceed 2x its memory request within 4 hours.
+          Investigate for potential memory leaks or increased workload.
+        runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/service-memory-resources.md
+        owning_team: hcp-sl

--- a/observability/alerts/serviceMemoryResources-prometheusRule_test.yaml
+++ b/observability/alerts/serviceMemoryResources-prometheusRule_test.yaml
@@ -1,0 +1,120 @@
+rule_files:
+- serviceMemoryResources-prometheusRule.yaml
+evaluation_interval: 1m
+tests:
+# ServiceMemoryDrift - alert fires when usage > 1.5x request (using frontend as example)
+- interval: 1m
+  input_series:
+  - series: 'container_memory_working_set_bytes{container="frontend", namespace="aro-hcp", pod="frontend-0", cluster="test"}'
+    values: "220200960+0x20"
+  - series: 'kube_pod_container_resource_requests{container="frontend", namespace="aro-hcp", pod="frontend-0", cluster="test", resource="memory", job="kube-state-metrics"}'
+    values: "134217728+0x20"
+  alert_rule_test:
+  - eval_time: 15m
+    alertname: ServiceMemoryDrift
+    exp_alerts:
+    - exp_labels:
+        alertname: ServiceMemoryDrift
+        severity: warning
+        team: hcp-sl
+        component: service-memory
+        cluster: test
+        container: frontend
+        namespace: aro-hcp
+        pod: frontend-0
+      exp_annotations:
+        summary: frontend in aro-hcp exceeds 1.5x its memory request on cluster test. pod:frontend-0
+        description: |
+          Container frontend in pod frontend-0 (namespace aro-hcp) on cluster test is using 164.1% of its memory request for more than 15 minutes.
+          This may indicate a memory leak or workload growth that requires right-sizing the request in config.yaml.
+        runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/service-memory-resources.md
+        owning_team: hcp-sl
+# ServiceMemoryDrift - no alert when usage is below 1.5x
+- interval: 1m
+  input_series:
+  - series: 'container_memory_working_set_bytes{container="frontend", namespace="aro-hcp", pod="frontend-0", cluster="test"}'
+    values: "134217728+0x20"
+  - series: 'kube_pod_container_resource_requests{container="frontend", namespace="aro-hcp", pod="frontend-0", cluster="test", resource="memory", job="kube-state-metrics"}'
+    values: "134217728+0x20"
+  alert_rule_test:
+  - eval_time: 15m
+    alertname: ServiceMemoryDrift
+    exp_alerts: []
+# ServiceMemoryDrift - alert fires for kube-applier namespace too
+- interval: 1m
+  input_series:
+  - series: 'container_memory_working_set_bytes{container="kube-applier", namespace="kube-applier", pod="kube-applier-0", cluster="test"}'
+    values: "220200960+0x20"
+  - series: 'kube_pod_container_resource_requests{container="kube-applier", namespace="kube-applier", pod="kube-applier-0", cluster="test", resource="memory", job="kube-state-metrics"}'
+    values: "134217728+0x20"
+  alert_rule_test:
+  - eval_time: 15m
+    alertname: ServiceMemoryDrift
+    exp_alerts:
+    - exp_labels:
+        alertname: ServiceMemoryDrift
+        severity: warning
+        team: hcp-sl
+        component: service-memory
+        cluster: test
+        container: kube-applier
+        namespace: kube-applier
+        pod: kube-applier-0
+      exp_annotations:
+        summary: kube-applier in kube-applier exceeds 1.5x its memory request on cluster test. pod:kube-applier-0
+        description: |
+          Container kube-applier in pod kube-applier-0 (namespace kube-applier) on cluster test is using 164.1% of its memory request for more than 15 minutes.
+          This may indicate a memory leak or workload growth that requires right-sizing the request in config.yaml.
+        runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/service-memory-resources.md
+        owning_team: hcp-sl
+# ServiceMemoryDrift - no alert for namespaces outside the regex
+- interval: 1m
+  input_series:
+  - series: 'container_memory_working_set_bytes{container="coredns", namespace="kube-system", pod="coredns-0", cluster="test"}'
+    values: "220200960+0x20"
+  - series: 'kube_pod_container_resource_requests{container="coredns", namespace="kube-system", pod="coredns-0", cluster="test", resource="memory", job="kube-state-metrics"}'
+    values: "134217728+0x20"
+  alert_rule_test:
+  - eval_time: 15m
+    alertname: ServiceMemoryDrift
+    exp_alerts: []
+# ServiceMemoryTrend - alert fires when predict_linear projects > 2x request
+- interval: 1m
+  input_series:
+  - series: 'container_memory_working_set_bytes{container="maestro", namespace="maestro", pod="maestro-0", cluster="test"}'
+    # Starts at 134217728 (128Mi) and grows by 1048576 (1Mi) per minute over 6h+30m
+    values: "134217728+1048576x390"
+  - series: 'kube_pod_container_resource_requests{container="maestro", namespace="maestro", pod="maestro-0", cluster="test", resource="memory", job="kube-state-metrics"}'
+    values: "134217728+0x390"
+  alert_rule_test:
+  - eval_time: 390m
+    alertname: ServiceMemoryTrend
+    exp_alerts:
+    - exp_labels:
+        alertname: ServiceMemoryTrend
+        severity: info
+        team: hcp-sl
+        component: service-memory
+        cluster: test
+        container: maestro
+        namespace: maestro
+        pod: maestro-0
+      exp_annotations:
+        summary: maestro in maestro memory trending toward 2x its request on cluster test. pod:maestro-0
+        description: |
+          Container maestro in pod maestro-0 (namespace maestro) on cluster test memory is growing steadily.
+          At the current rate over the past 6 hours, it will exceed 2x its memory request within 4 hours.
+          Investigate for potential memory leaks or increased workload.
+        runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/service-memory-resources.md
+        owning_team: hcp-sl
+# ServiceMemoryTrend - no alert when memory is stable
+- interval: 1m
+  input_series:
+  - series: 'container_memory_working_set_bytes{container="maestro", namespace="maestro", pod="maestro-0", cluster="test"}'
+    values: "134217728+0x390"
+  - series: 'kube_pod_container_resource_requests{container="maestro", namespace="maestro", pod="maestro-0", cluster="test", resource="memory", job="kube-state-metrics"}'
+    values: "134217728+0x390"
+  alert_rule_test:
+  - eval_time: 390m
+    alertname: ServiceMemoryTrend
+    exp_alerts: []


### PR DESCRIPTION
## Summary

Add two generic PrometheusRule alerts (ServiceMemoryDrift, ServiceMemoryTrend) that cover all ARO-HCP service namespaces. Any container with a configured memory request will be monitored for drift and growth trends — services without a request are naturally excluded.

- ServiceMemoryDrift (warning): fires when working set exceeds 1.5x the memory request for 15 minutes
- ServiceMemoryTrend (info): fires when predict_linear over 6h projects memory will exceed 2x the request within 4 hours

Ref: [AROSLSRE-1564](https://issues.redhat.com/browse/AROSLSRE-1564)

## What

- Generic alerts scoped by namespace regex covering: aro-hcp, aro-hcp-admin-api, aro-hcp-exporter, clusters-service, fleet, kube-applier, maestro, mgmt-agent, prometheus, secret-sync-controller, sessiongate
- Runbook at `docs/alerts/service-memory-resources.md`
- promtool unit tests for multiple services (frontend, kube-applier, maestro) plus a negative test for excluded namespaces

## Why

Per reviewer feedback on the original kube-applier-specific version, the alert logic is identical across all services and should be parameterized once rather than duplicated per component. Services without a memory request naturally don't match (no `kube_pod_container_resource_requests` series), so there is no noise risk.

This is part of [AROSLSRE-1027](https://issues.redhat.com/browse/AROSLSRE-1027) P1 (drift/trend alerting).

## Testing

- promtool unit tests included (`observability/alerts/serviceMemoryResources-prometheusRule_test.yaml`)
- `make alerts` passes (generates bicep and runs promtool tests)
- alert-tester eval against production data: TBD

## Special notes for your reviewer

This supersedes the earlier kube-applier-specific alerts per Steve's review comment. The new ticket is [AROSLSRE-1564](https://issues.redhat.com/browse/AROSLSRE-1564).

## PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WiP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge