### PR TITLE
fix(observability): alert on old prod e2e clusters

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
@@ -1549,6 +1549,35 @@ resource hcpTestClustersRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2
         for: 'PT5M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'ProdE2EHCPClusterOlderThan3Hours'
+        enabled: true
+        labels: {
+          severity: '3'
+        }
+        annotations: {
+          correlationId: 'ProdE2EClusterOlderThan3Hours{{ $labels.resource_id }}'
+          description: '''Prod e2e HCP cluster {{ $labels.resource_id }} in subscription {{ $labels.subscription_id }} on service cluster {{ $labels.cluster }} has existed for more than 3 hours.
+'''
+          info: '''Prod e2e HCP cluster {{ $labels.resource_id }} in subscription {{ $labels.subscription_id }} on service cluster {{ $labels.cluster }} has existed for more than 3 hours.
+'''
+          runbook_url: 'TBD'
+          summary: 'Prod e2e HCP is older than 3h'
+          title: 'Prod e2e HCP is older than 3h resource_id:{{ $labels.resource_id }} subscription_id:{{ $labels.subscription_id }} cluster:{{ $labels.cluster }}'
+        }
+        expression: 'max by (cluster, resource_id, environment, subscription_id) (time() - backend_cluster_created_time_seconds{environment="prod",subscription_id=~"403d9de9-132b-4974-94a5-5b78bdfa191e|8d696692-794f-4cdb-ba25-9250c9e9ec4c|ec435068-e722-475f-8504-c91b72a5dc51"}) > 3 * 3600'
+        for: 'PT5M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
     ]
     scopes: [
       azureMonitoring

--- a/observability/alerts/hcp-test-clusters-prometheusRule.yaml
+++ b/observability/alerts/hcp-test-clusters-prometheusRule.yaml
@@ -21,3 +21,20 @@ spec:
           HCP cluster {{ $labels.resource_id }} in {{ $labels.environment }} on service cluster {{ $labels.cluster }} has existed for more than 3 hours.
         runbook_url: TBD
         summary: HCP in {{ $labels.environment }} is older than 3h
+    - alert: ProdE2EHCPClusterOlderThan3Hours
+      expr: |
+        max by (cluster, resource_id, environment, subscription_id) (
+          time() - backend_cluster_created_time_seconds{
+            environment="prod",
+            subscription_id=~"403d9de9-132b-4974-94a5-5b78bdfa191e|8d696692-794f-4cdb-ba25-9250c9e9ec4c|ec435068-e722-475f-8504-c91b72a5dc51"
+          }
+        ) > 3 * 3600
+      for: 5m
+      labels:
+        severity: "3"
+      annotations:
+        correlationId: 'ProdE2EClusterOlderThan3Hours{{ $labels.resource_id }}'
+        description: |
+          Prod e2e HCP cluster {{ $labels.resource_id }} in subscription {{ $labels.subscription_id }} on service cluster {{ $labels.cluster }} has existed for more than 3 hours.
+        runbook_url: TBD
+        summary: Prod e2e HCP is older than 3h

--- a/observability/alerts/hcp-test-clusters-prometheusRule_test.yaml
+++ b/observability/alerts/hcp-test-clusters-prometheusRule_test.yaml
@@ -62,3 +62,80 @@ tests:
   - eval_time: 3h4m
     alertname: HCPClusterOlderThan3Hours
     exp_alerts: []
+# ProdE2EHCPClusterOlderThan3Hours - alert fires for prod e2e clusters older than 3 hours
+- interval: 1m
+  input_series:
+  - series: 'backend_cluster_created_time_seconds{cluster="prod-uksouth-svc-1",environment="prod",subscription_id="403d9de9-132b-4974-94a5-5b78bdfa191e",resource_id="/subscriptions/403d9de9-132b-4974-94a5-5b78bdfa191e/resourcegroups/test-rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/test-cluster"}'
+    values: "0+0x200"
+  alert_rule_test:
+  - eval_time: 3h6m
+    alertname: ProdE2EHCPClusterOlderThan3Hours
+    exp_alerts:
+    - exp_labels:
+        alertname: ProdE2EHCPClusterOlderThan3Hours
+        severity: "3"
+        cluster: prod-uksouth-svc-1
+        environment: prod
+        subscription_id: 403d9de9-132b-4974-94a5-5b78bdfa191e
+        resource_id: /subscriptions/403d9de9-132b-4974-94a5-5b78bdfa191e/resourcegroups/test-rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/test-cluster
+      exp_annotations:
+        correlationId: 'ProdE2EClusterOlderThan3Hours/subscriptions/403d9de9-132b-4974-94a5-5b78bdfa191e/resourcegroups/test-rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/test-cluster'
+        description: |
+          Prod e2e HCP cluster /subscriptions/403d9de9-132b-4974-94a5-5b78bdfa191e/resourcegroups/test-rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/test-cluster in subscription 403d9de9-132b-4974-94a5-5b78bdfa191e on service cluster prod-uksouth-svc-1 has existed for more than 3 hours.
+        runbook_url: TBD
+        summary: Prod e2e HCP is older than 3h
+# ProdE2EHCPClusterOlderThan3Hours - alert fires for all prod e2e subscriptions
+- interval: 1m
+  input_series:
+  - series: 'backend_cluster_created_time_seconds{cluster="prod-uksouth-svc-1",environment="prod",subscription_id="8d696692-794f-4cdb-ba25-9250c9e9ec4c",resource_id="/subscriptions/8d696692-794f-4cdb-ba25-9250c9e9ec4c/resourcegroups/test-rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/test-cluster"}'
+    values: "0+0x200"
+  - series: 'backend_cluster_created_time_seconds{cluster="prod-uksouth-svc-1",environment="prod",subscription_id="ec435068-e722-475f-8504-c91b72a5dc51",resource_id="/subscriptions/ec435068-e722-475f-8504-c91b72a5dc51/resourcegroups/test-rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/test-cluster"}'
+    values: "0+0x200"
+  alert_rule_test:
+  - eval_time: 3h6m
+    alertname: ProdE2EHCPClusterOlderThan3Hours
+    exp_alerts:
+    - exp_labels:
+        alertname: ProdE2EHCPClusterOlderThan3Hours
+        severity: "3"
+        cluster: prod-uksouth-svc-1
+        environment: prod
+        subscription_id: 8d696692-794f-4cdb-ba25-9250c9e9ec4c
+        resource_id: /subscriptions/8d696692-794f-4cdb-ba25-9250c9e9ec4c/resourcegroups/test-rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/test-cluster
+      exp_annotations:
+        correlationId: 'ProdE2EClusterOlderThan3Hours/subscriptions/8d696692-794f-4cdb-ba25-9250c9e9ec4c/resourcegroups/test-rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/test-cluster'
+        description: |
+          Prod e2e HCP cluster /subscriptions/8d696692-794f-4cdb-ba25-9250c9e9ec4c/resourcegroups/test-rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/test-cluster in subscription 8d696692-794f-4cdb-ba25-9250c9e9ec4c on service cluster prod-uksouth-svc-1 has existed for more than 3 hours.
+        runbook_url: TBD
+        summary: Prod e2e HCP is older than 3h
+    - exp_labels:
+        alertname: ProdE2EHCPClusterOlderThan3Hours
+        severity: "3"
+        cluster: prod-uksouth-svc-1
+        environment: prod
+        subscription_id: ec435068-e722-475f-8504-c91b72a5dc51
+        resource_id: /subscriptions/ec435068-e722-475f-8504-c91b72a5dc51/resourcegroups/test-rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/test-cluster
+      exp_annotations:
+        correlationId: 'ProdE2EClusterOlderThan3Hours/subscriptions/ec435068-e722-475f-8504-c91b72a5dc51/resourcegroups/test-rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/test-cluster'
+        description: |
+          Prod e2e HCP cluster /subscriptions/ec435068-e722-475f-8504-c91b72a5dc51/resourcegroups/test-rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/test-cluster in subscription ec435068-e722-475f-8504-c91b72a5dc51 on service cluster prod-uksouth-svc-1 has existed for more than 3 hours.
+        runbook_url: TBD
+        summary: Prod e2e HCP is older than 3h
+# ProdE2EHCPClusterOlderThan3Hours - no alert for other prod subscriptions
+- interval: 1m
+  input_series:
+  - series: 'backend_cluster_created_time_seconds{cluster="prod-uksouth-svc-1",environment="prod",subscription_id="00000000-0000-0000-0000-000000000000",resource_id="/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/test-cluster"}'
+    values: "0+0x200"
+  alert_rule_test:
+  - eval_time: 3h6m
+    alertname: ProdE2EHCPClusterOlderThan3Hours
+    exp_alerts: []
+# ProdE2EHCPClusterOlderThan3Hours - no alert before the cluster is older than 3 hours
+- interval: 1m
+  input_series:
+  - series: 'backend_cluster_created_time_seconds{cluster="prod-uksouth-svc-1",environment="prod",subscription_id="403d9de9-132b-4974-94a5-5b78bdfa191e",resource_id="/subscriptions/403d9de9-132b-4974-94a5-5b78bdfa191e/resourcegroups/test-rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/test-cluster"}'
+    values: "0+0x200"
+  alert_rule_test:
+  - eval_time: 3h4m
+    alertname: ProdE2EHCPClusterOlderThan3Hours
+    exp_alerts: []


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-1433

### What

Adds `ProdE2EHCPClusterOlderThan3Hours`, a prod-only version of the existing int/stg stale HCP cluster alert. The new alert uses `backend_cluster_created_time_seconds` and filters by the prod e2e subscription IDs exposed in the metric `subscription_id` label.

### Why

Prod e2e clusters can be left around and should page separately from the existing int/stg stale-cluster alert. Filtering by subscription keeps the alert scoped to prod e2e workloads instead of all prod customer clusters.

### Testing

- Ran `go run ./... --config-file ../../observability/alerts-sl-services.yaml` from `tooling/prometheus-rules`
- Verified prod Grafana `backend_cluster_created_time_seconds` has `subscription_id`, `environment`, `cluster`, and `resource_id` labels in live `services-*` datasources

### Special notes for your reviewer

The requested prod e2e subscriptions were checked against live prod Grafana. Current live series were present for `403d9de9-132b-4974-94a5-5b78bdfa191e`; no current series were returned for the other two subscriptions, but the alert covers all three requested IDs.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge