### PR TITLE
do not merge: OCPBUGS-98213 Verification

### DIFF
--- a/test/e2e/cluster_create_cpo_override_20240610.go
+++ b/test/e2e/cluster_create_cpo_override_20240610.go
@@ -1,0 +1,119 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/test/util/framework"
+	"github.com/Azure/ARO-HCP/test/util/labels"
+	"github.com/Azure/ARO-HCP/test/util/verifiers"
+)
+
+var _ = FDescribe("Create HCPOpenShiftCluster with CPO override (v20240610preview)", func() {
+	It("should create a 5.0 cluster with CPO image override using v20240610preview API",
+		labels.RequireNothing,
+		labels.Critical,
+		labels.Positive,
+		labels.AroRpApiCompatible,
+		labels.CreateCluster,
+		labels.MIContainers(1),
+		func(ctx context.Context) {
+			const customerClusterName = "cpo-override-2406"
+
+			tc := framework.NewTestContext()
+
+			if tc.UsePooledIdentities() {
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
+				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
+			}
+
+			By("creating a resource group")
+			resourceGroup, err := tc.NewResourceGroup(ctx, "cpo-override-2406", tc.Location())
+			Expect(err).NotTo(HaveOccurred(), "failed to create resource group for CPO override test")
+
+			const channelGroup = "candidate"
+
+			By("resolving 5.0 install version")
+			cpVersion, err := framework.GetLatestInstallVersion(ctx, channelGroup, "5.0")
+			Expect(err).NotTo(HaveOccurred(), "failed to resolve 5.0 install version")
+
+			By("creating cluster parameters")
+			clusterParams := framework.NewDefaultClusterParams20240610()
+			clusterParams.ClusterName = customerClusterName
+			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
+			clusterParams.ManagedResourceGroupName = managedResourceGroupName
+			clusterParams.OpenshiftVersionId = cpVersion
+			clusterParams.ChannelGroup = channelGroup
+			clusterParams.Tags[api.TagClusterCPOImageOverride] = to.Ptr(cpoOverrideImage)
+
+			By("creating customer resources (infrastructure and managed identities)")
+			clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,
+				resourceGroup,
+				clusterParams,
+				map[string]interface{}{},
+				TestArtifactsFS,
+				framework.RBACScopeResourceGroup,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to create customer resources for CPO override cluster")
+
+			By("creating the HCP cluster")
+			err = tc.CreateHCPClusterFromParam20240610(ctx,
+				GinkgoLogr,
+				*resourceGroup.Name,
+				clusterParams,
+				framework.ClusterCreationTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster %q with CPO override", customerClusterName)
+
+			By("creating the node pool")
+			nodePoolParams := framework.NewDefaultNodePoolParams20240610()
+			nodePoolParams.ClusterName = customerClusterName
+			nodePoolParams.NodePoolName = "np-1"
+			nodePoolParams.Replicas = int32(2)
+			nodePoolParams.OpenshiftVersionId = cpVersion
+			nodePoolParams.ChannelGroup = channelGroup
+
+			err = tc.CreateNodePoolFromParam20240610(ctx,
+				GinkgoLogr,
+				*resourceGroup.Name,
+				managedResourceGroupName,
+				customerClusterName,
+				nodePoolParams,
+				framework.NodePoolCreationTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to create node pool for CPO override cluster %q", customerClusterName)
+
+			By("getting admin credentials for the cluster")
+			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
+				ctx,
+				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
+				*resourceGroup.Name,
+				customerClusterName,
+				framework.GetAdminRESTConfigTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to get admin REST config for CPO override cluster %q", customerClusterName)
+
+			By("verifying the cluster is viable")
+			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig)
+			Expect(err).NotTo(HaveOccurred(), "failed to verify CPO override cluster %q is viable", customerClusterName)
+		})
+})

--- a/test/e2e/cluster_create_cpo_override_20240610.go
+++ b/test/e2e/cluster_create_cpo_override_20240610.go
@@ -29,7 +29,7 @@ import (
 )
 
 var _ = FDescribe("Create HCPOpenShiftCluster with CPO override (v20240610preview)", func() {
-	It("should create a 5.0 cluster with CPO image override using v20240610preview API",
+	It("should create a 4.22 cluster with CPO image override using v20240610preview API",
 		labels.RequireNothing,
 		labels.Critical,
 		labels.Positive,
@@ -52,9 +52,9 @@ var _ = FDescribe("Create HCPOpenShiftCluster with CPO override (v20240610previe
 
 			const channelGroup = "candidate"
 
-			By("resolving 5.0 install version")
-			cpVersion, err := framework.GetLatestInstallVersion(ctx, channelGroup, "5.0")
-			Expect(err).NotTo(HaveOccurred(), "failed to resolve 5.0 install version")
+			By("resolving 4.22 install version")
+			cpVersion, err := framework.GetLatestInstallVersion(ctx, channelGroup, "4.22")
+			Expect(err).NotTo(HaveOccurred(), "failed to resolve 4.22 install version")
 
 			By("creating cluster parameters")
 			clusterParams := framework.NewDefaultClusterParams20240610()

--- a/test/e2e/cluster_create_cpo_override_20251223.go
+++ b/test/e2e/cluster_create_cpo_override_20251223.go
@@ -1,0 +1,121 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/test/util/framework"
+	"github.com/Azure/ARO-HCP/test/util/labels"
+	"github.com/Azure/ARO-HCP/test/util/verifiers"
+)
+
+var _ = FDescribe("Create HCPOpenShiftCluster with CPO override (v20251223preview)", func() {
+	It("should create a 5.0 cluster with CPO image override using v20251223preview API",
+		labels.RequireNothing,
+		labels.Critical,
+		labels.Positive,
+		labels.AroRpApiCompatible,
+		labels.CreateCluster,
+		labels.MIContainers(1),
+		func(ctx context.Context) {
+			const customerClusterName = "cpo-override-2512"
+
+			tc := framework.NewTestContext()
+
+			if tc.UsePooledIdentities() {
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
+				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
+			}
+
+			By("creating a resource group")
+			resourceGroup, err := tc.NewResourceGroup(ctx, "cpo-override-2512", tc.Location())
+			Expect(err).NotTo(HaveOccurred(), "failed to create resource group for CPO override test")
+
+			const channelGroup = "candidate"
+
+			By("resolving 5.0 install version")
+			cpVersion, err := framework.GetLatestInstallVersion(ctx, channelGroup, "5.0")
+			Expect(err).NotTo(HaveOccurred(), "failed to resolve 5.0 install version")
+
+			By("creating cluster parameters")
+			clusterParams := framework.NewDefaultClusterParams20251223()
+			clusterParams.ClusterName = customerClusterName
+			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
+			clusterParams.ManagedResourceGroupName = managedResourceGroupName
+			clusterParams.OpenshiftVersionId = cpVersion
+			clusterParams.ChannelGroup = channelGroup
+			clusterParams.Tags[api.TagClusterCPOImageOverride] = to.Ptr(cpoOverrideImage)
+
+			By("creating customer resources (infrastructure and managed identities)")
+			clusterParams, err = tc.CreateClusterCustomerResources20251223(ctx,
+				resourceGroup,
+				clusterParams,
+				map[string]interface{}{},
+				TestArtifactsFS,
+				framework.RBACScopeResourceGroup,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to create customer resources for CPO override cluster")
+
+			By("creating the HCP cluster")
+			err = tc.CreateHCPClusterFromParam20251223(
+				ctx,
+				GinkgoLogr,
+				*resourceGroup.Name,
+				clusterParams,
+				nil,
+				framework.ClusterCreationTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster %q with CPO override", customerClusterName)
+
+			By("creating the node pool")
+			nodePoolParams := framework.NewDefaultNodePoolParams20240610()
+			nodePoolParams.ClusterName = customerClusterName
+			nodePoolParams.NodePoolName = "np-1"
+			nodePoolParams.Replicas = int32(2)
+			nodePoolParams.OpenshiftVersionId = cpVersion
+			nodePoolParams.ChannelGroup = channelGroup
+
+			err = tc.CreateNodePoolFromParam20240610(ctx,
+				GinkgoLogr,
+				*resourceGroup.Name,
+				managedResourceGroupName,
+				customerClusterName,
+				nodePoolParams,
+				framework.NodePoolCreationTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to create node pool for CPO override cluster %q", customerClusterName)
+
+			By("getting admin credentials for the cluster")
+			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
+				ctx,
+				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
+				*resourceGroup.Name,
+				customerClusterName,
+				framework.GetAdminRESTConfigTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to get admin REST config for CPO override cluster %q", customerClusterName)
+
+			By("verifying the cluster is viable")
+			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig)
+			Expect(err).NotTo(HaveOccurred(), "failed to verify CPO override cluster %q is viable", customerClusterName)
+		})
+})

--- a/test/e2e/cluster_create_cpo_override_20251223.go
+++ b/test/e2e/cluster_create_cpo_override_20251223.go
@@ -29,7 +29,7 @@ import (
 )
 
 var _ = FDescribe("Create HCPOpenShiftCluster with CPO override (v20251223preview)", func() {
-	It("should create a 5.0 cluster with CPO image override using v20251223preview API",
+	It("should create a 4.22 cluster with CPO image override using v20251223preview API",
 		labels.RequireNothing,
 		labels.Critical,
 		labels.Positive,
@@ -52,9 +52,9 @@ var _ = FDescribe("Create HCPOpenShiftCluster with CPO override (v20251223previe
 
 			const channelGroup = "candidate"
 
-			By("resolving 5.0 install version")
-			cpVersion, err := framework.GetLatestInstallVersion(ctx, channelGroup, "5.0")
-			Expect(err).NotTo(HaveOccurred(), "failed to resolve 5.0 install version")
+			By("resolving 4.22 install version")
+			cpVersion, err := framework.GetLatestInstallVersion(ctx, channelGroup, "4.22")
+			Expect(err).NotTo(HaveOccurred(), "failed to resolve 4.22 install version")
 
 			By("creating cluster parameters")
 			clusterParams := framework.NewDefaultClusterParams20251223()

--- a/test/e2e/cluster_create_private_kv.go
+++ b/test/e2e/cluster_create_private_kv.go
@@ -23,13 +23,14 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 
+	"github.com/Azure/ARO-HCP/internal/api"
 	hcpsdk20251223preview "github.com/Azure/ARO-HCP/test/sdk/v20251223preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
 	"github.com/Azure/ARO-HCP/test/util/framework"
 	"github.com/Azure/ARO-HCP/test/util/labels"
 	"github.com/Azure/ARO-HCP/test/util/verifiers"
 )
 
-var _ = Describe("Create HCPOpenShiftCluster with Private KeyVault", func() {
+var _ = FDescribe("Create HCPOpenShiftCluster with Private KeyVault", func() {
 	BeforeEach(func() {
 		// do nothing. per test initialization usually ages better than shared.
 	})
@@ -55,12 +56,21 @@ var _ = Describe("Create HCPOpenShiftCluster with Private KeyVault", func() {
 			resourceGroup, err := tc.NewResourceGroup(ctx, "private-keyvault", tc.Location())
 			Expect(err).NotTo(HaveOccurred(), "failed to create resource group for private keyvault test")
 
+			const channelGroup = "candidate"
+
+			By("resolving 4.22 install version")
+			cpVersion, err := framework.GetLatestInstallVersion(ctx, channelGroup, "4.22")
+			Expect(err).NotTo(HaveOccurred(), "failed to resolve 4.22 install version")
+
 			By("creating cluster parameters")
 			clusterParams := framework.NewDefaultClusterParams20251223()
 			clusterParams.ClusterName = customerClusterName
 			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
 			clusterParams.ManagedResourceGroupName = managedResourceGroupName
 			clusterParams.KeyVaultVisibility = "Private"
+			clusterParams.OpenshiftVersionId = cpVersion
+			clusterParams.ChannelGroup = channelGroup
+			clusterParams.Tags[api.TagClusterCPOImageOverride] = to.Ptr("arohcpocpdev.azurecr.io/control-plane-operator@sha256:9798300ddc444b64061b4e1630ebaf5c3ec196982d1f9f8fe71b0e3a90a9c90c")
 
 			By("creating customer resources (infrastructure and managed identities)")
 			clusterParams, err = tc.CreateClusterCustomerResources20251223(ctx,
@@ -125,6 +135,8 @@ var _ = Describe("Create HCPOpenShiftCluster with Private KeyVault", func() {
 			nodePoolParams.ClusterName = customerClusterName
 			nodePoolParams.NodePoolName = "np-1"
 			nodePoolParams.Replicas = int32(2)
+			nodePoolParams.OpenshiftVersionId = cpVersion
+			nodePoolParams.ChannelGroup = channelGroup
 
 			err = tc.CreateNodePoolFromParam20240610(ctx,
 				GinkgoLogr,

--- a/test/e2e/cluster_create_private_kv.go
+++ b/test/e2e/cluster_create_private_kv.go
@@ -58,9 +58,9 @@ var _ = FDescribe("Create HCPOpenShiftCluster with Private KeyVault", func() {
 
 			const channelGroup = "candidate"
 
-			By("resolving 4.22 install version")
-			cpVersion, err := framework.GetLatestInstallVersion(ctx, channelGroup, "4.22")
-			Expect(err).NotTo(HaveOccurred(), "failed to resolve 4.22 install version")
+			By("resolving 5.0 install version")
+			cpVersion, err := framework.GetLatestInstallVersion(ctx, channelGroup, "5.0")
+			Expect(err).NotTo(HaveOccurred(), "failed to resolve 5.0 install version")
 
 			By("creating cluster parameters")
 			clusterParams := framework.NewDefaultClusterParams20251223()
@@ -70,7 +70,7 @@ var _ = FDescribe("Create HCPOpenShiftCluster with Private KeyVault", func() {
 			clusterParams.KeyVaultVisibility = "Private"
 			clusterParams.OpenshiftVersionId = cpVersion
 			clusterParams.ChannelGroup = channelGroup
-			clusterParams.Tags[api.TagClusterCPOImageOverride] = to.Ptr("arohcpocpdev.azurecr.io/control-plane-operator@sha256:9798300ddc444b64061b4e1630ebaf5c3ec196982d1f9f8fe71b0e3a90a9c90c")
+			clusterParams.Tags[api.TagClusterCPOImageOverride] = to.Ptr("arohcpocpdev.azurecr.io/control-plane-operator@sha256:edb375fd935a683a08e56d7594513595d2fd05c8c9d10b4afab3e450fca0b674") // d565a6ed5b
 
 			By("creating customer resources (infrastructure and managed identities)")
 			clusterParams, err = tc.CreateClusterCustomerResources20251223(ctx,

--- a/test/e2e/cluster_create_private_kv.go
+++ b/test/e2e/cluster_create_private_kv.go
@@ -70,7 +70,7 @@ var _ = FDescribe("Create HCPOpenShiftCluster with Private KeyVault", func() {
 			clusterParams.KeyVaultVisibility = "Private"
 			clusterParams.OpenshiftVersionId = cpVersion
 			clusterParams.ChannelGroup = channelGroup
-			clusterParams.Tags[api.TagClusterCPOImageOverride] = to.Ptr("arohcpocpdev.azurecr.io/control-plane-operator@sha256:edb375fd935a683a08e56d7594513595d2fd05c8c9d10b4afab3e450fca0b674") // d565a6ed5b
+			clusterParams.Tags[api.TagClusterCPOImageOverride] = to.Ptr(cpoOverrideImage)
 
 			By("creating customer resources (infrastructure and managed identities)")
 			clusterParams, err = tc.CreateClusterCustomerResources20251223(ctx,

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -27,6 +27,8 @@ import (
 	"github.com/Azure/ARO-HCP/test/util/log"
 )
 
+const cpoOverrideImage = "arohcpocpdev.azurecr.io/control-plane-operator@sha256:edb375fd935a683a08e56d7594513595d2fd05c8c9d10b4afab3e450fca0b674"
+
 var (
 	e2eSetup integration.SetupModel
 )

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -27,7 +27,7 @@ import (
 	"github.com/Azure/ARO-HCP/test/util/log"
 )
 
-const cpoOverrideImage = "arohcpocpdev.azurecr.io/control-plane-operator@sha256:edb375fd935a683a08e56d7594513595d2fd05c8c9d10b4afab3e450fca0b674"
+const cpoOverrideImage = "arohcpocpdev.azurecr.io/control-plane-operator@sha256:2a9a553057e74e9263829ad636213cad63f9d8ae91a104e0a3d593a0164ce294"
 
 var (
 	e2eSetup integration.SetupModel

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_dev_cd_check_paralleldev_cd_check_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_dev_cd_check_paralleldev_cd_check_parallel.txt
@@ -8,6 +8,8 @@ Customer should be able to create an HCP cluster with custom autoscaling and upd
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
 Customer should be able to create a cluster and node pools with aggregated advanced features
+Create HCPOpenShiftCluster with CPO override (v20240610preview) should create a 5.0 cluster with CPO image override using v20240610preview API
+Create HCPOpenShiftCluster with CPO override (v20251223preview) should create a 5.0 cluster with CPO image override using v20251223preview API
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Customer should create a cluster with private ingress using v20260630preview and verify the ingress is internal
 Customer should create a cluster with private KAS and verify API server is only reachable from VNet while ingress remains public

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_dev_cd_check_paralleldev_cd_check_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_dev_cd_check_paralleldev_cd_check_parallel.txt
@@ -7,9 +7,9 @@ Authorized CIDRs Connectivity should allow API access only from authorized VM IP
 Customer should be able to create an HCP cluster with custom autoscaling and update the autoscaling configuration
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
+Create HCPOpenShiftCluster with CPO override (v20240610preview) should create a 4.22 cluster with CPO image override using v20240610preview API
+Create HCPOpenShiftCluster with CPO override (v20251223preview) should create a 4.22 cluster with CPO image override using v20251223preview API
 Customer should be able to create a cluster and node pools with aggregated advanced features
-Create HCPOpenShiftCluster with CPO override (v20240610preview) should create a 5.0 cluster with CPO image override using v20240610preview API
-Create HCPOpenShiftCluster with CPO override (v20251223preview) should create a 5.0 cluster with CPO image override using v20251223preview API
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Customer should create a cluster with private ingress using v20260630preview and verify the ingress is internal
 Customer should create a cluster with private KAS and verify API server is only reachable from VNet while ingress remains public

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
@@ -6,9 +6,9 @@ Authorized CIDRs Connectivity should allow API access only from authorized VM IP
 Customer should be able to create an HCP cluster with custom autoscaling and update the autoscaling configuration
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
+Create HCPOpenShiftCluster with CPO override (v20240610preview) should create a 4.22 cluster with CPO image override using v20240610preview API
+Create HCPOpenShiftCluster with CPO override (v20251223preview) should create a 4.22 cluster with CPO image override using v20251223preview API
 Customer should be able to create a cluster and node pools with aggregated advanced features
-Create HCPOpenShiftCluster with CPO override (v20240610preview) should create a 5.0 cluster with CPO image override using v20240610preview API
-Create HCPOpenShiftCluster with CPO override (v20251223preview) should create a 5.0 cluster with CPO image override using v20251223preview API
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Customer should create a cluster with private ingress using v20260630preview and verify the ingress is internal
 Customer should create a cluster with private KAS and verify API server is only reachable from VNet while ingress remains public

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
@@ -7,6 +7,8 @@ Customer should be able to create an HCP cluster with custom autoscaling and upd
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
 Customer should be able to create a cluster and node pools with aggregated advanced features
+Create HCPOpenShiftCluster with CPO override (v20240610preview) should create a 5.0 cluster with CPO image override using v20240610preview API
+Create HCPOpenShiftCluster with CPO override (v20251223preview) should create a 5.0 cluster with CPO image override using v20251223preview API
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Customer should create a cluster with private ingress using v20260630preview and verify the ingress is internal
 Customer should create a cluster with private KAS and verify API server is only reachable from VNet while ingress remains public

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
@@ -6,9 +6,9 @@ Authorized CIDRs Connectivity should allow API access only from authorized VM IP
 Customer should be able to create an HCP cluster with custom autoscaling and update the autoscaling configuration
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
+Create HCPOpenShiftCluster with CPO override (v20240610preview) should create a 4.22 cluster with CPO image override using v20240610preview API
+Create HCPOpenShiftCluster with CPO override (v20251223preview) should create a 4.22 cluster with CPO image override using v20251223preview API
 Customer should be able to create a cluster and node pools with aggregated advanced features
-Create HCPOpenShiftCluster with CPO override (v20240610preview) should create a 5.0 cluster with CPO image override using v20240610preview API
-Create HCPOpenShiftCluster with CPO override (v20251223preview) should create a 5.0 cluster with CPO image override using v20251223preview API
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Customer should create a cluster with private ingress using v20260630preview and verify the ingress is internal
 Customer should create a cluster with private KAS and verify API server is only reachable from VNet while ingress remains public

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
@@ -7,6 +7,8 @@ Customer should be able to create an HCP cluster with custom autoscaling and upd
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
 Customer should be able to create a cluster and node pools with aggregated advanced features
+Create HCPOpenShiftCluster with CPO override (v20240610preview) should create a 5.0 cluster with CPO image override using v20240610preview API
+Create HCPOpenShiftCluster with CPO override (v20251223preview) should create a 5.0 cluster with CPO image override using v20251223preview API
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Customer should create a cluster with private ingress using v20260630preview and verify the ingress is internal
 Customer should create a cluster with private KAS and verify API server is only reachable from VNet while ingress remains public

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
@@ -9,9 +9,9 @@ Authorized CIDRs Connectivity should allow API access only from authorized VM IP
 Customer should be able to create an HCP cluster with custom autoscaling and update the autoscaling configuration
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
+Create HCPOpenShiftCluster with CPO override (v20240610preview) should create a 4.22 cluster with CPO image override using v20240610preview API
+Create HCPOpenShiftCluster with CPO override (v20251223preview) should create a 4.22 cluster with CPO image override using v20251223preview API
 Customer should be able to create a cluster and node pools with aggregated advanced features
-Create HCPOpenShiftCluster with CPO override (v20240610preview) should create a 5.0 cluster with CPO image override using v20240610preview API
-Create HCPOpenShiftCluster with CPO override (v20251223preview) should create a 5.0 cluster with CPO image override using v20251223preview API
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Customer should create a cluster with private ingress using v20260630preview and verify the ingress is internal
 Customer should create a cluster with private KAS and verify API server is only reachable from VNet while ingress remains public

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
@@ -10,6 +10,8 @@ Customer should be able to create an HCP cluster with custom autoscaling and upd
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
 Customer should be able to create a cluster and node pools with aggregated advanced features
+Create HCPOpenShiftCluster with CPO override (v20240610preview) should create a 5.0 cluster with CPO image override using v20240610preview API
+Create HCPOpenShiftCluster with CPO override (v20251223preview) should create a 5.0 cluster with CPO image override using v20251223preview API
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Customer should create a cluster with private ingress using v20260630preview and verify the ingress is internal
 Customer should create a cluster with private KAS and verify API server is only reachable from VNet while ingress remains public

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
@@ -6,9 +6,9 @@ Authorized CIDRs Connectivity should allow API access only from authorized VM IP
 Customer should be able to create an HCP cluster with custom autoscaling and update the autoscaling configuration
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
+Create HCPOpenShiftCluster with CPO override (v20240610preview) should create a 4.22 cluster with CPO image override using v20240610preview API
+Create HCPOpenShiftCluster with CPO override (v20251223preview) should create a 4.22 cluster with CPO image override using v20251223preview API
 Customer should be able to create a cluster and node pools with aggregated advanced features
-Create HCPOpenShiftCluster with CPO override (v20240610preview) should create a 5.0 cluster with CPO image override using v20240610preview API
-Create HCPOpenShiftCluster with CPO override (v20251223preview) should create a 5.0 cluster with CPO image override using v20251223preview API
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Customer should create a cluster with private ingress using v20260630preview and verify the ingress is internal
 Customer should create a cluster with private KAS and verify API server is only reachable from VNet while ingress remains public

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
@@ -7,6 +7,8 @@ Customer should be able to create an HCP cluster with custom autoscaling and upd
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
 Customer should be able to create a cluster and node pools with aggregated advanced features
+Create HCPOpenShiftCluster with CPO override (v20240610preview) should create a 5.0 cluster with CPO image override using v20240610preview API
+Create HCPOpenShiftCluster with CPO override (v20251223preview) should create a 5.0 cluster with CPO image override using v20251223preview API
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Customer should create a cluster with private ingress using v20260630preview and verify the ingress is internal
 Customer should create a cluster with private KAS and verify API server is only reachable from VNet while ingress remains public

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
@@ -6,9 +6,9 @@ Authorized CIDRs Connectivity should allow API access only from authorized VM IP
 Customer should be able to create an HCP cluster with custom autoscaling and update the autoscaling configuration
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
+Create HCPOpenShiftCluster with CPO override (v20240610preview) should create a 4.22 cluster with CPO image override using v20240610preview API
+Create HCPOpenShiftCluster with CPO override (v20251223preview) should create a 4.22 cluster with CPO image override using v20251223preview API
 Customer should be able to create a cluster and node pools with aggregated advanced features
-Create HCPOpenShiftCluster with CPO override (v20240610preview) should create a 5.0 cluster with CPO image override using v20240610preview API
-Create HCPOpenShiftCluster with CPO override (v20251223preview) should create a 5.0 cluster with CPO image override using v20251223preview API
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Customer should create a cluster with private ingress using v20260630preview and verify the ingress is internal
 Customer should create a cluster with private KAS and verify API server is only reachable from VNet while ingress remains public

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
@@ -7,6 +7,8 @@ Customer should be able to create an HCP cluster with custom autoscaling and upd
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
 Customer should be able to create a cluster and node pools with aggregated advanced features
+Create HCPOpenShiftCluster with CPO override (v20240610preview) should create a 5.0 cluster with CPO image override using v20240610preview API
+Create HCPOpenShiftCluster with CPO override (v20251223preview) should create a 5.0 cluster with CPO image override using v20251223preview API
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Customer should create a cluster with private ingress using v20260630preview and verify the ingress is internal
 Customer should create a cluster with private KAS and verify API server is only reachable from VNet while ingress remains public


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Help verify router pod doesn't get deployed until all route are able to be rendered in the router configmap.  

### Why

### Testing
- Build and push https://github.com/openshift/hypershift/pull/8971 out of band to ACR
- FDescribe on private key vault test so only that e2e runs.
- Look at kusto for the run in question
    - Check events to validate there's only ever a single replicaset of the private-router pod in the hostedcluster namespace
    - Check mgmt-agent logs and kube-apiserver logs to validate the configmap is created, then updated later with the ignition route, then the router pod is created 
