### PR TITLE
feat: add KeyVaultCryptoOfficer assignment to CI bot

### DIFF
--- a/dev-infrastructure/openshift-ci/grant-openshift-release-bot-dev.sh
+++ b/dev-infrastructure/openshift-ci/grant-openshift-release-bot-dev.sh
@@ -147,6 +147,14 @@ for SUBSCRIPTION_NAME in "${SUBSCRIPTIONS[@]}"; do
     if [[ "${SUBSCRIPTION_NAME}" == "${GLOBAL_SUBSCRIPTION_NAME}" ]]; then
         GLOBAL_SUBSCRIPTION_ID="${SUBSCRIPTION_ID}"
     fi
+
+    # Assign Key Vault Crypto Officer for calling Key Vault data plane directly
+    # Used for create/enable/update/delete keys
+    echo "  Assigning Key Vault Crypto Officer role..."
+    az role assignment create \
+        --assignee "${APP_ID}" \
+        --role "Key Vault Crypto Officer" \
+        --scope "/subscriptions/${SUBSCRIPTION_ID}" 2>/dev/null || echo "    (already assigned)"
 done
 
 if [[ -z "${GLOBAL_SUBSCRIPTION_ID:-}" ]]; then

--- a/dev-infrastructure/templates/ci-bot-rbac-subscription.bicep
+++ b/dev-infrastructure/templates/ci-bot-rbac-subscription.bicep
@@ -19,6 +19,8 @@ var userAccessAdminRole = '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9'
 var keyVaultAdminRole = '00482a5a-887f-4fb3-b363-3b7fe8e74483'
 var grafanaAdminRole = '22926164-76b3-42b3-bc55-97df8dab3e41'
 
+var keyVaultCryptoOfficerRole = '14b46e9e-c2b7-41b4-b07b-48a6ebf60603'
+
 resource contributorAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   name: guid(subscription().id, botPrincipalId, contributorRole)
   scope: subscription()
@@ -69,5 +71,15 @@ resource grafanaAdminAssignment 'Microsoft.Authorization/roleAssignments@2022-04
     principalId: botPrincipalId
     principalType: 'ServicePrincipal'
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', grafanaAdminRole)
+  }
+}
+
+resource keyVaultCryptoOfficerAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(subscription().id, botPrincipalId, keyVaultCryptoOfficerRole)
+  scope: subscription()
+  properties: {
+    principalId: botPrincipalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', keyVaultCryptoOfficerRole)
   }
 }


### PR DESCRIPTION
### What

Assign KeyVaultCryptoOfficer role to the CI Bot. This is the more restrictive role that grants data plane keyVault permissions.

### Why

New E2E tests (introduced in this PR https://github.com/Azure/ARO-HCP/pull/5629) requires of keyVault data plane permissions to create/rotate/disable keys in the "customer" keyVault

### Testing
I am not sure if this requires any test.

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

