### PR TITLE
chore(config): bump opstool AKS to 1.34 toward fleet parity (AROSLSRE-1414)

### DIFF
--- a/config/config-dev-ci.yaml
+++ b/config/config-dev-ci.yaml
@@ -38,7 +38,7 @@ clouds:
           vnetAddressPrefix: "10.0.0.0/16"
           subnetPrefix: "10.0.1.0/24"
           podSubnetPrefix: "10.0.2.0/24"
-          kubernetesVersion: "1.33"
+          kubernetesVersion: "1.34"
           networkDataplane: "cilium"
           networkPolicy: "cilium"
           clusterOutboundIPAddressIPTags: ""


### PR DESCRIPTION
[AROSLSRE-1414](https://redhat.atlassian.net/browse/AROSLSRE-1414) (parent [AROSLSRE-863](https://redhat.atlassian.net/browse/AROSLSRE-863))

### What

Bump the `opstool` AKS `kubernetesVersion` in `config/config-dev-ci.yaml` from `"1.33"` to `"1.34"` — the next step toward fleet parity (`1.35`).

### Why

`opstool-usw3` is now on `1.33` (control plane and all three node pools at `1.33.12`, node image `202606.19.0`), while the rest of the fleet runs `1.35`. AKS upgrades one minor at a time, so this PR advances the next hop `1.33` → `1.34`; a follow-up will take it to `1.35`.

Bumping `kubernetesVersion` drives the `opstool-aks-pipeline` (`dev-infrastructure/scripts/upgrade-aks-cluster.sh` → `az aks upgrade`) to upgrade the control plane and roll the node pools onto the target minor. `az aks get-upgrades` confirms `1.34.x` is the only available upgrade target from `1.33`.

### Testing

No code paths change; this is a config version bump validated by the existing config schema (`config/config-dev-ci.schema.json` types `kubernetesVersion` as a string). `cd config && make materialize` produces no rendered-config changes (opstool config is not part of the rendered tree).

Post-deploy validation on `opstool-usw3`:

- `az aks show ... --query kubernetesVersion` → `1.34`
- `az aks nodepool list ... --query "[].currentOrchestratorVersion"` → `1.34.x` on all pools

### Special notes for your reviewer

Scope is intentionally limited to `opstool` (dev-ci). The product svc/mgmt clusters are already on `1.35` and are not affected. The `1.33` hop merged in [#5988](https://github.com/Azure/ARO-HCP/pull/5988) (pipeline fix so node pools roll, not just the control plane) and [#5936](https://github.com/Azure/ARO-HCP/pull/5936) (the `1.33` config bump), and has been rolled out and verified.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
