### PR TITLE
feat: move and enable asynchronous CS create interaction for externalauths

### DIFF
--- a/frontend/pkg/frontend/external_auth.go
+++ b/frontend/pkg/frontend/external_auth.go
@@ -256,20 +256,6 @@ func (f *Frontend) createExternalAuth(writer http.ResponseWriter, request *http.
 		return utils.TrackError(fmt.Errorf("cluster %s has no ClusterServiceID", cluster.ID))
 	}
 
-	csExternalAuthBuilder, err := ocm.BuildCSExternalAuth(ctx, newInternalExternalAuth, false)
-	if err != nil {
-		return utils.TrackError(err)
-	}
-	csExternalAuth, err := f.clusterServiceClient.PostExternalAuth(ctx, *cluster.ServiceProviderProperties.ClusterServiceID, csExternalAuthBuilder)
-	if err != nil {
-		return utils.TrackError(err)
-	}
-	csExternalAuthID, err := api.NewInternalID(csExternalAuth.HREF())
-	if err != nil {
-		return utils.TrackError(err)
-	}
-	newInternalExternalAuth.ServiceProviderProperties.ClusterServiceID = &csExternalAuthID
-
 	operationRequest := database.OperationRequestCreate
 
 	transaction := f.resourcesDBClient.NewTransaction(newInternalExternalAuth.ID.SubscriptionID)
@@ -277,7 +263,7 @@ func (f *Frontend) createExternalAuth(writer http.ResponseWriter, request *http.
 	createExternalAuthOperation := database.NewOperation(
 		operationRequest,
 		newInternalExternalAuth.ID,
-		*newInternalExternalAuth.ServiceProviderProperties.ClusterServiceID,
+		api.InternalID{},
 		f.azureLocation,
 		request.Header.Get(arm.HeaderNameHomeTenantID),
 		request.Header.Get(arm.HeaderNameClientObjectID),

--- a/frontend/pkg/frontend/external_auth.go
+++ b/frontend/pkg/frontend/external_auth.go
@@ -22,12 +22,14 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/operation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
 
+	"github.com/Azure/ARO-HCP/internal/admission"
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/conversion"
@@ -239,7 +241,29 @@ func (f *Frontend) createExternalAuth(writer http.ResponseWriter, request *http.
 		return utils.TrackError(err)
 	}
 
+	// We retrieve all external auths for the cluster. Used for admission validation.
+	externalAuthIterator, err := f.resourcesDBClient.HCPClusters(resourceID.SubscriptionID, resourceID.ResourceGroupName).ExternalAuth(resourceID.Parent.Name).List(ctx, nil)
+	if err != nil {
+		return utils.TrackError(err)
+	}
+	clusterExternalAuths := make([]*api.HCPOpenShiftClusterExternalAuth, 0)
+	for _, clusterExternalAuth := range externalAuthIterator.Items(ctx) {
+		clusterExternalAuths = append(clusterExternalAuths, clusterExternalAuth)
+	}
+	if err := externalAuthIterator.GetError(); err != nil {
+		return utils.TrackError(err)
+	}
+
+	restOperation := operation.Operation{
+		Type: operation.Create,
+		// TODO set operations when a need appears for it.
+	}
+	externalAuthAdmissionContext := &admission.ExternalAuthAdmissionContext{
+		ClusterExternalAuths: clusterExternalAuths,
+	}
+
 	validationErrs := validation.ValidateExternalAuthCreate(ctx, newInternalExternalAuth)
+	validationErrs = append(validationErrs, admission.AdmitExternalAuth(ctx, externalAuthAdmissionContext, restOperation, newInternalExternalAuth, nil)...)
 	if err := arm.CloudErrorFromFieldErrors(validationErrs); err != nil {
 		return utils.TrackError(err)
 	}

--- a/internal/admission/admit_external_auth.go
+++ b/internal/admission/admit_external_auth.go
@@ -1,0 +1,48 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package admission
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/operation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+)
+
+// ExternalAuthAdmissionContext carries dependencies that external auth mutation/admission needs
+// beyond the external auth object itself.
+type ExternalAuthAdmissionContext struct {
+	// ClusterExternalAuths is a list of all external auths for the cluster
+	ClusterExternalAuths []*api.HCPOpenShiftClusterExternalAuth
+}
+
+// AdmitExternalAuth performs non-static checks of external auth. Checks that require more information than is contained inside of
+// the external auth instance itself.
+func AdmitExternalAuth(ctx context.Context, admissionContext *ExternalAuthAdmissionContext, op operation.Operation, newExternalAuth, oldExternalAuth *api.HCPOpenShiftClusterExternalAuth) field.ErrorList {
+	errs := field.ErrorList{}
+
+	// We do a *best-effort* to check to see if there are other external auths on the cluster and if there are we
+	// prevent the creation of a new external auth. This is because as of now (2026-06-26) we do not allow creating more than one external auth
+	// per cluster.
+	if op.Type == operation.Create {
+		if len(admissionContext.ClusterExternalAuths) > 0 {
+			errs = append(errs, field.Forbidden(field.NewPath("name"), "There are other external auths on the cluster. Only one external auth is allowed per cluster."))
+		}
+	}
+
+	return errs
+}

--- a/internal/admission/admit_external_auth_test.go
+++ b/internal/admission/admit_external_auth_test.go
@@ -1,0 +1,106 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package admission
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/operation"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+func TestAdmitExternalAuth(t *testing.T) {
+	t.Parallel()
+
+	const (
+		existingExternalAuthResourceID = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster/externalAuths/existing"
+		otherExternalAuthResourceID    = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster/externalAuths/other"
+	)
+
+	externalAuthWithResourceID := func(resourceID string) *api.HCPOpenShiftClusterExternalAuth {
+		return api.NewDefaultHCPOpenShiftClusterExternalAuth(api.Must(azcorearm.ParseResourceID(resourceID)))
+	}
+
+	newExternalAuth := api.MinimumValidExternalAuthTestCase()
+	existingExternalAuth := externalAuthWithResourceID(existingExternalAuthResourceID)
+	otherExternalAuth := externalAuthWithResourceID(otherExternalAuthResourceID)
+
+	tests := []struct {
+		name             string
+		op               operation.Type
+		admissionContext *ExternalAuthAdmissionContext
+		newObj           *api.HCPOpenShiftClusterExternalAuth
+		oldObj           *api.HCPOpenShiftClusterExternalAuth
+		expectErrors     []utils.ExpectedError
+	}{
+		{
+			name: "create: no existing external auths allowed",
+			op:   operation.Create,
+			admissionContext: &ExternalAuthAdmissionContext{
+				ClusterExternalAuths: []*api.HCPOpenShiftClusterExternalAuth{},
+			},
+			newObj:       newExternalAuth,
+			expectErrors: []utils.ExpectedError{},
+		},
+		{
+			name: "create: one existing external auth rejected",
+			op:   operation.Create,
+			admissionContext: &ExternalAuthAdmissionContext{
+				ClusterExternalAuths: []*api.HCPOpenShiftClusterExternalAuth{existingExternalAuth},
+			},
+			newObj: newExternalAuth,
+			expectErrors: []utils.ExpectedError{
+				{
+					FieldPath: "name",
+					Message:   "Only one external auth is allowed per cluster",
+				},
+			},
+		},
+		{
+			name: "create: multiple existing external auths rejected",
+			op:   operation.Create,
+			admissionContext: &ExternalAuthAdmissionContext{
+				ClusterExternalAuths: []*api.HCPOpenShiftClusterExternalAuth{existingExternalAuth, otherExternalAuth},
+			},
+			newObj: newExternalAuth,
+			expectErrors: []utils.ExpectedError{
+				{
+					FieldPath: "name",
+					Message:   "Only one external auth is allowed per cluster",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			errs := AdmitExternalAuth(
+				context.Background(),
+				tt.admissionContext,
+				operation.Operation{Type: tt.op},
+				tt.newObj,
+				tt.oldObj,
+			)
+			utils.VerifyErrorsMatch(t, tt.expectErrors, errs)
+		})
+	}
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/second-external-auth-rejected/00-httpCreate-subscription/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/second-external-auth-rejected/00-httpCreate-subscription/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "2f2d4ba3-1ee6-57b6-bde9-b61d09eaf989",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/second-external-auth-rejected/00-httpCreate-subscription/subscription.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/second-external-auth-rejected/00-httpCreate-subscription/subscription.json
@@ -1,0 +1,7 @@
+{
+	"properties": {
+		"tenantId": "the-tenant"
+	},
+	"registrationDate": "2024-01-01T00:00:00Z",
+	"state": "Registered"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/second-external-auth-rejected/01-httpCreate-cluster/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/second-external-auth-rejected/01-httpCreate-cluster/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "ba036639-fb3b-5f2d-a4ac-3ce4603896f5",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/example-cluster"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/second-external-auth-rejected/01-httpCreate-cluster/cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/second-external-auth-rejected/01-httpCreate-cluster/cluster.json
@@ -1,0 +1,50 @@
+{
+	"identity": {
+		"type": "UserAssigned",
+		"userAssignedIdentities": {}
+	},
+	"name": "example-cluster",
+	"properties": {
+		"api": {
+			"visibility": "Public"
+		},
+		"clusterImageRegistry": {
+			"state": "Disabled"
+		},
+		"console": {},
+		"dns": {},
+		"etcd": {
+			"dataEncryption": {
+				"customerManaged": {
+					"encryptionType": "KMS",
+					"kms": {
+						"activeKey": {
+							"name": "encryptionKeyName",
+							"vaultName": "keyVaultName",
+							"version": "2024-12-01-preview"
+						}
+					}
+				},
+				"keyManagementMode": "CustomerManaged"
+			}
+		},
+		"network": {
+			"hostPrefix": 23,
+			"machineCidr": "10.0.0.0/16",
+			"networkType": "OVNKubernetes",
+			"podCidr": "10.128.0.0/14",
+			"serviceCidr": "172.30.0.0/16"
+		},
+		"platform": {
+			"managedResourceGroup": "managed-resource-group-name",
+			"networkSecurityGroupId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/networkSecurityGroups/nsg",
+			"outboundType": "LoadBalancer",
+			"subnetId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
+		},
+		"version": {
+			"channelGroup": "stable",
+			"id": "4.20"
+		}
+	},
+	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/second-external-auth-rejected/02-completeOperation-cluster/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/second-external-auth-rejected/02-completeOperation-cluster/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "ba036639-fb3b-5f2d-a4ac-3ce4603896f5",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/example-cluster"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/second-external-auth-rejected/03-httpCreate-externalauth-first/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/second-external-auth-rejected/03-httpCreate-externalauth-first/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "2359ef0b-7a03-52fb-a92c-f5f10b83f073",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/example-cluster/externalAuths/default"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/second-external-auth-rejected/03-httpCreate-externalauth-first/externalauth-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/second-external-auth-rejected/03-httpCreate-externalauth-first/externalauth-default.json
@@ -1,0 +1,42 @@
+{
+	"name": "default",
+	"properties": {
+		"claim": {
+			"mappings": {
+				"groups": {
+					"claim": "groups"
+				},
+				"username": {
+					"claim": "sub",
+					"prefix": "prefix-",
+					"prefixPolicy": "Prefix"
+				}
+			}
+		},
+		"clients": [
+			{
+				"clientId": "87654321-4321-4321-4321-abcdefghijkl",
+				"component": {
+					"authClientNamespace": "openshift-console",
+					"name": "console"
+				},
+				"type": "Confidential"
+			},
+			{
+				"clientId": "87654321-4321-4321-4321-abcdefghijkl",
+				"component": {
+					"authClientNamespace": "openshift-console",
+					"name": "cli"
+				},
+				"type": "Public"
+			}
+		],
+		"issuer": {
+			"audiences": [
+				"87654321-4321-4321-4321-abcdefghijkl"
+			],
+			"url": "https://login.microsoftonline.com/12345678-1234-1234-1234-123456789abc/v2.0"
+		}
+	},
+	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/externalAuths"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/second-external-auth-rejected/04-httpCreate-externalauth-second/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/second-external-auth-rejected/04-httpCreate-externalauth-second/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "3654a4bc-dc27-51c1-99b0-04b7e65de3ab",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/example-cluster/externalAuths/second"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/second-external-auth-rejected/04-httpCreate-externalauth-second/expected-error.txt
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/second-external-auth-rejected/04-httpCreate-externalauth-second/expected-error.txt
@@ -1,0 +1,3 @@
+"code": "InvalidRequestContent",
+    "message": "Forbidden: There are other external auths on the cluster. Only one external auth is allowed per cluster.",
+    "target": "name"

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/second-external-auth-rejected/04-httpCreate-externalauth-second/externalauth-second.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/second-external-auth-rejected/04-httpCreate-externalauth-second/externalauth-second.json
@@ -1,0 +1,42 @@
+{
+	"name": "second",
+	"properties": {
+		"claim": {
+			"mappings": {
+				"groups": {
+					"claim": "groups"
+				},
+				"username": {
+					"claim": "sub",
+					"prefix": "prefix-",
+					"prefixPolicy": "Prefix"
+				}
+			}
+		},
+		"clients": [
+			{
+				"clientId": "87654321-4321-4321-4321-abcdefghijkl",
+				"component": {
+					"authClientNamespace": "openshift-console",
+					"name": "console"
+				},
+				"type": "Confidential"
+			},
+			{
+				"clientId": "87654321-4321-4321-4321-abcdefghijkl",
+				"component": {
+					"authClientNamespace": "openshift-console",
+					"name": "cli"
+				},
+				"type": "Public"
+			}
+		],
+		"issuer": {
+			"audiences": [
+				"87654321-4321-4321-4321-abcdefghijkl"
+			],
+			"url": "https://login.microsoftonline.com/12345678-1234-1234-1234-123456789abc/v2.0"
+		}
+	},
+	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/externalAuths"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/second-external-auth-rejected/99-cosmosCompare-ending-content/cluster-example-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/second-external-auth-rejected/99-cosmosCompare-ending-content/cluster-example-cluster.json
@@ -1,0 +1,89 @@
+{
+	"id": "ba036639-fb3b-5f2d-a4ac-3ce4603896f5",
+	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
+	"properties": {
+		"cosmosMetadata": {
+			"instanceVersion": 2,
+			"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
+			"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/example-cluster"
+		},
+		"customerProperties": {
+			"api": {
+				"visibility": "Public"
+			},
+			"autoscaling": {
+				"maxNodeProvisionTimeSeconds": 900,
+				"maxPodGracePeriodSeconds": 600,
+				"podPriorityThreshold": -10
+			},
+			"clusterImageRegistry": {
+				"state": "Disabled"
+			},
+			"dns": {},
+			"etcd": {
+				"dataEncryption": {
+					"customerManaged": {
+						"encryptionType": "KMS",
+						"kms": {
+							"activeKey": {
+								"name": "encryptionKeyName",
+								"vaultName": "keyVaultName",
+								"version": "2024-12-01-preview"
+							},
+							"visibility": "Public"
+						}
+					},
+					"keyManagementMode": "CustomerManaged"
+				}
+			},
+			"ingress": {
+				"type": "Public"
+			},
+			"network": {
+				"hostPrefix": 23,
+				"machineCidr": "10.0.0.0/16",
+				"networkType": "OVNKubernetes",
+				"podCidr": "10.128.0.0/14",
+				"serviceCidr": "172.30.0.0/16"
+			},
+			"platform": {
+				"managedResourceGroup": "managed-resource-group-name",
+				"networkSecurityGroupId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/networkSecurityGroups/nsg",
+				"operatorsAuthentication": {
+					"userAssignedIdentities": {}
+				},
+				"outboundType": "LoadBalancer",
+				"subnetId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
+			},
+			"version": {
+				"channelGroup": "stable",
+				"id": "4.20"
+			}
+		},
+		"id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/example-cluster",
+		"identity": {
+			"type": "UserAssigned"
+		},
+		"location": "fake-location",
+		"name": "example-cluster",
+		"serviceProviderProperties": {
+			"api": {},
+			"console": {},
+			"dns": {},
+			"managedIdentitiesDataPlaneIdentityURL": "https://dummyhost.identity.azure.net/otherinformation?aqueryarg=somevalue",
+			"platform": {},
+			"provisioningState": "Succeeded",
+			"usesNewClusterDeletionApproach": false
+		},
+		"status": {},
+		"systemData": {
+			"createdBy": "Unknown-ARO-HCP-frontend",
+			"createdByType": "Application",
+			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+			"lastModifiedByType": "Application"
+		},
+		"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters"
+	},
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/example-cluster",
+	"resourceType": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/second-external-auth-rejected/99-cosmosCompare-ending-content/externalauth-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/second-external-auth-rejected/99-cosmosCompare-ending-content/externalauth-default.json
@@ -1,0 +1,70 @@
+{
+	"id": "2359ef0b-7a03-52fb-a92c-f5f10b83f073",
+	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
+	"properties": {
+		"cosmosMetadata": {
+			"instanceVersion": 1,
+			"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
+			"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/example-cluster/externalAuths/default"
+		},
+		"id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/example-cluster/externalAuths/default",
+		"name": "default",
+		"properties": {
+			"claim": {
+				"mappings": {
+					"groups": {
+						"claim": "groups",
+						"prefix": ""
+					},
+					"username": {
+						"claim": "sub",
+						"prefix": "prefix-",
+						"prefixPolicy": "Prefix"
+					}
+				},
+				"validationRules": []
+			},
+			"clients": [
+				{
+					"clientId": "87654321-4321-4321-4321-abcdefghijkl",
+					"component": {
+						"authClientNamespace": "openshift-console",
+						"name": "console"
+					},
+					"extraScopes": [],
+					"type": "Confidential"
+				},
+				{
+					"clientId": "87654321-4321-4321-4321-abcdefghijkl",
+					"component": {
+						"authClientNamespace": "openshift-console",
+						"name": "cli"
+					},
+					"extraScopes": [],
+					"type": "Public"
+				}
+			],
+			"issuer": {
+				"audiences": [
+					"87654321-4321-4321-4321-abcdefghijkl"
+				],
+				"ca": "",
+				"url": "https://login.microsoftonline.com/12345678-1234-1234-1234-123456789abc/v2.0"
+			},
+			"provisioningState": "Accepted"
+		},
+		"serviceProviderProperties": {
+			"usesNewExternalAuthDeletionApproach": false
+		},
+		"status": {},
+		"systemData": {
+			"createdBy": "Unknown-ARO-HCP-frontend",
+			"createdByType": "Application",
+			"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+			"lastModifiedByType": "Application"
+		},
+		"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/externalAuths"
+	},
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/example-cluster/externalAuths/default",
+	"resourceType": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/externalAuths"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/second-external-auth-rejected/99-cosmosCompare-ending-content/operation-cluster-create-example-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/second-external-auth-rejected/99-cosmosCompare-ending-content/operation-cluster-create-example-cluster.json
@@ -1,0 +1,14 @@
+{
+	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
+	"properties": {
+		"externalId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/example-cluster",
+		"request": "Create",
+		"status": "Succeeded",
+		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
+		"usesNewExternalAuthDeletionApproach": false,
+		"usesNewNodePoolDeletionApproach": false
+	},
+	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",
+	"ttl": 604800
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/second-external-auth-rejected/99-cosmosCompare-ending-content/operation-externalauth-create-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/second-external-auth-rejected/99-cosmosCompare-ending-content/operation-externalauth-create-default.json
@@ -1,0 +1,14 @@
+{
+	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
+	"properties": {
+		"externalId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/example-cluster/externalAuths/default",
+		"request": "Create",
+		"status": "Accepted",
+		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"usesNewClusterDeletionApproach": false,
+		"usesNewExternalAuthDeletionApproach": false,
+		"usesNewNodePoolDeletionApproach": false
+	},
+	"resourceType": "Microsoft.RedHatOpenShift/hcpOperationStatuses",
+	"ttl": 604800
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/second-external-auth-rejected/99-cosmosCompare-ending-content/subscription.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/second-external-auth-rejected/99-cosmosCompare-ending-content/subscription.json
@@ -1,0 +1,19 @@
+{
+	"id": "2f2d4ba3-1ee6-57b6-bde9-b61d09eaf989",
+	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
+	"properties": {
+		"cosmosMetadata": {
+			"instanceVersion": 1,
+			"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
+			"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7"
+		},
+		"properties": {
+			"tenantId": "the-tenant"
+		},
+		"registrationDate": "2024-01-01T00:00:00Z",
+		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7",
+		"state": "Registered"
+	},
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7",
+	"resourceType": "Microsoft.Resources/subscriptions"
+}

--- a/test-integration/frontend/cross_version_roundtrip_test.go
+++ b/test-integration/frontend/cross_version_roundtrip_test.go
@@ -642,6 +642,17 @@ func createExternalAuthAndComplete(
 
 	parsedID := api.Must(azcorearm.ParseResourceID(resourceID))
 	require.NoError(t, integrationutils.MarkOperationsCompleteForName(ctx, testInfo.ResourcesDBClient(), subscriptionID, parsedID.Name))
+
+	// Setting the Cluster Service ID for the external auth is needed until we move all cs interactions to the backend.
+	csID, err := integrationutils.DeriveClusterServiceID(
+		ctx,
+		testInfo.ResourcesDBClient(),
+		testInfo.ClusterServiceMock,
+		t.Name(),
+		resourceID,
+	)
+	require.NoError(t, err)
+	require.NoError(t, integrationutils.SetClusterServiceID(ctx, testInfo.ResourcesDBClient(), resourceID, csID))
 }
 
 // getResourceResponse returns the resource GET response as raw JSON bytes and

--- a/test/e2e/external_auth_list_and_verify.go
+++ b/test/e2e/external_auth_list_and_verify.go
@@ -142,6 +142,7 @@ var _ = Describe("Customer", func() {
 				framework.ExternalAuthCreationTimeout,
 			)
 			Expect(err).To(HaveOccurred(), "expected error when creating a second external auth config on cluster %s", clusterName)
+			Expect(err).To(MatchError(ContainSubstring("There are other external auths on the cluster. Only one external auth is allowed per cluster.")), "expected error when creating a second external auth config on cluster %s", clusterName)
 
 			By("listing all external auth configs to verify a list call works")
 			externalAuthClient := tc.Get20240610ClientFactoryOrDie(ctx).NewExternalAuthsClient()


### PR DESCRIPTION
Move Cluster Service interaction out of the frontend create path and hand it off to the backend's async externalauth creation controllers.

External Auth create operations no longer set an InternalID as it is not needed anymore when using the new external auth creation approach in backend.