### PR TITLE
e2e: use delta-only logging in all polling loops, remove event dumps

### DIFF
--- a/test/e2e/cluster_authorized_cidrs_connectivity.go
+++ b/test/e2e/cluster_authorized_cidrs_connectivity.go
@@ -334,6 +334,7 @@ var _ = Describe("Authorized CIDRs", func() {
 
 				// MSGraph is eventually consistent, wait up to 2 minutes for the token to be valid
 				var accessToken azcore.AccessToken
+				var lastTokenErr string
 				Eventually(func() error {
 					var err error
 					accessToken, err = cred.GetToken(ctx, policy.TokenRequestOptions{
@@ -341,7 +342,10 @@ var _ = Describe("Authorized CIDRs", func() {
 					})
 
 					if err != nil {
-						GinkgoWriter.Printf("GetToken failed: %v\n", err)
+						if msg := err.Error(); msg != lastTokenErr {
+							GinkgoWriter.Printf("GetToken failed: %v\n", err)
+							lastTokenErr = msg
+						}
 					}
 					return err
 				}, 2*time.Minute, 10*time.Second).Should(Succeed())

--- a/test/e2e/cluster_delayed_role_assignments.go
+++ b/test/e2e/cluster_delayed_role_assignments.go
@@ -139,16 +139,26 @@ var _ = Describe("ARO HCP Service", func() {
 				"timed out waiting for cluster resource to become visible after BeginCreateOrUpdate")
 
 			By("verifying cluster does not enter terminal Failed state while role assignments are missing")
+			var lastConsistentlyErr string
+			var lastConsistentlyState hcpsdk20251223preview.ProvisioningState
 			Consistently(func(g Gomega) {
 				resp, err := hcpClient.Get(ctx, *resourceGroup.Name, customerClusterName, nil)
 				if err != nil {
-					GinkgoLogr.Info("GET cluster returned error, skipping poll iteration", "error", err)
+					lastConsistentlyState = ""
+					if msg := err.Error(); msg != lastConsistentlyErr {
+						GinkgoLogr.Info("GET cluster returned error, skipping poll iteration", "error", err)
+						lastConsistentlyErr = msg
+					}
 					return
 				}
+				lastConsistentlyErr = ""
 				g.Expect(resp.Properties).NotTo(BeNil(), "cluster response has nil Properties")
 				g.Expect(resp.Properties.ProvisioningState).NotTo(BeNil(), "cluster response has nil ProvisioningState")
 				state := *resp.Properties.ProvisioningState
-				GinkgoLogr.Info("cluster provisioning state", "state", state)
+				if state != lastConsistentlyState {
+					GinkgoLogr.Info("cluster provisioning state", "state", state)
+					lastConsistentlyState = state
+				}
 				g.Expect(state).NotTo(Equal(hcpsdk20251223preview.ProvisioningStateFailed),
 					"cluster entered terminal Failed state — CS inflight validation should retry, not fail terminally (ARO-25805)")
 			}, consistentlyLoopDuration, 30*time.Second).Should(Succeed())
@@ -177,21 +187,31 @@ var _ = Describe("ARO HCP Service", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to deploy role assignments for managed identities")
 
 			By("waiting for cluster to reach Succeeded state")
+			var lastEventuallyErr string
+			var lastEventuallyState hcpsdk20251223preview.ProvisioningState
 			Eventually(func(g Gomega) {
 				resp, err := hcpClient.Get(ctx, *resourceGroup.Name, customerClusterName, nil)
 				if err != nil {
+					lastEventuallyState = ""
 					var respErr *azcore.ResponseError
 					if errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound {
 						g.Expect(err).NotTo(HaveOccurred(), "cluster returned 404 — resource disappeared after role assignment deployment")
 						return
 					}
-					GinkgoLogr.Info("GET cluster returned error, retrying", "error", err)
+					if msg := err.Error(); msg != lastEventuallyErr {
+						GinkgoLogr.Info("GET cluster returned error, retrying", "error", err)
+						lastEventuallyErr = msg
+					}
 					g.Expect(err).NotTo(HaveOccurred(), "GET cluster failed — RP returned an unexpected error")
 				}
+				lastEventuallyErr = ""
 				g.Expect(resp.Properties).NotTo(BeNil(), "cluster response has nil Properties")
 				g.Expect(resp.Properties.ProvisioningState).NotTo(BeNil(), "cluster response has nil ProvisioningState")
 				state := *resp.Properties.ProvisioningState
-				GinkgoLogr.Info("cluster provisioning state", "state", state)
+				if state != lastEventuallyState {
+					GinkgoLogr.Info("cluster provisioning state", "state", state)
+					lastEventuallyState = state
+				}
 				g.Expect(state).NotTo(Equal(hcpsdk20251223preview.ProvisioningStateFailed),
 					"cluster entered terminal Failed state after role assignment deployment")
 				g.Expect(state).To(Equal(hcpsdk20251223preview.ProvisioningStateSucceeded),

--- a/test/e2e/external_auth_create.go
+++ b/test/e2e/external_auth_create.go
@@ -189,6 +189,7 @@ var _ = Describe("Customer", func() {
 
 			// MSGraph is eventually consistent, wait up to 2 minutes for the token to be valid
 			var accessToken azcore.AccessToken
+			var lastTokenErr string
 			Eventually(func() error {
 				var err error
 				accessToken, err = cred.GetToken(ctx, policy.TokenRequestOptions{
@@ -196,7 +197,10 @@ var _ = Describe("Customer", func() {
 				})
 
 				if err != nil {
-					GinkgoWriter.Printf("GetToken failed: %v\n", err)
+					if msg := err.Error(); msg != lastTokenErr {
+						GinkgoWriter.Printf("GetToken failed: %v\n", err)
+						lastTokenErr = msg
+					}
 				}
 				return err
 			}, 2*time.Minute, 10*time.Second).Should(Succeed())

--- a/test/util/verifiers/cilium.go
+++ b/test/util/verifiers/cilium.go
@@ -63,6 +63,8 @@ func (v verifyCiliumOperational) Verify(ctx context.Context, adminRESTConfig *re
 
 	// Wait for all cilium pods to be running
 	var lastErr error
+	var lastErrMsg string
+	var lastNotRunningPods []string
 	err = wait.PollUntilContextTimeout(ctx, 30*time.Second, 10*time.Minute, true, func(ctx context.Context) (done bool, err error) {
 		listOptions := metav1.ListOptions{}
 		if v.ciliumLabelSelector != "" {
@@ -71,13 +73,21 @@ func (v verifyCiliumOperational) Verify(ctx context.Context, adminRESTConfig *re
 		pods, err := kubeClient.CoreV1().Pods(v.ciliumNamespace).List(ctx, listOptions)
 		if err != nil {
 			lastErr = fmt.Errorf("failed to list pods in %s namespace: %w", v.ciliumNamespace, err)
-			logger.Info("failed to list pods", "error", err)
+			lastNotRunningPods = nil
+			if msg := lastErr.Error(); msg != lastErrMsg {
+				logger.Info("failed to list pods", "error", err)
+				lastErrMsg = msg
+			}
 			return false, nil
 		}
 
 		if len(pods.Items) == 0 {
 			lastErr = fmt.Errorf("no cilium pods found in %s namespace", v.ciliumNamespace)
-			logger.Info("no cilium pods found yet in namespace", "namespace", v.ciliumNamespace)
+			lastNotRunningPods = nil
+			if msg := lastErr.Error(); msg != lastErrMsg {
+				logger.Info("no cilium pods found yet in namespace", "namespace", v.ciliumNamespace)
+				lastErrMsg = msg
+			}
 			return false, nil
 		}
 
@@ -89,33 +99,18 @@ func (v verifyCiliumOperational) Verify(ctx context.Context, adminRESTConfig *re
 		}
 
 		if len(notRunningPods) > 0 {
+			slices.Sort(notRunningPods)
 			lastErr = fmt.Errorf("cilium pods not yet running: %v", notRunningPods)
-			logger.Info("waiting for cilium pods to be running", "notRunning", notRunningPods)
+			if !slices.Equal(notRunningPods, lastNotRunningPods) {
+				logger.Info("waiting for cilium pods to be running", "notRunning", notRunningPods)
+				lastNotRunningPods = notRunningPods
+			}
 			return false, nil
 		}
 
 		return true, nil
 	})
 	if err != nil {
-		// Log all events in cilium namespace to help debug issues
-		events, eventsErr := kubeClient.CoreV1().Events(v.ciliumNamespace).List(ctx, metav1.ListOptions{})
-		if eventsErr != nil {
-			logger.Error(eventsErr, "failed to list events for debugging", "namespace", v.ciliumNamespace)
-		} else {
-			logger.Info("listing events for debugging", "namespace", v.ciliumNamespace, "eventCount", len(events.Items))
-			for _, event := range events.Items {
-				logger.Info("event",
-					"type", event.Type,
-					"reason", event.Reason,
-					"message", event.Message,
-					"object", fmt.Sprintf("%s/%s", event.InvolvedObject.Kind, event.InvolvedObject.Name),
-					"count", event.Count,
-					"firstTimestamp", event.FirstTimestamp,
-					"lastTimestamp", event.LastTimestamp,
-				)
-			}
-		}
-
 		if lastErr != nil {
 			return fmt.Errorf("not all pods in %s namespace are running: %w", v.ciliumNamespace, lastErr)
 		}
@@ -276,23 +271,6 @@ func (v verifyCiliumConnectivityChecks) Verify(ctx context.Context, adminRESTCon
 			return scheduled >= 2, nil
 		})
 		if waitErr != nil {
-			events, eventsErr := kubeClient.CoreV1().Events(namespaceName).List(ctx, metav1.ListOptions{})
-			if eventsErr != nil {
-				logger.Error(eventsErr, "failed to list events for debugging", "namespace", namespaceName)
-			} else {
-				logger.Info("listing events for debugging echo scheduling failure", "namespace", namespaceName, "eventCount", len(events.Items))
-				for _, event := range events.Items {
-					logger.Info("event",
-						"type", event.Type,
-						"reason", event.Reason,
-						"message", event.Message,
-						"object", fmt.Sprintf("%s/%s", event.InvolvedObject.Kind, event.InvolvedObject.Name),
-						"count", event.Count,
-						"firstTimestamp", event.FirstTimestamp,
-						"lastTimestamp", event.LastTimestamp,
-					)
-				}
-			}
 			return fmt.Errorf("echo-a/echo-b pods were not scheduled in time: %w", waitErr)
 		}
 		logger.Info("echo-a and echo-b pods are scheduled, deploying remaining resources")
@@ -387,25 +365,6 @@ func (v verifyCiliumConnectivityChecks) Verify(ctx context.Context, adminRESTCon
 	// If the waiting failed on a timeout, some connectivity check pod must
 	// have failed, so we need to report what failed exactly.
 	if err != nil {
-		// Log all events in the test namespace to help with debugging, as
-		// failures in liveness or readiness probes will be visible there
-		events, eventsErr := kubeClient.CoreV1().Events(namespaceName).List(ctx, metav1.ListOptions{})
-		if eventsErr != nil {
-			logger.Error(eventsErr, "failed to list k8s events", "namespace", namespaceName)
-		} else {
-			logger.Info("listing k8s events", "namespace", namespaceName, "eventCount", len(events.Items))
-			for _, event := range events.Items {
-				logger.Info("event",
-					"type", event.Type,
-					"reason", event.Reason,
-					"message", event.Message,
-					"object", fmt.Sprintf("%s/%s", event.InvolvedObject.Kind, event.InvolvedObject.Name),
-					"count", event.Count,
-					"firstTimestamp", event.FirstTimestamp,
-					"lastTimestamp", event.LastTimestamp,
-				)
-			}
-		}
 		// The pods use "terminationMessagePolicy: FallbackToLogsOnError"
 		// to report errors, so we log termination messages
 		pods, podsErr := kubeClient.CoreV1().Pods(namespaceName).List(ctx, metav1.ListOptions{})

--- a/test/util/verifiers/clusteroperator.go
+++ b/test/util/verifiers/clusteroperator.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -45,17 +46,24 @@ func (v verifyAllClusterOperatorsAvailableImpl) Verify(ctx context.Context, admi
 
 	start := time.Now()
 	var lastErr error
+	var lastErrMsg string
 	verifyErr := wait.PollUntilContextTimeout(ctx, 20*time.Second, 30*time.Minute, true, func(ctx context.Context) (done bool, err error) {
 		clusterOperators, err := configClient.ClusterOperators().List(ctx, metav1.ListOptions{})
 		if err != nil {
 			lastErr = fmt.Errorf("failed to list ClusterOperators: %w", err)
-			ginkgo.GinkgoLogr.Info("Failed to list ClusterOperators, retrying.", "error", err)
+			if msg := lastErr.Error(); msg != lastErrMsg {
+				ginkgo.GinkgoLogr.Info("Failed to list ClusterOperators, retrying.", "error", err)
+				lastErrMsg = msg
+			}
 			return false, nil
 		}
 
 		if len(clusterOperators.Items) == 0 {
 			lastErr = errors.New("no ClusterOperators found in the cluster")
-			ginkgo.GinkgoLogr.Info("ClusterOperators not yet ready.", "error", lastErr)
+			if msg := lastErr.Error(); msg != lastErrMsg {
+				ginkgo.GinkgoLogr.Info("ClusterOperators not yet ready.", "error", lastErr)
+				lastErrMsg = msg
+			}
 			return false, nil
 		}
 
@@ -72,8 +80,12 @@ func (v verifyAllClusterOperatorsAvailableImpl) Verify(ctx context.Context, admi
 		}
 
 		if len(unavailableOperators) > 0 {
+			slices.Sort(unavailableOperators)
 			lastErr = fmt.Errorf("cluster operators not available: %s", strings.Join(unavailableOperators, ", "))
-			ginkgo.GinkgoLogr.Info("ClusterOperators not yet ready.", "unavailable", unavailableOperators)
+			if msg := lastErr.Error(); msg != lastErrMsg {
+				ginkgo.GinkgoLogr.Info("ClusterOperators not yet ready.", "unavailable", unavailableOperators)
+				lastErrMsg = msg
+			}
 			return false, nil
 		}
 


### PR DESCRIPTION
Polling loops in e2e tests and verifiers were logging the same message on every iteration (every 20-30s), producing noisy output that obscured real state transitions. Apply the delta-only logging pattern already established in poll.go and cilium.go connectivity checks to all remaining pollers:

- cilium.go: track lastErrMsg and lastNotRunningPods in the first poll loop, only log when the observed state changes
- clusteroperator.go: track lastErrMsg across all three log sites in the ClusterOperator availability poll
- cluster_delayed_role_assignments.go: track last error and provisioning state in both Consistently and Eventually blocks
- cluster_authorized_cidrs_connectivity.go, external_auth_create.go: track lastTokenErr in GetToken retry loops

Additionally, remove event dump blocks from cilium.go on poll timeout. Events are available in Kusto and dumping them inline adds clutter without actionable value. The terminated container diagnostic dump is retained since that information is not available in Kusto.
