### PR TITLE
observability: keep track of the diff from upstream

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedKustoOnlyHCPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedKustoOnlyHCPPrometheusAlertingRules.bicep
@@ -1224,14 +1224,14 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
         }
         annotations: {
           correlationId: 'KubeNodeNotReady/{{ $labels.cluster }}/{{ $labels.node }}'
-          description: '{{ $labels.node }} has been unready for more than 15 minutes.'
-          info: '{{ $labels.node }} has been unready for more than 15 minutes.'
+          description: '{{ $labels.node }} has been unready for more than 30 minutes.'
+          info: '{{ $labels.node }} has been unready for more than 30 minutes.'
           runbook_url: 'https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubenodenotready'
           summary: 'Node is not ready.'
           title: 'Node is not ready. node:{{ $labels.node }}'
         }
         expression: 'kube_node_status_condition{condition="Ready",job="kube-state-metrics",status="true"} == 0'
-        for: 'PT15M'
+        for: 'PT30M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {

--- a/dev-infrastructure/modules/metrics/rules/generatedKustoOnlyServicePrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedKustoOnlyServicePrometheusAlertingRules.bicep
@@ -1224,14 +1224,14 @@ resource svcKubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGr
         }
         annotations: {
           correlationId: 'KubeNodeNotReady/{{ $labels.cluster }}/{{ $labels.node }}'
-          description: '{{ $labels.node }} has been unready for more than 15 minutes.'
-          info: '{{ $labels.node }} has been unready for more than 15 minutes.'
+          description: '{{ $labels.node }} has been unready for more than 30 minutes.'
+          info: '{{ $labels.node }} has been unready for more than 30 minutes.'
           runbook_url: 'https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubenodenotready'
           summary: 'Node is not ready.'
           title: 'Node is not ready. node:{{ $labels.node }}'
         }
         expression: 'kube_node_status_condition{condition="Ready",job="kube-state-metrics",status="true"} == 0'
-        for: 'PT15M'
+        for: 'PT30M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {

--- a/observability/.gitignore
+++ b/observability/.gitignore
@@ -1,0 +1,1 @@
+alerts/kubernetesControlPlane-prometheusRule.upstream.yaml

--- a/observability/Makefile
+++ b/observability/Makefile
@@ -2,39 +2,44 @@ deploy:
 	make -C ./tracing deploy
 .PHONY: deploy
 
-sync-upstream:
+UPSTREAM_RULE := alerts/kubernetesControlPlane-prometheusRule.upstream.yaml
+LOCAL_RULE := alerts/kubernetesControlPlane-prometheusRule.yaml
+LOCAL_DIFF := alerts/kubernetesControlPlane-prometheusRule.yaml.diff
+
+$(UPSTREAM_RULE): alerts-sl-services.yaml
 	PROMETHEUS_OPERATOR_REF=$$(yq -r '.prometheusRules.prometheusOperatorVersion' alerts-sl-services.yaml) && \
-	wget --quiet --output-document=alerts/kubernetesControlPlane-prometheusRule.yaml \
-	https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/$${PROMETHEUS_OPERATOR_REF}/manifests/kubernetesControlPlane-prometheusRule.yaml && \
-	if [ -f alerts/kubernetesControlPlane-prometheusRule.yaml.diff ]; then \
-		patch alerts/kubernetesControlPlane-prometheusRule.yaml alerts/kubernetesControlPlane-prometheusRule.yaml.diff; \
+	wget --quiet --output-document=$@ \
+	https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/$${PROMETHEUS_OPERATOR_REF}/manifests/kubernetesControlPlane-prometheusRule.yaml
+
+$(LOCAL_RULE): $(UPSTREAM_RULE) $(wildcard $(LOCAL_DIFF))
+	cp $(UPSTREAM_RULE) $(LOCAL_RULE)
+	@if [ -s $(LOCAL_DIFF) ]; then \
+		patch $(LOCAL_RULE) $(LOCAL_DIFF); \
 	fi
-.PHONY: sync-upstream
 
-generate-diff:
-	PROMETHEUS_OPERATOR_REF=$$(yq -r '.prometheusRules.prometheusOperatorVersion' alerts-sl-services.yaml) && \
-	UPSTREAM=$$(mktemp) && \
-	wget --quiet --output-document=$${UPSTREAM} \
-	https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/$${PROMETHEUS_OPERATOR_REF}/manifests/kubernetesControlPlane-prometheusRule.yaml && \
+$(LOCAL_DIFF): $(UPSTREAM_RULE) $(LOCAL_RULE)
 	diff -u --label upstream/kubernetesControlPlane-prometheusRule.yaml --label alerts/kubernetesControlPlane-prometheusRule.yaml \
-	$${UPSTREAM} alerts/kubernetesControlPlane-prometheusRule.yaml > alerts/kubernetesControlPlane-prometheusRule.yaml.diff || true && \
-	rm -f $${UPSTREAM}
-.PHONY: generate-diff
+	$(UPSTREAM_RULE) $(LOCAL_RULE) > $(LOCAL_DIFF); \
+	DIFF_EXIT=$$?; \
+	if [ $${DIFF_EXIT} -eq 0 ]; then \
+		rm -f $(LOCAL_DIFF); \
+	elif [ $${DIFF_EXIT} -ne 1 ]; then \
+		rm -f $(LOCAL_DIFF); \
+		exit $${DIFF_EXIT}; \
+	fi
 
-verify-sync-upstream: sync-upstream
-	@if [ -n "$$(git status --short alerts/kubernetesControlPlane-prometheusRule.yaml)" ]; then \
-		echo "The following files are out of date after running 'make -C observability/ sync-upstream':"; \
+verify-rule: $(LOCAL_RULE)
+	@if [ -n "$$(git status --short $(LOCAL_RULE))" ]; then \
+		echo "The following file is out of date after running 'make -C observability/ sync-upstream':"; \
 		echo; \
-		git status --short alerts/kubernetesControlPlane-prometheusRule.yaml; \
-		echo; \
-		git diff alerts/kubernetesControlPlane-prometheusRule.yaml; \
+		git diff $(LOCAL_RULE); \
 		echo; \
 		echo "===================================================="; \
 		echo "Run 'make -C observability/ generate-diff' and commit the changes."; \
 		echo "===================================================="; \
 		exit 1; \
 	fi
-.PHONY: verify-sync-upstream
+.PHONY: verify-rule
 
 alerts: verify-no-prom-alerts-in-bicep
 	EXTRA_FLAGS=$(GENERATOR_FLAGS) make -C ../tooling/prometheus-rules alerts
@@ -48,7 +53,7 @@ recording-rules:
 	EXTRA_FLAGS=$(GENERATOR_FLAGS) make -C ../tooling/prometheus-rules recording-rules
 .PHONY: recording-rules
 
-verify: verify-sync-upstream
+verify: verify-rule
 	go run ../tooling/grafanactl/main.go verify dashboards --config-file observability.yaml
 .PHONY: verify
 

--- a/observability/Makefile
+++ b/observability/Makefile
@@ -5,8 +5,36 @@ deploy:
 sync-upstream:
 	PROMETHEUS_OPERATOR_REF=$$(yq -r '.prometheusRules.prometheusOperatorVersion' alerts-sl-services.yaml) && \
 	wget --quiet --output-document=alerts/kubernetesControlPlane-prometheusRule.yaml \
-	https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/$${PROMETHEUS_OPERATOR_REF}/manifests/kubernetesControlPlane-prometheusRule.yaml
+	https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/$${PROMETHEUS_OPERATOR_REF}/manifests/kubernetesControlPlane-prometheusRule.yaml && \
+	if [ -f alerts/kubernetesControlPlane-prometheusRule.yaml.diff ]; then \
+		patch alerts/kubernetesControlPlane-prometheusRule.yaml alerts/kubernetesControlPlane-prometheusRule.yaml.diff; \
+	fi
 .PHONY: sync-upstream
+
+generate-diff:
+	PROMETHEUS_OPERATOR_REF=$$(yq -r '.prometheusRules.prometheusOperatorVersion' alerts-sl-services.yaml) && \
+	UPSTREAM=$$(mktemp) && \
+	wget --quiet --output-document=$${UPSTREAM} \
+	https://raw.githubusercontent.com/prometheus-operator/kube-prometheus/$${PROMETHEUS_OPERATOR_REF}/manifests/kubernetesControlPlane-prometheusRule.yaml && \
+	diff -u --label upstream/kubernetesControlPlane-prometheusRule.yaml --label alerts/kubernetesControlPlane-prometheusRule.yaml \
+	$${UPSTREAM} alerts/kubernetesControlPlane-prometheusRule.yaml > alerts/kubernetesControlPlane-prometheusRule.yaml.diff || true && \
+	rm -f $${UPSTREAM}
+.PHONY: generate-diff
+
+verify-sync-upstream: sync-upstream
+	@if [ -n "$$(git status --short alerts/kubernetesControlPlane-prometheusRule.yaml)" ]; then \
+		echo "The following files are out of date after running 'make -C observability/ sync-upstream':"; \
+		echo; \
+		git status --short alerts/kubernetesControlPlane-prometheusRule.yaml; \
+		echo; \
+		git diff alerts/kubernetesControlPlane-prometheusRule.yaml; \
+		echo; \
+		echo "===================================================="; \
+		echo "Run 'make -C observability/ generate-diff' and commit the changes."; \
+		echo "===================================================="; \
+		exit 1; \
+	fi
+.PHONY: verify-sync-upstream
 
 alerts: verify-no-prom-alerts-in-bicep
 	EXTRA_FLAGS=$(GENERATOR_FLAGS) make -C ../tooling/prometheus-rules alerts
@@ -20,7 +48,7 @@ recording-rules:
 	EXTRA_FLAGS=$(GENERATOR_FLAGS) make -C ../tooling/prometheus-rules recording-rules
 .PHONY: recording-rules
 
-verify:
+verify: verify-sync-upstream
 	go run ../tooling/grafanactl/main.go verify dashboards --config-file observability.yaml
 .PHONY: verify
 

--- a/observability/alerts/kubernetesControlPlane-prometheusRule.yaml
+++ b/observability/alerts/kubernetesControlPlane-prometheusRule.yaml
@@ -602,12 +602,12 @@ spec:
     rules:
     - alert: KubeNodeNotReady
       annotations:
-        description: '{{ $labels.node }} has been unready for more than 15 minutes.'
+        description: '{{ $labels.node }} has been unready for more than 30 minutes.'
         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubenodenotready
         summary: Node is not ready.
       expr: |
         kube_node_status_condition{job="kube-state-metrics",condition="Ready",status="true"} == 0
-      for: 15m
+      for: 30m
       labels:
         severity: warning
     - alert: KubeNodeUnreachable

--- a/observability/alerts/kubernetesControlPlane-prometheusRule.yaml.diff
+++ b/observability/alerts/kubernetesControlPlane-prometheusRule.yaml.diff
@@ -40,3 +40,18 @@
        labels:
          severity: warning
      - alert: KubeClientErrors
+@@ -602,12 +602,12 @@
+     rules:
+     - alert: KubeNodeNotReady
+       annotations:
+-        description: '{{ $labels.node }} has been unready for more than 15 minutes.'
++        description: '{{ $labels.node }} has been unready for more than 30 minutes.'
+         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubenodenotready
+         summary: Node is not ready.
+       expr: |
+         kube_node_status_condition{job="kube-state-metrics",condition="Ready",status="true"} == 0
+-      for: 15m
++      for: 30m
+       labels:
+         severity: warning
+     - alert: KubeNodeUnreachable

--- a/observability/alerts/kubernetesControlPlane-prometheusRule.yaml.diff
+++ b/observability/alerts/kubernetesControlPlane-prometheusRule.yaml.diff
@@ -1,0 +1,42 @@
+--- upstream/kubernetesControlPlane-prometheusRule.yaml
++++ alerts/kubernetesControlPlane-prometheusRule.yaml
+@@ -52,7 +52,7 @@
+         severity: warning
+     - alert: KubeDeploymentReplicasMismatch
+       annotations:
+-        description: Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has not matched the expected number of replicas for longer than 15 minutes.
++        description: Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has not matched the expected number of replicas for longer than 30 minutes.
+         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubedeploymentreplicasmismatch
+         summary: Deployment has not matched the expected number of replicas.
+       expr: |
+@@ -65,18 +65,18 @@
+             ==
+           0
+         )
+-      for: 15m
++      for: 30m
+       labels:
+         severity: warning
+     - alert: KubeDeploymentRolloutStuck
+       annotations:
+-        description: Rollout of deployment {{ $labels.namespace }}/{{ $labels.deployment }} is not progressing for longer than 15 minutes.
++        description: Rollout of deployment {{ $labels.namespace }}/{{ $labels.deployment }} is not progressing for longer than 30 minutes.
+         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubedeploymentrolloutstuck
+         summary: Deployment rollout is not progressing.
+       expr: |
+         kube_deployment_status_condition{condition="Progressing", status="false",job="kube-state-metrics"}
+         != 0
+-      for: 15m
++      for: 30m
+       labels:
+         severity: warning
+     - alert: KubeStatefulSetReplicasMismatch
+@@ -463,7 +463,7 @@
+         summary: Different semantic versions of Kubernetes components running.
+       expr: |
+         count by (cluster) (count by (git_version, cluster) (label_replace(kubernetes_build_info{job!~"kube-dns|coredns"},"git_version","$1","git_version","(v[0-9]*.[0-9]*).*"))) > 1
+-      for: 15m
++      for: 90m
+       labels:
+         severity: warning
+     - alert: KubeClientErrors


### PR DESCRIPTION
observability: keep track of the diff from upstream

We want to be free to vary our alerts based on upstream, and we think
it's relatively safe to do this as we don't expect upstream to change
much.

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---

observability: increase KubeNodeNotReady alert threshold to 30m

The AKS node auto-repair process can take up to 30 minutes to fully
fix or replace a node, so alerting before that time will just lead to
spurious issues.

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---

