### PR TITLE
dev: bump default AMW limits

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -389,10 +389,10 @@ defaults:
     hcpWorkspaceName: 'hcps-{{ .ctx.region }}'
     # Azure Monitor Workspace ingestion limits
     # 2M initial limit, bump per env when hitting 50% utilization (Azure requires <200% increase)
-    svcMaxActiveTimeSeriesMillions: 2
-    svcMaxEventsPerMinuteMillions: 2
-    hcpMaxActiveTimeSeriesMillions: 2
-    hcpMaxEventsPerMinuteMillions: 2
+    svcMaxActiveTimeSeriesMillions: 4
+    svcMaxEventsPerMinuteMillions: 4
+    hcpMaxActiveTimeSeriesMillions: 4
+    hcpMaxEventsPerMinuteMillions: 4
     alertRuleOwningTeamTag: ""
     # alertsEnabled: disables the Azure Action Group resource (affects all lanes: SRE, SL, RP, MSFT)
     alertsEnabled: false


### PR DESCRIPTION
In e2e, we are hitting both the timeseries limit and the ingestion limit for our per-e2e-test AMW. Try doubling the capacity. If this doesn't work, we may need to get our e2e subscriptions allow-listed by the AMW team to start off with a higher floor than they normally do.
