### PR TITLE
feat: enable setting maxSurge and maxUnavailable per env

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -501,6 +501,34 @@
         "zoneRedundantMode"
       ]
     },
+    "aksUpgradeSettings": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "maxSurge": {
+          "description": "Maximum number or percentage of nodes surged during upgrade.",
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "maxUnavailable": {
+          "description": "Maximum number or percentage of nodes unavailable during upgrade.",
+          "oneOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        }
+      }
+    },
     "aksConfig": {
       "type": "object",
       "additionalProperties": false,
@@ -558,6 +586,9 @@
         },
         "enableSwiftV2Nodepools": {
           "type": "boolean"
+        },
+        "upgradeSettings": {
+          "$ref": "#/definitions/aksUpgradeSettings"
         }
       },
       "required": [

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -509,7 +509,8 @@
           "description": "Maximum number or percentage of nodes surged during upgrade.",
           "oneOf": [
             {
-              "type": "integer"
+              "type": "integer",
+              "minimum": 0
             },
             {
               "type": "string"
@@ -520,14 +521,19 @@
           "description": "Maximum number or percentage of nodes unavailable during upgrade.",
           "oneOf": [
             {
-              "type": "integer"
+              "type": "integer",
+              "minimum": 0
             },
             {
               "type": "string"
             }
           ]
         }
-      }
+      },
+      "required": [
+        "maxSurge",
+        "maxUnavailable"
+      ]
     },
     "aksConfig": {
       "type": "object",

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -507,6 +507,9 @@ defaults:
       kubernetesVersion: "1.35"
       networkDataplane: "cilium"
       networkPolicy: "cilium"
+      upgradeSettings:
+        maxSurge: "10%"
+        maxUnavailable: 0
       systemAgentPool:
         name: 'system'
         minCount: 1
@@ -637,6 +640,9 @@ defaults:
       kubernetesVersion: "1.35"
       networkDataplane: "azure"
       networkPolicy: "azure"
+      upgradeSettings:
+        maxSurge: "10%"
+        maxUnavailable: 0
       etcd:
         name: "ah-{{ .ctx.environment }}-me-{{ .ctx.regionShort }}-{{ .ctx.stamp }}" # [globally-unique]
         softDelete: true

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -635,6 +635,9 @@ mgmt:
       vmSize: Standard_D16ds_v6
       zoneRedundantMode: Auto
       zones: ""
+    upgradeSettings:
+      maxSurge: 10%
+      maxUnavailable: 0
     userAgentPool:
       maxCount: 14
       minCount: 7
@@ -980,6 +983,9 @@ svc:
       vmSize: Standard_D4ds_v6
       zoneRedundantMode: Auto
       zones: ""
+    upgradeSettings:
+      maxSurge: 10%
+      maxUnavailable: 0
     userAgentPool:
       maxCount: 3
       minCount: 1

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -635,6 +635,9 @@ mgmt:
       vmSize: Standard_D16ds_v6
       zoneRedundantMode: Auto
       zones: ""
+    upgradeSettings:
+      maxSurge: 10%
+      maxUnavailable: 0
     userAgentPool:
       maxCount: 14
       minCount: 7
@@ -980,6 +983,9 @@ svc:
       vmSize: Standard_D4ds_v6
       zoneRedundantMode: Auto
       zones: ""
+    upgradeSettings:
+      maxSurge: 10%
+      maxUnavailable: 0
     userAgentPool:
       maxCount: 3
       minCount: 1

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -635,6 +635,9 @@ mgmt:
       vmSize: Standard_E8s_v3
       zoneRedundantMode: Auto
       zones: ""
+    upgradeSettings:
+      maxSurge: 10%
+      maxUnavailable: 0
     userAgentPool:
       maxCount: 3
       minCount: 1
@@ -978,6 +981,9 @@ svc:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
+    upgradeSettings:
+      maxSurge: 10%
+      maxUnavailable: 0
     userAgentPool:
       maxCount: 12
       minCount: 2

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -635,6 +635,9 @@ mgmt:
       vmSize: Standard_E8s_v3
       zoneRedundantMode: Auto
       zones: ""
+    upgradeSettings:
+      maxSurge: 10%
+      maxUnavailable: 0
     userAgentPool:
       maxCount: 3
       minCount: 1
@@ -978,6 +981,9 @@ svc:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
+    upgradeSettings:
+      maxSurge: 10%
+      maxUnavailable: 0
     userAgentPool:
       maxCount: 3
       minCount: 1

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -635,6 +635,9 @@ mgmt:
       vmSize: Standard_E8s_v3
       zoneRedundantMode: Auto
       zones: ""
+    upgradeSettings:
+      maxSurge: 10%
+      maxUnavailable: 0
     userAgentPool:
       maxCount: 3
       minCount: 1
@@ -978,6 +981,9 @@ svc:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
+    upgradeSettings:
+      maxSurge: 10%
+      maxUnavailable: 0
     userAgentPool:
       maxCount: 3
       minCount: 1

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -635,6 +635,9 @@ mgmt:
       vmSize: Standard_D4s_v3
       zoneRedundantMode: Auto
       zones: ""
+    upgradeSettings:
+      maxSurge: 10%
+      maxUnavailable: 0
     userAgentPool:
       maxCount: 6
       minCount: 1
@@ -980,6 +983,9 @@ svc:
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""
+    upgradeSettings:
+      maxSurge: 10%
+      maxUnavailable: 0
     userAgentPool:
       maxCount: 3
       minCount: 1

--- a/dev-infrastructure/configurations/mgmt-cluster.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/mgmt-cluster.tmpl.bicepparam
@@ -39,6 +39,8 @@ param aksNetworkDataplane = '{{ .mgmt.aks.networkDataplane }}'
 param aksNetworkPolicy = '{{ .mgmt.aks.networkDataplane }}'
 param aksEnableSwiftVnet = {{ .mgmt.aks.enableSwiftV2Vnet }}
 param aksEnableSwiftNodepools = {{ .mgmt.aks.enableSwiftV2Nodepools }}
+param aksUpgradeSettingsMaxSurge = '{{ .mgmt.aks.upgradeSettings.maxSurge }}'
+param aksUpgradeSettingsMaxUnavailable = '{{ .mgmt.aks.upgradeSettings.maxUnavailable }}'
 
 // Maestro
 param maestroConsumerMIName = '{{ .maestro.agent.managedIdentityName }}'

--- a/dev-infrastructure/configurations/svc-cluster.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/svc-cluster.tmpl.bicepparam
@@ -42,6 +42,8 @@ param userOsDiskSizeGB = {{ .svc.aks.userAgentPool.osDiskSizeGB }}
 param aksClusterOutboundIPAddressIPTags = '{{ .svc.aks.clusterOutboundIPAddressIPTags }}'
 param aksNetworkDataplane = '{{ .svc.aks.networkDataplane }}'
 param aksNetworkPolicy = '{{ .svc.aks.networkDataplane }}'
+param aksUpgradeSettingsMaxSurge = '{{ .svc.aks.upgradeSettings.maxSurge }}'
+param aksUpgradeSettingsMaxUnavailable = '{{ .svc.aks.upgradeSettings.maxUnavailable }}'
 
 param rpCosmosDbName = '{{ .frontend.cosmosDB.name }}'
 param rpCosmosDbPrivate = {{ .frontend.cosmosDB.private }}

--- a/dev-infrastructure/modules/aks-cluster-base.bicep
+++ b/dev-infrastructure/modules/aks-cluster-base.bicep
@@ -56,6 +56,9 @@ param networkDataplane string
 param networkPolicy string
 param enableSwiftV2Nodepools bool
 
+param upgradeSettingsMaxSurge string
+param upgradeSettingsMaxUnavailable string
+
 param aksClusterUserDefinedManagedIdentityName string
 
 @description('IPTags to be set on the cluster outbound IP address in the format of ipTagType:tag,ipTagType:tag')
@@ -503,6 +506,8 @@ module userAgentPools '../modules/aks/pool.bicep' = {
     vnetSubnetId: nodeSubnetId
     podSubnetId: aksPodSubnet.id
     zoneRedundantMode: userZoneRedundantMode
+    upgradeSettingsMaxSurge: upgradeSettingsMaxSurge
+    upgradeSettingsMaxUnavailable: upgradeSettingsMaxUnavailable
     maxPods: 225
   }
 }
@@ -524,6 +529,8 @@ module infraAgentPools '../modules/aks/pool.bicep' = {
     vnetSubnetId: nodeSubnetId
     podSubnetId: aksPodSubnet.id
     zoneRedundantMode: infraZoneRedundantMode
+    upgradeSettingsMaxSurge: upgradeSettingsMaxSurge
+    upgradeSettingsMaxUnavailable: upgradeSettingsMaxUnavailable
     maxPods: 225
     taints: [
       'infra=true:NoSchedule'

--- a/dev-infrastructure/modules/aks/pool.bicep
+++ b/dev-infrastructure/modules/aks/pool.bicep
@@ -19,6 +19,9 @@ param podSubnetId string
 
 param maxPods int
 
+param upgradeSettingsMaxSurge string
+param upgradeSettingsMaxUnavailable string
+
 param taints array = []
 
 type Pool = {
@@ -65,7 +68,7 @@ var userPools = concat(zonalPools, nonZonalPools)
 //   P O O L   C R E A T I O N
 //
 
-resource aksCluster 'Microsoft.ContainerService/managedClusters@2024-10-01' existing = {
+resource aksCluster 'Microsoft.ContainerService/managedClusters@2025-07-02-preview' existing = {
   name: aksClusterName
 }
 
@@ -81,7 +84,7 @@ var swiftNodepoolTags = enableSwiftV2
         })
   : null
 
-resource userAgentPools 'Microsoft.ContainerService/managedClusters/agentPools@2024-10-01' = [
+resource userAgentPools 'Microsoft.ContainerService/managedClusters/agentPools@2025-07-02-preview' = [
   for (pool, i) in userPools: {
     parent: aksCluster
     name: take(pool.name, 12)
@@ -102,7 +105,8 @@ resource userAgentPools 'Microsoft.ContainerService/managedClusters/agentPools@2
       vmSize: vmSize
       type: 'VirtualMachineScaleSets'
       upgradeSettings: {
-        maxSurge: '10%'
+        maxSurge: upgradeSettingsMaxSurge
+        maxUnavailable: upgradeSettingsMaxUnavailable
       }
       vnetSubnetID: vnetSubnetId
       podSubnetID: podSubnetId

--- a/dev-infrastructure/templates/mgmt-cluster.bicep
+++ b/dev-infrastructure/templates/mgmt-cluster.bicep
@@ -137,6 +137,12 @@ param aksEnableSwiftVnet bool
 @description('Enable Swift V2 for the AKS cluster nodepools')
 param aksEnableSwiftNodepools bool
 
+@description('Maximum surge for AKS node pool upgrades')
+param aksUpgradeSettingsMaxSurge string
+
+@description('Maximum unavailable for AKS node pool upgrades')
+param aksUpgradeSettingsMaxUnavailable string
+
 @description('The name of the maestro consumer.')
 param maestroConsumerName string
 
@@ -405,6 +411,8 @@ module mgmtCluster '../modules/aks-cluster-base.bicep' = {
     networkPolicy: aksNetworkPolicy
     deploymentMsiId: globalMSIId
     enableSwiftV2Nodepools: aksEnableSwiftNodepools
+    upgradeSettingsMaxSurge: aksUpgradeSettingsMaxSurge
+    upgradeSettingsMaxUnavailable: aksUpgradeSettingsMaxUnavailable
     owningTeamTagValue: owningTeamTagValue
     aksClusterUserDefinedManagedIdentityName: aksClusterUserDefinedManagedIdentity.name
   }

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -47,6 +47,12 @@ param aksNetworkDataplane string
 @description('Network policy plugin for the AKS cluster')
 param aksNetworkPolicy string
 
+@description('Maximum surge for AKS node pool upgrades')
+param aksUpgradeSettingsMaxSurge string
+
+@description('Maximum unavailable for AKS node pool upgrades')
+param aksUpgradeSettingsMaxUnavailable string
+
 @description('Name of the user agent pool')
 param userAgentPoolName string
 
@@ -685,6 +691,8 @@ module svcCluster '../modules/aks-cluster-base.bicep' = {
     pullAcrResourceIds: [svcAcrResourceId]
     deploymentMsiId: globalMSIId
     enableSwiftV2Nodepools: false
+    upgradeSettingsMaxSurge: aksUpgradeSettingsMaxSurge
+    upgradeSettingsMaxUnavailable: aksUpgradeSettingsMaxUnavailable
     owningTeamTagValue: owningTeamTagValue
     aksClusterUserDefinedManagedIdentityName: aksClusterUserDefinedManagedIdentity.name
   }


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-1470

### What
 
Added configurable AKS node pool upgradeSettings (maxSurge and maxUnavailable) to the config system, replacing the hardcoded maxSurge: '10%' in Bicep modules.

Config layer:
  - Added aksUpgradeSettings schema definition to config.schema.json (accepts both integers and strings, e.g. 1 or "10%")
  - Added upgradeSettings property to aksConfig
  - Set defaults in config.yaml: maxSurge: "10%", maxUnavailable: 0

Bicep layer:
  - Threaded upgradeSettingsMaxSurge and upgradeSettingsMaxUnavailable params through .tmpl.bicepparam → template .bicep → aks-cluster-base.bicep → pool.bicep
  - Bumped pool.bicep API version from @2024-10-01 to @2025-07-02-preview (matching aks-cluster-base.bicep) since the stable API doesn't support maxUnavailable
  - System pool upgradeSettings is left hardcoded at maxSurge: '10%' — AKS does not allow maxUnavailable > 0 on system pools, so making it configurable would only create a footgun

The settings apply to user and infra agent pools only.

### Why

Stage is stuck on an AKS node pool image upgrade. There is no capacity in the region to surge an extra node, so the rollout is blocked. Setting maxSurge: 0 and maxUnavailable: 1 for stage will allow AKS to drain and replace nodes in-place instead of surging.

This needs to be overridable per-environment so stage can use the in-place strategy while prod keeps the default surge behavior.


### Testing

Deployed to a personal dev environment (pers) with maxSurge: 0, maxUnavailable: 1 override on both svc and mgmt clusters. Validated:
  - User and infra agent pools accepted the settings and upgraded in-place
  - System pool was unaffected (keeps hardcoded maxSurge: '10%')
  - Default values (maxSurge: "10%", maxUnavailable: 0) produce identical Bicep behavior to the previous hardcoded upgradeSettings: { maxSurge: '10%' }

Discovered AKS constraints during testing:
  - System pools reject maxUnavailable > 0
  - maxSurge and maxUnavailable cannot both be greater than 0
  - The stable API (@2024-10-01) does not support maxUnavailable at all

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
