### PR TITLE
fix: add automatedRetry to Kusto deploy steps in geography pipelines

### DIFF
--- a/dev-infrastructure/geography-pipeline-stg.yaml
+++ b/dev-infrastructure/geography-pipeline-stg.yaml
@@ -32,3 +32,9 @@ resourceGroups:
     template: templates/kusto.bicep
     parameters: configurations/kusto-stg.tmpl.bicepparam
     deploymentLevel: ResourceGroup
+    automatedRetry:
+      errorContainsAny:
+      - "InternalServerError"
+      - "Internal server error"
+      maximumRetryCount: 3
+      durationBetweenRetries: 1m

--- a/dev-infrastructure/geography-pipeline.yaml
+++ b/dev-infrastructure/geography-pipeline.yaml
@@ -39,3 +39,9 @@ resourceGroups:
     template: templates/kusto.bicep
     parameters: configurations/kusto.tmpl.bicepparam
     deploymentLevel: ResourceGroup
+    automatedRetry:
+      errorContainsAny:
+      - "InternalServerError"
+      - "Internal server error"
+      maximumRetryCount: 3
+      durationBetweenRetries: 1m


### PR DESCRIPTION
[AROSLSRE-1461](https://redhat.atlassian.net/browse/AROSLSRE-1461)

### What

Add `automatedRetry` configuration to the Kusto ARM deploy steps in `geography-pipeline.yaml` and `geography-pipeline-stg.yaml`.

### Why

During a prod Global Resource Rollout, the Kusto RP returned a transient 500 "Internal server error" on the first deployment attempt. Because the Kusto deploy step had no `automatedRetry` configured, EV2 fell through to manual mitigation instead of auto-retrying. The delayed manual retry then hit the Kusto RP in a bad state where it accepted but never completed script resource creation — causing a 20+ hour hang.

Other ARM deployment steps in `svc-pipeline.yaml` and `mgmt-pipeline.yaml` already retry on `InternalServerError` / `Internal server error`, but the geography pipeline Kusto steps were missing this config.

### Testing

No code changes — YAML-only pipeline config. Validated with `make validate-config-pipelines` (passes).

No unit/integration/E2E tests needed: this is a declarative retry policy consumed by EV2.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes) — N/A
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide) — will verify after PR creation
- [ ] Draft PR used for WIP (if applicable) — N/A, ready
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented — N/A, declarative YAML
- [ ] Specific reviewers tagged
- [x] All comment threads resolved before merge