### PR TITLE
Add GRPC operation metrics panels to Maestro dashboard

### DIFF
--- a/observability/grafana-dashboards/maestro/maestro-server.json
+++ b/observability/grafana-dashboards/maestro/maestro-server.json
@@ -978,6 +978,402 @@
       ],
       "title": "REST API Inbound Request Duration",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 23
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (operation, source) (rate(grpc_server_called_total_by_operation{namespace=~\"$namespace\", type=\"Publish\"}[5m]))",
+          "instant": false,
+          "legendFormat": "{{operation}} ({{source}})",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "GRPC Request Rate by Operation",
+      "type": "timeseries",
+      "description": "Rate of GRPC Publish requests by operation type (create, update, delete) and source consumer"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 23
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (operation) (rate(grpc_server_processed_total_by_operation{namespace=~\"$namespace\", code!=\"OK\"}[5m])) / sum by (operation) (rate(grpc_server_processed_total_by_operation{namespace=~\"$namespace\"}[5m]))",
+          "instant": false,
+          "legendFormat": "{{operation}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "GRPC Error Rate by Operation",
+      "type": "timeseries",
+      "description": "Error rate (non-OK status codes) by operation type"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 31
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (operation, le) (rate(grpc_server_processed_duration_seconds_by_operation_bucket{namespace=~\"$namespace\"}[5m])))",
+          "instant": false,
+          "legendFormat": "{{operation}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "GRPC P95 Latency by Operation",
+      "type": "timeseries",
+      "description": "95th percentile request latency by operation type"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "msgps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 31
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (operation, source) (rate(grpc_server_message_received_total_by_operation{namespace=~\"$namespace\"}[5m]))",
+          "instant": false,
+          "legendFormat": "{{operation}} ({{source}})",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "GRPC Message Rate by Operation",
+      "type": "timeseries",
+      "description": "Rate of messages received by operation type and source consumer"
     }
   ],
   "preload": false,


### PR DESCRIPTION
# Add GRPC operation metrics panels to Maestro dashboard

## Summary

Adds 4 new Grafana panels to the Maestro server dashboard to visualize GRPC server metrics with operation-level granularity. These panels use the new non-breaking `_by_operation` metrics and have zero impact on existing dashboards.

## Changes

### Modified Files

**observability/grafana-dashboards/maestro/maestro-server.json**:
- Added 4 new time series panels (IDs 10-13)
- Total panels: 9 → 13
- No changes to existing panels

### New Panels

#### 1. GRPC Request Rate by Operation
- **Query**: `sum by (operation, source) (rate(grpc_server_called_total_by_operation{namespace=~"$namespace", type="Publish"}[5m]))`
- **Legend**: `{{operation}} ({{source}})`
- **Unit**: requests/sec
- **Purpose**: Track request rate broken down by operation and source consumer
- **Position**: Row 6, left (gridPos: h=8, w=12, x=0, y=23)

#### 2. GRPC Error Rate by Operation
- **Query**: `sum by (operation) (rate(grpc_server_processed_total_by_operation{namespace=~"$namespace", code!="OK"}[5m])) / sum by (operation) (rate(grpc_server_processed_total_by_operation{namespace=~"$namespace"}[5m]))`
- **Legend**: `{{operation}}`
- **Unit**: percent (0-1)
- **Purpose**: Track error rate (non-OK status codes) by operation
- **Position**: Row 6, right (gridPos: h=8, w=12, x=12, y=23)

#### 3. GRPC P95 Latency by Operation
- **Query**: `histogram_quantile(0.95, sum by (operation, le) (rate(grpc_server_processed_duration_seconds_by_operation_bucket{namespace=~"$namespace"}[5m])))`
- **Legend**: `{{operation}}`
- **Unit**: seconds
- **Purpose**: Track 95th percentile latency by operation to identify slow operations
- **Position**: Row 7, left (gridPos: h=8, w=12, x=0, y=31)

#### 4. GRPC Message Rate by Operation
- **Query**: `sum by (operation, source) (rate(grpc_server_message_received_total_by_operation{namespace=~"$namespace"}[5m]))`
- **Legend**: `{{operation}} ({{source}})`
- **Unit**: messages/sec
- **Purpose**: Track message throughput by operation and source
- **Position**: Row 7, right (gridPos: h=8, w=12, x=12, y=31)

## Non-Breaking Metrics Used

These panels use the NEW metrics with `_by_operation` suffix:
- `grpc_server_called_total_by_operation`
- `grpc_server_processed_total_by_operation`
- `grpc_server_processed_duration_seconds_by_operation`
- `grpc_server_message_received_total_by_operation`

**Important**: These are NEW metrics that coexist with the old metrics. Existing panels using `grpc_server_*` (without `_by_operation`) continue working unchanged.

## Dependencies

⚠️ **Requires Maestro metrics enhancement**: These panels will show "No data" until the Maestro PR is deployed.

- **Maestro PR**: https://github.com/openshift-online/maestro/pull/555 (non-breaking)
- **Deployment**: Can deploy independently - no coordination required

### Deployment Flexibility

Because this is a non-breaking change:
- ✅ Can deploy this dashboard PR **before** Maestro PR (panels show "No data")
- ✅ Can deploy this dashboard PR **after** Maestro PR (panels populate immediately)
- ✅ Can deploy **at the same time** (ideal)
- ✅ No downtime or migration window needed

## Visual Layout

The dashboard now has 7 rows:
- Rows 1-5: Existing panels (unchanged)
- **Row 6** (NEW): GRPC Request Rate + GRPC Error Rate
- **Row 7** (NEW): GRPC P95 Latency + GRPC Message Rate

## Testing

### Verification Steps

1. **Before Maestro deployment**: Panels show "No data" (expected, no errors)
2. **After Maestro deployment**:
   - Import dashboard to Grafana
   - Select namespace with Maestro pods
   - Verify panels populate with data
   - Check operations visible: create, update, delete, subscribe

### Expected Behavior

**With Maestro metrics deployed**:
- Panels show data for operations: create, update, delete, subscribe
- Legend shows operation types and source consumers
- Time series update in real-time

**Before Maestro metrics deployed**:
- Panels show "No data" (expected)
- No errors in Grafana logs
- Existing panels continue working normally

## Benefits

1. **Operation-level visibility**: See which operations (Create vs Update vs Delete) are most frequent
2. **Performance analysis**: Identify slow operations via P95 latency panel
3. **Error analysis**: Track which operations fail most often
4. **Consumer breakdown**: See which consumers (CS, etc.) use which operations
5. **Capacity planning**: Understand operation distribution for resource sizing
6. **Zero disruption**: Existing dashboards unaffected

## Example Insights

**From GRPC Request Rate panel**:
- "CS creates 50 resources/min but only deletes 5/min" → Potential leak investigation

**From GRPC Error Rate panel**:
- "Deletes have 5% error rate, creates have 0.1%" → Focus on delete error handling

**From GRPC P95 Latency panel**:
- "Updates take 500ms p95, creates take 50ms p95" → Update operation bottleneck

**From GRPC Message Rate panel**:
- "Subscribe sending 1000 msg/sec" → Throughput visibility

## Backwards Compatibility

✅ **100% Backwards Compatible**

- **Existing panels**: Continue working unchanged
- **Existing queries**: Not modified
- **New panels**: Use new `_by_operation` metrics only
- **No migration**: Nothing breaks if Maestro PR isn't deployed yet

## Related

- **Jira**: [ARO-26754](https://issues.redhat.com/browse/ARO-26754) - Add Maestro GRPC metrics instrumentation
- **Maestro PR**: https://github.com/openshift-online/maestro/pull/555 (non-breaking)
- **Root Cause**: [ARO-26043](https://redhat.atlassian.net/browse/ARO-26043) - Cluster provisioning latency investigation

## Checklist

- [x] Panels follow existing dashboard patterns
- [x] PromQL queries validated for correctness
- [x] Uses new `_by_operation` metrics (non-breaking)
- [x] Grid positions don't overlap existing panels
- [x] Panel IDs (10-13) don't conflict with existing IDs (1-9)
- [x] Legend formats include operation and source labels
- [x] Units set appropriately (reqps, percentunit, s, msgps)
- [x] Descriptions added to panels for context
- [x] Dependency on Maestro PR documented
- [x] **Non-breaking change** - no impact on existing panels
- [x] Testing steps provided

## Screenshots

*Screenshots will be added after Maestro metrics are deployed and panels populate with data.*
