### PR TITLE
Revert "Merge pull request #5844 from Azure/amw-hcp-internal-api"

### DIFF
--- a/dev-infrastructure/configurations/region.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/region.tmpl.bicepparam
@@ -28,4 +28,3 @@ param svcAmwMaxActiveTimeSeriesMillions = {{ .monitoring.svcMaxActiveTimeSeriesM
 param svcAmwMaxEventsPerMinuteMillions = {{ .monitoring.svcMaxEventsPerMinuteMillions }}
 param hcpAmwMaxActiveTimeSeriesMillions = {{ .monitoring.hcpMaxActiveTimeSeriesMillions }}
 param hcpAmwMaxEventsPerMinuteMillions = {{ .monitoring.hcpMaxEventsPerMinuteMillions }}
-param hcpMonitorUseInternalApi = {{ if eq .environmentName "int" }}true{{ else }}false{{ end }}

--- a/dev-infrastructure/modules/metrics/monitor.bicep
+++ b/dev-infrastructure/modules/metrics/monitor.bicep
@@ -7,23 +7,12 @@ param monitorName string
 @description('Purpose of the monitor')
 param purpose string
 
-@description('Use the internal Microsoft API version for the Azure Monitor Workspace')
-param useInternalApiVersion bool = false
-
 import * as res from '../resource.bicep'
 
 var grafanaRef = res.grafanaRefFromId(grafanaResourceId)
 var hasGrafanaResourceId = !empty(grafanaResourceId)
 
-resource monitor 'microsoft.monitor/accounts@2021-06-03-preview' = if (!useInternalApiVersion) {
-  name: monitorName
-  location: resourceGroup().location
-  tags: {
-    aroHCPPurpose: purpose
-  }
-}
-
-resource monitorInternal 'microsoft.monitor/accounts@2021-06-01-preview' = if (useInternalApiVersion) {
+resource monitor 'microsoft.monitor/accounts@2021-06-03-preview' = {
   name: monitorName
   location: resourceGroup().location
   tags: {
@@ -39,7 +28,7 @@ resource grafana 'Microsoft.Dashboard/grafana@2023-09-01' existing = if (hasGraf
   scope: resourceGroup(grafanaRef.resourceGroup.subscriptionId, grafanaRef.resourceGroup.name)
 }
 
-resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (hasGrafanaResourceId && !useInternalApiVersion) {
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (hasGrafanaResourceId) {
   name: guid(monitor.id, grafana!.id, dataReader)
   scope: monitor
   properties: {
@@ -49,17 +38,5 @@ resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = i
   }
 }
 
-resource roleAssignmentInternal 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (hasGrafanaResourceId && useInternalApiVersion) {
-  name: guid(monitorInternal.id, grafana!.id, dataReader)
-  scope: monitorInternal
-  properties: {
-    principalId: grafana!.identity.principalId
-    principalType: 'ServicePrincipal'
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', dataReader)
-  }
-}
-
-output monitorId string = useInternalApiVersion ? monitorInternal.id : monitor.id
-output monitorPrometheusQueryEndpoint string = useInternalApiVersion
-  ? monitorInternal.properties.metrics.prometheusQueryEndpoint
-  : monitor.properties.metrics.prometheusQueryEndpoint
+output monitorId string = monitor.id
+output monitorPrometheusQueryEndpoint string = monitor.properties.metrics.prometheusQueryEndpoint

--- a/dev-infrastructure/templates/region.bicep
+++ b/dev-infrastructure/templates/region.bicep
@@ -63,9 +63,6 @@ param hcpAmwMaxActiveTimeSeriesMillions int = 2
 @description('Maximum events per minute limit for the HCP Azure Monitor Workspace in millions (2M initial, bump when hitting 50% utilization)')
 param hcpAmwMaxEventsPerMinuteMillions int = 2
 
-@description('Use the internal Microsoft API version for the HCP Azure Monitor Workspace')
-param hcpMonitorUseInternalApi bool = false
-
 import { determineZoneRedundancyForRegion } from '../modules/common.bicep'
 import * as res from '../modules/resource.bicep'
 
@@ -178,7 +175,6 @@ module hcpMonitor '../modules/metrics/monitor.bicep' = {
     grafanaResourceId: grafanaResourceId
     monitorName: hcpMonitorName
     purpose: 'hcps'
-    useInternalApiVersion: hcpMonitorUseInternalApi
   }
 }
 


### PR DESCRIPTION
WHY?

We noticed the internal api version based JSON view already shows us the Managed Geneva Metric Account in all the Environments . This is not required .