### PR TITLE
fix(mgmt-agent): correctly place podwatcher to always run even if ksm is enabled/disabled

### DIFF
--- a/mgmt-agent/cmd/options.go
+++ b/mgmt-agent/cmd/options.go
@@ -170,11 +170,15 @@ func (o *ValidatedControllerOptions) Complete(ctx context.Context) (*ControllerO
 
 	resourceWatcher := controller.NewResourceWatcher(dynamicClient, discoveryClient)
 
+	clusterWideKubeInformers := kubeinformers.NewSharedInformerFactory(kubeClientset, 0)
+	podWatcher, err := controller.NewPodWatcher(clusterWideKubeInformers.Core().V1().Pods())
+	if err != nil {
+		return nil, fmt.Errorf("failed to create pod watcher: %w", err)
+	}
+
 	var ksmCtrl *ksmhcp.KSMHCPController
-	var podWatcher *controller.PodWatcher
 	var hsInformers hypershiftinformers.SharedInformerFactory
 	var ksmKubeInformers kubeinformers.SharedInformerFactory
-	var clusterWideKubeInformers kubeinformers.SharedInformerFactory
 	var dynInformers dynamicinformer.DynamicSharedInformerFactory
 	if o.KSMImage != "" {
 		hsClient, err := hypershiftclient.NewForConfig(kubeConfig)
@@ -204,13 +208,6 @@ func (o *ValidatedControllerOptions) Complete(ctx context.Context) (*ControllerO
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create KSM HCP controller: %w", err)
-		}
-
-		clusterWideKubeInformers = kubeinformers.NewSharedInformerFactory(kubeClientset, 0)
-
-		podWatcher, err = controller.NewPodWatcher(clusterWideKubeInformers.Core().V1().Pods())
-		if err != nil {
-			return nil, fmt.Errorf("failed to create pod watcher: %w", err)
 		}
 	}
 


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Always run the podwatcher controller.  

### Why

Was incorrectly nested within the KSM image property being set or not.  

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
