### PR TITLE
test(known-issues): mark BackendAsyncOperation*Stuck alerts as known (AROSLSRE-1471)

### DIFF
--- a/test/cmd/aro-hcp-tests/gather-observability/known-issues/knownIssues.yaml
+++ b/test/cmd/aro-hcp-tests/gather-observability/known-issues/knownIssues.yaml
@@ -17,3 +17,5 @@ knownIssues:
   reason: "Under investigation."
 - name: "OrphanedMRGDetected"
   reason: "Orphaned MRG cleanup is newly deployed and expected to fire while existing orphans are processed."
+- name: "BackendAsyncOperation.*Stuck"
+  reason: "Newly added stuck-async-operation alerts (https://github.com/Azure/ARO-HCP/pull/5952) surface a pre-existing problem: Azure Monitor Workspace ingestion latency (metrics can take ~10min to ingest) makes async operations look stuck and latches onto E2E runs even when the tests pass. Observed blocking green E2E runs (per https://cihealth.tools.hcpsvc.osadev.cloud/run-log?q=BackendAsync): BackendAsyncOperationClusterDeleteStuck, BackendAsyncOperationExternalAuthDeleteStuck, BackendAsyncOperationClusterCreateStuck, BackendAsyncOperationNodePoolDeleteStuck, BackendAsyncOperationNodePoolCreateStuck, BackendAsyncOperationStuck. Owner @stevekuznetsov; durable fix is the AMW auto-scaler (https://github.com/Azure/ARO-HCP/pull/6036). Marked known so it stops blocking the merge queue until that lands."


### PR DESCRIPTION
<!-- https://issues.redhat.com/browse/AROSLSRE-1471 -->

### What

Add a single anchored-regex entry `BackendAsyncOperation.*Stuck` to `test/cmd/aro-hcp-tests/gather-observability/known-issues/knownIssues.yaml`, marking the stuck-async-operation alert family (added in #5952) as a known issue so it no longer fails E2E runs.

### Why

The #5952 alerts surface a **pre-existing** problem — Azure Monitor Workspace ingestion latency (metrics can take ~10 min to ingest) makes async operations look stuck. They now latch onto E2E runs and fail otherwise-green runs (e.g. Prow `2076589050118017024`, `2076593480259342336`), stalling the merge queue: only one force-merged PR and one batch have merged since Friday against a ~200-PR backlog.

Observed blocking green E2E runs (per [run-log](https://cihealth.tools.hcpsvc.osadev.cloud/run-log?q=BackendAsync)):

```
BackendAsyncOperationClusterDeleteStuck      (81)
BackendAsyncOperationExternalAuthDeleteStuck (29)
BackendAsyncOperationClusterCreateStuck      (25)
BackendAsyncOperationNodePoolDeleteStuck     (17)
BackendAsyncOperationNodePoolCreateStuck      (9)
BackendAsyncOperationStuck                    (3)
```

Per @stevekuznetsov's direction in the alert thread ("add to known list and force-merge"). The durable fix is the AMW auto-scaler (#6036); the entry should be removed once that lands.

### Testing

- Unit tests: `go test ./cmd/aro-hcp-tests/gather-observability/...` passes.
- Verified the anchored regex (`^(?:BackendAsyncOperation.*Stuck)$`) matches all 12 alerts from #5952 and does **not** match unrelated alerts (e.g. `BackendControllerRetryHotLoop`, `KubeDaemonSetRolloutStuck`).

### Special notes for your reviewer

Temporary suppression to unblock the merge queue. Owner @stevekuznetsov; tracked in [AROSLSRE-1471](https://redhat.atlassian.net/browse/AROSLSRE-1471); remove after the AMW ingestion fix (#6036) is deployed.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows Conventional Commits format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Commit history is clean (rebased/squashed)
- [x] Specific reviewers tagged
