### PR TITLE
chore: route kernel (kmsg) logs to Kusto systemdLogs for node-freeze investigation

### DIFF
--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arobit.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arobit.yaml
@@ -120,6 +120,16 @@ data:
         Tag             systemd.*
         Systemd_Filter  _SYSTEMD_UNIT=containerd.service
         Systemd_Filter  _SYSTEMD_UNIT=kubelet.service
+        # AROSLSRE-1465: capture kernel ring-buffer (kmsg) messages so we can see
+        # the guest kernel stack (hung_task/soft-lockup/panic) in the seconds
+        # before a userswft node hard-freezes into NodeNotReady. Kernel journal
+        # records carry no _SYSTEMD_UNIT; they are matched by _TRANSPORT=kernel.
+        # Systemd_Filter entries are OR'd, so this only adds kernel lines. They
+        # flow to the existing systemdLogs Kusto table (no schema change): the
+        # full record is preserved in the `log` dynamic column, so _TRANSPORT /
+        # SYSLOG_IDENTIFIER / PRIORITY stay queryable, and `message` maps from
+        # $.log.MESSAGE. systemd_unit is simply empty for kernel lines.
+        Systemd_Filter  _TRANSPORT=kernel
         Read_From_Tail  On
         Strip_Underscores On
         DB              /var/fluent-bit/flb-storage/flb-systemdb.db
@@ -140,6 +150,24 @@ data:
         Alias   filter.drop_kube_proxy_topology_noise
         Match   kubernetes.var.log.containers.kube-proxy*
         Exclude log Ignoring same-(node|zone) topology hints
+
+    [FILTER]
+        # AROSLSRE-1465: the kernel journal (_TRANSPORT=kernel, captured by the
+        # systemd input above) carries SELinux/audit-subsystem records that are
+        # routed through kmsg: lines beginning with "audit:" (audit types such as
+        # 1300/1325/1327/1130/1131 -- syscall, netfilter and service-state audit
+        # events) and the "kauditd_printk_skb: N callbacks suppressed" throttle
+        # notices. These are process/security audit events, NOT kernel-health
+        # signals, and they account for ~87% of kernel-transport log volume. They
+        # are useless for diagnosing node hard-freezes (hung_task, soft lockup,
+        # RCU stall, OOM, MCE, kernel panic), so we drop them here and keep only
+        # actionable kernel diagnostics. kubelet/containerd systemd records and
+        # all non-audit kernel lines are unaffected (their MESSAGE never starts
+        # with these prefixes).
+        Name    grep
+        Alias   filter.drop_kernel_audit_noise
+        Match   systemd.*
+        Exclude MESSAGE ^(audit:|kauditd_printk_skb:)
 
     [FILTER]
         Name modify
@@ -592,7 +620,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 7e5331bafe7c892ba671104e27e8b78ecbd570950ed30b691c598c3337f1f404
+        checksum/configmap: 246640da15cbf2b85dc23052bc940f14ca5db8612a974e1661b607a5cdd35a3f
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_arobit.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_arobit.yaml
@@ -120,6 +120,16 @@ data:
         Tag             systemd.*
         Systemd_Filter  _SYSTEMD_UNIT=containerd.service
         Systemd_Filter  _SYSTEMD_UNIT=kubelet.service
+        # AROSLSRE-1465: capture kernel ring-buffer (kmsg) messages so we can see
+        # the guest kernel stack (hung_task/soft-lockup/panic) in the seconds
+        # before a userswft node hard-freezes into NodeNotReady. Kernel journal
+        # records carry no _SYSTEMD_UNIT; they are matched by _TRANSPORT=kernel.
+        # Systemd_Filter entries are OR'd, so this only adds kernel lines. They
+        # flow to the existing systemdLogs Kusto table (no schema change): the
+        # full record is preserved in the `log` dynamic column, so _TRANSPORT /
+        # SYSLOG_IDENTIFIER / PRIORITY stay queryable, and `message` maps from
+        # $.log.MESSAGE. systemd_unit is simply empty for kernel lines.
+        Systemd_Filter  _TRANSPORT=kernel
         Read_From_Tail  On
         Strip_Underscores On
         DB              /var/fluent-bit/flb-storage/flb-systemdb.db
@@ -140,6 +150,24 @@ data:
         Alias   filter.drop_kube_proxy_topology_noise
         Match   kubernetes.var.log.containers.kube-proxy*
         Exclude log Ignoring same-(node|zone) topology hints
+
+    [FILTER]
+        # AROSLSRE-1465: the kernel journal (_TRANSPORT=kernel, captured by the
+        # systemd input above) carries SELinux/audit-subsystem records that are
+        # routed through kmsg: lines beginning with "audit:" (audit types such as
+        # 1300/1325/1327/1130/1131 -- syscall, netfilter and service-state audit
+        # events) and the "kauditd_printk_skb: N callbacks suppressed" throttle
+        # notices. These are process/security audit events, NOT kernel-health
+        # signals, and they account for ~87% of kernel-transport log volume. They
+        # are useless for diagnosing node hard-freezes (hung_task, soft lockup,
+        # RCU stall, OOM, MCE, kernel panic), so we drop them here and keep only
+        # actionable kernel diagnostics. kubelet/containerd systemd records and
+        # all non-audit kernel lines are unaffected (their MESSAGE never starts
+        # with these prefixes).
+        Name    grep
+        Alias   filter.drop_kernel_audit_noise
+        Match   systemd.*
+        Exclude MESSAGE ^(audit:|kauditd_printk_skb:)
 
     [FILTER]
         Name modify
@@ -568,7 +596,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 7d62e084ce38da5386f0334e7c207089acd67818e8cabab1a83c3e5894cdc1fa
+        checksum/configmap: 72b09545852347671c0e6409a6aa6816a185140220f37a49e9fda808c6b66fa1
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/observability/arobit/deploy/templates/forwarder-configmap.yaml
+++ b/observability/arobit/deploy/templates/forwarder-configmap.yaml
@@ -126,6 +126,16 @@ data:
         Tag             systemd.*
         Systemd_Filter  _SYSTEMD_UNIT=containerd.service
         Systemd_Filter  _SYSTEMD_UNIT=kubelet.service
+        # AROSLSRE-1465: capture kernel ring-buffer (kmsg) messages so we can see
+        # the guest kernel stack (hung_task/soft-lockup/panic) in the seconds
+        # before a userswft node hard-freezes into NodeNotReady. Kernel journal
+        # records carry no _SYSTEMD_UNIT; they are matched by _TRANSPORT=kernel.
+        # Systemd_Filter entries are OR'd, so this only adds kernel lines. They
+        # flow to the existing systemdLogs Kusto table (no schema change): the
+        # full record is preserved in the `log` dynamic column, so _TRANSPORT /
+        # SYSLOG_IDENTIFIER / PRIORITY stay queryable, and `message` maps from
+        # $.log.MESSAGE. systemd_unit is simply empty for kernel lines.
+        Systemd_Filter  _TRANSPORT=kernel
         Read_From_Tail  On
         Strip_Underscores On
         DB              /var/fluent-bit/flb-storage/flb-systemdb.db
@@ -146,6 +156,24 @@ data:
         Alias   filter.drop_kube_proxy_topology_noise
         Match   kubernetes.var.log.containers.kube-proxy*
         Exclude log Ignoring same-(node|zone) topology hints
+
+    [FILTER]
+        # AROSLSRE-1465: the kernel journal (_TRANSPORT=kernel, captured by the
+        # systemd input above) carries SELinux/audit-subsystem records that are
+        # routed through kmsg: lines beginning with "audit:" (audit types such as
+        # 1300/1325/1327/1130/1131 -- syscall, netfilter and service-state audit
+        # events) and the "kauditd_printk_skb: N callbacks suppressed" throttle
+        # notices. These are process/security audit events, NOT kernel-health
+        # signals, and they account for ~87% of kernel-transport log volume. They
+        # are useless for diagnosing node hard-freezes (hung_task, soft lockup,
+        # RCU stall, OOM, MCE, kernel panic), so we drop them here and keep only
+        # actionable kernel diagnostics. kubelet/containerd systemd records and
+        # all non-audit kernel lines are unaffected (their MESSAGE never starts
+        # with these prefixes).
+        Name    grep
+        Alias   filter.drop_kernel_audit_noise
+        Match   systemd.*
+        Exclude MESSAGE ^(audit:|kauditd_printk_skb:)
 
     [FILTER]
         Name modify

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_buffering_disabled_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_buffering_disabled_svc.yaml
@@ -120,6 +120,16 @@ data:
         Tag             systemd.*
         Systemd_Filter  _SYSTEMD_UNIT=containerd.service
         Systemd_Filter  _SYSTEMD_UNIT=kubelet.service
+        # AROSLSRE-1465: capture kernel ring-buffer (kmsg) messages so we can see
+        # the guest kernel stack (hung_task/soft-lockup/panic) in the seconds
+        # before a userswft node hard-freezes into NodeNotReady. Kernel journal
+        # records carry no _SYSTEMD_UNIT; they are matched by _TRANSPORT=kernel.
+        # Systemd_Filter entries are OR'd, so this only adds kernel lines. They
+        # flow to the existing systemdLogs Kusto table (no schema change): the
+        # full record is preserved in the `log` dynamic column, so _TRANSPORT /
+        # SYSLOG_IDENTIFIER / PRIORITY stay queryable, and `message` maps from
+        # $.log.MESSAGE. systemd_unit is simply empty for kernel lines.
+        Systemd_Filter  _TRANSPORT=kernel
         Read_From_Tail  On
         Strip_Underscores On
         DB              /var/fluent-bit/flb-storage/flb-systemdb.db
@@ -140,6 +150,24 @@ data:
         Alias   filter.drop_kube_proxy_topology_noise
         Match   kubernetes.var.log.containers.kube-proxy*
         Exclude log Ignoring same-(node|zone) topology hints
+
+    [FILTER]
+        # AROSLSRE-1465: the kernel journal (_TRANSPORT=kernel, captured by the
+        # systemd input above) carries SELinux/audit-subsystem records that are
+        # routed through kmsg: lines beginning with "audit:" (audit types such as
+        # 1300/1325/1327/1130/1131 -- syscall, netfilter and service-state audit
+        # events) and the "kauditd_printk_skb: N callbacks suppressed" throttle
+        # notices. These are process/security audit events, NOT kernel-health
+        # signals, and they account for ~87% of kernel-transport log volume. They
+        # are useless for diagnosing node hard-freezes (hung_task, soft lockup,
+        # RCU stall, OOM, MCE, kernel panic), so we drop them here and keep only
+        # actionable kernel diagnostics. kubelet/containerd systemd records and
+        # all non-audit kernel lines are unaffected (their MESSAGE never starts
+        # with these prefixes).
+        Name    grep
+        Alias   filter.drop_kernel_audit_noise
+        Match   systemd.*
+        Exclude MESSAGE ^(audit:|kauditd_printk_skb:)
 
     [FILTER]
         Name modify
@@ -477,7 +505,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: fc8ecf2d00f28090a8f57c5943fc8f7055bc991f55c268e65aba5fe772259349
+        checksum/configmap: 4c70eb054d1139eef9f2cf17f73fbcb6141a31e82243ec5c251b3d40a1278897
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_disabled_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_disabled_svc.yaml
@@ -119,6 +119,16 @@ data:
         Tag             systemd.*
         Systemd_Filter  _SYSTEMD_UNIT=containerd.service
         Systemd_Filter  _SYSTEMD_UNIT=kubelet.service
+        # AROSLSRE-1465: capture kernel ring-buffer (kmsg) messages so we can see
+        # the guest kernel stack (hung_task/soft-lockup/panic) in the seconds
+        # before a userswft node hard-freezes into NodeNotReady. Kernel journal
+        # records carry no _SYSTEMD_UNIT; they are matched by _TRANSPORT=kernel.
+        # Systemd_Filter entries are OR'd, so this only adds kernel lines. They
+        # flow to the existing systemdLogs Kusto table (no schema change): the
+        # full record is preserved in the `log` dynamic column, so _TRANSPORT /
+        # SYSLOG_IDENTIFIER / PRIORITY stay queryable, and `message` maps from
+        # $.log.MESSAGE. systemd_unit is simply empty for kernel lines.
+        Systemd_Filter  _TRANSPORT=kernel
         Read_From_Tail  On
         Strip_Underscores On
         DB              /var/fluent-bit/flb-storage/flb-systemdb.db
@@ -139,6 +149,24 @@ data:
         Alias   filter.drop_kube_proxy_topology_noise
         Match   kubernetes.var.log.containers.kube-proxy*
         Exclude log Ignoring same-(node|zone) topology hints
+
+    [FILTER]
+        # AROSLSRE-1465: the kernel journal (_TRANSPORT=kernel, captured by the
+        # systemd input above) carries SELinux/audit-subsystem records that are
+        # routed through kmsg: lines beginning with "audit:" (audit types such as
+        # 1300/1325/1327/1130/1131 -- syscall, netfilter and service-state audit
+        # events) and the "kauditd_printk_skb: N callbacks suppressed" throttle
+        # notices. These are process/security audit events, NOT kernel-health
+        # signals, and they account for ~87% of kernel-transport log volume. They
+        # are useless for diagnosing node hard-freezes (hung_task, soft lockup,
+        # RCU stall, OOM, MCE, kernel panic), so we drop them here and keep only
+        # actionable kernel diagnostics. kubelet/containerd systemd records and
+        # all non-audit kernel lines are unaffected (their MESSAGE never starts
+        # with these prefixes).
+        Name    grep
+        Alias   filter.drop_kernel_audit_noise
+        Match   systemd.*
+        Exclude MESSAGE ^(audit:|kauditd_printk_skb:)
 
     [FILTER]
         Name modify
@@ -567,7 +595,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: cc0b6dbe4578bdcf3109961a5201933c5110a126d198bec409c6b17389f17d67
+        checksum/configmap: 448f36a7f59332bf2129467e81e71eac29e9e4c7f118d2bfaae7c658d8084ff7
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_unlimited_memory_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_unlimited_memory_svc.yaml
@@ -120,6 +120,16 @@ data:
         Tag             systemd.*
         Systemd_Filter  _SYSTEMD_UNIT=containerd.service
         Systemd_Filter  _SYSTEMD_UNIT=kubelet.service
+        # AROSLSRE-1465: capture kernel ring-buffer (kmsg) messages so we can see
+        # the guest kernel stack (hung_task/soft-lockup/panic) in the seconds
+        # before a userswft node hard-freezes into NodeNotReady. Kernel journal
+        # records carry no _SYSTEMD_UNIT; they are matched by _TRANSPORT=kernel.
+        # Systemd_Filter entries are OR'd, so this only adds kernel lines. They
+        # flow to the existing systemdLogs Kusto table (no schema change): the
+        # full record is preserved in the `log` dynamic column, so _TRANSPORT /
+        # SYSLOG_IDENTIFIER / PRIORITY stay queryable, and `message` maps from
+        # $.log.MESSAGE. systemd_unit is simply empty for kernel lines.
+        Systemd_Filter  _TRANSPORT=kernel
         Read_From_Tail  On
         Strip_Underscores On
         DB              /var/fluent-bit/flb-storage/flb-systemdb.db
@@ -140,6 +150,24 @@ data:
         Alias   filter.drop_kube_proxy_topology_noise
         Match   kubernetes.var.log.containers.kube-proxy*
         Exclude log Ignoring same-(node|zone) topology hints
+
+    [FILTER]
+        # AROSLSRE-1465: the kernel journal (_TRANSPORT=kernel, captured by the
+        # systemd input above) carries SELinux/audit-subsystem records that are
+        # routed through kmsg: lines beginning with "audit:" (audit types such as
+        # 1300/1325/1327/1130/1131 -- syscall, netfilter and service-state audit
+        # events) and the "kauditd_printk_skb: N callbacks suppressed" throttle
+        # notices. These are process/security audit events, NOT kernel-health
+        # signals, and they account for ~87% of kernel-transport log volume. They
+        # are useless for diagnosing node hard-freezes (hung_task, soft lockup,
+        # RCU stall, OOM, MCE, kernel panic), so we drop them here and keep only
+        # actionable kernel diagnostics. kubelet/containerd systemd records and
+        # all non-audit kernel lines are unaffected (their MESSAGE never starts
+        # with these prefixes).
+        Name    grep
+        Alias   filter.drop_kernel_audit_noise
+        Match   systemd.*
+        Exclude MESSAGE ^(audit:|kauditd_printk_skb:)
 
     [FILTER]
         Name modify
@@ -568,7 +596,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: f0d28b45ea337e1efbc7dbf1c8a737e99967001d684cd97645001ef5e0d8b48a
+        checksum/configmap: 12cda9db5062c4779892ea83f7bdade3c3fcc56bf0efa65f92b81c4869629fa7
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_mgmt.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_mgmt.yaml
@@ -122,6 +122,16 @@ data:
         Tag             systemd.*
         Systemd_Filter  _SYSTEMD_UNIT=containerd.service
         Systemd_Filter  _SYSTEMD_UNIT=kubelet.service
+        # AROSLSRE-1465: capture kernel ring-buffer (kmsg) messages so we can see
+        # the guest kernel stack (hung_task/soft-lockup/panic) in the seconds
+        # before a userswft node hard-freezes into NodeNotReady. Kernel journal
+        # records carry no _SYSTEMD_UNIT; they are matched by _TRANSPORT=kernel.
+        # Systemd_Filter entries are OR'd, so this only adds kernel lines. They
+        # flow to the existing systemdLogs Kusto table (no schema change): the
+        # full record is preserved in the `log` dynamic column, so _TRANSPORT /
+        # SYSLOG_IDENTIFIER / PRIORITY stay queryable, and `message` maps from
+        # $.log.MESSAGE. systemd_unit is simply empty for kernel lines.
+        Systemd_Filter  _TRANSPORT=kernel
         Read_From_Tail  On
         Strip_Underscores On
         DB              /var/fluent-bit/flb-storage/flb-systemdb.db
@@ -142,6 +152,24 @@ data:
         Alias   filter.drop_kube_proxy_topology_noise
         Match   kubernetes.var.log.containers.kube-proxy*
         Exclude log Ignoring same-(node|zone) topology hints
+
+    [FILTER]
+        # AROSLSRE-1465: the kernel journal (_TRANSPORT=kernel, captured by the
+        # systemd input above) carries SELinux/audit-subsystem records that are
+        # routed through kmsg: lines beginning with "audit:" (audit types such as
+        # 1300/1325/1327/1130/1131 -- syscall, netfilter and service-state audit
+        # events) and the "kauditd_printk_skb: N callbacks suppressed" throttle
+        # notices. These are process/security audit events, NOT kernel-health
+        # signals, and they account for ~87% of kernel-transport log volume. They
+        # are useless for diagnosing node hard-freezes (hung_task, soft lockup,
+        # RCU stall, OOM, MCE, kernel panic), so we drop them here and keep only
+        # actionable kernel diagnostics. kubelet/containerd systemd records and
+        # all non-audit kernel lines are unaffected (their MESSAGE never starts
+        # with these prefixes).
+        Name    grep
+        Alias   filter.drop_kernel_audit_noise
+        Match   systemd.*
+        Exclude MESSAGE ^(audit:|kauditd_printk_skb:)
 
     [FILTER]
         Name modify
@@ -780,7 +808,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 8a5e701d3d44ef5eea580e724c2b4543bcb94fccf28527f5e2e078d7c7a2d65c
+        checksum/configmap: 11ab5ef382c815cd496dd5ac1ea47145094ed1a3d3519bf4e62bf5a331800a56
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_svc.yaml
@@ -120,6 +120,16 @@ data:
         Tag             systemd.*
         Systemd_Filter  _SYSTEMD_UNIT=containerd.service
         Systemd_Filter  _SYSTEMD_UNIT=kubelet.service
+        # AROSLSRE-1465: capture kernel ring-buffer (kmsg) messages so we can see
+        # the guest kernel stack (hung_task/soft-lockup/panic) in the seconds
+        # before a userswft node hard-freezes into NodeNotReady. Kernel journal
+        # records carry no _SYSTEMD_UNIT; they are matched by _TRANSPORT=kernel.
+        # Systemd_Filter entries are OR'd, so this only adds kernel lines. They
+        # flow to the existing systemdLogs Kusto table (no schema change): the
+        # full record is preserved in the `log` dynamic column, so _TRANSPORT /
+        # SYSLOG_IDENTIFIER / PRIORITY stay queryable, and `message` maps from
+        # $.log.MESSAGE. systemd_unit is simply empty for kernel lines.
+        Systemd_Filter  _TRANSPORT=kernel
         Read_From_Tail  On
         Strip_Underscores On
         DB              /var/fluent-bit/flb-storage/flb-systemdb.db
@@ -140,6 +150,24 @@ data:
         Alias   filter.drop_kube_proxy_topology_noise
         Match   kubernetes.var.log.containers.kube-proxy*
         Exclude log Ignoring same-(node|zone) topology hints
+
+    [FILTER]
+        # AROSLSRE-1465: the kernel journal (_TRANSPORT=kernel, captured by the
+        # systemd input above) carries SELinux/audit-subsystem records that are
+        # routed through kmsg: lines beginning with "audit:" (audit types such as
+        # 1300/1325/1327/1130/1131 -- syscall, netfilter and service-state audit
+        # events) and the "kauditd_printk_skb: N callbacks suppressed" throttle
+        # notices. These are process/security audit events, NOT kernel-health
+        # signals, and they account for ~87% of kernel-transport log volume. They
+        # are useless for diagnosing node hard-freezes (hung_task, soft lockup,
+        # RCU stall, OOM, MCE, kernel panic), so we drop them here and keep only
+        # actionable kernel diagnostics. kubelet/containerd systemd records and
+        # all non-audit kernel lines are unaffected (their MESSAGE never starts
+        # with these prefixes).
+        Name    grep
+        Alias   filter.drop_kernel_audit_noise
+        Match   systemd.*
+        Exclude MESSAGE ^(audit:|kauditd_printk_skb:)
 
     [FILTER]
         Name modify
@@ -568,7 +596,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 9e17b716826b865057dd85af96718d04123d41e1428f52bde37ba5093820d60e
+        checksum/configmap: b05b040246a7737b0fe89d57aa9eaa55647384b62f63ab673a9471ae75d0edf8
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'


### PR DESCRIPTION
## Why

ARO-HCP management-cluster `userswft` nodes intermittently **hard-freeze** — the whole VM goes silent at once (kubelet, containerd and node-problem-detector all stop in the same instant) and the Azure platform then declares the VM unavailable. In dev CI this trips `KubeNodeNotReady` on ~12% of `e2e-parallel` runs (**[AROSLSRE-1465](https://redhat.atlassian.net/browse/AROSLSRE-1465)**), and it has also been seen in persistent environments.

When it happens we have **no window into the guest kernel** in the seconds before the freeze:

- AKS nodepools expose no settable boot/serial `diagnosticsProfile`, so boot diagnostics are off and cannot be turned on.
- The OS disk is wiped on reimage, so nothing is recoverable after the fact.

We need the guest kernel ring buffer (`hung_task` / soft-lockup / RCU stall / OOM / MCE / panic traces) streamed **off the node continuously**, so the pre-freeze lines survive even when the node itself does not. This is generally useful forensic data for node-failure triage, not just for this one bug.

## What

**1. Capture kernel (kmsg) logs.** Add `Systemd_Filter _TRANSPORT=kernel` to the existing arobit fluent-bit `systemd` input.

- Kernel journal records live in the **same** system journal fluent-bit already reads and carry no `_SYSTEMD_UNIT`; they are matched by `_TRANSPORT=kernel`.
- `Systemd_Filter` entries are OR'd, so this **only adds** kernel lines alongside the existing kubelet/containerd capture.
- fluent-bit streams continuously (`Flush 1s`), so lines emitted before the freeze instant ship off-node; only the final sub-second is lost.

**2. Drop kernel audit noise.** The kernel journal also carries SELinux/audit-subsystem records routed through kmsg — lines beginning with `audit:` (audit types `1300/1325/1327/1130/1131` — syscall/netfilter/service-state audits) and `kauditd_printk_skb: N callbacks suppressed` throttle notices. These are process/security audit events, not kernel-health signals. A `grep` filter drops them so only actionable kernel diagnostics are ingested. kubelet/containerd records and non-audit kernel lines are unaffected.

### No Kusto schema change

Kusto is shared, so this deliberately does **not** touch any schema. Kernel lines flow to the **existing** `systemdLogs` table via its existing ingestion mapping:

- The full journal record is preserved in the `log` dynamic column → `_TRANSPORT` / `SYSLOG_IDENTIFIER` / `PRIORITY` stay queryable.
- `message` maps from `$.log.MESSAGE`.
- `systemd_unit` is simply empty for kernel lines.

Query them with e.g. `ServiceLogs.systemdLogs | where log.TRANSPORT == "kernel"`.

## Volume / cost

Measured on real `e2e-parallel` runs (mgmt cluster, ~1.4h active, 21 `userswft` nodes), as full ingested payload:

| Feed | Volume | Share of existing `systemdLogs` |
|---|---:|---:|
| Existing (kubelet + containerd) | ~2,205 MB | baseline |
| Kernel — audit noise (**dropped by this PR**) | ~50.6 MB | — |
| **Kernel — diagnostics (kept)** | **~7.5 MB** | **+0.34%** |

The audit filter takes the added volume from +2.6% to **+0.34%** on top of the existing feed — a rounding error next to the kubelet/containerd and `containerLogs` feeds the clusters already sustain through the same pipeline. Verified live: on a run with the filter, audit records ingested = **0**, with the genuine kernel diagnostics retained.

## Testing

- Validated end-to-end on `e2e-parallel` runs from this PR: kernel records land in `systemdLogs` with full fidelity (captured complete kernel stack traces incl. registers/modules/call-chain), and the audit filter drops 100% of audit noise while keeping diagnostics.
- Helm golden fixtures regenerated via `UPDATE=true go test -count=1 ./...` in `tooling/helmtest`; verify-mode `go test` passes.
- No daemonset / RBAC change required (kernel records are already in the mounted journal).