### PR TITLE
Test: Bump CS image to pre-revert ARO-26913 (private KAS topology)

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1020,7 +1020,7 @@ defaults:
     image:
       registry: quay.io
       repository: app-sre/aro-hcp-clusters-service
-      digest: sha256:f22e16dbdac005abb1787e524a2dfa1571720240f33d00bfc57bd0bcdb04c59f # a18a1514ec54cc796dc83d6c12cd3da3ec5e43d4 (2026-07-17 10:26)
+      digest: sha256:b17f6fe9ab5f0be370c0f573f27a8281b0c053bf8ccdcf01e83f1de447c565f9 # ee741db6b5592f0cab9dd4da4b23f7b7180136a6 (pre-revert ARO-26913: private KAS topology wiring)
     # controls how many HCPs can be placed on an MC, sadly not configurable per MC
     provisionShardClusterLimit: 100
     provisionShardStatus: active

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -171,7 +171,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpci00
   image:
-    digest: sha256:f22e16dbdac005abb1787e524a2dfa1571720240f33d00bfc57bd0bcdb04c59f
+    digest: sha256:b17f6fe9ab5f0be370c0f573f27a8281b0c053bf8ccdcf01e83f1de447c565f9
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -171,7 +171,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpci01
   image:
-    digest: sha256:f22e16dbdac005abb1787e524a2dfa1571720240f33d00bfc57bd0bcdb04c59f
+    digest: sha256:b17f6fe9ab5f0be370c0f573f27a8281b0c053bf8ccdcf01e83f1de447c565f9
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -171,7 +171,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpcspr
   image:
-    digest: sha256:f22e16dbdac005abb1787e524a2dfa1571720240f33d00bfc57bd0bcdb04c59f
+    digest: sha256:b17f6fe9ab5f0be370c0f573f27a8281b0c053bf8ccdcf01e83f1de447c565f9
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -171,7 +171,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpdev
   image:
-    digest: sha256:f22e16dbdac005abb1787e524a2dfa1571720240f33d00bfc57bd0bcdb04c59f
+    digest: sha256:b17f6fe9ab5f0be370c0f573f27a8281b0c053bf8ccdcf01e83f1de447c565f9
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -171,7 +171,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpperf
   image:
-    digest: sha256:f22e16dbdac005abb1787e524a2dfa1571720240f33d00bfc57bd0bcdb04c59f
+    digest: sha256:b17f6fe9ab5f0be370c0f573f27a8281b0c053bf8ccdcf01e83f1de447c565f9
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -171,7 +171,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcppers
   image:
-    digest: sha256:f22e16dbdac005abb1787e524a2dfa1571720240f33d00bfc57bd0bcdb04c59f
+    digest: sha256:b17f6fe9ab5f0be370c0f573f27a8281b0c053bf8ccdcf01e83f1de447c565f9
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:


### PR DESCRIPTION
## Summary
- Bumps CS image to the version that includes [ARO-26913](https://redhat.atlassian.net/browse/ARO-26913) (private KAS topology wiring), which was previously reverted because HyperShift in CI envs didn't have the CPO topology support yet
- PR #8537 is now confirmed in 5.0.0-ec.4 and PR #8721 merged to release-4.22 on June 26
- This PR is to validate that e2e-parallel tests pass with the topology changes before re-landing the CS MR

## Context
- CS MR !341 was merged then reverted via MR !377 because CI HyperShift versions lacked topology field support
- The HyperShift backports have since landed in candidate releases
- This test PR uses the pre-revert CS image (`ee741db6b5`) to verify CI e2e tests pass

## Test plan
- [ ] e2e-parallel tests pass with the pre-revert CS image (4.22 and 5.0 cluster creation)
- This is a test-only PR — do not merge