### PR TITLE
backend/metricscontrollers: scope operation metric cleanup to operati…

### DIFF
--- a/backend/pkg/controllers/metricscontrollers/operation_phase_metrics_controller.go
+++ b/backend/pkg/controllers/metricscontrollers/operation_phase_metrics_controller.go
@@ -39,17 +39,16 @@ var operationMetricLabelNames = []string{"resource_id", "subscription_id", "reso
 // resources. This matches the format already used by the sibling
 // backend_resource_provision_state metric family.
 //
-// Multiple operations on the same ARM resource id collapse to one
-// series. On the AllOperations() informer's unordered iteration
-// (every relist / resync, or backend restart) whichever operation
-// is processed last wins for that resource_id; this may temporarily
-// or persistently reflect an older terminal op until a later emit
-// for that resource supersedes it. If the resource is idle, the stale
-// labels can persist indefinitely. Separate limitation: when the
-// last operation for a resource ages out of the Cosmos TTL, its
-// series persists until process restart (Delete is a no-op; see
-// Delete doc-comment for the rationale). Resource-level conditions
-// are the longer-term direction.
+// Multiple operations of the SAME type on the same ARM resource id
+// collapse to one series. On the AllOperations() informer's unordered
+// iteration (every relist / resync, or backend restart) whichever
+// same-type operation is processed last wins for that resource_id +
+// operation_type combination. Operations of DIFFERENT types (e.g. a
+// completed "create" and an in-flight "delete") coexist independently
+// and do not clobber each other. When the last operation for a
+// resource ages out of the Cosmos TTL, its series persists until
+// process restart (Delete is a no-op; see Delete doc-comment for the
+// rationale). Resource-level conditions are the longer-term direction.
 type operationPhaseMetricsHandler struct {
 	phaseInfo          *prometheus.GaugeVec
 	startTime          *prometheus.GaugeVec
@@ -104,17 +103,20 @@ func (h *operationPhaseMetricsHandler) Sync(ctx context.Context, op *api.Operati
 		return
 	}
 
-	// Clear any previous series for this resource before writing the current labels.
-	// Phase and operation labels are part of the metric identity, so updates would
-	// otherwise leave stale series behind for older label combinations. Multiple
-	// operations sharing this resource_id collapse to the latest-emitted labels.
-	h.deleteByResourceID(resourceID)
+	// Clear any previous series for this resource and operation type before writing
+	// the current labels. Phase is part of the metric identity, so updates would
+	// otherwise leave stale series behind for older phase values. We scope the
+	// deletion to resource_id + operation_type so that concurrent operations of
+	// different types (e.g. a completed "create" and an in-flight "delete") coexist
+	// without clobbering each other on informer relists.
+	opType := operationTypeMetricLabel(op.Request)
+	h.deleteByResourceIDAndOperationType(resourceID, opType)
 
 	labels := prometheus.Labels{
 		"resource_id":     resourceID,
 		"subscription_id": subscriptionID,
 		"resource_type":   resourceIDToTypeMetricLabel(op.ExternalID),
-		"operation_type":  operationTypeMetricLabel(op.Request),
+		"operation_type":  opType,
 		"phase":           phaseMetricLabel(op.Status),
 	}
 	h.phaseInfo.With(labels).Set(1.0)
@@ -151,14 +153,15 @@ func (h *operationPhaseMetricsHandler) Delete(key string) {
 	// no-op; see doc-comment above
 }
 
-// deleteByResourceID is used by Sync to clear stale labels before
-// writing new ones. Delete intentionally does not call this; see
-// the Delete doc-comment.
-func (h *operationPhaseMetricsHandler) deleteByResourceID(resourceID string) {
+// deleteByResourceIDAndOperationType is used by Sync to clear stale labels
+// before writing new ones. Scoped to resource_id + operation_type so that
+// operations of different types on the same resource are not affected.
+// Delete intentionally does not call this; see the Delete doc-comment.
+func (h *operationPhaseMetricsHandler) deleteByResourceIDAndOperationType(resourceID, operationType string) {
 	if len(resourceID) == 0 {
 		return
 	}
-	deleteSelector := prometheus.Labels{"resource_id": resourceID}
+	deleteSelector := prometheus.Labels{"resource_id": resourceID, "operation_type": operationType}
 	h.phaseInfo.DeletePartialMatch(deleteSelector)
 	h.startTime.DeletePartialMatch(deleteSelector)
 	h.lastTransitionTime.DeletePartialMatch(deleteSelector)

--- a/backend/pkg/controllers/metricscontrollers/operation_phase_metrics_controller_test.go
+++ b/backend/pkg/controllers/metricscontrollers/operation_phase_metrics_controller_test.go
@@ -565,20 +565,16 @@ func TestOperationPhaseMetricsHandler_DeleteIsNoOp(t *testing.T) {
 	require.Equal(t, 1, testutil.CollectAndCount(handler.phaseInfo))
 }
 
-// TestOperationPhaseMetricsHandler_MultipleOpsSameExternalIDCollapseToOneSeries
-// documents the design decision that multiple operations sharing one
-// ARM resource id collapse to a single Prometheus series. The handler
-// emits one series per resource (last-emitted-labels-win); operation_id
-// is intentionally not in the label set.
+// TestOperationPhaseMetricsHandler_MultipleOpsSameExternalIDCoexistByOperationType
+// documents the design decision that multiple operations of DIFFERENT types
+// sharing one ARM resource id coexist as independent Prometheus series. The
+// handler emits one series per (resource_id, operation_type) combination;
+// only operations of the SAME type collapse (last-emitted-labels-win).
 //
-// This test exercises natural processing order (older op first, newer
-// op second) and asserts the resulting collapse to one series with
-// the second op's labels. It does NOT assert "newest by
-// LastTransitionTime wins" under adversarial / relist iteration order
-// where the newer op might be processed first; that property is not
-// provided by the handler. See the handler doc-comment for the flutter
-// limitation.
-func TestOperationPhaseMetricsHandler_MultipleOpsSameExternalIDCollapseToOneSeries(t *testing.T) {
+// This ensures that e.g. a completed "create" operation does not clobber
+// an in-flight "delete" operation's metrics on informer relists, which
+// previously caused false alerts when the iteration order was unfavorable.
+func TestOperationPhaseMetricsHandler_MultipleOpsSameExternalIDCoexistByOperationType(t *testing.T) {
 	now := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	armID := "/subscriptions/sub-1/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster-1"
 
@@ -587,12 +583,43 @@ func TestOperationPhaseMetricsHandler_MultipleOpsSameExternalIDCollapseToOneSeri
 
 	handler, reg := newTestOperationHandler(t)
 
-	// Two ops on the same ARM id, processed in order. After both Syncs,
-	// the second emission's labels are the only ones present because
-	// DeletePartialMatch wipes by resource_id before each emit.
+	// Two ops of different types on the same ARM id. After both Syncs,
+	// both series are present because deletion is scoped to
+	// resource_id + operation_type.
 	handler.Sync(context.Background(), op1)
 	handler.Sync(context.Background(), op2)
 
+	expected := `# HELP backend_resource_operation_phase_info Current phase of each operation (value is always 1).
+# TYPE backend_resource_operation_phase_info gauge
+backend_resource_operation_phase_info{operation_type="create",phase="succeeded",resource_id="/subscriptions/sub-1/resourcegroups/rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/cluster-1",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",subscription_id="sub-1"} 1
+backend_resource_operation_phase_info{operation_type="update",phase="provisioning",resource_id="/subscriptions/sub-1/resourcegroups/rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/cluster-1",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",subscription_id="sub-1"} 1
+`
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expected), "backend_resource_operation_phase_info"))
+	require.Equal(t, 2, testutil.CollectAndCount(handler.phaseInfo))
+
+	// The bug this test guards against is specifically about start_time and
+	// last_transition_time being clobbered across operation types. Verify
+	// these metric vecs also retain both series.
+	require.Equal(t, 2, testutil.CollectAndCount(handler.startTime))
+	require.Equal(t, 2, testutil.CollectAndCount(handler.lastTransitionTime))
+}
+
+// TestOperationPhaseMetricsHandler_SameOperationTypeCollapsesToOneSeries
+// verifies that multiple operations of the SAME type on one ARM resource
+// still collapse: the last-processed operation's labels win.
+func TestOperationPhaseMetricsHandler_SameOperationTypeCollapsesToOneSeries(t *testing.T) {
+	now := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	armID := "/subscriptions/sub-1/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster-1"
+
+	op1 := newTestOperation(t, "op-1", api.OperationRequestUpdate, arm.ProvisioningStateSucceeded, armID, now, now)
+	op2 := newTestOperation(t, "op-2", api.OperationRequestUpdate, arm.ProvisioningStateProvisioning, armID, now.Add(time.Hour), now.Add(time.Hour))
+
+	handler, reg := newTestOperationHandler(t)
+
+	handler.Sync(context.Background(), op1)
+	handler.Sync(context.Background(), op2)
+
+	// Only op2's labels remain (same operation_type, last writer wins).
 	expected := `# HELP backend_resource_operation_phase_info Current phase of each operation (value is always 1).
 # TYPE backend_resource_operation_phase_info gauge
 backend_resource_operation_phase_info{operation_type="update",phase="provisioning",resource_id="/subscriptions/sub-1/resourcegroups/rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/cluster-1",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",subscription_id="sub-1"} 1
@@ -603,9 +630,9 @@ backend_resource_operation_phase_info{operation_type="update",phase="provisionin
 
 // TestOperationPhaseMetricsHandler_DeleteOnSiblingDoesNotBlankActiveSeries
 // is the direct regression guard for the bug a previous iteration of
-// this PR introduced: when two operations share an ExternalID
-// (collapsed to one series), Delete on the older terminal operation
-// must NOT blank the newer operation's currently-emitted series.
+// this PR introduced: when two operations share an ExternalID,
+// Delete on the older terminal operation must NOT blank the newer
+// operation's currently-emitted series.
 // The fix is that Delete is a no-op; this test pins it.
 func TestOperationPhaseMetricsHandler_DeleteOnSiblingDoesNotBlankActiveSeries(t *testing.T) {
 	now := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -620,8 +647,8 @@ func TestOperationPhaseMetricsHandler_DeleteOnSiblingDoesNotBlankActiveSeries(t 
 	handler.Sync(context.Background(), op1)
 	handler.Sync(context.Background(), op2)
 
-	// op2's labels currently own the shared series.
-	require.Equal(t, 1, testutil.CollectAndCount(handler.phaseInfo))
+	// Both ops coexist (different operation_type).
+	require.Equal(t, 2, testutil.CollectAndCount(handler.phaseInfo))
 
 	// op1 ages out of cosmos TTL: the controller framework calls
 	// handler.Delete with op1's cosmos doc id. This must NOT blank
@@ -630,10 +657,11 @@ func TestOperationPhaseMetricsHandler_DeleteOnSiblingDoesNotBlankActiveSeries(t 
 	require.NoError(t, err)
 	handler.Delete(op1CosmosKey)
 
-	// op2's series is still emitted.
-	require.Equal(t, 1, testutil.CollectAndCount(handler.phaseInfo))
+	// Both series are still emitted (Delete is a no-op).
+	require.Equal(t, 2, testutil.CollectAndCount(handler.phaseInfo))
 	expected := `# HELP backend_resource_operation_phase_info Current phase of each operation (value is always 1).
 # TYPE backend_resource_operation_phase_info gauge
+backend_resource_operation_phase_info{operation_type="create",phase="succeeded",resource_id="/subscriptions/sub-1/resourcegroups/rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/cluster-1",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",subscription_id="sub-1"} 1
 backend_resource_operation_phase_info{operation_type="update",phase="provisioning",resource_id="/subscriptions/sub-1/resourcegroups/rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/cluster-1",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",subscription_id="sub-1"} 1
 `
 	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expected), "backend_resource_operation_phase_info"))
@@ -641,11 +669,11 @@ backend_resource_operation_phase_info{operation_type="update",phase="provisionin
 
 // TestOperationPhaseMetricsHandler_NilOperationIDDoesNotBlankSibling
 // guards against future regressions of the nil-OperationID branch
-// in Sync. The branch must NOT call deleteByResourceID, because a
-// sibling operation may already own the emitted series for the
-// shared ExternalID. Implicit child-resource cleanups (parent
-// Delete cascades) produce nil-OperationID ops on child ARM ids in
-// production cosmos shape.
+// in Sync. The branch must NOT call deleteByResourceIDAndOperationType,
+// because a sibling operation may already own the emitted series for
+// the shared ExternalID and operation type. Implicit child-resource
+// cleanups (parent Delete cascades) produce nil-OperationID ops on
+// child ARM ids in production cosmos shape.
 func TestOperationPhaseMetricsHandler_NilOperationIDDoesNotBlankSibling(t *testing.T) {
 	now := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	armID := "/subscriptions/sub-1/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster-1"


### PR DESCRIPTION
…on_type

Previously, the operation phase metrics handler called deleteByResourceID before emitting new metric labels, which cleared ALL series for a given resource_id regardless of operation_type. When multiple operations of different types existed for the same ARM resource (e.g. a completed 'create' and an in-flight 'delete'), the informer's unordered relist iteration caused whichever operation was processed last to clobber the other's metrics. This race produced false 'stuck operation' alerts: an in-flight delete operation's start_time could be overwritten by the older create operation's start_time on one relist, then restored on the next.

Scope the pre-emit DeletePartialMatch to resource_id + operation_type. Operations of different types (create, update, delete, requestcredential, revokecredentials) now coexist as independent series on the same resource. Operations of the same type still collapse to one series (last writer wins), which is correct since only one operation of a given type can be active on a resource at a time.

Observed in production: an ExternalAuth delete operation completed at 05:07:04 UTC but the metric continued showing phase=deleting because the completed create operation (same resource_id, different operation_type) was intermittently winning the relist race and clobbering the delete series. This caused a BackendAsyncOperation- ExternalAuthDeleteStuck alert to fire 4 minutes after the operation had already succeeded.
