### PR TITLE
feat: introduce CS async update controllers in backend and additional state calculations

### DIFF
--- a/admin/server/handlers/hcp/desiredcontrolplanesize.go
+++ b/admin/server/handlers/hcp/desiredcontrolplanesize.go
@@ -56,9 +56,10 @@ func (h *HCPDesiredControlPlaneSizeHandler) ServeHTTP(writer http.ResponseWriter
 	if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
 		return arm.NewCloudError(http.StatusBadRequest, arm.CloudErrorCodeInvalidRequestContent, "", "invalid JSON body: %v", err)
 	}
-	// A nil body.Size means the caller is clearing the SRE-selected tier; that
-	// nil-on-SPC state is what the backend syncer will use to drive removal of
-	// the corresponding cluster-service property. An explicit empty string is
+	// A nil body.Size means the caller is clearing the SRE-selected tier; the
+	// cluster update dispatch controller applies the effective size override to
+	// cluster-service, and the desired-control-plane-size status reconciler
+	// records Status once CS confirms the change. An explicit empty string is
 	// not a valid tier and is rejected separately from the omitted case.
 	if body.Size != nil && *body.Size == "" {
 		return arm.NewCloudError(http.StatusBadRequest, arm.CloudErrorCodeInvalidRequestContent, "", "size must not be empty; omit the field to clear")

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/Azure/msi-dataplane v0.4.3
 	github.com/blang/semver/v4 v4.0.0
 	github.com/go-logr/logr v1.4.3
+	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/openshift-online/maestro v0.0.0-20260213014104-081c1f6df17b
 	github.com/openshift-online/ocm-sdk-go v0.1.499
@@ -88,7 +89,6 @@ require (
 	github.com/golang/glog v1.2.5 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/gorilla/css v1.0.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -32,6 +32,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.44.0
 	go.uber.org/mock v0.6.0
 	golang.org/x/sync v0.20.0
+	k8s.io/api v0.35.3
 	k8s.io/apimachinery v0.35.3
 	k8s.io/client-go v0.35.3
 	k8s.io/component-base v0.35.3
@@ -152,7 +153,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.35.3 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect

--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -46,6 +46,7 @@ import (
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/datadumpcontrollers"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/externalauthcreationcontrollers"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/externalauthdeletion"
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/externalauthupdate"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/managementclustercontrollers"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/metricscontrollers"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/mismatchcontrollers"
@@ -506,8 +507,10 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		b.clock,
 		b.options.ResourcesDBClient,
 		b.options.ClustersServiceClient,
+		unionReadDesireLister,
 		http.DefaultClient,
 		activeOperationInformer,
+		backendInformers,
 	)
 	operationExternalAuthDeleteController := operationcontrollers.NewOperationExternalAuthDeleteController(
 		b.clock,
@@ -832,6 +835,12 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		activeOperationLister,
 		backendInformers,
 	)
+	externalAuthClusterServiceUpdateDispatchController := externalauthupdate.NewExternalAuthClusterServiceUpdateDispatchController(
+		b.options.ResourcesDBClient,
+		b.options.ClustersServiceClient,
+		activeOperationLister,
+		backendInformers,
+	)
 
 	leaderElectionConfig := leaderelection.LeaderElectionConfig{
 		Lock:          b.options.LeaderElectionLock,
@@ -914,6 +923,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 				go clusterDeletionController.Run(ctx, 20)
 				go clusterClusterServiceUpdateDispatchController.Run(ctx, 20)
 				go nodePoolClusterServiceUpdateDispatchController.Run(ctx, 20)
+				go externalAuthClusterServiceUpdateDispatchController.Run(ctx, 20)
 				go operationPhaseMetricsController.Run(ctx, 1)
 				go clusterMetricsController.Run(ctx, 1)
 				go clusterVersionMetricsController.Run(ctx, 1)

--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -41,6 +41,7 @@ import (
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/clustercreation"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/clusterdeletion"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/clusterpropertiescontroller"
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/clusterupdate"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/datadumpcontrollers"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/externalauthcreationcontrollers"
@@ -455,8 +456,10 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		b.clock,
 		b.options.ResourcesDBClient,
 		b.options.ClustersServiceClient,
+		unionReadDesireLister,
 		http.DefaultClient,
 		activeOperationInformer,
+		backendInformers,
 	)
 	operationClusterDeleteController := operationcontrollers.NewOperationClusterDeleteController(
 		b.clock,
@@ -727,6 +730,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		backendInformers,
 		unionKubeApplierInformers,
 	)
+
 	nodePoolClusterServiceIDClearerController := nodepooldeletion.NewNodePoolClusterServiceIDClearerController(
 		b.options.ResourcesDBClient,
 		b.options.ClustersServiceClient,
@@ -812,6 +816,13 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		backendInformers,
 	)
 
+	clusterClusterServiceUpdateDispatchController := clusterupdate.NewClusterClusterServiceUpdateDispatchController(
+		b.options.ResourcesDBClient,
+		b.options.ClustersServiceClient,
+		activeOperationLister,
+		backendInformers,
+	)
+
 	leaderElectionConfig := leaderelection.LeaderElectionConfig{
 		Lock:          b.options.LeaderElectionLock,
 		LeaseDuration: sharedleaderelection.RecommendedLeaseDuration,
@@ -891,6 +902,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 				go clusterClusterServiceIDClearerController.Run(ctx, 20)
 				go clusterChildResourcesCleanupController.Run(ctx, 20)
 				go clusterDeletionController.Run(ctx, 20)
+				go clusterClusterServiceUpdateDispatchController.Run(ctx, 20)
 				go operationPhaseMetricsController.Run(ctx, 1)
 				go clusterMetricsController.Run(ctx, 1)
 				go clusterVersionMetricsController.Run(ctx, 1)

--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -51,6 +51,7 @@ import (
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/mismatchcontrollers"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/nodepoolcreationcontrollers"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/nodepooldeletion"
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/nodepoolupdate"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/operationcontrollers"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/statuscontrollers"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/upgradecontrollers"
@@ -481,8 +482,10 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		b.clock,
 		b.options.ResourcesDBClient,
 		b.options.ClustersServiceClient,
+		unionReadDesireLister,
 		http.DefaultClient,
 		activeOperationInformer,
+		backendInformers,
 	)
 	operationNodePoolDeleteController := operationcontrollers.NewOperationNodePoolDeleteController(
 		b.clock,
@@ -823,6 +826,13 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		backendInformers,
 	)
 
+	nodePoolClusterServiceUpdateDispatchController := nodepoolupdate.NewNodePoolClusterServiceUpdateDispatchController(
+		b.options.ResourcesDBClient,
+		b.options.ClustersServiceClient,
+		activeOperationLister,
+		backendInformers,
+	)
+
 	leaderElectionConfig := leaderelection.LeaderElectionConfig{
 		Lock:          b.options.LeaderElectionLock,
 		LeaseDuration: sharedleaderelection.RecommendedLeaseDuration,
@@ -903,6 +913,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 				go clusterChildResourcesCleanupController.Run(ctx, 20)
 				go clusterDeletionController.Run(ctx, 20)
 				go clusterClusterServiceUpdateDispatchController.Run(ctx, 20)
+				go nodePoolClusterServiceUpdateDispatchController.Run(ctx, 20)
 				go operationPhaseMetricsController.Run(ctx, 1)
 				go clusterMetricsController.Run(ctx, 1)
 				go clusterVersionMetricsController.Run(ctx, 1)

--- a/backend/pkg/controllers/clusterpropertiescontroller/desired_control_plane_size_sync.go
+++ b/backend/pkg/controllers/clusterpropertiescontroller/desired_control_plane_size_sync.go
@@ -21,8 +21,6 @@ import (
 
 	"k8s.io/utils/ptr"
 
-	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
-
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
 	"github.com/Azure/ARO-HCP/backend/pkg/informers"
 	"github.com/Azure/ARO-HCP/backend/pkg/listers"
@@ -34,21 +32,20 @@ import (
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
 
-// desiredControlPlaneSizeSyncer forwards the SRE-selected
-// DesiredHostedClusterControlPlaneSize from the ServiceProviderCluster into
-// cluster-service via the cluster's properties bag (CSPropertySizeOverride).
+// desiredControlPlaneSizeSyncer records ServiceProviderCluster.Status
+// DesiredHostedClusterControlPlaneSize once cluster-service reflects the
+// effective size override implied by SPC Spec and the cluster experimental
+// features (via ocm.ConvertHostedClusterSizeOverrideToCS).
 //
-// It reads the live cluster-service cluster, computes the desired property
-// value via ocm.DesiredHostedClusterSizeOverride (the same helper the frontend
-// update path uses), and only issues an UpdateCluster when the value actually
-// differs — avoiding the cost (and the CS "updating" state churn) of pushing
-// on every resync.
+// It does not PATCH cluster-service. The cluster update dispatch controller
+// is the sole writer for CSPropertySizeOverride. This syncer only observes
+// the live CS cluster and, when the property already matches the merged
+// desired value, mirrors SPC Spec into Status so NeedsWork can detect the
+// unset transition (Spec nil, Status non-nil) without round-tripping to CS.
 //
-// After a successful reconcile the syncer writes the applied size back to
-// ServiceProviderCluster.Status.DesiredHostedClusterControlPlaneSize so that
-// NeedsWork can detect the unset transition (Spec nil, Status non-nil)
-// without round-tripping to CS — the only signal that the previously-applied
-// property still needs to be cleared from CS.
+// Status records the SPC tier field only, not the merged CS property value.
+// For example, when SPC Spec is cleared and experimental Minimal applies,
+// Status is set to nil once CS holds e2e_minimal, not e2e_minimal itself.
 type desiredControlPlaneSizeSyncer struct {
 	cooldownChecker              controllerutil.CooldownChecker
 	serviceProviderClusterLister listers.ServiceProviderClusterLister
@@ -59,9 +56,10 @@ type desiredControlPlaneSizeSyncer struct {
 
 var _ controllerutils.ClusterSyncer = (*desiredControlPlaneSizeSyncer)(nil)
 
-// NewDesiredControlPlaneSizeController creates a controller that reads
-// ServiceProviderClusterSpec.DesiredHostedClusterControlPlaneSize and writes
-// the corresponding cluster-service property when it diverges.
+// NewDesiredControlPlaneSizeController creates a controller that reconciles
+// ServiceProviderCluster.Status.DesiredHostedClusterControlPlaneSize against
+// SPC Spec once the cluster update dispatch controller has applied the
+// effective size override to cluster-service.
 func NewDesiredControlPlaneSizeController(
 	resourcesDBClient database.ResourcesDBClient,
 	clusterServiceClient ocm.ClusterServiceClientSpec,
@@ -95,7 +93,7 @@ func (c *desiredControlPlaneSizeSyncer) CooldownChecker() controllerutil.Cooldow
 }
 
 // NeedsWork reports whether ServiceProviderCluster.Spec.DesiredHostedClusterControlPlaneSize
-// diverges from what we last wrote (ServiceProviderCluster.Status.DesiredHostedClusterControlPlaneSize).
+// diverges from what we last recorded (ServiceProviderCluster.Status.DesiredHostedClusterControlPlaneSize).
 // The comparison covers all three transitions we care about:
 //   - set → changed:  Spec=A, Status=B
 //   - unset → set:    Spec=A, Status=nil
@@ -153,33 +151,19 @@ func (c *desiredControlPlaneSizeSyncer) SyncOnce(ctx context.Context, key contro
 		return utils.TrackError(fmt.Errorf("failed to get cluster from Cluster Service: %w", err))
 	}
 
-	// Compute the desired CSPropertySizeOverride value using the same logic
-	// BuildCSCluster applies on the frontend update path — the helper is the
-	// single source of truth so the two writers cannot disagree.
-	desired, desiredPresent := ocm.DesiredHostedClusterSizeOverride(cachedServiceProviderCluster, cachedCluster)
+	// Compute the effective CSPropertySizeOverride using the same logic the
+	// cluster update dispatch controller applies. The helper is the single
+	// source of truth so dispatch and this status reconciler cannot disagree.
+	effectiveDesired, effectiveDesiredPresent := ocm.ConvertHostedClusterSizeOverrideToCS(cachedCluster.ServiceProviderProperties.ExperimentalFeatures.ControlPlanePodSizing, cachedServiceProviderCluster.Spec.DesiredHostedClusterControlPlaneSize)
 	current, currentPresent := clusterServiceCluster.Properties()[ocm.CSPropertySizeOverride]
 
-	if desiredPresent != currentPresent || desired != current {
-		// Overlay onto a copy of the existing properties so any other entries
-		// CS already holds (SingleReplica, provision shard, etc.) stay intact.
-		properties := map[string]string{}
-		for k, v := range clusterServiceCluster.Properties() {
-			properties[k] = v
-		}
-		if desiredPresent {
-			properties[ocm.CSPropertySizeOverride] = desired
-		} else {
-			delete(properties, ocm.CSPropertySizeOverride)
-		}
-
-		clusterBuilder := arohcpv1alpha1.NewCluster().Properties(properties)
-		if _, err := c.clusterServiceClient.UpdateCluster(ctx, clusterServiceID, clusterBuilder); err != nil {
-			return utils.TrackError(fmt.Errorf("failed to update cluster in Cluster Service: %w", err))
-		}
+	if effectiveDesiredPresent != currentPresent || effectiveDesired != current {
+		logger.V(1).Info("effective cluster-service size override not yet applied, waiting for update dispatch", "effectiveDesired", effectiveDesired, "effectiveDesiredPresent", effectiveDesiredPresent, "current", current, "currentPresent", currentPresent)
+		return nil
 	}
 
-	// Record what we just applied. Status mirrors Spec so NeedsWork can
-	// trivially detect the next divergence — including the unset case.
+	// Cluster-service reflects the merged desired value. Mirror SPC Spec into
+	// Status so NeedsWork can trivially detect the next divergence.
 	replacement := cachedServiceProviderCluster.DeepCopy()
 	if cachedServiceProviderCluster.Spec.DesiredHostedClusterControlPlaneSize == nil {
 		replacement.Status.DesiredHostedClusterControlPlaneSize = nil
@@ -197,9 +181,6 @@ func (c *desiredControlPlaneSizeSyncer) SyncOnce(ctx context.Context, key contro
 		return utils.TrackError(fmt.Errorf("failed to update ServiceProviderCluster status: %w", err))
 	}
 
-	logger.Info("reconciled DesiredHostedClusterControlPlaneSize with Cluster Service",
-		"size", desired,
-		"present", desiredPresent,
-	)
+	logger.Info("recorded DesiredHostedClusterControlPlaneSize status after cluster-service confirmed", "size", effectiveDesired, "present", effectiveDesiredPresent)
 	return nil
 }

--- a/backend/pkg/controllers/clusterpropertiescontroller/desired_control_plane_size_sync_test.go
+++ b/backend/pkg/controllers/clusterpropertiescontroller/desired_control_plane_size_sync_test.go
@@ -39,7 +39,7 @@ import (
 func TestDesiredControlPlaneSizeSyncer_SyncOnce(t *testing.T) {
 	largeStr := string(api.HostedClusterControlPlaneSizeLarge)
 	mediumStr := string(api.HostedClusterControlPlaneSizeMedium)
-	// CS stores the size override in lowercase (ocm.DesiredHostedClusterSizeOverride
+	// CS stores the size override in lowercase (ocm.ConvertHostedClusterSizeOverrideToCS
 	// normalizes it), so anything we seed into or expect from CS uses the
 	// lowercased form even though the API surface uses the capitalized enum.
 	largeCS := strings.ToLower(largeStr)
@@ -52,12 +52,7 @@ func TestDesiredControlPlaneSizeSyncer_SyncOnce(t *testing.T) {
 		seedServiceProviderCluster bool
 		csProperties               map[string]string
 		csGetErr                   error
-		csUpdateErr                error
 		expectCSGet                bool
-		expectCSPush               bool
-		// expectedProperties is the full properties map on the captured
-		// UpdateCluster builder. Only checked when expectCSPush is true.
-		expectedProperties map[string]string
 		// expectedStatusSize is what
 		// ServiceProviderCluster.Status.DesiredHostedClusterControlPlaneSize
 		// must equal after a successful reconcile. Nil pointer means absent.
@@ -111,7 +106,7 @@ func TestDesiredControlPlaneSizeSyncer_SyncOnce(t *testing.T) {
 			},
 		},
 		{
-			name: "set transition - writes CS and records Status",
+			name: "set transition - waits when cluster-service not yet updated",
 			setup: setup{
 				seedServiceProviderCluster: true,
 				specSize:                   &largeStr,
@@ -119,16 +114,10 @@ func TestDesiredControlPlaneSizeSyncer_SyncOnce(t *testing.T) {
 				cluster:                    newTestCluster(testClusterName),
 				csProperties:               nil,
 				expectCSGet:                true,
-				expectCSPush:               true,
-				expectedProperties: map[string]string{
-					ocm.CSPropertySizeOverride: largeCS,
-				},
-				expectedStatusSize:                &largeStr,
-				expectServiceProviderClusterWrite: true,
 			},
 		},
 		{
-			name: "change transition - overwrites stale CS and preserves other properties",
+			name: "change transition - waits when cluster-service still has stale value",
 			setup: setup{
 				seedServiceProviderCluster: true,
 				specSize:                   &mediumStr,
@@ -138,18 +127,11 @@ func TestDesiredControlPlaneSizeSyncer_SyncOnce(t *testing.T) {
 					ocm.CSPropertySizeOverride:  largeCS,
 					ocm.CSPropertySingleReplica: ocm.CSPropertyEnabled,
 				},
-				expectCSGet:  true,
-				expectCSPush: true,
-				expectedProperties: map[string]string{
-					ocm.CSPropertySizeOverride:  mediumCS,
-					ocm.CSPropertySingleReplica: ocm.CSPropertyEnabled,
-				},
-				expectedStatusSize:                &mediumStr,
-				expectServiceProviderClusterWrite: true,
+				expectCSGet: true,
 			},
 		},
 		{
-			name: "unset transition - clears CS property and clears Status",
+			name: "unset transition - waits when cluster-service still has override",
 			setup: setup{
 				seedServiceProviderCluster: true,
 				specSize:                   nil,
@@ -159,17 +141,11 @@ func TestDesiredControlPlaneSizeSyncer_SyncOnce(t *testing.T) {
 					ocm.CSPropertySizeOverride:  largeCS,
 					ocm.CSPropertySingleReplica: ocm.CSPropertyEnabled,
 				},
-				expectCSGet:  true,
-				expectCSPush: true,
-				expectedProperties: map[string]string{
-					ocm.CSPropertySingleReplica: ocm.CSPropertyEnabled,
-				},
-				expectedStatusSize:                nil,
-				expectServiceProviderClusterWrite: true,
+				expectCSGet: true,
 			},
 		},
 		{
-			name: "no CS write needed but Status drifted - just record Status",
+			name: "set transition - records Status when cluster-service already matches",
 			setup: setup{
 				seedServiceProviderCluster: true,
 				specSize:                   &largeStr,
@@ -179,8 +155,54 @@ func TestDesiredControlPlaneSizeSyncer_SyncOnce(t *testing.T) {
 					ocm.CSPropertySizeOverride: largeCS,
 				},
 				expectCSGet:                       true,
-				expectCSPush:                      false,
 				expectedStatusSize:                &largeStr,
+				expectServiceProviderClusterWrite: true,
+			},
+		},
+		{
+			name: "change transition - records Status when cluster-service already matches",
+			setup: setup{
+				seedServiceProviderCluster: true,
+				specSize:                   &mediumStr,
+				statusSize:                 &largeStr,
+				cluster:                    newTestCluster(testClusterName),
+				csProperties: map[string]string{
+					ocm.CSPropertySizeOverride: mediumCS,
+				},
+				expectCSGet:                       true,
+				expectedStatusSize:                &mediumStr,
+				expectServiceProviderClusterWrite: true,
+			},
+		},
+		{
+			name: "unset transition - records Status when cluster-service already cleared",
+			setup: setup{
+				seedServiceProviderCluster: true,
+				specSize:                   nil,
+				statusSize:                 &largeStr,
+				cluster:                    newTestCluster(testClusterName),
+				csProperties: map[string]string{
+					ocm.CSPropertySingleReplica: ocm.CSPropertyEnabled,
+				},
+				expectCSGet:                       true,
+				expectedStatusSize:                nil,
+				expectServiceProviderClusterWrite: true,
+			},
+		},
+		{
+			name: "unset transition - records Status when cluster-service has experimental fallback",
+			setup: setup{
+				seedServiceProviderCluster: true,
+				specSize:                   nil,
+				statusSize:                 &largeStr,
+				cluster: newTestCluster(testClusterName, func(c *api.HCPOpenShiftCluster) {
+					c.ServiceProviderProperties.ExperimentalFeatures.ControlPlanePodSizing = api.MinimalControlPlanePodSizing
+				}),
+				csProperties: map[string]string{
+					ocm.CSPropertySizeOverride: ocm.CSPropertyE2EMinimalControlPlaneSize,
+				},
+				expectCSGet:                       true,
+				expectedStatusSize:                nil,
 				expectServiceProviderClusterWrite: true,
 			},
 		},
@@ -193,18 +215,6 @@ func TestDesiredControlPlaneSizeSyncer_SyncOnce(t *testing.T) {
 				csGetErr:                   fmt.Errorf("boom"),
 				expectCSGet:                true,
 				expectErrContains:          "failed to get cluster from Cluster Service",
-			},
-		},
-		{
-			name: "CS UpdateCluster fails - error",
-			setup: setup{
-				seedServiceProviderCluster: true,
-				specSize:                   &largeStr,
-				cluster:                    newTestCluster(testClusterName),
-				csUpdateErr:                fmt.Errorf("boom"),
-				expectCSGet:                true,
-				expectCSPush:               true,
-				expectErrContains:          "failed to update cluster in Cluster Service",
 			},
 		},
 	}
@@ -251,15 +261,6 @@ func TestDesiredControlPlaneSizeSyncer_SyncOnce(t *testing.T) {
 					GetCluster(gomock.Any(), api.Must(api.NewInternalID(testClusterServiceIDStr))).
 					Return(buildBareCSCluster(t, tc.csProperties), tc.csGetErr)
 			}
-			var capturedBuilder *arohcpv1alpha1.ClusterBuilder
-			if tc.expectCSPush {
-				mockCSClient.EXPECT().
-					UpdateCluster(gomock.Any(), api.Must(api.NewInternalID(testClusterServiceIDStr)), gomock.Any()).
-					DoAndReturn(func(_ context.Context, _ api.InternalID, b *arohcpv1alpha1.ClusterBuilder) (*arohcpv1alpha1.Cluster, error) {
-						capturedBuilder = b
-						return buildBareCSCluster(t, tc.csProperties), tc.csUpdateErr
-					})
-			}
 
 			syncer := &desiredControlPlaneSizeSyncer{
 				cooldownChecker:              &alwaysSyncCooldownChecker{},
@@ -282,13 +283,6 @@ func TestDesiredControlPlaneSizeSyncer_SyncOnce(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-
-			if tc.expectCSPush && tc.expectedProperties != nil {
-				require.NotNil(t, capturedBuilder, "expected an UpdateCluster call with a builder")
-				built, buildErr := capturedBuilder.Build()
-				require.NoError(t, buildErr)
-				assert.Equal(t, tc.expectedProperties, built.Properties())
-			}
 
 			if !tc.expectServiceProviderClusterWrite {
 				return

--- a/backend/pkg/controllers/clusterupdate/cluster_cluster_service_update_dispatch_controller.go
+++ b/backend/pkg/controllers/clusterupdate/cluster_cluster_service_update_dispatch_controller.go
@@ -1,0 +1,324 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusterupdate
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/internal/api"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// clusterClusterServiceUpdateDispatchSyncer calls Cluster Service's Cluster PATCH when
+// the Cluster's dispatch-managed configuration has drifted. It reconciles a curated subset of
+// fields defined by ocm.clusterUpdateDispatchConfig.
+//
+// On each reconcile, the Cluster's state and the live Cluster Service cluster state
+// are projected into ocm.clusterUpdateDispatchConfig. When the projections from both sides
+// differ, it PATCHes Cluster Service (autoscaler first, then cluster).
+//
+// Dispatch is paired with operation state calculation in operationcontrollers
+// (operation_cluster_update_state_calculation.go): dispatch sends updates, operation state
+// verifies propagation before the ARM cluster update operation succeeds.
+type clusterClusterServiceUpdateDispatchSyncer struct {
+	cooldownChecker      controllerutil.CooldownChecker
+	clusterLister        listers.ClusterLister
+	subscriptionLister   listers.SubscriptionLister
+	resourcesDBClient    database.ResourcesDBClient
+	clusterServiceClient ocm.ClusterServiceClientSpec
+
+	// minimumReconcileTimeCooldownChecker ensures we don't hotloop from any source,
+	// by ensuring that we don't reconcile more often than the cooldown time in it.
+	minimumReconcileTimeCooldownChecker controllerutil.CooldownChecker
+}
+
+var _ controllerutils.ClusterSyncer = (*clusterClusterServiceUpdateDispatchSyncer)(nil)
+
+func NewClusterClusterServiceUpdateDispatchController(
+	resourcesDBClient database.ResourcesDBClient,
+	clusterServiceClient ocm.ClusterServiceClientSpec,
+	activeOperationLister listers.ActiveOperationLister,
+	informers informers.BackendInformers,
+) controllerutils.Controller {
+	_, clusterLister := informers.Clusters()
+	_, subscriptionLister := informers.Subscriptions()
+	syncer := NewClusterClusterServiceUpdateDispatchSyncer(
+		resourcesDBClient,
+		clusterServiceClient,
+		activeOperationLister,
+		clusterLister,
+		subscriptionLister,
+	)
+
+	return controllerutils.NewClusterWatchingController(
+		"ClusterClusterServiceUpdateDispatch",
+		resourcesDBClient,
+		informers,
+		nil,
+		time.Minute,
+		syncer,
+	)
+}
+
+func NewClusterClusterServiceUpdateDispatchSyncer(
+	resourcesDBClient database.ResourcesDBClient,
+	clusterServiceClient ocm.ClusterServiceClientSpec,
+	activeOperationLister listers.ActiveOperationLister,
+	clusterLister listers.ClusterLister,
+	subscriptionLister listers.SubscriptionLister,
+) controllerutils.ClusterSyncer {
+	return &clusterClusterServiceUpdateDispatchSyncer{
+		cooldownChecker: controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		// We set minimumReconcileTimeCooldownChecker so that SyncOnce is not executed
+		// more than once per minute.
+		minimumReconcileTimeCooldownChecker: controllerutil.NewTimeBasedCooldownChecker(1 * time.Minute),
+		clusterLister:                       clusterLister,
+		subscriptionLister:                  subscriptionLister,
+		resourcesDBClient:                   resourcesDBClient,
+		clusterServiceClient:                clusterServiceClient,
+	}
+}
+
+func needsWork(cluster *api.HCPOpenShiftCluster) bool {
+	if cluster.ServiceProviderProperties.DeletionTimestamp != nil {
+		return false
+	}
+
+	csID := cluster.ServiceProviderProperties.ClusterServiceID
+	if csID == nil || len(csID.String()) == 0 {
+		return false
+	}
+
+	return true
+}
+
+func (c *clusterClusterServiceUpdateDispatchSyncer) CooldownChecker() controllerutil.CooldownChecker {
+	return c.cooldownChecker
+}
+
+func (c *clusterClusterServiceUpdateDispatchSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPClusterKey) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	// Because this controller ends up calling Cluster Service each time it's reconciled and it's reconciled
+	// while the resource exists and while it is not being deleted, we establish a minimum reconcile time cooldown
+	// to avoid putting too much pressure on Cluster Service.
+	// TODO in the future, we could remove this cooldown checker by persisting a hash of the update dispatch configuration
+	// sent to Cluster Service and checking if it has changed since the last time we sent it.
+	if !c.minimumReconcileTimeCooldownChecker.CanSync(ctx, key) {
+		return nil
+	}
+
+	cachedCluster, err := c.clusterLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get cluster from cache: %w", err))
+	}
+	if !needsWork(cachedCluster) {
+		return nil
+	}
+
+	clusterCRUD := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName)
+	cluster, err := clusterCRUD.Get(ctx, key.HCPClusterName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get cluster: %w", err))
+	}
+	if !needsWork(cluster) {
+		return nil
+	}
+
+	subscription, err := c.subscriptionLister.Get(ctx, key.SubscriptionID)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get subscription from cache: %w", err))
+	}
+	if subscription.Properties == nil || subscription.Properties.TenantId == nil {
+		return utils.TrackError(fmt.Errorf("subscription properties or subscription tenant ID is nil"))
+	}
+
+	clusterCSID := cluster.ServiceProviderProperties.ClusterServiceID
+	serviceProviderCluster, err := c.resourcesDBClient.ServiceProviderClusters(cluster.ID.SubscriptionID, cluster.ID.ResourceGroupName, cluster.ID.Name).Get(ctx, api.ServiceProviderClusterResourceName)
+	if database.IsNotFoundError(err) {
+		// We expect the service provider cluster to be created when the cluster exists. If it doesn't exist, we wait for the next sync.
+		logger.Info("service provider cluster not found, waiting")
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get service provider cluster: %w", err))
+	}
+
+	clusterServiceCluster, err := c.clusterServiceClient.GetCluster(ctx, *clusterCSID)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get cluster from Cluster Service: %w", err))
+	}
+
+	// We check if the desired config coming from cosmos differs from the actual config coming from cluster service.
+	// If it doesn't, we are done and don't need to dispatch an update. If it does, we need to dispatch an update to
+	// cluster service. Comparison uses canonical JSON (sorted object keys at every level) so we can compare them
+	// using direct string equality.
+	desiredConfigJSON, err := ocm.ClusterUpdateDispatchConfigJSONFromRP(cluster, serviceProviderCluster)
+	if err != nil {
+		return utils.TrackError(err)
+	}
+	actualConfigJSON, err := ocm.ClusterUpdateDispatchConfigJSONFromCS(clusterServiceCluster)
+	if err != nil {
+		return utils.TrackError(err)
+	}
+	if desiredConfigJSON == actualConfigJSON {
+		return nil
+	}
+
+	configDiff := cmp.Diff(desiredConfigJSON, actualConfigJSON)
+
+	logger.Info("update dispatch config differs between RP and CS",
+		"clusterServiceID", clusterCSID.String(),
+		"desiredConfig", desiredConfigJSON,
+		"actualConfig", actualConfigJSON,
+		"configDiff", configDiff,
+	)
+
+	csClusterBuilder, csAutoscalerBuilder, err := ocm.BuildCSCluster(cluster.ID, *subscription.Properties.TenantId, cluster, nil, clusterServiceCluster, serviceProviderCluster)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to build CS cluster: %w", err))
+	}
+
+	// We marshal the autoscaler CS builder config we are going to submit for cs cluster autoscaler update for logging purposes
+	clusterAutoscalerPayload, err := c.marshalClusterServiceClusterAutoscalerUpdatePayload(csAutoscalerBuilder)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to marshal Cluster Service autoscaler update payload: %w", err))
+	}
+
+	logger.Info("dispatching cluster autoscaler update to Cluster Service",
+		"clusterServiceID", clusterCSID.String(),
+		"clusterServiceClusterAutoscalerPayload", clusterAutoscalerPayload,
+	)
+
+	_, err = c.clusterServiceClient.UpdateClusterAutoscaler(ctx, *clusterCSID, csAutoscalerBuilder)
+	if err != nil {
+		var ocmError *ocmerrors.Error
+		// XXX Matching an error message is brittle, but Clusters Service
+		//     returns 400 Bad Request for a wide range of errors and there
+		//     is no other information in the response to distinguish them.
+		//
+		//     If the error is indicating that a the cluster autoscaler is not in
+		//     an updatable state, we return without error and retry again on the
+		//     next sync. This can happen for example when the CS cluster is still in
+		//     the initial creation process.
+		if errors.As(err, &ocmError) && ocmError.Status() == http.StatusBadRequest &&
+			strings.Contains(ocmError.Reason(), "Cluster") &&
+			strings.Contains(ocmError.Reason(), "is in state") &&
+			strings.Contains(ocmError.Reason(), "can't update") {
+			logger.Info("Cluster Service rejected cluster autoscaler update because the cluster is not updatable. Retrying on next sync.",
+				"clusterServiceID", clusterCSID.String(),
+				"error", err.Error(),
+			)
+			return nil
+		}
+		return utils.TrackError(fmt.Errorf("failed to update cluster-service ClusterAutoscaler: %w", err))
+	}
+
+	logger.Info("dispatched cluster autoscaler update to Cluster Service", "clusterServiceID", clusterCSID.String())
+
+	// We marshal the cluster CS builder config we are going to submit for cs cluster update for logging purposes
+	clusterPayload, err := c.marshalClusterServiceClusterUpdatePayload(csClusterBuilder)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to marshal Cluster Service cluster update payload: %w", err))
+	}
+
+	logger.Info("dispatching cluster update to Cluster Service",
+		"clusterServiceID", clusterCSID.String(),
+		"clusterServiceClusterPayload", clusterPayload,
+	)
+
+	_, err = c.clusterServiceClient.UpdateCluster(ctx, *clusterCSID, csClusterBuilder)
+	if err != nil {
+		var ocmError *ocmerrors.Error
+		// XXX Matching an error message is brittle, but Clusters Service
+		//     returns 400 Bad Request for a wide range of errors and there
+		//     is no other information in the response to distinguish them.
+		//
+		//     If the error is indicating that a the cluster autoscaler is not in
+		//     an updatable state, we return without error and retry again on the
+		//     next sync. This can happen for example when the CS cluster is still in
+		//     the initial creation process.
+		if errors.As(err, &ocmError) && ocmError.Status() == http.StatusBadRequest &&
+			strings.Contains(ocmError.Reason(), "Cluster") &&
+			strings.Contains(ocmError.Reason(), "is in state") &&
+			strings.Contains(ocmError.Reason(), "can't update") {
+			logger.Info("Cluster Service rejected cluster update because the cluster is not updatable. Retrying on next sync.",
+				"clusterServiceID", clusterCSID.String(),
+				"error", err.Error(),
+			)
+			return nil
+		}
+		return utils.TrackError(fmt.Errorf("failed to update cluster-service Cluster: %w", err))
+	}
+
+	logger.Info("dispatched cluster update to Cluster Service", "clusterServiceID", clusterCSID.String())
+	return nil
+}
+
+// marshalClusterServiceClusterUpdatePayload serializes the cluster PATCH body for logging.
+func (c *clusterClusterServiceUpdateDispatchSyncer) marshalClusterServiceClusterUpdatePayload(clusterBuilder *arohcpv1alpha1.ClusterBuilder) (string, error) {
+	cluster, err := clusterBuilder.Build()
+	if err != nil {
+		return "", err
+	}
+
+	var clusterBuffer bytes.Buffer
+	if err := arohcpv1alpha1.MarshalCluster(cluster, &clusterBuffer); err != nil {
+		return "", err
+	}
+
+	return clusterBuffer.String(), nil
+}
+
+// marshalClusterServiceClusterAutoscalerUpdatePayload serializes the autoscaler PATCH body for logging.
+func (c *clusterClusterServiceUpdateDispatchSyncer) marshalClusterServiceClusterAutoscalerUpdatePayload(autoscalerBuilder *arohcpv1alpha1.ClusterAutoscalerBuilder) (string, error) {
+	autoscaler, err := autoscalerBuilder.Build()
+	if err != nil {
+		return "", err
+	}
+
+	var autoscalerBuffer bytes.Buffer
+	if err := arohcpv1alpha1.MarshalClusterAutoscaler(autoscaler, &autoscalerBuffer); err != nil {
+		return "", err
+	}
+
+	return autoscalerBuffer.String(), nil
+}

--- a/backend/pkg/controllers/clusterupdate/cluster_cluster_service_update_dispatch_controller_test.go
+++ b/backend/pkg/controllers/clusterupdate/cluster_cluster_service_update_dispatch_controller_test.go
@@ -1,0 +1,467 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusterupdate
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+)
+
+const (
+	testSubscriptionID      = "00000000-0000-0000-0000-000000000000"
+	testResourceGroupName   = "test-rg"
+	testClusterName         = "test-cluster"
+	testClusterServiceIDStr = "/api/aro_hcp/v1alpha1/clusters/abc123"
+)
+
+func TestClusterUpdateDispatchSyncer_SyncOnce(t *testing.T) {
+	csID := api.Must(api.NewInternalID(testClusterServiceIDStr))
+
+	defaultExistingCSCluster := api.Must(arohcpv1alpha1.NewCluster().Build())
+
+	newClusterWithConfigDiff := func() *api.HCPOpenShiftCluster {
+		return newTestCluster(func(c *api.HCPOpenShiftCluster) {
+			c.CustomerProperties.NodeDrainTimeoutMinutes = 60
+			c.CustomerProperties.Autoscaling.MaxNodesTotal = 10
+		})
+	}
+
+	newFakeOCMClusterNotUpdatableError := func() error {
+		e, _ := ocmerrors.NewError().
+			Status(http.StatusBadRequest).
+			Reason("Cluster 'abc123' is in state 'installing', can't update").
+			Build()
+		return e
+	}
+
+	newFakeOCMUnrelatedBadRequestError := func() error {
+		e, _ := ocmerrors.NewError().
+			Status(http.StatusBadRequest).
+			Reason("some other validation error").
+			Build()
+		return e
+	}
+
+	testCases := []struct {
+		name                           string
+		existingCluster                *api.HCPOpenShiftCluster
+		existingSubscription           *arm.Subscription
+		existingServiceProviderCluster *api.ServiceProviderCluster
+		existingCSCluster              *arohcpv1alpha1.Cluster
+		// When not set, the syncer uses a cluster lister backed by the seeded Cosmos resources.
+		clusterLister                       listers.ClusterLister
+		setupMockCSClient                   func(mock *ocm.MockClusterServiceClientSpec)
+		minimumReconcileTimeCooldownChecker controllerutil.CooldownChecker
+		wantErr                             bool
+		wantErrContain                      string
+	}{
+		{
+			name: "skip without CS call when no CSID",
+			existingCluster: newTestCluster(func(c *api.HCPOpenShiftCluster) {
+				c.ServiceProviderProperties.ClusterServiceID = nil
+				c.CustomerProperties.NodeDrainTimeoutMinutes = 30
+			}),
+			minimumReconcileTimeCooldownChecker: &alwaysSyncCooldownChecker{},
+		},
+		{
+			name:                           "dispatches CS calls when config differs",
+			existingCluster:                newClusterWithConfigDiff(),
+			existingSubscription:           newTestSubscription(),
+			existingServiceProviderCluster: newTestServiceProviderCluster(testClusterName),
+			existingCSCluster:              defaultExistingCSCluster,
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetCluster(gomock.Any(), csID).
+					Return(defaultExistingCSCluster, nil)
+				mock.EXPECT().
+					UpdateClusterAutoscaler(gomock.Any(), csID, gomock.Any()).
+					Return(nil, nil)
+				mock.EXPECT().
+					UpdateCluster(gomock.Any(), csID, gomock.Any()).
+					Return(nil, nil)
+			},
+			minimumReconcileTimeCooldownChecker: &alwaysSyncCooldownChecker{},
+		},
+		{
+			name: "no-op when config matches",
+			existingCluster: newTestCluster(func(c *api.HCPOpenShiftCluster) {
+				c.CustomerProperties.NodeDrainTimeoutMinutes = 30
+			}),
+			existingSubscription:           newTestSubscription(),
+			existingServiceProviderCluster: newTestServiceProviderCluster(testClusterName),
+			existingCSCluster: mustBuildCSClusterFromRP(t, newTestCluster(func(c *api.HCPOpenShiftCluster) {
+				c.CustomerProperties.NodeDrainTimeoutMinutes = 30
+			})),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetCluster(gomock.Any(), csID).
+					Return(mustBuildCSClusterFromRP(t, newTestCluster(func(c *api.HCPOpenShiftCluster) {
+						c.CustomerProperties.NodeDrainTimeoutMinutes = 30
+					})), nil)
+			},
+			minimumReconcileTimeCooldownChecker: &alwaysSyncCooldownChecker{},
+		},
+		{
+			name:                           "when CS autoscaler update returns cluster not updatable no error is returned and cluster update is not called",
+			existingCluster:                newClusterWithConfigDiff(),
+			existingSubscription:           newTestSubscription(),
+			existingServiceProviderCluster: newTestServiceProviderCluster(testClusterName),
+			existingCSCluster:              defaultExistingCSCluster,
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetCluster(gomock.Any(), csID).
+					Return(defaultExistingCSCluster, nil)
+				mock.EXPECT().
+					UpdateClusterAutoscaler(gomock.Any(), csID, gomock.Any()).
+					Return(nil, newFakeOCMClusterNotUpdatableError())
+			},
+			minimumReconcileTimeCooldownChecker: &alwaysSyncCooldownChecker{},
+		},
+		{
+			name:                           "when CS cluster update returns cluster not updatable no error is returned",
+			existingCluster:                newClusterWithConfigDiff(),
+			existingSubscription:           newTestSubscription(),
+			existingServiceProviderCluster: newTestServiceProviderCluster(testClusterName),
+			existingCSCluster:              defaultExistingCSCluster,
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetCluster(gomock.Any(), csID).
+					Return(defaultExistingCSCluster, nil)
+				mock.EXPECT().
+					UpdateClusterAutoscaler(gomock.Any(), csID, gomock.Any()).
+					Return(nil, nil)
+				mock.EXPECT().
+					UpdateCluster(gomock.Any(), csID, gomock.Any()).
+					Return(nil, newFakeOCMClusterNotUpdatableError())
+			},
+			minimumReconcileTimeCooldownChecker: &alwaysSyncCooldownChecker{},
+		},
+		{
+			name:                           "when CS autoscaler update returns unhandled error error is propagated",
+			existingCluster:                newClusterWithConfigDiff(),
+			existingSubscription:           newTestSubscription(),
+			existingServiceProviderCluster: newTestServiceProviderCluster(testClusterName),
+			existingCSCluster:              defaultExistingCSCluster,
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetCluster(gomock.Any(), csID).
+					Return(defaultExistingCSCluster, nil)
+				mock.EXPECT().
+					UpdateClusterAutoscaler(gomock.Any(), csID, gomock.Any()).
+					Return(nil, errors.New("boom"))
+			},
+			wantErr:                             true,
+			wantErrContain:                      "failed to update cluster-service ClusterAutoscaler",
+			minimumReconcileTimeCooldownChecker: &alwaysSyncCooldownChecker{},
+		},
+		{
+			name:                           "when CS cluster update returns unhandled error error is propagated",
+			existingCluster:                newClusterWithConfigDiff(),
+			existingSubscription:           newTestSubscription(),
+			existingServiceProviderCluster: newTestServiceProviderCluster(testClusterName),
+			existingCSCluster:              defaultExistingCSCluster,
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetCluster(gomock.Any(), csID).
+					Return(defaultExistingCSCluster, nil)
+				mock.EXPECT().
+					UpdateClusterAutoscaler(gomock.Any(), csID, gomock.Any()).
+					Return(nil, nil)
+				mock.EXPECT().
+					UpdateCluster(gomock.Any(), csID, gomock.Any()).
+					Return(nil, errors.New("boom"))
+			},
+			wantErr:                             true,
+			wantErrContain:                      "failed to update cluster-service Cluster",
+			minimumReconcileTimeCooldownChecker: &alwaysSyncCooldownChecker{},
+		},
+		{
+			name:                           "when CS autoscaler update returns unrelated bad request error error is propagated",
+			existingCluster:                newClusterWithConfigDiff(),
+			existingSubscription:           newTestSubscription(),
+			existingServiceProviderCluster: newTestServiceProviderCluster(testClusterName),
+			existingCSCluster:              defaultExistingCSCluster,
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetCluster(gomock.Any(), csID).
+					Return(defaultExistingCSCluster, nil)
+				mock.EXPECT().
+					UpdateClusterAutoscaler(gomock.Any(), csID, gomock.Any()).
+					Return(nil, newFakeOCMUnrelatedBadRequestError())
+			},
+			wantErr:                             true,
+			wantErrContain:                      "failed to update cluster-service ClusterAutoscaler",
+			minimumReconcileTimeCooldownChecker: &alwaysSyncCooldownChecker{},
+		},
+		{
+			name:                           "when CS GetCluster fails error is propagated",
+			existingCluster:                newClusterWithConfigDiff(),
+			existingSubscription:           newTestSubscription(),
+			existingServiceProviderCluster: newTestServiceProviderCluster(testClusterName),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetCluster(gomock.Any(), csID).
+					Return(nil, errors.New("boom"))
+			},
+			wantErr:                             true,
+			wantErrContain:                      "failed to get cluster from Cluster Service",
+			minimumReconcileTimeCooldownChecker: &alwaysSyncCooldownChecker{},
+		},
+		{
+			name:                                "when subscription properties are nil error is propagated",
+			existingCluster:                     newClusterWithConfigDiff(),
+			existingSubscription:                newTestSubscription(func(s *arm.Subscription) { s.Properties = nil }),
+			existingServiceProviderCluster:      newTestServiceProviderCluster(testClusterName),
+			wantErr:                             true,
+			wantErrContain:                      "subscription properties or subscription tenant ID is nil",
+			minimumReconcileTimeCooldownChecker: &alwaysSyncCooldownChecker{},
+		},
+		{
+			name:                                "when subscription tenant ID is nil error is propagated",
+			existingCluster:                     newClusterWithConfigDiff(),
+			existingSubscription:                newTestSubscription(func(s *arm.Subscription) { s.Properties.TenantId = nil }),
+			existingServiceProviderCluster:      newTestServiceProviderCluster(testClusterName),
+			wantErr:                             true,
+			wantErrContain:                      "subscription properties or subscription tenant ID is nil",
+			minimumReconcileTimeCooldownChecker: &alwaysSyncCooldownChecker{},
+		},
+		{
+			name:                                "minimum reconcile cooldown prevents sync",
+			existingCluster:                     newTestCluster(),
+			minimumReconcileTimeCooldownChecker: &neverSyncCooldownChecker{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			seedResources := []any{}
+			if tc.existingCluster != nil {
+				seedResources = append(seedResources, tc.existingCluster)
+			}
+			if tc.existingServiceProviderCluster != nil {
+				seedResources = append(seedResources, tc.existingServiceProviderCluster)
+			}
+
+			mockResourcesDB, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, seedResources)
+			require.NoError(t, err)
+
+			clusterLister := tc.clusterLister
+			if clusterLister == nil {
+				clusterLister = &listertesting.DBClusterLister{ResourcesDBClient: mockResourcesDB}
+			}
+
+			var subscriptionLister listers.SubscriptionLister
+			if tc.existingSubscription != nil {
+				subscriptionLister = &listertesting.SliceSubscriptionLister{
+					Subscriptions: []*arm.Subscription{tc.existingSubscription},
+				}
+			}
+
+			mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
+			if tc.setupMockCSClient != nil {
+				tc.setupMockCSClient(mockCSClient)
+			}
+
+			syncer := &clusterClusterServiceUpdateDispatchSyncer{
+				cooldownChecker:                     &alwaysSyncCooldownChecker{},
+				minimumReconcileTimeCooldownChecker: tc.minimumReconcileTimeCooldownChecker,
+				clusterLister:                       clusterLister,
+				subscriptionLister:                  subscriptionLister,
+				resourcesDBClient:                   mockResourcesDB,
+				clusterServiceClient:                mockCSClient,
+			}
+
+			key := controllerutils.HCPClusterKey{
+				SubscriptionID:    testSubscriptionID,
+				ResourceGroupName: testResourceGroupName,
+				HCPClusterName:    testClusterName,
+			}
+
+			err = syncer.SyncOnce(ctx, key)
+			if tc.wantErr {
+				require.Error(t, err)
+				if tc.wantErrContain != "" {
+					assert.Contains(t, err.Error(), tc.wantErrContain)
+				}
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestNeedsWork(t *testing.T) {
+	csID := api.Must(api.NewInternalID(testClusterServiceIDStr))
+	now := metav1.Now()
+
+	tests := []struct {
+		name    string
+		cluster *api.HCPOpenShiftCluster
+		want    bool
+	}{
+		{
+			name: "proceed when CSID set",
+			cluster: &api.HCPOpenShiftCluster{
+				ServiceProviderProperties: api.HCPOpenShiftClusterServiceProviderProperties{
+					ClusterServiceID: &csID,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "skip when deletion timestamp is set",
+			cluster: &api.HCPOpenShiftCluster{
+				ServiceProviderProperties: api.HCPOpenShiftClusterServiceProviderProperties{
+					DeletionTimestamp: &now,
+					ClusterServiceID:  &csID,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "skip when no CSID",
+			cluster: &api.HCPOpenShiftCluster{
+				ServiceProviderProperties: api.HCPOpenShiftClusterServiceProviderProperties{},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, needsWork(tt.cluster))
+		})
+	}
+}
+
+func mustBuildCSClusterFromRP(t *testing.T, hcpCluster *api.HCPOpenShiftCluster) *arohcpv1alpha1.Cluster {
+	t.Helper()
+
+	oldClusterServiceCluster, err := arohcpv1alpha1.NewCluster().Build()
+	require.NoError(t, err)
+
+	clusterBuilder, autoscalerBuilder, err := ocm.BuildCSCluster(hcpCluster.ID, "", hcpCluster, nil, oldClusterServiceCluster, &api.ServiceProviderCluster{})
+	require.NoError(t, err)
+
+	csCluster, err := clusterBuilder.Autoscaler(autoscalerBuilder).Build()
+	require.NoError(t, err)
+	return csCluster
+}
+
+func newTestSubscription(opts ...func(*arm.Subscription)) *arm.Subscription {
+	subResourceID := api.Must(azcorearm.ParseResourceID("/subscriptions/" + testSubscriptionID))
+	subscription := &arm.Subscription{
+		CosmosMetadata: arm.CosmosMetadata{ResourceID: subResourceID},
+		ResourceID:     subResourceID,
+		Properties: &arm.SubscriptionProperties{
+			TenantId: api.Ptr("11111111-1111-1111-1111-111111111111"),
+		},
+	}
+	for _, opt := range opts {
+		opt(subscription)
+	}
+	return subscription
+}
+
+func newTestCluster(opts ...func(*api.HCPOpenShiftCluster)) *api.HCPOpenShiftCluster {
+	resourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName,
+	))
+
+	csID := api.Must(api.NewInternalID(testClusterServiceIDStr))
+	cluster := &api.HCPOpenShiftCluster{
+		CosmosMetadata: arm.CosmosMetadata{
+			ResourceID:   resourceID,
+			PartitionKey: strings.ToLower(resourceID.SubscriptionID),
+		},
+		TrackedResource: arm.TrackedResource{
+			Resource: arm.Resource{
+				ID:   resourceID,
+				Name: testClusterName,
+				Type: resourceID.ResourceType.String(),
+			},
+		},
+		ServiceProviderProperties: api.HCPOpenShiftClusterServiceProviderProperties{
+			ClusterServiceID: &csID,
+		},
+	}
+
+	for _, opt := range opts {
+		opt(cluster)
+	}
+
+	return cluster
+}
+
+func newTestServiceProviderCluster(clusterName string) *api.ServiceProviderCluster {
+	clusterResourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + clusterName,
+	))
+	resourceID := api.Must(azcorearm.ParseResourceID(
+		clusterResourceID.String() + "/" +
+			api.ServiceProviderClusterResourceTypeName + "/" +
+			api.ServiceProviderClusterResourceName,
+	))
+
+	return &api.ServiceProviderCluster{
+		CosmosMetadata: arm.CosmosMetadata{
+			ResourceID:   resourceID,
+			PartitionKey: strings.ToLower(resourceID.SubscriptionID),
+		},
+	}
+}
+
+type alwaysSyncCooldownChecker struct{}
+
+func (c *alwaysSyncCooldownChecker) CanSync(_ context.Context, _ any) bool {
+	return true
+}
+
+type neverSyncCooldownChecker struct{}
+
+func (c *neverSyncCooldownChecker) CanSync(_ context.Context, _ any) bool {
+	return false
+}

--- a/backend/pkg/controllers/externalauthupdate/external_auth_cluster_service_update_dispatch_controller.go
+++ b/backend/pkg/controllers/externalauthupdate/external_auth_cluster_service_update_dispatch_controller.go
@@ -1,0 +1,265 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package externalauthupdate
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/internal/api"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// externalAuthClusterServiceUpdateDispatchSyncer calls Cluster Service's ExternalAuth PATCH when
+// the ExternalAuth's dispatch-managed configuration has drifted. It reconciles a curated subset of
+// fields defined by ocm.externalAuthUpdateDispatchConfig.
+//
+// On each reconcile, the ExternalAuth's state and the live Cluster Service external auth state
+// are projected into ocm.externalAuthUpdateDispatchConfig. When the projections from both sides
+// differ, it PATCHes Cluster Service.
+//
+// Dispatch is paired with operation state calculation in operationcontrollers
+// (operation_external_auth_update_state_calculation.go): dispatch sends updates, operation state
+// verifies propagation before the ARM external auth update operation succeeds.
+type externalAuthClusterServiceUpdateDispatchSyncer struct {
+	cooldownChecker      controllerutil.CooldownChecker
+	externalAuthLister   listers.ExternalAuthLister
+	resourcesDBClient    database.ResourcesDBClient
+	clusterServiceClient ocm.ClusterServiceClientSpec
+
+	// minimumReconcileTimeCooldownChecker ensures we don't hotloop from any source,
+	// by ensuring that we don't reconcile more often than the cooldown time in it.
+	minimumReconcileTimeCooldownChecker controllerutil.CooldownChecker
+}
+
+var _ controllerutils.ExternalAuthSyncer = (*externalAuthClusterServiceUpdateDispatchSyncer)(nil)
+
+func NewExternalAuthClusterServiceUpdateDispatchController(
+	resourcesDBClient database.ResourcesDBClient,
+	clusterServiceClient ocm.ClusterServiceClientSpec,
+	activeOperationLister listers.ActiveOperationLister,
+	backendInformers informers.BackendInformers,
+) controllerutils.Controller {
+	_, externalAuthLister := backendInformers.ExternalAuths()
+	syncer := NewExternalAuthClusterServiceUpdateDispatchSyncer(
+		resourcesDBClient,
+		clusterServiceClient,
+		activeOperationLister,
+		externalAuthLister,
+	)
+
+	return controllerutils.NewExternalAuthWatchingController(
+		"ExternalAuthClusterServiceUpdateDispatch",
+		resourcesDBClient,
+		backendInformers,
+		time.Minute,
+		syncer,
+	)
+}
+
+func NewExternalAuthClusterServiceUpdateDispatchSyncer(
+	resourcesDBClient database.ResourcesDBClient,
+	clusterServiceClient ocm.ClusterServiceClientSpec,
+	activeOperationLister listers.ActiveOperationLister,
+	externalAuthLister listers.ExternalAuthLister,
+) controllerutils.ExternalAuthSyncer {
+	return &externalAuthClusterServiceUpdateDispatchSyncer{
+		cooldownChecker: controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		// We set minimumReconcileTimeCooldownChecker so that SyncOnce is not executed
+		// more than once per minute.
+		minimumReconcileTimeCooldownChecker: controllerutil.NewTimeBasedCooldownChecker(1 * time.Minute),
+		externalAuthLister:                  externalAuthLister,
+		resourcesDBClient:                   resourcesDBClient,
+		clusterServiceClient:                clusterServiceClient,
+	}
+}
+
+func needsWork(ea *api.HCPOpenShiftClusterExternalAuth) bool {
+	if ea.ServiceProviderProperties.DeletionTimestamp != nil {
+		return false
+	}
+
+	csID := ea.ServiceProviderProperties.ClusterServiceID
+	if csID == nil || len(csID.String()) == 0 {
+		return false
+	}
+
+	return true
+}
+
+func (c *externalAuthClusterServiceUpdateDispatchSyncer) CooldownChecker() controllerutil.CooldownChecker {
+	return c.cooldownChecker
+}
+
+func (c *externalAuthClusterServiceUpdateDispatchSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPExternalAuthKey) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	// Because this controller ends up calling Cluster Service each time it's reconciled and it's reconciled
+	// while the resource exists and while it is not being deleted, we establish a minimum reconcile time cooldown
+	// to avoid putting too much pressure on Cluster Service.
+	// TODO in the future, we could remove this cooldown checker by persisting a hash of the update dispatch configuration
+	// sent to Cluster Service and checking if it has changed since the last time we sent it.
+	if !c.minimumReconcileTimeCooldownChecker.CanSync(ctx, key) {
+		return nil
+	}
+
+	cachedExternalAuth, err := c.externalAuthLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPExternalAuthName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get external auth from cache: %w", err))
+	}
+	if !needsWork(cachedExternalAuth) {
+		return nil
+	}
+
+	externalAuthCRUD := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).ExternalAuth(key.HCPClusterName)
+	externalAuth, err := externalAuthCRUD.Get(ctx, key.HCPExternalAuthName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get external auth: %w", err))
+	}
+	if !needsWork(externalAuth) {
+		return nil
+	}
+
+	externalAuthCSID := externalAuth.ServiceProviderProperties.ClusterServiceID
+	csExternalAuth, err := c.clusterServiceClient.GetExternalAuth(ctx, *externalAuthCSID)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get external auth from Cluster Service: %w", err))
+	}
+
+	// We check if the desired config coming from cosmos differs from the actual config coming from cluster service.
+	// If it doesn't, we are done and don't need to dispatch an update. If it does, we need to dispatch an update to
+	// cluster service. Comparison uses canonical JSON (sorted object keys at every level) so we can compare them
+	// using direct string equality.
+	desiredConfigJSON, err := ocm.ExternalAuthUpdateDispatchConfigJSONFromRP(externalAuth)
+	if err != nil {
+		return utils.TrackError(err)
+	}
+	actualConfigJSON, err := ocm.ExternalAuthUpdateDispatchConfigJSONFromCS(csExternalAuth)
+	if err != nil {
+		return utils.TrackError(err)
+	}
+	if desiredConfigJSON == actualConfigJSON {
+		return nil
+	}
+
+	configDiff := cmp.Diff(desiredConfigJSON, actualConfigJSON)
+
+	logger.Info("external auth update dispatch config differs between RP and CS",
+		"clusterServiceID", externalAuthCSID.String(),
+		"desiredConfig", desiredConfigJSON,
+		"actualConfig", actualConfigJSON,
+		"configDiff", configDiff,
+	)
+
+	// We marshal the external auth CS builder config we are going to submit for cs external auth update for logging purposes
+	externalAuthPayload, err := c.marshalClusterServiceExternalAuthUpdatePayload(ctx, externalAuth)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to marshal Cluster Service external auth update payload: %w", err))
+	}
+
+	logger.Info("dispatching external auth update to Cluster Service",
+		"clusterServiceID", externalAuthCSID.String(),
+		"clusterServiceExternalAuthPayload", externalAuthPayload,
+	)
+
+	csExternalAuthBuilder, err := ocm.BuildCSExternalAuth(ctx, externalAuth, true)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to build CS external auth builder: %w", err))
+	}
+
+	_, err = c.clusterServiceClient.UpdateExternalAuth(ctx, *externalAuthCSID, csExternalAuthBuilder)
+	if err != nil {
+		var ocmError *ocmerrors.Error
+		// XXX Matching an error message is brittle, but Clusters Service
+		//     returns 400 Bad Request for a wide range of errors and there
+		//     is no other information in the response to distinguish them.
+		//
+		//     If the error is indicating that an external auth is not in
+		//     an updatable state because the external auth's parent cluster is not
+		//     in an updatable state, we return without error and retry again on the
+		//     next sync. This can happen for example when the CS cluster is being updated.
+		if errors.As(err, &ocmError) && ocmError.Status() == http.StatusBadRequest &&
+			strings.Contains(ocmError.Reason(), "ExternalAuths can only be updated on clusters in an updatable state") &&
+			strings.Contains(ocmError.Reason(), "cluster requested is in") &&
+			strings.Contains(ocmError.Reason(), "state.") {
+			logger.Info("Cluster Service rejected external auth update because the external auth's parent cluster is not updatable. Retrying on next sync.",
+				"clusterServiceID", externalAuthCSID.String(),
+				"error", err.Error(),
+			)
+			return nil
+		}
+		// XXX Matching an error message is brittle, but Clusters Service
+		//     returns 400 Bad Request for a wide range of errors and there
+		//     is no other information in the response to distinguish them.
+		//
+		//     If the error is indicating that the console clients cannot be configured without any ready node pool,
+		//     we return without error and retry again on the next sync.
+		if errors.As(err, &ocmError) && ocmError.Status() == http.StatusBadRequest &&
+			strings.Contains(ocmError.Reason(), "console clients cannot be configured without a ready node pool") &&
+			strings.Contains(ocmError.Reason(), "Please ensure at least one node pool is in 'ready' state before configuring console authentication") {
+			logger.Info("Cluster Service rejected external auth update because the console clients cannot be configured without a ready node pool. Retrying on next sync.",
+				"clusterServiceID", externalAuthCSID.String(),
+				"error", err.Error(),
+			)
+			return nil
+		}
+		return utils.TrackError(fmt.Errorf("failed to update cluster-service ExternalAuth: %w", err))
+	}
+
+	logger.Info("dispatched external auth update to Cluster Service", "clusterServiceID", externalAuthCSID.String())
+	return nil
+}
+
+// marshalClusterServiceExternalAuthUpdatePayload serializes the external auth PATCH body for logging.
+func (c *externalAuthClusterServiceUpdateDispatchSyncer) marshalClusterServiceExternalAuthUpdatePayload(ctx context.Context, externalAuth *api.HCPOpenShiftClusterExternalAuth) (string, error) {
+	builder, err := ocm.BuildCSExternalAuth(ctx, externalAuth, true)
+	if err != nil {
+		return "", err
+	}
+
+	csExternalAuth, err := builder.Build()
+	if err != nil {
+		return "", err
+	}
+
+	var buf bytes.Buffer
+	if err := arohcpv1alpha1.MarshalExternalAuth(csExternalAuth, &buf); err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}

--- a/backend/pkg/controllers/externalauthupdate/external_auth_cluster_service_update_dispatch_controller_test.go
+++ b/backend/pkg/controllers/externalauthupdate/external_auth_cluster_service_update_dispatch_controller_test.go
@@ -1,0 +1,390 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package externalauthupdate
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+)
+
+const (
+	testSubscriptionID      = "00000000-0000-0000-0000-000000000000"
+	testResourceGroupName   = "test-rg"
+	testClusterName         = "test-cluster"
+	testExternalAuthName    = "test-externalauth"
+	testExternalAuthCSIDStr = "/api/aro_hcp/v1alpha1/clusters/abc123/external_auth_config/external_auths/" + testExternalAuthName
+)
+
+type alwaysSyncCooldownChecker struct{}
+
+func (c *alwaysSyncCooldownChecker) CanSync(_ context.Context, _ any) bool {
+	return true
+}
+
+type neverSyncCooldownChecker struct{}
+
+func (c *neverSyncCooldownChecker) CanSync(_ context.Context, _ any) bool {
+	return false
+}
+
+func TestExternalAuthClusterServiceUpdateDispatchSyncer_SyncOnce(t *testing.T) {
+	externalAuthCSID := api.Must(api.NewInternalID(testExternalAuthCSIDStr))
+
+	testKey := controllerutils.HCPExternalAuthKey{
+		SubscriptionID:      testSubscriptionID,
+		ResourceGroupName:   testResourceGroupName,
+		HCPClusterName:      testClusterName,
+		HCPExternalAuthName: testExternalAuthName,
+	}
+
+	newExternalAuthWithConfigDiff := func() *api.HCPOpenShiftClusterExternalAuth {
+		return newTestExternalAuth(func(ea *api.HCPOpenShiftClusterExternalAuth) {
+			ea.Properties.Issuer.URL = "https://changed.example.com"
+		})
+	}
+
+	newFakeOCMParentClusterNotUpdatableError := func() error {
+		e, _ := ocmerrors.NewError().
+			Status(http.StatusBadRequest).
+			Reason("ExternalAuths can only be updated on clusters in an updatable state. The cluster requested is in 'updating' state.").
+			Build()
+		return e
+	}
+
+	newFakeOCMNoReadyNodePoolError := func() error {
+		e, _ := ocmerrors.NewError().
+			Status(http.StatusBadRequest).
+			Reason("console clients cannot be configured without a ready node pool. Please ensure at least one node pool is in 'ready' state before configuring console authentication").
+			Build()
+		return e
+	}
+
+	newFakeOCMUnrelatedBadRequestError := func() error {
+		e, _ := ocmerrors.NewError().
+			Status(http.StatusBadRequest).
+			Reason("some other validation error").
+			Build()
+		return e
+	}
+
+	testCases := []struct {
+		name                                string
+		existingExternalAuth                *api.HCPOpenShiftClusterExternalAuth
+		setupMockCSClient                   func(mock *ocm.MockClusterServiceClientSpec)
+		minimumReconcileTimeCooldownChecker controllerutil.CooldownChecker
+		wantErr                             bool
+		wantErrContain                      string
+	}{
+		{
+			name: "skip without CS call when no CSID",
+			existingExternalAuth: newTestExternalAuth(func(ea *api.HCPOpenShiftClusterExternalAuth) {
+				ea.ServiceProviderProperties.ClusterServiceID = nil
+				ea.Properties.Issuer.URL = "https://changed.example.com"
+			}),
+			minimumReconcileTimeCooldownChecker: &alwaysSyncCooldownChecker{},
+		},
+		{
+			name:                                "no-op when config matches",
+			existingExternalAuth:                newTestExternalAuth(),
+			minimumReconcileTimeCooldownChecker: &alwaysSyncCooldownChecker{},
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetExternalAuth(gomock.Any(), externalAuthCSID).
+					Return(mustBuildCSExternalAuthFromRP(t, newTestExternalAuth()), nil)
+			},
+		},
+		{
+			name:                                "dispatches CS call when config differs",
+			existingExternalAuth:                newExternalAuthWithConfigDiff(),
+			minimumReconcileTimeCooldownChecker: &alwaysSyncCooldownChecker{},
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetExternalAuth(gomock.Any(), externalAuthCSID).
+					Return(mustBuildCSExternalAuthFromRP(t, newTestExternalAuth()), nil)
+				mock.EXPECT().
+					UpdateExternalAuth(gomock.Any(), externalAuthCSID, gomock.Any()).
+					Return(nil, nil)
+			},
+		},
+		{
+			name:                                "when CS update returns parent cluster not updatable no error is returned",
+			existingExternalAuth:                newExternalAuthWithConfigDiff(),
+			minimumReconcileTimeCooldownChecker: &alwaysSyncCooldownChecker{},
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetExternalAuth(gomock.Any(), externalAuthCSID).
+					Return(mustBuildCSExternalAuthFromRP(t, newTestExternalAuth()), nil)
+				mock.EXPECT().
+					UpdateExternalAuth(gomock.Any(), externalAuthCSID, gomock.Any()).
+					Return(nil, newFakeOCMParentClusterNotUpdatableError())
+			},
+		},
+		{
+			name:                                "when CS update returns no ready node pool no error is returned",
+			existingExternalAuth:                newExternalAuthWithConfigDiff(),
+			minimumReconcileTimeCooldownChecker: &alwaysSyncCooldownChecker{},
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetExternalAuth(gomock.Any(), externalAuthCSID).
+					Return(mustBuildCSExternalAuthFromRP(t, newTestExternalAuth()), nil)
+				mock.EXPECT().
+					UpdateExternalAuth(gomock.Any(), externalAuthCSID, gomock.Any()).
+					Return(nil, newFakeOCMNoReadyNodePoolError())
+			},
+		},
+		{
+			name:                                "when CS update returns unhandled error error is propagated",
+			existingExternalAuth:                newExternalAuthWithConfigDiff(),
+			minimumReconcileTimeCooldownChecker: &alwaysSyncCooldownChecker{},
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetExternalAuth(gomock.Any(), externalAuthCSID).
+					Return(mustBuildCSExternalAuthFromRP(t, newTestExternalAuth()), nil)
+				mock.EXPECT().
+					UpdateExternalAuth(gomock.Any(), externalAuthCSID, gomock.Any()).
+					Return(nil, errors.New("boom"))
+			},
+			wantErr:        true,
+			wantErrContain: "failed to update cluster-service ExternalAuth",
+		},
+		{
+			name:                                "when CS update returns unrelated bad request error error is propagated",
+			existingExternalAuth:                newExternalAuthWithConfigDiff(),
+			minimumReconcileTimeCooldownChecker: &alwaysSyncCooldownChecker{},
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetExternalAuth(gomock.Any(), externalAuthCSID).
+					Return(mustBuildCSExternalAuthFromRP(t, newTestExternalAuth()), nil)
+				mock.EXPECT().
+					UpdateExternalAuth(gomock.Any(), externalAuthCSID, gomock.Any()).
+					Return(nil, newFakeOCMUnrelatedBadRequestError())
+			},
+			wantErr:        true,
+			wantErrContain: "failed to update cluster-service ExternalAuth",
+		},
+		{
+			name:                                "when CS GetExternalAuth fails error is propagated",
+			existingExternalAuth:                newExternalAuthWithConfigDiff(),
+			minimumReconcileTimeCooldownChecker: &alwaysSyncCooldownChecker{},
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetExternalAuth(gomock.Any(), externalAuthCSID).
+					Return(nil, errors.New("boom"))
+			},
+			wantErr:        true,
+			wantErrContain: "failed to get external auth from Cluster Service",
+		},
+		{
+			name:                                "external auth not found no-op is performed",
+			minimumReconcileTimeCooldownChecker: &alwaysSyncCooldownChecker{},
+		},
+		{
+			name:                                "minimum reconcile cooldown prevents sync",
+			existingExternalAuth:                newTestExternalAuth(),
+			minimumReconcileTimeCooldownChecker: &neverSyncCooldownChecker{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			ctrl := gomock.NewController(t)
+
+			resources := []any{}
+			if tc.existingExternalAuth != nil {
+				resources = append(resources, tc.existingExternalAuth)
+			}
+			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, resources)
+			require.NoError(t, err)
+
+			externalAuthsForLister := []*api.HCPOpenShiftClusterExternalAuth{}
+			if tc.existingExternalAuth != nil {
+				externalAuthsForLister = append(externalAuthsForLister, tc.existingExternalAuth)
+			}
+
+			mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
+			if tc.setupMockCSClient != nil {
+				tc.setupMockCSClient(mockCSClient)
+			}
+
+			syncer := &externalAuthClusterServiceUpdateDispatchSyncer{
+				cooldownChecker:                     &alwaysSyncCooldownChecker{},
+				minimumReconcileTimeCooldownChecker: tc.minimumReconcileTimeCooldownChecker,
+				externalAuthLister:                  &listertesting.SliceExternalAuthLister{ExternalAuths: externalAuthsForLister},
+				resourcesDBClient:                   mockResourcesDBClient,
+				clusterServiceClient:                mockCSClient,
+			}
+
+			err = syncer.SyncOnce(ctx, testKey)
+			if tc.wantErr {
+				require.Error(t, err)
+				if tc.wantErrContain != "" {
+					assert.Contains(t, err.Error(), tc.wantErrContain)
+				}
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestNeedsWork(t *testing.T) {
+	csID := api.Must(api.NewInternalID(testExternalAuthCSIDStr))
+	now := metav1.Now()
+
+	tests := []struct {
+		name         string
+		externalAuth *api.HCPOpenShiftClusterExternalAuth
+		want         bool
+	}{
+		{
+			name: "proceed when CSID set",
+			externalAuth: &api.HCPOpenShiftClusterExternalAuth{
+				ServiceProviderProperties: api.HCPOpenShiftClusterExternalAuthServiceProviderProperties{
+					ClusterServiceID: &csID,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "skip when deletion timestamp is set",
+			externalAuth: &api.HCPOpenShiftClusterExternalAuth{
+				ServiceProviderProperties: api.HCPOpenShiftClusterExternalAuthServiceProviderProperties{
+					DeletionTimestamp: &now,
+					ClusterServiceID:  &csID,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "skip when no CSID",
+			externalAuth: &api.HCPOpenShiftClusterExternalAuth{
+				ServiceProviderProperties: api.HCPOpenShiftClusterExternalAuthServiceProviderProperties{},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, needsWork(tt.externalAuth))
+		})
+	}
+}
+
+func mustBuildCSExternalAuthFromRP(t *testing.T, ea *api.HCPOpenShiftClusterExternalAuth) *arohcpv1alpha1.ExternalAuth {
+	t.Helper()
+
+	csBuilder, err := ocm.BuildCSExternalAuth(context.Background(), ea, true)
+	require.NoError(t, err)
+
+	csExternalAuth, err := csBuilder.Build()
+	require.NoError(t, err)
+	return csExternalAuth
+}
+
+func newTestExternalAuth(opts ...func(*api.HCPOpenShiftClusterExternalAuth)) *api.HCPOpenShiftClusterExternalAuth {
+	resourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+			"/externalAuths/" + testExternalAuthName,
+	))
+	externalAuthInternalID := api.Must(api.NewInternalID(testExternalAuthCSIDStr))
+
+	ea := &api.HCPOpenShiftClusterExternalAuth{
+		CosmosMetadata: arm.CosmosMetadata{
+			ResourceID:   resourceID,
+			PartitionKey: strings.ToLower(resourceID.SubscriptionID),
+		},
+		ProxyResource: arm.ProxyResource{
+			Resource: arm.Resource{
+				ID:   resourceID,
+				Name: testExternalAuthName,
+				Type: api.ExternalAuthResourceType.String(),
+			},
+		},
+		Properties: api.HCPOpenShiftClusterExternalAuthProperties{
+			Issuer: api.TokenIssuerProfile{
+				URL:       "https://issuer.example.com",
+				Audiences: []string{"aud1", "aud2"},
+				CA:        "test-ca-cert",
+			},
+			Clients: []api.ExternalAuthClientProfile{
+				{
+					Component: api.ExternalAuthClientComponentProfile{
+						Name:                "console",
+						AuthClientNamespace: "openshift-console",
+					},
+					ClientID:    "client-id-1",
+					ExtraScopes: []string{"email", "profile"},
+					Type:        api.ExternalAuthClientTypePublic,
+				},
+			},
+			Claim: api.ExternalAuthClaimProfile{
+				Mappings: api.TokenClaimMappingsProfile{
+					Username: api.UsernameClaimProfile{
+						Claim:        "email",
+						PrefixPolicy: api.UsernameClaimPrefixPolicyNoPrefix,
+					},
+					Groups: &api.GroupClaimProfile{
+						Claim:  "groups",
+						Prefix: "oidc:",
+					},
+				},
+				ValidationRules: []api.TokenClaimValidationRule{
+					{
+						Type: api.TokenValidationRuleTypeRequiredClaim,
+						RequiredClaim: api.TokenRequiredClaim{
+							Claim:         "hd",
+							RequiredValue: "example.com",
+						},
+					},
+				},
+			},
+		},
+		ServiceProviderProperties: api.HCPOpenShiftClusterExternalAuthServiceProviderProperties{
+			ClusterServiceID: &externalAuthInternalID,
+		},
+	}
+
+	for _, opt := range opts {
+		opt(ea)
+	}
+
+	return ea
+}

--- a/backend/pkg/controllers/nodepoolupdate/node_pool_cluster_service_update_dispatch_controller.go
+++ b/backend/pkg/controllers/nodepoolupdate/node_pool_cluster_service_update_dispatch_controller.go
@@ -1,0 +1,272 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodepoolupdate
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/internal/api"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// nodePoolClusterServiceUpdateDispatchSyncer calls Cluster Service's NodePool PATCH when
+// the NodePool's dispatch-managed configuration has drifted. It reconciles a curated subset of
+// fields defined by ocm.nodePoolUpdateDispatchConfig.
+//
+// On each reconcile, the NodePool's state and the live Cluster Service node pool state
+// are projected into ocm.nodePoolUpdateDispatchConfig. When the projections from both sides
+// differ, it PATCHes Cluster Service.
+//
+// Dispatch is paired with operation state calculation in operationcontrollers
+// (operation_node_pool_update_state_calculation.go): dispatch sends updates, operation state
+// verifies propagation before the ARM node pool update operation succeeds.
+type nodePoolClusterServiceUpdateDispatchSyncer struct {
+	cooldownChecker      controllerutil.CooldownChecker
+	nodePoolLister       listers.NodePoolLister
+	resourcesDBClient    database.ResourcesDBClient
+	clusterServiceClient ocm.ClusterServiceClientSpec
+
+	// minimumReconcileTimeCooldownChecker ensures we don't hotloop from any source,
+	// by ensuring that we don't reconcile more often than the cooldown time in it.
+	minimumReconcileTimeCooldownChecker controllerutil.CooldownChecker
+}
+
+var _ controllerutils.NodePoolSyncer = (*nodePoolClusterServiceUpdateDispatchSyncer)(nil)
+
+func NewNodePoolClusterServiceUpdateDispatchController(
+	resourcesDBClient database.ResourcesDBClient,
+	clusterServiceClient ocm.ClusterServiceClientSpec,
+	activeOperationLister listers.ActiveOperationLister,
+	informers informers.BackendInformers,
+) controllerutils.Controller {
+	_, nodePoolLister := informers.NodePools()
+	syncer := NewNodePoolClusterServiceUpdateDispatchSyncer(
+		resourcesDBClient,
+		clusterServiceClient,
+		activeOperationLister,
+		nodePoolLister,
+	)
+
+	return controllerutils.NewNodePoolWatchingController(
+		"NodePoolClusterServiceUpdateDispatch",
+		resourcesDBClient,
+		informers,
+		nil,
+		time.Minute,
+		syncer,
+	)
+}
+
+func NewNodePoolClusterServiceUpdateDispatchSyncer(
+	resourcesDBClient database.ResourcesDBClient,
+	clusterServiceClient ocm.ClusterServiceClientSpec,
+	activeOperationLister listers.ActiveOperationLister,
+	nodePoolLister listers.NodePoolLister,
+) controllerutils.NodePoolSyncer {
+	return &nodePoolClusterServiceUpdateDispatchSyncer{
+		cooldownChecker: controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		// We set minimumReconcileTimeCooldownChecker so that SyncOnce is not executed
+		// more than once per minute.
+		minimumReconcileTimeCooldownChecker: controllerutil.NewTimeBasedCooldownChecker(1 * time.Minute),
+		nodePoolLister:                      nodePoolLister,
+		resourcesDBClient:                   resourcesDBClient,
+		clusterServiceClient:                clusterServiceClient,
+	}
+}
+
+func needsWork(nodePool *api.HCPOpenShiftClusterNodePool) bool {
+	if nodePool.ServiceProviderProperties.DeletionTimestamp != nil {
+		return false
+	}
+
+	csID := nodePool.ServiceProviderProperties.ClusterServiceID
+	if csID == nil || len(csID.String()) == 0 {
+		return false
+	}
+
+	return true
+}
+
+func (c *nodePoolClusterServiceUpdateDispatchSyncer) CooldownChecker() controllerutil.CooldownChecker {
+	return c.cooldownChecker
+}
+
+func (c *nodePoolClusterServiceUpdateDispatchSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPNodePoolKey) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	// Because this controller ends up calling Cluster Service each time it's reconciled and it's reconciled
+	// while the resource exists and while it is not being deleted, we establish a minimum reconcile time cooldown
+	// to avoid putting too much pressure on Cluster Service.
+	// TODO in the future, we could remove this cooldown checker by persisting a hash of the update dispatch configuration
+	// sent to Cluster Service and checking if it has changed since the last time we sent it.
+	if !c.minimumReconcileTimeCooldownChecker.CanSync(ctx, key) {
+		return nil
+	}
+
+	cachedNodePool, err := c.nodePoolLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get node pool from cache: %w", err))
+	}
+	if !needsWork(cachedNodePool) {
+		return nil
+	}
+
+	nodePoolCRUD := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).NodePools(key.HCPClusterName)
+	nodePool, err := nodePoolCRUD.Get(ctx, key.HCPNodePoolName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get node pool: %w", err))
+	}
+	if !needsWork(nodePool) {
+		return nil
+	}
+
+	nodePoolCSID := nodePool.ServiceProviderProperties.ClusterServiceID
+	csNodePool, err := c.clusterServiceClient.GetNodePool(ctx, *nodePoolCSID)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get node pool from Cluster Service: %w", err))
+	}
+
+	// We check if the desired config coming from cosmos differs from the actual config coming from cluster service.
+	// If it doesn't, we are done and don't need to dispatch an update. If it does, we need to dispatch an update to
+	// cluster service. Comparison uses canonical JSON (sorted object keys at every level) so we can compare them
+	// using direct string equality. For the particular case of the node drain-timeout attribute,
+	// normalization is applied when RP has no override.
+	desiredConfigJSON, actualConfigJSON, err := ocm.NodePoolUpdateDispatchConfigDiffJSON(nodePool, csNodePool)
+	if err != nil {
+		return err
+	}
+	if desiredConfigJSON == actualConfigJSON {
+		return nil
+	}
+
+	configDiff := cmp.Diff(desiredConfigJSON, actualConfigJSON)
+
+	logger.Info("node pool update dispatch config differs between RP and CS",
+		"clusterServiceID", nodePoolCSID.String(),
+		"desiredConfig", desiredConfigJSON,
+		"actualConfig", actualConfigJSON,
+		"configDiff", configDiff,
+	)
+
+	// We marshal the node pool CS builder config we are going to submit for cs node pool update for logging purposes
+	nodePoolPayload, err := c.marshalClusterServiceNodePoolUpdatePayload(ctx, nodePool)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to marshal Cluster Service node pool update payload: %w", err))
+	}
+
+	logger.Info("dispatching node pool update to Cluster Service",
+		"clusterServiceID", nodePoolCSID.String(),
+		"clusterServiceNodePoolPayload", nodePoolPayload,
+	)
+
+	csNodePoolBuilder, err := c.buildNodePoolUpdateBuilder(ctx, nodePool)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to build CS node pool builder: %w", err))
+	}
+
+	_, err = c.clusterServiceClient.UpdateNodePool(ctx, *nodePoolCSID, csNodePoolBuilder)
+	if err != nil {
+		var ocmError *ocmerrors.Error
+		// XXX Matching an error message is brittle, but Clusters Service
+		//     returns 400 Bad Request for a wide range of errors and there
+		//     is no other information in the response to distinguish them.
+		//
+		//     If the error is indicating that a the node pool is not in
+		//     an updatable state because the parent cluster is not in an updatable state,
+		//     we return without error and retry again on the next sync. This can happen for
+		//     example when the CS cluster is being updated.
+		if errors.As(err, &ocmError) && ocmError.Status() == http.StatusBadRequest &&
+			strings.Contains(ocmError.Reason(), "Node pools can only be") &&
+			strings.Contains(ocmError.Reason(), "on clusters in an updatable state") &&
+			strings.Contains(ocmError.Reason(), "cluster requested is in") &&
+			strings.Contains(ocmError.Reason(), "state.") {
+			logger.Info("Cluster Service rejected node pool update because the node pool's parent cluster is not updatable. Retrying on next sync.",
+				"clusterServiceID", nodePoolCSID.String(),
+				"error", err.Error(),
+			)
+			return nil
+		}
+		// XXX Matching an error message is brittle, but Clusters Service
+		//     returns 400 Bad Request for a wide range of errors and there
+		//     is no other information in the response to distinguish them.
+		//
+		//     If the error is indicating that a the node pool is not in
+		//     an updatable state, we return without error and retry again on the
+		//     next sync. This can happen for example when the CS node pool is still in
+		//     the initial creation process.
+		if errors.As(err, &ocmError) && ocmError.Status() == http.StatusBadRequest &&
+			strings.Contains(ocmError.Reason(), "Node pool can only be updated in") &&
+			strings.Contains(ocmError.Reason(), "the node pool requested is in") &&
+			strings.Contains(ocmError.Reason(), "state.") {
+			logger.Info("Cluster Service rejected node pool update because the node pool is not updatable. Retrying on next sync.",
+				"clusterServiceID", nodePoolCSID.String(),
+				"error", err.Error(),
+			)
+			return nil
+		}
+		return utils.TrackError(fmt.Errorf("failed to update cluster-service NodePool: %w", err))
+	}
+
+	logger.Info("dispatched node pool update to Cluster Service", "clusterServiceID", nodePoolCSID.String())
+	return nil
+}
+
+// buildNodePoolUpdateBuilder builds the Cluster Service node pool PATCH payload from RP desired state.
+func (c *nodePoolClusterServiceUpdateDispatchSyncer) buildNodePoolUpdateBuilder(ctx context.Context, nodePool *api.HCPOpenShiftClusterNodePool) (*arohcpv1alpha1.NodePoolBuilder, error) {
+	return ocm.BuildCSNodePool(ctx, nodePool, true)
+}
+
+// marshalClusterServiceNodePoolUpdatePayload serializes the CS node pool PATCH body for logging.
+func (c *nodePoolClusterServiceUpdateDispatchSyncer) marshalClusterServiceNodePoolUpdatePayload(ctx context.Context, nodePool *api.HCPOpenShiftClusterNodePool) (string, error) {
+	builder, err := c.buildNodePoolUpdateBuilder(ctx, nodePool)
+	if err != nil {
+		return "", err
+	}
+
+	csNodePool, err := builder.Build()
+	if err != nil {
+		return "", err
+	}
+
+	var buf bytes.Buffer
+	if err := arohcpv1alpha1.MarshalNodePool(csNodePool, &buf); err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}

--- a/backend/pkg/controllers/nodepoolupdate/node_pool_cluster_service_update_dispatch_controller_test.go
+++ b/backend/pkg/controllers/nodepoolupdate/node_pool_cluster_service_update_dispatch_controller_test.go
@@ -1,0 +1,385 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodepoolupdate
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+)
+
+const (
+	testSubscriptionID      = "00000000-0000-0000-0000-000000000000"
+	testResourceGroupName   = "test-rg"
+	testClusterName         = "test-cluster"
+	testNodePoolName        = "test-nodepool"
+	testClusterServiceIDStr = "/api/aro_hcp/v1alpha1/clusters/abc123"
+	testNodePoolCSIDStr     = testClusterServiceIDStr + "/node_pools/" + testNodePoolName
+)
+
+func TestNodePoolUpdateDispatchSyncer_SyncOnce(t *testing.T) {
+	csID := api.Must(api.NewInternalID(testNodePoolCSIDStr))
+
+	defaultExistingCSNodePool := api.Must(arohcpv1alpha1.NewNodePool().Build())
+
+	newNodePoolWithConfigDiff := func() *api.HCPOpenShiftClusterNodePool {
+		return newTestNodePool(func(np *api.HCPOpenShiftClusterNodePool) {
+			np.Properties.Replicas = 5
+			np.Properties.Labels = map[string]string{"env": "prod"}
+		})
+	}
+
+	newFakeOCMParentClusterNotUpdatableError := func() error {
+		e, _ := ocmerrors.NewError().
+			Status(http.StatusBadRequest).
+			Reason("Node pools can only be updated on clusters in an updatable state. The cluster requested is in 'installing' state.").
+			Build()
+		return e
+	}
+
+	newFakeOCMNodePoolNotUpdatableError := func() error {
+		e, _ := ocmerrors.NewError().
+			Status(http.StatusBadRequest).
+			Reason("Node pool can only be updated in 'ready' state. the node pool requested is in 'installing' state.").
+			Build()
+		return e
+	}
+
+	newFakeOCMUnrelatedBadRequestError := func() error {
+		e, _ := ocmerrors.NewError().
+			Status(http.StatusBadRequest).
+			Reason("some other validation error").
+			Build()
+		return e
+	}
+
+	testCases := []struct {
+		name               string
+		existingNodePool   *api.HCPOpenShiftClusterNodePool
+		existingCSNodePool *arohcpv1alpha1.NodePool
+		// When not set, the syncer uses a node pool lister backed by the seeded Cosmos resources.
+		nodePoolLister                      listers.NodePoolLister
+		setupMockCSClient                   func(mock *ocm.MockClusterServiceClientSpec)
+		minimumReconcileTimeCooldownChecker controllerutil.CooldownChecker
+		wantErr                             bool
+		wantErrContain                      string
+	}{
+		{
+			name: "skip without CS call when no CSID",
+			existingNodePool: newTestNodePool(func(np *api.HCPOpenShiftClusterNodePool) {
+				np.ServiceProviderProperties.ClusterServiceID = nil
+				np.Properties.Replicas = 5
+			}),
+			minimumReconcileTimeCooldownChecker: &alwaysSyncCooldownChecker{},
+		},
+		{
+			name:               "dispatches CS calls when config differs",
+			existingNodePool:   newNodePoolWithConfigDiff(),
+			existingCSNodePool: defaultExistingCSNodePool,
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetNodePool(gomock.Any(), csID).
+					Return(defaultExistingCSNodePool, nil)
+				mock.EXPECT().
+					UpdateNodePool(gomock.Any(), csID, gomock.Any()).
+					Return(nil, nil)
+			},
+			minimumReconcileTimeCooldownChecker: &alwaysSyncCooldownChecker{},
+		},
+		{
+			name: "no-op when config matches",
+			existingNodePool: newTestNodePool(func(np *api.HCPOpenShiftClusterNodePool) {
+				np.Properties.Replicas = 2
+			}),
+			existingCSNodePool: mustBuildCSNodePoolFromRP(t, newTestNodePool(func(np *api.HCPOpenShiftClusterNodePool) {
+				np.Properties.Replicas = 2
+			})),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetNodePool(gomock.Any(), csID).
+					Return(mustBuildCSNodePoolFromRP(t, newTestNodePool(func(np *api.HCPOpenShiftClusterNodePool) {
+						np.Properties.Replicas = 2
+					})), nil)
+			},
+			minimumReconcileTimeCooldownChecker: &alwaysSyncCooldownChecker{},
+		},
+		{
+			name:               "when CS update returns parent cluster not updatable no error is returned",
+			existingNodePool:   newNodePoolWithConfigDiff(),
+			existingCSNodePool: defaultExistingCSNodePool,
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetNodePool(gomock.Any(), csID).
+					Return(defaultExistingCSNodePool, nil)
+				mock.EXPECT().
+					UpdateNodePool(gomock.Any(), csID, gomock.Any()).
+					Return(nil, newFakeOCMParentClusterNotUpdatableError())
+			},
+			minimumReconcileTimeCooldownChecker: &alwaysSyncCooldownChecker{},
+		},
+		{
+			name:               "when CS update returns node pool not updatable no error is returned",
+			existingNodePool:   newNodePoolWithConfigDiff(),
+			existingCSNodePool: defaultExistingCSNodePool,
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetNodePool(gomock.Any(), csID).
+					Return(defaultExistingCSNodePool, nil)
+				mock.EXPECT().
+					UpdateNodePool(gomock.Any(), csID, gomock.Any()).
+					Return(nil, newFakeOCMNodePoolNotUpdatableError())
+			},
+			minimumReconcileTimeCooldownChecker: &alwaysSyncCooldownChecker{},
+		},
+		{
+			name:               "when CS update returns unhandled error error is propagated",
+			existingNodePool:   newNodePoolWithConfigDiff(),
+			existingCSNodePool: defaultExistingCSNodePool,
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetNodePool(gomock.Any(), csID).
+					Return(defaultExistingCSNodePool, nil)
+				mock.EXPECT().
+					UpdateNodePool(gomock.Any(), csID, gomock.Any()).
+					Return(nil, errors.New("boom"))
+			},
+			wantErr:                             true,
+			wantErrContain:                      "failed to update cluster-service NodePool",
+			minimumReconcileTimeCooldownChecker: &alwaysSyncCooldownChecker{},
+		},
+		{
+			name:               "when CS update returns unrelated bad request error error is propagated",
+			existingNodePool:   newNodePoolWithConfigDiff(),
+			existingCSNodePool: defaultExistingCSNodePool,
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetNodePool(gomock.Any(), csID).
+					Return(defaultExistingCSNodePool, nil)
+				mock.EXPECT().
+					UpdateNodePool(gomock.Any(), csID, gomock.Any()).
+					Return(nil, newFakeOCMUnrelatedBadRequestError())
+			},
+			wantErr:                             true,
+			wantErrContain:                      "failed to update cluster-service NodePool",
+			minimumReconcileTimeCooldownChecker: &alwaysSyncCooldownChecker{},
+		},
+		{
+			name:             "when CS GetNodePool fails error is propagated",
+			existingNodePool: newNodePoolWithConfigDiff(),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetNodePool(gomock.Any(), csID).
+					Return(nil, errors.New("boom"))
+			},
+			wantErr:                             true,
+			wantErrContain:                      "failed to get node pool from Cluster Service",
+			minimumReconcileTimeCooldownChecker: &alwaysSyncCooldownChecker{},
+		},
+		{
+			name:                                "minimum reconcile cooldown prevents sync",
+			existingNodePool:                    newTestNodePool(),
+			minimumReconcileTimeCooldownChecker: &neverSyncCooldownChecker{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			seedResources := []any{}
+			if tc.existingNodePool != nil {
+				seedResources = append(seedResources, tc.existingNodePool)
+			}
+
+			mockResourcesDB, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, seedResources)
+			require.NoError(t, err)
+
+			nodePoolLister := tc.nodePoolLister
+			if nodePoolLister == nil {
+				nodePoolLister = &listertesting.DBNodePoolLister{ResourcesDBClient: mockResourcesDB}
+			}
+
+			mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
+			if tc.setupMockCSClient != nil {
+				tc.setupMockCSClient(mockCSClient)
+			}
+
+			syncer := &nodePoolClusterServiceUpdateDispatchSyncer{
+				cooldownChecker:                     &alwaysSyncCooldownChecker{},
+				minimumReconcileTimeCooldownChecker: tc.minimumReconcileTimeCooldownChecker,
+				nodePoolLister:                      nodePoolLister,
+				resourcesDBClient:                   mockResourcesDB,
+				clusterServiceClient:                mockCSClient,
+			}
+
+			key := controllerutils.HCPNodePoolKey{
+				SubscriptionID:    testSubscriptionID,
+				ResourceGroupName: testResourceGroupName,
+				HCPClusterName:    testClusterName,
+				HCPNodePoolName:   testNodePoolName,
+			}
+
+			err = syncer.SyncOnce(ctx, key)
+			if tc.wantErr {
+				require.Error(t, err)
+				if tc.wantErrContain != "" {
+					assert.Contains(t, err.Error(), tc.wantErrContain)
+				}
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestNeedsWork(t *testing.T) {
+	csID := api.Must(api.NewInternalID(testNodePoolCSIDStr))
+	now := metav1.Now()
+
+	tests := []struct {
+		name     string
+		nodePool *api.HCPOpenShiftClusterNodePool
+		want     bool
+	}{
+		{
+			name: "proceed when CSID set",
+			nodePool: &api.HCPOpenShiftClusterNodePool{
+				ServiceProviderProperties: api.HCPOpenShiftClusterNodePoolServiceProviderProperties{
+					ClusterServiceID: &csID,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "skip when deletion timestamp is set",
+			nodePool: &api.HCPOpenShiftClusterNodePool{
+				ServiceProviderProperties: api.HCPOpenShiftClusterNodePoolServiceProviderProperties{
+					DeletionTimestamp: &now,
+					ClusterServiceID:  &csID,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "skip when no CSID",
+			nodePool: &api.HCPOpenShiftClusterNodePool{
+				ServiceProviderProperties: api.HCPOpenShiftClusterNodePoolServiceProviderProperties{},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, needsWork(tt.nodePool))
+		})
+	}
+}
+
+func mustBuildCSNodePoolFromRP(t *testing.T, hcpNodePool *api.HCPOpenShiftClusterNodePool) *arohcpv1alpha1.NodePool {
+	t.Helper()
+
+	builder, err := ocm.BuildCSNodePool(context.Background(), hcpNodePool, true)
+	require.NoError(t, err)
+
+	csNodePool, err := builder.Build()
+	require.NoError(t, err)
+	return csNodePool
+}
+
+func newTestNodePool(opts ...func(*api.HCPOpenShiftClusterNodePool)) *api.HCPOpenShiftClusterNodePool {
+	resourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+			"/nodePools/" + testNodePoolName,
+	))
+
+	csID := api.Must(api.NewInternalID(testNodePoolCSIDStr))
+	nodePool := &api.HCPOpenShiftClusterNodePool{
+		CosmosMetadata: arm.CosmosMetadata{
+			ResourceID:   resourceID,
+			PartitionKey: strings.ToLower(resourceID.SubscriptionID),
+		},
+		TrackedResource: arm.TrackedResource{
+			Resource: arm.Resource{
+				ID:   resourceID,
+				Name: testNodePoolName,
+				Type: resourceID.ResourceType.String(),
+			},
+		},
+		ServiceProviderProperties: api.HCPOpenShiftClusterNodePoolServiceProviderProperties{
+			ClusterServiceID: &csID,
+		},
+		Properties: api.HCPOpenShiftClusterNodePoolProperties{
+			Replicas: 2,
+			Version: api.NodePoolVersionProfile{
+				ID:           "4.20.8",
+				ChannelGroup: "stable",
+			},
+			Platform: api.NodePoolPlatformProfile{
+				VMSize: "Standard_D4s_v3",
+				OSDisk: api.OSDiskProfile{
+					SizeGiB:                ptr.To(int32(128)),
+					DiskType:               api.OsDiskTypeManaged,
+					DiskStorageAccountType: api.DiskStorageAccountTypePremium_LRS,
+				},
+			},
+		},
+	}
+
+	for _, opt := range opts {
+		opt(nodePool)
+	}
+
+	return nodePool
+}
+
+type alwaysSyncCooldownChecker struct{}
+
+func (c *alwaysSyncCooldownChecker) CanSync(_ context.Context, _ any) bool {
+	return true
+}
+
+type neverSyncCooldownChecker struct{}
+
+func (c *neverSyncCooldownChecker) CanSync(_ context.Context, _ any) bool {
+	return false
+}

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_create.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_create.go
@@ -162,7 +162,7 @@ func (c *operationClusterCreate) SynchronizeOperation(ctx context.Context, key c
 	if err != nil {
 		return utils.TrackError(err)
 	}
-	logger.Info("new status via cosmos", "newStatus", cosmosNewOperationState.provisioningState, "newOperationMessage", cosmosNewOperationState.message)
+	logger.Info("new status via cosmos", "newStatus", cosmosNewOperationState.ProvisioningState, "newOperationMessage", cosmosNewOperationState.Message)
 
 	newOperationStatus, opError, err := convertClusterStatus(ctx, c.clusterServiceClient, operation, clusterStatus, clusterServiceID)
 	if err != nil {
@@ -170,11 +170,11 @@ func (c *operationClusterCreate) SynchronizeOperation(ctx context.Context, key c
 	}
 	logger.Info("new status via cluster-service", "newStatus", newOperationStatus, "newOperationError", opError)
 
-	if newOperationStatus == arm.ProvisioningStateSucceeded && cosmosNewOperationState.provisioningState != arm.ProvisioningStateSucceeded {
+	if newOperationStatus == arm.ProvisioningStateSucceeded && cosmosNewOperationState.ProvisioningState != arm.ProvisioningStateSucceeded {
 		// we want to require that the cosmos view of cluster creation is also complete before we mark it.  This ensures (among other things)
 		// that our ability to read maestro is successful.
 		// Once we have confidence in our ability to determine that cluster is functional, we'll stop checking cluster-service at all.
-		return fmt.Errorf("cosmos operation status is %q, but cluster-service operation status is %q: %s", cosmosNewOperationState.provisioningState, newOperationStatus, cosmosNewOperationState.message)
+		return fmt.Errorf("cosmos operation status is %q, but cluster-service operation status is %q: %s", cosmosNewOperationState.ProvisioningState, newOperationStatus, cosmosNewOperationState.Message)
 	}
 
 	logger.Info("updating status")
@@ -198,12 +198,12 @@ func (c *operationClusterCreate) determineOperationStatus(ctx context.Context, o
 	if currState, err := c.hostedClusterOperationStatus(ctx, operation); err != nil {
 		errs = append(errs, utils.TrackError(err))
 	} else {
-		operationStates = append(operationStates, currState)
+		operationStates = append(operationStates, currState.withSource("hypershiftHostedCluster"))
 	}
 	if currState, err := c.clusterOperationStatus(ctx, operation); err != nil {
 		errs = append(errs, utils.TrackError(err))
 	} else {
-		operationStates = append(operationStates, currState)
+		operationStates = append(operationStates, currState.withSource("cosmosCluster"))
 	}
 
 	if err := errors.Join(errs...); err != nil {
@@ -224,7 +224,7 @@ func (c *operationClusterCreate) determineOperationStatus(ctx context.Context, o
 	if err != nil {
 		return nil, utils.TrackError(err)
 	}
-	logger.Info("picked cluster create operation status", "provisioningState", picked.provisioningState, "message", picked.message)
+	logger.Info("picked cluster create operation status", "picked", picked)
 	return picked, nil
 }
 

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_create_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_create_test.go
@@ -312,13 +312,13 @@ func TestDetermineOperationStatus(t *testing.T) {
 	operation := fixture.newOperation(database.OperationRequestCreate)
 
 	tests := []struct {
-		name             string
-		clusterLister    listers.ClusterLister
-		readDesireLister dblisters.ReadDesireLister
-		expectedState    arm.ProvisioningState
-		expectedMessage  string
-		expectError      bool
-		errContains      string
+		name              string
+		clusterLister     listers.ClusterLister
+		readDesireLister  dblisters.ReadDesireLister
+		expectedState     arm.ProvisioningState
+		wantMessageSubstr string
+		expectError       bool
+		errContains       string
 	}{
 		{
 			name: "both checks succeed → Succeeded",
@@ -345,8 +345,8 @@ func TestDetermineOperationStatus(t *testing.T) {
 					}),
 				},
 			},
-			expectedState:   arm.ProvisioningStateSucceeded,
-			expectedMessage: "",
+			expectedState:     arm.ProvisioningStateSucceeded,
+			wantMessageSubstr: "",
 		},
 		{
 			name: "cluster API URL empty → Provisioning (lowest priority wins)",
@@ -373,8 +373,8 @@ func TestDetermineOperationStatus(t *testing.T) {
 					}),
 				},
 			},
-			expectedState:   arm.ProvisioningStateProvisioning,
-			expectedMessage: ".api.url is empty",
+			expectedState:     arm.ProvisioningStateProvisioning,
+			wantMessageSubstr: ".api.url is empty",
 		},
 		{
 			name: "hosted cluster not found → Provisioning",
@@ -437,8 +437,8 @@ func TestDetermineOperationStatus(t *testing.T) {
 						metav1.Condition{Type: kubeapplier.ConditionTypeSuccessful, Status: metav1.ConditionFalse, Reason: kubeapplier.ConditionReasonKubeAPIError, Message: "boom"}),
 				},
 			},
-			expectedState:   arm.ProvisioningStateProvisioning,
-			expectedMessage: "ReadDesire is not successful: KubeAPIError: boom",
+			expectedState:     arm.ProvisioningStateProvisioning,
+			wantMessageSubstr: "ReadDesire is not successful: KubeAPIError: boom",
 		},
 		{
 			name: "hosted cluster not available → Provisioning",
@@ -461,8 +461,8 @@ func TestDetermineOperationStatus(t *testing.T) {
 					}),
 				},
 			},
-			expectedState:   arm.ProvisioningStateProvisioning,
-			expectedMessage: "hosted cluster is not available: NotReady: cluster is not ready",
+			expectedState:     arm.ProvisioningStateProvisioning,
+			wantMessageSubstr: "hosted cluster is not available: NotReady: cluster is not ready",
 		},
 		{
 			name: "no control plane endpoint host → Provisioning",
@@ -485,8 +485,8 @@ func TestDetermineOperationStatus(t *testing.T) {
 					}),
 				},
 			},
-			expectedState:   arm.ProvisioningStateProvisioning,
-			expectedMessage: "hosted cluster has no control plane endpoint host",
+			expectedState:     arm.ProvisioningStateProvisioning,
+			wantMessageSubstr: "hosted cluster has no control plane endpoint host",
 		},
 		{
 			name: "no control plane endpoint port → Provisioning",
@@ -512,8 +512,8 @@ func TestDetermineOperationStatus(t *testing.T) {
 					}),
 				},
 			},
-			expectedState:   arm.ProvisioningStateProvisioning,
-			expectedMessage: "hosted cluster has no control plane endpoint port",
+			expectedState:     arm.ProvisioningStateProvisioning,
+			wantMessageSubstr: "hosted cluster has no control plane endpoint port",
 		},
 		{
 			name: "version with valid success condition but not installed → Provisioning",
@@ -540,8 +540,8 @@ func TestDetermineOperationStatus(t *testing.T) {
 					}),
 				},
 			},
-			expectedState:   arm.ProvisioningStateProvisioning,
-			expectedMessage: "hosted cluster has no installed version",
+			expectedState:     arm.ProvisioningStateProvisioning,
+			wantMessageSubstr: "hosted cluster has no installed version",
 		},
 	}
 
@@ -566,9 +566,9 @@ func TestDetermineOperationStatus(t *testing.T) {
 
 			require.NoError(t, err)
 			require.NotNil(t, result)
-			assert.Equal(t, tt.expectedState, result.provisioningState)
-			if tt.expectedMessage != "" {
-				assert.Equal(t, tt.expectedMessage, result.message)
+			assert.Equal(t, tt.expectedState, result.ProvisioningState)
+			if tt.wantMessageSubstr != "" {
+				assert.Contains(t, result.Message, tt.wantMessageSubstr)
 			}
 		})
 	}

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_update.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_update.go
@@ -31,10 +31,15 @@ import (
 	utilsclock "k8s.io/utils/clock"
 	"k8s.io/utils/lru"
 
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/database"
+	dblisters "github.com/Azure/ARO-HCP/internal/database/listers"
 	"github.com/Azure/ARO-HCP/internal/ocm"
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
@@ -43,6 +48,10 @@ type operationClusterUpdate struct {
 	clock                           utilsclock.PassiveClock
 	resourcesDBClient               database.ResourcesDBClient
 	clusterServiceClient            ocm.ClusterServiceClientSpec
+	clusterLister                   listers.ClusterLister
+	serviceProviderClusterLister    listers.ServiceProviderClusterLister
+	readDesireLister                dblisters.ReadDesireLister
+	activeOperationsLister          listers.ActiveOperationLister
 	notificationClient              *http.Client
 	desiredVersionMismatchFirstSeen *lru.Cache
 }
@@ -65,13 +74,23 @@ func NewOperationClusterUpdateController(
 	clock utilsclock.PassiveClock,
 	resourcesDBClient database.ResourcesDBClient,
 	clusterServiceClient ocm.ClusterServiceClientSpec,
+	readDesireLister dblisters.ReadDesireLister,
 	notificationClient *http.Client,
 	activeOperationInformer cache.SharedIndexInformer,
+	backendInformers informers.BackendInformers,
 ) controllerutils.Controller {
+	_, clusterLister := backendInformers.Clusters()
+	_, serviceProviderClusterLister := backendInformers.ServiceProviderClusters()
+	_, activeOperationsLister := backendInformers.ActiveOperations()
+
 	syncer := &operationClusterUpdate{
 		clock:                           clock,
 		resourcesDBClient:               resourcesDBClient,
 		clusterServiceClient:            clusterServiceClient,
+		clusterLister:                   clusterLister,
+		serviceProviderClusterLister:    serviceProviderClusterLister,
+		readDesireLister:                readDesireLister,
+		activeOperationsLister:          activeOperationsLister,
 		notificationClient:              notificationClient,
 		desiredVersionMismatchFirstSeen: lru.New(100000),
 	}
@@ -100,11 +119,16 @@ func (c *operationClusterUpdate) ShouldProcess(ctx context.Context, operation *a
 	return true
 }
 
+func (c *operationClusterUpdate) shouldReconcileOperationAndResourceStatus(cluster *api.HCPOpenShiftCluster) bool {
+	return cluster.ServiceProviderProperties.DeletionTimestamp == nil &&
+		cluster.ServiceProviderProperties.ClusterServiceID != nil
+}
+
 func (c *operationClusterUpdate) SynchronizeOperation(ctx context.Context, key controllerutils.OperationKey) error {
 	logger := utils.LoggerFromContext(ctx)
 	logger.Info("checking operation")
 
-	operation, err := c.resourcesDBClient.Operations(key.SubscriptionID).Get(ctx, key.OperationName)
+	operation, err := c.activeOperationsLister.Get(ctx, key.SubscriptionID, key.OperationName)
 	if database.IsNotFoundError(err) {
 		return nil // no work to do
 	}
@@ -114,46 +138,87 @@ func (c *operationClusterUpdate) SynchronizeOperation(ctx context.Context, key c
 	if !c.ShouldProcess(ctx, operation) {
 		return nil // no work to do
 	}
-	if len(operation.InternalID.String()) == 0 {
-		// we cannot proceed: yet.
-		// TODO when we update to make clusterserice creation async, we need to handle this correctly.
+
+	existingCluster, err := c.clusterLister.Get(ctx, operation.ExternalID.SubscriptionID, operation.ExternalID.ResourceGroupName, operation.ExternalID.Name)
+	if database.IsNotFoundError(err) {
+		logger.Info("cluster not found in cache, waiting")
+		return nil // no work to do
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get cluster: %w", err))
+	}
+
+	if operation.ResourceID.Name != existingCluster.ServiceProviderProperties.ActiveOperationID {
+		logger.Info("cluster active operation id mismatch, returning early", "synchronizedActiveOperationID", operation.ResourceID.Name, "clusterActiveOperationID", existingCluster.ServiceProviderProperties.ActiveOperationID)
 		return nil
 	}
 
-	operationalState, err := c.determineOperationState(ctx, operation)
+	if !c.shouldReconcileOperationAndResourceStatus(existingCluster) {
+		return nil // no work to do
+	}
+
+	operationalState, err := c.determineOperationState(ctx, operation, existingCluster)
 	if err != nil {
 		return utils.TrackError(err)
 	}
 
 	var persistErr *arm.CloudErrorBody
-	if operationalState.provisioningState == arm.ProvisioningStateFailed {
+	if operationalState.ProvisioningState == arm.ProvisioningStateFailed {
 		persistErr = &arm.CloudErrorBody{
 			Code:    arm.CloudErrorCodeInvalidRequestContent,
-			Message: operationalState.message,
+			Message: operationalState.Message,
 		}
 	}
 
 	logger.Info("updating status")
-	if err := UpdateOperationStatus(ctx, c.clock, c.resourcesDBClient, operation, operationalState.provisioningState, persistErr, postAsyncNotificationFn(c.notificationClient)); err != nil {
+	err = UpdateOperationStatus(ctx, c.clock, c.resourcesDBClient, operation, operationalState.ProvisioningState, persistErr, postAsyncNotificationFn(c.notificationClient))
+	if database.IsPreconditionFailedError(err) {
+		// if we have a conflict error, then we're guaranteed that our informer will eventually see an update and trigger us again.
+		return nil
+	}
+	if err != nil {
 		return utils.TrackError(err)
 	}
 	return nil
 }
 
-func (c *operationClusterUpdate) determineOperationState(ctx context.Context, operation *api.Operation) (*operationState, error) {
+func (c *operationClusterUpdate) determineOperationState(ctx context.Context, operation *api.Operation, existingCluster *api.HCPOpenShiftCluster) (*operationState, error) {
 	logger := utils.LoggerFromContext(ctx)
+
+	clusterCSID := existingCluster.ServiceProviderProperties.ClusterServiceID
+	existingCSCluster, err := c.clusterServiceClient.GetCluster(ctx, *clusterCSID)
+	if err != nil {
+		return nil, utils.TrackError(fmt.Errorf("failed to get cluster from cluster service: %w", err))
+	}
+
+	existingServiceProviderCluster, err := c.serviceProviderClusterLister.Get(ctx, operation.ExternalID.SubscriptionID, operation.ExternalID.ResourceGroupName, operation.ExternalID.Name)
+	if err != nil {
+		return nil, utils.TrackError(fmt.Errorf("failed to get service provider cluster from cache: %w", err))
+	}
+
 	errs := []error{}
 	operationStates := []*operationState{}
 
-	if operationState, err := c.desiredVersionResolutionOperationState(ctx, operation); err != nil {
+	if operationState, err := c.desiredVersionResolutionOperationState(ctx, operation, existingCluster, existingServiceProviderCluster); err != nil {
 		errs = append(errs, utils.TrackError(err))
 	} else {
-		operationStates = append(operationStates, operationState)
+		operationStates = append(operationStates, operationState.withSource("controlPlaneDesiredVersionResolution"))
 	}
-	if operationState, csErr := c.clusterServiceUpdateOperationState(ctx, operation); csErr != nil {
+	if operationState, csErr := c.clusterServiceClusterStatusOperationState(ctx, operation, existingCSCluster.Status(), *clusterCSID); csErr != nil {
 		errs = append(errs, utils.TrackError(csErr))
 	} else {
-		operationStates = append(operationStates, operationState)
+		operationStates = append(operationStates, operationState.withSource("clusterServiceClusterStatus"))
+	}
+	if operationState, csErr := c.clusterServiceClusterSpecOperationState(existingCluster, existingCSCluster); csErr != nil {
+		errs = append(errs, utils.TrackError(csErr))
+	} else {
+		operationStates = append(operationStates, operationState.withSource("clusterServiceClusterSpec"))
+	}
+
+	if operationState, hsErr := c.hypershiftHostedClusterOperationState(ctx, existingCluster, existingServiceProviderCluster); hsErr != nil {
+		errs = append(errs, utils.TrackError(hsErr))
+	} else {
+		operationStates = append(operationStates, operationState.withSource("hypershiftHostedCluster"))
 	}
 
 	if err := errors.Join(errs...); err != nil {
@@ -171,19 +236,11 @@ func (c *operationClusterUpdate) determineOperationState(ctx context.Context, op
 	if err != nil {
 		return nil, utils.TrackError(err)
 	}
-	logger.Info("picked cluster update operation status", "provisioningState", picked.provisioningState, "message", picked.message)
+	logger.Info("picked cluster update operation status", "picked", picked)
 	return picked, nil
 }
 
-func (c *operationClusterUpdate) desiredVersionResolutionOperationState(ctx context.Context, operation *api.Operation) (*operationState, error) {
-	existingCluster, err := c.resourcesDBClient.HCPClusters(operation.ExternalID.SubscriptionID, operation.ExternalID.ResourceGroupName).Get(ctx, operation.ExternalID.Name)
-	if err != nil {
-		return nil, utils.TrackError(err)
-	}
-	existingServiceProviderCluster, err := c.resourcesDBClient.ServiceProviderClusters(operation.ExternalID.SubscriptionID, operation.ExternalID.ResourceGroupName, operation.ExternalID.Name).Get(ctx, api.ServiceProviderClusterResourceName)
-	if err != nil {
-		return nil, utils.TrackError(err)
-	}
+func (c *operationClusterUpdate) desiredVersionResolutionOperationState(ctx context.Context, operation *api.Operation, existingCluster *api.HCPOpenShiftCluster, existingServiceProviderCluster *api.ServiceProviderCluster) (*operationState, error) {
 	resultingDesiredVersion := existingServiceProviderCluster.Spec.ControlPlaneVersion.DesiredVersion
 	if resultingDesiredVersion == nil {
 		return nil, utils.TrackError(fmt.Errorf("service provider cluster has no desired version"))
@@ -241,13 +298,10 @@ func (c *operationClusterUpdate) desiredVersionResolutionOperationState(ctx cont
 	return newOperationState(arm.ProvisioningStateFailed, intentFailedCondition.Message), nil
 }
 
-func (c *operationClusterUpdate) clusterServiceUpdateOperationState(ctx context.Context, operation *api.Operation) (*operationState, error) {
+func (c *operationClusterUpdate) clusterServiceClusterStatusOperationState(ctx context.Context, operation *api.Operation, existingCSClusterStatus *arohcpv1alpha1.ClusterStatus, clusterServiceID api.InternalID) (*operationState, error) {
 	logger := utils.LoggerFromContext(ctx)
-	clusterStatus, err := c.clusterServiceClient.GetClusterStatus(ctx, operation.InternalID)
-	if err != nil {
-		return nil, utils.TrackError(err)
-	}
-	newOperationStatus, opError, err := convertClusterStatus(ctx, c.clusterServiceClient, operation, clusterStatus, operation.InternalID)
+
+	newOperationStatus, opError, err := convertClusterStatus(ctx, c.clusterServiceClient, operation, existingCSClusterStatus, clusterServiceID)
 	if err != nil {
 		return nil, utils.TrackError(err)
 	}
@@ -256,5 +310,6 @@ func (c *operationClusterUpdate) clusterServiceUpdateOperationState(ctx context.
 	if opError != nil {
 		msg = opError.Message
 	}
+
 	return newOperationState(newOperationStatus, msg), nil
 }

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_update_state_calculation.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_update_state_calculation.go
@@ -1,0 +1,436 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operationcontrollers
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"time"
+
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+	"github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/maestrohelpers"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// Cluster update operation state calculation for the cluster update operation controller.
+
+// hypershiftHostedClusterOperationState contains the cluster update operation state calculation comparing desired state
+// against Hypershift's HostedCluster in the management cluster.
+func (c *operationClusterUpdate) hypershiftHostedClusterOperationState(ctx context.Context, cluster *api.HCPOpenShiftCluster, spc *api.ServiceProviderCluster) (*operationState, error) {
+	hostedCluster, err := maestrohelpers.GetCachedHostedClusterForCluster(
+		ctx,
+		c.readDesireLister,
+		cluster.ID.SubscriptionID,
+		cluster.ID.ResourceGroupName,
+		cluster.ID.Name,
+	)
+	if err != nil {
+		return nil, utils.TrackError(err)
+	}
+	if hostedCluster == nil {
+		return newOperationState(arm.ProvisioningStateUpdating, "Hypershift HostedCluster has not been observed yet"), nil
+	}
+
+	if matches, message := c.hypershiftHostedClusterSpecMatchesDesired(cluster, spc, hostedCluster); !matches {
+		return newOperationState(arm.ProvisioningStateUpdating, message), nil
+	}
+
+	// TODO: add hypershiftHostedClusterStatusMatchesDesired to perform checks against Hypershift's HostedCluster status.
+
+	return newOperationState(arm.ProvisioningStateSucceeded, ""), nil
+}
+
+// hypershiftHostedClusterSpecMatchesDesired reports whether Hypershift HostedCluster .Spec fields
+// and other non status configuration matches desired state. Returns false and a diagnostic message
+// when any leaf check fails. HostedCluster .status is not checked here.
+func (c *operationClusterUpdate) hypershiftHostedClusterSpecMatchesDesired(cluster *api.HCPOpenShiftCluster, spc *api.ServiceProviderCluster, hostedCluster *v1beta1.HostedCluster) (bool, string) {
+	if matches, message := c.hypershiftHostedClusterAllowedCIDRBlocksSpecMatchesDesired(cluster.CustomerProperties.API.AuthorizedCIDRs, &hostedCluster.Spec); !matches {
+		return false, message
+	}
+	if matches, message := c.hypershiftHostedClusterAvailabilityPoliciesSpecMatchesDesired(cluster.ServiceProviderProperties.ExperimentalFeatures.ControlPlaneAvailability, &hostedCluster.Spec); !matches {
+		return false, message
+	}
+	if matches, message := c.hypershiftHostedClusterSizeOverrideAnnotationMatchesDesired(cluster.ServiceProviderProperties.ExperimentalFeatures.ControlPlanePodSizing, spc.Spec.DesiredHostedClusterControlPlaneSize, hostedCluster.Annotations); !matches {
+		return false, message
+	}
+	if matches, message := c.hypershiftHostedClusterControlPlaneOperatorImageAnnotationMatchesDesired(cluster.ServiceProviderProperties.ExperimentalFeatures.ControlPlaneOperatorImage, hostedCluster.Annotations); !matches {
+		return false, message
+	}
+	if matches, message := c.hypershiftHostedClusterAutoscalingSpecMatchesDesired(cluster.CustomerProperties.Autoscaling, &hostedCluster.Spec.Autoscaling); !matches {
+		return false, message
+	}
+	if matches, message := c.hypershiftHostedClusterImageContentSourcesSpecMatchesDesired(cluster.CustomerProperties.ImageDigestMirrors, hostedCluster.Spec.ImageContentSources); !matches {
+		return false, message
+	}
+	return true, ""
+}
+
+// hypershiftHostedClusterAllowedCIDRBlocksSpecMatchesDesired reports whether HostedCluster's apiserver allowedCIDRBlocks spec
+// reflects desired state's authorizedCIDRs. Nil desired means allow-all (no blocks). When restrictions are
+// enabled, every customer CIDR must appear in the observed list.
+// Note: For now this check is incomplete: it can confirm additions but cannot
+// detect removal of a previously configured customer CIDR. See TODO below on details, why and what
+// needs to be done to fix this. For now we partially compensate by checking state from CS too in its corresponding
+// state calculation.
+func (c *operationClusterUpdate) hypershiftHostedClusterAllowedCIDRBlocksSpecMatchesDesired(desired []string, observedSpec *v1beta1.HostedClusterSpec) (bool, string) {
+	var observedCIDRs []string
+	if observedSpec.Networking.APIServer != nil && len(observedSpec.Networking.APIServer.AllowedCIDRBlocks) > 0 {
+		observedCIDRs = make([]string, len(observedSpec.Networking.APIServer.AllowedCIDRBlocks))
+		for i, block := range observedSpec.Networking.APIServer.AllowedCIDRBlocks {
+			observedCIDRs[i] = string(block)
+		}
+	}
+
+	if desired == nil {
+		if len(observedCIDRs) > 0 {
+			return false, fmt.Sprintf("hypershift HostedCluster apiServer allowedCIDRBlocks is %v, want unset (allow all)", observedCIDRs)
+		}
+		return true, ""
+	}
+
+	if len(observedCIDRs) == 0 {
+		return false, fmt.Sprintf("hypershift HostedCluster apiServer allowedCIDRBlocks is unset, want %v", desired)
+	}
+
+	// When restrictions are enabled, Cluster Service adds internal CIDR blocks that
+	// are not surfaced in customer authorizedCidrs. Require every customer CIDR
+	// to be present in observed allowedCIDRBlocks, but ignore extra entries.
+	//
+	// TODO This subset check is incomplete for now: it can confirm additions but cannot
+	// detect removal of a previously configured customer CIDR, because extras
+	// cannot be distinguished from internal blocks. Clearing all restrictions
+	// (nil desired) is handled above by requiring allowedCIDRBlocks to be unset.
+	// TODO Revisit when we have the information of the nodes egress lb IPs in the RP
+	// (or can read the internally set allow-list from Cluster Service) so stale customer entries can be rejected.
+	observedSet := make(map[string]struct{}, len(observedCIDRs))
+	for _, cidr := range observedCIDRs {
+		observedSet[cidr] = struct{}{}
+	}
+	for _, want := range desired {
+		if _, ok := observedSet[want]; !ok {
+			return false, fmt.Sprintf("hypershift HostedCluster apiServer allowedCIDRBlocks is missing %q, want %v", want, desired)
+		}
+	}
+	return true, ""
+}
+
+// hypershiftHostedClusterAvailabilityPoliciesSpecMatchesDesired reports whether HostedCluster's
+// controller and infrastructure availability policies match the desired state's control plane availability setting.
+func (c *operationClusterUpdate) hypershiftHostedClusterAvailabilityPoliciesSpecMatchesDesired(desired api.ControlPlaneAvailability, observedSpec *v1beta1.HostedClusterSpec) (bool, string) {
+	expectedAvailability := v1beta1.HighlyAvailable
+	if desired == api.SingleReplicaControlPlane {
+		expectedAvailability = v1beta1.SingleReplica
+	}
+
+	if observedSpec.ControllerAvailabilityPolicy != expectedAvailability {
+		return false, fmt.Sprintf(
+			"hypershift HostedCluster controllerAvailabilityPolicy is %q, want %q",
+			string(observedSpec.ControllerAvailabilityPolicy),
+			expectedAvailability,
+		)
+	}
+
+	if observedSpec.InfrastructureAvailabilityPolicy != expectedAvailability {
+		return false, fmt.Sprintf(
+			"hypershift HostedCluster infrastructureAvailabilityPolicy is %q, want %q",
+			string(observedSpec.InfrastructureAvailabilityPolicy),
+			expectedAvailability,
+		)
+	}
+
+	return true, ""
+}
+
+// hypershiftHostedClusterSizeOverrideAnnotationMatchesDesired reports whether HostedCluster's
+// cluster size override annotation matches desired state of control plane sizing from cluster experimental
+// features and/or spc.Spec.DesiredHostedClusterControlPlaneSize.
+func (c *operationClusterUpdate) hypershiftHostedClusterSizeOverrideAnnotationMatchesDesired(desiredClusterControlPlanePodSizing api.ControlPlanePodSizing, desiredSPCControlPlanePodSizing *string, observedAnnotations map[string]string) (bool, string) {
+	annotationKey := v1beta1.ClusterSizeOverrideAnnotation
+	observedValue, ok := observedAnnotations[annotationKey]
+
+	if desiredSPCControlPlanePodSizing == nil &&
+		desiredClusterControlPlanePodSizing != "" &&
+		desiredClusterControlPlanePodSizing != api.MinimalControlPlanePodSizing {
+		return false, fmt.Sprintf("unrecognized cluster-level control plane pod sizing: %q", desiredClusterControlPlanePodSizing)
+	}
+
+	expected, wantSet := ocm.ConvertHostedClusterSizeOverrideToCS(desiredClusterControlPlanePodSizing, desiredSPCControlPlanePodSizing)
+	if wantSet {
+		if !ok {
+			return false, fmt.Sprintf(
+				"hypershift HostedCluster annotation %q is unset, want %q",
+				annotationKey,
+				expected,
+			)
+		}
+		if observedValue != expected {
+			return false, fmt.Sprintf(
+				"hypershift HostedCluster annotation %q is %q, want %q",
+				annotationKey,
+				observedValue,
+				expected,
+			)
+		}
+		return true, ""
+	}
+
+	if ok {
+		return false, fmt.Sprintf(
+			"hypershift HostedCluster annotation %q is %q, want unset",
+			annotationKey,
+			observedValue,
+		)
+	}
+	return true, ""
+}
+
+// hypershiftHostedClusterControlPlaneOperatorImageAnnotationMatchesDesired reports whether the
+// HostedCluster's control plane operator image annotation matches the desired state's experimental feature override.
+// An empty desired value requires the annotation to be absent.
+func (c *operationClusterUpdate) hypershiftHostedClusterControlPlaneOperatorImageAnnotationMatchesDesired(desired string, observedAnnotations map[string]string) (bool, string) {
+	observedValue, ok := observedAnnotations[v1beta1.ControlPlaneOperatorImageAnnotation]
+
+	if desired != "" {
+		if !ok {
+			return false, fmt.Sprintf(
+				"hypershift HostedCluster annotation %q is unset, want %q",
+				v1beta1.ControlPlaneOperatorImageAnnotation,
+				desired,
+			)
+		}
+		if observedValue != desired {
+			return false, fmt.Sprintf(
+				"hypershift HostedCluster annotation %q is %q, want %q",
+				v1beta1.ControlPlaneOperatorImageAnnotation,
+				observedValue,
+				desired,
+			)
+		}
+		return true, ""
+	}
+
+	if ok {
+		return false, fmt.Sprintf(
+			"hypershift HostedCluster annotation %q is %q, want unset",
+			v1beta1.ControlPlaneOperatorImageAnnotation,
+			observedValue,
+		)
+	}
+	return true, ""
+}
+
+// hypershiftHostedClusterAutoscalingSpecMatchesDesired reports whether HostedCluster's autoscaling spec
+// matches the desired state's cluster autoscaling profile.
+func (c *operationClusterUpdate) hypershiftHostedClusterAutoscalingSpecMatchesDesired(desired api.ClusterAutoscalingProfile, observed *v1beta1.ClusterAutoscaling) (bool, string) {
+	observedMaxNodesStr := "unset"
+	if observed.MaxNodesTotal != nil {
+		observedMaxNodesStr = fmt.Sprintf("%d", *observed.MaxNodesTotal)
+	}
+	if observed.MaxNodesTotal == nil || *observed.MaxNodesTotal != desired.MaxNodesTotal {
+		return false, fmt.Sprintf("hypershift HostedCluster autoscaling maxNodesTotal is %s, want %d", observedMaxNodesStr, desired.MaxNodesTotal)
+	}
+
+	observedMaxPodGraceStr := "unset"
+	if observed.MaxPodGracePeriod != nil {
+		observedMaxPodGraceStr = fmt.Sprintf("%d", *observed.MaxPodGracePeriod)
+	}
+	if observed.MaxPodGracePeriod == nil || *observed.MaxPodGracePeriod != desired.MaxPodGracePeriodSeconds {
+		return false, fmt.Sprintf("hypershift HostedCluster autoscaling maxPodGracePeriod is %s, want %d", observedMaxPodGraceStr, desired.MaxPodGracePeriodSeconds)
+	}
+
+	wantDuration := time.Duration(desired.MaxNodeProvisionTimeSeconds) * time.Second
+	wantDisplay := fmt.Sprint(wantDuration.Minutes(), "m")
+	if observed.MaxNodeProvisionTime == "" {
+		return false, fmt.Sprintf("hypershift HostedCluster autoscaling maxNodeProvisionTime is unset, want %q", wantDisplay)
+	}
+	observedDuration, err := time.ParseDuration(observed.MaxNodeProvisionTime)
+	if err != nil {
+		return false, fmt.Sprintf("hypershift HostedCluster autoscaling maxNodeProvisionTime has an invalid duration: %q, want %q", observed.MaxNodeProvisionTime, wantDisplay)
+	}
+	if observedDuration != wantDuration {
+		return false, fmt.Sprintf("hypershift HostedCluster autoscaling maxNodeProvisionTime is %q, want %q", observed.MaxNodeProvisionTime, wantDisplay)
+	}
+
+	observedPodPriorityThresholdStr := "unset"
+	if observed.PodPriorityThreshold != nil {
+		observedPodPriorityThresholdStr = fmt.Sprintf("%d", *observed.PodPriorityThreshold)
+	}
+	if observed.PodPriorityThreshold == nil || *observed.PodPriorityThreshold != desired.PodPriorityThreshold {
+		return false, fmt.Sprintf("hypershift HostedCluster autoscaling podPriorityThreshold is %s, want %d", observedPodPriorityThresholdStr, desired.PodPriorityThreshold)
+	}
+
+	return true, ""
+}
+
+// platformImageContentSources lists HostedCluster imageContentSources managed internally by the
+// service. These are ignored when comparing customer imageDigestMirrors propagation.
+var platformImageContentSources = map[string]struct{}{
+	"quay.io/openshift-release-dev/ocp-v4.0-art-dev":    {},
+	"quay.io/openshift-release-dev/ocp-v5.0-art-dev":    {},
+	"quay.io/openshift-release-dev/ocp-release":         {},
+	"quay.io/openshift-release-dev/ocp-release-nightly": {},
+}
+
+// isPlatformImageContentSource reports whether source is a service-managed platform image source.
+func isPlatformImageContentSource(source string) bool {
+	_, ok := platformImageContentSources[source]
+	return ok
+}
+
+// hypershiftHostedClusterImageContentSourcesSpecMatchesDesired reports whether HostedCluster
+// imageContentSources spec matches desired state's imageDigestMirrors. Platform-managed sources may be
+// present on the HostedCluster without matching a customer desired entry.
+func (c *operationClusterUpdate) hypershiftHostedClusterImageContentSourcesSpecMatchesDesired(desired []api.ImageDigestMirror, observed []v1beta1.ImageContentSource) (bool, string) {
+	desiredBySource := make(map[string]api.ImageDigestMirror, len(desired))
+	for _, want := range desired {
+		desiredBySource[want.Source] = want
+	}
+
+	observedBySource := make(map[string]v1beta1.ImageContentSource, len(observed))
+	for _, ics := range observed {
+		observedBySource[ics.Source] = ics
+	}
+
+	// We check that the desired imageContentSources are present in the observed imageContentSources.
+	for source, want := range desiredBySource {
+		got, ok := observedBySource[source]
+		if !ok {
+			return false, fmt.Sprintf("hypershift HostedCluster imageContentSources is missing source %q", source)
+		}
+		if !slices.Equal(want.Mirrors, got.Mirrors) {
+			return false, fmt.Sprintf("hypershift HostedCluster imageContentSources for source %q mirrors do not match", source)
+		}
+	}
+
+	// We check that there are no unexpected observed imageContentSources (excluding platform-managed sources)
+	for source := range observedBySource {
+		if _, ok := desiredBySource[source]; ok {
+			continue
+		}
+		if isPlatformImageContentSource(source) {
+			continue
+		}
+		return false, fmt.Sprintf("hypershift HostedCluster has unexpected imageContentSource %q", source)
+	}
+
+	return true, ""
+}
+
+// clusterServiceClusterSpecOperationState reports whether Cluster Service cluster spec fields
+// match desired state intent for the cluster update operation. Only checks outside CS .status.
+// Checks that can only be performed against Cluster Service instead of the management cluster
+// directly can be added here
+// Add checks against the management cluster state when possible instead of here, to reduce the number of checks against Cluster Service, as
+// CS will be removed in the future.
+func (c *operationClusterUpdate) clusterServiceClusterSpecOperationState(cluster *api.HCPOpenShiftCluster, csCluster *arohcpv1alpha1.Cluster) (*operationState, error) {
+	if matches, message := c.clusterServiceClusterSpecMatchesDesired(cluster, csCluster); !matches {
+		return newOperationState(arm.ProvisioningStateUpdating, message), nil
+	}
+	return newOperationState(arm.ProvisioningStateSucceeded, ""), nil
+}
+
+// clusterServiceClusterSpecMatchesDesired reports whether Cluster Service cluster spec fields
+// relevant to the cluster update operation match desired state. Returns false and a diagnostic
+// message when any leaf check fails.
+func (c *operationClusterUpdate) clusterServiceClusterSpecMatchesDesired(cluster *api.HCPOpenShiftCluster, csCluster *arohcpv1alpha1.Cluster) (bool, string) {
+	// TODO for now we calculate authorized CIDR against CS because we cannot calculate the difference on
+	// the Hypershift HostedCluster because there are internal IPs associated to the Node Pools egress LB that we
+	// do not track on the RP side yet. Once that is tracked we should remove this and update the logic that calculates
+	// state from the Hypershift HostedCluster instead.
+	if matches, message := c.clusterServiceClusterAuthorizedCIDRsSpecMatchesDesired(cluster.CustomerProperties.API.AuthorizedCIDRs, csCluster); !matches {
+		return false, message
+	}
+	if matches, message := c.clusterServiceClusterNodeDrainTimeoutSpecMatchesDesired(cluster.CustomerProperties.NodeDrainTimeoutMinutes, csCluster); !matches {
+		return false, message
+	}
+	return true, ""
+}
+
+// clusterServiceClusterAuthorizedCIDRsSpecMatchesDesired reports whether Cluster Service
+// k8sAPIServerAuthorizedCIDRs matches desired state's authorizedCIDRs. Nil desired requires allow-all mode
+// with no CIDR entries. Non-nil desired requires allow-list mode with an exact CIDR match.
+func (c *operationClusterUpdate) clusterServiceClusterAuthorizedCIDRsSpecMatchesDesired(desired []string, csCluster *arohcpv1alpha1.Cluster) (bool, string) {
+	csClusterAPI := csCluster.API()
+
+	formatClusterServiceCIDRBlockAllowAccess := func(mode string, values []string) string {
+		switch mode {
+		case ocm.CSCIDRBlockAllowAccessModeAllowAll:
+			return ocm.CSCIDRBlockAllowAccessModeAllowAll
+		case ocm.CSCIDRBlockAllowAccessModeAllowList:
+			return fmt.Sprintf("%s %v", ocm.CSCIDRBlockAllowAccessModeAllowList, values)
+		case "":
+			return "unset"
+		default:
+			return fmt.Sprintf("%q with %v", mode, values)
+		}
+	}
+
+	csObservedAuthorizedCIDRs := ocm.ClusterUpdateDispatchConfigAuthorizedCIDRsFromCS(csClusterAPI)
+
+	csObservedAllowMode := ""
+	if allow := csClusterAPI.CIDRBlockAccess().Allow(); allow != nil {
+		csObservedAllowMode, _ = allow.GetMode()
+	}
+	csObservedMessage := formatClusterServiceCIDRBlockAllowAccess(csObservedAllowMode, csObservedAuthorizedCIDRs)
+
+	if desired == nil {
+		if csObservedAllowMode != ocm.CSCIDRBlockAllowAccessModeAllowAll {
+			return false, fmt.Sprintf(
+				"Cluster Service k8sAPIServerAuthorizedCIDRs is %s, want %s",
+				csObservedMessage, ocm.CSCIDRBlockAllowAccessModeAllowAll,
+			)
+		}
+		if len(csObservedAuthorizedCIDRs) > 0 {
+			return false, fmt.Sprintf(
+				"Cluster Service k8sAPIServerAuthorizedCIDRs is %s, want %s",
+				csObservedMessage, ocm.CSCIDRBlockAllowAccessModeAllowAll,
+			)
+		}
+		return true, ""
+	}
+
+	if csObservedAllowMode != ocm.CSCIDRBlockAllowAccessModeAllowList {
+		return false, fmt.Sprintf(
+			"Cluster Service k8sAPIServerAuthorizedCIDRs is %s, want %s",
+			csObservedMessage, ocm.CSCIDRBlockAllowAccessModeAllowList,
+		)
+	}
+
+	if !slices.Equal(desired, csObservedAuthorizedCIDRs) {
+		return false, fmt.Sprintf(
+			"Cluster Service k8sAPIServerAuthorizedCIDRs allow_list is %v, want %v",
+			csObservedAuthorizedCIDRs,
+			desired,
+		)
+	}
+
+	return true, ""
+}
+
+// clusterServiceClusterNodeDrainTimeoutSpecMatchesDesired reports whether Cluster Service
+// nodeDrainGracePeriod matches desired state's nodeDrainTimeoutMinutes.
+func (c *operationClusterUpdate) clusterServiceClusterNodeDrainTimeoutSpecMatchesDesired(desired int32, csCluster *arohcpv1alpha1.Cluster) (bool, string) {
+	got := ocm.ClusterUpdateDispatchConfigNodeDrainTimeoutFromCS(csCluster)
+	if got != desired {
+		return false, fmt.Sprintf("Cluster Service nodeDrainGracePeriod is %d minutes, want %d", got, desired)
+	}
+	return true, ""
+}

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_update_state_calculation_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_update_state_calculation_test.go
@@ -1,0 +1,1439 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operationcontrollers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+	"github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/api/kubeapplier"
+	internallistertesting "github.com/Azure/ARO-HCP/internal/database/listertesting"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+func TestHypershiftHostedClusterOperationState(t *testing.T) {
+	t.Parallel()
+
+	// From platformImageContentSources in operation_cluster_update_state_calculation.go.
+	testClusterUpdatePlatformImageContentSource := "quay.io/openshift-release-dev/ocp-release"
+
+	fixture := newClusterTestFixture()
+	emptySPC := &api.ServiceProviderCluster{}
+
+	tests := []struct {
+		name                   string
+		cluster                *api.HCPOpenShiftCluster
+		serviceProviderCluster *api.ServiceProviderCluster
+		readDesires            []*kubeapplier.ReadDesire
+		wantState              arm.ProvisioningState
+		wantMessageSubstr      string
+	}{
+		{
+			name:                   "no ReadDesire returns Updating",
+			cluster:                fixture.newCluster(nil),
+			serviceProviderCluster: emptySPC,
+			readDesires:            nil,
+			wantState:              arm.ProvisioningStateUpdating,
+			wantMessageSubstr:      "Hypershift HostedCluster has not been observed yet",
+		},
+		{
+			name:                   "empty cluster matches empty HostedCluster",
+			cluster:                fixture.newCluster(nil),
+			serviceProviderCluster: emptySPC,
+			readDesires: []*kubeapplier.ReadDesire{
+				newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+					Spec: testClusterUpdateMatchingHostedClusterSpec(),
+				}),
+			},
+			wantState: arm.ProvisioningStateSucceeded,
+		},
+		{
+			name: "autoscaling maxNodesTotal mismatch returns Updating",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := fixture.newCluster(nil)
+				c.CustomerProperties.Autoscaling.MaxNodesTotal = 10
+				return c
+			}(),
+			serviceProviderCluster: emptySPC,
+			readDesires: []*kubeapplier.ReadDesire{
+				newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+					Spec: func() v1beta1.HostedClusterSpec {
+						spec := testClusterUpdateMatchingHostedClusterSpec()
+						spec.Autoscaling.MaxNodesTotal = ptr.To[int32](5)
+						return spec
+					}(),
+				}),
+			},
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: `maxNodesTotal is 5, want 10`,
+		},
+		{
+			name: "autoscaling matches returns Succeeded",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := fixture.newCluster(nil)
+				c.CustomerProperties.Autoscaling.MaxNodesTotal = 10
+				c.CustomerProperties.Autoscaling.MaxPodGracePeriodSeconds = 60
+				c.CustomerProperties.Autoscaling.PodPriorityThreshold = -5
+				return c
+			}(),
+			serviceProviderCluster: emptySPC,
+			readDesires: []*kubeapplier.ReadDesire{
+				newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+					Spec: func() v1beta1.HostedClusterSpec {
+						spec := testClusterUpdateMatchingHostedClusterSpec()
+						spec.Autoscaling = v1beta1.ClusterAutoscaling{
+							MaxNodesTotal:        ptr.To[int32](10),
+							MaxPodGracePeriod:    ptr.To[int32](60),
+							MaxNodeProvisionTime: "0m",
+							PodPriorityThreshold: ptr.To[int32](-5),
+						}
+						return spec
+					}(),
+				}),
+			},
+			wantState: arm.ProvisioningStateSucceeded,
+		},
+		{
+			name: "maxNodeProvisionTime mismatch returns Updating",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := fixture.newCluster(nil)
+				c.CustomerProperties.Autoscaling.MaxNodeProvisionTimeSeconds = 900
+				return c
+			}(),
+			serviceProviderCluster: emptySPC,
+			readDesires: []*kubeapplier.ReadDesire{
+				newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+					Spec: func() v1beta1.HostedClusterSpec {
+						spec := testClusterUpdateMatchingHostedClusterSpec()
+						spec.Autoscaling.MaxNodeProvisionTime = "10m"
+						return spec
+					}(),
+				}),
+			},
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: `maxNodeProvisionTime is "10m", want "15m"`,
+		},
+		{
+			name: "maxNodeProvisionTime matches when converted",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := fixture.newCluster(nil)
+				c.CustomerProperties.Autoscaling.MaxNodeProvisionTimeSeconds = 900
+				return c
+			}(),
+			serviceProviderCluster: emptySPC,
+			readDesires: []*kubeapplier.ReadDesire{
+				newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+					Spec: func() v1beta1.HostedClusterSpec {
+						spec := testClusterUpdateMatchingHostedClusterSpec()
+						spec.Autoscaling.MaxNodeProvisionTime = "15m"
+						return spec
+					}(),
+				}),
+			},
+			wantState: arm.ProvisioningStateSucceeded,
+		},
+		{
+			name: "imageContentSources missing desired source returns Updating",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := fixture.newCluster(nil)
+				c.CustomerProperties.ImageDigestMirrors = []api.ImageDigestMirror{
+					{Source: "quay.io/foo", Mirrors: []string{"mirror.io/foo"}},
+				}
+				return c
+			}(),
+			serviceProviderCluster: emptySPC,
+			readDesires: []*kubeapplier.ReadDesire{
+				newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+					Spec: testClusterUpdateMatchingHostedClusterSpec(),
+				}),
+			},
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: `missing source "quay.io/foo"`,
+		},
+		{
+			name: "imageContentSources source mismatch returns Updating",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := fixture.newCluster(nil)
+				c.CustomerProperties.ImageDigestMirrors = []api.ImageDigestMirror{
+					{Source: "quay.io/foo", Mirrors: []string{"mirror.io/foo"}},
+				}
+				return c
+			}(),
+			serviceProviderCluster: emptySPC,
+			readDesires: []*kubeapplier.ReadDesire{
+				newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+					Spec: func() v1beta1.HostedClusterSpec {
+						spec := testClusterUpdateMatchingHostedClusterSpec()
+						spec.ImageContentSources = []v1beta1.ImageContentSource{
+							{Source: "quay.io/bar", Mirrors: []string{"mirror.io/foo"}},
+						}
+						return spec
+					}(),
+				}),
+			},
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: `missing source "quay.io/foo"`,
+		},
+		{
+			name: "imageContentSources matches returns Succeeded",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := fixture.newCluster(nil)
+				c.CustomerProperties.ImageDigestMirrors = []api.ImageDigestMirror{
+					{Source: "quay.io/foo", Mirrors: []string{"mirror.io/foo", "mirror2.io/foo"}},
+				}
+				return c
+			}(),
+			serviceProviderCluster: emptySPC,
+			readDesires: []*kubeapplier.ReadDesire{
+				newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+					Spec: func() v1beta1.HostedClusterSpec {
+						spec := testClusterUpdateMatchingHostedClusterSpec()
+						spec.ImageContentSources = []v1beta1.ImageContentSource{
+							{Source: "quay.io/foo", Mirrors: []string{"mirror.io/foo", "mirror2.io/foo"}},
+						}
+						return spec
+					}(),
+				}),
+			},
+			wantState: arm.ProvisioningStateSucceeded,
+		},
+		{
+			name: "imageContentSources unset with stale customer source returns Updating",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := fixture.newCluster(nil)
+				c.CustomerProperties.ImageDigestMirrors = nil
+				return c
+			}(),
+			serviceProviderCluster: emptySPC,
+			readDesires: []*kubeapplier.ReadDesire{
+				newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+					Spec: func() v1beta1.HostedClusterSpec {
+						spec := testClusterUpdateMatchingHostedClusterSpec()
+						spec.ImageContentSources = []v1beta1.ImageContentSource{
+							{Source: testClusterUpdatePlatformImageContentSource, Mirrors: []string{"platform-mirror"}},
+							{Source: "quay.io/foo", Mirrors: []string{"mirror.io/foo"}},
+						}
+						return spec
+					}(),
+				}),
+			},
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: `unexpected imageContentSource "quay.io/foo"`,
+		},
+		{
+			name: "allowedCIDRBlocks mismatch returns Updating",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := fixture.newCluster(nil)
+				c.CustomerProperties.API.AuthorizedCIDRs = []string{"10.0.0.0/8"}
+				return c
+			}(),
+			serviceProviderCluster: emptySPC,
+			readDesires: []*kubeapplier.ReadDesire{
+				newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+					Spec: v1beta1.HostedClusterSpec{
+						Networking: v1beta1.ClusterNetworking{
+							APIServer: &v1beta1.APIServerNetworking{
+								AllowedCIDRBlocks: []v1beta1.CIDRBlock{"192.168.0.0/16"},
+							},
+						},
+					},
+				}),
+			},
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: `is missing "10.0.0.0/8", want [10.0.0.0/8]`,
+		},
+		{
+			name: "temporary - allowedCIDRBlocks match with internal extras returns Succeeded",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := fixture.newCluster(nil)
+				c.CustomerProperties.API.AuthorizedCIDRs = []string{"10.0.0.0/8"}
+				return c
+			}(),
+			serviceProviderCluster: emptySPC,
+			readDesires: []*kubeapplier.ReadDesire{
+				newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+					Spec: func() v1beta1.HostedClusterSpec {
+						spec := testClusterUpdateMatchingHostedClusterSpec()
+						spec.Networking = v1beta1.ClusterNetworking{
+							APIServer: &v1beta1.APIServerNetworking{
+								AllowedCIDRBlocks: []v1beta1.CIDRBlock{
+									"10.0.0.0/8",
+									"172.16.0.0/32",
+								},
+							},
+						}
+						return spec
+					}(),
+				}),
+			},
+			wantState: arm.ProvisioningStateSucceeded,
+		},
+		{
+			name: "allowedCIDRBlocks match returns Succeeded",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := fixture.newCluster(nil)
+				c.CustomerProperties.API.AuthorizedCIDRs = []string{"10.0.0.0/8", "192.168.0.0/16"}
+				return c
+			}(),
+			serviceProviderCluster: emptySPC,
+			readDesires: []*kubeapplier.ReadDesire{
+				newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+					Spec: func() v1beta1.HostedClusterSpec {
+						spec := testClusterUpdateMatchingHostedClusterSpec()
+						spec.Networking = v1beta1.ClusterNetworking{
+							APIServer: &v1beta1.APIServerNetworking{
+								AllowedCIDRBlocks: []v1beta1.CIDRBlock{"192.168.0.0/16", "10.0.0.0/8"},
+							},
+						}
+						return spec
+					}(),
+				}),
+			},
+			wantState: arm.ProvisioningStateSucceeded,
+		},
+		{
+			name: "nil authorizedCIDRs with observed blocks returns Updating",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := fixture.newCluster(nil)
+				c.CustomerProperties.API.AuthorizedCIDRs = nil
+				return c
+			}(),
+			serviceProviderCluster: emptySPC,
+			readDesires: []*kubeapplier.ReadDesire{
+				newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+					Spec: v1beta1.HostedClusterSpec{
+						Networking: v1beta1.ClusterNetworking{
+							APIServer: &v1beta1.APIServerNetworking{
+								AllowedCIDRBlocks: []v1beta1.CIDRBlock{"10.0.0.0/8"},
+							},
+						},
+					},
+				}),
+			},
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: `allowedCIDRBlocks is [10.0.0.0/8], want unset (allow all)`,
+		},
+		{
+			name: "imageContentSources with extra hypershift sources returns Succeeded",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := fixture.newCluster(nil)
+				c.CustomerProperties.ImageDigestMirrors = []api.ImageDigestMirror{
+					{Source: "quay.io/foo", Mirrors: []string{"mirror.io/foo"}},
+				}
+				return c
+			}(),
+			serviceProviderCluster: emptySPC,
+			readDesires: []*kubeapplier.ReadDesire{
+				newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+					Spec: func() v1beta1.HostedClusterSpec {
+						spec := testClusterUpdateMatchingHostedClusterSpec()
+						spec.ImageContentSources = []v1beta1.ImageContentSource{
+							{Source: testClusterUpdatePlatformImageContentSource, Mirrors: []string{"internal-mirror.example.io"}},
+							{Source: "quay.io/foo", Mirrors: []string{"mirror.io/foo"}},
+						}
+						return spec
+					}(),
+				}),
+			},
+			wantState: arm.ProvisioningStateSucceeded,
+		},
+		{
+			name: "single replica availability policies match returns Succeeded",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := fixture.newCluster(nil)
+				c.ServiceProviderProperties.ExperimentalFeatures.ControlPlaneAvailability = api.SingleReplicaControlPlane
+				return c
+			}(),
+			serviceProviderCluster: emptySPC,
+			readDesires: []*kubeapplier.ReadDesire{
+				newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+					Spec: func() v1beta1.HostedClusterSpec {
+						spec := testClusterUpdateMatchingHostedClusterSpec()
+						spec.ControllerAvailabilityPolicy = v1beta1.SingleReplica
+						spec.InfrastructureAvailabilityPolicy = v1beta1.SingleReplica
+						return spec
+					}(),
+				}),
+			},
+			wantState: arm.ProvisioningStateSucceeded,
+		},
+		{
+			name: "single replica controller policy mismatch returns Updating",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := fixture.newCluster(nil)
+				c.ServiceProviderProperties.ExperimentalFeatures.ControlPlaneAvailability = api.SingleReplicaControlPlane
+				return c
+			}(),
+			serviceProviderCluster: emptySPC,
+			readDesires: []*kubeapplier.ReadDesire{
+				newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+					Spec: func() v1beta1.HostedClusterSpec {
+						spec := testClusterUpdateMatchingHostedClusterSpec()
+						spec.ControllerAvailabilityPolicy = v1beta1.HighlyAvailable
+						spec.InfrastructureAvailabilityPolicy = v1beta1.SingleReplica
+						return spec
+					}(),
+				}),
+			},
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: `controllerAvailabilityPolicy is "HighlyAvailable", want "SingleReplica"`,
+		},
+		{
+			name: "single replica infrastructure policy mismatch returns Updating",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := fixture.newCluster(nil)
+				c.ServiceProviderProperties.ExperimentalFeatures.ControlPlaneAvailability = api.SingleReplicaControlPlane
+				return c
+			}(),
+			serviceProviderCluster: emptySPC,
+			readDesires: []*kubeapplier.ReadDesire{
+				newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+					Spec: func() v1beta1.HostedClusterSpec {
+						spec := testClusterUpdateMatchingHostedClusterSpec()
+						spec.ControllerAvailabilityPolicy = v1beta1.SingleReplica
+						spec.InfrastructureAvailabilityPolicy = v1beta1.HighlyAvailable
+						return spec
+					}(),
+				}),
+			},
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: `infrastructureAvailabilityPolicy is "HighlyAvailable", want "SingleReplica"`,
+		},
+		{
+			name: "default availability policies (highly available) match highly available hypershift side returns Succeeded",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := fixture.newCluster(nil)
+				return c
+			}(),
+			serviceProviderCluster: emptySPC,
+			readDesires: []*kubeapplier.ReadDesire{
+				newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+					Spec: testClusterUpdateMatchingHostedClusterSpec(),
+				}),
+			},
+			wantState: arm.ProvisioningStateSucceeded,
+		},
+		{
+			name: "default availability policies (highly available) mismatch hypershift sidereturns Updating",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := fixture.newCluster(nil)
+				return c
+			}(),
+			serviceProviderCluster: emptySPC,
+			readDesires: []*kubeapplier.ReadDesire{
+				newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+					Spec: func() v1beta1.HostedClusterSpec {
+						spec := testClusterUpdateMatchingHostedClusterSpec()
+						spec.ControllerAvailabilityPolicy = v1beta1.SingleReplica
+						spec.InfrastructureAvailabilityPolicy = v1beta1.SingleReplica
+						return spec
+					}(),
+				}),
+			},
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: `controllerAvailabilityPolicy is "SingleReplica", want "HighlyAvailable"`,
+		},
+		{
+			name: "minimal pod sizing annotation match returns Succeeded",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := fixture.newCluster(nil)
+				c.ServiceProviderProperties.ExperimentalFeatures.ControlPlanePodSizing = api.MinimalControlPlanePodSizing
+				return c
+			}(),
+			serviceProviderCluster: emptySPC,
+			readDesires: []*kubeapplier.ReadDesire{
+				newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							v1beta1.ClusterSizeOverrideAnnotation: ocm.CSPropertyE2EMinimalControlPlaneSize,
+						},
+					},
+					Spec: testClusterUpdateMatchingHostedClusterSpec(),
+				}),
+			},
+			wantState: arm.ProvisioningStateSucceeded,
+		},
+		{
+			name: "minimal pod sizing set on cluster but missing annotation on hypershift side returns Updating",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := fixture.newCluster(nil)
+				c.ServiceProviderProperties.ExperimentalFeatures.ControlPlanePodSizing = api.MinimalControlPlanePodSizing
+				return c
+			}(),
+			serviceProviderCluster: emptySPC,
+			readDesires: []*kubeapplier.ReadDesire{
+				newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+					Spec: testClusterUpdateMatchingHostedClusterSpec(),
+				}),
+			},
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: `is unset, want "e2e_minimal"`,
+		},
+		{
+			name: "default pod sizing with stale annotation returns Updating",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := fixture.newCluster(nil)
+				return c
+			}(),
+			serviceProviderCluster: emptySPC,
+			readDesires: []*kubeapplier.ReadDesire{
+				newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							v1beta1.ClusterSizeOverrideAnnotation: "e2e_minimal",
+						},
+					},
+					Spec: testClusterUpdateMatchingHostedClusterSpec(),
+				}),
+			},
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: `is "e2e_minimal", want unset`,
+		},
+		{
+			name: "SPC level size override matches annotation returns Succeeded",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := fixture.newCluster(nil)
+				return c
+			}(),
+			serviceProviderCluster: &api.ServiceProviderCluster{
+				Spec: api.ServiceProviderClusterSpec{
+					DesiredHostedClusterControlPlaneSize: ptr.To("large"),
+				},
+			},
+			readDesires: []*kubeapplier.ReadDesire{
+				newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							v1beta1.ClusterSizeOverrideAnnotation: "large",
+						},
+					},
+					Spec: testClusterUpdateMatchingHostedClusterSpec(),
+				}),
+			},
+			wantState: arm.ProvisioningStateSucceeded,
+		},
+		{
+			name: "SPC level size override mismatch returns Updating",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := fixture.newCluster(nil)
+				return c
+			}(),
+			serviceProviderCluster: &api.ServiceProviderCluster{
+				Spec: api.ServiceProviderClusterSpec{
+					DesiredHostedClusterControlPlaneSize: ptr.To("large"),
+				},
+			},
+			readDesires: []*kubeapplier.ReadDesire{
+				newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							v1beta1.ClusterSizeOverrideAnnotation: "medium",
+						},
+					},
+					Spec: testClusterUpdateMatchingHostedClusterSpec(),
+				}),
+			},
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: `is "medium", want "large"`,
+		},
+		{
+			name: "control plane operator image annotation match returns Succeeded",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := fixture.newCluster(nil)
+				c.ServiceProviderProperties.ExperimentalFeatures.ControlPlaneOperatorImage = "quay.io/openshift/cpo:test"
+				return c
+			}(),
+			serviceProviderCluster: emptySPC,
+			readDesires: []*kubeapplier.ReadDesire{
+				newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							v1beta1.ControlPlaneOperatorImageAnnotation: "quay.io/openshift/cpo:test",
+						},
+					},
+					Spec: testClusterUpdateMatchingHostedClusterSpec(),
+				}),
+			},
+			wantState: arm.ProvisioningStateSucceeded,
+		},
+		{
+			name: "control plane operator image missing annotation returns Updating",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := fixture.newCluster(nil)
+				c.ServiceProviderProperties.ExperimentalFeatures.ControlPlaneOperatorImage = "quay.io/openshift/cpo:test"
+				return c
+			}(),
+			serviceProviderCluster: emptySPC,
+			readDesires: []*kubeapplier.ReadDesire{
+				newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+					Spec: testClusterUpdateMatchingHostedClusterSpec(),
+				}),
+			},
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: `is unset, want "quay.io/openshift/cpo:test"`,
+		},
+		{
+			name: "default control plane operator image with stale annotation returns Updating",
+			cluster: func() *api.HCPOpenShiftCluster {
+				c := fixture.newCluster(nil)
+				return c
+			}(),
+			serviceProviderCluster: emptySPC,
+			readDesires: []*kubeapplier.ReadDesire{
+				newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							v1beta1.ControlPlaneOperatorImageAnnotation: "quay.io/openshift/cpo:test",
+						},
+					},
+					Spec: testClusterUpdateMatchingHostedClusterSpec(),
+				}),
+			},
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: `is "quay.io/openshift/cpo:test", want unset`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			ctx = utils.ContextWithLogger(ctx, testr.New(t))
+
+			controller := &operationClusterUpdate{
+				readDesireLister: &internallistertesting.SliceReadDesireLister{
+					Desires: tt.readDesires,
+				},
+			}
+
+			state, err := controller.hypershiftHostedClusterOperationState(ctx, tt.cluster, tt.serviceProviderCluster)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantState, state.ProvisioningState)
+			if tt.wantMessageSubstr != "" {
+				assert.Contains(t, state.Message, tt.wantMessageSubstr)
+			}
+		})
+	}
+}
+
+func TestHypershiftHostedClusterAllowedCIDRBlocksSpecMatchesDesired(t *testing.T) {
+	t.Parallel()
+
+	controller := &operationClusterUpdate{}
+
+	tests := []struct {
+		name       string
+		desired    []string
+		observed   v1beta1.HostedClusterSpec
+		wantMatch  bool
+		wantSubstr string
+	}{
+		{
+			name:    "nil desired and no observed blocks",
+			desired: nil,
+			observed: v1beta1.HostedClusterSpec{
+				Networking: v1beta1.ClusterNetworking{},
+			},
+			wantMatch: true,
+		},
+		{
+			name:    "nil desired with observed blocks",
+			desired: nil,
+			observed: v1beta1.HostedClusterSpec{
+				Networking: v1beta1.ClusterNetworking{
+					APIServer: &v1beta1.APIServerNetworking{
+						AllowedCIDRBlocks: []v1beta1.CIDRBlock{"10.0.0.0/8"},
+					},
+				},
+			},
+			wantMatch:  false,
+			wantSubstr: `allowedCIDRBlocks is [10.0.0.0/8], want unset (allow all)`,
+		},
+		{
+			name:    "desired blocks missing on observed",
+			desired: []string{"10.0.0.0/8"},
+			observed: v1beta1.HostedClusterSpec{
+				Networking: v1beta1.ClusterNetworking{},
+			},
+			wantMatch:  false,
+			wantSubstr: `allowedCIDRBlocks is unset, want [10.0.0.0/8]`,
+		},
+		{
+			name:    "desired blocks missing with internal extras present",
+			desired: []string{"10.0.0.0/8"},
+			observed: v1beta1.HostedClusterSpec{
+				Networking: v1beta1.ClusterNetworking{
+					APIServer: &v1beta1.APIServerNetworking{
+						AllowedCIDRBlocks: []v1beta1.CIDRBlock{"172.16.0.0/32"},
+					},
+				},
+			},
+			wantMatch:  false,
+			wantSubstr: `is missing "10.0.0.0/8"`,
+		},
+		{
+			name:    "desired blocks mismatch",
+			desired: []string{"10.0.0.0/8"},
+			observed: v1beta1.HostedClusterSpec{
+				Networking: v1beta1.ClusterNetworking{
+					APIServer: &v1beta1.APIServerNetworking{
+						AllowedCIDRBlocks: []v1beta1.CIDRBlock{"192.168.0.0/16"},
+					},
+				},
+			},
+			wantMatch:  false,
+			wantSubstr: `is missing "10.0.0.0/8"`,
+		},
+		{
+			name:    "temporary: desired subset present with internal extras",
+			desired: []string{"10.0.0.0/8", "192.168.0.0/16"},
+			observed: v1beta1.HostedClusterSpec{
+				Networking: v1beta1.ClusterNetworking{
+					APIServer: &v1beta1.APIServerNetworking{
+						AllowedCIDRBlocks: []v1beta1.CIDRBlock{
+							"192.168.0.0/16",
+							"10.0.0.0/8",
+							"172.16.0.0/32",
+						},
+					},
+				},
+			},
+			wantMatch: true,
+		},
+		{
+			name:    "full match regardless of order",
+			desired: []string{"10.0.0.0/8", "192.168.0.0/16"},
+			observed: v1beta1.HostedClusterSpec{
+				Networking: v1beta1.ClusterNetworking{
+					APIServer: &v1beta1.APIServerNetworking{
+						AllowedCIDRBlocks: []v1beta1.CIDRBlock{"192.168.0.0/16", "10.0.0.0/8"},
+					},
+				},
+			},
+			wantMatch: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			matches, msg := controller.hypershiftHostedClusterAllowedCIDRBlocksSpecMatchesDesired(tt.desired, &tt.observed)
+			assert.Equal(t, tt.wantMatch, matches)
+			if tt.wantSubstr != "" {
+				assert.Contains(t, msg, tt.wantSubstr)
+			}
+		})
+	}
+}
+
+func TestHypershiftHostedClusterAvailabilityPoliciesSpecMatchesDesired(t *testing.T) {
+	t.Parallel()
+
+	controller := &operationClusterUpdate{}
+
+	tests := []struct {
+		name       string
+		desired    api.ControlPlaneAvailability
+		observed   v1beta1.HostedClusterSpec
+		wantMatch  bool
+		wantSubstr string
+	}{
+		{
+			name:       "default desired rejects unset policies",
+			desired:    api.DefaultControlPlaneAvailability,
+			observed:   v1beta1.HostedClusterSpec{},
+			wantMatch:  false,
+			wantSubstr: `hypershift HostedCluster controllerAvailabilityPolicy is "", want "HighlyAvailable"`,
+		},
+		{
+			name:    "default desired matches highly available policies",
+			desired: api.DefaultControlPlaneAvailability,
+			observed: v1beta1.HostedClusterSpec{
+				ControllerAvailabilityPolicy:     v1beta1.HighlyAvailable,
+				InfrastructureAvailabilityPolicy: v1beta1.HighlyAvailable,
+			},
+			wantMatch: true,
+		},
+		{
+			name:    "default desired rejects single replica controller",
+			desired: api.DefaultControlPlaneAvailability,
+			observed: v1beta1.HostedClusterSpec{
+				ControllerAvailabilityPolicy:     v1beta1.SingleReplica,
+				InfrastructureAvailabilityPolicy: v1beta1.SingleReplica,
+			},
+			wantMatch:  false,
+			wantSubstr: `hypershift HostedCluster controllerAvailabilityPolicy is "SingleReplica", want "HighlyAvailable"`,
+		},
+		{
+			name:    "single replica desired matches both policies",
+			desired: api.SingleReplicaControlPlane,
+			observed: v1beta1.HostedClusterSpec{
+				ControllerAvailabilityPolicy:     v1beta1.SingleReplica,
+				InfrastructureAvailabilityPolicy: v1beta1.SingleReplica,
+			},
+			wantMatch: true,
+		},
+		{
+			name:    "single replica desired rejects unset controller policy",
+			desired: api.SingleReplicaControlPlane,
+			observed: v1beta1.HostedClusterSpec{
+				InfrastructureAvailabilityPolicy: v1beta1.SingleReplica,
+			},
+			wantMatch:  false,
+			wantSubstr: `hypershift HostedCluster controllerAvailabilityPolicy is "", want "SingleReplica"`,
+		},
+		{
+			name:    "single replica desired rejects highly available infrastructure",
+			desired: api.SingleReplicaControlPlane,
+			observed: v1beta1.HostedClusterSpec{
+				ControllerAvailabilityPolicy:     v1beta1.SingleReplica,
+				InfrastructureAvailabilityPolicy: v1beta1.HighlyAvailable,
+			},
+			wantMatch:  false,
+			wantSubstr: `hypershift HostedCluster infrastructureAvailabilityPolicy is "HighlyAvailable", want "SingleReplica"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			matches, msg := controller.hypershiftHostedClusterAvailabilityPoliciesSpecMatchesDesired(tt.desired, &tt.observed)
+			assert.Equal(t, tt.wantMatch, matches)
+			if tt.wantSubstr != "" {
+				assert.Contains(t, msg, tt.wantSubstr)
+			}
+		})
+	}
+}
+
+func TestHypershiftHostedClusterSizeOverrideAnnotationMatchesDesired(t *testing.T) {
+	t.Parallel()
+
+	controller := &operationClusterUpdate{}
+
+	tests := []struct {
+		name                string
+		clusterPodSizing    api.ControlPlanePodSizing
+		spcControlPlaneSize *string
+		observed            map[string]string
+		wantMatch           bool
+		wantSubstr          string
+	}{
+		{
+			name:             "default desired with no annotations",
+			clusterPodSizing: api.DefaultControlPlanePodSizing,
+			observed:         nil,
+			wantMatch:        true,
+		},
+		{
+			name:             "default desired rejects stale annotation",
+			clusterPodSizing: api.DefaultControlPlanePodSizing,
+			observed: map[string]string{
+				v1beta1.ClusterSizeOverrideAnnotation: ocm.CSPropertyE2EMinimalControlPlaneSize,
+			},
+			wantMatch:  false,
+			wantSubstr: `is "e2e_minimal", want unset`,
+		},
+		{
+			name:             "minimal desired matches annotation",
+			clusterPodSizing: api.MinimalControlPlanePodSizing,
+			observed: map[string]string{
+				v1beta1.ClusterSizeOverrideAnnotation: ocm.CSPropertyE2EMinimalControlPlaneSize,
+			},
+			wantMatch: true,
+		},
+		{
+			name:             "minimal desired rejects missing annotation",
+			clusterPodSizing: api.MinimalControlPlanePodSizing,
+			observed:         nil,
+			wantMatch:        false,
+			wantSubstr:       `is unset, want "e2e_minimal"`,
+		},
+		{
+			name:             "minimal desired rejects different annotation value",
+			clusterPodSizing: api.MinimalControlPlanePodSizing,
+			observed: map[string]string{
+				v1beta1.ClusterSizeOverrideAnnotation: "small",
+			},
+			wantMatch:  false,
+			wantSubstr: `is "small", want "e2e_minimal"`,
+		},
+		{
+			name:                "SPC size takes precedence and matches",
+			clusterPodSizing:    api.MinimalControlPlanePodSizing,
+			spcControlPlaneSize: ptr.To("large"),
+			observed: map[string]string{
+				v1beta1.ClusterSizeOverrideAnnotation: "large",
+			},
+			wantMatch: true,
+		},
+		{
+			name:                "SPC size takes precedence and rejects mismatch",
+			clusterPodSizing:    api.MinimalControlPlanePodSizing,
+			spcControlPlaneSize: ptr.To("large"),
+			observed: map[string]string{
+				v1beta1.ClusterSizeOverrideAnnotation: "medium",
+			},
+			wantMatch:  false,
+			wantSubstr: `is "medium", want "large"`,
+		},
+		{
+			name:                "whenSPC size set it rejects missing annotation",
+			clusterPodSizing:    "",
+			spcControlPlaneSize: ptr.To("large"),
+			observed:            nil,
+			wantMatch:           false,
+			wantSubstr:          `is unset, want "large"`,
+		},
+		{
+			name:             "unrecognized cluster-level pod sizing returns not completed",
+			clusterPodSizing: api.ControlPlanePodSizing("unknown"),
+			observed:         nil,
+			wantMatch:        false,
+			wantSubstr:       `unrecognized cluster-level control plane pod sizing: "unknown"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			matches, msg := controller.hypershiftHostedClusterSizeOverrideAnnotationMatchesDesired(tt.clusterPodSizing, tt.spcControlPlaneSize, tt.observed)
+			assert.Equal(t, tt.wantMatch, matches)
+			if tt.wantSubstr != "" {
+				assert.Contains(t, msg, tt.wantSubstr)
+			}
+		})
+	}
+}
+
+func TestHypershiftHostedClusterControlPlaneOperatorImageAnnotationMatchesDesired(t *testing.T) {
+	t.Parallel()
+
+	controller := &operationClusterUpdate{}
+
+	tests := []struct {
+		name       string
+		desired    string
+		observed   map[string]string
+		wantMatch  bool
+		wantSubstr string
+	}{
+		{
+			name:      "default desired with no annotations",
+			desired:   "",
+			observed:  nil,
+			wantMatch: true,
+		},
+		{
+			name:    "default desired rejects stale annotation",
+			desired: "",
+			observed: map[string]string{
+				v1beta1.ControlPlaneOperatorImageAnnotation: "quay.io/openshift/cpo:test",
+			},
+			wantMatch:  false,
+			wantSubstr: `is "quay.io/openshift/cpo:test", want unset`,
+		},
+		{
+			name:    "desired image matches annotation",
+			desired: "quay.io/openshift/cpo:test",
+			observed: map[string]string{
+				v1beta1.ControlPlaneOperatorImageAnnotation: "quay.io/openshift/cpo:test",
+			},
+			wantMatch: true,
+		},
+		{
+			name:       "desired image rejects missing annotation",
+			desired:    "quay.io/openshift/cpo:test",
+			observed:   nil,
+			wantMatch:  false,
+			wantSubstr: `is unset, want "quay.io/openshift/cpo:test"`,
+		},
+		{
+			name:    "desired image rejects wrong annotation value",
+			desired: "quay.io/openshift/cpo:test",
+			observed: map[string]string{
+				v1beta1.ControlPlaneOperatorImageAnnotation: "quay.io/openshift/cpo:other",
+			},
+			wantMatch:  false,
+			wantSubstr: `is "quay.io/openshift/cpo:other", want "quay.io/openshift/cpo:test"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			matches, msg := controller.hypershiftHostedClusterControlPlaneOperatorImageAnnotationMatchesDesired(tt.desired, tt.observed)
+			assert.Equal(t, tt.wantMatch, matches)
+			if tt.wantSubstr != "" {
+				assert.Contains(t, msg, tt.wantSubstr)
+			}
+		})
+	}
+}
+
+func TestHypershiftHostedClusterAutoscalingSpecMatchesDesired(t *testing.T) {
+	t.Parallel()
+
+	controller := &operationClusterUpdate{}
+
+	tests := []struct {
+		name       string
+		desired    api.ClusterAutoscalingProfile
+		observed   v1beta1.ClusterAutoscaling
+		wantMatch  bool
+		wantSubstr string
+	}{
+		{
+			name:      "maxNodesTotal zero exact match",
+			desired:   api.ClusterAutoscalingProfile{},
+			observed:  testClusterUpdateMatchingHostedClusterSpec().Autoscaling,
+			wantMatch: true,
+		},
+		{
+			name:    "maxNodesTotal desired zero observed nil",
+			desired: api.ClusterAutoscalingProfile{},
+			observed: func() v1beta1.ClusterAutoscaling {
+				autoscaling := testClusterUpdateMatchingHostedClusterSpec().Autoscaling
+				autoscaling.MaxNodesTotal = nil
+				return autoscaling
+			}(),
+			wantMatch:  false,
+			wantSubstr: `maxNodesTotal is unset, want 0`,
+		},
+		{
+			name:    "maxPodGracePeriod desired zero observed nil",
+			desired: api.ClusterAutoscalingProfile{MaxPodGracePeriodSeconds: 0},
+			observed: func() v1beta1.ClusterAutoscaling {
+				autoscaling := testClusterUpdateMatchingHostedClusterSpec().Autoscaling
+				autoscaling.MaxPodGracePeriod = nil
+				return autoscaling
+			}(),
+			wantMatch:  false,
+			wantSubstr: `maxPodGracePeriod is unset, want 0`,
+		},
+		{
+			name:    "maxNodesTotal mismatch",
+			desired: api.ClusterAutoscalingProfile{MaxNodesTotal: 10},
+			observed: func() v1beta1.ClusterAutoscaling {
+				autoscaling := testClusterUpdateMatchingHostedClusterSpec().Autoscaling
+				autoscaling.MaxNodesTotal = ptr.To[int32](5)
+				return autoscaling
+			}(),
+			wantMatch:  false,
+			wantSubstr: `maxNodesTotal is 5, want 10`,
+		},
+		{
+			name:       "maxNodesTotal desired nonzero observed nil",
+			desired:    api.ClusterAutoscalingProfile{MaxNodesTotal: 10},
+			observed:   testClusterUpdateMatchingHostedClusterSpec().Autoscaling,
+			wantMatch:  false,
+			wantSubstr: `maxNodesTotal is 0, want 10`,
+		},
+		{
+			name:    "maxNodeProvisionTime equivalent duration match",
+			desired: api.ClusterAutoscalingProfile{MaxNodeProvisionTimeSeconds: 900},
+			observed: func() v1beta1.ClusterAutoscaling {
+				autoscaling := testClusterUpdateMatchingHostedClusterSpec().Autoscaling
+				autoscaling.MaxNodeProvisionTime = "900s"
+				return autoscaling
+			}(),
+			wantMatch: true,
+		},
+		{
+			name:    "maxNodeProvisionTime invalid duration",
+			desired: api.ClusterAutoscalingProfile{MaxNodeProvisionTimeSeconds: 900},
+			observed: func() v1beta1.ClusterAutoscaling {
+				autoscaling := testClusterUpdateMatchingHostedClusterSpec().Autoscaling
+				autoscaling.MaxNodeProvisionTime = "not-a-duration"
+				return autoscaling
+			}(),
+			wantMatch:  false,
+			wantSubstr: `maxNodeProvisionTime has an invalid duration: "not-a-duration", want "15m"`,
+		},
+		{
+			name:    "maxPodGracePeriod mismatch",
+			desired: api.ClusterAutoscalingProfile{MaxPodGracePeriodSeconds: 60},
+			observed: func() v1beta1.ClusterAutoscaling {
+				autoscaling := testClusterUpdateMatchingHostedClusterSpec().Autoscaling
+				autoscaling.MaxPodGracePeriod = ptr.To[int32](30)
+				return autoscaling
+			}(),
+			wantMatch:  false,
+			wantSubstr: `maxPodGracePeriod is 30, want 60`,
+		},
+		{
+			name:    "podPriorityThreshold mismatch",
+			desired: api.ClusterAutoscalingProfile{PodPriorityThreshold: -10},
+			observed: func() v1beta1.ClusterAutoscaling {
+				autoscaling := testClusterUpdateMatchingHostedClusterSpec().Autoscaling
+				autoscaling.PodPriorityThreshold = ptr.To[int32](0)
+				return autoscaling
+			}(),
+			wantMatch:  false,
+			wantSubstr: `podPriorityThreshold is 0, want -10`,
+		},
+		{
+			name:    "all match",
+			desired: api.ClusterAutoscalingProfile{MaxNodesTotal: 10, MaxPodGracePeriodSeconds: 60, PodPriorityThreshold: -5},
+			observed: v1beta1.ClusterAutoscaling{
+				MaxNodesTotal:        ptr.To[int32](10),
+				MaxPodGracePeriod:    ptr.To[int32](60),
+				MaxNodeProvisionTime: "0m",
+				PodPriorityThreshold: ptr.To[int32](-5),
+			},
+			wantMatch: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			matches, msg := controller.hypershiftHostedClusterAutoscalingSpecMatchesDesired(tt.desired, &tt.observed)
+			assert.Equal(t, tt.wantMatch, matches)
+			if tt.wantSubstr != "" {
+				assert.Contains(t, msg, tt.wantSubstr)
+			}
+		})
+	}
+}
+
+func TestHypershiftHostedClusterImageContentSourcesSpecMatchesDesired(t *testing.T) {
+	t.Parallel()
+
+	// From platformImageContentSources in operation_cluster_update_state_calculation.go.
+	testClusterUpdatePlatformImageContentSource := "quay.io/openshift-release-dev/ocp-release"
+
+	controller := &operationClusterUpdate{}
+
+	tests := []struct {
+		name       string
+		desired    []api.ImageDigestMirror
+		observed   []v1beta1.ImageContentSource
+		wantMatch  bool
+		wantSubstr string
+	}{
+		{
+			name:      "both nil",
+			desired:   nil,
+			observed:  nil,
+			wantMatch: true,
+		},
+		{
+			name:      "both empty",
+			desired:   []api.ImageDigestMirror{},
+			observed:  []v1beta1.ImageContentSource{},
+			wantMatch: true,
+		},
+		{
+			name: "missing desired source",
+			desired: []api.ImageDigestMirror{
+				{Source: "a"},
+			},
+			observed:   nil,
+			wantMatch:  false,
+			wantSubstr: `missing source "a"`,
+		},
+		{
+			name: "extra platform observed sources",
+			desired: []api.ImageDigestMirror{
+				{Source: "a", Mirrors: []string{"m1"}},
+			},
+			observed: []v1beta1.ImageContentSource{
+				{Source: testClusterUpdatePlatformImageContentSource, Mirrors: []string{"platform-mirror"}},
+				{Source: "a", Mirrors: []string{"m1"}},
+			},
+			wantMatch: true,
+		},
+		{
+			name:      "desired empty observed has only platform sources",
+			desired:   []api.ImageDigestMirror{},
+			observed:  []v1beta1.ImageContentSource{{Source: testClusterUpdatePlatformImageContentSource, Mirrors: []string{"platform-mirror"}}},
+			wantMatch: true,
+		},
+		{
+			name:    "desired empty and observed has stale customer sources",
+			desired: []api.ImageDigestMirror{},
+			observed: []v1beta1.ImageContentSource{
+				{Source: testClusterUpdatePlatformImageContentSource, Mirrors: []string{"platform-mirror"}},
+				{Source: "quay.io/foo", Mirrors: []string{"mirror.io/foo"}},
+			},
+			wantMatch:  false,
+			wantSubstr: `unexpected imageContentSource "quay.io/foo"`,
+		},
+		{
+			name: "unset customer source still present",
+			desired: []api.ImageDigestMirror{
+				{Source: "quay.io/foo", Mirrors: []string{"mirror.io/foo"}},
+			},
+			observed: []v1beta1.ImageContentSource{
+				{Source: testClusterUpdatePlatformImageContentSource, Mirrors: []string{"platform-mirror"}},
+				{Source: "quay.io/foo", Mirrors: []string{"mirror.io/foo"}},
+				{Source: "quay.io/bar", Mirrors: []string{"mirror.io/bar"}},
+			},
+			wantMatch:  false,
+			wantSubstr: `unexpected imageContentSource "quay.io/bar"`,
+		},
+		{
+			name: "source mismatch",
+			desired: []api.ImageDigestMirror{
+				{Source: "a", Mirrors: []string{"m1"}},
+			},
+			observed: []v1beta1.ImageContentSource{
+				{Source: "b", Mirrors: []string{"m1"}},
+			},
+			wantMatch:  false,
+			wantSubstr: `missing source "a"`,
+		},
+		{
+			name: "mirrors mismatch",
+			desired: []api.ImageDigestMirror{
+				{Source: "a", Mirrors: []string{"m1", "m2"}},
+			},
+			observed: []v1beta1.ImageContentSource{
+				{Source: "a", Mirrors: []string{"m1", "m3"}},
+			},
+			wantMatch:  false,
+			wantSubstr: `for source "a" mirrors do not match`,
+		},
+		{
+			name: "full match",
+			desired: []api.ImageDigestMirror{
+				{Source: "a", Mirrors: []string{"m1"}},
+				{Source: "b", Mirrors: []string{"m2", "m3"}},
+			},
+			observed: []v1beta1.ImageContentSource{
+				{Source: "a", Mirrors: []string{"m1"}},
+				{Source: "b", Mirrors: []string{"m2", "m3"}},
+			},
+			wantMatch: true,
+		},
+		{
+			name: "full match regardless of order",
+			desired: []api.ImageDigestMirror{
+				{Source: "a", Mirrors: []string{"m1"}},
+				{Source: "b", Mirrors: []string{"m2", "m3"}},
+			},
+			observed: []v1beta1.ImageContentSource{
+				{Source: testClusterUpdatePlatformImageContentSource, Mirrors: []string{"platform-mirror"}},
+				{Source: "b", Mirrors: []string{"m2", "m3"}},
+				{Source: "a", Mirrors: []string{"m1"}},
+			},
+			wantMatch: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			matches, msg := controller.hypershiftHostedClusterImageContentSourcesSpecMatchesDesired(tt.desired, tt.observed)
+			assert.Equal(t, tt.wantMatch, matches)
+			if tt.wantSubstr != "" {
+				assert.Contains(t, msg, tt.wantSubstr)
+			}
+		})
+	}
+}
+
+func TestClusterServiceClusterSpecOperationState(t *testing.T) {
+	t.Parallel()
+
+	newCSClusterWithCIDRBlockAllowAccess := func(t *testing.T, mode string, cidrs ...string) *arohcpv1alpha1.Cluster {
+		t.Helper()
+		allowAccess := arohcpv1alpha1.NewCIDRBlockAllowAccess().Mode(mode)
+		if len(cidrs) > 0 {
+			allowAccess = allowAccess.Values(cidrs...)
+		}
+		cluster, err := arohcpv1alpha1.NewCluster().
+			API(arohcpv1alpha1.NewClusterAPI().
+				CIDRBlockAccess(arohcpv1alpha1.NewCIDRBlockAccess().
+					Allow(allowAccess))).
+			Build()
+		require.NoError(t, err)
+		return cluster
+	}
+	newCSCluster := func(t *testing.T) *arohcpv1alpha1.Cluster {
+		t.Helper()
+		cluster, err := arohcpv1alpha1.NewCluster().Build()
+		require.NoError(t, err)
+		return cluster
+	}
+	newCSClusterWithAllowAll := func(t *testing.T) *arohcpv1alpha1.Cluster {
+		t.Helper()
+		return newCSClusterWithCIDRBlockAllowAccess(t, ocm.CSCIDRBlockAllowAccessModeAllowAll)
+	}
+	newCSClusterWithNodeDrainTimeoutAndAllowAll := func(t *testing.T, minutes int32) *arohcpv1alpha1.Cluster {
+		t.Helper()
+		allowAccess := arohcpv1alpha1.NewCIDRBlockAllowAccess().Mode(ocm.CSCIDRBlockAllowAccessModeAllowAll)
+		cluster, err := arohcpv1alpha1.NewCluster().
+			NodeDrainGracePeriod(arohcpv1alpha1.NewValue().
+				Unit("minutes").
+				Value(float64(minutes))).
+			API(arohcpv1alpha1.NewClusterAPI().
+				CIDRBlockAccess(arohcpv1alpha1.NewCIDRBlockAccess().
+					Allow(allowAccess))).
+			Build()
+		require.NoError(t, err)
+		return cluster
+	}
+	newCSClusterWithAuthorizedCIDRs := func(t *testing.T, cidrs ...string) *arohcpv1alpha1.Cluster {
+		t.Helper()
+		return newCSClusterWithCIDRBlockAllowAccess(t, ocm.CSCIDRBlockAllowAccessModeAllowList, cidrs...)
+	}
+
+	controller := &operationClusterUpdate{}
+
+	tests := []struct {
+		name              string
+		cluster           *api.HCPOpenShiftCluster
+		csCluster         *arohcpv1alpha1.Cluster
+		wantState         arm.ProvisioningState
+		wantMessageSubstr string
+	}{
+		{
+			name: "matching node drain timeout returns Succeeded",
+			cluster: &api.HCPOpenShiftCluster{
+				CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
+					NodeDrainTimeoutMinutes: 30,
+				},
+			},
+			csCluster: newCSClusterWithNodeDrainTimeoutAndAllowAll(t, 30),
+			wantState: arm.ProvisioningStateSucceeded,
+		},
+		{
+			name: "zero desired with unset CS value returns Succeeded",
+			cluster: &api.HCPOpenShiftCluster{
+				CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{},
+			},
+			csCluster: newCSClusterWithAllowAll(t),
+			wantState: arm.ProvisioningStateSucceeded,
+		},
+		{
+			name: "mismatch returns Updating",
+			cluster: &api.HCPOpenShiftCluster{
+				CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
+					NodeDrainTimeoutMinutes: 60,
+				},
+			},
+			csCluster:         newCSClusterWithNodeDrainTimeoutAndAllowAll(t, 30),
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: `nodeDrainGracePeriod is 30 minutes, want 60`,
+		},
+		{
+			name: "matching authorized CIDRs returns Succeeded",
+			cluster: &api.HCPOpenShiftCluster{
+				CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
+					API: api.CustomerAPIProfile{
+						AuthorizedCIDRs: []string{"10.0.0.0/8", "192.168.0.0/16"},
+					},
+				},
+			},
+			csCluster: newCSClusterWithAuthorizedCIDRs(t, "10.0.0.0/8", "192.168.0.0/16"),
+			wantState: arm.ProvisioningStateSucceeded,
+		},
+		{
+			name: "nil desired with unset CS CIDR config returns Updating",
+			cluster: &api.HCPOpenShiftCluster{
+				CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
+					API: api.CustomerAPIProfile{},
+				},
+			},
+			csCluster:         newCSCluster(t),
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: `k8sAPIServerAuthorizedCIDRs is unset, want allow_all`,
+		},
+		{
+			name: "authorized CIDR mismatch returns Updating",
+			cluster: &api.HCPOpenShiftCluster{
+				CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
+					API: api.CustomerAPIProfile{
+						AuthorizedCIDRs: []string{"203.0.113.0/24"},
+					},
+				},
+			},
+			csCluster:         newCSClusterWithAuthorizedCIDRs(t, "10.0.0.0/8"),
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: `allow_list is [10.0.0.0/8], want [203.0.113.0/24]`,
+		},
+		{
+			name: "explicit allow_all CS config with nil desired returns Succeeded",
+			cluster: &api.HCPOpenShiftCluster{
+				CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
+					API: api.CustomerAPIProfile{},
+				},
+			},
+			csCluster: newCSClusterWithCIDRBlockAllowAccess(t, ocm.CSCIDRBlockAllowAccessModeAllowAll),
+			wantState: arm.ProvisioningStateSucceeded,
+		},
+		{
+			name: "allow_all CS config with stale values and nil desired returns Succeeded",
+			cluster: &api.HCPOpenShiftCluster{
+				CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
+					API: api.CustomerAPIProfile{},
+				},
+			},
+			csCluster: newCSClusterWithCIDRBlockAllowAccess(t, ocm.CSCIDRBlockAllowAccessModeAllowAll, "10.0.0.0/8"),
+			wantState: arm.ProvisioningStateSucceeded,
+		},
+		{
+			name: "allow_list CS config with nil desired returns Updating",
+			cluster: &api.HCPOpenShiftCluster{
+				CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
+					API: api.CustomerAPIProfile{},
+				},
+			},
+			csCluster:         newCSClusterWithCIDRBlockAllowAccess(t, ocm.CSCIDRBlockAllowAccessModeAllowList, "10.0.0.0/8"),
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: `k8sAPIServerAuthorizedCIDRs is allow_list [10.0.0.0/8], want allow_all`,
+		},
+		{
+			name: "allow_all CS config with desired CIDR list returns Updating",
+			cluster: &api.HCPOpenShiftCluster{
+				CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
+					API: api.CustomerAPIProfile{
+						AuthorizedCIDRs: []string{"203.0.113.0/24"},
+					},
+				},
+			},
+			csCluster:         newCSClusterWithCIDRBlockAllowAccess(t, ocm.CSCIDRBlockAllowAccessModeAllowAll),
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: `k8sAPIServerAuthorizedCIDRs is allow_all, want allow_list`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			state, err := controller.clusterServiceClusterSpecOperationState(tt.cluster, tt.csCluster)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantState, state.ProvisioningState)
+			if tt.wantMessageSubstr != "" {
+				assert.Contains(t, state.Message, tt.wantMessageSubstr)
+			}
+		})
+	}
+}

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_update_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_update_test.go
@@ -35,32 +35,137 @@ import (
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
 	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+	"github.com/openshift/hypershift/api/hypershift/v1beta1"
 
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/api/kubeapplier"
 	"github.com/Azure/ARO-HCP/internal/database"
+	dblisters "github.com/Azure/ARO-HCP/internal/database/listers"
+	internallistertesting "github.com/Azure/ARO-HCP/internal/database/listertesting"
 	"github.com/Azure/ARO-HCP/internal/databasetesting"
 	"github.com/Azure/ARO-HCP/internal/ocm"
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
 
 func TestOperationClusterUpdate_SynchronizeOperation(t *testing.T) {
-	t.Parallel()
 	testClockNow := mustParseTime("2024-06-01T12:00:00Z")
-	tests := []struct {
-		name                                           string
-		clusterState                                   arohcpv1alpha1.ClusterState
-		customerVersionID                              string
-		serviceProviderClusterStatusConditions         []metav1.Condition
-		controlPlaneDesiredVersionControllerConditions []metav1.Condition
-		seedMismatchFirstSeenAt                        time.Time
-		verify                                         func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *clusterTestFixture)
+	fixture := newClusterTestFixture()
+
+	newClusterWithCustomerVersion := func(versionID string, mutate ...func(*api.HCPOpenShiftCluster)) *api.HCPOpenShiftCluster {
+		cluster := fixture.newCluster(nil)
+		cluster.CustomerProperties.Version.ID = versionID
+		for _, fn := range mutate {
+			if fn != nil {
+				fn(cluster)
+			}
+		}
+		return cluster
+	}
+
+	newCSClusterWithState := func(state arohcpv1alpha1.ClusterState) *arohcpv1alpha1.Cluster {
+		allowAccess := arohcpv1alpha1.NewCIDRBlockAllowAccess().Mode(ocm.CSCIDRBlockAllowAccessModeAllowAll)
+		csCluster, err := arohcpv1alpha1.NewCluster().
+			API(arohcpv1alpha1.NewClusterAPI().
+				CIDRBlockAccess(arohcpv1alpha1.NewCIDRBlockAccess().
+					Allow(allowAccess))).
+			Status(arohcpv1alpha1.NewClusterStatus().State(state)).
+			Build()
+		require.NoError(t, err)
+		return csCluster
+	}
+
+	newCSClusterReadyWithNodeDrainMinutes := func(minutes int32) *arohcpv1alpha1.Cluster {
+		allowAccess := arohcpv1alpha1.NewCIDRBlockAllowAccess().Mode(ocm.CSCIDRBlockAllowAccessModeAllowAll)
+		csCluster, err := arohcpv1alpha1.NewCluster().
+			NodeDrainGracePeriod(arohcpv1alpha1.NewValue().
+				Unit("minutes").
+				Value(float64(minutes))).
+			API(arohcpv1alpha1.NewClusterAPI().
+				CIDRBlockAccess(arohcpv1alpha1.NewCIDRBlockAccess().
+					Allow(allowAccess))).
+			Status(arohcpv1alpha1.NewClusterStatus().State(arohcpv1alpha1.ClusterStateReady)).
+			Build()
+		require.NoError(t, err)
+		return csCluster
+	}
+
+	newOperationAccepted := func() *api.Operation {
+		return fixture.newOperation(database.OperationRequestUpdate)
+	}
+
+	newServiceProviderClusterWithSpecControlPlaneVersion := func(version string) *api.ServiceProviderCluster {
+		resourceID := api.Must(azcorearm.ParseResourceID(fmt.Sprintf("%s/%s/%s",
+			fixture.clusterResourceID.String(),
+			api.ServiceProviderClusterResourceTypeName,
+			api.ServiceProviderClusterResourceName,
+		)))
+		parsedVersion, err := semver.ParseTolerant(version)
+		require.NoError(t, err)
+		return &api.ServiceProviderCluster{
+			CosmosMetadata: api.CosmosMetadata{ResourceID: resourceID, PartitionKey: strings.ToLower(resourceID.SubscriptionID)},
+			Spec: api.ServiceProviderClusterSpec{
+				ControlPlaneVersion: api.ServiceProviderClusterSpecVersion{
+					DesiredVersion: ptr.To(parsedVersion),
+				},
+			},
+			Status: api.ServiceProviderClusterStatus{},
+		}
+	}
+	newDefaultControlPlaneDesiredVersionController := func() *api.Controller {
+		resourceID := api.Must(azcorearm.ParseResourceID(fixture.clusterResourceID.String() + "/hcpOpenShiftControllers/ControlPlaneDesiredVersion"))
+		return &api.Controller{
+			CosmosMetadata: api.CosmosMetadata{ResourceID: resourceID, PartitionKey: strings.ToLower(resourceID.SubscriptionID)},
+			ExternalID:     fixture.clusterResourceID,
+			Status:         api.ControllerStatus{},
+		}
+	}
+
+	newControlPlaneDesiredVersionControllerWithConditions := func(conditions []metav1.Condition) *api.Controller {
+		controller := newDefaultControlPlaneDesiredVersionController()
+		controller.Status.Conditions = conditions
+		return controller
+	}
+
+	newPassingCachedHostedClusterReadDesire := func() *kubeapplier.ReadDesire {
+		return newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+			Spec: testClusterUpdateMatchingHostedClusterSpec(),
+		})
+	}
+
+	testCases := []struct {
+		name            string
+		existingCluster *api.HCPOpenShiftCluster
+		// When not set, the controller uses a cluster lister that contains the existingCluster
+		clusterLister     listers.ClusterLister
+		existingOperation *api.Operation
+		// When not set, the controller uses an active operations lister that contains the existingOperation
+		activeOperationsLister         listers.ActiveOperationLister
+		existingServiceProviderCluster *api.ServiceProviderCluster
+		// When not set, the controller uses a service provider cluster lister that contains the existingServiceProviderCluster
+		serviceProviderClusterLister                 listers.ServiceProviderClusterLister
+		existingControlPlaneDesiredVersionController *api.Controller
+		// When set, wires a ReadDesireLister containing this cached HostedCluster mirror.
+		cachedHostedClusterReadDesire *kubeapplier.ReadDesire
+		seedMismatchFirstSeenAt       time.Time
+		setupMockCSClient             func(*ocm.MockClusterServiceClientSpec)
+		wantErr                       bool
+		verifyDB                      func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient)
 	}{
 		{
-			name:              "cluster ready transitions operation to succeeded",
-			clusterState:      arohcpv1alpha1.ClusterStateReady,
-			customerVersionID: "4.19",
-			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *clusterTestFixture) {
+			name:                           "cs cluster ready transitions operation to succeeded",
+			existingCluster:                newClusterWithCustomerVersion("4.19"),
+			existingOperation:              newOperationAccepted(),
+			existingServiceProviderCluster: newServiceProviderClusterWithSpecControlPlaneVersion("4.19"),
+			cachedHostedClusterReadDesire:  newPassingCachedHostedClusterReadDesire(),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetCluster(gomock.Any(), fixture.clusterInternalID).
+					Return(newCSClusterWithState(arohcpv1alpha1.ClusterStateReady), nil)
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateSucceeded, op.Status)
@@ -72,10 +177,17 @@ func TestOperationClusterUpdate_SynchronizeOperation(t *testing.T) {
 			},
 		},
 		{
-			name:              "cluster updating transitions operation to updating",
-			clusterState:      arohcpv1alpha1.ClusterStateUpdating,
-			customerVersionID: "4.19",
-			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *clusterTestFixture) {
+			name:                           "cs cluster updating transitions operation to updating",
+			existingCluster:                newClusterWithCustomerVersion("4.19"),
+			existingOperation:              newOperationAccepted(),
+			existingServiceProviderCluster: newServiceProviderClusterWithSpecControlPlaneVersion("4.19"),
+			cachedHostedClusterReadDesire:  newPassingCachedHostedClusterReadDesire(),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetCluster(gomock.Any(), fixture.clusterInternalID).
+					Return(newCSClusterWithState(arohcpv1alpha1.ClusterStateUpdating), nil)
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateUpdating, op.Status)
@@ -87,10 +199,17 @@ func TestOperationClusterUpdate_SynchronizeOperation(t *testing.T) {
 			},
 		},
 		{
-			name:              "cluster error transitions operation to failed",
-			clusterState:      arohcpv1alpha1.ClusterStateError,
-			customerVersionID: "4.19",
-			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *clusterTestFixture) {
+			name:                           "cs cluster error transitions operation to failed",
+			existingCluster:                newClusterWithCustomerVersion("4.19"),
+			existingOperation:              newOperationAccepted(),
+			existingServiceProviderCluster: newServiceProviderClusterWithSpecControlPlaneVersion("4.19"),
+			cachedHostedClusterReadDesire:  newPassingCachedHostedClusterReadDesire(),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetCluster(gomock.Any(), fixture.clusterInternalID).
+					Return(newCSClusterWithState(arohcpv1alpha1.ClusterStateError), nil)
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateFailed, op.Status)
@@ -103,34 +222,48 @@ func TestOperationClusterUpdate_SynchronizeOperation(t *testing.T) {
 			},
 		},
 		{
-			name:              "cluster pending keeps operation accepted",
-			clusterState:      arohcpv1alpha1.ClusterStatePending,
-			customerVersionID: "4.19",
-			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *clusterTestFixture) {
+			name:                           "cs cluster pending keeps operation accepted",
+			existingCluster:                newClusterWithCustomerVersion("4.19"),
+			existingOperation:              newOperationAccepted(),
+			existingServiceProviderCluster: newServiceProviderClusterWithSpecControlPlaneVersion("4.19"),
+			cachedHostedClusterReadDesire:  newPassingCachedHostedClusterReadDesire(),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetCluster(gomock.Any(), fixture.clusterInternalID).
+					Return(newCSClusterWithState(arohcpv1alpha1.ClusterStatePending), nil)
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
 			},
 		},
 		{
-			name:              "customer minor mismatch with IntentFailed on ControlPlaneDesiredVersion controller marks operation failed",
-			clusterState:      arohcpv1alpha1.ClusterStateReady,
-			customerVersionID: "4.20",
-			controlPlaneDesiredVersionControllerConditions: []metav1.Condition{
+			name:                           "customer minor mismatch with IntentFailed on ControlPlaneDesiredVersion controller marks operation failed",
+			existingCluster:                newClusterWithCustomerVersion("4.20"),
+			existingOperation:              newOperationAccepted(),
+			existingServiceProviderCluster: newServiceProviderClusterWithSpecControlPlaneVersion("4.19"),
+			existingControlPlaneDesiredVersionController: newControlPlaneDesiredVersionControllerWithConditions([]metav1.Condition{
 				{
 					Type:    api.ControllerConditionTypeIntentFailed,
 					Status:  metav1.ConditionTrue,
 					Reason:  api.VersionUpgradeNotAcceptedReason,
-					Message: "no downgrades allowed",
+					Message: "example intent failed message",
 				},
+			}),
+			cachedHostedClusterReadDesire: newPassingCachedHostedClusterReadDesire(),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetCluster(gomock.Any(), fixture.clusterInternalID).
+					Return(newCSClusterWithState(arohcpv1alpha1.ClusterStateReady), nil)
 			},
-			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *clusterTestFixture) {
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateFailed, op.Status)
 				require.NotNil(t, op.Error)
 				assert.Equal(t, arm.CloudErrorCodeInvalidRequestContent, op.Error.Code)
-				assert.Contains(t, op.Error.Message, "no downgrades allowed")
+				assert.Contains(t, op.Error.Message, "example intent failed message")
 
 				cluster, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
 				require.NoError(t, err)
@@ -139,10 +272,17 @@ func TestOperationClusterUpdate_SynchronizeOperation(t *testing.T) {
 			},
 		},
 		{
-			name:              "customer minor mismatch without ControlPlaneDesiredVersion IntentFailed leaves operation accepted",
-			clusterState:      arohcpv1alpha1.ClusterStateReady,
-			customerVersionID: "4.20",
-			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *clusterTestFixture) {
+			name:                           "customer minor mismatch without ControlPlaneDesiredVersion IntentFailed leaves operation accepted",
+			existingCluster:                newClusterWithCustomerVersion("4.20"),
+			existingOperation:              newOperationAccepted(),
+			existingServiceProviderCluster: newServiceProviderClusterWithSpecControlPlaneVersion("4.19"),
+			cachedHostedClusterReadDesire:  newPassingCachedHostedClusterReadDesire(),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetCluster(gomock.Any(), fixture.clusterInternalID).
+					Return(newCSClusterWithState(arohcpv1alpha1.ClusterStateReady), nil)
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
@@ -155,11 +295,18 @@ func TestOperationClusterUpdate_SynchronizeOperation(t *testing.T) {
 			},
 		},
 		{
-			name:                    "customer minor mismatch without ControlPlaneDesiredVersion IntentFailed leaves operation accepted when first seen within 29s",
-			clusterState:            arohcpv1alpha1.ClusterStateReady,
-			customerVersionID:       "4.20",
-			seedMismatchFirstSeenAt: testClockNow.Add(-20 * time.Second),
-			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *clusterTestFixture) {
+			name:                           "customer minor mismatch without ControlPlaneDesiredVersion IntentFailed leaves operation accepted when first seen within 29s",
+			existingCluster:                newClusterWithCustomerVersion("4.20"),
+			existingOperation:              newOperationAccepted(),
+			existingServiceProviderCluster: newServiceProviderClusterWithSpecControlPlaneVersion("4.19"),
+			cachedHostedClusterReadDesire:  newPassingCachedHostedClusterReadDesire(),
+			seedMismatchFirstSeenAt:        testClockNow.Add(-20 * time.Second),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetCluster(gomock.Any(), fixture.clusterInternalID).
+					Return(newCSClusterWithState(arohcpv1alpha1.ClusterStateReady), nil)
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
@@ -172,11 +319,18 @@ func TestOperationClusterUpdate_SynchronizeOperation(t *testing.T) {
 			},
 		},
 		{
-			name:                    "customer minor mismatch without IntentFailed fails when mismatch first seen exceeds 29s",
-			clusterState:            arohcpv1alpha1.ClusterStateReady,
-			customerVersionID:       "4.20",
-			seedMismatchFirstSeenAt: testClockNow.Add(-30 * time.Second),
-			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *clusterTestFixture) {
+			name:                           "customer minor mismatch without IntentFailed fails when mismatch first seen exceeds 29s",
+			existingCluster:                newClusterWithCustomerVersion("4.20"),
+			existingOperation:              newOperationAccepted(),
+			existingServiceProviderCluster: newServiceProviderClusterWithSpecControlPlaneVersion("4.19"),
+			cachedHostedClusterReadDesire:  newPassingCachedHostedClusterReadDesire(),
+			seedMismatchFirstSeenAt:        testClockNow.Add(-30 * time.Second),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetCluster(gomock.Any(), fixture.clusterInternalID).
+					Return(newCSClusterWithState(arohcpv1alpha1.ClusterStateReady), nil)
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateFailed, op.Status)
@@ -185,89 +339,187 @@ func TestOperationClusterUpdate_SynchronizeOperation(t *testing.T) {
 
 				cluster, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
 				require.NoError(t, err)
-				wantMsg := fmt.Sprintf(
+				wantMessageSubstr := fmt.Sprintf(
 					"timed out after 29s waiting for resolution of desired version from '%s' cluster version",
 					cluster.CustomerProperties.Version.ID,
 				)
-				assert.Equal(t, wantMsg, op.Error.Message)
+				assert.Contains(t, op.Error.Message, wantMessageSubstr)
 
 				assert.Equal(t, arm.ProvisioningStateFailed, cluster.ServiceProviderProperties.ProvisioningState)
 				assert.Empty(t, cluster.ServiceProviderProperties.ActiveOperationID)
+			},
+		},
+		{
+			name: "shouldReconcile gate not passed when ClusterServiceID is nil",
+			existingCluster: newClusterWithCustomerVersion("4.19", func(cluster *api.HCPOpenShiftCluster) {
+				cluster.ServiceProviderProperties.ClusterServiceID = nil
+			}),
+			existingOperation: newOperationAccepted(),
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+			},
+		},
+		{
+			name: "shouldReconcile gate not passed when cluster is deleting",
+			existingCluster: newClusterWithCustomerVersion("4.19", func(cluster *api.HCPOpenShiftCluster) {
+				cluster.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: testClockNow}
+			}),
+			existingOperation: newOperationAccepted(),
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+			},
+		},
+		{
+			name:              "cluster not in lister cache leaves operation unchanged",
+			existingCluster:   newClusterWithCustomerVersion("4.19"),
+			existingOperation: newOperationAccepted(),
+			clusterLister:     &listertesting.SliceClusterLister{},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+
+				cluster, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
+				require.NoError(t, err)
+				assert.Equal(t, testOperationName, cluster.ServiceProviderProperties.ActiveOperationID)
+				assert.Empty(t, cluster.ServiceProviderProperties.ProvisioningState)
+			},
+		},
+		{
+			name: "cs cluster ready with node drain spec mismatch keeps operation updating",
+			existingCluster: newClusterWithCustomerVersion("4.19", func(cluster *api.HCPOpenShiftCluster) {
+				cluster.CustomerProperties.NodeDrainTimeoutMinutes = 60
+			}),
+			existingOperation:              newOperationAccepted(),
+			existingServiceProviderCluster: newServiceProviderClusterWithSpecControlPlaneVersion("4.19"),
+			cachedHostedClusterReadDesire:  newPassingCachedHostedClusterReadDesire(),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetCluster(gomock.Any(), fixture.clusterInternalID).
+					Return(newCSClusterReadyWithNodeDrainMinutes(30), nil)
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateUpdating, op.Status)
+				assert.Nil(t, op.Error)
+
+				cluster, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateUpdating, cluster.ServiceProviderProperties.ProvisioningState)
+				assert.Equal(t, testOperationName, cluster.ServiceProviderProperties.ActiveOperationID)
+			},
+		},
+		{
+			name: "cs cluster ready with hypershift autoscaling spec mismatch keeps operation updating",
+			existingCluster: newClusterWithCustomerVersion("4.19", func(cluster *api.HCPOpenShiftCluster) {
+				cluster.CustomerProperties.Autoscaling.MaxNodesTotal = 10
+			}),
+			existingOperation:              newOperationAccepted(),
+			existingServiceProviderCluster: newServiceProviderClusterWithSpecControlPlaneVersion("4.19"),
+			cachedHostedClusterReadDesire: newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+				Spec: func() v1beta1.HostedClusterSpec {
+					spec := testClusterUpdateMatchingHostedClusterSpec()
+					spec.Autoscaling.MaxNodesTotal = ptr.To[int32](5)
+					return spec
+				}(),
+			}),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
+					GetCluster(gomock.Any(), fixture.clusterInternalID).
+					Return(newCSClusterWithState(arohcpv1alpha1.ClusterStateReady), nil)
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateUpdating, op.Status)
+				assert.Nil(t, op.Error)
+
+				cluster, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateUpdating, cluster.ServiceProviderProperties.ProvisioningState)
+				assert.Equal(t, testOperationName, cluster.ServiceProviderProperties.ActiveOperationID)
 			},
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			ctx := context.Background()
-			ctx = utils.ContextWithLogger(ctx, testr.New(t))
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
 			ctrl := gomock.NewController(t)
 
-			fixture := newClusterTestFixture()
-			cluster := fixture.newCluster(nil)
-			cluster.CustomerProperties.Version.ID = tt.customerVersionID
-			operation := fixture.newOperation(database.OperationRequestUpdate)
+			resources := []any{}
+			if tc.existingCluster != nil {
+				resources = append(resources, tc.existingCluster)
+			}
+			if tc.existingOperation != nil {
+				resources = append(resources, tc.existingOperation)
+			}
+			if tc.existingServiceProviderCluster != nil {
+				resources = append(resources, tc.existingServiceProviderCluster)
+			}
+			if tc.existingControlPlaneDesiredVersionController != nil {
+				resources = append(resources, tc.existingControlPlaneDesiredVersionController)
+			}
 
-			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, []any{cluster, operation})
-			require.NoError(t, err)
-			resourceId := api.Must(azcorearm.ParseResourceID(fmt.Sprintf("%s/%s/%s",
-				fixture.clusterResourceID.String(),
-				api.ServiceProviderClusterResourceTypeName,
-				api.ServiceProviderClusterResourceName,
-			)))
-
-			_, err = mockResourcesDBClient.ServiceProviderClusters(testSubscriptionID, testResourceGroupName, testClusterName).Create(ctx, &api.ServiceProviderCluster{
-				CosmosMetadata: api.CosmosMetadata{ResourceID: resourceId, PartitionKey: strings.ToLower(resourceId.SubscriptionID)},
-				Spec: api.ServiceProviderClusterSpec{
-					ControlPlaneVersion: api.ServiceProviderClusterSpecVersion{
-						DesiredVersion: ptr.To(semver.MustParse("4.19.0")),
-					},
-				},
-				Status: api.ServiceProviderClusterStatus{
-					Conditions: tt.serviceProviderClusterStatusConditions,
-				},
-			}, nil)
+			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, resources)
 			require.NoError(t, err)
 
-			rid := api.Must(azcorearm.ParseResourceID(
-				fixture.clusterResourceID.String() + "/hcpOpenShiftControllers/ControlPlaneDesiredVersion",
-			))
-			_, err = mockResourcesDBClient.HCPClusters(testSubscriptionID, testResourceGroupName).Controllers(testClusterName).Create(ctx, &api.Controller{
-				CosmosMetadata: api.CosmosMetadata{ResourceID: rid, PartitionKey: strings.ToLower(rid.SubscriptionID)},
-				ExternalID:     fixture.clusterResourceID,
-				Status: api.ControllerStatus{
-					Conditions: tt.controlPlaneDesiredVersionControllerConditions,
-				},
-			}, nil)
-			require.NoError(t, err)
+			var readDesireLister dblisters.ReadDesireLister
+			if tc.cachedHostedClusterReadDesire != nil {
+				readDesireLister = &internallistertesting.SliceReadDesireLister{
+					Desires: []*kubeapplier.ReadDesire{tc.cachedHostedClusterReadDesire},
+				}
+			}
+
+			clusterLister := tc.clusterLister
+			if clusterLister == nil {
+				clusterLister = &listertesting.DBClusterLister{ResourcesDBClient: mockResourcesDBClient}
+			}
+			activeOperationsLister := tc.activeOperationsLister
+			if activeOperationsLister == nil {
+				activeOperationsLister = &listertesting.DBActiveOperationLister{ResourcesDBClient: mockResourcesDBClient}
+			}
+			serviceProviderClusterLister := tc.serviceProviderClusterLister
+			if serviceProviderClusterLister == nil {
+				serviceProviderClusterLister = &listertesting.DBServiceProviderClusterLister{ResourcesDBClient: mockResourcesDBClient}
+			}
 
 			mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
-			clusterStatus, err := arohcpv1alpha1.NewClusterStatus().
-				State(tt.clusterState).
-				Build()
-			require.NoError(t, err)
-			mockCSClient.EXPECT().
-				GetClusterStatus(gomock.Any(), fixture.clusterInternalID).
-				Return(clusterStatus, nil)
+			if tc.setupMockCSClient != nil {
+				tc.setupMockCSClient(mockCSClient)
+			}
 
 			fakeClock := clocktesting.NewFakeClock(testClockNow)
 			controller := &operationClusterUpdate{
 				resourcesDBClient:               mockResourcesDBClient,
 				clusterServiceClient:            mockCSClient,
+				clusterLister:                   clusterLister,
+				activeOperationsLister:          activeOperationsLister,
+				serviceProviderClusterLister:    serviceProviderClusterLister,
+				readDesireLister:                readDesireLister,
 				notificationClient:              nil,
 				clock:                           fakeClock,
 				desiredVersionMismatchFirstSeen: lru.New(100000),
 			}
-			if !tt.seedMismatchFirstSeenAt.IsZero() {
-				controller.desiredVersionMismatchFirstSeen.Add(operation.ResourceID.String(), tt.seedMismatchFirstSeenAt)
+			if !tc.seedMismatchFirstSeenAt.IsZero() {
+				require.NotNil(t, tc.existingOperation)
+				controller.desiredVersionMismatchFirstSeen.Add(tc.existingOperation.ResourceID.String(), tc.seedMismatchFirstSeenAt)
 			}
 
 			err = controller.SynchronizeOperation(ctx, fixture.operationKey())
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
 			require.NoError(t, err)
 
-			if tt.verify != nil {
-				tt.verify(t, ctx, mockResourcesDBClient, fixture)
+			if tc.verifyDB != nil {
+				tc.verifyDB(t, ctx, mockResourcesDBClient)
 			}
 		})
 	}

--- a/backend/pkg/controllers/operationcontrollers/operation_external_auth_create.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_external_auth_create.go
@@ -142,18 +142,18 @@ func (c *operationExternalAuthCreate) SynchronizeOperation(ctx context.Context, 
 	}
 
 	var persistErr *arm.CloudErrorBody
-	if operationalState.provisioningState == arm.ProvisioningStateFailed {
+	if operationalState.ProvisioningState == arm.ProvisioningStateFailed {
 		persistErr = &arm.CloudErrorBody{
 			// TODO for now we always set the error code to InternalServerError, but we should improve to be able
 			// to be more specific than that when we calculate operationalState. When work is done to improve on this, we
 			// should design it in a way where no internal details are exposed to the operation's error.
 			Code:    arm.CloudErrorCodeInternalServerError,
-			Message: operationalState.message,
+			Message: operationalState.Message,
 		}
 	}
 
 	logger.Info("updating status")
-	err = UpdateOperationStatus(ctx, c.clock, c.resourcesDBClient, operation, operationalState.provisioningState, persistErr, postAsyncNotificationFn(c.notificationClient))
+	err = UpdateOperationStatus(ctx, c.clock, c.resourcesDBClient, operation, operationalState.ProvisioningState, persistErr, postAsyncNotificationFn(c.notificationClient))
 	if database.IsPreconditionFailedError(err) {
 		// if we have a conflict error, then we're guaranteed that our informer will eventually see an update and trigger us again.
 		return nil
@@ -178,7 +178,7 @@ func (c *operationExternalAuthCreate) determineOperationState(ctx context.Contex
 	if state, err := c.externalAuthClusterServiceCreateOperationState(ctx, externalAuth); err != nil {
 		errs = append(errs, utils.TrackError(err))
 	} else {
-		operationStates = append(operationStates, state)
+		operationStates = append(operationStates, state.withSource("externalAuthClusterServiceCreate"))
 	}
 
 	if err := errors.Join(errs...); err != nil {
@@ -196,7 +196,7 @@ func (c *operationExternalAuthCreate) determineOperationState(ctx context.Contex
 	if err != nil {
 		return nil, utils.TrackError(err)
 	}
-	logger.Info("picked external auth create operation status", "provisioningState", picked.provisioningState, "message", picked.message)
+	logger.Info("picked external auth create operation status", "provisioningState", picked.ProvisioningState, "message", picked.Message)
 	return picked, nil
 }
 

--- a/backend/pkg/controllers/operationcontrollers/operation_external_auth_update.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_external_auth_update.go
@@ -16,8 +16,10 @@ package operationcontrollers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -25,17 +27,24 @@ import (
 	utilsclock "k8s.io/utils/clock"
 
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
 	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/database"
+	dblisters "github.com/Azure/ARO-HCP/internal/database/listers"
 	"github.com/Azure/ARO-HCP/internal/ocm"
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
 
 type operationExternalAuthUpdate struct {
-	clock                utilsclock.PassiveClock
-	resourcesDBClient    database.ResourcesDBClient
-	clusterServiceClient ocm.ClusterServiceClientSpec
-	notificationClient   *http.Client
+	clock                  utilsclock.PassiveClock
+	resourcesDBClient      database.ResourcesDBClient
+	clusterServiceClient   ocm.ClusterServiceClientSpec
+	externalAuthLister     listers.ExternalAuthLister
+	readDesireLister       dblisters.ReadDesireLister
+	activeOperationsLister listers.ActiveOperationLister
+	notificationClient     *http.Client
 }
 
 // NewOperationExternalAuthUpdateController returns a new Controller instance that
@@ -56,14 +65,22 @@ func NewOperationExternalAuthUpdateController(
 	clock utilsclock.PassiveClock,
 	resourcesDBClient database.ResourcesDBClient,
 	clusterServiceClient ocm.ClusterServiceClientSpec,
+	readDesireLister dblisters.ReadDesireLister,
 	notificationClient *http.Client,
 	activeOperationInformer cache.SharedIndexInformer,
+	backendInformers informers.BackendInformers,
 ) controllerutils.Controller {
+	_, externalAuthLister := backendInformers.ExternalAuths()
+	_, activeOperationsLister := backendInformers.ActiveOperations()
+
 	syncer := &operationExternalAuthUpdate{
-		clock:                clock,
-		resourcesDBClient:    resourcesDBClient,
-		clusterServiceClient: clusterServiceClient,
-		notificationClient:   notificationClient,
+		clock:                  clock,
+		resourcesDBClient:      resourcesDBClient,
+		clusterServiceClient:   clusterServiceClient,
+		externalAuthLister:     externalAuthLister,
+		readDesireLister:       readDesireLister,
+		activeOperationsLister: activeOperationsLister,
+		notificationClient:     notificationClient,
 	}
 
 	controller := NewGenericOperationController(
@@ -90,11 +107,16 @@ func (c *operationExternalAuthUpdate) ShouldProcess(ctx context.Context, operati
 	return true
 }
 
+func (c *operationExternalAuthUpdate) shouldReconcileOperationAndResourceStatus(ea *api.HCPOpenShiftClusterExternalAuth) bool {
+	return ea.ServiceProviderProperties.DeletionTimestamp == nil &&
+		ea.ServiceProviderProperties.ClusterServiceID != nil
+}
+
 func (c *operationExternalAuthUpdate) SynchronizeOperation(ctx context.Context, key controllerutils.OperationKey) error {
 	logger := utils.LoggerFromContext(ctx)
 	logger.Info("checking operation")
 
-	operation, err := c.resourcesDBClient.Operations(key.SubscriptionID).Get(ctx, key.OperationName)
+	operation, err := c.activeOperationsLister.Get(ctx, key.SubscriptionID, key.OperationName)
 	if database.IsNotFoundError(err) {
 		return nil // no work to do
 	}
@@ -105,5 +127,88 @@ func (c *operationExternalAuthUpdate) SynchronizeOperation(ctx context.Context, 
 		return nil // no work to do
 	}
 
-	return pollExternalAuthStatus(ctx, c.clock, c.resourcesDBClient, c.clusterServiceClient, operation, c.notificationClient)
+	existingExternalAuth, err := c.externalAuthLister.Get(ctx, operation.ExternalID.SubscriptionID, operation.ExternalID.ResourceGroupName, operation.ExternalID.Parent.Name, operation.ExternalID.Name)
+	if database.IsNotFoundError(err) {
+		logger.Info("external auth not found in cache, waiting")
+		return nil // no work to do
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get external auth: %w", err))
+	}
+
+	if operation.ResourceID.Name != existingExternalAuth.ServiceProviderProperties.ActiveOperationID {
+		logger.Info("external auth active operation id mismatch, returning early", "synchronizedActiveOperationID", operation.ResourceID.Name, "externalAuthActiveOperationID", existingExternalAuth.ServiceProviderProperties.ActiveOperationID)
+		return nil
+	}
+
+	if !c.shouldReconcileOperationAndResourceStatus(existingExternalAuth) {
+		return nil // no work to do
+	}
+
+	operationalState, err := c.determineOperationState(ctx, existingExternalAuth)
+	if err != nil {
+		return utils.TrackError(err)
+	}
+
+	var persistErr *arm.CloudErrorBody
+	if operationalState.ProvisioningState == arm.ProvisioningStateFailed {
+		persistErr = &arm.CloudErrorBody{
+			Code:    arm.CloudErrorCodeInvalidRequestContent,
+			Message: operationalState.Message,
+		}
+	}
+
+	logger.Info("updating status")
+	err = UpdateOperationStatus(ctx, c.clock, c.resourcesDBClient, operation, operationalState.ProvisioningState, persistErr, postAsyncNotificationFn(c.notificationClient))
+	if database.IsPreconditionFailedError(err) {
+		// if we have a conflict error, then we're guaranteed that our informer will eventually see an update and trigger us again.
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(err)
+	}
+	return nil
+}
+
+func (c *operationExternalAuthUpdate) determineOperationState(ctx context.Context, existingExternalAuth *api.HCPOpenShiftClusterExternalAuth) (*operationState, error) {
+	logger := utils.LoggerFromContext(ctx)
+
+	externalAuthCSID := existingExternalAuth.ServiceProviderProperties.ClusterServiceID
+	csExternalAuth, err := c.clusterServiceClient.GetExternalAuth(ctx, *externalAuthCSID)
+	if err != nil {
+		return nil, utils.TrackError(fmt.Errorf("failed to get external auth from cluster service: %w", err))
+	}
+
+	errs := []error{}
+	operationStates := []*operationState{}
+
+	if operationState, csErr := c.clusterServiceExternalAuthSpecOperationState(existingExternalAuth, csExternalAuth); csErr != nil {
+		errs = append(errs, utils.TrackError(csErr))
+	} else {
+		operationStates = append(operationStates, operationState.withSource("clusterServiceExternalAuthSpec"))
+	}
+
+	if operationState, hsErr := c.hypershiftHostedClusterExternalAuthOperationState(ctx, existingExternalAuth); hsErr != nil {
+		errs = append(errs, utils.TrackError(hsErr))
+	} else {
+		operationStates = append(operationStates, operationState.withSource("hypershiftHostedClusterExternalAuth"))
+	}
+
+	if err := errors.Join(errs...); err != nil {
+		return nil, err
+	}
+	if len(operationStates) == 0 {
+		return nil, errors.New("no operation states")
+	}
+	slices.SortStableFunc(operationStates, compareOperationState)
+	if operationStates[0] == nil {
+		return nil, errors.New("nil operation state")
+	}
+	logger.Info("determined external auth update operation status", "operationStates", operationStates)
+	picked, err := pickWorstOperationState(operationStates)
+	if err != nil {
+		return nil, utils.TrackError(err)
+	}
+	logger.Info("picked external auth update operation status", "picked", picked)
+	return picked, nil
 }

--- a/backend/pkg/controllers/operationcontrollers/operation_external_auth_update_state_calculation.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_external_auth_update_state_calculation.go
@@ -1,0 +1,319 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operationcontrollers
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/maestrohelpers"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// External auth update operation state calculation for the external auth update operation controller.
+
+// hypershiftHostedClusterExternalAuthOperationState contains the external auth update operation state calculation
+// comparing desired state against Hypershift's HostedCluster in the management cluster.
+func (c *operationExternalAuthUpdate) hypershiftHostedClusterExternalAuthOperationState(ctx context.Context, externalAuth *api.HCPOpenShiftClusterExternalAuth) (*operationState, error) {
+	hostedCluster, err := maestrohelpers.GetCachedHostedClusterForCluster(
+		ctx,
+		c.readDesireLister,
+		externalAuth.ID.SubscriptionID,
+		externalAuth.ID.ResourceGroupName,
+		externalAuth.ID.Parent.Name,
+	)
+	if err != nil {
+		return nil, utils.TrackError(err)
+	}
+	if hostedCluster == nil {
+		return newOperationState(arm.ProvisioningStateUpdating, "Hypershift HostedCluster has not been observed yet"), nil
+	}
+
+	if matches, message := c.hypershiftHostedClusterExternalAuthSpecMatchesDesired(externalAuth, hostedCluster); !matches {
+		return newOperationState(arm.ProvisioningStateUpdating, message), nil
+	}
+
+	// TODO compare with Hypershift HostedCluster relevant parts of status.configuration.authentication when possible.
+	// At the moment of writing this (2026-06-29) the status.configuration.authentication is only available on
+	// HostedClusters >= 4.21.
+
+	return newOperationState(arm.ProvisioningStateSucceeded, ""), nil
+}
+
+// hypershiftHostedClusterExternalAuthSpecMatchesDesired reports whether Hypershift HostedCluster .Spec fields
+// and other non status configuration matches desired external auth state. Returns false and a diagnostic message
+// when any leaf check fails. HostedCluster .status is not checked here.
+func (c *operationExternalAuthUpdate) hypershiftHostedClusterExternalAuthSpecMatchesDesired(externalAuth *api.HCPOpenShiftClusterExternalAuth, hostedCluster *v1beta1.HostedCluster) (bool, string) {
+	if hostedCluster.Spec.Configuration == nil ||
+		hostedCluster.Spec.Configuration.Authentication == nil ||
+		len(hostedCluster.Spec.Configuration.Authentication.OIDCProviders) == 0 {
+		return false, "Hypershift HostedCluster has no OIDCProviders configured"
+	}
+
+	// We lowercase the external auth name to match the HostedCluster OIDCProvider name, because
+	// we create the external auth in CS with its name in lowercase.
+	expectedName := strings.ToLower(externalAuth.Name)
+	var observedProvider *configv1.OIDCProvider
+	for i := range hostedCluster.Spec.Configuration.Authentication.OIDCProviders {
+		if strings.EqualFold(hostedCluster.Spec.Configuration.Authentication.OIDCProviders[i].Name, expectedName) {
+			observedProvider = &hostedCluster.Spec.Configuration.Authentication.OIDCProviders[i]
+			break
+		}
+	}
+	if observedProvider == nil {
+		return false, fmt.Sprintf("Hypershift HostedCluster OIDCProvider %q not found", expectedName)
+	}
+
+	if matches, message := c.hypershiftHostedClusterExternalAuthIssuerSpecMatchesDesired(externalAuth.Properties.Issuer, *observedProvider); !matches {
+		return false, message
+	}
+	if matches, message := c.hypershiftHostedClusterExternalAuthClientsSpecMatchesDesired(externalAuth.Properties.Clients, observedProvider.OIDCClients); !matches {
+		return false, message
+	}
+	if matches, message := c.hypershiftHostedClusterExternalAuthClaimMappingsSpecMatchesDesired(externalAuth.Properties.Claim, *observedProvider); !matches {
+		return false, message
+	}
+
+	return true, ""
+}
+
+// hypershiftHostedClusterExternalAuthIssuerSpecMatchesDesired reports whether HostedCluster OIDCProvider issuer
+// configuration matches desired external auth issuer profile.
+func (c *operationExternalAuthUpdate) hypershiftHostedClusterExternalAuthIssuerSpecMatchesDesired(desired api.TokenIssuerProfile, observed configv1.OIDCProvider) (bool, string) {
+	if desired.URL != observed.Issuer.URL {
+		return false, fmt.Sprintf(
+			"hypershift HostedCluster OIDCProvider issuer URL is %q, want %q",
+			observed.Issuer.URL, desired.URL,
+		)
+	}
+
+	desiredAudiences := desired.Audiences
+	observedAudiences := make([]string, len(observed.Issuer.Audiences))
+	for i, a := range observed.Issuer.Audiences {
+		observedAudiences[i] = string(a)
+	}
+	if !slices.Equal(desiredAudiences, observedAudiences) {
+		return false, fmt.Sprintf(
+			"hypershift HostedCluster OIDCProvider issuer audiences is %v, want %v",
+			observedAudiences, desiredAudiences,
+		)
+	}
+
+	return true, ""
+}
+
+// hypershiftHostedClusterExternalAuthClientsSpecMatchesDesired reports whether HostedCluster OIDCProvider clients
+// match desired external auth client profiles.
+func (c *operationExternalAuthUpdate) hypershiftHostedClusterExternalAuthClientsSpecMatchesDesired(desired []api.ExternalAuthClientProfile, observed []configv1.OIDCClientConfig) (bool, string) {
+	if len(desired) != len(observed) {
+		return false, fmt.Sprintf(
+			"hypershift HostedCluster OIDCProvider has %d clients, want %d",
+			len(observed), len(desired),
+		)
+	}
+
+	for i := range desired {
+		desiredExternalAuthClientProfile := desired[i]
+		observedOIDCClientConfig := observed[i]
+
+		if desiredExternalAuthClientProfile.ClientID != observedOIDCClientConfig.ClientID {
+			return false, fmt.Sprintf(
+				"hypershift HostedCluster OIDCProvider client[%d] clientID is %q, want %q",
+				i, observedOIDCClientConfig.ClientID, desiredExternalAuthClientProfile.ClientID,
+			)
+		}
+		if desiredExternalAuthClientProfile.Component.Name != observedOIDCClientConfig.ComponentName {
+			return false, fmt.Sprintf(
+				"hypershift HostedCluster OIDCProvider client %q componentName is %q, want %q",
+				desiredExternalAuthClientProfile.ClientID, observedOIDCClientConfig.ComponentName, desiredExternalAuthClientProfile.Component.Name,
+			)
+		}
+		if desiredExternalAuthClientProfile.Component.AuthClientNamespace != observedOIDCClientConfig.ComponentNamespace {
+			return false, fmt.Sprintf(
+				"hypershift HostedCluster OIDCProvider client %q componentNamespace is %q, want %q",
+				desiredExternalAuthClientProfile.ClientID, observedOIDCClientConfig.ComponentNamespace, desiredExternalAuthClientProfile.Component.AuthClientNamespace,
+			)
+		}
+		if !slices.Equal(desiredExternalAuthClientProfile.ExtraScopes, observedOIDCClientConfig.ExtraScopes) {
+			return false, fmt.Sprintf(
+				"hypershift HostedCluster OIDCProvider client %q extraScopes is %v, want %v",
+				desiredExternalAuthClientProfile.ClientID, observedOIDCClientConfig.ExtraScopes, desiredExternalAuthClientProfile.ExtraScopes,
+			)
+		}
+	}
+
+	return true, ""
+}
+
+// hypershiftHostedClusterExternalAuthClaimMappingsSpecMatchesDesired reports whether HostedCluster OIDCProvider
+// claim mappings match desired external auth claim profile.
+func (c *operationExternalAuthUpdate) hypershiftHostedClusterExternalAuthClaimMappingsSpecMatchesDesired(desired api.ExternalAuthClaimProfile, observed configv1.OIDCProvider) (bool, string) {
+	if desired.Mappings.Username.Claim != observed.ClaimMappings.Username.Claim {
+		return false, fmt.Sprintf(
+			"hypershift HostedCluster OIDCProvider username claim is %q, want %q",
+			observed.ClaimMappings.Username.Claim, desired.Mappings.Username.Claim,
+		)
+	}
+
+	var expectedPrefixPolicy configv1.UsernamePrefixPolicy
+	switch desired.Mappings.Username.PrefixPolicy {
+	case api.UsernameClaimPrefixPolicyPrefix:
+		expectedPrefixPolicy = configv1.Prefix
+	case api.UsernameClaimPrefixPolicyNoPrefix:
+		expectedPrefixPolicy = configv1.NoPrefix
+	case api.UsernameClaimPrefixPolicyNone:
+		expectedPrefixPolicy = configv1.NoOpinion
+	}
+	if observed.ClaimMappings.Username.PrefixPolicy != expectedPrefixPolicy {
+		return false, fmt.Sprintf(
+			"hypershift HostedCluster OIDCProvider username prefixPolicy is %q, want %q",
+			observed.ClaimMappings.Username.PrefixPolicy, expectedPrefixPolicy,
+		)
+	}
+
+	expectedUsernamePrefix := ""
+	if desired.Mappings.Username.PrefixPolicy == api.UsernameClaimPrefixPolicyPrefix {
+		expectedUsernamePrefix = desired.Mappings.Username.Prefix
+	}
+	observedUsernamePrefix := ""
+	if observed.ClaimMappings.Username.Prefix != nil {
+		observedUsernamePrefix = observed.ClaimMappings.Username.Prefix.PrefixString
+	}
+	if observedUsernamePrefix != expectedUsernamePrefix {
+		return false, fmt.Sprintf(
+			"hypershift HostedCluster OIDCProvider username prefix is %q, want %q",
+			observedUsernamePrefix, expectedUsernamePrefix,
+		)
+	}
+
+	if desired.Mappings.Groups != nil {
+		if observed.ClaimMappings.Groups.Claim != desired.Mappings.Groups.Claim {
+			return false, fmt.Sprintf(
+				"hypershift HostedCluster OIDCProvider groups claim is %q, want %q",
+				observed.ClaimMappings.Groups.Claim, desired.Mappings.Groups.Claim,
+			)
+		}
+		if observed.ClaimMappings.Groups.Prefix != desired.Mappings.Groups.Prefix {
+			return false, fmt.Sprintf(
+				"hypershift HostedCluster OIDCProvider groups prefix is %q, want %q",
+				observed.ClaimMappings.Groups.Prefix, desired.Mappings.Groups.Prefix,
+			)
+		}
+	} else if observed.ClaimMappings.Groups.Claim != "" || observed.ClaimMappings.Groups.Prefix != "" {
+		return false, fmt.Sprintf(
+			"hypershift HostedCluster OIDCProvider has groups claim %q prefix %q, want no groups",
+			observed.ClaimMappings.Groups.Claim, observed.ClaimMappings.Groups.Prefix,
+		)
+	}
+
+	if matches, message := c.hypershiftHostedClusterExternalAuthValidationRulesSpecMatchesDesired(desired.ValidationRules, observed.ClaimValidationRules); !matches {
+		return false, message
+	}
+
+	return true, ""
+}
+
+// hypershiftHostedClusterExternalAuthValidationRulesSpecMatchesDesired reports whether HostedCluster OIDCProvider
+// validation rules match desired external auth validation rules.
+func (c *operationExternalAuthUpdate) hypershiftHostedClusterExternalAuthValidationRulesSpecMatchesDesired(desired []api.TokenClaimValidationRule, observed []configv1.TokenClaimValidationRule) (bool, string) {
+	if len(desired) != len(observed) {
+		return false, fmt.Sprintf(
+			"hypershift HostedCluster OIDCProvider has %d validation rules, want %d",
+			len(observed), len(desired),
+		)
+	}
+
+	for i := range desired {
+		desiredRule := desired[i]
+		observedRule := observed[i]
+
+		switch desiredRule.Type {
+		case api.TokenValidationRuleTypeRequiredClaim:
+			if observedRule.Type != configv1.TokenValidationRuleTypeRequiredClaim {
+				return false, fmt.Sprintf(
+					"hypershift HostedCluster OIDCProvider validation rule[%d] type is %q, want %q",
+					i, observedRule.Type, configv1.TokenValidationRuleTypeRequiredClaim,
+				)
+			}
+			if observedRule.RequiredClaim == nil {
+				return false, fmt.Sprintf(
+					"hypershift HostedCluster OIDCProvider validation rule[%d] has nil requiredClaim but expects a requiredClaim",
+					i,
+				)
+			}
+			if desiredRule.RequiredClaim.Claim != observedRule.RequiredClaim.Claim {
+				return false, fmt.Sprintf(
+					"hypershift HostedCluster OIDCProvider validation rule[%d] claim is %q, want %q",
+					i, observedRule.RequiredClaim.Claim, desiredRule.RequiredClaim.Claim,
+				)
+			}
+			if desiredRule.RequiredClaim.RequiredValue != observedRule.RequiredClaim.RequiredValue {
+				return false, fmt.Sprintf(
+					"hypershift HostedCluster OIDCProvider validation rule[%d] requiredValue is %q, want %q",
+					i, observedRule.RequiredClaim.RequiredValue, desiredRule.RequiredClaim.RequiredValue,
+				)
+			}
+		default:
+			return false, fmt.Sprintf(
+				"hypershift HostedCluster OIDCProvider validation rule[%d] has unsupported desired type %q",
+				i, desiredRule.Type,
+			)
+		}
+	}
+
+	return true, ""
+}
+
+// clusterServiceExternalAuthSpecOperationState reports whether Cluster Service external auth spec fields
+// match desired state intent for the external auth update operation. Only checks outside CS .status.
+func (c *operationExternalAuthUpdate) clusterServiceExternalAuthSpecOperationState(externalAuth *api.HCPOpenShiftClusterExternalAuth, csExternalAuth *arohcpv1alpha1.ExternalAuth) (*operationState, error) {
+	if matches, message, err := c.clusterServiceExternalAuthSpecMatchesDesired(externalAuth, csExternalAuth); err != nil {
+		return nil, err
+	} else if !matches {
+		return newOperationState(arm.ProvisioningStateUpdating, message), nil
+	}
+	return newOperationState(arm.ProvisioningStateSucceeded, ""), nil
+}
+
+// clusterServiceExternalAuthSpecMatchesDesired reports whether Cluster Service external auth spec fields
+// relevant to the external auth update operation match desired state. Returns false and a diagnostic
+// message when any leaf check fails.
+func (c *operationExternalAuthUpdate) clusterServiceExternalAuthSpecMatchesDesired(externalAuth *api.HCPOpenShiftClusterExternalAuth, csExternalAuth *arohcpv1alpha1.ExternalAuth) (bool, string, error) {
+	desiredJSON, err := ocm.ExternalAuthUpdateDispatchConfigJSONFromRP(externalAuth)
+	if err != nil {
+		return false, "", err
+	}
+	observedJSON, err := ocm.ExternalAuthUpdateDispatchConfigJSONFromCS(csExternalAuth)
+	if err != nil {
+		return false, "", err
+	}
+	// We check if the desired config coming from cosmos differs from the actual config coming from cluster service.
+	// Comparison uses canonical JSON (sorted object keys at every level) so we can compare them
+	// using direct string equality.
+	if desiredJSON == observedJSON {
+		return true, "", nil
+	}
+
+	return false, fmt.Sprintf("Cluster Service external auth spec does not match desired: desired=%s, actual=%s", desiredJSON, observedJSON), nil
+}

--- a/backend/pkg/controllers/operationcontrollers/operation_external_auth_update_state_calculation_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_external_auth_update_state_calculation_test.go
@@ -1,0 +1,724 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operationcontrollers
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/api/kubeapplier"
+	internallistertesting "github.com/Azure/ARO-HCP/internal/database/listertesting"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+func TestHypershiftHostedClusterExternalAuthOperationState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		externalAuth      *api.HCPOpenShiftClusterExternalAuth
+		readDesires       []*kubeapplier.ReadDesire
+		wantState         arm.ProvisioningState
+		wantMessageSubstr string
+	}{
+		{
+			name:              "no ReadDesire returns Updating",
+			externalAuth:      newExternalAuthUpdateTestExternalAuth(),
+			readDesires:       nil,
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: "Hypershift HostedCluster has not been observed yet",
+		},
+		{
+			name:         "matching external auth returns Succeeded",
+			externalAuth: newExternalAuthUpdateTestExternalAuth(),
+			readDesires: []*kubeapplier.ReadDesire{
+				newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+					Spec: testExternalAuthUpdateMatchingHostedClusterSpec(),
+				}),
+			},
+			wantState: arm.ProvisioningStateSucceeded,
+		},
+		{
+			name:         "oidc provider name match is case insensitive",
+			externalAuth: newExternalAuthUpdateTestExternalAuth(),
+			readDesires: []*kubeapplier.ReadDesire{
+				newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+					Spec: func() v1beta1.HostedClusterSpec {
+						spec := testExternalAuthUpdateMatchingHostedClusterSpec()
+						provider := testExternalAuthUpdateMatchingOIDCProvider()
+						provider.Name = strings.ToUpper(testExternalAuthName)
+						spec.Configuration.Authentication.OIDCProviders = []configv1.OIDCProvider{provider}
+						return spec
+					}(),
+				}),
+			},
+			wantState: arm.ProvisioningStateSucceeded,
+		},
+		{
+			name:         "missing OIDC providers returns Updating",
+			externalAuth: newExternalAuthUpdateTestExternalAuth(),
+			readDesires: []*kubeapplier.ReadDesire{
+				newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+					Spec: v1beta1.HostedClusterSpec{
+						Configuration: &v1beta1.ClusterConfiguration{
+							Authentication: &configv1.AuthenticationSpec{},
+						},
+					},
+				}),
+			},
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: "Hypershift HostedCluster has no OIDCProviders configured",
+		},
+		{
+			name:         "OIDC provider not found returns Updating",
+			externalAuth: newExternalAuthUpdateTestExternalAuth(),
+			readDesires: []*kubeapplier.ReadDesire{
+				newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+					Spec: func() v1beta1.HostedClusterSpec {
+						spec := testExternalAuthUpdateMatchingHostedClusterSpec()
+						provider := testExternalAuthUpdateMatchingOIDCProvider()
+						provider.Name = "other-provider"
+						spec.Configuration.Authentication.OIDCProviders = []configv1.OIDCProvider{provider}
+						return spec
+					}(),
+				}),
+			},
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: `OIDCProvider "test-external-auth" not found`,
+		},
+		{
+			name: "issuer URL mismatch returns Updating",
+			externalAuth: newExternalAuthUpdateTestExternalAuth(func(ea *api.HCPOpenShiftClusterExternalAuth) {
+				ea.Properties.Issuer.URL = "https://changed.example.com"
+			}),
+			readDesires: []*kubeapplier.ReadDesire{
+				newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+					Spec: testExternalAuthUpdateMatchingHostedClusterSpec(),
+				}),
+			},
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: `issuer URL is "https://issuer.example.com", want "https://changed.example.com"`,
+		},
+		{
+			name: "client count mismatch returns Updating",
+			externalAuth: newExternalAuthUpdateTestExternalAuth(func(ea *api.HCPOpenShiftClusterExternalAuth) {
+				ea.Properties.Clients = append(ea.Properties.Clients, api.ExternalAuthClientProfile{
+					Component: api.ExternalAuthClientComponentProfile{
+						Name:                "oauth",
+						AuthClientNamespace: "openshift-authentication",
+					},
+					ClientID: "client-id-2",
+				})
+			}),
+			readDesires: []*kubeapplier.ReadDesire{
+				newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+					Spec: testExternalAuthUpdateMatchingHostedClusterSpec(),
+				}),
+			},
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: "has 1 clients, want 2",
+		},
+		{
+			name: "username claim mismatch returns Updating",
+			externalAuth: newExternalAuthUpdateTestExternalAuth(func(ea *api.HCPOpenShiftClusterExternalAuth) {
+				ea.Properties.Claim.Mappings.Username.Claim = "sub"
+			}),
+			readDesires: []*kubeapplier.ReadDesire{
+				newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+					Spec: testExternalAuthUpdateMatchingHostedClusterSpec(),
+				}),
+			},
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: `username claim is "email", want "sub"`,
+		},
+		{
+			name: "validation rule mismatch returns Updating",
+			externalAuth: newExternalAuthUpdateTestExternalAuth(func(ea *api.HCPOpenShiftClusterExternalAuth) {
+				ea.Properties.Claim.ValidationRules[0].RequiredClaim.RequiredValue = "other.example.com"
+			}),
+			readDesires: []*kubeapplier.ReadDesire{
+				newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+					Spec: testExternalAuthUpdateMatchingHostedClusterSpec(),
+				}),
+			},
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: `requiredValue is "example.com", want "other.example.com"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			ctx = utils.ContextWithLogger(ctx, testr.New(t))
+
+			controller := &operationExternalAuthUpdate{
+				readDesireLister: &internallistertesting.SliceReadDesireLister{
+					Desires: tt.readDesires,
+				},
+			}
+
+			state, err := controller.hypershiftHostedClusterExternalAuthOperationState(ctx, tt.externalAuth)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantState, state.ProvisioningState)
+			if tt.wantMessageSubstr != "" {
+				assert.Contains(t, state.Message, tt.wantMessageSubstr)
+			}
+		})
+	}
+}
+
+func TestHypershiftHostedClusterExternalAuthIssuerSpecMatchesDesired(t *testing.T) {
+	t.Parallel()
+
+	controller := &operationExternalAuthUpdate{}
+	matchingProvider := testExternalAuthUpdateMatchingOIDCProvider()
+
+	tests := []struct {
+		name       string
+		desired    api.TokenIssuerProfile
+		observed   configv1.OIDCProvider
+		wantMatch  bool
+		wantSubstr string
+	}{
+		{
+			name: "matching issuer",
+			desired: api.TokenIssuerProfile{
+				URL:       "https://issuer.example.com",
+				Audiences: []string{"aud1", "aud2"},
+			},
+			observed:  matchingProvider,
+			wantMatch: true,
+		},
+		{
+			name: "URL mismatch",
+			desired: api.TokenIssuerProfile{
+				URL: "https://other.example.com",
+			},
+			observed:   matchingProvider,
+			wantMatch:  false,
+			wantSubstr: `issuer URL is "https://issuer.example.com", want "https://other.example.com"`,
+		},
+		{
+			name: "audiences mismatch",
+			desired: api.TokenIssuerProfile{
+				URL:       "https://issuer.example.com",
+				Audiences: []string{"aud1"},
+			},
+			observed:   matchingProvider,
+			wantMatch:  false,
+			wantSubstr: `issuer audiences is [aud1 aud2], want [aud1]`,
+		},
+		{
+			name:      "both empty audiences match",
+			desired:   api.TokenIssuerProfile{},
+			observed:  configv1.OIDCProvider{},
+			wantMatch: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			matches, msg := controller.hypershiftHostedClusterExternalAuthIssuerSpecMatchesDesired(tt.desired, tt.observed)
+			assert.Equal(t, tt.wantMatch, matches)
+			if tt.wantSubstr != "" {
+				assert.Contains(t, msg, tt.wantSubstr)
+			}
+		})
+	}
+}
+
+func TestHypershiftHostedClusterExternalAuthClientsSpecMatchesDesired(t *testing.T) {
+	t.Parallel()
+
+	controller := &operationExternalAuthUpdate{}
+	matchingClients := testExternalAuthUpdateMatchingOIDCProvider().OIDCClients
+
+	tests := []struct {
+		name       string
+		desired    []api.ExternalAuthClientProfile
+		observed   []configv1.OIDCClientConfig
+		wantMatch  bool
+		wantSubstr string
+	}{
+		{
+			name: "matching clients",
+			desired: []api.ExternalAuthClientProfile{
+				{
+					Component: api.ExternalAuthClientComponentProfile{
+						Name:                "console",
+						AuthClientNamespace: "openshift-console",
+					},
+					ClientID:    "client-id-1",
+					ExtraScopes: []string{"email", "profile"},
+				},
+			},
+			observed:  matchingClients,
+			wantMatch: true,
+		},
+		{
+			name: "client order mismatch",
+			desired: []api.ExternalAuthClientProfile{
+				{
+					Component: api.ExternalAuthClientComponentProfile{
+						Name:                "oauth",
+						AuthClientNamespace: "openshift-authentication",
+					},
+					ClientID: "client-id-2",
+				},
+				{
+					Component: api.ExternalAuthClientComponentProfile{
+						Name:                "console",
+						AuthClientNamespace: "openshift-console",
+					},
+					ClientID:    "client-id-1",
+					ExtraScopes: []string{"email", "profile"},
+				},
+			},
+			observed: []configv1.OIDCClientConfig{
+				matchingClients[0],
+				{
+					ComponentName:      "oauth",
+					ComponentNamespace: "openshift-authentication",
+					ClientID:           "client-id-2",
+				},
+			},
+			wantMatch:  false,
+			wantSubstr: `client[0] clientID is "client-id-1", want "client-id-2"`,
+		},
+		{
+			name:       "count mismatch",
+			desired:    []api.ExternalAuthClientProfile{{ClientID: "a"}},
+			observed:   nil,
+			wantMatch:  false,
+			wantSubstr: "has 0 clients, want 1",
+		},
+		{
+			name: "clientID mismatch",
+			desired: []api.ExternalAuthClientProfile{
+				{ClientID: "want-this"},
+			},
+			observed: []configv1.OIDCClientConfig{
+				{ClientID: "got-that"},
+			},
+			wantMatch:  false,
+			wantSubstr: `clientID is "got-that", want "want-this"`,
+		},
+		{
+			name: "componentName mismatch",
+			desired: []api.ExternalAuthClientProfile{
+				{
+					Component: api.ExternalAuthClientComponentProfile{Name: "console"},
+					ClientID:  "client-id-1",
+				},
+			},
+			observed: []configv1.OIDCClientConfig{
+				{
+					ComponentName: "oauth",
+					ClientID:      "client-id-1",
+				},
+			},
+			wantMatch:  false,
+			wantSubstr: `componentName is "oauth", want "console"`,
+		},
+		{
+			name: "componentNamespace mismatch",
+			desired: []api.ExternalAuthClientProfile{
+				{
+					Component: api.ExternalAuthClientComponentProfile{
+						Name:                "console",
+						AuthClientNamespace: "openshift-console",
+					},
+					ClientID: "client-id-1",
+				},
+			},
+			observed: []configv1.OIDCClientConfig{
+				{
+					ComponentName:      "console",
+					ComponentNamespace: "other-namespace",
+					ClientID:           "client-id-1",
+				},
+			},
+			wantMatch:  false,
+			wantSubstr: `componentNamespace is "other-namespace", want "openshift-console"`,
+		},
+		{
+			name: "extraScopes mismatch",
+			desired: []api.ExternalAuthClientProfile{
+				{
+					ClientID:    "client-id-1",
+					ExtraScopes: []string{"email"},
+				},
+			},
+			observed: []configv1.OIDCClientConfig{
+				{
+					ClientID:    "client-id-1",
+					ExtraScopes: []string{"profile"},
+				},
+			},
+			wantMatch:  false,
+			wantSubstr: `extraScopes is [profile], want [email]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			matches, msg := controller.hypershiftHostedClusterExternalAuthClientsSpecMatchesDesired(tt.desired, tt.observed)
+			assert.Equal(t, tt.wantMatch, matches)
+			if tt.wantSubstr != "" {
+				assert.Contains(t, msg, tt.wantSubstr)
+			}
+		})
+	}
+}
+
+func TestHypershiftHostedClusterExternalAuthClaimMappingsSpecMatchesDesired(t *testing.T) {
+	t.Parallel()
+
+	controller := &operationExternalAuthUpdate{}
+
+	newMatchingClaim := func() api.ExternalAuthClaimProfile {
+		return newExternalAuthUpdateTestExternalAuth().Properties.Claim
+	}
+	newMatchingProvider := func() configv1.OIDCProvider {
+		return testExternalAuthUpdateMatchingOIDCProvider()
+	}
+
+	tests := []struct {
+		name       string
+		desired    api.ExternalAuthClaimProfile
+		observed   configv1.OIDCProvider
+		wantMatch  bool
+		wantSubstr string
+	}{
+		{
+			name:      "matching claim mappings",
+			desired:   newMatchingClaim(),
+			observed:  newMatchingProvider(),
+			wantMatch: true,
+		},
+		{
+			name: "username claim mismatch",
+			desired: func() api.ExternalAuthClaimProfile {
+				claim := newMatchingClaim()
+				claim.Mappings.Username.Claim = "sub"
+				return claim
+			}(),
+			observed:   newMatchingProvider(),
+			wantMatch:  false,
+			wantSubstr: `username claim is "email", want "sub"`,
+		},
+		{
+			name: "username prefixPolicy mismatch",
+			desired: func() api.ExternalAuthClaimProfile {
+				claim := newMatchingClaim()
+				claim.Mappings.Username.PrefixPolicy = api.UsernameClaimPrefixPolicyNone
+				return claim
+			}(),
+			observed:   newMatchingProvider(),
+			wantMatch:  false,
+			wantSubstr: `username prefixPolicy is "NoPrefix", want ""`,
+		},
+		{
+			name: "username prefix mismatch when policy is Prefix",
+			desired: func() api.ExternalAuthClaimProfile {
+				claim := newMatchingClaim()
+				claim.Mappings.Username.PrefixPolicy = api.UsernameClaimPrefixPolicyPrefix
+				claim.Mappings.Username.Prefix = "oidc:"
+				return claim
+			}(),
+			observed: func() configv1.OIDCProvider {
+				provider := newMatchingProvider()
+				provider.ClaimMappings.Username.PrefixPolicy = configv1.Prefix
+				provider.ClaimMappings.Username.Prefix = &configv1.UsernamePrefix{PrefixString: "other:"}
+				return provider
+			}(),
+			wantMatch:  false,
+			wantSubstr: `username prefix is "other:", want "oidc:"`,
+		},
+		{
+			name: "username prefix policy Prefix matches",
+			desired: func() api.ExternalAuthClaimProfile {
+				claim := newMatchingClaim()
+				claim.Mappings.Username.PrefixPolicy = api.UsernameClaimPrefixPolicyPrefix
+				claim.Mappings.Username.Prefix = "oidc:"
+				return claim
+			}(),
+			observed: func() configv1.OIDCProvider {
+				provider := newMatchingProvider()
+				provider.ClaimMappings.Username.PrefixPolicy = configv1.Prefix
+				provider.ClaimMappings.Username.Prefix = &configv1.UsernamePrefix{PrefixString: "oidc:"}
+				return provider
+			}(),
+			wantMatch: true,
+		},
+		{
+			name: "groups claim mismatch",
+			desired: func() api.ExternalAuthClaimProfile {
+				claim := newMatchingClaim()
+				claim.Mappings.Groups.Claim = "custom-groups"
+				return claim
+			}(),
+			observed:   newMatchingProvider(),
+			wantMatch:  false,
+			wantSubstr: `groups claim is "groups", want "custom-groups"`,
+		},
+		{
+			name: "groups prefix mismatch",
+			desired: func() api.ExternalAuthClaimProfile {
+				claim := newMatchingClaim()
+				claim.Mappings.Groups.Prefix = "custom:"
+				return claim
+			}(),
+			observed:   newMatchingProvider(),
+			wantMatch:  false,
+			wantSubstr: `groups prefix is "oidc:", want "custom:"`,
+		},
+		{
+			name: "nil groups desired matches when observed has no groups",
+			desired: func() api.ExternalAuthClaimProfile {
+				claim := newMatchingClaim()
+				claim.Mappings.Groups = nil
+				return claim
+			}(),
+			observed: func() configv1.OIDCProvider {
+				provider := newMatchingProvider()
+				provider.ClaimMappings.Groups = configv1.PrefixedClaimMapping{}
+				return provider
+			}(),
+			wantMatch: true,
+		},
+		{
+			name: "nil groups desired rejects observed groups",
+			desired: func() api.ExternalAuthClaimProfile {
+				claim := newMatchingClaim()
+				claim.Mappings.Groups = nil
+				return claim
+			}(),
+			observed:   newMatchingProvider(),
+			wantMatch:  false,
+			wantSubstr: `has groups claim "groups" prefix "oidc:", want no groups`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			matches, msg := controller.hypershiftHostedClusterExternalAuthClaimMappingsSpecMatchesDesired(tt.desired, tt.observed)
+			assert.Equal(t, tt.wantMatch, matches)
+			if tt.wantSubstr != "" {
+				assert.Contains(t, msg, tt.wantSubstr)
+			}
+		})
+	}
+}
+
+func TestHypershiftHostedClusterExternalAuthValidationRulesSpecMatchesDesired(t *testing.T) {
+	t.Parallel()
+
+	controller := &operationExternalAuthUpdate{}
+	matchingRules := testExternalAuthUpdateMatchingOIDCProvider().ClaimValidationRules
+
+	tests := []struct {
+		name       string
+		desired    []api.TokenClaimValidationRule
+		observed   []configv1.TokenClaimValidationRule
+		wantMatch  bool
+		wantSubstr string
+	}{
+		{
+			name: "matching required claim rule",
+			desired: []api.TokenClaimValidationRule{
+				{
+					Type: api.TokenValidationRuleTypeRequiredClaim,
+					RequiredClaim: api.TokenRequiredClaim{
+						Claim:         "hd",
+						RequiredValue: "example.com",
+					},
+				},
+			},
+			observed:  matchingRules,
+			wantMatch: true,
+		},
+		{
+			name:       "count mismatch",
+			desired:    []api.TokenClaimValidationRule{{Type: api.TokenValidationRuleTypeRequiredClaim}},
+			observed:   nil,
+			wantMatch:  false,
+			wantSubstr: "has 0 validation rules, want 1",
+		},
+		{
+			name: "rule type mismatch",
+			desired: []api.TokenClaimValidationRule{
+				{Type: api.TokenValidationRuleTypeRequiredClaim},
+			},
+			observed: []configv1.TokenClaimValidationRule{
+				{Type: configv1.TokenValidationRuleTypeCEL},
+			},
+			wantMatch:  false,
+			wantSubstr: `validation rule[0] type is "CEL", want "RequiredClaim"`,
+		},
+		{
+			name: "nil requiredClaim errors when token validation rule type is RequiredClaim",
+			desired: []api.TokenClaimValidationRule{
+				{Type: api.TokenValidationRuleTypeRequiredClaim},
+			},
+			observed: []configv1.TokenClaimValidationRule{
+				{Type: configv1.TokenValidationRuleTypeRequiredClaim},
+			},
+			wantMatch:  false,
+			wantSubstr: "validation rule[0] has nil requiredClaim but expects a requiredClaim",
+		},
+		{
+			name: "claim mismatch",
+			desired: []api.TokenClaimValidationRule{
+				{
+					Type: api.TokenValidationRuleTypeRequiredClaim,
+					RequiredClaim: api.TokenRequiredClaim{
+						Claim:         "iss",
+						RequiredValue: "example.com",
+					},
+				},
+			},
+			observed:   matchingRules,
+			wantMatch:  false,
+			wantSubstr: `validation rule[0] claim is "hd", want "iss"`,
+		},
+		{
+			name: "requiredValue mismatch",
+			desired: []api.TokenClaimValidationRule{
+				{
+					Type: api.TokenValidationRuleTypeRequiredClaim,
+					RequiredClaim: api.TokenRequiredClaim{
+						Claim:         "hd",
+						RequiredValue: "other.example.com",
+					},
+				},
+			},
+			observed:   matchingRules,
+			wantMatch:  false,
+			wantSubstr: `validation rule[0] requiredValue is "example.com", want "other.example.com"`,
+		},
+		{
+			name: "unsupported desired type",
+			desired: []api.TokenClaimValidationRule{
+				{Type: api.TokenValidationRuleType("Unsupported")},
+			},
+			observed: []configv1.TokenClaimValidationRule{
+				{Type: configv1.TokenValidationRuleTypeRequiredClaim},
+			},
+			wantMatch:  false,
+			wantSubstr: `validation rule[0] has unsupported desired type "Unsupported"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			matches, msg := controller.hypershiftHostedClusterExternalAuthValidationRulesSpecMatchesDesired(tt.desired, tt.observed)
+			assert.Equal(t, tt.wantMatch, matches)
+			if tt.wantSubstr != "" {
+				assert.Contains(t, msg, tt.wantSubstr)
+			}
+		})
+	}
+}
+
+func TestClusterServiceExternalAuthSpecOperationState(t *testing.T) {
+	t.Parallel()
+
+	newCSExternalAuthFromRP := func(t *testing.T, externalAuth *api.HCPOpenShiftClusterExternalAuth) *arohcpv1alpha1.ExternalAuth {
+		t.Helper()
+		builder, err := ocm.BuildCSExternalAuth(context.Background(), externalAuth, true)
+		require.NoError(t, err)
+		csExternalAuth, err := builder.Build()
+		require.NoError(t, err)
+		return csExternalAuth
+	}
+
+	controller := &operationExternalAuthUpdate{}
+
+	tests := []struct {
+		name              string
+		externalAuth      *api.HCPOpenShiftClusterExternalAuth
+		csExternalAuth    *arohcpv1alpha1.ExternalAuth
+		wantState         arm.ProvisioningState
+		wantMessageSubstr string
+	}{
+		{
+			name:           "matching external auth returns Succeeded",
+			externalAuth:   newExternalAuthUpdateTestExternalAuth(),
+			csExternalAuth: newCSExternalAuthFromRP(t, newExternalAuthUpdateTestExternalAuth()),
+			wantState:      arm.ProvisioningStateSucceeded,
+		},
+		{
+			name: "issuer URL mismatch returns Updating",
+			externalAuth: newExternalAuthUpdateTestExternalAuth(func(ea *api.HCPOpenShiftClusterExternalAuth) {
+				ea.Properties.Issuer.URL = "https://changed.example.com"
+			}),
+			csExternalAuth:    newCSExternalAuthFromRP(t, newExternalAuthUpdateTestExternalAuth()),
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: "Cluster Service external auth spec does not match desired",
+		},
+		{
+			name:           "empty default external auth matches empty CS external auth",
+			externalAuth:   newExternalAuthTestFixture().newExternalAuth(),
+			csExternalAuth: mustBuildEmptyCSExternalAuth(t),
+			wantState:      arm.ProvisioningStateSucceeded,
+		},
+		{
+			name: "validation rule mismatch returns Updating",
+			externalAuth: newExternalAuthUpdateTestExternalAuth(func(ea *api.HCPOpenShiftClusterExternalAuth) {
+				ea.Properties.Claim.ValidationRules[0].RequiredClaim.RequiredValue = "changed.example.com"
+			}),
+			csExternalAuth:    newCSExternalAuthFromRP(t, newExternalAuthUpdateTestExternalAuth()),
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: "changed.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			state, err := controller.clusterServiceExternalAuthSpecOperationState(tt.externalAuth, tt.csExternalAuth)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantState, state.ProvisioningState)
+			if tt.wantMessageSubstr != "" {
+				assert.Contains(t, state.Message, tt.wantMessageSubstr)
+			}
+		})
+	}
+}
+
+func mustBuildEmptyCSExternalAuth(t *testing.T) *arohcpv1alpha1.ExternalAuth {
+	t.Helper()
+	csExternalAuth, err := arohcpv1alpha1.NewExternalAuth().Build()
+	require.NoError(t, err)
+	return csExternalAuth
+}

--- a/backend/pkg/controllers/operationcontrollers/operation_external_auth_update_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_external_auth_update_test.go
@@ -18,49 +18,116 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr/testr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilsclock "k8s.io/utils/clock"
 
 	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/hypershift/api/hypershift/v1beta1"
 
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
+	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/api/kubeapplier"
 	"github.com/Azure/ARO-HCP/internal/database"
+	internallistertesting "github.com/Azure/ARO-HCP/internal/database/listertesting"
 	"github.com/Azure/ARO-HCP/internal/databasetesting"
 	"github.com/Azure/ARO-HCP/internal/ocm"
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
 
 func TestOperationExternalAuthUpdate_SynchronizeOperation(t *testing.T) {
-	tests := []struct {
-		name        string
-		setupMock   func(ctrl *gomock.Controller, fixture *externalAuthTestFixture) ocm.ClusterServiceClientSpec
-		expectError bool
-		verify      func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *externalAuthTestFixture)
+	testClockNow := time.Now()
+	fixture := newExternalAuthTestFixture()
+
+	newExternalAuth := func(mutate ...func(*api.HCPOpenShiftClusterExternalAuth)) *api.HCPOpenShiftClusterExternalAuth {
+		externalAuth := fixture.newExternalAuth()
+		for _, fn := range mutate {
+			if fn != nil {
+				fn(externalAuth)
+			}
+		}
+		return externalAuth
+	}
+
+	newOperationAccepted := func() *api.Operation {
+		return fixture.newOperation(database.OperationRequestUpdate)
+	}
+
+	preconditionExistingOperation := fixture.newOperation(database.OperationRequestUpdate)
+	preconditionListerOperation := fixture.newOperation(database.OperationRequestUpdate)
+	preconditionListerOperation.CosmosETag = "stale-etag"
+	// Not seeded to Cosmos, so PrepareForCreate never runs. UpdateOperationStatus still
+	// requires a non-zero InstanceVersion before it will attempt the etag-checked replace.
+	preconditionListerOperation.InstanceVersion = 1
+
+	newPassingCachedHostedClusterReadDesire := func() *kubeapplier.ReadDesire {
+		return newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+			Spec: testExternalAuthUpdateMatchingHostedClusterSpec(),
+		})
+	}
+
+	newPassingCSExternalAuth := func(t *testing.T, externalAuth *api.HCPOpenShiftClusterExternalAuth) *arohcpv1alpha1.ExternalAuth {
+		t.Helper()
+		builder, err := ocm.BuildCSExternalAuth(context.Background(), externalAuth, true)
+		require.NoError(t, err)
+		csExternalAuth, err := builder.Build()
+		require.NoError(t, err)
+		return csExternalAuth
+	}
+
+	newPassingExternalAuth := func(mutate ...func(*api.HCPOpenShiftClusterExternalAuth)) *api.HCPOpenShiftClusterExternalAuth {
+		return newExternalAuthUpdateTestExternalAuth(mutate...)
+	}
+
+	verifyOperationAndExternalAuthUpdating := func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+		t.Helper()
+		op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+		require.NoError(t, err)
+		assert.Equal(t, arm.ProvisioningStateUpdating, op.Status)
+		assert.Nil(t, op.Error)
+
+		externalAuth, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).ExternalAuth(testClusterName).Get(ctx, testExternalAuthName)
+		require.NoError(t, err)
+		assert.Equal(t, arm.ProvisioningStateUpdating, externalAuth.Properties.ProvisioningState)
+		assert.Equal(t, testOperationName, externalAuth.ServiceProviderProperties.ActiveOperationID)
+	}
+
+	testCases := []struct {
+		name                          string
+		existingExternalAuth          *api.HCPOpenShiftClusterExternalAuth
+		existingOperation             *api.Operation
+		externalAuthLister            listers.ExternalAuthLister
+		activeOperationsLister        listers.ActiveOperationLister
+		cachedHostedClusterReadDesire *kubeapplier.ReadDesire
+		setupMockCSClient             func(*ocm.MockClusterServiceClientSpec)
+		wantErr                       bool
+		verifyDB                      func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient)
 	}{
 		{
-			name: "external auth exists transitions to succeeded",
-			setupMock: func(ctrl *gomock.Controller, fixture *externalAuthTestFixture) ocm.ClusterServiceClientSpec {
-				mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
-				externalAuth, _ := arohcpv1alpha1.NewExternalAuth().
-					ID(testExternalAuthIDStr).
-					Build()
-				mockCSClient.EXPECT().
+			name:                          "external auth update succeeds when CS and hypershift specs match desired",
+			existingExternalAuth:          newPassingExternalAuth(),
+			existingOperation:             newOperationAccepted(),
+			cachedHostedClusterReadDesire: newPassingCachedHostedClusterReadDesire(),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				passingExternalAuth := newPassingExternalAuth()
+				mock.EXPECT().
 					GetExternalAuth(gomock.Any(), fixture.externalAuthInternalID).
-					Return(externalAuth, nil)
-				return mockCSClient
+					Return(newPassingCSExternalAuth(t, passingExternalAuth), nil)
 			},
-			expectError: false,
-			verify: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *externalAuthTestFixture) {
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateSucceeded, op.Status)
 
-				// Verify external auth provisioning state was also updated
 				externalAuth, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).ExternalAuth(testClusterName).Get(ctx, testExternalAuthName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateSucceeded, externalAuth.Properties.ProvisioningState)
@@ -68,53 +135,195 @@ func TestOperationExternalAuthUpdate_SynchronizeOperation(t *testing.T) {
 			},
 		},
 		{
-			name: "external auth get error returns error",
-			setupMock: func(ctrl *gomock.Controller, fixture *externalAuthTestFixture) ocm.ClusterServiceClientSpec {
-				mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
-				mockCSClient.EXPECT().
+			name:                          "cs external auth spec mismatch keeps operation updating",
+			existingExternalAuth:          newPassingExternalAuth(),
+			existingOperation:             newOperationAccepted(),
+			cachedHostedClusterReadDesire: newPassingCachedHostedClusterReadDesire(),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				staleCSExternalAuth := newPassingCSExternalAuth(t, newPassingExternalAuth(func(ea *api.HCPOpenShiftClusterExternalAuth) {
+					ea.Properties.Issuer.URL = "https://stale.example.com"
+				}))
+				mock.EXPECT().
+					GetExternalAuth(gomock.Any(), fixture.externalAuthInternalID).
+					Return(staleCSExternalAuth, nil)
+			},
+			verifyDB: verifyOperationAndExternalAuthUpdating,
+		},
+		{
+			name:                 "hypershift not observed keeps operation updating",
+			existingExternalAuth: newPassingExternalAuth(),
+			existingOperation:    newOperationAccepted(),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				passingExternalAuth := newPassingExternalAuth()
+				mock.EXPECT().
+					GetExternalAuth(gomock.Any(), fixture.externalAuthInternalID).
+					Return(newPassingCSExternalAuth(t, passingExternalAuth), nil)
+			},
+			verifyDB: verifyOperationAndExternalAuthUpdating,
+		},
+		{
+			name:                 "hypershift issuer spec mismatch keeps operation updating",
+			existingExternalAuth: newPassingExternalAuth(),
+			existingOperation:    newOperationAccepted(),
+			cachedHostedClusterReadDesire: newHostedClusterReadDesire(t, &v1beta1.HostedCluster{
+				Spec: func() v1beta1.HostedClusterSpec {
+					spec := testExternalAuthUpdateMatchingHostedClusterSpec()
+					provider := testExternalAuthUpdateMatchingOIDCProvider()
+					provider.Issuer.URL = "https://stale.example.com"
+					spec.Configuration.Authentication.OIDCProviders = []configv1.OIDCProvider{provider}
+					return spec
+				}(),
+			}),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				passingExternalAuth := newPassingExternalAuth()
+				mock.EXPECT().
+					GetExternalAuth(gomock.Any(), fixture.externalAuthInternalID).
+					Return(newPassingCSExternalAuth(t, passingExternalAuth), nil)
+			},
+			verifyDB: verifyOperationAndExternalAuthUpdating,
+		},
+		{
+			name:                          "cs external auth get error returns error",
+			existingExternalAuth:          newExternalAuth(),
+			existingOperation:             newOperationAccepted(),
+			cachedHostedClusterReadDesire: newPassingCachedHostedClusterReadDesire(),
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				mock.EXPECT().
 					GetExternalAuth(gomock.Any(), fixture.externalAuthInternalID).
 					Return(nil, fmt.Errorf("cluster service error"))
-				return mockCSClient
 			},
-			expectError: true,
-			verify:      nil,
+			wantErr: true,
+		},
+		{
+			name:                 "external auth not in lister cache leaves operation unchanged",
+			existingExternalAuth: newExternalAuth(),
+			existingOperation:    newOperationAccepted(),
+			externalAuthLister:   &listertesting.SliceExternalAuthLister{},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+
+				externalAuth, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).ExternalAuth(testClusterName).Get(ctx, testExternalAuthName)
+				require.NoError(t, err)
+				assert.Equal(t, testOperationName, externalAuth.ServiceProviderProperties.ActiveOperationID)
+				assert.Equal(t, arm.ProvisioningStateAccepted, externalAuth.Properties.ProvisioningState)
+			},
+		},
+		{
+			name: "active operation id mismatch leaves operation unchanged",
+			existingExternalAuth: newExternalAuth(func(ea *api.HCPOpenShiftClusterExternalAuth) {
+				ea.ServiceProviderProperties.ActiveOperationID = "other-operation"
+			}),
+			existingOperation: newOperationAccepted(),
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+			},
+		},
+		{
+			name: "shouldReconcile gate not passed when ClusterServiceID is nil",
+			existingExternalAuth: newExternalAuth(func(ea *api.HCPOpenShiftClusterExternalAuth) {
+				ea.ServiceProviderProperties.ClusterServiceID = nil
+			}),
+			existingOperation: newOperationAccepted(),
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+			},
+		},
+		{
+			name: "shouldReconcile gate not passed when external auth is deleting",
+			existingExternalAuth: newExternalAuth(func(ea *api.HCPOpenShiftClusterExternalAuth) {
+				ea.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: testClockNow}
+			}),
+			existingOperation: newOperationAccepted(),
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+			},
+		},
+		{
+			name:                          "precondition failed on status update is ignored",
+			existingExternalAuth:          newPassingExternalAuth(),
+			existingOperation:             preconditionExistingOperation,
+			cachedHostedClusterReadDesire: newPassingCachedHostedClusterReadDesire(),
+			activeOperationsLister: &listertesting.SliceActiveOperationLister{
+				Operations: []*api.Operation{preconditionListerOperation},
+			},
+			setupMockCSClient: func(mock *ocm.MockClusterServiceClientSpec) {
+				passingExternalAuth := newPassingExternalAuth()
+				mock.EXPECT().
+					GetExternalAuth(gomock.Any(), fixture.externalAuthInternalID).
+					Return(newPassingCSExternalAuth(t, passingExternalAuth), nil)
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status, "operation should be unchanged after optimistic concurrency conflict")
+			},
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
-			ctx = utils.ContextWithLogger(ctx, testr.New(t))
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
-			fixture := newExternalAuthTestFixture()
-			cluster := fixture.newCluster()
-			externalAuth := fixture.newExternalAuth()
-			operation := fixture.newOperation(database.OperationRequestUpdate)
+			resources := []any{fixture.newCluster()}
+			if tc.existingExternalAuth != nil {
+				resources = append(resources, tc.existingExternalAuth)
+			}
+			if tc.existingOperation != nil {
+				resources = append(resources, tc.existingOperation)
+			}
 
-			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, []any{cluster, externalAuth, operation})
+			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, resources)
 			require.NoError(t, err)
 
-			mockCSClient := tt.setupMock(ctrl, fixture)
+			var readDesireLister internallistertesting.SliceReadDesireLister
+			if tc.cachedHostedClusterReadDesire != nil {
+				readDesireLister = internallistertesting.SliceReadDesireLister{
+					Desires: []*kubeapplier.ReadDesire{tc.cachedHostedClusterReadDesire},
+				}
+			}
+
+			externalAuthLister := tc.externalAuthLister
+			if externalAuthLister == nil {
+				externalAuthLister = &listertesting.DBExternalAuthLister{ResourcesDBClient: mockResourcesDBClient}
+			}
+			activeOperationsLister := tc.activeOperationsLister
+			if activeOperationsLister == nil {
+				activeOperationsLister = &listertesting.DBActiveOperationLister{ResourcesDBClient: mockResourcesDBClient}
+			}
+
+			mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
+			if tc.setupMockCSClient != nil {
+				tc.setupMockCSClient(mockCSClient)
+			}
 
 			controller := &operationExternalAuthUpdate{
-				clock:                utilsclock.RealClock{},
-				resourcesDBClient:    mockResourcesDBClient,
-				clusterServiceClient: mockCSClient,
-				notificationClient:   nil,
+				clock:                  utilsclock.RealClock{},
+				resourcesDBClient:      mockResourcesDBClient,
+				clusterServiceClient:   mockCSClient,
+				externalAuthLister:     externalAuthLister,
+				readDesireLister:       &readDesireLister,
+				activeOperationsLister: activeOperationsLister,
+				notificationClient:     nil,
 			}
 
 			err = controller.SynchronizeOperation(ctx, fixture.operationKey())
-
-			if tt.expectError {
+			if tc.wantErr {
 				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
+				return
 			}
+			require.NoError(t, err)
 
-			if tt.verify != nil {
-				tt.verify(t, ctx, mockResourcesDBClient, fixture)
+			if tc.verifyDB != nil {
+				tc.verifyDB(t, ctx, mockResourcesDBClient)
 			}
 		})
 	}

--- a/backend/pkg/controllers/operationcontrollers/operation_node_pool_create.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_node_pool_create.go
@@ -144,18 +144,18 @@ func (c *operationNodePoolCreate) SynchronizeOperation(ctx context.Context, key 
 	}
 
 	var persistErr *arm.CloudErrorBody
-	if operationalState.provisioningState == arm.ProvisioningStateFailed {
+	if operationalState.ProvisioningState == arm.ProvisioningStateFailed {
 		persistErr = &arm.CloudErrorBody{
 			// TODO for now we always set the error code to InternalServerError, but we should improve to be able
 			// to be more specific than that when we calculate operationalState. When work is done to improve on this, we
 			// should design it in a way where no internal details are exposed to the operation's error.
 			Code:    arm.CloudErrorCodeInternalServerError,
-			Message: operationalState.message,
+			Message: operationalState.Message,
 		}
 	}
 
 	logger.Info("updating status")
-	err = UpdateOperationStatus(ctx, c.clock, c.resourcesDBClient, operation, operationalState.provisioningState, persistErr, postAsyncNotificationFn(c.notificationClient))
+	err = UpdateOperationStatus(ctx, c.clock, c.resourcesDBClient, operation, operationalState.ProvisioningState, persistErr, postAsyncNotificationFn(c.notificationClient))
 	if database.IsPreconditionFailedError(err) {
 		// if we have a conflict error, then we're guaranteed that our informer will eventually see an update and trigger us again.
 		return nil
@@ -180,7 +180,7 @@ func (c *operationNodePoolCreate) determineOperationState(ctx context.Context, o
 	if state, err := c.nodePoolServiceCreateOperationState(ctx, operation, nodePool); err != nil {
 		errs = append(errs, utils.TrackError(err))
 	} else {
-		operationStates = append(operationStates, state)
+		operationStates = append(operationStates, state.withSource("clusterServiceNodePoolStatus"))
 	}
 
 	if err := errors.Join(errs...); err != nil {
@@ -198,7 +198,7 @@ func (c *operationNodePoolCreate) determineOperationState(ctx context.Context, o
 	if err != nil {
 		return nil, utils.TrackError(err)
 	}
-	logger.Info("picked node pool create operation status", "provisioningState", picked.provisioningState, "message", picked.message)
+	logger.Info("picked node pool create operation status", "provisioningState", picked.ProvisioningState, "message", picked.Message)
 	return picked, nil
 }
 

--- a/backend/pkg/controllers/operationcontrollers/operation_node_pool_create_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_node_pool_create_test.go
@@ -148,7 +148,7 @@ func TestOperationNodePoolCreate_SynchronizeOperation(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateFailed, op.Status)
 				assert.NotNil(t, op.Error)
-				assert.Equal(t, "node pool creation failed", op.Error.Message)
+				assert.Equal(t, "[clusterServiceNodePoolStatus] node pool creation failed", op.Error.Message)
 
 				nodePool, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).NodePools(testClusterName).Get(ctx, testNodePoolName)
 				require.NoError(t, err)

--- a/backend/pkg/controllers/operationcontrollers/operation_node_pool_update.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_node_pool_update.go
@@ -31,20 +31,29 @@ import (
 	utilsclock "k8s.io/utils/clock"
 	"k8s.io/utils/lru"
 
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/upgradecontrollers"
+	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/database"
+	dblisters "github.com/Azure/ARO-HCP/internal/database/listers"
 	"github.com/Azure/ARO-HCP/internal/ocm"
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
 
 type operationNodePoolUpdate struct {
+	clock                           utilsclock.PassiveClock
 	resourcesDBClient               database.ResourcesDBClient
 	clusterServiceClient            ocm.ClusterServiceClientSpec
+	nodePoolLister                  listers.NodePoolLister
+	serviceProviderNodePoolLister   listers.ServiceProviderNodePoolLister
+	readDesireLister                dblisters.ReadDesireLister
+	activeOperationsLister          listers.ActiveOperationLister
 	notificationClient              *http.Client
-	clock                           utilsclock.PassiveClock
 	desiredVersionMismatchFirstSeen *lru.Cache
 }
 
@@ -66,14 +75,24 @@ func NewOperationNodePoolUpdateController(
 	clock utilsclock.PassiveClock,
 	resourcesDBClient database.ResourcesDBClient,
 	clusterServiceClient ocm.ClusterServiceClientSpec,
+	readDesireLister dblisters.ReadDesireLister,
 	notificationClient *http.Client,
 	activeOperationInformer cache.SharedIndexInformer,
+	backendInformers informers.BackendInformers,
 ) controllerutils.Controller {
+	_, nodePoolLister := backendInformers.NodePools()
+	_, serviceProviderNodePoolLister := backendInformers.ServiceProviderNodePools()
+	_, activeOperationsLister := backendInformers.ActiveOperations()
+
 	syncer := &operationNodePoolUpdate{
+		clock:                           clock,
 		resourcesDBClient:               resourcesDBClient,
 		clusterServiceClient:            clusterServiceClient,
+		nodePoolLister:                  nodePoolLister,
+		serviceProviderNodePoolLister:   serviceProviderNodePoolLister,
+		readDesireLister:                readDesireLister,
+		activeOperationsLister:          activeOperationsLister,
 		notificationClient:              notificationClient,
-		clock:                           clock,
 		desiredVersionMismatchFirstSeen: lru.New(100000),
 	}
 
@@ -105,7 +124,7 @@ func (c *operationNodePoolUpdate) SynchronizeOperation(ctx context.Context, key 
 	logger := utils.LoggerFromContext(ctx)
 	logger.Info("checking operation")
 
-	operation, err := c.resourcesDBClient.Operations(key.SubscriptionID).Get(ctx, key.OperationName)
+	operation, err := c.activeOperationsLister.Get(ctx, key.SubscriptionID, key.OperationName)
 	if database.IsNotFoundError(err) {
 		return nil // no work to do
 	}
@@ -115,13 +134,26 @@ func (c *operationNodePoolUpdate) SynchronizeOperation(ctx context.Context, key 
 	if !c.ShouldProcess(ctx, operation) {
 		return nil // no work to do
 	}
-	if len(operation.InternalID.String()) == 0 {
-		// Cannot proceed yet
-		// TODO when we update to clusterservice node pool creation async, we need to handle this correctly.
+
+	existingNodePool, err := c.nodePoolLister.Get(ctx, operation.ExternalID.SubscriptionID, operation.ExternalID.ResourceGroupName, operation.ExternalID.Parent.Name, operation.ExternalID.Name)
+	if database.IsNotFoundError(err) {
+		logger.Info("node pool not found in cache, waiting")
+		return nil // no work to do
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get node pool: %w", err))
+	}
+
+	if operation.ResourceID.Name != existingNodePool.ServiceProviderProperties.ActiveOperationID {
+		logger.Info("node pool active operation id mismatch, returning early", "synchronizedActiveOperationID", operation.ResourceID.Name, "nodePoolActiveOperationID", existingNodePool.ServiceProviderProperties.ActiveOperationID)
 		return nil
 	}
 
-	operationalState, err := c.determineOperationState(ctx, operation)
+	if !c.shouldReconcileOperationAndResourceStatus(existingNodePool) {
+		return nil // no work to do
+	}
+
+	operationalState, err := c.determineOperationState(ctx, operation, existingNodePool)
 	if err != nil {
 		return utils.TrackError(err)
 	}
@@ -135,26 +167,60 @@ func (c *operationNodePoolUpdate) SynchronizeOperation(ctx context.Context, key 
 	}
 
 	logger.Info("updating status")
-	if err := UpdateOperationStatus(ctx, c.clock, c.resourcesDBClient, operation, operationalState.ProvisioningState, persistErr, postAsyncNotificationFn(c.notificationClient)); err != nil {
+	err = UpdateOperationStatus(ctx, c.clock, c.resourcesDBClient, operation, operationalState.ProvisioningState, persistErr, postAsyncNotificationFn(c.notificationClient))
+	if database.IsPreconditionFailedError(err) {
+		// if we have a conflict error, then we're guaranteed that our informer will eventually see an update and trigger us again.
+		return nil
+	}
+	if err != nil {
 		return utils.TrackError(err)
 	}
+
 	return nil
 }
 
-func (c *operationNodePoolUpdate) determineOperationState(ctx context.Context, operation *api.Operation) (*operationState, error) {
+func (c *operationNodePoolUpdate) shouldReconcileOperationAndResourceStatus(nodePool *api.HCPOpenShiftClusterNodePool) bool {
+	return nodePool.ServiceProviderProperties.DeletionTimestamp == nil &&
+		nodePool.ServiceProviderProperties.ClusterServiceID != nil
+}
+
+func (c *operationNodePoolUpdate) determineOperationState(ctx context.Context, operation *api.Operation, existingNodePool *api.HCPOpenShiftClusterNodePool) (*operationState, error) {
 	logger := utils.LoggerFromContext(ctx)
+
+	nodePoolCSID := existingNodePool.ServiceProviderProperties.ClusterServiceID
+	existingCSNodePool, err := c.clusterServiceClient.GetNodePool(ctx, *nodePoolCSID)
+	if err != nil {
+		return nil, utils.TrackError(fmt.Errorf("failed to get node pool from cluster service: %w", err))
+	}
+
+	existingServiceProviderNodePool, err := c.serviceProviderNodePoolLister.Get(ctx, operation.ExternalID.SubscriptionID, operation.ExternalID.ResourceGroupName, operation.ExternalID.Parent.Name, operation.ExternalID.Name)
+	if err != nil {
+		return nil, utils.TrackError(fmt.Errorf("failed to get service provider node pool from cache: %w", err))
+	}
+
 	errs := []error{}
 	operationStates := []*operationState{}
 
-	if operationState, err := c.desiredVersionResolutionOperationState(ctx, operation); err != nil {
+	if operationState, err := c.desiredVersionResolutionOperationState(ctx, operation, existingNodePool, existingServiceProviderNodePool); err != nil {
 		errs = append(errs, utils.TrackError(err))
 	} else {
 		operationStates = append(operationStates, operationState.withSource("nodePoolDesiredVersionResolution"))
 	}
-	if operationState, csErr := c.nodePoolServiceUpdateOperationState(ctx, operation); csErr != nil {
+	if operationState, csErr := c.clusterServiceNodePoolStatusOperationState(ctx, operation, existingCSNodePool.Status()); csErr != nil {
 		errs = append(errs, utils.TrackError(csErr))
 	} else {
 		operationStates = append(operationStates, operationState.withSource("clusterServiceNodePoolStatus"))
+	}
+	if operationState, csErr := c.clusterServiceNodePoolSpecOperationState(existingNodePool, existingCSNodePool); csErr != nil {
+		errs = append(errs, utils.TrackError(csErr))
+	} else {
+		operationStates = append(operationStates, operationState.withSource("clusterServiceNodePoolSpec"))
+	}
+
+	if operationState, hsErr := c.hypershiftNodePoolOperationState(ctx, existingNodePool, existingCSNodePool); hsErr != nil {
+		errs = append(errs, utils.TrackError(hsErr))
+	} else {
+		operationStates = append(operationStates, operationState.withSource("hypershiftNodePool"))
 	}
 
 	if err := errors.Join(errs...); err != nil {
@@ -176,18 +242,7 @@ func (c *operationNodePoolUpdate) determineOperationState(ctx context.Context, o
 	return picked, nil
 }
 
-func (c *operationNodePoolUpdate) desiredVersionResolutionOperationState(ctx context.Context, operation *api.Operation) (*operationState, error) {
-	existingNodePool, err := c.resourcesDBClient.HCPClusters(operation.ExternalID.SubscriptionID, operation.ExternalID.ResourceGroupName).
-		NodePools(operation.ExternalID.Parent.Name).Get(ctx, operation.ExternalID.Name)
-	if err != nil {
-		return nil, utils.TrackError(err)
-	}
-
-	existingServiceProviderNodePool, err := c.resourcesDBClient.ServiceProviderNodePools(operation.ExternalID.SubscriptionID, operation.ExternalID.ResourceGroupName, operation.ExternalID.Parent.Name, operation.ExternalID.Name).Get(ctx, api.ServiceProviderNodePoolResourceName)
-	if err != nil {
-		return nil, utils.TrackError(err)
-	}
-
+func (c *operationNodePoolUpdate) desiredVersionResolutionOperationState(ctx context.Context, operation *api.Operation, existingNodePool *api.HCPOpenShiftClusterNodePool, existingServiceProviderNodePool *api.ServiceProviderNodePool) (*operationState, error) {
 	resultingDesiredVersion := existingServiceProviderNodePool.Spec.NodePoolVersion.DesiredVersion
 	if resultingDesiredVersion == nil {
 		return nil, utils.TrackError(fmt.Errorf("service provider node pool has no desired version"))
@@ -251,13 +306,9 @@ func (c *operationNodePoolUpdate) desiredVersionResolutionOperationState(ctx con
 	return newOperationState(arm.ProvisioningStateFailed, intentFailedCondition.Message), nil
 }
 
-func (c *operationNodePoolUpdate) nodePoolServiceUpdateOperationState(ctx context.Context, operation *api.Operation) (*operationState, error) {
+func (c *operationNodePoolUpdate) clusterServiceNodePoolStatusOperationState(ctx context.Context, operation *api.Operation, existingCSNodePoolStatus *arohcpv1alpha1.NodePoolStatus) (*operationState, error) {
 	logger := utils.LoggerFromContext(ctx)
-	nodePoolStatus, err := c.clusterServiceClient.GetNodePoolStatus(ctx, operation.InternalID)
-	if err != nil {
-		return nil, utils.TrackError(err)
-	}
-	newOperationStatus, opError, err := convertNodePoolStatus(operation, nodePoolStatus)
+	newOperationStatus, opError, err := convertNodePoolStatus(operation, existingCSNodePoolStatus)
 	if err != nil {
 		return nil, utils.TrackError(err)
 	}

--- a/backend/pkg/controllers/operationcontrollers/operation_node_pool_update.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_node_pool_update.go
@@ -127,15 +127,15 @@ func (c *operationNodePoolUpdate) SynchronizeOperation(ctx context.Context, key 
 	}
 
 	var persistErr *arm.CloudErrorBody
-	if operationalState.provisioningState == arm.ProvisioningStateFailed {
+	if operationalState.ProvisioningState == arm.ProvisioningStateFailed {
 		persistErr = &arm.CloudErrorBody{
 			Code:    arm.CloudErrorCodeInvalidRequestContent,
-			Message: operationalState.message,
+			Message: operationalState.Message,
 		}
 	}
 
 	logger.Info("updating status")
-	if err := UpdateOperationStatus(ctx, c.clock, c.resourcesDBClient, operation, operationalState.provisioningState, persistErr, postAsyncNotificationFn(c.notificationClient)); err != nil {
+	if err := UpdateOperationStatus(ctx, c.clock, c.resourcesDBClient, operation, operationalState.ProvisioningState, persistErr, postAsyncNotificationFn(c.notificationClient)); err != nil {
 		return utils.TrackError(err)
 	}
 	return nil
@@ -149,12 +149,12 @@ func (c *operationNodePoolUpdate) determineOperationState(ctx context.Context, o
 	if operationState, err := c.desiredVersionResolutionOperationState(ctx, operation); err != nil {
 		errs = append(errs, utils.TrackError(err))
 	} else {
-		operationStates = append(operationStates, operationState)
+		operationStates = append(operationStates, operationState.withSource("nodePoolDesiredVersionResolution"))
 	}
 	if operationState, csErr := c.nodePoolServiceUpdateOperationState(ctx, operation); csErr != nil {
 		errs = append(errs, utils.TrackError(csErr))
 	} else {
-		operationStates = append(operationStates, operationState)
+		operationStates = append(operationStates, operationState.withSource("clusterServiceNodePoolStatus"))
 	}
 
 	if err := errors.Join(errs...); err != nil {
@@ -172,7 +172,7 @@ func (c *operationNodePoolUpdate) determineOperationState(ctx context.Context, o
 	if err != nil {
 		return nil, utils.TrackError(err)
 	}
-	logger.Info("picked node pool update operation status", "provisioningState", picked.provisioningState, "message", picked.message)
+	logger.Info("picked node pool update operation status", "provisioningState", picked.ProvisioningState, "message", picked.Message)
 	return picked, nil
 }
 

--- a/backend/pkg/controllers/operationcontrollers/operation_node_pool_update_state_calculation.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_node_pool_update_state_calculation.go
@@ -1,0 +1,296 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operationcontrollers
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+	"github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/maestrohelpers"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// Node pool update operation state calculation for the node pool update operation controller.
+
+// hypershiftNodePoolOperationState contains the node pool update operation state calculation comparing desired state
+// against Hypershift's NodePool in the management cluster.
+func (c *operationNodePoolUpdate) hypershiftNodePoolOperationState(ctx context.Context, nodePool *api.HCPOpenShiftClusterNodePool, csNodePool *arohcpv1alpha1.NodePool) (*operationState, error) {
+	logger := utils.LoggerFromContext(ctx)
+
+	hypershiftNodePool, err := maestrohelpers.GetCachedNodePoolForNodePool(
+		ctx,
+		c.readDesireLister,
+		nodePool.ID.SubscriptionID,
+		nodePool.ID.ResourceGroupName,
+		nodePool.ID.Parent.Name,
+		nodePool.ID.Name,
+	)
+	if err != nil {
+		return nil, utils.TrackError(err)
+	}
+	if hypershiftNodePool == nil {
+		return newOperationState(arm.ProvisioningStateUpdating, "Hypershift NodePool has not been observed yet"), nil
+	}
+
+	if matches, message := c.hypershiftNodePoolSpecMatchesDesired(nodePool, csNodePool, hypershiftNodePool); !matches {
+		logger.Info("hypershift NodePool spec does not match desired configuration", "message", message)
+		return newOperationState(arm.ProvisioningStateUpdating, message), nil
+	}
+
+	if matches, message := c.hypershiftNodePoolStatusMatchesDesired(nodePool, hypershiftNodePool.Status); !matches {
+		logger.Info("hypershift NodePool status does not match desired configuration", "message", message)
+		return newOperationState(arm.ProvisioningStateUpdating, message), nil
+	}
+
+	return newOperationState(arm.ProvisioningStateSucceeded, ""), nil
+}
+
+// hypershiftNodePoolSpecMatchesDesired reports whether Hypershift NodePool .Spec fields
+// and other non status configuration matches desired state. Returns false and a diagnostic message
+// when any leaf check fails. NodePool .status is not checked here.
+func (c *operationNodePoolUpdate) hypershiftNodePoolSpecMatchesDesired(nodePool *api.HCPOpenShiftClusterNodePool, csNodePool *arohcpv1alpha1.NodePool, hypershiftNodePool *v1beta1.NodePool) (bool, string) {
+	if matches, message := c.hypershiftNodePoolLabelsSpecMatchesDesired(nodePool.Properties.Labels, hypershiftNodePool.Spec.NodeLabels); !matches {
+		return false, message
+	}
+	if matches, message := c.hypershiftNodePoolReplicasOrAutoscalingSpecMatchesDesired(nodePool, hypershiftNodePool.Spec); !matches {
+		return false, message
+	}
+	if matches, message := c.hypershiftNodePoolTaintsSpecMatchesDesired(nodePool.Properties.Taints, hypershiftNodePool.Spec.Taints); !matches {
+		return false, message
+	}
+	if matches, message := c.hypershiftNodePoolNodeDrainTimeoutSpecMatchesDesired(nodePool, csNodePool, hypershiftNodePool.Spec.NodeDrainTimeout); !matches {
+		return false, message
+	}
+	return true, ""
+}
+
+// hypershiftNodePoolLabelsSpecMatchesDesired reports whether Hypershift NodePool nodeLabels spec
+// reflects desired state's labels.
+//
+// Note: For now this check is incomplete: it can confirm additions but cannot
+// detect removal of a previously configured label, because Spec.NodeLabels may
+// contain labels managed by other controllers that we should not interfere with.
+// clusterServiceNodePoolSpecMatchesDesired partially compensates with an exact
+// Cluster Service labels check.
+func (c *operationNodePoolUpdate) hypershiftNodePoolLabelsSpecMatchesDesired(desired map[string]string, observed map[string]string) (bool, string) {
+	for k, v := range desired {
+		if observed[k] != v {
+			return false, fmt.Sprintf("hypershift NodePool nodeLabels are %v, want at least %v", observed, desired)
+		}
+	}
+	return true, ""
+}
+
+// hypershiftNodePoolReplicasOrAutoscalingSpecMatchesDesired reports whether Hypershift NodePool
+// replicas or autoscaling spec matches desired state.
+func (c *operationNodePoolUpdate) hypershiftNodePoolReplicasOrAutoscalingSpecMatchesDesired(desired *api.HCPOpenShiftClusterNodePool, observed v1beta1.NodePoolSpec) (bool, string) {
+	if desired.Properties.AutoScaling != nil {
+		if observed.AutoScaling == nil {
+			return false, fmt.Sprintf("hypershift NodePool autoscaling is unset, want min=%d max=%d", desired.Properties.AutoScaling.Min, desired.Properties.AutoScaling.Max)
+		}
+		observedMin := int32(0)
+		if observed.AutoScaling.Min != nil {
+			observedMin = *observed.AutoScaling.Min
+		}
+		observedMax := observed.AutoScaling.Max
+		if observedMin != desired.Properties.AutoScaling.Min || observedMax != desired.Properties.AutoScaling.Max {
+			return false, fmt.Sprintf("hypershift NodePool autoscaling is min=%d max=%d, want min=%d max=%d", observedMin, observedMax, desired.Properties.AutoScaling.Min, desired.Properties.AutoScaling.Max)
+		}
+		return true, ""
+	}
+
+	if observed.AutoScaling != nil {
+		observedMin := int32(0)
+		if observed.AutoScaling.Min != nil {
+			observedMin = *observed.AutoScaling.Min
+		}
+		return false, fmt.Sprintf("hypershift NodePool autoscaling is set (min=%d max=%d), want replicas=%d", observedMin, observed.AutoScaling.Max, desired.Properties.Replicas)
+	}
+
+	observedReplicas := int32(0)
+	if observed.Replicas != nil {
+		observedReplicas = *observed.Replicas
+	}
+	if observedReplicas != desired.Properties.Replicas {
+		return false, fmt.Sprintf("hypershift NodePool replicas is %d, want %d", observedReplicas, desired.Properties.Replicas)
+	}
+	return true, ""
+}
+
+// hypershiftNodePoolTaintsSpecMatchesDesired reports whether Hypershift NodePool taints spec
+// reflects desired state's taints.
+//
+// Note: For now this check is incomplete: it can confirm additions but cannot
+// detect removal of a previously configured taint, because Spec.Taints may
+// contain taints managed by other controllers that we should not interfere with.
+// clusterServiceNodePoolSpecMatchesDesired partially compensates with an exact
+// Cluster Service taints check.
+func (c *operationNodePoolUpdate) hypershiftNodePoolTaintsSpecMatchesDesired(desired []api.Taint, observed []v1beta1.Taint) (bool, string) {
+	for _, want := range desired {
+		found := false
+		for _, got := range observed {
+			if got.Key == want.Key && got.Value == want.Value && string(got.Effect) == string(want.Effect) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false, fmt.Sprintf("hypershift NodePool missing desired taint {effect:%s key:%s value:%s}", want.Effect, want.Key, want.Value)
+		}
+	}
+	return true, ""
+}
+
+// hypershiftNodePoolNodeDrainTimeoutSpecMatchesDesired reports whether Hypershift NodePool
+// nodeDrainTimeout spec matches desired state's nodeDrainTimeoutMinutes.
+func (c *operationNodePoolUpdate) hypershiftNodePoolNodeDrainTimeoutSpecMatchesDesired(desired *api.HCPOpenShiftClusterNodePool, csNodePool *arohcpv1alpha1.NodePool, observed *metav1.Duration) (bool, string) {
+	// If the desired node drain timeout is nil it means that the node pool drain timeout is inherited from the parent
+	// cluster's default that was set at the moment of the node pool creation. In that case, we
+	// want to compare the observed node drain timeout with cluster's service returned value. This is because CS does not
+	// support PATCH omit/null to clear the node pool drain timeout or re-inherit from a more recent cluster default.
+	if desired.Properties.NodeDrainTimeoutMinutes == nil &&
+		ocm.NodePoolUpdateDispatchConfigNodeDrainTimeoutFromCS(csNodePool) == nil {
+		return false, "Cluster Service node pool node_drain_grace_period is unset, want inherited cluster default"
+	}
+
+	effectiveDesiredMinutes := ocm.NodePoolUpdateDispatchConfigEffectiveNodeDrainTimeoutMinutes(desired, csNodePool)
+	want := time.Duration(*effectiveDesiredMinutes) * time.Minute
+	// Fail closed: once effective minutes are known, require Hypershift to report nodeDrainTimeout to either null
+	// or a non null non zero duration value before completing. A non null zero duration value means that something
+	// unexpected happened because in ARO-HCP we do not expect the node pool drain timeout to be set to an explicit
+	// zero duration because CS current logic should never set it to an explicit zero duration. If that occurs for some
+	// reason, we want to prevent the operation from completing as it's an unexpected state.
+	if observed != nil && observed.Duration == 0 {
+		return false, fmt.Sprintf("unexpected hypershift NodePool nodeDrainTimeout set to an explicit zero duration, want %s", want)
+	}
+	if want == 0 {
+		if observed != nil {
+			return false, fmt.Sprintf("hypershift NodePool nodeDrainTimeout is %s, want unset", observed.Duration)
+		}
+		return true, ""
+	}
+	if observed == nil {
+		return false, fmt.Sprintf("hypershift NodePool nodeDrainTimeout is unset, want %s", want)
+	}
+	if observed.Duration != want {
+		return false, fmt.Sprintf("hypershift NodePool nodeDrainTimeout is %s, want %s", observed.Duration, want)
+	}
+	return true, ""
+}
+
+// hypershiftNodePoolStatusMatchesDesired reports whether Hypershift NodePool .Status fields match desired state.
+func (c *operationNodePoolUpdate) hypershiftNodePoolStatusMatchesDesired(nodePool *api.HCPOpenShiftClusterNodePool, observed v1beta1.NodePoolStatus) (bool, string) {
+	if matches, message := c.hypershiftNodePoolStatusReplicasMatchesDesired(nodePool, observed.Replicas); !matches {
+		return false, message
+	}
+	// Skip AllMachinesReady check when scaling to zero -- there are no machines to be ready.
+	if nodePool.Properties.Replicas > 0 || nodePool.Properties.AutoScaling != nil {
+		if matches, message := c.hypershiftNodePoolAllMachinesReadyConditionStatusMatchesDesired(observed.Conditions); !matches {
+			return false, message
+		}
+	}
+	return true, ""
+}
+
+// hypershiftNodePoolAllMachinesReadyConditionStatusMatchesDesired reports whether Hypershift NodePool
+// AllMachinesReady condition status reflects that all machines are ready.
+func (c *operationNodePoolUpdate) hypershiftNodePoolAllMachinesReadyConditionStatusMatchesDesired(conditions []v1beta1.NodePoolCondition) (bool, string) {
+	for _, condition := range conditions {
+		if condition.Type == v1beta1.NodePoolAllMachinesReadyConditionType {
+			if condition.Status != corev1.ConditionTrue {
+				return false, fmt.Sprintf("hypershift NodePool condition %s is %s: %s", condition.Type, condition.Status, condition.Message)
+			}
+			return true, ""
+		}
+	}
+	return false, fmt.Sprintf("hypershift NodePool condition %s not yet reported", v1beta1.NodePoolAllMachinesReadyConditionType)
+}
+
+// hypershiftNodePoolStatusReplicasMatchesDesired reports whether Hypershift NodePool status replicas
+// match desired state's replicas or autoscaling bounds.
+func (c *operationNodePoolUpdate) hypershiftNodePoolStatusReplicasMatchesDesired(desired *api.HCPOpenShiftClusterNodePool, observedReplicas int32) (bool, string) {
+	if desired.Properties.AutoScaling != nil {
+		if observedReplicas < desired.Properties.AutoScaling.Min {
+			return false, fmt.Sprintf("hypershift NodePool status replicas is %d, want >= %d (autoscaling min)", observedReplicas, desired.Properties.AutoScaling.Min)
+		}
+		if observedReplicas > desired.Properties.AutoScaling.Max {
+			return false, fmt.Sprintf("hypershift NodePool status replicas is %d, want <= %d (autoscaling max)", observedReplicas, desired.Properties.AutoScaling.Max)
+		}
+		return true, ""
+	}
+
+	if observedReplicas != desired.Properties.Replicas {
+		return false, fmt.Sprintf("hypershift NodePool status replicas is %d, want %d", observedReplicas, desired.Properties.Replicas)
+	}
+	return true, ""
+}
+
+// clusterServiceNodePoolSpecOperationState reports whether Cluster Service node pool spec fields
+// match desired state intent for the node pool update operation. Only checks outside CS .status.
+// Labels and taints are checked here because Hypershift subset checks cannot detect removals.
+// Add checks against the management cluster state when possible instead of here, to reduce the
+// number of checks against Cluster Service, as CS will be removed in the future.
+func (c *operationNodePoolUpdate) clusterServiceNodePoolSpecOperationState(nodePool *api.HCPOpenShiftClusterNodePool, csNodePool *arohcpv1alpha1.NodePool) (*operationState, error) {
+	if matches, message := c.clusterServiceNodePoolSpecMatchesDesired(nodePool, csNodePool); !matches {
+		return newOperationState(arm.ProvisioningStateUpdating, message), nil
+	}
+	return newOperationState(arm.ProvisioningStateSucceeded, ""), nil
+}
+
+// clusterServiceNodePoolSpecMatchesDesired reports whether Cluster Service node pool spec fields
+// relevant to the node pool update operation match desired state. Returns false and a diagnostic
+// message when any leaf check fails.
+func (c *operationNodePoolUpdate) clusterServiceNodePoolSpecMatchesDesired(nodePool *api.HCPOpenShiftClusterNodePool, csNodePool *arohcpv1alpha1.NodePool) (bool, string) {
+	if matches, message := c.clusterServiceNodePoolLabelsSpecMatchesDesired(nodePool.Properties.Labels, csNodePool); !matches {
+		return false, message
+	}
+	if matches, message := c.clusterServiceNodePoolTaintsSpecMatchesDesired(nodePool.Properties.Taints, csNodePool); !matches {
+		return false, message
+	}
+	return true, ""
+}
+
+// clusterServiceNodePoolLabelsSpecMatchesDesired reports whether Cluster Service node pool
+// labels exactly match RP desired labels.
+func (c *operationNodePoolUpdate) clusterServiceNodePoolLabelsSpecMatchesDesired(desired map[string]string, csNodePool *arohcpv1alpha1.NodePool) (bool, string) {
+	observed := ocm.NodePoolUpdateDispatchConfigLabelsFromCS(csNodePool)
+	if !maps.Equal(desired, observed) {
+		return false, fmt.Sprintf("Cluster Service node pool labels are %v, want %v", observed, desired)
+	}
+	return true, ""
+}
+
+// clusterServiceNodePoolTaintsSpecMatchesDesired reports whether Cluster Service node pool
+// taints exactly match RP desired taints.
+func (c *operationNodePoolUpdate) clusterServiceNodePoolTaintsSpecMatchesDesired(desired []api.Taint, csNodePool *arohcpv1alpha1.NodePool) (bool, string) {
+	desiredTaints := ocm.NodePoolUpdateDispatchConfigTaintsFromRP(desired)
+	observedTaints := ocm.NodePoolUpdateDispatchConfigTaintsFromCS(csNodePool)
+	if !slices.Equal(desiredTaints, observedTaints) {
+		return false, fmt.Sprintf("Cluster Service node pool taints are %v, want %v", observedTaints, desiredTaints)
+	}
+	return true, ""
+}

--- a/backend/pkg/controllers/operationcontrollers/operation_node_pool_update_state_calculation_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_node_pool_update_state_calculation_test.go
@@ -1,0 +1,1411 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operationcontrollers
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+	"github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/maestrohelpers"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/api/kubeapplier"
+	internallistertesting "github.com/Azure/ARO-HCP/internal/database/listertesting"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+func TestHypershiftNodePoolOperationState(t *testing.T) {
+	t.Parallel()
+
+	fixture := newNodePoolTestFixture()
+
+	tests := []struct {
+		name              string
+		nodePool          *api.HCPOpenShiftClusterNodePool
+		csNodePool        *arohcpv1alpha1.NodePool
+		readDesires       []*kubeapplier.ReadDesire
+		wantState         arm.ProvisioningState
+		wantMessageSubstr string
+	}{
+		{
+			name:              "no ReadDesire returns Updating",
+			nodePool:          fixture.newNodePool(),
+			csNodePool:        testCSNodePoolWithNodeDrainTimeout(t, 0),
+			readDesires:       nil,
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: "Hypershift NodePool has not been observed yet",
+		},
+		{
+			name:       "empty node pool matches empty Hypershift NodePool",
+			nodePool:   fixture.newNodePool(),
+			csNodePool: testCSNodePoolWithNodeDrainTimeout(t, 0),
+			readDesires: []*kubeapplier.ReadDesire{
+				newHypershiftNodePoolReadDesire(t, testNodePoolUpdateMatchingHypershiftNodePool(0)),
+			},
+			wantState: arm.ProvisioningStateSucceeded,
+		},
+		{
+			name: "replicas mismatch returns Updating",
+			nodePool: func() *api.HCPOpenShiftClusterNodePool {
+				np := fixture.newNodePool()
+				np.Properties.Replicas = 3
+				return np
+			}(),
+			csNodePool: testCSNodePoolWithReplicasAndNodeDrainTimeout(t, 3, 0),
+			readDesires: []*kubeapplier.ReadDesire{
+				newHypershiftNodePoolReadDesire(t, func() *v1beta1.NodePool {
+					np := testNodePoolUpdateMatchingHypershiftNodePool(0)
+					np.Spec.Replicas = ptr.To(int32(1))
+					np.Status.Replicas = 1
+					return np
+				}()),
+			},
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: "replicas is 1, want 3",
+		},
+		{
+			name: "replicas match returns Succeeded",
+			nodePool: func() *api.HCPOpenShiftClusterNodePool {
+				np := fixture.newNodePool()
+				np.Properties.Replicas = 3
+				return np
+			}(),
+			csNodePool: testCSNodePoolWithReplicasAndNodeDrainTimeout(t, 3, 0),
+			readDesires: []*kubeapplier.ReadDesire{
+				newHypershiftNodePoolReadDesire(t, func() *v1beta1.NodePool {
+					np := testNodePoolUpdateMatchingHypershiftNodePool(0)
+					np.Spec.Replicas = ptr.To(int32(3))
+					np.Status.Replicas = 3
+					np.Status.Conditions = []v1beta1.NodePoolCondition{
+						{Type: v1beta1.NodePoolAllMachinesReadyConditionType, Status: corev1.ConditionTrue},
+					}
+					return np
+				}()),
+			},
+			wantState: arm.ProvisioningStateSucceeded,
+		},
+		{
+			name: "spec replicas mismatch while status already at desired returns Updating",
+			nodePool: func() *api.HCPOpenShiftClusterNodePool {
+				np := fixture.newNodePool()
+				np.Properties.Replicas = 3
+				return np
+			}(),
+			csNodePool: testCSNodePoolWithNodeDrainTimeout(t, 0),
+			readDesires: []*kubeapplier.ReadDesire{
+				newHypershiftNodePoolReadDesire(t, func() *v1beta1.NodePool {
+					np := testNodePoolUpdateMatchingHypershiftNodePool(0)
+					np.Spec.Replicas = ptr.To(int32(1))
+					np.Status.Replicas = 3
+					return np
+				}()),
+			},
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: "replicas is 1, want 3",
+		},
+		{
+			name: "autoscaling mismatch returns Updating",
+			nodePool: func() *api.HCPOpenShiftClusterNodePool {
+				np := fixture.newNodePool()
+				np.Properties.AutoScaling = &api.NodePoolAutoScaling{Min: 1, Max: 5}
+				return np
+			}(),
+			csNodePool: testCSNodePoolWithAutoscalingAndNodeDrainTimeout(t, 1, 5, 0),
+			readDesires: []*kubeapplier.ReadDesire{
+				newHypershiftNodePoolReadDesire(t, func() *v1beta1.NodePool {
+					np := testNodePoolUpdateMatchingHypershiftNodePool(0)
+					np.Spec.AutoScaling = &v1beta1.NodePoolAutoScaling{Min: ptr.To(int32(2)), Max: 5}
+					np.Spec.Replicas = nil
+					np.Status.Replicas = 2
+					return np
+				}()),
+			},
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: "autoscaling is min=2 max=5, want min=1 max=5",
+		},
+		{
+			name: "autoscaling match returns Succeeded",
+			nodePool: func() *api.HCPOpenShiftClusterNodePool {
+				np := fixture.newNodePool()
+				np.Properties.AutoScaling = &api.NodePoolAutoScaling{Min: 1, Max: 5}
+				return np
+			}(),
+			csNodePool: testCSNodePoolWithAutoscalingAndNodeDrainTimeout(t, 1, 5, 0),
+			readDesires: []*kubeapplier.ReadDesire{
+				newHypershiftNodePoolReadDesire(t, func() *v1beta1.NodePool {
+					np := testNodePoolUpdateMatchingHypershiftNodePool(0)
+					np.Spec.AutoScaling = &v1beta1.NodePoolAutoScaling{Min: ptr.To(int32(1)), Max: 5}
+					np.Spec.Replicas = nil
+					np.Status.Replicas = 1
+					np.Status.Conditions = []v1beta1.NodePoolCondition{
+						{Type: v1beta1.NodePoolAllMachinesReadyConditionType, Status: corev1.ConditionTrue},
+					}
+					return np
+				}()),
+			},
+			wantState: arm.ProvisioningStateSucceeded,
+		},
+		{
+			name: "replicas desired but observed autoscaling set returns Updating",
+			nodePool: func() *api.HCPOpenShiftClusterNodePool {
+				np := fixture.newNodePool()
+				np.Properties.Replicas = 3
+				return np
+			}(),
+			csNodePool: testCSNodePoolWithReplicasAndNodeDrainTimeout(t, 3, 0),
+			readDesires: []*kubeapplier.ReadDesire{
+				newHypershiftNodePoolReadDesire(t, func() *v1beta1.NodePool {
+					np := testNodePoolUpdateMatchingHypershiftNodePool(0)
+					np.Spec.AutoScaling = &v1beta1.NodePoolAutoScaling{Min: ptr.To(int32(1)), Max: 5}
+					np.Spec.Replicas = nil
+					np.Status.Replicas = 3
+					return np
+				}()),
+			},
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: "autoscaling is set (min=1 max=5), want replicas=3",
+		},
+		{
+			name: "autoscaling desired but observed replicas set returns Updating",
+			nodePool: func() *api.HCPOpenShiftClusterNodePool {
+				np := fixture.newNodePool()
+				np.Properties.AutoScaling = &api.NodePoolAutoScaling{Min: 1, Max: 5}
+				return np
+			}(),
+			csNodePool: testCSNodePoolWithAutoscalingAndNodeDrainTimeout(t, 1, 5, 0),
+			readDesires: []*kubeapplier.ReadDesire{
+				newHypershiftNodePoolReadDesire(t, func() *v1beta1.NodePool {
+					np := testNodePoolUpdateMatchingHypershiftNodePool(0)
+					np.Spec.Replicas = ptr.To(int32(3))
+					np.Spec.AutoScaling = nil
+					np.Status.Replicas = 3
+					return np
+				}()),
+			},
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: "autoscaling is unset, want min=1 max=5",
+		},
+		{
+			name: "autoscaling spec match status below min returns Updating",
+			nodePool: func() *api.HCPOpenShiftClusterNodePool {
+				np := fixture.newNodePool()
+				np.Properties.AutoScaling = &api.NodePoolAutoScaling{Min: 1, Max: 5}
+				return np
+			}(),
+			csNodePool: testCSNodePoolWithAutoscalingAndNodeDrainTimeout(t, 1, 5, 0),
+			readDesires: []*kubeapplier.ReadDesire{
+				newHypershiftNodePoolReadDesire(t, func() *v1beta1.NodePool {
+					np := testNodePoolUpdateMatchingHypershiftNodePool(0)
+					np.Spec.AutoScaling = &v1beta1.NodePoolAutoScaling{Min: ptr.To(int32(1)), Max: 5}
+					np.Spec.Replicas = nil
+					np.Status.Replicas = 0
+					return np
+				}()),
+			},
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: "status replicas is 0, want >= 1 (autoscaling min)",
+		},
+		{
+			name: "autoscaling spec match status above max returns Updating",
+			nodePool: func() *api.HCPOpenShiftClusterNodePool {
+				np := fixture.newNodePool()
+				np.Properties.AutoScaling = &api.NodePoolAutoScaling{Min: 1, Max: 5}
+				return np
+			}(),
+			csNodePool: testCSNodePoolWithAutoscalingAndNodeDrainTimeout(t, 1, 5, 0),
+			readDesires: []*kubeapplier.ReadDesire{
+				newHypershiftNodePoolReadDesire(t, func() *v1beta1.NodePool {
+					np := testNodePoolUpdateMatchingHypershiftNodePool(0)
+					np.Spec.AutoScaling = &v1beta1.NodePoolAutoScaling{Min: ptr.To(int32(1)), Max: 5}
+					np.Spec.Replicas = nil
+					np.Status.Replicas = 6
+					return np
+				}()),
+			},
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: "status replicas is 6, want <= 5 (autoscaling max)",
+		},
+		{
+			name: "labels mismatch returns Updating",
+			nodePool: func() *api.HCPOpenShiftClusterNodePool {
+				np := fixture.newNodePool()
+				np.Properties.Labels = map[string]string{"env": "prod"}
+				return np
+			}(),
+			csNodePool: testCSNodePoolWithNodeDrainTimeout(t, 0),
+			readDesires: []*kubeapplier.ReadDesire{
+				newHypershiftNodePoolReadDesire(t, testNodePoolUpdateMatchingHypershiftNodePool(0)),
+			},
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: "nodeLabels are map[], want at least map[env:prod]",
+		},
+		{
+			name: "labels exact match returns Succeeded",
+			nodePool: func() *api.HCPOpenShiftClusterNodePool {
+				np := fixture.newNodePool()
+				np.Properties.Labels = map[string]string{"env": "prod"}
+				return np
+			}(),
+			csNodePool: testCSNodePoolWithNodeDrainTimeout(t, 0),
+			readDesires: []*kubeapplier.ReadDesire{
+				newHypershiftNodePoolReadDesire(t, func() *v1beta1.NodePool {
+					np := testNodePoolUpdateMatchingHypershiftNodePool(0)
+					np.Spec.NodeLabels = map[string]string{"env": "prod"}
+					return np
+				}()),
+			},
+			wantState: arm.ProvisioningStateSucceeded,
+		},
+		{
+			name: "temporary: labels match with extra observed labels returns Succeeded",
+			nodePool: func() *api.HCPOpenShiftClusterNodePool {
+				np := fixture.newNodePool()
+				np.Properties.Labels = map[string]string{"env": "prod"}
+				return np
+			}(),
+			csNodePool: testCSNodePoolWithNodeDrainTimeout(t, 0),
+			readDesires: []*kubeapplier.ReadDesire{
+				newHypershiftNodePoolReadDesire(t, func() *v1beta1.NodePool {
+					np := testNodePoolUpdateMatchingHypershiftNodePool(0)
+					np.Spec.NodeLabels = map[string]string{"env": "prod", "managed-by": "other"}
+					return np
+				}()),
+			},
+			wantState: arm.ProvisioningStateSucceeded,
+		},
+		{
+			name: "taints mismatch returns Updating",
+			nodePool: func() *api.HCPOpenShiftClusterNodePool {
+				np := fixture.newNodePool()
+				np.Properties.Taints = []api.Taint{
+					{Effect: api.EffectNoSchedule, Key: "key1", Value: "val1"},
+				}
+				return np
+			}(),
+			csNodePool: testCSNodePoolWithNodeDrainTimeout(t, 0),
+			readDesires: []*kubeapplier.ReadDesire{
+				newHypershiftNodePoolReadDesire(t, testNodePoolUpdateMatchingHypershiftNodePool(0)),
+			},
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: "missing desired taint {effect:NoSchedule key:key1 value:val1}",
+		},
+		{
+			name: "taints exact match returns Succeeded",
+			nodePool: func() *api.HCPOpenShiftClusterNodePool {
+				np := fixture.newNodePool()
+				np.Properties.Taints = []api.Taint{
+					{Effect: api.EffectNoSchedule, Key: "key1", Value: "val1"},
+				}
+				return np
+			}(),
+			csNodePool: testCSNodePoolWithNodeDrainTimeout(t, 0),
+			readDesires: []*kubeapplier.ReadDesire{
+				newHypershiftNodePoolReadDesire(t, func() *v1beta1.NodePool {
+					np := testNodePoolUpdateMatchingHypershiftNodePool(0)
+					np.Spec.Taints = []v1beta1.Taint{
+						{Effect: corev1.TaintEffectNoSchedule, Key: "key1", Value: "val1"},
+					}
+					return np
+				}()),
+			},
+			wantState: arm.ProvisioningStateSucceeded,
+		},
+		{
+			name: "temporary: taints match with extra observed taints returns Succeeded",
+			nodePool: func() *api.HCPOpenShiftClusterNodePool {
+				np := fixture.newNodePool()
+				np.Properties.Taints = []api.Taint{
+					{Effect: api.EffectNoSchedule, Key: "key1", Value: "val1"},
+				}
+				return np
+			}(),
+			csNodePool: testCSNodePoolWithNodeDrainTimeout(t, 0),
+			readDesires: []*kubeapplier.ReadDesire{
+				newHypershiftNodePoolReadDesire(t, func() *v1beta1.NodePool {
+					np := testNodePoolUpdateMatchingHypershiftNodePool(0)
+					np.Spec.Taints = []v1beta1.Taint{
+						{Effect: corev1.TaintEffectNoSchedule, Key: "key1", Value: "val1"},
+						{Effect: corev1.TaintEffectNoExecute, Key: "internal", Value: "true"},
+					}
+					return np
+				}()),
+			},
+			wantState: arm.ProvisioningStateSucceeded,
+		},
+		{
+			name: "explicit node drain timeout mismatch returns Updating",
+			nodePool: func() *api.HCPOpenShiftClusterNodePool {
+				np := fixture.newNodePool()
+				np.Properties.NodeDrainTimeoutMinutes = ptr.To(int32(15))
+				return np
+			}(),
+			csNodePool: testCSNodePoolWithNodeDrainTimeout(t, 15),
+			readDesires: []*kubeapplier.ReadDesire{
+				newHypershiftNodePoolReadDesire(t, func() *v1beta1.NodePool {
+					np := testNodePoolUpdateMatchingHypershiftNodePool(15)
+					np.Spec.NodeDrainTimeout = &metav1.Duration{Duration: 10 * time.Minute}
+					return np
+				}()),
+			},
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: "nodeDrainTimeout is 10m0s, want 15m0s",
+		},
+		{
+			name:       "inherited node drain timeout from CS returns Succeeded",
+			nodePool:   fixture.newNodePool(),
+			csNodePool: testCSNodePoolWithNodeDrainTimeout(t, 4),
+			readDesires: []*kubeapplier.ReadDesire{
+				newHypershiftNodePoolReadDesire(t, testNodePoolUpdateMatchingHypershiftNodePool(4)),
+			},
+			wantState: arm.ProvisioningStateSucceeded,
+		},
+		{
+			name:       "cosmos unset but CS frozen value not yet on hypershift returns Updating",
+			nodePool:   fixture.newNodePool(),
+			csNodePool: testCSNodePoolWithNodeDrainTimeout(t, 4),
+			readDesires: []*kubeapplier.ReadDesire{
+				newHypershiftNodePoolReadDesire(t, testNodePoolUpdateMatchingHypershiftNodePool(0)),
+			},
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: "nodeDrainTimeout is unset, want 4m0s",
+		},
+		{
+			name:       "cosmos unset CS frozen value mismatches hypershift returns Updating",
+			nodePool:   fixture.newNodePool(),
+			csNodePool: testCSNodePoolWithNodeDrainTimeout(t, 4),
+			readDesires: []*kubeapplier.ReadDesire{
+				newHypershiftNodePoolReadDesire(t, testNodePoolUpdateMatchingHypershiftNodePool(3)),
+			},
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: "nodeDrainTimeout is 3m0s, want 4m0s",
+		},
+		{
+			name:       "cosmos unset and CS unset returns Updating",
+			nodePool:   fixture.newNodePool(),
+			csNodePool: testCSNodePool(t),
+			readDesires: []*kubeapplier.ReadDesire{
+				newHypershiftNodePoolReadDesire(t, testNodePoolUpdateMatchingHypershiftNodePool(0)),
+			},
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: "Cluster Service node pool node_drain_grace_period is unset, want inherited cluster default",
+		},
+		{
+			name: "status replicas mismatch returns Updating",
+			nodePool: func() *api.HCPOpenShiftClusterNodePool {
+				np := fixture.newNodePool()
+				np.Properties.Replicas = 3
+				return np
+			}(),
+			csNodePool: testCSNodePoolWithReplicasAndNodeDrainTimeout(t, 3, 0),
+			readDesires: []*kubeapplier.ReadDesire{
+				newHypershiftNodePoolReadDesire(t, func() *v1beta1.NodePool {
+					np := testNodePoolUpdateMatchingHypershiftNodePool(0)
+					np.Spec.Replicas = ptr.To(int32(3))
+					np.Status.Replicas = 1
+					return np
+				}()),
+			},
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: "status replicas is 1, want 3",
+		},
+		{
+			name:       "scale to zero spec match status replicas nonzero returns Updating",
+			nodePool:   fixture.newNodePool(),
+			csNodePool: testCSNodePoolWithNodeDrainTimeout(t, 0),
+			readDesires: []*kubeapplier.ReadDesire{
+				newHypershiftNodePoolReadDesire(t, func() *v1beta1.NodePool {
+					np := testNodePoolUpdateMatchingHypershiftNodePool(0)
+					np.Status.Replicas = 1
+					return np
+				}()),
+			},
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: "status replicas is 1, want 0",
+		},
+		{
+			name: "AllMachinesReady false returns Updating",
+			nodePool: func() *api.HCPOpenShiftClusterNodePool {
+				np := fixture.newNodePool()
+				np.Properties.Replicas = 3
+				return np
+			}(),
+			csNodePool: testCSNodePoolWithReplicasAndNodeDrainTimeout(t, 3, 0),
+			readDesires: []*kubeapplier.ReadDesire{
+				newHypershiftNodePoolReadDesire(t, func() *v1beta1.NodePool {
+					np := testNodePoolUpdateMatchingHypershiftNodePool(0)
+					np.Spec.Replicas = ptr.To(int32(3))
+					np.Status.Replicas = 3
+					np.Status.Conditions = []v1beta1.NodePoolCondition{
+						{Type: v1beta1.NodePoolAllMachinesReadyConditionType, Status: corev1.ConditionFalse, Message: "waiting"},
+					}
+					return np
+				}()),
+			},
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: "condition AllMachinesReady is False: waiting",
+		},
+		{
+			name:       "scaling to zero skips AllMachinesReady check",
+			nodePool:   fixture.newNodePool(),
+			csNodePool: testCSNodePoolWithNodeDrainTimeout(t, 0),
+			readDesires: []*kubeapplier.ReadDesire{
+				newHypershiftNodePoolReadDesire(t, testNodePoolUpdateMatchingHypershiftNodePool(0)),
+			},
+			wantState: arm.ProvisioningStateSucceeded,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			ctx = utils.ContextWithLogger(ctx, testr.New(t))
+
+			controller := &operationNodePoolUpdate{
+				readDesireLister: &internallistertesting.SliceReadDesireLister{
+					Desires: tt.readDesires,
+				},
+			}
+
+			state, err := controller.hypershiftNodePoolOperationState(ctx, tt.nodePool, tt.csNodePool)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantState, state.ProvisioningState)
+			if tt.wantMessageSubstr != "" {
+				assert.Contains(t, state.Message, tt.wantMessageSubstr)
+			}
+		})
+	}
+}
+
+func TestClusterServiceNodePoolSpecOperationState(t *testing.T) {
+	t.Parallel()
+
+	fixture := newNodePoolTestFixture()
+	controller := &operationNodePoolUpdate{}
+
+	tests := []struct {
+		name              string
+		nodePool          *api.HCPOpenShiftClusterNodePool
+		csNodePool        *arohcpv1alpha1.NodePool
+		wantState         arm.ProvisioningState
+		wantMessageSubstr string
+	}{
+		{
+			name:       "matching labels and taints returns Succeeded",
+			nodePool:   fixture.newNodePool(),
+			csNodePool: testCSNodePoolWithNodeDrainTimeout(t, 0),
+			wantState:  arm.ProvisioningStateSucceeded,
+		},
+		{
+			name: "matching labels returns Succeeded",
+			nodePool: func() *api.HCPOpenShiftClusterNodePool {
+				np := fixture.newNodePool()
+				np.Properties.Labels = map[string]string{"env": "prod"}
+				return np
+			}(),
+			csNodePool: testCSNodePoolWithLabels(t, map[string]string{"env": "prod"}),
+			wantState:  arm.ProvisioningStateSucceeded,
+		},
+		{
+			name: "label mismatch returns Updating",
+			nodePool: func() *api.HCPOpenShiftClusterNodePool {
+				np := fixture.newNodePool()
+				np.Properties.Labels = map[string]string{"env": "prod"}
+				return np
+			}(),
+			csNodePool:        testCSNodePoolWithLabels(t, map[string]string{"env": "staging"}),
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: `Cluster Service node pool labels are map[env:staging], want map[env:prod]`,
+		},
+		{
+			name: "stale label on CS after removal returns Updating",
+			nodePool: func() *api.HCPOpenShiftClusterNodePool {
+				np := fixture.newNodePool()
+				np.Properties.Labels = nil
+				return np
+			}(),
+			csNodePool:        testCSNodePoolWithLabels(t, map[string]string{"env": "prod"}),
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: `Cluster Service node pool labels are map[env:prod], want map[]`,
+		},
+		{
+			name: "matching taints returns Succeeded",
+			nodePool: func() *api.HCPOpenShiftClusterNodePool {
+				np := fixture.newNodePool()
+				np.Properties.Taints = []api.Taint{
+					{Effect: api.EffectNoSchedule, Key: "key1", Value: "val1"},
+				}
+				return np
+			}(),
+			csNodePool: testCSNodePoolWithTaints(t, arohcpv1alpha1.NewTaint().
+				Effect(string(api.EffectNoSchedule)).
+				Key("key1").
+				Value("val1")),
+			wantState: arm.ProvisioningStateSucceeded,
+		},
+		{
+			name: "taint mismatch returns Updating",
+			nodePool: func() *api.HCPOpenShiftClusterNodePool {
+				np := fixture.newNodePool()
+				np.Properties.Taints = []api.Taint{
+					{Effect: api.EffectNoSchedule, Key: "key1", Value: "val1"},
+				}
+				return np
+			}(),
+			csNodePool:        testCSNodePool(t),
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: `Cluster Service node pool taints are [], want [{NoSchedule key1 val1}]`,
+		},
+		{
+			name: "stale taint on CS after removal returns Updating",
+			nodePool: func() *api.HCPOpenShiftClusterNodePool {
+				np := fixture.newNodePool()
+				np.Properties.Taints = nil
+				return np
+			}(),
+			csNodePool: testCSNodePoolWithTaints(t, arohcpv1alpha1.NewTaint().
+				Effect(string(api.EffectNoSchedule)).
+				Key("key1").
+				Value("val1")),
+			wantState:         arm.ProvisioningStateUpdating,
+			wantMessageSubstr: `Cluster Service node pool taints are [{NoSchedule key1 val1}], want []`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			state, err := controller.clusterServiceNodePoolSpecOperationState(tt.nodePool, tt.csNodePool)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantState, state.ProvisioningState)
+			if tt.wantMessageSubstr != "" {
+				assert.Contains(t, state.Message, tt.wantMessageSubstr)
+			}
+		})
+	}
+}
+
+func TestHypershiftNodePoolLabelsSpecMatchesDesired(t *testing.T) {
+	t.Parallel()
+
+	controller := &operationNodePoolUpdate{}
+
+	tests := []struct {
+		name       string
+		desired    map[string]string
+		observed   map[string]string
+		wantMatch  bool
+		wantSubstr string
+	}{
+		{
+			name:      "both nil",
+			desired:   nil,
+			observed:  nil,
+			wantMatch: true,
+		},
+		{
+			name:      "temporary: desired empty with extra observed labels",
+			desired:   map[string]string{},
+			observed:  map[string]string{"managed-by": "other"},
+			wantMatch: true,
+		},
+		{
+			name:       "desired label missing on observed",
+			desired:    map[string]string{"env": "prod"},
+			observed:   nil,
+			wantMatch:  false,
+			wantSubstr: "nodeLabels are map[], want at least map[env:prod]",
+		},
+		{
+			name:       "desired label value mismatch",
+			desired:    map[string]string{"env": "prod"},
+			observed:   map[string]string{"env": "staging"},
+			wantMatch:  false,
+			wantSubstr: "nodeLabels are map[env:staging], want at least map[env:prod]",
+		},
+		{
+			name:      "desired labels match observed exactly",
+			desired:   map[string]string{"env": "prod"},
+			observed:  map[string]string{"env": "prod"},
+			wantMatch: true,
+		},
+		{
+			name:      "temporary:desired subset present with extra observed labels",
+			desired:   map[string]string{"env": "prod"},
+			observed:  map[string]string{"env": "prod", "zone": "east"},
+			wantMatch: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			match, msg := controller.hypershiftNodePoolLabelsSpecMatchesDesired(tt.desired, tt.observed)
+			assert.Equal(t, tt.wantMatch, match)
+			if tt.wantSubstr != "" {
+				assert.Contains(t, msg, tt.wantSubstr)
+			}
+		})
+	}
+}
+
+func TestHypershiftNodePoolReplicasOrAutoscalingSpecMatchesDesired(t *testing.T) {
+	t.Parallel()
+
+	controller := &operationNodePoolUpdate{}
+
+	tests := []struct {
+		name       string
+		desired    *api.HCPOpenShiftClusterNodePool
+		observed   v1beta1.NodePoolSpec
+		wantMatch  bool
+		wantSubstr string
+	}{
+		{
+			name: "replicas match",
+			desired: &api.HCPOpenShiftClusterNodePool{
+				Properties: api.HCPOpenShiftClusterNodePoolProperties{Replicas: 3},
+			},
+			observed:  v1beta1.NodePoolSpec{Replicas: ptr.To(int32(3))},
+			wantMatch: true,
+		},
+		{
+			name: "replicas mismatch",
+			desired: &api.HCPOpenShiftClusterNodePool{
+				Properties: api.HCPOpenShiftClusterNodePoolProperties{Replicas: 3},
+			},
+			observed:   v1beta1.NodePoolSpec{Replicas: ptr.To(int32(1))},
+			wantMatch:  false,
+			wantSubstr: "replicas is 1, want 3",
+		},
+		{
+			name: "replicas desired observed unset",
+			desired: &api.HCPOpenShiftClusterNodePool{
+				Properties: api.HCPOpenShiftClusterNodePoolProperties{Replicas: 3},
+			},
+			observed:   v1beta1.NodePoolSpec{},
+			wantMatch:  false,
+			wantSubstr: "replicas is 0, want 3",
+		},
+		{
+			name: "autoscaling match",
+			desired: &api.HCPOpenShiftClusterNodePool{
+				Properties: api.HCPOpenShiftClusterNodePoolProperties{
+					AutoScaling: &api.NodePoolAutoScaling{Min: 1, Max: 5},
+				},
+			},
+			observed: v1beta1.NodePoolSpec{
+				AutoScaling: &v1beta1.NodePoolAutoScaling{Min: ptr.To(int32(1)), Max: 5},
+			},
+			wantMatch: true,
+		},
+		{
+			name: "autoscaling desired but observed unset",
+			desired: &api.HCPOpenShiftClusterNodePool{
+				Properties: api.HCPOpenShiftClusterNodePoolProperties{
+					AutoScaling: &api.NodePoolAutoScaling{Min: 1, Max: 5},
+				},
+			},
+			observed:   v1beta1.NodePoolSpec{},
+			wantMatch:  false,
+			wantSubstr: "autoscaling is unset, want min=1 max=5",
+		},
+		{
+			name: "autoscaling mismatch",
+			desired: &api.HCPOpenShiftClusterNodePool{
+				Properties: api.HCPOpenShiftClusterNodePoolProperties{
+					AutoScaling: &api.NodePoolAutoScaling{Min: 1, Max: 5},
+				},
+			},
+			observed: v1beta1.NodePoolSpec{
+				AutoScaling: &v1beta1.NodePoolAutoScaling{Min: ptr.To(int32(2)), Max: 5},
+			},
+			wantMatch:  false,
+			wantSubstr: "autoscaling is min=2 max=5, want min=1 max=5",
+		},
+		{
+			name: "autoscaling desired but observed replicas set",
+			desired: &api.HCPOpenShiftClusterNodePool{
+				Properties: api.HCPOpenShiftClusterNodePoolProperties{
+					AutoScaling: &api.NodePoolAutoScaling{Min: 1, Max: 5},
+				},
+			},
+			observed: v1beta1.NodePoolSpec{
+				Replicas: ptr.To(int32(3)),
+			},
+			wantMatch:  false,
+			wantSubstr: "autoscaling is unset, want min=1 max=5",
+		},
+		{
+			name: "replicas desired but observed autoscaling set",
+			desired: &api.HCPOpenShiftClusterNodePool{
+				Properties: api.HCPOpenShiftClusterNodePoolProperties{Replicas: 3},
+			},
+			observed: v1beta1.NodePoolSpec{
+				AutoScaling: &v1beta1.NodePoolAutoScaling{Min: ptr.To(int32(1)), Max: 5},
+			},
+			wantMatch:  false,
+			wantSubstr: "autoscaling is set (min=1 max=5), want replicas=3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			match, msg := controller.hypershiftNodePoolReplicasOrAutoscalingSpecMatchesDesired(tt.desired, tt.observed)
+			assert.Equal(t, tt.wantMatch, match)
+			if tt.wantSubstr != "" {
+				assert.Contains(t, msg, tt.wantSubstr)
+			}
+		})
+	}
+}
+
+func TestHypershiftNodePoolTaintsSpecMatchesDesired(t *testing.T) {
+	t.Parallel()
+
+	controller := &operationNodePoolUpdate{}
+
+	tests := []struct {
+		name       string
+		desired    []api.Taint
+		observed   []v1beta1.Taint
+		wantMatch  bool
+		wantSubstr string
+	}{
+		{
+			name:      "both nil",
+			desired:   nil,
+			observed:  nil,
+			wantMatch: true,
+		},
+		{
+			name:      "temporary: desired empty with extra observed taints",
+			desired:   []api.Taint{},
+			observed:  []v1beta1.Taint{{Effect: corev1.TaintEffectNoSchedule, Key: "internal", Value: "true"}},
+			wantMatch: true,
+		},
+		{
+			name: "desired taint missing on observed",
+			desired: []api.Taint{
+				{Effect: api.EffectNoSchedule, Key: "key1", Value: "val1"},
+			},
+			observed:   nil,
+			wantMatch:  false,
+			wantSubstr: "missing desired taint {effect:NoSchedule key:key1 value:val1}",
+		},
+		{
+			name: "desired taint effect mismatch",
+			desired: []api.Taint{
+				{Effect: api.EffectNoSchedule, Key: "key1", Value: "val1"},
+			},
+			observed: []v1beta1.Taint{
+				{Effect: corev1.TaintEffectNoExecute, Key: "key1", Value: "val1"},
+			},
+			wantMatch:  false,
+			wantSubstr: "missing desired taint {effect:NoSchedule key:key1 value:val1}",
+		},
+		{
+			name: "desired taints match observed exactly",
+			desired: []api.Taint{
+				{Effect: api.EffectNoSchedule, Key: "key1", Value: "val1"},
+			},
+			observed: []v1beta1.Taint{
+				{Effect: corev1.TaintEffectNoSchedule, Key: "key1", Value: "val1"},
+			},
+			wantMatch: true,
+		},
+		{
+			name: "temporary: desired subset present with extra observed taints",
+			desired: []api.Taint{
+				{Effect: api.EffectNoSchedule, Key: "key1", Value: "val1"},
+			},
+			observed: []v1beta1.Taint{
+				{Effect: corev1.TaintEffectNoSchedule, Key: "key1", Value: "val1"},
+				{Effect: corev1.TaintEffectNoExecute, Key: "internal", Value: "true"},
+			},
+			wantMatch: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			match, msg := controller.hypershiftNodePoolTaintsSpecMatchesDesired(tt.desired, tt.observed)
+			assert.Equal(t, tt.wantMatch, match)
+			if tt.wantSubstr != "" {
+				assert.Contains(t, msg, tt.wantSubstr)
+			}
+		})
+	}
+}
+
+func TestHypershiftNodePoolNodeDrainTimeoutSpecMatchesDesired(t *testing.T) {
+	t.Parallel()
+
+	controller := &operationNodePoolUpdate{}
+
+	baseDesired := &api.HCPOpenShiftClusterNodePool{
+		Properties: api.HCPOpenShiftClusterNodePoolProperties{},
+	}
+
+	tests := []struct {
+		name       string
+		desired    *api.HCPOpenShiftClusterNodePool
+		cs         func(t *testing.T) *arohcpv1alpha1.NodePool
+		observed   *metav1.Duration
+		wantMatch  bool
+		wantSubstr string
+	}{
+		{
+			name:    "cosmos unset and CS unset does not match",
+			desired: baseDesired,
+			cs: func(t *testing.T) *arohcpv1alpha1.NodePool {
+				return testCSNodePool(t)
+			},
+			wantMatch:  false,
+			wantSubstr: "Cluster Service node pool node_drain_grace_period is unset, want inherited cluster default",
+		},
+		{
+			name: "cosmos explicit zero observed nil",
+			desired: &api.HCPOpenShiftClusterNodePool{
+				Properties: api.HCPOpenShiftClusterNodePoolProperties{
+					NodeDrainTimeoutMinutes: ptr.To(int32(0)),
+				},
+			},
+			cs: func(t *testing.T) *arohcpv1alpha1.NodePool {
+				return testCSNodePoolWithReplicas(t, 3)
+			},
+			wantMatch: true,
+		},
+		{
+			name: "cosmos explicit zero observed zero duration",
+			desired: &api.HCPOpenShiftClusterNodePool{
+				Properties: api.HCPOpenShiftClusterNodePoolProperties{
+					NodeDrainTimeoutMinutes: ptr.To(int32(0)),
+				},
+			},
+			cs: func(t *testing.T) *arohcpv1alpha1.NodePool {
+				return testCSNodePoolWithReplicas(t, 3)
+			},
+			observed:   &metav1.Duration{Duration: 0},
+			wantMatch:  false,
+			wantSubstr: "unexpected hypershift NodePool nodeDrainTimeout set to an explicit zero duration, want 0s",
+		},
+		{
+			name: "cosmos explicit zero observed nonzero duration",
+			desired: &api.HCPOpenShiftClusterNodePool{
+				Properties: api.HCPOpenShiftClusterNodePoolProperties{
+					NodeDrainTimeoutMinutes: ptr.To(int32(0)),
+				},
+			},
+			cs: func(t *testing.T) *arohcpv1alpha1.NodePool {
+				return testCSNodePoolWithReplicas(t, 3)
+			},
+			observed:   &metav1.Duration{Duration: 4 * time.Minute},
+			wantMatch:  false,
+			wantSubstr: "nodeDrainTimeout is 4m0s, want unset",
+		},
+		{
+			name: "cosmos explicit nonzero observed nil",
+			desired: &api.HCPOpenShiftClusterNodePool{
+				Properties: api.HCPOpenShiftClusterNodePoolProperties{
+					NodeDrainTimeoutMinutes: ptr.To(int32(15)),
+				},
+			},
+			cs: func(t *testing.T) *arohcpv1alpha1.NodePool {
+				return testCSNodePoolWithReplicas(t, 3)
+			},
+			wantMatch:  false,
+			wantSubstr: "hypershift NodePool nodeDrainTimeout is unset, want 15m0s",
+		},
+		{
+			name:    "cosmos unset uses CS frozen value",
+			desired: baseDesired,
+			cs: func(t *testing.T) *arohcpv1alpha1.NodePool {
+				return testCSNodePoolWithNodeDrainTimeout(t, 4)
+			},
+			observed:  &metav1.Duration{Duration: 4 * time.Minute},
+			wantMatch: true,
+		},
+		{
+			name:    "cosmos unset but CS frozen value is not yet on Hypershift",
+			desired: baseDesired,
+			cs: func(t *testing.T) *arohcpv1alpha1.NodePool {
+				return testCSNodePoolWithNodeDrainTimeout(t, 4)
+			},
+			wantMatch:  false,
+			wantSubstr: "hypershift NodePool nodeDrainTimeout is unset, want 4m0s",
+		},
+		{
+			name:    "cosmos unset but CS frozen value mismatches hypershift",
+			desired: baseDesired,
+			cs: func(t *testing.T) *arohcpv1alpha1.NodePool {
+				return testCSNodePoolWithNodeDrainTimeout(t, 4)
+			},
+			observed:   &metav1.Duration{Duration: 3 * time.Minute},
+			wantMatch:  false,
+			wantSubstr: "nodeDrainTimeout is 3m0s, want 4m0s",
+		},
+		{
+			name:    "cosmos unset and CS frozen zero observed nil matches",
+			desired: baseDesired,
+			cs: func(t *testing.T) *arohcpv1alpha1.NodePool {
+				return testCSNodePoolWithNodeDrainTimeout(t, 0)
+			},
+			wantMatch: true,
+		},
+		{
+			name:    "cosmos unset and CS frozen zero but observed nonzero duration",
+			desired: baseDesired,
+			cs: func(t *testing.T) *arohcpv1alpha1.NodePool {
+				return testCSNodePoolWithNodeDrainTimeout(t, 0)
+			},
+			observed:   &metav1.Duration{Duration: 4 * time.Minute},
+			wantMatch:  false,
+			wantSubstr: "nodeDrainTimeout is 4m0s, want unset",
+		},
+		{
+			name:    "cosmos unset and CS frozen zero but observed explicit zero duration",
+			desired: baseDesired,
+			cs: func(t *testing.T) *arohcpv1alpha1.NodePool {
+				return testCSNodePoolWithNodeDrainTimeout(t, 0)
+			},
+			observed:   &metav1.Duration{Duration: 0},
+			wantMatch:  false,
+			wantSubstr: "unexpected hypershift NodePool nodeDrainTimeout set to an explicit zero duration, want 0s",
+		},
+		{
+			name:    "cosmos unset and CS frozen has non zero value but observed hypershift has explicit zero duration",
+			desired: baseDesired,
+			cs: func(t *testing.T) *arohcpv1alpha1.NodePool {
+				return testCSNodePoolWithNodeDrainTimeout(t, 4)
+			},
+			observed:   &metav1.Duration{Duration: 0},
+			wantMatch:  false,
+			wantSubstr: "unexpected hypershift NodePool nodeDrainTimeout set to an explicit zero duration, want 4m0s",
+		},
+		{
+			name: "cosmos explicit mismatches observed",
+			desired: &api.HCPOpenShiftClusterNodePool{
+				Properties: api.HCPOpenShiftClusterNodePoolProperties{
+					NodeDrainTimeoutMinutes: ptr.To(int32(4)),
+				},
+			},
+			cs: func(t *testing.T) *arohcpv1alpha1.NodePool {
+				return testCSNodePoolWithNodeDrainTimeout(t, 4)
+			},
+			observed:   &metav1.Duration{Duration: 3 * time.Minute},
+			wantMatch:  false,
+			wantSubstr: "nodeDrainTimeout is 3m0s, want 4m0s",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			match, msg := controller.hypershiftNodePoolNodeDrainTimeoutSpecMatchesDesired(tt.desired, tt.cs(t), tt.observed)
+			assert.Equal(t, tt.wantMatch, match)
+			if tt.wantSubstr != "" {
+				assert.Contains(t, msg, tt.wantSubstr)
+			}
+		})
+	}
+}
+
+func TestHypershiftNodePoolStatusReplicasMatchesDesired(t *testing.T) {
+	t.Parallel()
+
+	controller := &operationNodePoolUpdate{}
+
+	tests := []struct {
+		name             string
+		desired          *api.HCPOpenShiftClusterNodePool
+		observedReplicas int32
+		wantMatch        bool
+		wantSubstr       string
+	}{
+		{
+			name: "fixed replicas match",
+			desired: &api.HCPOpenShiftClusterNodePool{
+				Properties: api.HCPOpenShiftClusterNodePoolProperties{Replicas: 3},
+			},
+			observedReplicas: 3,
+			wantMatch:        true,
+		},
+		{
+			name: "fixed replicas mismatch",
+			desired: &api.HCPOpenShiftClusterNodePool{
+				Properties: api.HCPOpenShiftClusterNodePoolProperties{Replicas: 3},
+			},
+			observedReplicas: 1,
+			wantMatch:        false,
+			wantSubstr:       "status replicas is 1, want 3",
+		},
+		{
+			name: "autoscaling within range",
+			desired: &api.HCPOpenShiftClusterNodePool{
+				Properties: api.HCPOpenShiftClusterNodePoolProperties{
+					AutoScaling: &api.NodePoolAutoScaling{Min: 1, Max: 5},
+				},
+			},
+			observedReplicas: 3,
+			wantMatch:        true,
+		},
+		{
+			name: "autoscaling below min",
+			desired: &api.HCPOpenShiftClusterNodePool{
+				Properties: api.HCPOpenShiftClusterNodePoolProperties{
+					AutoScaling: &api.NodePoolAutoScaling{Min: 2, Max: 5},
+				},
+			},
+			observedReplicas: 1,
+			wantMatch:        false,
+			wantSubstr:       "status replicas is 1, want >= 2 (autoscaling min)",
+		},
+		{
+			name: "autoscaling above max",
+			desired: &api.HCPOpenShiftClusterNodePool{
+				Properties: api.HCPOpenShiftClusterNodePoolProperties{
+					AutoScaling: &api.NodePoolAutoScaling{Min: 1, Max: 5},
+				},
+			},
+			observedReplicas: 6,
+			wantMatch:        false,
+			wantSubstr:       "status replicas is 6, want <= 5 (autoscaling max)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			match, msg := controller.hypershiftNodePoolStatusReplicasMatchesDesired(tt.desired, tt.observedReplicas)
+			assert.Equal(t, tt.wantMatch, match)
+			if tt.wantSubstr != "" {
+				assert.Contains(t, msg, tt.wantSubstr)
+			}
+		})
+	}
+}
+
+func TestHypershiftNodePoolAllMachinesReadyConditionStatusMatchesDesired(t *testing.T) {
+	t.Parallel()
+
+	controller := &operationNodePoolUpdate{}
+
+	tests := []struct {
+		name       string
+		conditions []v1beta1.NodePoolCondition
+		wantMatch  bool
+		wantSubstr string
+	}{
+		{
+			name: "condition true",
+			conditions: []v1beta1.NodePoolCondition{
+				{Type: v1beta1.NodePoolAllMachinesReadyConditionType, Status: corev1.ConditionTrue},
+			},
+			wantMatch: true,
+		},
+		{
+			name: "condition false",
+			conditions: []v1beta1.NodePoolCondition{
+				{Type: v1beta1.NodePoolAllMachinesReadyConditionType, Status: corev1.ConditionFalse, Message: "waiting"},
+			},
+			wantMatch:  false,
+			wantSubstr: "condition AllMachinesReady is False: waiting",
+		},
+		{
+			name:       "condition not yet reported",
+			conditions: nil,
+			wantMatch:  false,
+			wantSubstr: "condition AllMachinesReady not yet reported",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			match, msg := controller.hypershiftNodePoolAllMachinesReadyConditionStatusMatchesDesired(tt.conditions)
+			assert.Equal(t, tt.wantMatch, match)
+			if tt.wantSubstr != "" {
+				assert.Contains(t, msg, tt.wantSubstr)
+			}
+		})
+	}
+}
+
+func TestHypershiftNodePoolStatusMatchesDesired(t *testing.T) {
+	t.Parallel()
+
+	controller := &operationNodePoolUpdate{}
+
+	tests := []struct {
+		name       string
+		desired    *api.HCPOpenShiftClusterNodePool
+		observed   v1beta1.NodePoolStatus
+		wantMatch  bool
+		wantSubstr string
+	}{
+		{
+			name: "fixed replicas with ready machines",
+			desired: &api.HCPOpenShiftClusterNodePool{
+				Properties: api.HCPOpenShiftClusterNodePoolProperties{Replicas: 3},
+			},
+			observed: v1beta1.NodePoolStatus{
+				Replicas: 3,
+				Conditions: []v1beta1.NodePoolCondition{
+					{Type: v1beta1.NodePoolAllMachinesReadyConditionType, Status: corev1.ConditionTrue},
+				},
+			},
+			wantMatch: true,
+		},
+		{
+			name: "scaling to zero skips AllMachinesReady",
+			desired: &api.HCPOpenShiftClusterNodePool{
+				Properties: api.HCPOpenShiftClusterNodePoolProperties{Replicas: 0},
+			},
+			observed: v1beta1.NodePoolStatus{
+				Replicas: 0,
+			},
+			wantMatch: true,
+		},
+		{
+			name: "autoscaling at min with ready machines returns match",
+			desired: &api.HCPOpenShiftClusterNodePool{
+				Properties: api.HCPOpenShiftClusterNodePoolProperties{
+					AutoScaling: &api.NodePoolAutoScaling{Min: 1, Max: 5},
+				},
+			},
+			observed: v1beta1.NodePoolStatus{
+				Replicas: 1,
+				Conditions: []v1beta1.NodePoolCondition{
+					{Type: v1beta1.NodePoolAllMachinesReadyConditionType, Status: corev1.ConditionTrue},
+				},
+			},
+			wantMatch: true,
+		},
+		{
+			name: "autoscaling in range but AllMachinesReady false returns mismatch",
+			desired: &api.HCPOpenShiftClusterNodePool{
+				Properties: api.HCPOpenShiftClusterNodePoolProperties{
+					AutoScaling: &api.NodePoolAutoScaling{Min: 1, Max: 5},
+				},
+			},
+			observed: v1beta1.NodePoolStatus{
+				Replicas: 3,
+				Conditions: []v1beta1.NodePoolCondition{
+					{Type: v1beta1.NodePoolAllMachinesReadyConditionType, Status: corev1.ConditionFalse, Message: "waiting"},
+				},
+			},
+			wantMatch:  false,
+			wantSubstr: "condition AllMachinesReady is False: waiting",
+		},
+		{
+			name: "autoscaling in range but AllMachinesReady not reported returns mismatch",
+			desired: &api.HCPOpenShiftClusterNodePool{
+				Properties: api.HCPOpenShiftClusterNodePoolProperties{
+					AutoScaling: &api.NodePoolAutoScaling{Min: 1, Max: 5},
+				},
+			},
+			observed: v1beta1.NodePoolStatus{
+				Replicas: 3,
+			},
+			wantMatch:  false,
+			wantSubstr: "condition AllMachinesReady not yet reported",
+		},
+		{
+			name: "autoscaling status below min",
+			desired: &api.HCPOpenShiftClusterNodePool{
+				Properties: api.HCPOpenShiftClusterNodePoolProperties{
+					AutoScaling: &api.NodePoolAutoScaling{Min: 2, Max: 5},
+				},
+			},
+			observed: v1beta1.NodePoolStatus{
+				Replicas: 1,
+			},
+			wantMatch:  false,
+			wantSubstr: "status replicas is 1, want >= 2 (autoscaling min)",
+		},
+		{
+			name: "autoscaling status above max",
+			desired: &api.HCPOpenShiftClusterNodePool{
+				Properties: api.HCPOpenShiftClusterNodePoolProperties{
+					AutoScaling: &api.NodePoolAutoScaling{Min: 1, Max: 5},
+				},
+			},
+			observed: v1beta1.NodePoolStatus{
+				Replicas: 6,
+			},
+			wantMatch:  false,
+			wantSubstr: "status replicas is 6, want <= 5 (autoscaling max)",
+		},
+		{
+			name: "replicas mismatch fails before AllMachinesReady",
+			desired: &api.HCPOpenShiftClusterNodePool{
+				Properties: api.HCPOpenShiftClusterNodePoolProperties{Replicas: 3},
+			},
+			observed: v1beta1.NodePoolStatus{
+				Replicas: 1,
+				Conditions: []v1beta1.NodePoolCondition{
+					{Type: v1beta1.NodePoolAllMachinesReadyConditionType, Status: corev1.ConditionTrue},
+				},
+			},
+			wantMatch:  false,
+			wantSubstr: "status replicas is 1, want 3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			match, msg := controller.hypershiftNodePoolStatusMatchesDesired(tt.desired, tt.observed)
+			assert.Equal(t, tt.wantMatch, match)
+			if tt.wantSubstr != "" {
+				assert.Contains(t, msg, tt.wantSubstr)
+			}
+		})
+	}
+}
+
+// testNodePoolUpdateMatchingHypershiftNodePool returns a Hypershift NodePool that
+// matches the default node pool fixture for node pool update state calculation tests.
+func testNodePoolUpdateMatchingHypershiftNodePool(nodeDrainTimeoutMinutes int32) *v1beta1.NodePool {
+	spec := v1beta1.NodePoolSpec{
+		Replicas: ptr.To(int32(0)),
+	}
+	if nodeDrainTimeoutMinutes != 0 {
+		spec.NodeDrainTimeout = &metav1.Duration{Duration: time.Duration(nodeDrainTimeoutMinutes) * time.Minute}
+	}
+	return &v1beta1.NodePool{
+		Spec: spec,
+		Status: v1beta1.NodePoolStatus{
+			Replicas: 0,
+		},
+	}
+}
+
+func newHypershiftNodePoolReadDesire(t *testing.T, nodePool *v1beta1.NodePool) *kubeapplier.ReadDesire {
+	t.Helper()
+	raw, err := json.Marshal(nodePool)
+	require.NoError(t, err)
+
+	resourceID := api.Must(azcorearm.ParseResourceID(
+		kubeapplier.ToNodePoolScopedReadDesireResourceIDString(
+			testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName,
+			maestrohelpers.ReadDesireNameReadonlyNodePool)))
+
+	return &kubeapplier.ReadDesire{
+		CosmosMetadata: api.CosmosMetadata{
+			ResourceID:   resourceID,
+			PartitionKey: strings.ToLower(resourceID.SubscriptionID),
+		},
+		Status: kubeapplier.ReadDesireStatus{
+			Conditions: []metav1.Condition{
+				{Type: kubeapplier.ConditionTypeSuccessful, Status: metav1.ConditionTrue, Reason: kubeapplier.ConditionReasonNoErrors},
+			},
+			KubeContent: &kruntime.RawExtension{Raw: raw},
+		},
+	}
+}
+
+func testCSNodePool(t *testing.T) *arohcpv1alpha1.NodePool {
+	t.Helper()
+	csNodePool, err := arohcpv1alpha1.NewNodePool().Replicas(0).Build()
+	require.NoError(t, err)
+	return csNodePool
+}
+
+func testCSNodePoolWithReplicas(t *testing.T, replicas int) *arohcpv1alpha1.NodePool {
+	t.Helper()
+	csNodePool, err := arohcpv1alpha1.NewNodePool().Replicas(replicas).Build()
+	require.NoError(t, err)
+	return csNodePool
+}
+
+func testCSNodePoolWithNodeDrainTimeout(t *testing.T, minutes int32) *arohcpv1alpha1.NodePool {
+	t.Helper()
+	csNodePool, err := arohcpv1alpha1.NewNodePool().
+		Replicas(0).
+		NodeDrainGracePeriod(arohcpv1alpha1.NewValue().
+			Unit("minutes").
+			Value(float64(minutes))).
+		Build()
+	require.NoError(t, err)
+	return csNodePool
+}
+
+func testCSNodePoolWithReplicasAndNodeDrainTimeout(t *testing.T, replicas int, minutes int32) *arohcpv1alpha1.NodePool {
+	t.Helper()
+	csNodePool, err := arohcpv1alpha1.NewNodePool().
+		Replicas(replicas).
+		NodeDrainGracePeriod(arohcpv1alpha1.NewValue().
+			Unit("minutes").
+			Value(float64(minutes))).
+		Build()
+	require.NoError(t, err)
+	return csNodePool
+}
+
+func testCSNodePoolWithAutoscalingAndNodeDrainTimeout(t *testing.T, min, max int, minutes int32) *arohcpv1alpha1.NodePool {
+	t.Helper()
+	csNodePool, err := arohcpv1alpha1.NewNodePool().
+		Autoscaling(arohcpv1alpha1.NewNodePoolAutoscaling().
+			MinReplica(min).
+			MaxReplica(max)).
+		NodeDrainGracePeriod(arohcpv1alpha1.NewValue().
+			Unit("minutes").
+			Value(float64(minutes))).
+		Build()
+	require.NoError(t, err)
+	return csNodePool
+}
+
+func testCSNodePoolWithLabels(t *testing.T, labels map[string]string) *arohcpv1alpha1.NodePool {
+	t.Helper()
+	csNodePool, err := arohcpv1alpha1.NewNodePool().
+		Replicas(0).
+		Labels(labels).
+		Build()
+	require.NoError(t, err)
+	return csNodePool
+}
+
+func testCSNodePoolWithTaints(t *testing.T, taints ...*arohcpv1alpha1.TaintBuilder) *arohcpv1alpha1.NodePool {
+	t.Helper()
+	builder := arohcpv1alpha1.NewNodePool().Replicas(0)
+	if len(taints) > 0 {
+		builder.Taints(taints...)
+	}
+	csNodePool, err := builder.Build()
+	require.NoError(t, err)
+	return csNodePool
+}

--- a/backend/pkg/controllers/operationcontrollers/operation_node_pool_update_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_node_pool_update_test.go
@@ -186,7 +186,7 @@ func TestOperationNodePoolUpdate_SynchronizeOperation(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateFailed, op.Status)
 				assert.NotNil(t, op.Error)
-				assert.Equal(t, "temporary error occurred", op.Error.Message)
+				assert.Contains(t, op.Error.Message, "temporary error occurred")
 			},
 		},
 		{

--- a/backend/pkg/controllers/operationcontrollers/operation_node_pool_update_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_node_pool_update_test.go
@@ -16,6 +16,8 @@ package operationcontrollers
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -25,67 +27,140 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/json"
 	clocktesting "k8s.io/utils/clock/testing"
 	"k8s.io/utils/lru"
 	"k8s.io/utils/ptr"
 
-	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+	"github.com/openshift/hypershift/api/hypershift/v1beta1"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
+	"github.com/Azure/ARO-HCP/backend/pkg/maestrohelpers"
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/api/kubeapplier"
 	"github.com/Azure/ARO-HCP/internal/database"
+	dblisters "github.com/Azure/ARO-HCP/internal/database/listers"
+	internallistertesting "github.com/Azure/ARO-HCP/internal/database/listertesting"
 	"github.com/Azure/ARO-HCP/internal/databasetesting"
 	"github.com/Azure/ARO-HCP/internal/ocm"
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
 
 func TestOperationNodePoolUpdate_SynchronizeOperation(t *testing.T) {
-	t.Parallel()
 	testClockNow := mustParseTime("2024-06-01T12:00:00Z")
 	fixture := newNodePoolTestFixture()
-	newNodePool := func(version string) *api.HCPOpenShiftClusterNodePool {
-		np := fixture.newNodePool()
-		np.Properties.Version.ID = version
-		return np
+
+	newNodePoolWithVersion := func(version string, mutate ...func(*api.HCPOpenShiftClusterNodePool)) *api.HCPOpenShiftClusterNodePool {
+		nodePool := fixture.newNodePool()
+		nodePool.Properties.Version.ID = version
+		for _, fn := range mutate {
+			if fn != nil {
+				fn(nodePool)
+			}
+		}
+		return nodePool
 	}
-	newServiceProviderNodePool := func(desiredVersion *semver.Version) *api.ServiceProviderNodePool {
+
+	newOperationAccepted := func() *api.Operation {
+		return fixture.newOperation(database.OperationRequestUpdate)
+	}
+
+	newServiceProviderNodePoolWithDesiredVersion := func(version string) *api.ServiceProviderNodePool {
 		sp := fixture.newServiceProviderNodePool()
-		sp.Spec.NodePoolVersion.DesiredVersion = desiredVersion
+		sp.Spec.NodePoolVersion.DesiredVersion = ptr.To(semver.MustParse(version))
 		return sp
 	}
-	tests := []struct {
-		name                              string
-		mockCS                            func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec)
-		nodePool                          *api.HCPOpenShiftClusterNodePool
-		serviceProviderNodePool           *api.ServiceProviderNodePool
-		nodePoolVersionController         *api.Controller
-		desiredVersionMismatchFirstSeenAt time.Time
-		expectError                       bool
-		verifyDB                          func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture)
+
+	newDefaultNodePoolVersionController := func() *api.Controller {
+		return fixture.newNodePoolVersionController(nil)
+	}
+
+	newNodePoolVersionControllerWithConditions := func(conditions []metav1.Condition) *api.Controller {
+		return fixture.newNodePoolVersionController(conditions)
+	}
+
+	newPassingCachedNodePoolReadDesire := func(nodePool *api.HCPOpenShiftClusterNodePool) *kubeapplier.ReadDesire {
+		return newNodePoolReadDesire(t, nodePool, fixture.newCluster())
+	}
+
+	setupMockCSClientForNodePoolState := func(state NodePoolStateValue, statusMessage ...string) func(*ocm.MockClusterServiceClientSpec) {
+		return func(mock *ocm.MockClusterServiceClientSpec) {
+			stateBuilder := arohcpv1alpha1.NewNodePoolState().NodePoolStateValue(string(state))
+			statusBuilder := arohcpv1alpha1.NewNodePoolStatus().State(stateBuilder)
+			if len(statusMessage) > 0 {
+				statusBuilder = statusBuilder.Message(statusMessage[0])
+			}
+			csNodePool, err := arohcpv1alpha1.NewNodePool().
+				Replicas(0).
+				NodeDrainGracePeriod(arohcpv1alpha1.NewValue().
+					Unit("minutes").
+					Value(float64(0))).
+				Status(statusBuilder).
+				Build()
+			require.NoError(t, err)
+			mock.EXPECT().
+				GetNodePool(gomock.Any(), gomock.Any()).
+				Return(csNodePool, nil)
+		}
+	}
+
+	setupMockCSClientForNodePoolReadyWithSpec := func(replicas int, nodeDrainMinutes int32) func(*ocm.MockClusterServiceClientSpec) {
+		return func(mock *ocm.MockClusterServiceClientSpec) {
+			stateBuilder := arohcpv1alpha1.NewNodePoolState().NodePoolStateValue(string(NodePoolStateReady))
+			statusBuilder := arohcpv1alpha1.NewNodePoolStatus().State(stateBuilder)
+			csNodePool, err := arohcpv1alpha1.NewNodePool().
+				Replicas(replicas).
+				NodeDrainGracePeriod(arohcpv1alpha1.NewValue().
+					Unit("minutes").
+					Value(float64(nodeDrainMinutes))).
+				Status(statusBuilder).
+				Build()
+			require.NoError(t, err)
+			mock.EXPECT().
+				GetNodePool(gomock.Any(), gomock.Any()).
+				Return(csNodePool, nil)
+		}
+	}
+
+	testCases := []struct {
+		name             string
+		existingNodePool *api.HCPOpenShiftClusterNodePool
+		// When not set, the controller uses a node pool lister that contains the existingNodePool.
+		nodePoolLister    listers.NodePoolLister
+		existingOperation *api.Operation
+		// When not set, the controller uses an active operations lister that contains the existingOperation.
+		activeOperationsLister          listers.ActiveOperationLister
+		existingServiceProviderNodePool *api.ServiceProviderNodePool
+		// When not set, the controller uses a service provider node pool lister that contains the existingServiceProviderNodePool.
+		serviceProviderNodePoolLister     listers.ServiceProviderNodePoolLister
+		existingNodePoolVersionController *api.Controller
+		// When set, wires a ReadDesireLister containing this cached Hypershift NodePool mirror.
+		cachedNodePoolReadDesire *kubeapplier.ReadDesire
+		seedMismatchFirstSeenAt  time.Time
+		setupMockCSClient        func(*ocm.MockClusterServiceClientSpec)
+		wantErr                  bool
+		verifyDB                 func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient)
 	}{
 		{
-			name: "node pool ready transitions to succeeded",
-			mockCS: func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec) {
-				t.Helper()
-				nodePoolStatus, err := arohcpv1alpha1.NewNodePoolStatus().
-					State(arohcpv1alpha1.NewNodePoolState().NodePoolStateValue(string(NodePoolStateReady))).
-					Build()
-				require.NoError(t, err)
-				mockCS.EXPECT().
-					GetNodePoolStatus(gomock.Any(), gomock.Any()).
-					Return(nodePoolStatus, nil)
-			},
-			nodePool:                  newNodePool("4.19.0"),
-			serviceProviderNodePool:   newServiceProviderNodePool(ptr.To(semver.MustParse("4.19.0"))),
-			nodePoolVersionController: fixture.newNodePoolVersionController(nil),
-			expectError:               false,
-			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
+			name:                            "cs node pool ready transitions operation to succeeded",
+			existingNodePool:                newNodePoolWithVersion("4.19.0"),
+			existingOperation:               newOperationAccepted(),
+			existingServiceProviderNodePool: newServiceProviderNodePoolWithDesiredVersion("4.19.0"),
+			cachedNodePoolReadDesire:        newPassingCachedNodePoolReadDesire(newNodePoolWithVersion("4.19.0")),
+			setupMockCSClient:               setupMockCSClientForNodePoolState(NodePoolStateReady),
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateSucceeded, op.Status)
 
-				// Verify node pool provisioning state was also updated
 				nodePool, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).NodePools(testClusterName).Get(ctx, testNodePoolName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateSucceeded, nodePool.Properties.ProvisioningState)
@@ -93,27 +168,17 @@ func TestOperationNodePoolUpdate_SynchronizeOperation(t *testing.T) {
 			},
 		},
 		{
-			name: "node pool updating transitions to updating",
-			mockCS: func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec) {
-				t.Helper()
-				nodePoolStatus, err := arohcpv1alpha1.NewNodePoolStatus().
-					State(arohcpv1alpha1.NewNodePoolState().NodePoolStateValue(string(NodePoolStateUpdating))).
-					Build()
-				require.NoError(t, err)
-				mockCS.EXPECT().
-					GetNodePoolStatus(gomock.Any(), gomock.Any()).
-					Return(nodePoolStatus, nil)
-			},
-			nodePool:                  newNodePool("4.19.0"),
-			serviceProviderNodePool:   newServiceProviderNodePool(ptr.To(semver.MustParse("4.19.0"))),
-			nodePoolVersionController: fixture.newNodePoolVersionController(nil),
-			expectError:               false,
-			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
+			name:                            "cs node pool updating transitions operation to updating",
+			existingNodePool:                newNodePoolWithVersion("4.19.0"),
+			existingOperation:               newOperationAccepted(),
+			existingServiceProviderNodePool: newServiceProviderNodePoolWithDesiredVersion("4.19.0"),
+			cachedNodePoolReadDesire:        newPassingCachedNodePoolReadDesire(newNodePoolWithVersion("4.19.0")),
+			setupMockCSClient:               setupMockCSClientForNodePoolState(NodePoolStateUpdating),
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateUpdating, op.Status)
 
-				// Verify node pool still has active operation
 				nodePool, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).NodePools(testClusterName).Get(ctx, testNodePoolName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateUpdating, nodePool.Properties.ProvisioningState)
@@ -121,67 +186,39 @@ func TestOperationNodePoolUpdate_SynchronizeOperation(t *testing.T) {
 			},
 		},
 		{
-			name: "node pool validating_update stays accepted",
-			mockCS: func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec) {
-				t.Helper()
-				nodePoolStatus, err := arohcpv1alpha1.NewNodePoolStatus().
-					State(arohcpv1alpha1.NewNodePoolState().NodePoolStateValue(string(NodePoolStateValidatingUpdate))).
-					Build()
-				require.NoError(t, err)
-				mockCS.EXPECT().
-					GetNodePoolStatus(gomock.Any(), gomock.Any()).
-					Return(nodePoolStatus, nil)
-			},
-			nodePool:                  newNodePool("4.19.0"),
-			serviceProviderNodePool:   newServiceProviderNodePool(ptr.To(semver.MustParse("4.19.0"))),
-			nodePoolVersionController: fixture.newNodePoolVersionController(nil),
-			expectError:               false,
-			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
+			name:                            "cs node pool validating_update keeps operation accepted",
+			existingNodePool:                newNodePoolWithVersion("4.19.0"),
+			existingOperation:               newOperationAccepted(),
+			existingServiceProviderNodePool: newServiceProviderNodePoolWithDesiredVersion("4.19.0"),
+			cachedNodePoolReadDesire:        newPassingCachedNodePoolReadDesire(newNodePoolWithVersion("4.19.0")),
+			setupMockCSClient:               setupMockCSClientForNodePoolState(NodePoolStateValidatingUpdate),
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
 			},
 		},
 		{
-			name: "node pool pending_update stays accepted",
-			mockCS: func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec) {
-				t.Helper()
-				nodePoolStatus, err := arohcpv1alpha1.NewNodePoolStatus().
-					State(arohcpv1alpha1.NewNodePoolState().NodePoolStateValue(string(NodePoolStatePendingUpdate))).
-					Build()
-				require.NoError(t, err)
-				mockCS.EXPECT().
-					GetNodePoolStatus(gomock.Any(), gomock.Any()).
-					Return(nodePoolStatus, nil)
-			},
-			nodePool:                  newNodePool("4.19.0"),
-			serviceProviderNodePool:   newServiceProviderNodePool(ptr.To(semver.MustParse("4.19.0"))),
-			nodePoolVersionController: fixture.newNodePoolVersionController(nil),
-			expectError:               false,
-			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
+			name:                            "cs node pool pending_update keeps operation accepted",
+			existingNodePool:                newNodePoolWithVersion("4.19.0"),
+			existingOperation:               newOperationAccepted(),
+			existingServiceProviderNodePool: newServiceProviderNodePoolWithDesiredVersion("4.19.0"),
+			cachedNodePoolReadDesire:        newPassingCachedNodePoolReadDesire(newNodePoolWithVersion("4.19.0")),
+			setupMockCSClient:               setupMockCSClientForNodePoolState(NodePoolStatePendingUpdate),
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
 			},
 		},
 		{
-			name: "node pool recoverable_error transitions to failed",
-			mockCS: func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec) {
-				t.Helper()
-				nodePoolStatus, err := arohcpv1alpha1.NewNodePoolStatus().
-					State(arohcpv1alpha1.NewNodePoolState().NodePoolStateValue(string(NodePoolStateRecoverableError))).
-					Message("temporary error occurred").
-					Build()
-				require.NoError(t, err)
-				mockCS.EXPECT().
-					GetNodePoolStatus(gomock.Any(), gomock.Any()).
-					Return(nodePoolStatus, nil)
-			},
-			nodePool:                  newNodePool("4.19.0"),
-			serviceProviderNodePool:   newServiceProviderNodePool(ptr.To(semver.MustParse("4.19.0"))),
-			nodePoolVersionController: fixture.newNodePoolVersionController(nil),
-			expectError:               false,
-			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
+			name:                            "cs node pool recoverable_error transitions operation to failed",
+			existingNodePool:                newNodePoolWithVersion("4.19.0"),
+			existingOperation:               newOperationAccepted(),
+			existingServiceProviderNodePool: newServiceProviderNodePoolWithDesiredVersion("4.19.0"),
+			cachedNodePoolReadDesire:        newPassingCachedNodePoolReadDesire(newNodePoolWithVersion("4.19.0")),
+			setupMockCSClient:               setupMockCSClientForNodePoolState(NodePoolStateRecoverableError, "temporary error occurred"),
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateFailed, op.Status)
@@ -190,47 +227,11 @@ func TestOperationNodePoolUpdate_SynchronizeOperation(t *testing.T) {
 			},
 		},
 		{
-			name: "node pool ready with exact version match transitions operation to succeeded",
-			mockCS: func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec) {
-				t.Helper()
-				nodePoolStatus, err := arohcpv1alpha1.NewNodePoolStatus().
-					State(arohcpv1alpha1.NewNodePoolState().NodePoolStateValue(string(NodePoolStateReady))).
-					Build()
-				require.NoError(t, err)
-				mockCS.EXPECT().
-					GetNodePoolStatus(gomock.Any(), gomock.Any()).
-					Return(nodePoolStatus, nil)
-			},
-			nodePool:                  newNodePool("4.20.5"),
-			serviceProviderNodePool:   newServiceProviderNodePool(ptr.To(semver.MustParse("4.20.5"))),
-			nodePoolVersionController: fixture.newNodePoolVersionController(nil),
-			expectError:               false,
-			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
-				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
-				require.NoError(t, err)
-				assert.Equal(t, arm.ProvisioningStateSucceeded, op.Status)
-
-				nodePool, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).NodePools(testClusterName).Get(ctx, testNodePoolName)
-				require.NoError(t, err)
-				assert.Equal(t, arm.ProvisioningStateSucceeded, nodePool.Properties.ProvisioningState)
-				assert.Empty(t, nodePool.ServiceProviderProperties.ActiveOperationID)
-			},
-		},
-		{
-			name: "node pool with version mismatch and IntentFailed condition marks operation failed",
-			mockCS: func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec) {
-				t.Helper()
-				nodePoolStatus, err := arohcpv1alpha1.NewNodePoolStatus().
-					State(arohcpv1alpha1.NewNodePoolState().NodePoolStateValue(string(NodePoolStateReady))).
-					Build()
-				require.NoError(t, err)
-				mockCS.EXPECT().
-					GetNodePoolStatus(gomock.Any(), gomock.Any()).
-					Return(nodePoolStatus, nil)
-			},
-			nodePool:                newNodePool("4.21.5"),
-			serviceProviderNodePool: newServiceProviderNodePool(ptr.To(semver.MustParse("4.20.5"))),
-			nodePoolVersionController: fixture.newNodePoolVersionController([]metav1.Condition{
+			name:                            "customer version mismatch with IntentFailed on NodePoolVersion controller marks operation failed",
+			existingNodePool:                newNodePoolWithVersion("4.21.5"),
+			existingOperation:               newOperationAccepted(),
+			existingServiceProviderNodePool: newServiceProviderNodePoolWithDesiredVersion("4.20.5"),
+			existingNodePoolVersionController: newNodePoolVersionControllerWithConditions([]metav1.Condition{
 				{
 					Type:    api.ControllerConditionTypeIntentFailed,
 					Status:  metav1.ConditionTrue,
@@ -238,8 +239,9 @@ func TestOperationNodePoolUpdate_SynchronizeOperation(t *testing.T) {
 					Message: "invalid node pool version 4.21.5: cannot exceed control plane version 4.20.5",
 				},
 			}),
-			expectError: false,
-			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
+			cachedNodePoolReadDesire: newPassingCachedNodePoolReadDesire(newNodePoolWithVersion("4.21.5")),
+			setupMockCSClient:        setupMockCSClientForNodePoolState(NodePoolStateReady),
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateFailed, op.Status)
@@ -254,22 +256,14 @@ func TestOperationNodePoolUpdate_SynchronizeOperation(t *testing.T) {
 			},
 		},
 		{
-			name: "node pool with version mismatch without IntentFailed leaves operation accepted",
-			mockCS: func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec) {
-				t.Helper()
-				nodePoolStatus, err := arohcpv1alpha1.NewNodePoolStatus().
-					State(arohcpv1alpha1.NewNodePoolState().NodePoolStateValue(string(NodePoolStateReady))).
-					Build()
-				require.NoError(t, err)
-				mockCS.EXPECT().
-					GetNodePoolStatus(gomock.Any(), gomock.Any()).
-					Return(nodePoolStatus, nil)
-			},
-			nodePool:                  newNodePool("4.20.5"),
-			serviceProviderNodePool:   newServiceProviderNodePool(ptr.To(semver.MustParse("4.20.4"))),
-			nodePoolVersionController: fixture.newNodePoolVersionController(nil),
-			expectError:               false,
-			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
+			name:                              "customer version mismatch without NodePoolVersion IntentFailed leaves operation accepted",
+			existingNodePool:                  newNodePoolWithVersion("4.20.5"),
+			existingOperation:                 newOperationAccepted(),
+			existingServiceProviderNodePool:   newServiceProviderNodePoolWithDesiredVersion("4.20.4"),
+			existingNodePoolVersionController: newDefaultNodePoolVersionController(),
+			cachedNodePoolReadDesire:          newPassingCachedNodePoolReadDesire(newNodePoolWithVersion("4.20.5")),
+			setupMockCSClient:                 setupMockCSClientForNodePoolState(NodePoolStateReady),
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
@@ -281,23 +275,17 @@ func TestOperationNodePoolUpdate_SynchronizeOperation(t *testing.T) {
 			},
 		},
 		{
-			name: "node pool with version mismatch without IntentFailed leaves operation accepted when first seen within 59s",
-			mockCS: func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec) {
-				t.Helper()
-				nodePoolStatus, err := arohcpv1alpha1.NewNodePoolStatus().
-					State(arohcpv1alpha1.NewNodePoolState().NodePoolStateValue(string(NodePoolStateReady))).
-					Build()
-				require.NoError(t, err)
-				mockCS.EXPECT().
-					GetNodePoolStatus(gomock.Any(), gomock.Any()).
-					Return(nodePoolStatus, nil)
-			},
-			nodePool:                          newNodePool("4.20.5"),
-			serviceProviderNodePool:           newServiceProviderNodePool(ptr.To(semver.MustParse("4.20.4"))),
-			nodePoolVersionController:         fixture.newNodePoolVersionController(nil),
-			desiredVersionMismatchFirstSeenAt: testClockNow.Add(-50 * time.Second),
-			expectError:                       false,
-			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
+			name:                            "customer version mismatch without NodePoolVersion IntentFailed leaves operation accepted when first seen within 59s",
+			existingNodePool:                newNodePoolWithVersion("4.20.5"),
+			existingOperation:               newOperationAccepted(),
+			existingServiceProviderNodePool: newServiceProviderNodePoolWithDesiredVersion("4.20.4"),
+			existingNodePoolVersionController: newNodePoolVersionControllerWithConditions([]metav1.Condition{
+				{Type: api.ControllerConditionTypeIntentFailed, Status: metav1.ConditionFalse},
+			}),
+			cachedNodePoolReadDesire: newPassingCachedNodePoolReadDesire(newNodePoolWithVersion("4.20.5")),
+			seedMismatchFirstSeenAt:  testClockNow.Add(-50 * time.Second),
+			setupMockCSClient:        setupMockCSClientForNodePoolState(NodePoolStateReady),
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
@@ -309,50 +297,43 @@ func TestOperationNodePoolUpdate_SynchronizeOperation(t *testing.T) {
 			},
 		},
 		{
-			name: "node pool with version mismatch without IntentFailed stays accepted even after 59s",
-			mockCS: func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec) {
-				t.Helper()
-				nodePoolStatus, err := arohcpv1alpha1.NewNodePoolStatus().
-					State(arohcpv1alpha1.NewNodePoolState().NodePoolStateValue(string(NodePoolStateReady))).
-					Build()
-				require.NoError(t, err)
-				mockCS.EXPECT().
-					GetNodePoolStatus(gomock.Any(), gomock.Any()).
-					Return(nodePoolStatus, nil)
-			},
-			nodePool:                          newNodePool("4.20.5"),
-			serviceProviderNodePool:           newServiceProviderNodePool(ptr.To(semver.MustParse("4.20.4"))),
-			nodePoolVersionController:         fixture.newNodePoolVersionController(nil),
-			desiredVersionMismatchFirstSeenAt: testClockNow.Add(-60 * time.Second),
-			expectError:                       false,
-			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
+			name:                            "customer version mismatch without IntentFailed fails when mismatch first seen exceeds 59s",
+			existingNodePool:                newNodePoolWithVersion("4.20.5"),
+			existingOperation:               newOperationAccepted(),
+			existingServiceProviderNodePool: newServiceProviderNodePoolWithDesiredVersion("4.20.4"),
+			existingNodePoolVersionController: newNodePoolVersionControllerWithConditions([]metav1.Condition{
+				{Type: api.ControllerConditionTypeIntentFailed, Status: metav1.ConditionFalse},
+			}),
+			cachedNodePoolReadDesire: newPassingCachedNodePoolReadDesire(newNodePoolWithVersion("4.20.5")),
+			seedMismatchFirstSeenAt:  testClockNow.Add(-60 * time.Second),
+			setupMockCSClient:        setupMockCSClientForNodePoolState(NodePoolStateReady),
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
-				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
-				assert.Nil(t, op.Error)
+				assert.Equal(t, arm.ProvisioningStateFailed, op.Status)
+				require.NotNil(t, op.Error)
+				assert.Equal(t, arm.CloudErrorCodeInvalidRequestContent, op.Error.Code)
 
 				nodePool, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).NodePools(testClusterName).Get(ctx, testNodePoolName)
 				require.NoError(t, err)
-				assert.Equal(t, testOperationName, nodePool.ServiceProviderProperties.ActiveOperationID)
+				wantMessageSubstr := fmt.Sprintf(
+					"timed out after 59s waiting for resolution of desired version from '%s' node pool version",
+					nodePool.Properties.Version.ID,
+				)
+				assert.Contains(t, op.Error.Message, wantMessageSubstr)
+
+				assert.Equal(t, arm.ProvisioningStateFailed, nodePool.Properties.ProvisioningState)
+				assert.Empty(t, nodePool.ServiceProviderProperties.ActiveOperationID)
 			},
 		},
 		{
-			name: "node pool with exact version match but cluster service still updating transitions operation to updating",
-			mockCS: func(t *testing.T, mockCS *ocm.MockClusterServiceClientSpec) {
-				t.Helper()
-				nodePoolStatus, err := arohcpv1alpha1.NewNodePoolStatus().
-					State(arohcpv1alpha1.NewNodePoolState().NodePoolStateValue(string(NodePoolStateUpdating))).
-					Build()
-				require.NoError(t, err)
-				mockCS.EXPECT().
-					GetNodePoolStatus(gomock.Any(), gomock.Any()).
-					Return(nodePoolStatus, nil)
-			},
-			nodePool:                  newNodePool("4.20.5"),
-			serviceProviderNodePool:   newServiceProviderNodePool(ptr.To(semver.MustParse("4.20.5"))),
-			nodePoolVersionController: fixture.newNodePoolVersionController(nil),
-			expectError:               false,
-			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, fixture *nodePoolTestFixture) {
+			name:                            "exact version match but cs node pool still updating transitions operation to updating",
+			existingNodePool:                newNodePoolWithVersion("4.20.5"),
+			existingOperation:               newOperationAccepted(),
+			existingServiceProviderNodePool: newServiceProviderNodePoolWithDesiredVersion("4.20.5"),
+			cachedNodePoolReadDesire:        newPassingCachedNodePoolReadDesire(newNodePoolWithVersion("4.20.5")),
+			setupMockCSClient:               setupMockCSClientForNodePoolState(NodePoolStateUpdating),
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
 				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, arm.ProvisioningStateUpdating, op.Status)
@@ -363,54 +344,239 @@ func TestOperationNodePoolUpdate_SynchronizeOperation(t *testing.T) {
 				assert.Equal(t, testOperationName, nodePool.ServiceProviderProperties.ActiveOperationID)
 			},
 		},
+		{
+			name: "cs node pool ready with hypershift node drain spec mismatch keeps operation updating",
+			existingNodePool: newNodePoolWithVersion("4.19.0", func(nodePool *api.HCPOpenShiftClusterNodePool) {
+				nodePool.Properties.NodeDrainTimeoutMinutes = ptr.To(int32(60))
+			}),
+			existingOperation:               newOperationAccepted(),
+			existingServiceProviderNodePool: newServiceProviderNodePoolWithDesiredVersion("4.19.0"),
+			cachedNodePoolReadDesire:        newHypershiftNodePoolReadDesire(t, testNodePoolUpdateMatchingHypershiftNodePool(30)),
+			setupMockCSClient:               setupMockCSClientForNodePoolReadyWithSpec(0, 60),
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateUpdating, op.Status)
+				assert.Nil(t, op.Error)
+
+				nodePool, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).NodePools(testClusterName).Get(ctx, testNodePoolName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateUpdating, nodePool.Properties.ProvisioningState)
+				assert.Equal(t, testOperationName, nodePool.ServiceProviderProperties.ActiveOperationID)
+			},
+		},
+		{
+			name: "cs node pool ready with hypershift replicas spec mismatch keeps operation updating",
+			existingNodePool: newNodePoolWithVersion("4.19.0", func(nodePool *api.HCPOpenShiftClusterNodePool) {
+				nodePool.Properties.Replicas = 3
+			}),
+			existingOperation:               newOperationAccepted(),
+			existingServiceProviderNodePool: newServiceProviderNodePoolWithDesiredVersion("4.19.0"),
+			cachedNodePoolReadDesire: newHypershiftNodePoolReadDesire(t, func() *v1beta1.NodePool {
+				np := testNodePoolUpdateMatchingHypershiftNodePool(0)
+				np.Spec.Replicas = ptr.To(int32(1))
+				np.Status.Replicas = 1
+				return np
+			}()),
+			setupMockCSClient: setupMockCSClientForNodePoolReadyWithSpec(3, 0),
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateUpdating, op.Status)
+				assert.Nil(t, op.Error)
+
+				nodePool, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).NodePools(testClusterName).Get(ctx, testNodePoolName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateUpdating, nodePool.Properties.ProvisioningState)
+				assert.Equal(t, testOperationName, nodePool.ServiceProviderProperties.ActiveOperationID)
+			},
+		},
+		{
+			name: "shouldReconcile gate not passed when ClusterServiceID is nil",
+			existingNodePool: newNodePoolWithVersion("4.19.0", func(nodePool *api.HCPOpenShiftClusterNodePool) {
+				nodePool.ServiceProviderProperties.ClusterServiceID = nil
+			}),
+			existingOperation: newOperationAccepted(),
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+			},
+		},
+		{
+			name: "shouldReconcile gate not passed when node pool is deleting",
+			existingNodePool: newNodePoolWithVersion("4.19.0", func(nodePool *api.HCPOpenShiftClusterNodePool) {
+				nodePool.ServiceProviderProperties.DeletionTimestamp = &metav1.Time{Time: testClockNow}
+			}),
+			existingOperation: newOperationAccepted(),
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+			},
+		},
+		{
+			name:              "node pool not in lister cache leaves operation unchanged",
+			existingNodePool:  newNodePoolWithVersion("4.19.0"),
+			existingOperation: newOperationAccepted(),
+			nodePoolLister:    &listertesting.SliceNodePoolLister{},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateAccepted, op.Status)
+
+				nodePool, err := db.HCPClusters(testSubscriptionID, testResourceGroupName).NodePools(testClusterName).Get(ctx, testNodePoolName)
+				require.NoError(t, err)
+				assert.Equal(t, testOperationName, nodePool.ServiceProviderProperties.ActiveOperationID)
+				assert.Equal(t, arm.ProvisioningStateAccepted, nodePool.Properties.ProvisioningState)
+			},
+		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			ctx := context.Background()
-			ctx = utils.ContextWithLogger(ctx, testr.New(t))
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
 			ctrl := gomock.NewController(t)
 
-			cluster := fixture.newCluster()
-			operation := fixture.newOperation(database.OperationRequestUpdate)
+			resources := []any{}
+			if tc.existingNodePool != nil {
+				resources = append(resources, tc.existingNodePool)
+			}
+			if tc.existingOperation != nil {
+				resources = append(resources, tc.existingOperation)
+			}
+			if tc.existingServiceProviderNodePool != nil {
+				resources = append(resources, tc.existingServiceProviderNodePool)
+			}
+			if tc.existingNodePoolVersionController != nil {
+				resources = append(resources, tc.existingNodePoolVersionController)
+			}
 
-			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, []any{cluster, tt.nodePool, operation})
+			mockResourcesDBClient, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, resources)
 			require.NoError(t, err)
 
-			_, err = mockResourcesDBClient.ServiceProviderNodePools(testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName).Create(ctx, tt.serviceProviderNodePool, nil)
-			require.NoError(t, err)
+			var readDesireLister dblisters.ReadDesireLister
+			if tc.cachedNodePoolReadDesire != nil {
+				readDesireLister = &internallistertesting.SliceReadDesireLister{
+					Desires: []*kubeapplier.ReadDesire{tc.cachedNodePoolReadDesire},
+				}
+			}
 
-			_, err = mockResourcesDBClient.HCPClusters(testSubscriptionID, testResourceGroupName).
-				NodePools(testClusterName).Controllers(testNodePoolName).Create(ctx, tt.nodePoolVersionController, nil)
-			require.NoError(t, err)
+			nodePoolLister := tc.nodePoolLister
+			if nodePoolLister == nil {
+				nodePoolLister = &listertesting.DBNodePoolLister{ResourcesDBClient: mockResourcesDBClient}
+			}
+			activeOperationsLister := tc.activeOperationsLister
+			if activeOperationsLister == nil {
+				activeOperationsLister = &listertesting.DBActiveOperationLister{ResourcesDBClient: mockResourcesDBClient}
+			}
+			serviceProviderNodePoolLister := tc.serviceProviderNodePoolLister
+			if serviceProviderNodePoolLister == nil {
+				serviceProviderNodePoolLister = &listertesting.DBServiceProviderNodePoolLister{ResourcesDBClient: mockResourcesDBClient}
+			}
 
 			mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
-			tt.mockCS(t, mockCSClient)
+			if tc.setupMockCSClient != nil {
+				tc.setupMockCSClient(mockCSClient)
+			}
 
 			fakeClock := clocktesting.NewFakeClock(testClockNow)
 			controller := &operationNodePoolUpdate{
 				resourcesDBClient:               mockResourcesDBClient,
 				clusterServiceClient:            mockCSClient,
+				nodePoolLister:                  nodePoolLister,
+				serviceProviderNodePoolLister:   serviceProviderNodePoolLister,
+				readDesireLister:                readDesireLister,
+				activeOperationsLister:          activeOperationsLister,
 				notificationClient:              nil,
 				clock:                           fakeClock,
 				desiredVersionMismatchFirstSeen: lru.New(100000),
 			}
-			if !tt.desiredVersionMismatchFirstSeenAt.IsZero() {
-				controller.desiredVersionMismatchFirstSeen.Add(operation.ResourceID.String(), tt.desiredVersionMismatchFirstSeenAt)
+			if !tc.seedMismatchFirstSeenAt.IsZero() {
+				require.NotNil(t, tc.existingOperation)
+				controller.desiredVersionMismatchFirstSeen.Add(strings.ToLower(tc.existingOperation.ResourceID.String()), tc.seedMismatchFirstSeenAt)
 			}
 
 			err = controller.SynchronizeOperation(ctx, fixture.operationKey())
-
-			if tt.expectError {
+			if tc.wantErr {
 				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
+				return
 			}
+			require.NoError(t, err)
 
-			if tt.verifyDB != nil {
-				tt.verifyDB(t, ctx, mockResourcesDBClient, fixture)
+			if tc.verifyDB != nil {
+				tc.verifyDB(t, ctx, mockResourcesDBClient)
 			}
 		})
 	}
+}
+
+func newNodePoolReadDesire(t *testing.T, nodePool *api.HCPOpenShiftClusterNodePool, cluster *api.HCPOpenShiftCluster) *kubeapplier.ReadDesire {
+	t.Helper()
+
+	hsNodePool := nodePoolToHypershiftNodePool(nodePool, cluster)
+	raw, err := json.Marshal(hsNodePool)
+	require.NoError(t, err)
+
+	resourceID := api.Must(azcorearm.ParseResourceID(
+		kubeapplier.ToNodePoolScopedReadDesireResourceIDString(
+			testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName,
+			maestrohelpers.ReadDesireNameReadonlyNodePool)))
+
+	return &kubeapplier.ReadDesire{
+		CosmosMetadata: api.CosmosMetadata{
+			ResourceID: resourceID,
+		},
+		Status: kubeapplier.ReadDesireStatus{
+			Conditions: []metav1.Condition{
+				{Type: kubeapplier.ConditionTypeSuccessful, Status: metav1.ConditionTrue, Reason: kubeapplier.ConditionReasonNoErrors},
+			},
+			KubeContent: &kruntime.RawExtension{Raw: raw},
+		},
+	}
+}
+
+func nodePoolToHypershiftNodePool(nodePool *api.HCPOpenShiftClusterNodePool, cluster *api.HCPOpenShiftCluster) *v1beta1.NodePool {
+	effectiveNodeDrainMinutes := nodePool.Properties.NodeDrainTimeoutMinutes
+	if effectiveNodeDrainMinutes == nil {
+		effectiveNodeDrainMinutes = &cluster.CustomerProperties.NodeDrainTimeoutMinutes
+	}
+
+	np := &v1beta1.NodePool{
+		Spec: v1beta1.NodePoolSpec{
+			NodeLabels: nodePool.Properties.Labels,
+			Replicas:   ptr.To(nodePool.Properties.Replicas),
+		},
+		Status: v1beta1.NodePoolStatus{
+			Replicas: nodePool.Properties.Replicas,
+			Conditions: []v1beta1.NodePoolCondition{
+				{
+					Type:   v1beta1.NodePoolAllMachinesReadyConditionType,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+	if *effectiveNodeDrainMinutes != 0 {
+		np.Spec.NodeDrainTimeout = &metav1.Duration{Duration: time.Duration(*effectiveNodeDrainMinutes) * time.Minute}
+	}
+	if nodePool.Properties.AutoScaling != nil {
+		np.Spec.AutoScaling = &v1beta1.NodePoolAutoScaling{
+			Min: ptr.To(nodePool.Properties.AutoScaling.Min),
+			Max: nodePool.Properties.AutoScaling.Max,
+		}
+		np.Spec.Replicas = nil
+		np.Status.Replicas = nodePool.Properties.AutoScaling.Min
+	}
+	if len(nodePool.Properties.Taints) > 0 {
+		np.Spec.Taints = make([]v1beta1.Taint, 0, len(nodePool.Properties.Taints))
+		for _, taint := range nodePool.Properties.Taints {
+			np.Spec.Taints = append(np.Spec.Taints, v1beta1.Taint{
+				Key:    taint.Key,
+				Value:  taint.Value,
+				Effect: corev1.TaintEffect(taint.Effect),
+			})
+		}
+	}
+	return np
 }

--- a/backend/pkg/controllers/operationcontrollers/operation_state.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_state.go
@@ -16,20 +16,30 @@ package operationcontrollers
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 )
 
 type operationState struct {
-	provisioningState arm.ProvisioningState
-	message           string
+	// Source is a name that identifies the source of the operation state.
+	Source            string                `json:"source"`
+	ProvisioningState arm.ProvisioningState `json:"provisioningState"`
+	Message           string                `json:"message"`
 }
 
+// withSource sets the source of the operation state.
+func (s *operationState) withSource(source string) *operationState {
+	s.Source = source
+	return s
+}
+
+// newOperationState creates a new operation state with the given provisioning state and message, without a source.
 func newOperationState(provisioningState arm.ProvisioningState, message string) *operationState {
 	return &operationState{
-		provisioningState: provisioningState,
-		message:           message,
+		ProvisioningState: provisioningState,
+		Message:           message,
 	}
 }
 
@@ -59,13 +69,13 @@ func compareOperationState(lhs, rhs *operationState) int {
 		return 1
 	}
 
-	if provisioningStatePriority[lhs.provisioningState] < provisioningStatePriority[rhs.provisioningState] {
+	if provisioningStatePriority[lhs.ProvisioningState] < provisioningStatePriority[rhs.ProvisioningState] {
 		return -1
 	}
-	if provisioningStatePriority[lhs.provisioningState] > provisioningStatePriority[rhs.provisioningState] {
+	if provisioningStatePriority[lhs.ProvisioningState] > provisioningStatePriority[rhs.ProvisioningState] {
 		return 1
 	}
-	return strings.Compare(lhs.message, rhs.message)
+	return strings.Compare(lhs.Message, rhs.Message)
 }
 
 // pickWorstOperationState expects states pre-sorted and returns the worst state with merged messages.
@@ -73,16 +83,24 @@ func pickWorstOperationState(states []*operationState) (*operationState, error) 
 	if len(states) == 0 {
 		return nil, errors.New("no operation states")
 	}
-	worstProvisioningState := states[0].provisioningState
+	worstProvisioningState := states[0].ProvisioningState
 	if len(worstProvisioningState) == 0 {
 		return nil, errors.New("empty provisioning state")
 	}
 	var messageParts []string
 	for _, s := range states {
-		if s.provisioningState != worstProvisioningState {
+		if s.ProvisioningState != worstProvisioningState {
 			break
 		}
-		messageParts = append(messageParts, s.message)
+		currentSource := "<no_source>"
+		if s.Source != "" {
+			currentSource = s.Source
+		}
+		currentMessage := "<no_message>"
+		if s.Message != "" {
+			currentMessage = s.Message
+		}
+		messageParts = append(messageParts, fmt.Sprintf("[%s] %s", currentSource, currentMessage))
 	}
 	return newOperationState(worstProvisioningState, strings.Join(messageParts, "; ")), nil
 }

--- a/backend/pkg/controllers/operationcontrollers/operation_state_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_state_test.go
@@ -99,12 +99,20 @@ func TestPickWorstOperationState(t *testing.T) {
 			wantErr: "empty provisioning state",
 		},
 		{
-			name: "single state",
+			name: "single state without source",
 			states: []*operationState{
 				newOperationState(arm.ProvisioningStateFailed, "first failure"),
 			},
 			wantProv:    arm.ProvisioningStateFailed,
-			wantMessage: "first failure",
+			wantMessage: "[<no_source>] first failure",
+		},
+		{
+			name: "single state with source",
+			states: []*operationState{
+				newOperationState(arm.ProvisioningStateFailed, "NotReady: cluster is not ready").withSource("hypershiftHostedCluster"),
+			},
+			wantProv:    arm.ProvisioningStateFailed,
+			wantMessage: "[hypershiftHostedCluster] NotReady: cluster is not ready",
 		},
 		{
 			name: "merges messages for consecutive same provisioning state",
@@ -114,7 +122,16 @@ func TestPickWorstOperationState(t *testing.T) {
 				newOperationState(arm.ProvisioningStateFailed, "c"),
 			},
 			wantProv:    arm.ProvisioningStateFailed,
-			wantMessage: "a; b; c",
+			wantMessage: "[<no_source>] a; [<no_source>] b; [<no_source>] c",
+		},
+		{
+			name: "merges messages with sources",
+			states: []*operationState{
+				newOperationState(arm.ProvisioningStateFailed, "a").withSource("checkA"),
+				newOperationState(arm.ProvisioningStateFailed, "b").withSource("checkB"),
+			},
+			wantProv:    arm.ProvisioningStateFailed,
+			wantMessage: "[checkA] a; [checkB] b",
 		},
 		{
 			name: "stops merging when provisioning state changes",
@@ -123,7 +140,15 @@ func TestPickWorstOperationState(t *testing.T) {
 				newOperationState(arm.ProvisioningStateSucceeded, "ignored"),
 			},
 			wantProv:    arm.ProvisioningStateFailed,
-			wantMessage: "worst",
+			wantMessage: "[<no_source>] worst",
+		},
+		{
+			name: "empty message uses placeholder",
+			states: []*operationState{
+				newOperationState(arm.ProvisioningStateFailed, "").withSource("checkA"),
+			},
+			wantProv:    arm.ProvisioningStateFailed,
+			wantMessage: "[checkA] <no_message>",
 		},
 	}
 
@@ -139,8 +164,8 @@ func TestPickWorstOperationState(t *testing.T) {
 			}
 			assert.NoError(t, err)
 			assert.NotNil(t, got)
-			assert.Equal(t, tt.wantProv, got.provisioningState)
-			assert.Equal(t, tt.wantMessage, got.message)
+			assert.Equal(t, tt.wantProv, got.ProvisioningState)
+			assert.Equal(t, tt.wantMessage, got.Message)
 		})
 	}
 }

--- a/backend/pkg/controllers/operationcontrollers/test_helpers_test.go
+++ b/backend/pkg/controllers/operationcontrollers/test_helpers_test.go
@@ -24,6 +24,7 @@ import (
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/hypershift/api/hypershift/v1beta1"
 
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
@@ -376,5 +377,112 @@ func testClusterUpdateMatchingHostedClusterSpec() v1beta1.HostedClusterSpec {
 		},
 		ControllerAvailabilityPolicy:     v1beta1.HighlyAvailable,
 		InfrastructureAvailabilityPolicy: v1beta1.HighlyAvailable,
+	}
+}
+
+// newExternalAuthUpdateTestExternalAuth returns an external auth whose properties match
+// testExternalAuthUpdateMatchingOIDCProvider for external auth update state calculation tests.
+func newExternalAuthUpdateTestExternalAuth(mutate ...func(*api.HCPOpenShiftClusterExternalAuth)) *api.HCPOpenShiftClusterExternalAuth {
+	externalAuth := newExternalAuthTestFixture().newExternalAuth()
+	externalAuth.Properties = api.HCPOpenShiftClusterExternalAuthProperties{
+		ProvisioningState: arm.ProvisioningStateAccepted,
+		Issuer: api.TokenIssuerProfile{
+			URL:       "https://issuer.example.com",
+			Audiences: []string{"aud1", "aud2"},
+			CA:        "test-ca-cert",
+		},
+		Clients: []api.ExternalAuthClientProfile{
+			{
+				Component: api.ExternalAuthClientComponentProfile{
+					Name:                "console",
+					AuthClientNamespace: "openshift-console",
+				},
+				ClientID:    "client-id-1",
+				ExtraScopes: []string{"email", "profile"},
+				Type:        api.ExternalAuthClientTypePublic,
+			},
+		},
+		Claim: api.ExternalAuthClaimProfile{
+			Mappings: api.TokenClaimMappingsProfile{
+				Username: api.UsernameClaimProfile{
+					Claim:        "email",
+					PrefixPolicy: api.UsernameClaimPrefixPolicyNoPrefix,
+				},
+				Groups: &api.GroupClaimProfile{
+					Claim:  "groups",
+					Prefix: "oidc:",
+				},
+			},
+			ValidationRules: []api.TokenClaimValidationRule{
+				{
+					Type: api.TokenValidationRuleTypeRequiredClaim,
+					RequiredClaim: api.TokenRequiredClaim{
+						Claim:         "hd",
+						RequiredValue: "example.com",
+					},
+				},
+			},
+		},
+	}
+	for _, fn := range mutate {
+		if fn != nil {
+			fn(externalAuth)
+		}
+	}
+	return externalAuth
+}
+
+// testExternalAuthUpdateMatchingOIDCProvider returns an OIDCProvider that matches
+// newExternalAuthUpdateTestExternalAuth for external auth update state calculation tests.
+func testExternalAuthUpdateMatchingOIDCProvider() configv1.OIDCProvider {
+	return configv1.OIDCProvider{
+		Name: strings.ToLower(testExternalAuthName),
+		Issuer: configv1.TokenIssuer{
+			URL:       "https://issuer.example.com",
+			Audiences: []configv1.TokenAudience{"aud1", "aud2"},
+		},
+		OIDCClients: []configv1.OIDCClientConfig{
+			{
+				ComponentName:      "console",
+				ComponentNamespace: "openshift-console",
+				ClientID:           "client-id-1",
+				ExtraScopes:        []string{"email", "profile"},
+			},
+		},
+		ClaimMappings: configv1.TokenClaimMappings{
+			Username: configv1.UsernameClaimMapping{
+				Claim:        "email",
+				PrefixPolicy: configv1.NoPrefix,
+			},
+			Groups: configv1.PrefixedClaimMapping{
+				TokenClaimMapping: configv1.TokenClaimMapping{
+					Claim: "groups",
+				},
+				Prefix: "oidc:",
+			},
+		},
+		ClaimValidationRules: []configv1.TokenClaimValidationRule{
+			{
+				Type: configv1.TokenValidationRuleTypeRequiredClaim,
+				RequiredClaim: &configv1.TokenRequiredClaim{
+					Claim:         "hd",
+					RequiredValue: "example.com",
+				},
+			},
+		},
+	}
+}
+
+// testExternalAuthUpdateMatchingHostedClusterSpec returns a HostedCluster spec that matches
+// newExternalAuthUpdateTestExternalAuth for external auth update state calculation tests.
+func testExternalAuthUpdateMatchingHostedClusterSpec() v1beta1.HostedClusterSpec {
+	return v1beta1.HostedClusterSpec{
+		Configuration: &v1beta1.ClusterConfiguration{
+			Authentication: &configv1.AuthenticationSpec{
+				OIDCProviders: []configv1.OIDCProvider{
+					testExternalAuthUpdateMatchingOIDCProvider(),
+				},
+			},
+		},
 	}
 }

--- a/backend/pkg/controllers/operationcontrollers/test_helpers_test.go
+++ b/backend/pkg/controllers/operationcontrollers/test_helpers_test.go
@@ -20,8 +20,11 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/openshift/hypershift/api/hypershift/v1beta1"
 
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/api"
@@ -358,5 +361,20 @@ func (f *externalAuthTestFixture) operationKey() controllerutils.OperationKey {
 		SubscriptionID:   testSubscriptionID,
 		OperationName:    testOperationName,
 		ParentResourceID: f.externalAuthResourceID.String(),
+	}
+}
+
+// testClusterUpdateMatchingHostedClusterSpec returns a HostedCluster spec that matches the
+// default cluster fixture for cluster update state calculation tests.
+func testClusterUpdateMatchingHostedClusterSpec() v1beta1.HostedClusterSpec {
+	return v1beta1.HostedClusterSpec{
+		Autoscaling: v1beta1.ClusterAutoscaling{
+			MaxNodesTotal:        ptr.To[int32](0),
+			MaxPodGracePeriod:    ptr.To[int32](0),
+			MaxNodeProvisionTime: "0m",
+			PodPriorityThreshold: ptr.To[int32](0),
+		},
+		ControllerAvailabilityPolicy:     v1beta1.HighlyAvailable,
+		InfrastructureAvailabilityPolicy: v1beta1.HighlyAvailable,
 	}
 }

--- a/backend/pkg/controllers/operationcontrollers/utils.go
+++ b/backend/pkg/controllers/operationcontrollers/utils.go
@@ -562,40 +562,6 @@ func convertExternalAuthStatus(operation *api.Operation, externalAuthStatus *aro
 	return newOperationStatus, opError, err
 }
 
-// pollExternalAuthStatus converts an external auth status from Cluster
-// Service to info for an Azure async operation status endpoint.
-func pollExternalAuthStatus(
-	ctx context.Context,
-	clock utilsclock.PassiveClock,
-	resourcesDBClient database.ResourcesDBClient,
-	clusterServiceClient ocm.ClusterServiceClientSpec,
-	operation *api.Operation,
-	notificationClient *http.Client) error {
-	// XXX This is currently called by the operationExternalAuthCreate and
-	//     operationExternalAuthUpdate controllers because the logic flows
-	//     are identical. If the logic flows ever diverge, then this
-	//     function should be split up and the pieces moved back to
-	//     their respective controllers.
-
-	logger := utils.LoggerFromContext(ctx)
-
-	_, err := clusterServiceClient.GetExternalAuth(ctx, operation.InternalID)
-	if err != nil {
-		return utils.TrackError(err)
-	}
-
-	newOperationStatus := arm.ProvisioningStateSucceeded
-	logger.Info("new status", "newStatus", newOperationStatus)
-
-	logger.Info("updating status")
-	err = UpdateOperationStatus(ctx, clock, resourcesDBClient, operation, newOperationStatus, nil, postAsyncNotificationFn(notificationClient))
-	if err != nil {
-		return utils.TrackError(err)
-	}
-
-	return nil
-}
-
 // convertInflightChecks gets a cluster internal ID, fetches inflight check errors from CS endpoint, and converts them
 // to arm.CloudErrorBody type.
 // The function should be triggered only if inflight errors occurred with provision error code OCM4001.

--- a/internal/api/types_serviceprovider_cluster.go
+++ b/internal/api/types_serviceprovider_cluster.go
@@ -165,11 +165,12 @@ type ServiceProviderClusterStatus struct {
 	ManagementClusterResourceID *azcorearm.ResourceID `json:"managementClusterResourceID,omitempty"`
 
 	// DesiredHostedClusterControlPlaneSize mirrors the value of
-	// Spec.DesiredHostedClusterControlPlaneSize that the backend reconciler
-	// last successfully pushed to cluster-service. It exists so NeedsWork can
-	// cheaply detect divergence — including the unset transition (Spec nil,
-	// Status non-nil), where there is no signal on Spec alone that the CS
-	// property still needs to be cleared.
+	// Spec.DesiredHostedClusterControlPlaneSize once cluster-service reflects
+	// the effective size override (as confirmed by the desired-control-plane-size
+	// status reconciler). It exists so NeedsWork can cheaply detect divergence,
+	// including the unset transition (Spec nil, Status non-nil), where there
+	// is no signal on Spec alone that dispatch still needs to clear the CS
+	// property.
 	DesiredHostedClusterControlPlaneSize *string `json:"desiredHostedClusterControlPlaneSize,omitempty"`
 }
 

--- a/internal/ocm/cluster_update_dispatch_config.go
+++ b/internal/ocm/cluster_update_dispatch_config.go
@@ -1,0 +1,500 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocm
+
+import (
+	"time"
+
+	"k8s.io/utils/ptr"
+
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+)
+
+// clusterUpdateDispatchConfig is a dispatch-specific canonical model of the Cluster's
+// Cluster Service fields that are considered by the cluster's cluster service update dispatch controller. Its shape
+// intentionally does not mirror RP resources or the Cluster Service API. Conversion functions
+// project external state into this form and back out when dispatching to Cluster Service.
+//
+// The same struct is built from either RP desired state (from one or more RP resources,
+// currently HCPOpenShiftCluster and ServiceProviderCluster) or from the live Cluster Service
+// Cluster. This applies only to Cluster CS updates. Node pool and external auth updates
+// use separate dispatch paths and update dispatch config structs. Drift between the two projections
+// may trigger the cluster's cluster service update dispatch controller to
+// PATCH Cluster Service.
+//
+// The cluster's cluster service update dispatch controller compares desired and
+// actual configs in this canonical form and sends a CS PATCH only when they differ.
+//
+// Note: This does not include all fields updatable via the Cluster's Cluster Service API, only
+// the subset that the cluster's cluster service update dispatch controller considers.
+//
+// Note: Do not embed internal/api struct types (for example api.ClusterAutoscalingProfile,
+// api.ImageDigestMirror, or api.ExperimentalFeatures) in this struct or its nested field types. We want to make
+// those internal/api struct types independent of this so they can evolve independently. For example, if a field here
+// referenced an internal/api struct type directly, any new field added to that struct would be automatically considered
+// as updatable automatically, but we might not want that field to be updatable and/or CS side doesn't really support
+// updating it. Instead, define curated local structs with only the fields that dispatch should
+// hash and sync, and copy values explicitly from api types at the conversion boundaries. Using api/internal enum or
+// scalar types for individual curated fields is fine (for example api.ControlPlaneAvailability). This is because
+// adding an enum/scalar field they do not pull extra fields, but adding struct types does.
+//
+// IMPORTANT: how to add a new dispatch-managed config field:
+//
+// Dispatch and operation state are related but wired separately. You need both for a correct
+// cluster update experience:
+//   - Dispatch (this file): detects drift and PATCHes Cluster Service.
+//   - Operation state (operation_cluster_update_state_calculation.go): decides when the ARM
+//     cluster update operation can leave Updating and report Succeeded.
+//
+// If you wire dispatch but skip operation state calculation, the update may be sent to CS but the operation
+// can succeed too early (or stay Updating forever if dispatch is missing).
+//
+// Before you start:
+//
+//   - Confirm this is a cluster-level Cluster Service update (not node pool or external auth).
+//   - Confirm Cluster Service supports updating the field on an existing cluster.
+//   - Identify where RP desired state lives (HCPOpenShiftCluster, ServiceProviderCluster, etc.).
+//
+// 1. Dispatch wiring (this file)
+//
+//   - Add the field to clusterUpdateDispatchConfig or a curated nested struct.
+//     Do not embed internal/api struct types.
+//   - Populate it in clusterUpdateDispatchConfigFromRP. This ensures RP projection works correctly
+//   - Populate it in clusterUpdateDispatchConfigFromCS. This ensures CS projection works correctly
+//   - Apply it in applyToCSBuilders and/or autoscalerBuilder. This ensures the CS builders work correctly.
+//
+// 2. Operation state wiring (backend/pkg/controllers/operationcontrollers/operation_cluster_update.go)
+//
+//	determineOperationState aggregates several sources and picks the worst state. Your new
+//	check must succeed along with version resolution, CS status, CS spec, and Hypershift checks.
+//
+//	Choose where to observe the change and implement it:
+//	  - Prefer observing directly from the Management Cluster side when the field is visible there after propagation.
+//	    Most dispatch fields today are checked here: autoscaling, image mirrors, experimental features, etc.
+//	  - Observe from Cluster Service when the Management Cluster side is not a reliable source of
+//	    truth yet or simply can't be calculated from there
+//	  - Sometimes you might want to observe it on both sides for extra validation
+//
+//	Return (false, message) with a clear message when observed != desired so Updating state
+//	is actionable in logs.
+//
+// 3. Tests
+//
+//   - cluster_update_dispatch_config_test.go: hash, FromCS, round-trip, apply payload.
+//   - operation_cluster_update_state_calculation_test.go: match/mismatch cases for your new
+//     helper and, if useful, an end-to-end clusterServiceClusterSpecOperationState or
+//     hypershiftClusterOperationState case.
+//   - Consider both "not applied yet" (Updating) and "applied" (Succeeded) scenarios.
+//
+// 4. Sanity checks
+//
+//   - Create path: applyToCSBuilders is also used by BuildCSCluster in internal/ocm/convert.go
+//     when the frontend first creates a Cluster Service cluster (not only when the update
+//     dispatch controller PATCHes an existing one). Verify the new field is present on create.
+//   - Desired state must exist in Cosmos before dispatch can sync it. If customers set this
+//     field via ARM, also wire the full ingest path: ARM API, frontend validation/conversion,
+//     and persistence onto HCPOpenShiftCluster or ServiceProviderCluster. Internal-only
+//     fields still need whatever backend path writes the value Cosmos holds.
+type clusterUpdateDispatchConfig struct {
+	NodeDrainTimeoutMinutes        int32                                                     `json:"nodeDrainTimeoutMinutes,omitempty"`
+	K8sAPIServerAuthorizedCIDRs    []string                                                  `json:"k8sAPIServerAuthorizedCIDRs,omitempty"`
+	ImageDigestMirrors             []clusterUpdateDispatchConfigImageDigestMirror            `json:"imageDigestMirrors,omitempty"`
+	Autoscaling                    clusterUpdateDispatchConfigAutoscaling                    `json:"autoscaling,omitempty"`
+	ExperimentalFeatures           clusterUpdateDispatchConfigExperimentalFeatures           `json:"experimentalFeatures,omitempty"`
+	ServiceProviderClusterDispatch clusterUpdateDispatchConfigServiceProviderClusterDispatch `json:"serviceProviderClusterDispatch,omitempty"`
+}
+
+// clusterUpdateDispatchConfigImageDigestMirror is the curated image mirror subset used for
+// dispatch hash and sync. See clusterUpdateDispatchConfig: do not embed api.ImageDigestMirror.
+type clusterUpdateDispatchConfigImageDigestMirror struct {
+	Source  string   `json:"source,omitempty"`
+	Mirrors []string `json:"mirrors,omitempty"`
+}
+
+// clusterUpdateDispatchConfigAutoscaling is the curated autoscaling subset used for dispatch
+// hash and sync. See clusterUpdateDispatchConfig: do not embed api.ClusterAutoscalingProfile.
+type clusterUpdateDispatchConfigAutoscaling struct {
+	MaxNodesTotal               int32 `json:"maxNodesTotal,omitempty"`
+	MaxPodGracePeriodSeconds    int32 `json:"maxPodGracePeriodSeconds,omitempty"`
+	MaxNodeProvisionTimeSeconds int32 `json:"maxNodeProvisionTimeSeconds,omitempty"`
+	PodPriorityThreshold        int32 `json:"podPriorityThreshold,omitempty"`
+}
+
+// clusterUpdateDispatchConfigExperimentalFeatures is the curated experimental subset used for
+// dispatch hash and sync. See clusterUpdateDispatchConfig: do not embed api.ExperimentalFeatures.
+type clusterUpdateDispatchConfigExperimentalFeatures struct {
+	ControlPlaneAvailability  api.ControlPlaneAvailability `json:"controlPlaneAvailability,omitempty"`
+	ControlPlanePodSizing     api.ControlPlanePodSizing    `json:"controlPlanePodSizing,omitempty"`
+	ControlPlaneOperatorImage string                       `json:"controlPlaneOperatorImage,omitempty"`
+}
+
+// clusterUpdateDispatchConfigServiceProviderClusterDispatch holds the dispatch-managed
+// subset of api.ServiceProviderCluster fields included in cluster update dispatch.
+type clusterUpdateDispatchConfigServiceProviderClusterDispatch struct {
+	DesiredHostedClusterControlPlaneSize *string `json:"desiredHostedClusterControlPlaneSize,omitempty"`
+}
+
+// ClusterUpdateDispatchConfigJSONFromRP returns the canonical JSON of the dispatch config
+// projected from RP desired state.
+func ClusterUpdateDispatchConfigJSONFromRP(cluster *api.HCPOpenShiftCluster, serviceProviderCluster *api.ServiceProviderCluster) (string, error) {
+	raw, err := clusterUpdateDispatchConfigFromRP(cluster, serviceProviderCluster).canonicalJSON()
+	if err != nil {
+		return "", err
+	}
+	return string(raw), nil
+}
+
+// ClusterUpdateDispatchConfigJSONFromCS returns the canonical JSON of the dispatch config
+// projected from a Cluster Service cluster.
+func ClusterUpdateDispatchConfigJSONFromCS(csCluster *arohcpv1alpha1.Cluster) (string, error) {
+	config, err := clusterUpdateDispatchConfigFromCS(csCluster)
+	if err != nil {
+		return "", err
+	}
+	raw, err := config.canonicalJSON()
+	if err != nil {
+		return "", err
+	}
+	return string(raw), nil
+}
+
+// clusterUpdateDispatchConfigFromRP projects RP desired state into the dispatch canonical form.
+func clusterUpdateDispatchConfigFromRP(cluster *api.HCPOpenShiftCluster, serviceProviderCluster *api.ServiceProviderCluster) *clusterUpdateDispatchConfig {
+	res := &clusterUpdateDispatchConfig{
+		NodeDrainTimeoutMinutes:     cluster.CustomerProperties.NodeDrainTimeoutMinutes,
+		K8sAPIServerAuthorizedCIDRs: cluster.CustomerProperties.API.AuthorizedCIDRs,
+		ImageDigestMirrors:          clusterUpdateDispatchConfigImageDigestMirrorsFromRP(cluster.CustomerProperties.ImageDigestMirrors),
+		Autoscaling:                 clusterUpdateDispatchConfigAutoscalingFromRP(cluster.CustomerProperties.Autoscaling),
+		ExperimentalFeatures: clusterUpdateDispatchConfigExperimentalFeatures{
+			ControlPlaneAvailability:  cluster.ServiceProviderProperties.ExperimentalFeatures.ControlPlaneAvailability,
+			ControlPlanePodSizing:     cluster.ServiceProviderProperties.ExperimentalFeatures.ControlPlanePodSizing,
+			ControlPlaneOperatorImage: cluster.ServiceProviderProperties.ExperimentalFeatures.ControlPlaneOperatorImage,
+		},
+		ServiceProviderClusterDispatch: clusterUpdateDispatchConfigServiceProviderClusterDispatch{},
+	}
+
+	if serviceProviderCluster != nil {
+		res.ServiceProviderClusterDispatch.DesiredHostedClusterControlPlaneSize = serviceProviderCluster.Spec.DesiredHostedClusterControlPlaneSize
+	}
+
+	return res
+}
+
+// clusterUpdateDispatchConfigImageDigestMirrorsFromRP copies image mirrors from RP into the
+// dispatch canonical form.
+func clusterUpdateDispatchConfigImageDigestMirrorsFromRP(mirrors []api.ImageDigestMirror) []clusterUpdateDispatchConfigImageDigestMirror {
+	if len(mirrors) == 0 {
+		return nil
+	}
+
+	out := make([]clusterUpdateDispatchConfigImageDigestMirror, 0, len(mirrors))
+	for _, mirror := range mirrors {
+		out = append(out, clusterUpdateDispatchConfigImageDigestMirror{
+			Source:  mirror.Source,
+			Mirrors: append([]string(nil), mirror.Mirrors...),
+		})
+	}
+	return out
+}
+
+// clusterUpdateDispatchConfigAutoscalingFromRP copies autoscaling settings from RP into the
+// dispatch canonical form.
+func clusterUpdateDispatchConfigAutoscalingFromRP(profile api.ClusterAutoscalingProfile) clusterUpdateDispatchConfigAutoscaling {
+	return clusterUpdateDispatchConfigAutoscaling{
+		MaxNodesTotal:               profile.MaxNodesTotal,
+		MaxPodGracePeriodSeconds:    profile.MaxPodGracePeriodSeconds,
+		MaxNodeProvisionTimeSeconds: profile.MaxNodeProvisionTimeSeconds,
+		PodPriorityThreshold:        profile.PodPriorityThreshold,
+	}
+}
+
+// clusterUpdateDispatchConfigFromCS projects a Cluster Service cluster into the dispatch
+// canonical form.
+func clusterUpdateDispatchConfigFromCS(csCluster *arohcpv1alpha1.Cluster) (*clusterUpdateDispatchConfig, error) {
+	config := &clusterUpdateDispatchConfig{}
+
+	config.NodeDrainTimeoutMinutes = ClusterUpdateDispatchConfigNodeDrainTimeoutFromCS(csCluster)
+	config.K8sAPIServerAuthorizedCIDRs = ClusterUpdateDispatchConfigAuthorizedCIDRsFromCS(csCluster.API())
+	config.ImageDigestMirrors = clusterUpdateDispatchConfigImageDigestMirrorsFromCS(csCluster.RegistryConfig())
+	config.ExperimentalFeatures = clusterUpdateDispatchConfigExperimentalFeaturesFromCS(csCluster)
+	config.ServiceProviderClusterDispatch.DesiredHostedClusterControlPlaneSize = clusterUpdateDispatchConfigServiceProviderClusterDispatchDesiredHostedClusterControlPlaneSizeFromCS(csCluster)
+	autoscaling, err := clusterUpdateDispatchConfigAutoscalingFromCS(csCluster.Autoscaler())
+	if err != nil {
+		return nil, err
+	}
+	config.Autoscaling = autoscaling
+
+	return config, nil
+}
+
+// ClusterUpdateDispatchConfigNodeDrainTimeoutFromCS extracts the node drain timeout in
+// minutes from a Cluster Service cluster. Returns 0 when unset or not expressed in minutes.
+func ClusterUpdateDispatchConfigNodeDrainTimeoutFromCS(in *arohcpv1alpha1.Cluster) int32 {
+	if nodeDrainGracePeriod, ok := in.GetNodeDrainGracePeriod(); ok {
+		if unit, ok := nodeDrainGracePeriod.GetUnit(); ok && unit == csNodeDrainGracePeriodUnit {
+			return int32(nodeDrainGracePeriod.Value())
+		}
+	}
+	return 0
+}
+
+// ClusterUpdateDispatchConfigAuthorizedCIDRsFromCS extracts customer authorized CIDRs from
+// a Cluster Service cluster API configuration. Returns nil when access is not allow-list mode.
+func ClusterUpdateDispatchConfigAuthorizedCIDRsFromCS(in *arohcpv1alpha1.ClusterAPI) []string {
+	cidrAccess := in.CIDRBlockAccess()
+	if cidrAccess.Empty() {
+		return nil
+	}
+
+	allow := cidrAccess.Allow()
+	if allow == nil {
+		return nil
+	}
+
+	allowMode, _ := allow.GetMode()
+	// We assume if it's not allow_list mode then it's allow_all mode so there are no CIDRs
+	if allowMode != CSCIDRBlockAllowAccessModeAllowList {
+		return nil
+	}
+
+	allowValues := allow.Values()
+	return allowValues
+}
+
+// clusterUpdateDispatchConfigImageDigestMirrorsFromCS extracts image mirrors from a Cluster
+// Service cluster registry config into the dispatch canonical form.
+func clusterUpdateDispatchConfigImageDigestMirrorsFromCS(in *arohcpv1alpha1.ClusterRegistryConfig) []clusterUpdateDispatchConfigImageDigestMirror {
+	if in == nil {
+		return nil
+	}
+	imageDigestMirrors := in.ImageDigestMirrors()
+	if len(imageDigestMirrors) == 0 {
+		return nil
+	}
+
+	out := make([]clusterUpdateDispatchConfigImageDigestMirror, 0, len(imageDigestMirrors))
+	for _, mirror := range imageDigestMirrors {
+		source, sourceOK := mirror.GetSource()
+		if !sourceOK {
+			continue
+		}
+		item := clusterUpdateDispatchConfigImageDigestMirror{Source: source}
+
+		mirrors, mirrorsOK := mirror.GetMirrors()
+		if mirrorsOK {
+			item.Mirrors = append([]string(nil), mirrors...)
+		}
+		out = append(out, item)
+	}
+	return out
+}
+
+// clusterUpdateDispatchConfigExperimentalFeaturesFromCS extracts experimental feature flags from
+// Cluster Service cluster properties into the dispatch canonical form.
+func clusterUpdateDispatchConfigExperimentalFeaturesFromCS(in *arohcpv1alpha1.Cluster) clusterUpdateDispatchConfigExperimentalFeatures {
+	if in == nil {
+		return clusterUpdateDispatchConfigExperimentalFeatures{}
+	}
+
+	out := clusterUpdateDispatchConfigExperimentalFeatures{}
+
+	for key, value := range in.Properties() {
+		switch key {
+		case CSPropertySingleReplica:
+			if value == CSPropertyEnabled {
+				out.ControlPlaneAvailability = api.SingleReplicaControlPlane
+			}
+		case CSPropertySizeOverride:
+			// We only set the cluster level ControlPlanePodSizing attribute when
+			// the returned value from CS is one of the ones defined as a api.ControlPlanePodSizing.
+			// If it were to have a non empty value that is not among those, we consider it's a
+			// size specified via the ServiceProviderCluster's spec.
+			if value == CSPropertyE2EMinimalControlPlaneSize {
+				out.ControlPlanePodSizing = api.MinimalControlPlanePodSizing
+			}
+		case CSPropertyCPOImageOverride:
+			if value != "" {
+				out.ControlPlaneOperatorImage = value
+			}
+		}
+	}
+
+	return out
+}
+
+// clusterUpdateDispatchConfigServiceProviderClusterDispatchDesiredHostedClusterControlPlaneSizeFromCS extracts
+// the ServiceProviderCluster-hosted control plane size override from Cluster Service properties.
+// Returns nil when the size override is absent or encoded as a cluster-level ControlPlanePodSizing.
+func clusterUpdateDispatchConfigServiceProviderClusterDispatchDesiredHostedClusterControlPlaneSizeFromCS(in *arohcpv1alpha1.Cluster) *string {
+	if in == nil {
+		return nil
+	}
+
+	property, found := in.Properties()[CSPropertySizeOverride]
+	if !found {
+		return nil
+	}
+
+	if property == "" {
+		return nil
+	}
+
+	// We do not set this attribute if the CS value matches any of the ones that match to a corresponding
+	// api.ControlPlanePodSizing.
+	if property == CSPropertyE2EMinimalControlPlaneSize {
+		return nil
+	}
+
+	// When the property value does not match any of the ones any of the ones that match to a corresponding
+	// api.ControlPlanePodSizing then we assume that its value comes from having it being set beforehand through
+	// ServiceProviderCluster's spec.
+	return ptr.To(property)
+}
+
+// clusterUpdateDispatchConfigAutoscalingFromCS extracts autoscaling settings from a Cluster
+// Service autoscaler into the dispatch canonical form.
+func clusterUpdateDispatchConfigAutoscalingFromCS(in *arohcpv1alpha1.ClusterAutoscaler) (clusterUpdateDispatchConfigAutoscaling, error) {
+	if in == nil {
+		return clusterUpdateDispatchConfigAutoscaling{}, nil
+	}
+
+	var maxNodeProvisionTime int32
+	if len(in.MaxNodeProvisionTime()) > 0 {
+		// maxNodeProvisionTime (string) - minutes e.g - “15m”
+		// https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/blob/master/pkg/api/autoscaler.go?ref_type=heads#L30-42
+		maxNodeProvisionTimeDuration, err := time.ParseDuration(in.MaxNodeProvisionTime())
+		if err != nil {
+			return clusterUpdateDispatchConfigAutoscaling{}, err
+		}
+		maxNodeProvisionTime = int32(maxNodeProvisionTimeDuration.Seconds())
+	}
+
+	return clusterUpdateDispatchConfigAutoscaling{
+		MaxNodesTotal: int32(in.ResourceLimits().MaxNodesTotal()),
+		// MaxPodGracePeriod (int) - seconds e.g - 300
+		// https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/blob/master/pkg/api/autoscaler.go?ref_type=heads#L30-42
+		MaxPodGracePeriodSeconds:    int32(in.MaxPodGracePeriod()),
+		MaxNodeProvisionTimeSeconds: maxNodeProvisionTime,
+		PodPriorityThreshold:        int32(in.PodPriorityThreshold()),
+	}, nil
+}
+
+// clusterUpdateDispatchConfigHash returns a SHA-256 hex digest of the dispatch config
+// projected from RP desired state. The digest is computed from canonical JSON (sorted object
+// keys at every level), not from a raw json.Marshal of the struct.
+func clusterUpdateDispatchConfigHash(cluster *api.HCPOpenShiftCluster, serviceProviderCluster *api.ServiceProviderCluster) (string, error) {
+	return clusterUpdateDispatchConfigFromRP(cluster, serviceProviderCluster).hash()
+}
+
+// hash returns a SHA-256 hex digest of c's canonical JSON.
+func (c *clusterUpdateDispatchConfig) hash() (string, error) {
+	return hashUpdateDispatchConfig(c)
+}
+
+// canonicalJSON returns the deterministic JSON encoding of c used for hashing and comparison.
+// Keys are sorted at every object level and the payload is indented with two spaces; see
+// canonicalJSONForUpdateDispatchConfig.
+func (c *clusterUpdateDispatchConfig) canonicalJSON() ([]byte, error) {
+	return canonicalJSONForUpdateDispatchConfig(c)
+}
+
+// applyToCSBuilders maps the dispatch config onto Cluster Service cluster builders.
+// baseProperties may contain existing CS properties. Experimental features are overlaid on
+// baseProperties depending on how they evaluate. If they evaluate to enabled then the corresponding
+// key is set to the value of the Experimental feature. If they evaluate to disabled then the corresponding key
+// is deleted from the baseProperties map.
+func (c *clusterUpdateDispatchConfig) applyToCSBuilders(clusterBuilder *arohcpv1alpha1.ClusterBuilder, clusterAPIBuilder *arohcpv1alpha1.ClusterAPIBuilder, baseProperties map[string]string) error {
+	if baseProperties == nil {
+		baseProperties = map[string]string{}
+	}
+
+	clusterBuilder.NodeDrainGracePeriod(arohcpv1alpha1.NewValue().
+		Unit(csNodeDrainGracePeriodUnit).
+		Value(float64(c.NodeDrainTimeoutMinutes)))
+
+	cidrBlockAccess, err := convertCIDRBlockAllowAccessRPToCS(api.CustomerAPIProfile{
+		AuthorizedCIDRs: c.K8sAPIServerAuthorizedCIDRs,
+	})
+	if err != nil {
+		return err
+	}
+	clusterBuilder.API(clusterAPIBuilder.CIDRBlockAccess(cidrBlockAccess))
+
+	clusterBuilder.RegistryConfig(arohcpv1alpha1.NewClusterRegistryConfig().
+		ImageDigestMirrors(convertImageDigestMirrorsToCSBuilder(clusterUpdateDispatchConfigImageDigestMirrorsToRP(c.ImageDigestMirrors))...))
+
+	experimentalFeatures := c.ExperimentalFeatures
+	if experimentalFeatures.ControlPlaneAvailability == api.SingleReplicaControlPlane {
+		baseProperties[CSPropertySingleReplica] = CSPropertyEnabled
+	} else {
+		delete(baseProperties, CSPropertySingleReplica)
+	}
+
+	// We calculate the hosted cluster size override updatable configuration dynamically by checking
+	// both the corresponding cluster's experimental feature property as well as the ServiceProviderCluster's
+	// DesiredHostedClusterControlPlaneSize
+	sizeOverride, toSet := ConvertHostedClusterSizeOverrideToCS(c.ExperimentalFeatures.ControlPlanePodSizing, c.ServiceProviderClusterDispatch.DesiredHostedClusterControlPlaneSize)
+	if toSet {
+		baseProperties[CSPropertySizeOverride] = sizeOverride
+	} else {
+		delete(baseProperties, CSPropertySizeOverride)
+	}
+
+	if experimentalFeatures.ControlPlaneOperatorImage != "" {
+		baseProperties[CSPropertyCPOImageOverride] = experimentalFeatures.ControlPlaneOperatorImage
+	} else {
+		delete(baseProperties, CSPropertyCPOImageOverride)
+	}
+	clusterBuilder.Properties(baseProperties)
+
+	return nil
+}
+
+// autoscalerBuilder builds the Cluster Service autoscaler update payload from the dispatch
+// config autoscaling fields.
+func (c *clusterUpdateDispatchConfig) autoscalerBuilder() (*arohcpv1alpha1.ClusterAutoscalerBuilder, error) {
+	profile := clusterUpdateDispatchConfigAutoscalingToRP(c.Autoscaling)
+	return convertRpAutoscalarToCSBuilder(&profile)
+}
+
+// clusterUpdateDispatchConfigImageDigestMirrorsToRP converts dispatch image mirrors into
+// api.ImageDigestMirror values for shared CS conversion helpers.
+func clusterUpdateDispatchConfigImageDigestMirrorsToRP(mirrors []clusterUpdateDispatchConfigImageDigestMirror) []api.ImageDigestMirror {
+	if len(mirrors) == 0 {
+		return nil
+	}
+
+	out := make([]api.ImageDigestMirror, 0, len(mirrors))
+	for _, mirror := range mirrors {
+		out = append(out, api.ImageDigestMirror{
+			Source:  mirror.Source,
+			Mirrors: append([]string(nil), mirror.Mirrors...),
+		})
+	}
+	return out
+}
+
+// clusterUpdateDispatchConfigAutoscalingToRP converts dispatch autoscaling fields into
+// api.ClusterAutoscalingProfile for shared CS conversion helpers.
+func clusterUpdateDispatchConfigAutoscalingToRP(profile clusterUpdateDispatchConfigAutoscaling) api.ClusterAutoscalingProfile {
+	return api.ClusterAutoscalingProfile{
+		MaxNodesTotal:               profile.MaxNodesTotal,
+		MaxPodGracePeriodSeconds:    profile.MaxPodGracePeriodSeconds,
+		MaxNodeProvisionTimeSeconds: profile.MaxNodeProvisionTimeSeconds,
+		PodPriorityThreshold:        profile.PodPriorityThreshold,
+	}
+}

--- a/internal/ocm/cluster_update_dispatch_config_test.go
+++ b/internal/ocm/cluster_update_dispatch_config_test.go
@@ -1,0 +1,1009 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/utils/ptr"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+)
+
+func TestClusterUpdateDispatchConfigHash(t *testing.T) {
+	baseCustomerProperties := api.HCPOpenShiftClusterCustomerProperties{
+		NodeDrainTimeoutMinutes: 30,
+		API: api.CustomerAPIProfile{
+			AuthorizedCIDRs: []string{"10.0.0.0/8"},
+		},
+		Autoscaling: api.ClusterAutoscalingProfile{
+			MaxNodesTotal:            10,
+			MaxPodGracePeriodSeconds: 600,
+		},
+	}
+
+	base := &api.HCPOpenShiftCluster{
+		CustomerProperties: baseCustomerProperties,
+	}
+
+	baseHash, err := clusterUpdateDispatchConfigHash(base, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, baseHash)
+
+	hashAgain, err := clusterUpdateDispatchConfigHash(base, nil)
+	require.NoError(t, err)
+	assert.Equal(t, baseHash, hashAgain)
+
+	tests := []struct {
+		name    string
+		cluster *api.HCPOpenShiftCluster
+		spc     *api.ServiceProviderCluster
+	}{
+		{
+			name: "different node drain timeout",
+			cluster: &api.HCPOpenShiftCluster{
+				CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
+					NodeDrainTimeoutMinutes: 60,
+					API:                     baseCustomerProperties.API,
+					Autoscaling:             baseCustomerProperties.Autoscaling,
+				},
+			},
+		},
+		{
+			name: "different authorized CIDRs",
+			cluster: &api.HCPOpenShiftCluster{
+				CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
+					NodeDrainTimeoutMinutes: baseCustomerProperties.NodeDrainTimeoutMinutes,
+					API: api.CustomerAPIProfile{
+						AuthorizedCIDRs: []string{"192.168.0.0/16"},
+					},
+					Autoscaling: baseCustomerProperties.Autoscaling,
+				},
+			},
+		},
+		{
+			name: "image digest mirrors",
+			cluster: &api.HCPOpenShiftCluster{
+				CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
+					NodeDrainTimeoutMinutes: baseCustomerProperties.NodeDrainTimeoutMinutes,
+					API:                     baseCustomerProperties.API,
+					ImageDigestMirrors: []api.ImageDigestMirror{
+						{Source: "quay.io/openshift-release-dev", Mirrors: []string{"mirror.example.com"}},
+					},
+					Autoscaling: baseCustomerProperties.Autoscaling,
+				},
+			},
+		},
+		{
+			name: "different autoscaling",
+			cluster: &api.HCPOpenShiftCluster{
+				CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
+					NodeDrainTimeoutMinutes: baseCustomerProperties.NodeDrainTimeoutMinutes,
+					API:                     baseCustomerProperties.API,
+					Autoscaling: api.ClusterAutoscalingProfile{
+						MaxNodesTotal:            20,
+						MaxPodGracePeriodSeconds: baseCustomerProperties.Autoscaling.MaxPodGracePeriodSeconds,
+					},
+				},
+			},
+		},
+		{
+			name: "control plane availability single replica",
+			cluster: &api.HCPOpenShiftCluster{
+				CustomerProperties: baseCustomerProperties,
+				ServiceProviderProperties: api.HCPOpenShiftClusterServiceProviderProperties{
+					ExperimentalFeatures: api.ExperimentalFeatures{
+						ControlPlaneAvailability: api.SingleReplicaControlPlane,
+					},
+				},
+			},
+		},
+		{
+			name: "control plane pod sizing",
+			cluster: &api.HCPOpenShiftCluster{
+				CustomerProperties: baseCustomerProperties,
+				ServiceProviderProperties: api.HCPOpenShiftClusterServiceProviderProperties{
+					ExperimentalFeatures: api.ExperimentalFeatures{
+						ControlPlanePodSizing: api.MinimalControlPlanePodSizing,
+					},
+				},
+			},
+		},
+		{
+			name: "control plane operator image",
+			cluster: &api.HCPOpenShiftCluster{
+				CustomerProperties: baseCustomerProperties,
+				ServiceProviderProperties: api.HCPOpenShiftClusterServiceProviderProperties{
+					ExperimentalFeatures: api.ExperimentalFeatures{
+						ControlPlaneOperatorImage: "quay.io/openshift/cpo:test",
+					},
+				},
+			},
+		},
+		{
+			name: "service provider cluster control plane size",
+			cluster: &api.HCPOpenShiftCluster{
+				CustomerProperties: baseCustomerProperties,
+			},
+			spc: &api.ServiceProviderCluster{
+				Spec: api.ServiceProviderClusterSpec{
+					DesiredHostedClusterControlPlaneSize: ptr.To("Large"),
+				},
+			},
+		},
+	}
+
+	// Each row changes one dispatch-managed field from the baseline above. Comparing against
+	// baseHash checks that the field is included in the canonical hash. It does not prove the
+	// field mapped correctly. See FromCS round-trip and per-helper tests for that.
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hash, err := clusterUpdateDispatchConfigHash(tt.cluster, tt.spc)
+			require.NoError(t, err)
+			assert.NotEqual(t, baseHash, hash, "changing %q should change the dispatch config hash", tt.name)
+		})
+	}
+}
+
+func TestClusterUpdateDispatchConfigHashExcludesNonUpdatableFields(t *testing.T) {
+	cluster1 := &api.HCPOpenShiftCluster{
+		CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
+			NodeDrainTimeoutMinutes: 30,
+			Version:                 api.VersionProfile{ID: "4.19.1"},
+			Network: api.NetworkProfile{
+				PodCIDR: "10.128.0.0/14",
+			},
+		},
+	}
+
+	cluster2 := &api.HCPOpenShiftCluster{
+		CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
+			NodeDrainTimeoutMinutes: 30,
+			Version:                 api.VersionProfile{ID: "4.19.2"},
+			Network: api.NetworkProfile{
+				PodCIDR: "10.200.0.0/14",
+			},
+		},
+	}
+
+	hash1, err := clusterUpdateDispatchConfigHash(cluster1, &api.ServiceProviderCluster{})
+	require.NoError(t, err)
+	hash2, err := clusterUpdateDispatchConfigHash(cluster2, &api.ServiceProviderCluster{})
+	require.NoError(t, err)
+	assert.Equal(t, hash1, hash2)
+}
+
+func TestClusterUpdateDispatchConfigHashExcludesTagsWithoutExperimentalFeatures(t *testing.T) {
+	cluster1 := &api.HCPOpenShiftCluster{
+		TrackedResource: arm.TrackedResource{
+			Tags: map[string]string{api.TagClusterSizeOverride: string(api.MinimalControlPlanePodSizing)},
+		},
+		CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
+			NodeDrainTimeoutMinutes: 30,
+		},
+	}
+	cluster2 := &api.HCPOpenShiftCluster{
+		CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
+			NodeDrainTimeoutMinutes: 30,
+		},
+	}
+
+	hash1, err := clusterUpdateDispatchConfigHash(cluster1, &api.ServiceProviderCluster{})
+	require.NoError(t, err)
+	hash2, err := clusterUpdateDispatchConfigHash(cluster2, &api.ServiceProviderCluster{})
+	require.NoError(t, err)
+	assert.Equal(t, hash1, hash2)
+}
+
+// TestClusterUpdateDispatchConfigFromCSRoundTrip checks that RP and Cluster Service agree on
+// dispatch-managed config after materializing RP desired state onto an existing Cluster Service
+// cluster via BuildCSCluster (update path: non-nil old cluster). clusterUpdateDispatchConfigFromCS
+// and clusterUpdateDispatchConfigFromRP must then produce the same canonical hash.
+func TestClusterUpdateDispatchConfigFromCSRoundTrip(t *testing.T) {
+	resourceID, err := azcorearm.ParseResourceID("/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/testResourceGroup/providers/Microsoft.RedHatOpenShift/openShiftClusters/testCluster")
+	require.NoError(t, err)
+
+	oldClusterServiceCluster, err := arohcpv1alpha1.NewCluster().Build()
+	require.NoError(t, err)
+
+	hcpCluster := &api.HCPOpenShiftCluster{
+		CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
+			NodeDrainTimeoutMinutes: 45,
+			API: api.CustomerAPIProfile{
+				AuthorizedCIDRs: []string{"10.0.0.0/8", "192.168.0.0/16"},
+			},
+			ImageDigestMirrors: []api.ImageDigestMirror{
+				{Source: "quay.io/openshift-release-dev", Mirrors: []string{"mirror.example.com"}},
+			},
+			Autoscaling: api.ClusterAutoscalingProfile{
+				MaxNodesTotal:               12,
+				MaxPodGracePeriodSeconds:    600,
+				MaxNodeProvisionTimeSeconds: 900,
+				PodPriorityThreshold:        -10,
+			},
+		},
+		ServiceProviderProperties: api.HCPOpenShiftClusterServiceProviderProperties{
+			ExperimentalFeatures: api.ExperimentalFeatures{
+				ControlPlaneAvailability:  api.SingleReplicaControlPlane,
+				ControlPlanePodSizing:     api.MinimalControlPlanePodSizing,
+				ControlPlaneOperatorImage: "quay.io/openshift/cpo:test",
+			},
+		},
+	}
+	spc := &api.ServiceProviderCluster{}
+
+	clusterBuilder, autoscalerBuilder, err := BuildCSCluster(resourceID, api.TestTenantID, hcpCluster, nil, oldClusterServiceCluster, spc)
+	require.NoError(t, err)
+
+	csCluster, err := clusterBuilder.Autoscaler(autoscalerBuilder).Build()
+	require.NoError(t, err)
+
+	actualConfig, err := clusterUpdateDispatchConfigFromCS(csCluster)
+	require.NoError(t, err)
+
+	desiredHash, err := clusterUpdateDispatchConfigFromRP(hcpCluster, spc).hash()
+	require.NoError(t, err)
+	actualHash, err := actualConfig.hash()
+	require.NoError(t, err)
+	assert.Equal(t, desiredHash, actualHash)
+}
+
+// TestClusterUpdateDispatchConfigFromCSRoundTripServiceProviderClusterSize checks that RP
+// desired state with a ServiceProviderCluster-level size override round-trips through
+// BuildCSCluster and clusterUpdateDispatchConfigFromCS with matching hash and field split.
+func TestClusterUpdateDispatchConfigFromCSRoundTripServiceProviderClusterSize(t *testing.T) {
+	oldClusterServiceCluster, err := arohcpv1alpha1.NewCluster().Build()
+	require.NoError(t, err)
+
+	hcpCluster := &api.HCPOpenShiftCluster{
+		CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
+			NodeDrainTimeoutMinutes: 30,
+		},
+	}
+	spc := &api.ServiceProviderCluster{
+		Spec: api.ServiceProviderClusterSpec{
+			// Use lowercase to match the value CS stores after ConvertHostedClusterSizeOverrideToCS.
+			DesiredHostedClusterControlPlaneSize: ptr.To("large"),
+		},
+	}
+
+	clusterBuilder, autoscalerBuilder, err := BuildCSCluster(nil, "11111111-1111-1111-1111-111111111111", hcpCluster, nil, oldClusterServiceCluster, spc)
+	require.NoError(t, err)
+
+	csCluster, err := clusterBuilder.Autoscaler(autoscalerBuilder).Build()
+	require.NoError(t, err)
+
+	actualConfig, err := clusterUpdateDispatchConfigFromCS(csCluster)
+	require.NoError(t, err)
+
+	assert.Equal(t, clusterUpdateDispatchConfigExperimentalFeatures{}, actualConfig.ExperimentalFeatures)
+	require.NotNil(t, actualConfig.ServiceProviderClusterDispatch.DesiredHostedClusterControlPlaneSize)
+	assert.Equal(t, "large", *actualConfig.ServiceProviderClusterDispatch.DesiredHostedClusterControlPlaneSize)
+
+	desiredHash, err := clusterUpdateDispatchConfigFromRP(hcpCluster, spc).hash()
+	require.NoError(t, err)
+	actualHash, err := actualConfig.hash()
+	require.NoError(t, err)
+	assert.Equal(t, desiredHash, actualHash)
+}
+
+func TestClusterUpdateDispatchConfigFromCS(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		csCluster func(t *testing.T) *arohcpv1alpha1.Cluster
+		want      *clusterUpdateDispatchConfig
+	}{
+		{
+			name: "custom size override maps to SPC dispatch not cluster pod sizing",
+			csCluster: func(t *testing.T) *arohcpv1alpha1.Cluster {
+				t.Helper()
+				cluster, err := arohcpv1alpha1.NewCluster().Properties(map[string]string{
+					CSPropertySizeOverride: "large",
+				}).Build()
+				require.NoError(t, err)
+				return cluster
+			},
+			want: &clusterUpdateDispatchConfig{
+				ExperimentalFeatures: clusterUpdateDispatchConfigExperimentalFeatures{},
+				ServiceProviderClusterDispatch: clusterUpdateDispatchConfigServiceProviderClusterDispatch{
+					DesiredHostedClusterControlPlaneSize: ptr.To("large"),
+				},
+			},
+		},
+		{
+			name: "e2e_minimal size override maps to cluster pod sizing experimental feature and not to SPC dispatch",
+			csCluster: func(t *testing.T) *arohcpv1alpha1.Cluster {
+				t.Helper()
+				cluster, err := arohcpv1alpha1.NewCluster().Properties(map[string]string{
+					CSPropertySizeOverride: CSPropertyE2EMinimalControlPlaneSize,
+				}).Build()
+				require.NoError(t, err)
+				return cluster
+			},
+			want: &clusterUpdateDispatchConfig{
+				ExperimentalFeatures: clusterUpdateDispatchConfigExperimentalFeatures{
+					ControlPlanePodSizing: api.MinimalControlPlanePodSizing,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := clusterUpdateDispatchConfigFromCS(tt.csCluster(t))
+			require.NoError(t, err)
+			assert.Equal(t, tt.want.ExperimentalFeatures, got.ExperimentalFeatures)
+			assert.Equal(t, tt.want.ServiceProviderClusterDispatch, got.ServiceProviderClusterDispatch)
+		})
+	}
+}
+
+func TestClusterUpdateDispatchConfigAuthorizedCIDRsFromCS(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		clusterAPI func() *arohcpv1alpha1.ClusterAPI
+		want       []string
+	}{
+		{
+			name: "not set CIDR block access section",
+			clusterAPI: func() *arohcpv1alpha1.ClusterAPI {
+				clusterAPI, err := arohcpv1alpha1.NewClusterAPI().Build()
+				require.NoError(t, err)
+				return clusterAPI
+			},
+			want: nil,
+		},
+		{
+			name: "allow all mode",
+			clusterAPI: func() *arohcpv1alpha1.ClusterAPI {
+				clusterAPI, err := arohcpv1alpha1.NewClusterAPI().CIDRBlockAccess(arohcpv1alpha1.NewCIDRBlockAccess().
+					Allow(arohcpv1alpha1.NewCIDRBlockAllowAccess().
+						Mode(CSCIDRBlockAllowAccessModeAllowAll))).
+					Build()
+				require.NoError(t, err)
+				return clusterAPI
+			},
+			want: nil,
+		},
+		{
+			name: "allow all mode with stale values returns nil",
+			clusterAPI: func() *arohcpv1alpha1.ClusterAPI {
+				clusterAPI, err := arohcpv1alpha1.NewClusterAPI().CIDRBlockAccess(arohcpv1alpha1.NewCIDRBlockAccess().
+					Allow(arohcpv1alpha1.NewCIDRBlockAllowAccess().
+						Mode(CSCIDRBlockAllowAccessModeAllowAll).
+						Values("10.0.0.0/8", "192.168.0.0/16"))).
+					Build()
+				require.NoError(t, err)
+				return clusterAPI
+			},
+			want: nil,
+		},
+		{
+			name: "CIDR block access section set without allow returns nil",
+			clusterAPI: func() *arohcpv1alpha1.ClusterAPI {
+				clusterAPI, err := arohcpv1alpha1.NewClusterAPI().CIDRBlockAccess(arohcpv1alpha1.NewCIDRBlockAccess()).Build()
+				require.NoError(t, err)
+				return clusterAPI
+			},
+			want: nil,
+		},
+		{
+			name: "allow list mode",
+			clusterAPI: func() *arohcpv1alpha1.ClusterAPI {
+				clusterAPI, err := arohcpv1alpha1.NewClusterAPI().CIDRBlockAccess(arohcpv1alpha1.NewCIDRBlockAccess().
+					Allow(arohcpv1alpha1.NewCIDRBlockAllowAccess().
+						Mode(CSCIDRBlockAllowAccessModeAllowList).
+						Values("10.0.0.0/8", "192.168.0.0/16"))).
+					Build()
+				require.NoError(t, err)
+				return clusterAPI
+			},
+			want: []string{"10.0.0.0/8", "192.168.0.0/16"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, ClusterUpdateDispatchConfigAuthorizedCIDRsFromCS(tt.clusterAPI()))
+		})
+	}
+}
+
+func TestClusterUpdateDispatchConfigNodeDrainTimeoutFromCS(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		csCluster *arohcpv1alpha1.Cluster
+		want      int32
+	}{
+		{
+			name: "unset cs node drain grace period returns zero",
+			csCluster: func() *arohcpv1alpha1.Cluster {
+				cluster, err := arohcpv1alpha1.NewCluster().Build()
+				require.NoError(t, err)
+				return cluster
+			}(),
+			want: 0,
+		},
+		{
+			name: "cs node drain grace period set in minutes unit returns the set value",
+			csCluster: func() *arohcpv1alpha1.Cluster {
+				cluster, err := arohcpv1alpha1.NewCluster().
+					NodeDrainGracePeriod(arohcpv1alpha1.NewValue().
+						Unit(csNodeDrainGracePeriodUnit).
+						Value(float64(45))).
+					Build()
+				require.NoError(t, err)
+				return cluster
+			}(),
+			want: 45,
+		},
+		{
+			name: "cs node drain grace period set in non-minutes unit returns zero",
+			csCluster: func() *arohcpv1alpha1.Cluster {
+				cluster, err := arohcpv1alpha1.NewCluster().
+					NodeDrainGracePeriod(arohcpv1alpha1.NewValue().
+						Unit("hours").
+						Value(float64(1))).
+					Build()
+				require.NoError(t, err)
+				return cluster
+			}(),
+			want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, ClusterUpdateDispatchConfigNodeDrainTimeoutFromCS(tt.csCluster))
+		})
+	}
+}
+
+func TestClusterUpdateDispatchConfigJSONFromRPAndCS(t *testing.T) {
+	hcpCluster := &api.HCPOpenShiftCluster{
+		CustomerProperties: api.HCPOpenShiftClusterCustomerProperties{
+			NodeDrainTimeoutMinutes: 45,
+			API: api.CustomerAPIProfile{
+				AuthorizedCIDRs: []string{"10.0.0.0/8"},
+			},
+			Autoscaling: api.ClusterAutoscalingProfile{
+				MaxNodesTotal:               12,
+				MaxPodGracePeriodSeconds:    600,
+				MaxNodeProvisionTimeSeconds: 900,
+				PodPriorityThreshold:        -10,
+			},
+		},
+	}
+	spc := &api.ServiceProviderCluster{}
+
+	// We pass a non nil oldClusterServiceCluster so when we call BuildCSCluster, it will consider
+	// it is an update, so it will not attempt to set the immutable attributes.
+	oldClusterServiceCluster, err := arohcpv1alpha1.NewCluster().Build()
+	require.NoError(t, err)
+
+	clusterBuilder, autoscalerBuilder, err := BuildCSCluster(nil, "11111111-1111-1111-1111-111111111111", hcpCluster, nil, oldClusterServiceCluster, spc)
+
+	require.NoError(t, err)
+	csCluster, err := clusterBuilder.Autoscaler(autoscalerBuilder).Build()
+	require.NoError(t, err)
+
+	desiredJSON, err := ClusterUpdateDispatchConfigJSONFromRP(hcpCluster, spc)
+	require.NoError(t, err)
+	actualJSON, err := ClusterUpdateDispatchConfigJSONFromCS(csCluster)
+	require.NoError(t, err)
+
+	// We assert both semantic and byte-for-byte JSON equality on purpose:
+	//   - JSONEq checks that RP and CS projections represent the same config (values and structure).
+	//   - Equal checks that canonicalJSON produces identical strings on both sides. The cluster
+	//     service update dispatch controller uses string equality (==) for drift detection, so
+	//     this must hold whenever the configs match; JSONEq alone would not catch encoding
+	//     differences such as key ordering or whitespace that would cause a false drift signal.
+	assert.JSONEq(t, desiredJSON, actualJSON)
+	assert.Equal(t, desiredJSON, actualJSON)
+	assert.Contains(t, desiredJSON, `"nodeDrainTimeoutMinutes": 45`)
+	assert.Contains(t, desiredJSON, `"maxNodesTotal": 12`)
+
+	hcpCluster.CustomerProperties.Autoscaling.MaxNodesTotal = 20
+	desiredJSON, err = ClusterUpdateDispatchConfigJSONFromRP(hcpCluster, spc)
+	require.NoError(t, err)
+	assert.NotEqual(t, desiredJSON, actualJSON)
+}
+
+func TestClusterUpdateDispatchConfigApplyToCSBuilders(t *testing.T) {
+	clusterBuilder := arohcpv1alpha1.NewCluster()
+	clusterAPIBuilder := arohcpv1alpha1.NewClusterAPI()
+
+	tests := []struct {
+		name           string
+		config         clusterUpdateDispatchConfig
+		properties     map[string]string
+		wantProperties map[string]string
+	}{
+		{
+			name: "enables both experimental properties",
+			config: clusterUpdateDispatchConfig{
+				ExperimentalFeatures: clusterUpdateDispatchConfigExperimentalFeatures{
+					ControlPlaneAvailability: api.SingleReplicaControlPlane,
+					ControlPlanePodSizing:    api.MinimalControlPlanePodSizing,
+				},
+			},
+			properties: map[string]string{},
+			wantProperties: map[string]string{
+				CSPropertySingleReplica: CSPropertyEnabled,
+				CSPropertySizeOverride:  CSPropertyE2EMinimalControlPlaneSize,
+			},
+		},
+		{
+			name:   "deletes experimental properties when disabled",
+			config: clusterUpdateDispatchConfig{},
+			properties: map[string]string{
+				CSPropertySingleReplica:    CSPropertyEnabled,
+				CSPropertySizeOverride:     CSPropertyEnabled,
+				CSPropertyCPOImageOverride: "quay.io/openshift/cpo:old",
+				"other":                    "value",
+			},
+			wantProperties: map[string]string{"other": "value"},
+		},
+		{
+			name: "nil properties is treated as empty map",
+			config: clusterUpdateDispatchConfig{
+				ExperimentalFeatures: clusterUpdateDispatchConfigExperimentalFeatures{
+					ControlPlanePodSizing: api.MinimalControlPlanePodSizing,
+				},
+			},
+			properties: nil,
+		},
+		{
+			name: "overrides conflicting caller properties",
+			config: clusterUpdateDispatchConfig{
+				ExperimentalFeatures: clusterUpdateDispatchConfigExperimentalFeatures{
+					ControlPlaneAvailability: api.SingleReplicaControlPlane,
+					ControlPlanePodSizing:    api.MinimalControlPlanePodSizing,
+				},
+			},
+			properties: map[string]string{
+				CSPropertySingleReplica: "false",
+				CSPropertySizeOverride:  "false",
+			},
+			wantProperties: map[string]string{
+				CSPropertySingleReplica: CSPropertyEnabled,
+				CSPropertySizeOverride:  CSPropertyE2EMinimalControlPlaneSize,
+			},
+		},
+		{
+			name: "sets CPO image override property",
+			config: clusterUpdateDispatchConfig{
+				ExperimentalFeatures: clusterUpdateDispatchConfigExperimentalFeatures{
+					ControlPlaneOperatorImage: "quay.io/openshift/cpo:test",
+				},
+			},
+			properties: map[string]string{},
+			wantProperties: map[string]string{
+				CSPropertyCPOImageOverride: "quay.io/openshift/cpo:test",
+			},
+		},
+		{
+			name: "overrides conflicting CPO image property",
+			config: clusterUpdateDispatchConfig{
+				ExperimentalFeatures: clusterUpdateDispatchConfigExperimentalFeatures{
+					ControlPlaneOperatorImage: "quay.io/openshift/cpo:test",
+				},
+			},
+			properties: map[string]string{
+				CSPropertyCPOImageOverride: "quay.io/openshift/cpo:old",
+			},
+			wantProperties: map[string]string{
+				CSPropertyCPOImageOverride: "quay.io/openshift/cpo:test",
+			},
+		},
+		{
+			name: "size override wins over cluster level experimental pod sizing",
+			config: clusterUpdateDispatchConfig{
+				ExperimentalFeatures: clusterUpdateDispatchConfigExperimentalFeatures{
+					ControlPlanePodSizing: api.MinimalControlPlanePodSizing,
+				},
+				ServiceProviderClusterDispatch: clusterUpdateDispatchConfigServiceProviderClusterDispatch{
+					DesiredHostedClusterControlPlaneSize: ptr.To("Large"),
+				},
+			},
+			properties: map[string]string{},
+			wantProperties: map[string]string{
+				CSPropertySizeOverride: "large",
+			},
+		},
+		{
+			name: "size override alone sets the property",
+			config: clusterUpdateDispatchConfig{
+				ServiceProviderClusterDispatch: clusterUpdateDispatchConfigServiceProviderClusterDispatch{
+					DesiredHostedClusterControlPlaneSize: ptr.To("Medium"),
+				},
+			},
+			properties: map[string]string{},
+			wantProperties: map[string]string{
+				CSPropertySizeOverride: "medium",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.applyToCSBuilders(clusterBuilder, clusterAPIBuilder, tt.properties)
+			require.NoError(t, err)
+			if tt.wantProperties != nil {
+				assert.Equal(t, tt.wantProperties, tt.properties)
+			}
+		})
+	}
+}
+
+func TestClusterUpdateDispatchConfigExperimentalFeaturesFromCS(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		csCluster *arohcpv1alpha1.Cluster
+		want      clusterUpdateDispatchConfigExperimentalFeatures
+	}{
+		{
+			name:      "nil cluster returns empty experimental features",
+			csCluster: nil,
+			want:      clusterUpdateDispatchConfigExperimentalFeatures{},
+		},
+		{
+			name: "single replica enabled",
+			csCluster: func() *arohcpv1alpha1.Cluster {
+				cluster, err := arohcpv1alpha1.NewCluster().Properties(map[string]string{
+					CSPropertySingleReplica: CSPropertyEnabled,
+				}).Build()
+				require.NoError(t, err)
+				return cluster
+			}(),
+			want: clusterUpdateDispatchConfigExperimentalFeatures{
+				ControlPlaneAvailability: api.SingleReplicaControlPlane,
+			},
+		},
+		{
+			name: "single replica disabled value ignored",
+			csCluster: func() *arohcpv1alpha1.Cluster {
+				cluster, err := arohcpv1alpha1.NewCluster().Properties(map[string]string{
+					CSPropertySingleReplica: "false",
+				}).Build()
+				require.NoError(t, err)
+				return cluster
+			}(),
+			want: clusterUpdateDispatchConfigExperimentalFeatures{},
+		},
+		{
+			name: "size override e2e_minimal maps to MinimalControlPlanePodSizing",
+			csCluster: func() *arohcpv1alpha1.Cluster {
+				cluster, err := arohcpv1alpha1.NewCluster().Properties(map[string]string{
+					CSPropertySizeOverride: CSPropertyE2EMinimalControlPlaneSize,
+				}).Build()
+				require.NoError(t, err)
+				return cluster
+			}(),
+			want: clusterUpdateDispatchConfigExperimentalFeatures{
+				ControlPlanePodSizing: api.MinimalControlPlanePodSizing,
+			},
+		},
+		{
+			name: "size override non e2e_minimal value does not set cluster level pod sizing",
+			csCluster: func() *arohcpv1alpha1.Cluster {
+				cluster, err := arohcpv1alpha1.NewCluster().Properties(map[string]string{
+					CSPropertySizeOverride: "large",
+				}).Build()
+				require.NoError(t, err)
+				return cluster
+			}(),
+			want: clusterUpdateDispatchConfigExperimentalFeatures{},
+		},
+		{
+			name: "size override disabled value ignored",
+			csCluster: func() *arohcpv1alpha1.Cluster {
+				cluster, err := arohcpv1alpha1.NewCluster().Properties(map[string]string{
+					CSPropertySizeOverride: "false",
+				}).Build()
+				require.NoError(t, err)
+				return cluster
+			}(),
+			want: clusterUpdateDispatchConfigExperimentalFeatures{},
+		},
+		{
+			name: "CPO image override",
+			csCluster: func() *arohcpv1alpha1.Cluster {
+				cluster, err := arohcpv1alpha1.NewCluster().Properties(map[string]string{
+					CSPropertyCPOImageOverride: "quay.io/openshift/cpo:test",
+				}).Build()
+				require.NoError(t, err)
+				return cluster
+			}(),
+			want: clusterUpdateDispatchConfigExperimentalFeatures{
+				ControlPlaneOperatorImage: "quay.io/openshift/cpo:test",
+			},
+		},
+		{
+			name: "empty CPO image override ignored",
+			csCluster: func() *arohcpv1alpha1.Cluster {
+				cluster, err := arohcpv1alpha1.NewCluster().Properties(map[string]string{
+					CSPropertyCPOImageOverride: "",
+				}).Build()
+				require.NoError(t, err)
+				return cluster
+			}(),
+			want: clusterUpdateDispatchConfigExperimentalFeatures{},
+		},
+		{
+			name: "all experimental properties enabled",
+			csCluster: func() *arohcpv1alpha1.Cluster {
+				cluster, err := arohcpv1alpha1.NewCluster().Properties(map[string]string{
+					CSPropertySingleReplica:    CSPropertyEnabled,
+					CSPropertySizeOverride:     CSPropertyE2EMinimalControlPlaneSize,
+					CSPropertyCPOImageOverride: "quay.io/openshift/cpo:test",
+				}).Build()
+				require.NoError(t, err)
+				return cluster
+			}(),
+			want: clusterUpdateDispatchConfigExperimentalFeatures{
+				ControlPlaneAvailability:  api.SingleReplicaControlPlane,
+				ControlPlanePodSizing:     api.MinimalControlPlanePodSizing,
+				ControlPlaneOperatorImage: "quay.io/openshift/cpo:test",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, clusterUpdateDispatchConfigExperimentalFeaturesFromCS(tt.csCluster))
+		})
+	}
+}
+
+func TestClusterUpdateDispatchConfigServiceProviderClusterDispatchDesiredHostedClusterControlPlaneSizeFromCS(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		csCluster *arohcpv1alpha1.Cluster
+		want      *string
+	}{
+		{
+			name:      "nil cluster returns nil",
+			csCluster: nil,
+			want:      nil,
+		},
+		{
+			name: "no size override property returns nil",
+			csCluster: func() *arohcpv1alpha1.Cluster {
+				cluster, err := arohcpv1alpha1.NewCluster().Build()
+				require.NoError(t, err)
+				return cluster
+			}(),
+			want: nil,
+		},
+		{
+			name: "empty size override property returns nil",
+			csCluster: func() *arohcpv1alpha1.Cluster {
+				cluster, err := arohcpv1alpha1.NewCluster().Properties(map[string]string{
+					CSPropertySizeOverride: "",
+				}).Build()
+				require.NoError(t, err)
+				return cluster
+			}(),
+			want: nil,
+		},
+		{
+			name: "e2e_minimal size override returns nil",
+			csCluster: func() *arohcpv1alpha1.Cluster {
+				cluster, err := arohcpv1alpha1.NewCluster().Properties(map[string]string{
+					CSPropertySizeOverride: CSPropertyE2EMinimalControlPlaneSize,
+				}).Build()
+				require.NoError(t, err)
+				return cluster
+			}(),
+			want: nil,
+		},
+		{
+			name: "custom size override returns the set value",
+			csCluster: func() *arohcpv1alpha1.Cluster {
+				cluster, err := arohcpv1alpha1.NewCluster().Properties(map[string]string{
+					CSPropertySizeOverride: "large",
+				}).Build()
+				require.NoError(t, err)
+				return cluster
+			}(),
+			want: ptr.To("large"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, clusterUpdateDispatchConfigServiceProviderClusterDispatchDesiredHostedClusterControlPlaneSizeFromCS(tt.csCluster))
+		})
+	}
+}
+
+func TestClusterUpdateDispatchConfigAutoscalingFromCS(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		autoscaler func(t *testing.T) *arohcpv1alpha1.ClusterAutoscaler
+		want       clusterUpdateDispatchConfigAutoscaling
+		wantErr    bool
+	}{
+		{
+			name: "nil autoscaler returns empty autoscaling",
+			autoscaler: func(t *testing.T) *arohcpv1alpha1.ClusterAutoscaler {
+				t.Helper()
+				return nil
+			},
+			want: clusterUpdateDispatchConfigAutoscaling{},
+		},
+		{
+			name: "populated autoscaler maps all fields",
+			autoscaler: func(t *testing.T) *arohcpv1alpha1.ClusterAutoscaler {
+				t.Helper()
+				autoscaler, err := arohcpv1alpha1.NewClusterAutoscaler().
+					MaxNodeProvisionTime("15m").
+					MaxPodGracePeriod(600).
+					PodPriorityThreshold(-10).
+					ResourceLimits(arohcpv1alpha1.NewAutoscalerResourceLimits().MaxNodesTotal(12)).
+					Build()
+				require.NoError(t, err)
+				return autoscaler
+			},
+			want: clusterUpdateDispatchConfigAutoscaling{
+				MaxNodesTotal:               12,
+				MaxPodGracePeriodSeconds:    600,
+				MaxNodeProvisionTimeSeconds: 900,
+				PodPriorityThreshold:        -10,
+			},
+		},
+		{
+			name: "invalid max node provision time returns error",
+			autoscaler: func(t *testing.T) *arohcpv1alpha1.ClusterAutoscaler {
+				t.Helper()
+				autoscaler, err := arohcpv1alpha1.NewClusterAutoscaler().
+					MaxNodeProvisionTime("not-a-duration").
+					Build()
+				require.NoError(t, err)
+				return autoscaler
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := clusterUpdateDispatchConfigAutoscalingFromCS(tt.autoscaler(t))
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestClusterUpdateDispatchConfigImageDigestMirrorsFromCS(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		registryConfig func(t *testing.T) *arohcpv1alpha1.ClusterRegistryConfig
+		want           []clusterUpdateDispatchConfigImageDigestMirror
+	}{
+		{
+			name: "nil registry config returns nil",
+			registryConfig: func(t *testing.T) *arohcpv1alpha1.ClusterRegistryConfig {
+				t.Helper()
+				return nil
+			},
+			want: nil,
+		},
+		{
+			name: "empty image digest mirrors returns nil",
+			registryConfig: func(t *testing.T) *arohcpv1alpha1.ClusterRegistryConfig {
+				t.Helper()
+				registryConfig, err := arohcpv1alpha1.NewClusterRegistryConfig().ImageDigestMirrors().Build()
+				require.NoError(t, err)
+				return registryConfig
+			},
+			want: nil,
+		},
+		{
+			name: "mirrors with source and targets are copied",
+			registryConfig: func(t *testing.T) *arohcpv1alpha1.ClusterRegistryConfig {
+				t.Helper()
+				registryConfig, err := arohcpv1alpha1.NewClusterRegistryConfig().
+					ImageDigestMirrors(
+						arohcpv1alpha1.NewImageMirror().
+							Source("quay.io/openshift-release-dev").
+							Mirrors("mirror.example.com", "mirror2.example.com"),
+					).Build()
+				require.NoError(t, err)
+				return registryConfig
+			},
+			want: []clusterUpdateDispatchConfigImageDigestMirror{
+				{
+					Source:  "quay.io/openshift-release-dev",
+					Mirrors: []string{"mirror.example.com", "mirror2.example.com"},
+				},
+			},
+		},
+		{
+			name: "mirror without source is skipped",
+			registryConfig: func(t *testing.T) *arohcpv1alpha1.ClusterRegistryConfig {
+				t.Helper()
+				registryConfig, err := arohcpv1alpha1.NewClusterRegistryConfig().
+					ImageDigestMirrors(
+						arohcpv1alpha1.NewImageMirror().Mirrors("mirror.example.com"),
+					).Build()
+				require.NoError(t, err)
+				return registryConfig
+			},
+			want: []clusterUpdateDispatchConfigImageDigestMirror{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, clusterUpdateDispatchConfigImageDigestMirrorsFromCS(tt.registryConfig(t)))
+		})
+	}
+}
+
+func TestClusterUpdateDispatchConfigAutoscalerBuilder(t *testing.T) {
+	config := clusterUpdateDispatchConfig{
+		Autoscaling: clusterUpdateDispatchConfigAutoscaling{
+			MaxNodesTotal:               12,
+			MaxPodGracePeriodSeconds:    600,
+			MaxNodeProvisionTimeSeconds: 900,
+			PodPriorityThreshold:        -10,
+		},
+	}
+
+	builder, err := config.autoscalerBuilder()
+	require.NoError(t, err)
+
+	autoscaler, err := builder.Build()
+	require.NoError(t, err)
+
+	got, err := clusterUpdateDispatchConfigAutoscalingFromCS(autoscaler)
+	require.NoError(t, err)
+	assert.Equal(t, config.Autoscaling, got)
+}

--- a/internal/ocm/convert.go
+++ b/internal/ocm/convert.go
@@ -598,33 +598,7 @@ func BuildCSNodePool(ctx context.Context, nodePool *api.HCPOpenShiftClusterNodeP
 			AutoRepair(nodePool.Properties.AutoRepair)
 	}
 
-	nodePoolBuilder.Labels(nodePool.Properties.Labels)
-
-	if nodePool.Properties.AutoScaling != nil {
-		nodePoolBuilder.Autoscaling(arohcpv1alpha1.NewNodePoolAutoscaling().
-			MinReplica(int(nodePool.Properties.AutoScaling.Min)).
-			MaxReplica(int(nodePool.Properties.AutoScaling.Max)))
-	} else {
-		nodePoolBuilder.Replicas(int(nodePool.Properties.Replicas))
-	}
-
-	if nodePool.Properties.Taints != nil {
-		taintBuilders := []*arohcpv1alpha1.TaintBuilder{}
-		for _, t := range nodePool.Properties.Taints {
-			newTaintBuilder := arohcpv1alpha1.NewTaint().
-				Effect(string(t.Effect)).
-				Key(t.Key).
-				Value(t.Value)
-			taintBuilders = append(taintBuilders, newTaintBuilder)
-		}
-		nodePoolBuilder.Taints(taintBuilders...)
-	}
-
-	if nodePool.Properties.NodeDrainTimeoutMinutes != nil {
-		nodePoolBuilder.NodeDrainGracePeriod(arohcpv1alpha1.NewValue().
-			Unit(csNodeDrainGracePeriodUnit).
-			Value(float64(*nodePool.Properties.NodeDrainTimeoutMinutes)))
-	}
+	nodePoolUpdateDispatchConfigFromRP(nodePool).applyToCSBuilder(nodePoolBuilder)
 
 	return nodePoolBuilder, nil
 }

--- a/internal/ocm/convert.go
+++ b/internal/ocm/convert.go
@@ -188,6 +188,19 @@ func convertUsernameClaimPrefixPolicyRPToCS(prefixPolicyRP api.UsernameClaimPref
 	}
 }
 
+func convertUsernameClaimPrefixPolicyCSToRP(prefixPolicyCS string) (api.UsernameClaimPrefixPolicy, error) {
+	switch prefixPolicyCS {
+	case csUsernameClaimPrefixPolicyPrefix:
+		return api.UsernameClaimPrefixPolicyPrefix, nil
+	case csUsernameClaimPrefixPolicyNoPrefix:
+		return api.UsernameClaimPrefixPolicyNoPrefix, nil
+	case "":
+		return api.UsernameClaimPrefixPolicyNone, nil
+	default:
+		return "", conversionError[api.UsernameClaimPrefixPolicy](prefixPolicyCS)
+	}
+}
+
 func convertEnableEncryptionAtHostToCSBuilder(in api.NodePoolPlatformProfile) *arohcpv1alpha1.AzureNodePoolEncryptionAtHostBuilder {
 	var state string
 
@@ -230,6 +243,28 @@ func convertExternalAuthClientTypeRPToCS(externalAuthClientTypeRP api.ExternalAu
 		return arohcpv1alpha1.ExternalAuthClientTypePublic, nil
 	default:
 		return "", conversionError[arohcpv1alpha1.ExternalAuthClientType](externalAuthClientTypeRP)
+	}
+}
+
+func convertExternalAuthClientTypeCSToRP(externalAuthClientTypeCS arohcpv1alpha1.ExternalAuthClientType) (api.ExternalAuthClientType, error) {
+	switch externalAuthClientTypeCS {
+	case arohcpv1alpha1.ExternalAuthClientTypeConfidential:
+		return api.ExternalAuthClientTypeConfidential, nil
+	case arohcpv1alpha1.ExternalAuthClientTypePublic:
+		return api.ExternalAuthClientTypePublic, nil
+	default:
+		return "", conversionError[api.ExternalAuthClientType](externalAuthClientTypeCS)
+	}
+}
+
+func convertTokenClaimValidationRuleRPToCS(rule externalAuthUpdateDispatchConfigValidationRule) (*arohcpv1alpha1.TokenClaimValidationRuleBuilder, error) {
+	switch rule.Type {
+	case api.TokenValidationRuleTypeRequiredClaim:
+		return arohcpv1alpha1.NewTokenClaimValidationRule().
+			Claim(rule.RequiredClaim.Claim).
+			RequiredValue(rule.RequiredClaim.RequiredValue), nil
+	default:
+		return nil, conversionError[*arohcpv1alpha1.TokenClaimValidationRuleBuilder](rule.Type)
 	}
 }
 
@@ -612,74 +647,16 @@ func BuildCSExternalAuth(ctx context.Context, externalAuth *api.HCPOpenShiftClus
 		externalAuthBuilder.ID(strings.ToLower(externalAuth.Name))
 	}
 
-	externalAuthBuilder.Issuer(arohcpv1alpha1.NewTokenIssuer().
-		URL(externalAuth.Properties.Issuer.URL).
-		CA(externalAuth.Properties.Issuer.CA).
-		Audiences(externalAuth.Properties.Issuer.Audiences...),
-	)
-
-	clientConfigs := []*arohcpv1alpha1.ExternalAuthClientConfigBuilder{}
-	for _, t := range externalAuth.Properties.Clients {
-		clientType, err := convertExternalAuthClientTypeRPToCS(t.Type)
-		if err != nil {
-			return nil, err
-		}
-
-		newClientConfig := arohcpv1alpha1.NewExternalAuthClientConfig().
-			ID(t.ClientID).
-			Component(arohcpv1alpha1.NewClientComponent().
-				Name(t.Component.Name).
-				Namespace(t.Component.AuthClientNamespace),
-			).
-			ExtraScopes(t.ExtraScopes...).
-			Type(clientType)
-		clientConfigs = append(clientConfigs, newClientConfig)
+	dispatchConfig, err := externalAuthUpdateDispatchConfigFromRP(externalAuth)
+	if err != nil {
+		return nil, err
 	}
-	externalAuthBuilder.Clients(clientConfigs...)
-
-	err := buildClaims(externalAuthBuilder, *externalAuth)
+	err = dispatchConfig.applyToCSBuilder(externalAuthBuilder)
 	if err != nil {
 		return nil, err
 	}
 
 	return externalAuthBuilder, nil
-}
-
-func buildClaims(externalAuthBuilder *arohcpv1alpha1.ExternalAuthBuilder, hcpExternalAuth api.HCPOpenShiftClusterExternalAuth) error {
-	usernameClaimPrefixPolicy, err := convertUsernameClaimPrefixPolicyRPToCS(hcpExternalAuth.Properties.Claim.Mappings.Username.PrefixPolicy)
-	if err != nil {
-		return err
-	}
-
-	tokenClaimMappingsBuilder := arohcpv1alpha1.NewTokenClaimMappings().
-		UserName(arohcpv1alpha1.NewUsernameClaim().
-			Claim(hcpExternalAuth.Properties.Claim.Mappings.Username.Claim).
-			Prefix(hcpExternalAuth.Properties.Claim.Mappings.Username.Prefix).
-			PrefixPolicy(usernameClaimPrefixPolicy),
-		)
-	if hcpExternalAuth.Properties.Claim.Mappings.Groups != nil {
-		tokenClaimMappingsBuilder = tokenClaimMappingsBuilder.Groups(
-			arohcpv1alpha1.NewGroupsClaim().
-				Claim(hcpExternalAuth.Properties.Claim.Mappings.Groups.Claim).
-				Prefix(hcpExternalAuth.Properties.Claim.Mappings.Groups.Prefix),
-		)
-	}
-
-	validationRules := []*arohcpv1alpha1.TokenClaimValidationRuleBuilder{}
-	for _, t := range hcpExternalAuth.Properties.Claim.ValidationRules {
-		newClientConfig := arohcpv1alpha1.NewTokenClaimValidationRule().
-			Claim(t.RequiredClaim.Claim).
-			RequiredValue(t.RequiredClaim.RequiredValue)
-		validationRules = append(validationRules, newClientConfig)
-	}
-
-	externalAuthBuilder.
-		Claim(arohcpv1alpha1.NewExternalAuthClaim().
-			Mappings(tokenClaimMappingsBuilder).
-			ValidationRules(validationRules...),
-		)
-
-	return nil
 }
 
 // ConvertCStoAdminCredential converts a CS BreakGlassCredential object into an HCPOpenShiftClusterAdminCredential object.

--- a/internal/ocm/convert.go
+++ b/internal/ocm/convert.go
@@ -77,8 +77,8 @@ const (
 	csOutboundType                      string = "load_balancer"
 	csUsernameClaimPrefixPolicyNoPrefix string = "NoPrefix"
 	csUsernameClaimPrefixPolicyPrefix   string = "Prefix"
-	csCIDRBlockAllowAccessModeAllowAll  string = "allow_all"
-	csCIDRBlockAllowAccessModeAllowList string = "allow_list"
+	CSCIDRBlockAllowAccessModeAllowAll  string = "allow_all"
+	CSCIDRBlockAllowAccessModeAllowList string = "allow_list"
 	csOsDiskPersistencePersistent       string = "persistent"
 	csOsDiskPersistenceEphemeral        string = "ephemeral"
 	CSProvisionShardStatusActive        string = "active"
@@ -276,9 +276,9 @@ func convertCIDRBlockAllowAccessRPToCS(in api.CustomerAPIProfile) (*arohcpv1alph
 	cidrBlockAllowAccess := arohcpv1alpha1.NewCIDRBlockAllowAccess()
 
 	if in.AuthorizedCIDRs == nil {
-		cidrBlockAllowAccess.Mode(csCIDRBlockAllowAccessModeAllowAll)
+		cidrBlockAllowAccess.Mode(CSCIDRBlockAllowAccessModeAllowAll)
 	} else if len(in.AuthorizedCIDRs) > 0 {
-		cidrBlockAllowAccess.Mode(csCIDRBlockAllowAccessModeAllowList)
+		cidrBlockAllowAccess.Mode(CSCIDRBlockAllowAccessModeAllowList)
 		cidrBlockAllowAccess.Values(in.AuthorizedCIDRs...)
 	} else {
 		// Unreachable: empty AuthorizedCIDRs list is disallowed by validation
@@ -399,28 +399,9 @@ func BuildCSCluster(resourceID *azcorearm.ResourceID, tenantID string, hcpCluste
 		))
 	}
 
-	clusterBuilder.NodeDrainGracePeriod(arohcpv1alpha1.NewValue().
-		Unit(csNodeDrainGracePeriodUnit).
-		Value(float64(hcpCluster.CustomerProperties.NodeDrainTimeoutMinutes)))
-
-	cidrBlockAccess, err := convertCIDRBlockAllowAccessRPToCS(hcpCluster.CustomerProperties.API)
-	if err != nil {
-		return nil, nil, err
-	}
-	clusterBuilder.API(clusterAPIBuilder.CIDRBlockAccess(cidrBlockAccess))
-
-	clusterBuilder.RegistryConfig(arohcpv1alpha1.NewClusterRegistryConfig().
-		ImageDigestMirrors(convertImageDigestMirrorsToCSBuilder(hcpCluster.CustomerProperties.ImageDigestMirrors)...))
-
-	clusterAutoscalerBuilder, err := convertRpAutoscalarToCSBuilder(&hcpCluster.CustomerProperties.Autoscaling)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Property layering: preserve existing CS properties (on update), then
-	// overlay caller-specified properties, then experimental features.
-	// Experimental feature properties are added when enabled and deleted
-	// when disabled to ensure tag removal clears previously set values.
+	// Property layering for CS Properties(): preserve existing values (on update),
+	// overlay caller-specified properties, then clusterUpdateDispatchConfig.applyToCSBuilders overlays
+	// dispatch-managed experimental features.
 	properties := map[string]string{}
 	if oldClusterServiceCluster != nil {
 		for k, v := range oldClusterServiceCluster.Properties() {
@@ -430,23 +411,17 @@ func BuildCSCluster(resourceID *azcorearm.ResourceID, tenantID string, hcpCluste
 	for k, v := range requiredProperties {
 		properties[k] = v
 	}
-	experimentalFeatures := hcpCluster.ServiceProviderProperties.ExperimentalFeatures
-	if experimentalFeatures.ControlPlaneAvailability == api.SingleReplicaControlPlane {
-		properties[CSPropertySingleReplica] = CSPropertyEnabled
-	} else {
-		delete(properties, CSPropertySingleReplica)
+
+	clusterUpdateDispatchConfig := clusterUpdateDispatchConfigFromRP(hcpCluster, serviceProviderCluster)
+	err = clusterUpdateDispatchConfig.applyToCSBuilders(clusterBuilder, clusterAPIBuilder, properties)
+	if err != nil {
+		return nil, nil, err
 	}
-	if value, ok := DesiredHostedClusterSizeOverride(serviceProviderCluster, hcpCluster); ok {
-		properties[CSPropertySizeOverride] = value
-	} else {
-		delete(properties, CSPropertySizeOverride)
+
+	clusterAutoscalerBuilder, err := clusterUpdateDispatchConfig.autoscalerBuilder()
+	if err != nil {
+		return nil, nil, err
 	}
-	if experimentalFeatures.ControlPlaneOperatorImage != "" {
-		properties[CSPropertyCPOImageOverride] = experimentalFeatures.ControlPlaneOperatorImage
-	} else {
-		delete(properties, CSPropertyCPOImageOverride)
-	}
-	clusterBuilder = clusterBuilder.Properties(properties)
 
 	return clusterBuilder, clusterAutoscalerBuilder, nil
 }
@@ -466,30 +441,30 @@ func clusterCSVersionID(serviceProviderCluster *api.ServiceProviderCluster, hcpC
 	return NewOpenShiftVersionXYZ(hcpCluster.CustomerProperties.Version.ID, channelGroup)
 }
 
-// DesiredHostedClusterSizeOverride returns the value the CSPropertySizeOverride
-// entry should have for a given (ServiceProviderCluster, HCP cluster) pair,
-// and whether the property should be present at all. This is the single
-// source of truth for computing the override and is shared between the
-// BuildCSCluster property layering (frontend update path) and the
-// desired-control-plane-size reconciler (backend ServiceProviderCluster-driven
-// path) so the two cannot disagree.
+// ConvertHostedClusterSizeOverrideToCS returns the value the CSPropertySizeOverride
+// entry should have when receiving desiredClusterControlPlanePodSizing, which is the Cosmos
+// level ControlPlanePodSizing configuration, as well as the ServiceProviderCluster level one.
+// It also returns whether the property should be set at all on CS side.
+// This is the single source of truth for computing the override and is shared between the
+// cluster update dispatch controller (CS writer) and the desired-control-plane-size
+// status reconciler (SPC Status confirmation) so the two cannot disagree.
 //
 // Precedence:
-//  1. ServiceProviderCluster.Spec.DesiredHostedClusterControlPlaneSize, when
-//     set, wins. Returned lowercased because cluster-service's
+//  1. desiredServiceProviderClusterControlPlanePodSizing, when set to non nil wins. Returned lowercased because cluster-service's
 //     clustersizingconfiguration uses lowercase tier names.
-//  2. Otherwise, hcpCluster.ServiceProviderProperties.ExperimentalFeatures.
-//     ControlPlanePodSizing == MinimalControlPlanePodSizing returns
+//  2. Otherwise, desiredClusterControlPlanePodSizing == MinimalControlPlanePodSizing returns
 //     CSPropertyE2EMinimalControlPlaneSize ("e2e_minimal"), the named
 //     internal-only tier cluster-service uses for the e2e minimal layout.
-//  3. Otherwise the property is absent.
-func DesiredHostedClusterSizeOverride(serviceProviderCluster *api.ServiceProviderCluster, hcpCluster *api.HCPOpenShiftCluster) (string, bool) {
-	if serviceProviderCluster != nil && serviceProviderCluster.Spec.DesiredHostedClusterControlPlaneSize != nil {
-		return strings.ToLower(*serviceProviderCluster.Spec.DesiredHostedClusterControlPlaneSize), true
+//  3. Otherwise the property is determined to need to be absent
+func ConvertHostedClusterSizeOverrideToCS(desiredClusterControlPlanePodSizing api.ControlPlanePodSizing, desiredServiceProviderClusterControlPlanePodSizing *string) (string, bool) {
+	if desiredServiceProviderClusterControlPlanePodSizing != nil {
+		return strings.ToLower(*desiredServiceProviderClusterControlPlanePodSizing), true
 	}
-	if hcpCluster != nil && hcpCluster.ServiceProviderProperties.ExperimentalFeatures.ControlPlanePodSizing == api.MinimalControlPlanePodSizing {
+
+	if desiredClusterControlPlanePodSizing == api.MinimalControlPlanePodSizing {
 		return CSPropertyE2EMinimalControlPlaneSize, true
 	}
+
 	return "", false
 }
 

--- a/internal/ocm/convert_test.go
+++ b/internal/ocm/convert_test.go
@@ -652,7 +652,7 @@ func getBaseCSClusterBuilder(updating bool) *arohcpv1alpha1.ClusterBuilder {
 		Properties(map[string]string{}).
 		API(clusterAPIBuilder.CIDRBlockAccess(arohcpv1alpha1.NewCIDRBlockAccess().
 			Allow(arohcpv1alpha1.NewCIDRBlockAllowAccess().
-				Mode(csCIDRBlockAllowAccessModeAllowAll)))).
+				Mode(CSCIDRBlockAllowAccessModeAllowAll)))).
 		RegistryConfig(arohcpv1alpha1.NewClusterRegistryConfig().ImageDigestMirrors())
 }
 
@@ -700,7 +700,7 @@ func TestBuildCSCluster(t *testing.T) {
 					Listening(arohcpv1alpha1.ListeningMethodInternal).
 					CIDRBlockAccess(arohcpv1alpha1.NewCIDRBlockAccess().
 						Allow(arohcpv1alpha1.NewCIDRBlockAllowAccess().
-							Mode(csCIDRBlockAllowAccessModeAllowList).
+							Mode(CSCIDRBlockAllowAccessModeAllowList).
 							Values("10.0.0.0/8", "192.168.0.0/16")))),
 		},
 		{
@@ -771,7 +771,7 @@ func TestBuildCSCluster(t *testing.T) {
 				API(arohcpv1alpha1.NewClusterAPI().
 					CIDRBlockAccess(arohcpv1alpha1.NewCIDRBlockAccess().
 						Allow(arohcpv1alpha1.NewCIDRBlockAllowAccess().
-							Mode(csCIDRBlockAllowAccessModeAllowList).
+							Mode(CSCIDRBlockAllowAccessModeAllowList).
 							Values("172.16.0.0/12", "203.0.113.0/24")))),
 		},
 		{
@@ -1043,7 +1043,7 @@ func TestBuildCSCluster(t *testing.T) {
 					Listening(arohcpv1alpha1.ListeningMethodExternal).
 					CIDRBlockAccess(arohcpv1alpha1.NewCIDRBlockAccess().
 						Allow(arohcpv1alpha1.NewCIDRBlockAllowAccess().
-							Mode(csCIDRBlockAllowAccessModeAllowAll)))).
+							Mode(CSCIDRBlockAllowAccessModeAllowAll)))).
 				Ingresses(arohcpv1alpha1.NewIngressList().Items(
 					arohcpv1alpha1.NewIngress().Default(true).Listening(arohcpv1alpha1.ListeningMethodExternal),
 				)).
@@ -1113,7 +1113,7 @@ func TestBuildCSCluster(t *testing.T) {
 					Listening(arohcpv1alpha1.ListeningMethodExternal).
 					CIDRBlockAccess(arohcpv1alpha1.NewCIDRBlockAccess().
 						Allow(arohcpv1alpha1.NewCIDRBlockAllowAccess().
-							Mode(csCIDRBlockAllowAccessModeAllowAll)))).
+							Mode(CSCIDRBlockAllowAccessModeAllowAll)))).
 				Ingresses(arohcpv1alpha1.NewIngressList().Items(
 					arohcpv1alpha1.NewIngress().Default(true).Listening(arohcpv1alpha1.ListeningMethodExternal),
 				)).
@@ -1242,67 +1242,48 @@ func TestClusterCSVersionID(t *testing.T) {
 	}
 }
 
-func TestDesiredHostedClusterSizeOverride(t *testing.T) {
+func TestConvertHostedClusterSizeOverrideToCS(t *testing.T) {
 	largeStr := "Large"
-	spcWithSize := func(s *string) *api.ServiceProviderCluster {
-		return &api.ServiceProviderCluster{
-			Spec: api.ServiceProviderClusterSpec{
-				DesiredHostedClusterControlPlaneSize: s,
-			},
-		}
-	}
-	clusterWithPodSizing := func(p api.ControlPlanePodSizing) *api.HCPOpenShiftCluster {
-		c := &api.HCPOpenShiftCluster{}
-		c.ServiceProviderProperties.ExperimentalFeatures.ControlPlanePodSizing = p
-		return c
-	}
 
 	tests := []struct {
-		name         string
-		spc          *api.ServiceProviderCluster
-		hcpCluster   *api.HCPOpenShiftCluster
-		expectValue  string
-		expectActive bool
+		name                         string
+		clusterControlPlanePodSizing api.ControlPlanePodSizing
+		spcControlPlaneSize          *string
+		expectValue                  string
+		expectActive                 bool
 	}{
 		{
-			name:         "SPC size wins over experimental feature",
-			spc:          spcWithSize(&largeStr),
-			hcpCluster:   clusterWithPodSizing(api.MinimalControlPlanePodSizing),
-			expectValue:  "large",
-			expectActive: true,
+			name:                         "SPC size wins over experimental feature",
+			clusterControlPlanePodSizing: api.MinimalControlPlanePodSizing,
+			spcControlPlaneSize:          &largeStr,
+			expectValue:                  "large",
+			expectActive:                 true,
 		},
 		{
-			name:         "SPC size set, no experimental feature",
-			spc:          spcWithSize(&largeStr),
-			hcpCluster:   clusterWithPodSizing(""),
-			expectValue:  "large",
-			expectActive: true,
+			name:                         "SPC size set, no experimental feature",
+			clusterControlPlanePodSizing: "",
+			spcControlPlaneSize:          &largeStr,
+			expectValue:                  "large",
+			expectActive:                 true,
 		},
 		{
-			name:         "SPC nil, experimental feature active → legacy sentinel",
-			spc:          nil,
-			hcpCluster:   clusterWithPodSizing(api.MinimalControlPlanePodSizing),
-			expectValue:  CSPropertyE2EMinimalControlPlaneSize,
-			expectActive: true,
+			name:                         "SPC nil, experimental feature active returns legacy sentinel",
+			clusterControlPlanePodSizing: api.MinimalControlPlanePodSizing,
+			spcControlPlaneSize:          nil,
+			expectValue:                  CSPropertyE2EMinimalControlPlaneSize,
+			expectActive:                 true,
 		},
 		{
-			name:         "SPC has nil size, experimental feature active → legacy sentinel",
-			spc:          spcWithSize(nil),
-			hcpCluster:   clusterWithPodSizing(api.MinimalControlPlanePodSizing),
-			expectValue:  CSPropertyE2EMinimalControlPlaneSize,
-			expectActive: true,
-		},
-		{
-			name:         "neither input set → property absent",
-			spc:          nil,
-			hcpCluster:   clusterWithPodSizing(""),
-			expectActive: false,
+			name:                         "neither input set returns property absent",
+			clusterControlPlanePodSizing: "",
+			spcControlPlaneSize:          nil,
+			expectActive:                 false,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			value, active := DesiredHostedClusterSizeOverride(tc.spc, tc.hcpCluster)
+			value, active := ConvertHostedClusterSizeOverrideToCS(tc.clusterControlPlanePodSizing, tc.spcControlPlaneSize)
 			assert.Equal(t, tc.expectActive, active)
 			if tc.expectActive {
 				assert.Equal(t, tc.expectValue, value)

--- a/internal/ocm/external_auth_update_dispatch_config.go
+++ b/internal/ocm/external_auth_update_dispatch_config.go
@@ -1,0 +1,452 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocm
+
+import (
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+)
+
+// externalAuthUpdateDispatchConfig is a dispatch-specific canonical model of the ExternalAuth's
+// Cluster Service fields that are considered by the external auth's cluster service update dispatch
+// controller. Its shape intentionally does not mirror RP resources or the Cluster Service API.
+// Conversion functions project external state into this form and back out when dispatching to
+// Cluster Service.
+//
+// The same struct is built from either RP desired state (HCPOpenShiftClusterExternalAuth) or from
+// the live Cluster Service ExternalAuth. This applies only to ExternalAuth CS updates. Cluster and
+// node pool updates use separate dispatch paths and update dispatch config structs. Drift between the
+// two projections may trigger the external auth's cluster service update dispatch controller to
+// PATCH Cluster Service.
+//
+// The external auth's cluster service update dispatch controller compares desired and actual
+// configs in this canonical form and sends a CS PATCH only when they differ.
+//
+// Note: This does not include all fields updatable via the ExternalAuth Cluster Service API, only
+// the subset that the external auth's cluster service update dispatch controller considers.
+//
+// Note: Do not embed internal/api struct types (for example api.ExternalAuthClientProfile,
+// api.TokenClaimMappingsProfile, or api.TokenClaimValidationRule) in this struct or its nested
+// field types. We want to make those internal/api struct types independent of this so they can
+// evolve independently. For example, if a field here referenced an internal/api struct type
+// directly, any new field added to that struct would be automatically considered as updatable
+// automatically, but we might not want that field to be updatable and/or CS side doesn't really
+// support updating it. Instead, define curated local structs with only the fields that dispatch
+// should hash and sync, and copy values explicitly from api types at the conversion boundaries.
+// Using api/internal enum or scalar types for individual curated fields is fine. Some fields are
+// stored as Cluster Service string values (for example client Type and username PrefixPolicy) so
+// both fromRP() and fromCS() produce identical values without needing CS-to-RP reverse conversion.
+//
+// IMPORTANT: how to add a new dispatch-managed config field:
+//
+// Dispatch and operation state are related but wired separately. You need both for a correct
+// external auth update experience:
+//   - Dispatch (this file): detects drift and PATCHes Cluster Service.
+//   - Operation state (operation_external_auth_update_state_calculation.go): decides when the ARM
+//     external auth update operation can leave Updating and report Succeeded.
+//
+// If you wire dispatch but skip operation state calculation, the update may be sent to CS but the
+// operation can succeed too early (or stay Updating forever if dispatch is missing).
+//
+// Before you start:
+//
+//   - Confirm this is an ExternalAuth-level Cluster Service update (not cluster or node pool).
+//   - Confirm Cluster Service supports updating the field on an existing external auth.
+//   - Identify where RP desired state lives (HCPOpenShiftClusterExternalAuth).
+//
+// 1. Dispatch wiring (this file)
+//
+//   - Add the field to externalAuthUpdateDispatchConfig or a curated nested struct.
+//     Do not embed internal/api struct types.
+//   - Populate it in externalAuthUpdateDispatchConfigFromRP. This ensures RP projection works correctly
+//   - Populate it in externalAuthUpdateDispatchConfigFromCS. This ensures CS projection works correctly
+//   - Apply it in applyToCSBuilder. This ensures the CS builders work correctly.
+//
+// 2. Operation state wiring (backend/pkg/controllers/operationcontrollers/operation_external_auth_update.go)
+//
+//	determineOperationState aggregates several sources and picks the worst state. Your new
+//	check must succeed along with CS spec and Hypershift checks.
+//
+//	Choose where to observe the change and implement it:
+//	  - Prefer observing directly from the Management Cluster side when the field is visible there after propagation.
+//	    Most dispatch fields today are checked here: issuer, clients, claim mappings, validation rules, etc.
+//	  - Observe from Cluster Service when the Management Cluster side is not a reliable source of
+//	    truth yet or simply can't be calculated from there
+//	  - Sometimes you might want to observe it on both sides for extra validation
+//
+//	Return (false, message) with a clear message when observed != desired so Updating state
+//	is actionable in logs.
+//
+// 3. Tests
+//
+//   - external_auth_update_dispatch_config_test.go: hash, FromCS, round-trip, apply payload.
+//   - operation_external_auth_update_test.go: match/mismatch cases for your new helper and, if
+//     useful, an end-to-end clusterServiceExternalAuthSpecOperationState or
+//     hypershiftExternalAuthOperationState case.
+//   - Consider both "not applied yet" (Updating) and "applied" (Succeeded) scenarios.
+//
+// 4. Sanity checks
+//
+//   - Create path: applyToCSBuilder is also used by BuildCSExternalAuth in internal/ocm/convert.go
+//     when the frontend first creates a Cluster Service external auth (not only when the update
+//     dispatch controller PATCHes an existing one). Verify the new field is present on create.
+//   - Desired state must exist in Cosmos before dispatch can sync it. If customers set this
+//     field via ARM, also wire the full ingest path: ARM API, frontend validation/conversion,
+//     and persistence onto HCPOpenShiftClusterExternalAuth. Internal-only fields still need
+//     whatever backend path writes the value Cosmos holds.
+type externalAuthUpdateDispatchConfig struct {
+	Issuer  externalAuthUpdateDispatchConfigIssuer   `json:"issuer"`
+	Clients []externalAuthUpdateDispatchConfigClient `json:"clients"`
+	Claim   externalAuthUpdateDispatchConfigClaim    `json:"claim"`
+}
+
+// externalAuthUpdateDispatchConfigIssuer is the curated issuer subset used for dispatch hash and
+// sync. See externalAuthUpdateDispatchConfig: do not embed api.TokenIssuerProfile.
+type externalAuthUpdateDispatchConfigIssuer struct {
+	URL       string   `json:"url"`
+	Audiences []string `json:"audiences"`
+	CA        string   `json:"ca"`
+}
+
+// externalAuthUpdateDispatchConfigClient is the curated client subset used for dispatch hash and
+// sync. See externalAuthUpdateDispatchConfig: do not embed api.ExternalAuthClientProfile.
+// Type uses the RP enum in the dispatch canonical form. fromCS() and applyToCSBuilder() convert
+// through convertExternalAuthClientTypeCSToRP and convertExternalAuthClientTypeRPToCS because CS
+// uses lowercase values ("public", "confidential") while RP uses PascalCase ("Public", "Confidential").
+type externalAuthUpdateDispatchConfigClient struct {
+	ComponentName      string                     `json:"componentName"`
+	ComponentNamespace string                     `json:"componentNamespace"`
+	ClientID           string                     `json:"clientId"`
+	ExtraScopes        []string                   `json:"extraScopes"`
+	Type               api.ExternalAuthClientType `json:"type"`
+}
+
+// externalAuthUpdateDispatchConfigClaim is the curated claim subset used for dispatch hash and
+// sync. See externalAuthUpdateDispatchConfig: do not embed api.ExternalAuthClaimProfile.
+type externalAuthUpdateDispatchConfigClaim struct {
+	Mappings        externalAuthUpdateDispatchConfigClaimMappings    `json:"mappings"`
+	ValidationRules []externalAuthUpdateDispatchConfigValidationRule `json:"validationRules"`
+}
+
+// externalAuthUpdateDispatchConfigClaimMappings is the curated claim mappings subset used for
+// dispatch hash and sync. See externalAuthUpdateDispatchConfig: do not embed api.TokenClaimMappingsProfile.
+type externalAuthUpdateDispatchConfigClaimMappings struct {
+	Username externalAuthUpdateDispatchConfigUsernameClaim `json:"username"`
+	Groups   *externalAuthUpdateDispatchConfigGroupsClaim  `json:"groups"`
+}
+
+// externalAuthUpdateDispatchConfigUsernameClaim is the curated username claim subset used for
+// dispatch hash and sync. See externalAuthUpdateDispatchConfig: do not embed api.UsernameClaimProfile.
+type externalAuthUpdateDispatchConfigUsernameClaim struct {
+	Claim        string                        `json:"claim"`
+	Prefix       string                        `json:"prefix"`
+	PrefixPolicy api.UsernameClaimPrefixPolicy `json:"prefixPolicy"`
+}
+
+// externalAuthUpdateDispatchConfigGroupsClaim is the curated groups claim subset used for dispatch
+// hash and sync. See externalAuthUpdateDispatchConfig: do not embed api.GroupClaimProfile.
+type externalAuthUpdateDispatchConfigGroupsClaim struct {
+	Claim  string `json:"claim"`
+	Prefix string `json:"prefix"`
+}
+
+// externalAuthUpdateDispatchConfigValidationRule is the curated validation rule subset used for
+// dispatch hash and sync. See externalAuthUpdateDispatchConfig: do not embed api.TokenClaimValidationRule.
+type externalAuthUpdateDispatchConfigValidationRule struct {
+	Type          api.TokenValidationRuleType                   `json:"type"`
+	RequiredClaim externalAuthUpdateDispatchConfigRequiredClaim `json:"requiredClaim"`
+}
+
+// externalAuthUpdateDispatchConfigRequiredClaim is the curated required-claim subset used for
+// dispatch hash and sync. See externalAuthUpdateDispatchConfig: do not embed api.TokenRequiredClaim.
+type externalAuthUpdateDispatchConfigRequiredClaim struct {
+	Claim         string `json:"claim"`
+	RequiredValue string `json:"requiredValue"`
+}
+
+// ExternalAuthUpdateDispatchConfigJSONFromRP returns the canonical JSON of the dispatch config
+// projected from RP desired state.
+func ExternalAuthUpdateDispatchConfigJSONFromRP(externalAuth *api.HCPOpenShiftClusterExternalAuth) (string, error) {
+	config, err := externalAuthUpdateDispatchConfigFromRP(externalAuth)
+	if err != nil {
+		return "", err
+	}
+	raw, err := config.canonicalJSON()
+	if err != nil {
+		return "", err
+	}
+	return string(raw), nil
+}
+
+// ExternalAuthUpdateDispatchConfigJSONFromCS returns the canonical JSON of the dispatch config
+// projected from a Cluster Service external auth.
+func ExternalAuthUpdateDispatchConfigJSONFromCS(csExternalAuth *arohcpv1alpha1.ExternalAuth) (string, error) {
+	raw, err := externalAuthUpdateDispatchConfigFromCS(csExternalAuth)
+	if err != nil {
+		return "", err
+	}
+	canonicalJSON, err := raw.canonicalJSON()
+	if err != nil {
+		return "", err
+	}
+	return string(canonicalJSON), nil
+}
+
+// externalAuthUpdateDispatchConfigFromRP projects RP desired state into the dispatch canonical form.
+func externalAuthUpdateDispatchConfigFromRP(ea *api.HCPOpenShiftClusterExternalAuth) (*externalAuthUpdateDispatchConfig, error) {
+	clients, err := externalAuthUpdateDispatchConfigClientsFromRP(ea.Properties.Clients)
+	if err != nil {
+		return nil, err
+	}
+
+	config := &externalAuthUpdateDispatchConfig{
+		Issuer: externalAuthUpdateDispatchConfigIssuer{
+			URL:       ea.Properties.Issuer.URL,
+			Audiences: ea.Properties.Issuer.Audiences,
+			CA:        ea.Properties.Issuer.CA,
+		},
+		Clients: clients,
+		Claim: externalAuthUpdateDispatchConfigClaim{
+			Mappings: externalAuthUpdateDispatchConfigClaimMappings{
+				Username: externalAuthUpdateDispatchConfigUsernameClaim{
+					Claim:        ea.Properties.Claim.Mappings.Username.Claim,
+					Prefix:       ea.Properties.Claim.Mappings.Username.Prefix,
+					PrefixPolicy: ea.Properties.Claim.Mappings.Username.PrefixPolicy,
+				},
+			},
+			ValidationRules: externalAuthUpdateDispatchConfigValidationRulesFromRP(ea.Properties.Claim.ValidationRules),
+		},
+	}
+
+	if ea.Properties.Claim.Mappings.Groups != nil {
+		config.Claim.Mappings.Groups = &externalAuthUpdateDispatchConfigGroupsClaim{
+			Claim:  ea.Properties.Claim.Mappings.Groups.Claim,
+			Prefix: ea.Properties.Claim.Mappings.Groups.Prefix,
+		}
+	}
+
+	return config, nil
+}
+
+// externalAuthUpdateDispatchConfigClientsFromRP copies clients from RP into the dispatch canonical form.
+func externalAuthUpdateDispatchConfigClientsFromRP(clients []api.ExternalAuthClientProfile) ([]externalAuthUpdateDispatchConfigClient, error) {
+	if len(clients) == 0 {
+		return nil, nil
+	}
+
+	out := make([]externalAuthUpdateDispatchConfigClient, 0, len(clients))
+	for _, c := range clients {
+		out = append(out, externalAuthUpdateDispatchConfigClient{
+			ComponentName:      c.Component.Name,
+			ComponentNamespace: c.Component.AuthClientNamespace,
+			ClientID:           c.ClientID,
+			ExtraScopes:        c.ExtraScopes,
+			Type:               c.Type,
+		})
+	}
+
+	return out, nil
+}
+
+// externalAuthUpdateDispatchConfigValidationRulesFromRP copies validation rules from RP into the
+// dispatch canonical form.
+func externalAuthUpdateDispatchConfigValidationRulesFromRP(rules []api.TokenClaimValidationRule) []externalAuthUpdateDispatchConfigValidationRule {
+	if len(rules) == 0 {
+		return nil
+	}
+
+	out := make([]externalAuthUpdateDispatchConfigValidationRule, 0, len(rules))
+	for _, r := range rules {
+		out = append(out, externalAuthUpdateDispatchConfigValidationRule{
+			Type: r.Type,
+			RequiredClaim: externalAuthUpdateDispatchConfigRequiredClaim{
+				Claim:         r.RequiredClaim.Claim,
+				RequiredValue: r.RequiredClaim.RequiredValue,
+			},
+		})
+	}
+	return out
+}
+
+// externalAuthUpdateDispatchConfigFromCS projects a Cluster Service external auth into the dispatch
+// canonical form.
+func externalAuthUpdateDispatchConfigFromCS(csEA *arohcpv1alpha1.ExternalAuth) (*externalAuthUpdateDispatchConfig, error) {
+	config := &externalAuthUpdateDispatchConfig{}
+
+	if issuer, ok := csEA.GetIssuer(); ok && issuer != nil {
+		config.Issuer.URL = issuer.URL()
+		if audiences, ok := issuer.GetAudiences(); ok {
+			config.Issuer.Audiences = audiences
+		}
+		config.Issuer.CA = issuer.CA()
+	}
+
+	clients, err := externalAuthUpdateDispatchConfigClientsFromCS(csEA)
+	if err != nil {
+		return nil, err
+	}
+	config.Clients = clients
+
+	if claim, ok := csEA.GetClaim(); ok && claim != nil {
+		if mappings, ok := claim.GetMappings(); ok && mappings != nil {
+			if userName, ok := mappings.GetUserName(); ok && userName != nil {
+				prefixPolicy, err := convertUsernameClaimPrefixPolicyCSToRP(userName.PrefixPolicy())
+				if err != nil {
+					return nil, err
+				}
+				config.Claim.Mappings.Username = externalAuthUpdateDispatchConfigUsernameClaim{
+					Claim:        userName.Claim(),
+					Prefix:       userName.Prefix(),
+					PrefixPolicy: prefixPolicy,
+				}
+			}
+
+			if groups, ok := mappings.GetGroups(); ok && groups != nil && !groups.Empty() {
+				config.Claim.Mappings.Groups = &externalAuthUpdateDispatchConfigGroupsClaim{
+					Claim:  groups.Claim(),
+					Prefix: groups.Prefix(),
+				}
+			}
+		}
+
+		if validationRules, ok := claim.GetValidationRules(); ok {
+			config.Claim.ValidationRules = externalAuthUpdateDispatchConfigValidationRulesFromCS(validationRules)
+		}
+	}
+
+	return config, nil
+}
+
+// externalAuthUpdateDispatchConfigClientsFromCS extracts clients from a Cluster Service external
+// auth into the dispatch canonical form.
+func externalAuthUpdateDispatchConfigClientsFromCS(csEA *arohcpv1alpha1.ExternalAuth) ([]externalAuthUpdateDispatchConfigClient, error) {
+	csClients, ok := csEA.GetClients()
+	if !ok || len(csClients) == 0 {
+		return nil, nil
+	}
+
+	out := make([]externalAuthUpdateDispatchConfigClient, 0, len(csClients))
+	for _, c := range csClients {
+		clientType, err := convertExternalAuthClientTypeCSToRP(c.Type())
+		if err != nil {
+			return nil, err
+		}
+		client := externalAuthUpdateDispatchConfigClient{
+			ClientID: c.ID(),
+			Type:     clientType,
+		}
+
+		if component, ok := c.GetComponent(); ok && component != nil {
+			client.ComponentName = component.Name()
+			client.ComponentNamespace = component.Namespace()
+		}
+
+		if extraScopes, ok := c.GetExtraScopes(); ok {
+			client.ExtraScopes = extraScopes
+		}
+
+		out = append(out, client)
+	}
+
+	return out, nil
+}
+
+// externalAuthUpdateDispatchConfigValidationRulesFromCS extracts validation rules from a Cluster
+// Service external auth into the dispatch canonical form.
+func externalAuthUpdateDispatchConfigValidationRulesFromCS(rules []*arohcpv1alpha1.TokenClaimValidationRule) []externalAuthUpdateDispatchConfigValidationRule {
+	if len(rules) == 0 {
+		return nil
+	}
+
+	out := make([]externalAuthUpdateDispatchConfigValidationRule, 0, len(rules))
+	for _, r := range rules {
+		out = append(out, externalAuthUpdateDispatchConfigValidationRule{
+			Type: api.TokenValidationRuleTypeRequiredClaim,
+			RequiredClaim: externalAuthUpdateDispatchConfigRequiredClaim{
+				Claim:         r.Claim(),
+				RequiredValue: r.RequiredValue(),
+			},
+		})
+	}
+	return out
+}
+
+// hash returns a SHA-256 hex digest of c's canonical JSON.
+func (c *externalAuthUpdateDispatchConfig) hash() (string, error) {
+	return hashUpdateDispatchConfig(c)
+}
+
+// canonicalJSON returns the deterministic JSON encoding of c used for hashing and comparison.
+// Keys are sorted at every object level and the payload is indented with two spaces; see
+// canonicalJSONForUpdateDispatchConfig.
+func (c *externalAuthUpdateDispatchConfig) canonicalJSON() ([]byte, error) {
+	return canonicalJSONForUpdateDispatchConfig(c)
+}
+
+// applyToCSBuilder maps the dispatch config onto a Cluster Service external auth builder.
+func (c *externalAuthUpdateDispatchConfig) applyToCSBuilder(builder *arohcpv1alpha1.ExternalAuthBuilder) error {
+	builder.Issuer(arohcpv1alpha1.NewTokenIssuer().
+		URL(c.Issuer.URL).
+		CA(c.Issuer.CA).
+		Audiences(c.Issuer.Audiences...))
+
+	clientConfigBuilders := make([]*arohcpv1alpha1.ExternalAuthClientConfigBuilder, 0, len(c.Clients))
+	for _, client := range c.Clients {
+		clientType, err := convertExternalAuthClientTypeRPToCS(client.Type)
+		if err != nil {
+			return err
+		}
+		clientConfigBuilders = append(clientConfigBuilders, arohcpv1alpha1.NewExternalAuthClientConfig().
+			ID(client.ClientID).
+			Component(arohcpv1alpha1.NewClientComponent().
+				Name(client.ComponentName).
+				Namespace(client.ComponentNamespace)).
+			ExtraScopes(client.ExtraScopes...).
+			Type(clientType))
+	}
+	builder.Clients(clientConfigBuilders...)
+
+	prefixPolicy, err := convertUsernameClaimPrefixPolicyRPToCS(c.Claim.Mappings.Username.PrefixPolicy)
+	if err != nil {
+		return err
+	}
+	tokenClaimMappingsBuilder := arohcpv1alpha1.NewTokenClaimMappings().
+		UserName(arohcpv1alpha1.NewUsernameClaim().
+			Claim(c.Claim.Mappings.Username.Claim).
+			Prefix(c.Claim.Mappings.Username.Prefix).
+			PrefixPolicy(prefixPolicy))
+
+	if c.Claim.Mappings.Groups != nil {
+		tokenClaimMappingsBuilder = tokenClaimMappingsBuilder.Groups(
+			arohcpv1alpha1.NewGroupsClaim().
+				Claim(c.Claim.Mappings.Groups.Claim).
+				Prefix(c.Claim.Mappings.Groups.Prefix))
+	}
+
+	validationRuleBuilders := make([]*arohcpv1alpha1.TokenClaimValidationRuleBuilder, 0, len(c.Claim.ValidationRules))
+	for _, rule := range c.Claim.ValidationRules {
+		ruleBuilder, err := convertTokenClaimValidationRuleRPToCS(rule)
+		if err != nil {
+			return err
+		}
+		validationRuleBuilders = append(validationRuleBuilders, ruleBuilder)
+	}
+
+	builder.Claim(arohcpv1alpha1.NewExternalAuthClaim().
+		Mappings(tokenClaimMappingsBuilder).
+		ValidationRules(validationRuleBuilders...))
+	return nil
+}

--- a/internal/ocm/external_auth_update_dispatch_config_test.go
+++ b/internal/ocm/external_auth_update_dispatch_config_test.go
@@ -1,0 +1,640 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocm
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+)
+
+func newTestExternalAuth() *api.HCPOpenShiftClusterExternalAuth {
+	return &api.HCPOpenShiftClusterExternalAuth{
+		Properties: api.HCPOpenShiftClusterExternalAuthProperties{
+			Issuer: api.TokenIssuerProfile{
+				URL:       "https://issuer.example.com",
+				Audiences: []string{"aud1", "aud2"},
+				CA:        "test-ca-cert",
+			},
+			Clients: []api.ExternalAuthClientProfile{
+				{
+					Component: api.ExternalAuthClientComponentProfile{
+						Name:                "console",
+						AuthClientNamespace: "openshift-console",
+					},
+					ClientID:    "client-id-1",
+					ExtraScopes: []string{"email", "profile"},
+					Type:        api.ExternalAuthClientTypePublic,
+				},
+			},
+			Claim: api.ExternalAuthClaimProfile{
+				Mappings: api.TokenClaimMappingsProfile{
+					Username: api.UsernameClaimProfile{
+						Claim:        "email",
+						PrefixPolicy: api.UsernameClaimPrefixPolicyNoPrefix,
+					},
+					Groups: &api.GroupClaimProfile{
+						Claim:  "groups",
+						Prefix: "oidc:",
+					},
+				},
+				ValidationRules: []api.TokenClaimValidationRule{
+					{
+						Type: api.TokenValidationRuleTypeRequiredClaim,
+						RequiredClaim: api.TokenRequiredClaim{
+							Claim:         "hd",
+							RequiredValue: "example.com",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestExternalAuthUpdateDispatchConfigHash(t *testing.T) {
+	base := newTestExternalAuth()
+
+	config1, err := externalAuthUpdateDispatchConfigFromRP(base)
+	require.NoError(t, err)
+	hash1, err := config1.hash()
+	require.NoError(t, err)
+	require.NotEmpty(t, hash1)
+
+	config2, err := externalAuthUpdateDispatchConfigFromRP(base)
+	require.NoError(t, err)
+	hash2, err := config2.hash()
+	require.NoError(t, err)
+	assert.Equal(t, hash1, hash2)
+
+	differentIssuer := newTestExternalAuth()
+	differentIssuer.Properties.Issuer.URL = "https://other.example.com"
+	configDiffIssuer, err := externalAuthUpdateDispatchConfigFromRP(differentIssuer)
+	require.NoError(t, err)
+	hashDiffIssuer, err := configDiffIssuer.hash()
+	require.NoError(t, err)
+	assert.NotEqual(t, hash1, hashDiffIssuer)
+
+	differentClient := newTestExternalAuth()
+	differentClient.Properties.Clients[0].ClientID = "different-client-id"
+	configDiffClient, err := externalAuthUpdateDispatchConfigFromRP(differentClient)
+	require.NoError(t, err)
+	hashDiffClient, err := configDiffClient.hash()
+	require.NoError(t, err)
+	assert.NotEqual(t, hash1, hashDiffClient)
+
+	differentClaim := newTestExternalAuth()
+	differentClaim.Properties.Claim.Mappings.Username.Claim = "sub"
+	configDiffClaim, err := externalAuthUpdateDispatchConfigFromRP(differentClaim)
+	require.NoError(t, err)
+	hashDiffClaim, err := configDiffClaim.hash()
+	require.NoError(t, err)
+	assert.NotEqual(t, hash1, hashDiffClaim)
+
+	noGroups := newTestExternalAuth()
+	noGroups.Properties.Claim.Mappings.Groups = nil
+	configNoGroups, err := externalAuthUpdateDispatchConfigFromRP(noGroups)
+	require.NoError(t, err)
+	hashNoGroups, err := configNoGroups.hash()
+	require.NoError(t, err)
+	assert.NotEqual(t, hash1, hashNoGroups)
+
+	differentValidationRule := newTestExternalAuth()
+	differentValidationRule.Properties.Claim.ValidationRules[0].RequiredClaim.RequiredValue = "other.example.com"
+	configDiffValidationRule, err := externalAuthUpdateDispatchConfigFromRP(differentValidationRule)
+	require.NoError(t, err)
+	hashDiffValidationRule, err := configDiffValidationRule.hash()
+	require.NoError(t, err)
+	assert.NotEqual(t, hash1, hashDiffValidationRule)
+}
+
+func TestExternalAuthUpdateDispatchConfigHashExcludesNonUpdatableFields(t *testing.T) {
+	ea1 := newTestExternalAuth()
+	ea1.Properties.ProvisioningState = "Succeeded"
+	ea1.Name = "auth1"
+
+	ea2 := newTestExternalAuth()
+	ea2.Properties.ProvisioningState = "Updating"
+	ea2.Name = "auth2"
+
+	config1, err := externalAuthUpdateDispatchConfigFromRP(ea1)
+	require.NoError(t, err)
+	hash1, err := config1.hash()
+	require.NoError(t, err)
+
+	config2, err := externalAuthUpdateDispatchConfigFromRP(ea2)
+	require.NoError(t, err)
+	hash2, err := config2.hash()
+	require.NoError(t, err)
+
+	assert.Equal(t, hash1, hash2)
+}
+
+func TestExternalAuthUpdateDispatchConfigFromCSRoundTrip(t *testing.T) {
+	ea := newTestExternalAuth()
+
+	csBuilder, err := BuildCSExternalAuth(context.Background(), ea, true)
+	require.NoError(t, err)
+
+	csExternalAuth, err := csBuilder.Build()
+	require.NoError(t, err)
+
+	actualConfig, err := externalAuthUpdateDispatchConfigFromCS(csExternalAuth)
+	require.NoError(t, err)
+
+	desiredConfig, err := externalAuthUpdateDispatchConfigFromRP(ea)
+	require.NoError(t, err)
+	desiredHash, err := desiredConfig.hash()
+	require.NoError(t, err)
+	actualHash, err := actualConfig.hash()
+	require.NoError(t, err)
+	assert.Equal(t, desiredHash, actualHash)
+
+	require.Len(t, actualConfig.Claim.ValidationRules, 1)
+	assert.Equal(t, api.TokenValidationRuleTypeRequiredClaim, actualConfig.Claim.ValidationRules[0].Type)
+	assert.Equal(t, "hd", actualConfig.Claim.ValidationRules[0].RequiredClaim.Claim)
+	assert.Equal(t, "example.com", actualConfig.Claim.ValidationRules[0].RequiredClaim.RequiredValue)
+	require.Len(t, actualConfig.Clients, 1)
+	assert.Equal(t, api.ExternalAuthClientTypePublic, actualConfig.Clients[0].Type)
+}
+
+func TestExternalAuthUpdateDispatchConfigFromCSRoundTripNoGroups(t *testing.T) {
+	ea := newTestExternalAuth()
+	ea.Properties.Claim.Mappings.Groups = nil
+
+	csBuilder, err := BuildCSExternalAuth(context.Background(), ea, true)
+	require.NoError(t, err)
+
+	csExternalAuth, err := csBuilder.Build()
+	require.NoError(t, err)
+
+	actualConfig, err := externalAuthUpdateDispatchConfigFromCS(csExternalAuth)
+	require.NoError(t, err)
+
+	desiredConfig, err := externalAuthUpdateDispatchConfigFromRP(ea)
+	require.NoError(t, err)
+	desiredHash, err := desiredConfig.hash()
+	require.NoError(t, err)
+	actualHash, err := actualConfig.hash()
+	require.NoError(t, err)
+	assert.Equal(t, desiredHash, actualHash)
+	assert.Nil(t, actualConfig.Claim.Mappings.Groups)
+}
+
+func TestExternalAuthUpdateDispatchConfigFromCSRoundTripMultipleClients(t *testing.T) {
+	ea := newTestExternalAuth()
+	ea.Properties.Clients = append(ea.Properties.Clients, api.ExternalAuthClientProfile{
+		Component: api.ExternalAuthClientComponentProfile{
+			Name:                "cli",
+			AuthClientNamespace: "openshift-cli",
+		},
+		ClientID:    "aaa-first-alphabetically",
+		ExtraScopes: []string{"openid"},
+		Type:        api.ExternalAuthClientTypeConfidential,
+	})
+
+	csBuilder, err := BuildCSExternalAuth(context.Background(), ea, true)
+	require.NoError(t, err)
+
+	csExternalAuth, err := csBuilder.Build()
+	require.NoError(t, err)
+
+	actualConfig, err := externalAuthUpdateDispatchConfigFromCS(csExternalAuth)
+	require.NoError(t, err)
+
+	desiredConfig, err := externalAuthUpdateDispatchConfigFromRP(ea)
+	require.NoError(t, err)
+	desiredHash, err := desiredConfig.hash()
+	require.NoError(t, err)
+	actualHash, err := actualConfig.hash()
+	require.NoError(t, err)
+	assert.Equal(t, desiredHash, actualHash)
+}
+
+func TestExternalAuthUpdateDispatchConfigJSONFromRPAndCS(t *testing.T) {
+	ea := newTestExternalAuth()
+
+	csBuilder, err := BuildCSExternalAuth(context.Background(), ea, true)
+	require.NoError(t, err)
+	csExternalAuth, err := csBuilder.Build()
+	require.NoError(t, err)
+
+	desiredJSON, err := ExternalAuthUpdateDispatchConfigJSONFromRP(ea)
+	require.NoError(t, err)
+	actualJSON, err := ExternalAuthUpdateDispatchConfigJSONFromCS(csExternalAuth)
+	require.NoError(t, err)
+
+	// We assert both semantic and byte-for-byte JSON equality on purpose:
+	//   - JSONEq checks that RP and CS projections represent the same config (values and structure).
+	//   - Equal checks that canonicalJSON produces identical strings on both sides. The external auth
+	//     service update dispatch controller uses string equality (==) for drift detection, so
+	//     this must hold whenever the configs match; JSONEq alone would not catch encoding
+	//     differences such as key ordering or whitespace that would cause a false drift signal.
+	assert.JSONEq(t, desiredJSON, actualJSON)
+	assert.Equal(t, desiredJSON, actualJSON)
+	assert.Contains(t, desiredJSON, `"url": "https://issuer.example.com"`)
+	assert.Contains(t, desiredJSON, `"clientId": "client-id-1"`)
+	assert.Contains(t, desiredJSON, `"type": "RequiredClaim"`)
+	assert.Contains(t, desiredJSON, `"requiredValue": "example.com"`)
+	assert.Contains(t, desiredJSON, `"type": "Public"`)
+
+	ea.Properties.Issuer.URL = "https://changed.example.com"
+	desiredJSON, err = ExternalAuthUpdateDispatchConfigJSONFromRP(ea)
+	require.NoError(t, err)
+	assert.NotEqual(t, desiredJSON, actualJSON)
+}
+
+func TestExternalAuthUpdateDispatchConfigClientPreservesOrderFromRP(t *testing.T) {
+	ea := newTestExternalAuth()
+	ea.Properties.Clients = []api.ExternalAuthClientProfile{
+		{
+			Component:   api.ExternalAuthClientComponentProfile{Name: "z-component", AuthClientNamespace: "ns-z"},
+			ClientID:    "zzz-client",
+			ExtraScopes: []string{"openid"},
+			Type:        api.ExternalAuthClientTypePublic,
+		},
+		{
+			Component:   api.ExternalAuthClientComponentProfile{Name: "a-component", AuthClientNamespace: "ns-a"},
+			ClientID:    "aaa-client",
+			ExtraScopes: []string{"email"},
+			Type:        api.ExternalAuthClientTypePublic,
+		},
+	}
+
+	config, err := externalAuthUpdateDispatchConfigFromRP(ea)
+	require.NoError(t, err)
+
+	require.Len(t, config.Clients, 2)
+	assert.Equal(t, "zzz-client", config.Clients[0].ClientID)
+	assert.Equal(t, "aaa-client", config.Clients[1].ClientID)
+}
+
+func TestExternalAuthUpdateDispatchConfigPrefixPolicyNone(t *testing.T) {
+	ea := newTestExternalAuth()
+	ea.Properties.Claim.Mappings.Username.PrefixPolicy = api.UsernameClaimPrefixPolicyNone
+
+	config, err := externalAuthUpdateDispatchConfigFromRP(ea)
+	require.NoError(t, err)
+	assert.Equal(t, api.UsernameClaimPrefixPolicyNone, config.Claim.Mappings.Username.PrefixPolicy)
+}
+
+func TestExternalAuthUpdateDispatchConfigValidationRulesFromRP(t *testing.T) {
+	ea := newTestExternalAuth()
+
+	config, err := externalAuthUpdateDispatchConfigFromRP(ea)
+	require.NoError(t, err)
+
+	require.Len(t, config.Claim.ValidationRules, 1)
+	assert.Equal(t, api.TokenValidationRuleTypeRequiredClaim, config.Claim.ValidationRules[0].Type)
+	assert.Equal(t, "hd", config.Claim.ValidationRules[0].RequiredClaim.Claim)
+	assert.Equal(t, "example.com", config.Claim.ValidationRules[0].RequiredClaim.RequiredValue)
+}
+
+func TestExternalAuthUpdateDispatchConfigValidationRulesFromCS(t *testing.T) {
+	csExternalAuth, err := arohcpv1alpha1.NewExternalAuth().
+		Claim(arohcpv1alpha1.NewExternalAuthClaim().
+			ValidationRules(
+				arohcpv1alpha1.NewTokenClaimValidationRule().
+					Claim("hd").
+					RequiredValue("example.com"),
+			)).
+		Build()
+	require.NoError(t, err)
+
+	config, err := externalAuthUpdateDispatchConfigFromCS(csExternalAuth)
+	require.NoError(t, err)
+
+	require.Len(t, config.Claim.ValidationRules, 1)
+	assert.Equal(t, api.TokenValidationRuleTypeRequiredClaim, config.Claim.ValidationRules[0].Type)
+	assert.Equal(t, "hd", config.Claim.ValidationRules[0].RequiredClaim.Claim)
+	assert.Equal(t, "example.com", config.Claim.ValidationRules[0].RequiredClaim.RequiredValue)
+}
+
+func TestExternalAuthUpdateDispatchConfigClientTypeConversionFromCS(t *testing.T) {
+	csExternalAuth, err := arohcpv1alpha1.NewExternalAuth().
+		Clients(
+			arohcpv1alpha1.NewExternalAuthClientConfig().
+				ID("client-id-1").
+				Type(arohcpv1alpha1.ExternalAuthClientTypePublic),
+			arohcpv1alpha1.NewExternalAuthClientConfig().
+				ID("client-id-2").
+				Type(arohcpv1alpha1.ExternalAuthClientTypeConfidential),
+		).
+		Build()
+	require.NoError(t, err)
+
+	config, err := externalAuthUpdateDispatchConfigFromCS(csExternalAuth)
+	require.NoError(t, err)
+
+	require.Len(t, config.Clients, 2)
+	assert.Equal(t, api.ExternalAuthClientTypePublic, config.Clients[0].Type)
+	assert.Equal(t, api.ExternalAuthClientTypeConfidential, config.Clients[1].Type)
+}
+
+func TestExternalAuthUpdateDispatchConfigFromCSUnknownClientType(t *testing.T) {
+	csExternalAuth, err := arohcpv1alpha1.NewExternalAuth().
+		Clients(
+			arohcpv1alpha1.NewExternalAuthClientConfig().
+				ID("client-id-1").
+				Type(arohcpv1alpha1.ExternalAuthClientType("unknown")),
+		).
+		Build()
+	require.NoError(t, err)
+
+	_, err = externalAuthUpdateDispatchConfigFromCS(csExternalAuth)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnknownValue)
+}
+
+func TestConvertTokenClaimValidationRuleRPToCS(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		rule    externalAuthUpdateDispatchConfigValidationRule
+		wantErr bool
+	}{
+		{
+			name: "RequiredClaim maps to CS builder",
+			rule: externalAuthUpdateDispatchConfigValidationRule{
+				Type: api.TokenValidationRuleTypeRequiredClaim,
+				RequiredClaim: externalAuthUpdateDispatchConfigRequiredClaim{
+					Claim:         "hd",
+					RequiredValue: "example.com",
+				},
+			},
+		},
+		{
+			name: "unsupported type returns error",
+			rule: externalAuthUpdateDispatchConfigValidationRule{
+				Type: api.TokenValidationRuleType("Unsupported"),
+				RequiredClaim: externalAuthUpdateDispatchConfigRequiredClaim{
+					Claim:         "hd",
+					RequiredValue: "example.com",
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			builder, err := convertTokenClaimValidationRuleRPToCS(tt.rule)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, ErrUnknownValue)
+				assert.Nil(t, builder)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, builder)
+
+			csRule, err := builder.Build()
+			require.NoError(t, err)
+			assert.Equal(t, "hd", csRule.Claim())
+			assert.Equal(t, "example.com", csRule.RequiredValue())
+		})
+	}
+}
+
+func TestExternalAuthUpdateDispatchConfigApplyToCSBuilder(t *testing.T) {
+	tests := []struct {
+		name               string
+		config             externalAuthUpdateDispatchConfig
+		wantCSExternalAuth *arohcpv1alpha1.ExternalAuthBuilder
+		wantErr            bool
+		errContains        string
+	}{
+		{
+			name: "maps issuer clients claim and validation rules",
+			config: externalAuthUpdateDispatchConfig{
+				Issuer: externalAuthUpdateDispatchConfigIssuer{
+					URL:       "https://issuer.example.com",
+					Audiences: []string{"aud1", "aud2"},
+					CA:        "test-ca-cert",
+				},
+				Clients: []externalAuthUpdateDispatchConfigClient{
+					{
+						ComponentName:      "console",
+						ComponentNamespace: "openshift-console",
+						ClientID:           "client-id-1",
+						ExtraScopes:        []string{"email", "profile"},
+						Type:               api.ExternalAuthClientTypePublic,
+					},
+				},
+				Claim: externalAuthUpdateDispatchConfigClaim{
+					Mappings: externalAuthUpdateDispatchConfigClaimMappings{
+						Username: externalAuthUpdateDispatchConfigUsernameClaim{
+							Claim:        "email",
+							Prefix:       "",
+							PrefixPolicy: api.UsernameClaimPrefixPolicyNoPrefix,
+						},
+						Groups: &externalAuthUpdateDispatchConfigGroupsClaim{
+							Claim:  "groups",
+							Prefix: "oidc:",
+						},
+					},
+					ValidationRules: []externalAuthUpdateDispatchConfigValidationRule{
+						{
+							Type: api.TokenValidationRuleTypeRequiredClaim,
+							RequiredClaim: externalAuthUpdateDispatchConfigRequiredClaim{
+								Claim:         "hd",
+								RequiredValue: "example.com",
+							},
+						},
+					},
+				},
+			},
+			wantCSExternalAuth: arohcpv1alpha1.NewExternalAuth().
+				Issuer(arohcpv1alpha1.NewTokenIssuer().
+					URL("https://issuer.example.com").
+					CA("test-ca-cert").
+					Audiences("aud1", "aud2")).
+				Clients(
+					arohcpv1alpha1.NewExternalAuthClientConfig().
+						ID("client-id-1").
+						Component(arohcpv1alpha1.NewClientComponent().
+							Name("console").
+							Namespace("openshift-console")).
+						ExtraScopes("email", "profile").
+						Type(arohcpv1alpha1.ExternalAuthClientTypePublic),
+				).
+				Claim(arohcpv1alpha1.NewExternalAuthClaim().
+					Mappings(arohcpv1alpha1.NewTokenClaimMappings().
+						UserName(arohcpv1alpha1.NewUsernameClaim().
+							Claim("email").
+							Prefix("").
+							PrefixPolicy("NoPrefix")).
+						Groups(arohcpv1alpha1.NewGroupsClaim().
+							Claim("groups").
+							Prefix("oidc:"))).
+					ValidationRules(
+						arohcpv1alpha1.NewTokenClaimValidationRule().
+							Claim("hd").
+							RequiredValue("example.com"),
+					)),
+		},
+		{
+			name: "omits groups when unset",
+			config: externalAuthUpdateDispatchConfig{
+				Claim: externalAuthUpdateDispatchConfigClaim{
+					Mappings: externalAuthUpdateDispatchConfigClaimMappings{
+						Username: externalAuthUpdateDispatchConfigUsernameClaim{
+							Claim:        "sub",
+							PrefixPolicy: api.UsernameClaimPrefixPolicyNone,
+						},
+					},
+				},
+			},
+			wantCSExternalAuth: arohcpv1alpha1.NewExternalAuth().
+				Issuer(arohcpv1alpha1.NewTokenIssuer().URL("").CA("").Audiences()).
+				Clients().
+				Claim(arohcpv1alpha1.NewExternalAuthClaim().
+					Mappings(arohcpv1alpha1.NewTokenClaimMappings().
+						UserName(arohcpv1alpha1.NewUsernameClaim().
+							Claim("sub").
+							Prefix("").
+							PrefixPolicy(""))).
+					ValidationRules()),
+		},
+		{
+			name: "converts RP client types to CS lowercase values",
+			config: externalAuthUpdateDispatchConfig{
+				Clients: []externalAuthUpdateDispatchConfigClient{
+					{
+						ClientID: "public-client",
+						Type:     api.ExternalAuthClientTypePublic,
+					},
+					{
+						ClientID: "confidential-client",
+						Type:     api.ExternalAuthClientTypeConfidential,
+					},
+				},
+				Claim: externalAuthUpdateDispatchConfigClaim{
+					Mappings: externalAuthUpdateDispatchConfigClaimMappings{
+						Username: externalAuthUpdateDispatchConfigUsernameClaim{
+							PrefixPolicy: api.UsernameClaimPrefixPolicyNone,
+						},
+					},
+				},
+			},
+			wantCSExternalAuth: arohcpv1alpha1.NewExternalAuth().
+				Issuer(arohcpv1alpha1.NewTokenIssuer().URL("").CA("").Audiences()).
+				Clients(
+					arohcpv1alpha1.NewExternalAuthClientConfig().
+						ID("public-client").
+						Component(arohcpv1alpha1.NewClientComponent().Name("").Namespace("")).
+						ExtraScopes().
+						Type(arohcpv1alpha1.ExternalAuthClientTypePublic),
+					arohcpv1alpha1.NewExternalAuthClientConfig().
+						ID("confidential-client").
+						Component(arohcpv1alpha1.NewClientComponent().Name("").Namespace("")).
+						ExtraScopes().
+						Type(arohcpv1alpha1.ExternalAuthClientTypeConfidential),
+				).
+				Claim(arohcpv1alpha1.NewExternalAuthClaim().
+					Mappings(arohcpv1alpha1.NewTokenClaimMappings().
+						UserName(arohcpv1alpha1.NewUsernameClaim().
+							Claim("").
+							Prefix("").
+							PrefixPolicy(""))).
+					ValidationRules()),
+		},
+		{
+			name: "unknown client type returns error",
+			config: externalAuthUpdateDispatchConfig{
+				Clients: []externalAuthUpdateDispatchConfigClient{
+					{
+						ClientID: "client-id-1",
+						Type:     api.ExternalAuthClientType("Unknown"),
+					},
+				},
+			},
+			wantErr:     true,
+			errContains: "ExternalAuthClientType",
+		},
+		{
+			name: "unsupported validation rule type returns error",
+			config: externalAuthUpdateDispatchConfig{
+				Claim: externalAuthUpdateDispatchConfigClaim{
+					Mappings: externalAuthUpdateDispatchConfigClaimMappings{
+						Username: externalAuthUpdateDispatchConfigUsernameClaim{
+							PrefixPolicy: api.UsernameClaimPrefixPolicyNone,
+						},
+					},
+					ValidationRules: []externalAuthUpdateDispatchConfigValidationRule{
+						{
+							Type: api.TokenValidationRuleType("Unsupported"),
+							RequiredClaim: externalAuthUpdateDispatchConfigRequiredClaim{
+								Claim:         "hd",
+								RequiredValue: "example.com",
+							},
+						},
+					},
+				},
+			},
+			wantErr:     true,
+			errContains: "TokenValidationRuleType",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := arohcpv1alpha1.NewExternalAuth()
+			err := tt.config.applyToCSBuilder(builder)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, ErrUnknownValue)
+				assert.Contains(t, err.Error(), tt.errContains)
+				return
+			}
+			require.NoError(t, err)
+
+			got, err := builder.Build()
+			require.NoError(t, err)
+
+			want, err := tt.wantCSExternalAuth.Build()
+			require.NoError(t, err)
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
+func TestConvertExternalAuthClientTypeRPToCSAndCSToRP(t *testing.T) {
+	t.Parallel()
+
+	rpToCS, err := convertExternalAuthClientTypeRPToCS(api.ExternalAuthClientTypePublic)
+	require.NoError(t, err)
+	assert.Equal(t, arohcpv1alpha1.ExternalAuthClientTypePublic, rpToCS)
+
+	csToRP, err := convertExternalAuthClientTypeCSToRP(arohcpv1alpha1.ExternalAuthClientTypeConfidential)
+	require.NoError(t, err)
+	assert.Equal(t, api.ExternalAuthClientTypeConfidential, csToRP)
+
+	_, err = convertExternalAuthClientTypeRPToCS(api.ExternalAuthClientType("Unknown"))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnknownValue)
+
+	_, err = convertExternalAuthClientTypeCSToRP(arohcpv1alpha1.ExternalAuthClientType("unknown"))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnknownValue)
+}

--- a/internal/ocm/node_pool_update_dispatch_config.go
+++ b/internal/ocm/node_pool_update_dispatch_config.go
@@ -1,0 +1,348 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocm
+
+import (
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+)
+
+// nodePoolUpdateDispatchConfig is a dispatch-specific canonical model of the NodePool's
+// Cluster Service fields that are considered by the node pool cluster service update dispatch
+// controller. Its shape intentionally does not mirror RP resources or the Cluster Service API.
+// Conversion functions project external state into this form and back out when dispatching to
+// Cluster Service.
+//
+// The same struct is built from either RP desired state (from HCPOpenShiftClusterNodePool) or
+// from the live Cluster Service NodePool. This applies only to NodePool CS updates. Cluster and
+// external auth updates use separate dispatch paths and update dispatch config structs. Drift
+// between the two projections may trigger the node pool cluster service update dispatch controller
+// to PATCH Cluster Service.
+//
+// The node pool cluster service update dispatch controller compares desired and actual configs in
+// this canonical form and sends a CS PATCH only when they differ.
+//
+// Note: This does not include all fields updatable via the NodePool Cluster Service API, only
+// the subset that the node pool cluster service update dispatch controller considers.
+//
+// Note: Do not embed internal/api struct types (for example api.NodePoolAutoScaling)
+// in this struct or its nested field types. We want to make those internal/api struct types
+// independent of this so they can evolve independently. For example, if a field here referenced
+// an internal/api struct type directly, any new field added to that struct would be automatically
+// considered as updatable automatically, but we might not want that field to be updatable and/or
+// CS side doesn't really support updating it. Instead, define curated local structs with only the
+// fields that dispatch should hash and sync, and copy values explicitly from api types at the
+// conversion boundaries. Using api/internal enum or scalar types for individual curated fields is
+// fine. This is because adding an enum/scalar field they do not pull extra fields, but adding
+// struct types does.
+//
+// Node drain timeout has special diff semantics: when RP stores nil (inherit cluster default),
+// Cluster Service PATCH omit/null cannot clear or re-inherit that default. nodePoolUpdateDispatchConfigsForDiff
+// normalizes the CS value out of the diff so dispatch does not endlessly PATCH fields CS cannot
+// change. Operation state and Hypershift reconciliation use NodePoolUpdateDispatchConfigEffectiveNodeDrainTimeoutMinutes
+// to compare the effective desired value instead.
+//
+// IMPORTANT: how to add a new dispatch-managed config field:
+//
+// Dispatch and operation state are related but wired separately. You need both for a correct
+// node pool update experience:
+//   - Dispatch (this file): detects drift and PATCHes Cluster Service.
+//   - Operation state (operation_node_pool_update.go, operation_node_pool_update_state_calculation.go):
+//     decides when the ARM node pool update operation can leave Updating and report Succeeded.
+//
+// If you wire dispatch but skip operation state calculation, the update may be sent to CS but the
+// operation can succeed too early (or stay Updating forever if dispatch is missing).
+//
+// Before you start:
+//
+//   - Confirm this is a node-pool-level Cluster Service update (not cluster or external auth).
+//   - Confirm Cluster Service supports updating the field on an existing node pool.
+//   - Identify where RP desired state lives (HCPOpenShiftClusterNodePool.Properties, etc.).
+//
+// 1. Dispatch wiring (this file)
+//
+//   - Add the field to nodePoolUpdateDispatchConfig or a curated nested struct.
+//     Do not embed internal/api struct types.
+//   - Populate it in nodePoolUpdateDispatchConfigFromRP. This ensures RP projection works correctly.
+//   - Populate it in nodePoolUpdateDispatchConfigFromCS. This ensures CS projection works correctly.
+//   - Apply it in applyToCSBuilder. This ensures the CS builder works correctly.
+//   - If the field has CS PATCH limitations (like node drain timeout inherit/clear), document and
+//     handle normalization in nodePoolUpdateDispatchConfigsForDiff and wire effective desired
+//     comparison helpers for operation state if needed.
+//
+// 2. Operation state wiring (backend/pkg/controllers/operationcontrollers/operation_node_pool_update.go)
+//
+//	determineOperationState aggregates several sources and picks the worst state. Your new
+//	check must succeed along with version resolution, CS checks and Hypershift checks.
+//
+//	Choose where to observe the change and implement it:
+//	  - Prefer observing directly from the Management Cluster side when the field is visible there
+//	    after propagation. Most dispatch fields today are checked in here: labels, replicas/autoscaling, taints, node drain timeout, ...
+//	  - Observe from Cluster Service when the Management Cluster side is not a reliable source of
+//	    truth yet or simply can't be calculated from there.
+//	  - Sometimes you might want to observe it on both sides for extra validation.
+//
+//	Return (false, message) with a clear message when observed != desired so Updating state
+//	is actionable in logs.
+//
+// 3. Tests
+//
+//   - node_pool_update_dispatch_config_test.go: hash, FromCS, round-trip, apply payload, diff
+//     normalization if applicable.
+//   - operation_node_pool_update_state_calculation_test.go: match/mismatch cases for your new
+//     helper and, if useful, an end-to-end hypershiftNodePoolOperationState case.
+//   - Consider both "not applied yet" (Updating) and "applied" (Succeeded) scenarios.
+//
+// 4. Sanity checks
+//
+//   - Create path: applyToCSBuilder is also used by BuildCSNodePool in internal/ocm/convert.go
+//     when the frontend first creates a Cluster Service node pool (not only when the update
+//     dispatch controller PATCHes an existing one). Verify the new field is present on create.
+//   - Desired state must exist in Cosmos before dispatch can sync it. If customers set this
+//     field via ARM, also wire the full ingest path: ARM API, frontend validation/conversion,
+//     and persistence onto HCPOpenShiftClusterNodePool. Internal-only fields still need whatever
+//     backend path writes the value Cosmos holds.
+type nodePoolUpdateDispatchConfig struct {
+	Labels                  map[string]string                        `json:"labels,omitempty"`
+	Replicas                int32                                    `json:"replicas,omitempty"`
+	AutoScaling             *nodePoolUpdateDispatchConfigAutoScaling `json:"autoScaling,omitempty"`
+	Taints                  []NodePoolUpdateDispatchConfigTaint      `json:"taints,omitempty"`
+	NodeDrainTimeoutMinutes *int32                                   `json:"nodeDrainTimeoutMinutes,omitempty"`
+}
+
+// nodePoolUpdateDispatchConfigAutoScaling is the curated autoscaling subset used for
+// dispatch hash and sync. See nodePoolUpdateDispatchConfig: do not embed api.NodePoolAutoScaling.
+type nodePoolUpdateDispatchConfigAutoScaling struct {
+	Min int32 `json:"min,omitempty"`
+	Max int32 `json:"max,omitempty"`
+}
+
+// NodePoolUpdateDispatchConfigTaint is the curated taint subset used for dispatch
+// hash and sync. See nodePoolUpdateDispatchConfig: do not embed api.Taint.
+type NodePoolUpdateDispatchConfigTaint struct {
+	Effect string `json:"effect,omitempty"`
+	Key    string `json:"key,omitempty"`
+	Value  string `json:"value,omitempty"`
+}
+
+// NodePoolUpdateDispatchConfigDiffJSON returns canonical JSON for both sides of the
+// dispatch diff comparison, including drain-timeout normalization when RP has no override.
+func NodePoolUpdateDispatchConfigDiffJSON(nodePool *api.HCPOpenShiftClusterNodePool, csNodePool *arohcpv1alpha1.NodePool) (string, string, error) {
+	desiredConfig, actualConfig := nodePoolUpdateDispatchConfigsForDiff(nodePool, csNodePool)
+
+	desiredRaw, err := desiredConfig.canonicalJSON()
+	if err != nil {
+		return "", "", err
+	}
+	actualRaw, err := actualConfig.canonicalJSON()
+	if err != nil {
+		return "", "", err
+	}
+
+	return string(desiredRaw), string(actualRaw), nil
+}
+
+// nodePoolUpdateDispatchConfigsForDiff builds RP and CS projections for diff comparison.
+// When RP has no drain-timeout override, the CS value is cleared from the actual side so
+// dispatch does not endlessly PATCH fields CS cannot change via omit/null.
+func nodePoolUpdateDispatchConfigsForDiff(nodePool *api.HCPOpenShiftClusterNodePool, csNodePool *arohcpv1alpha1.NodePool) (*nodePoolUpdateDispatchConfig, *nodePoolUpdateDispatchConfig) {
+	desiredConfig := nodePoolUpdateDispatchConfigFromRP(nodePool)
+	actualConfig := nodePoolUpdateDispatchConfigFromCS(csNodePool)
+	// When RP has no drain-timeout override, CS PATCH cannot clear or re-inherit via omit/null.
+	// Normalize the CS value out of the diff so we do not endlessly dispatch PATCHes that cannot change it.
+	if desiredConfig.NodeDrainTimeoutMinutes == nil {
+		actualConfig.NodeDrainTimeoutMinutes = nil
+	}
+	return desiredConfig, actualConfig
+}
+
+// NodePoolUpdateDispatchConfigJSONFromRP returns the canonical JSON of the dispatch config
+// projected from RP desired state.
+func NodePoolUpdateDispatchConfigJSONFromRP(nodePool *api.HCPOpenShiftClusterNodePool) (string, error) {
+	raw, err := nodePoolUpdateDispatchConfigFromRP(nodePool).canonicalJSON()
+	if err != nil {
+		return "", err
+	}
+	return string(raw), nil
+}
+
+// NodePoolUpdateDispatchConfigJSONFromCS returns the canonical JSON of the dispatch config
+// projected from a Cluster Service node pool.
+func NodePoolUpdateDispatchConfigJSONFromCS(csNodePool *arohcpv1alpha1.NodePool) (string, error) {
+	raw, err := nodePoolUpdateDispatchConfigFromCS(csNodePool).canonicalJSON()
+	if err != nil {
+		return "", err
+	}
+	return string(raw), nil
+}
+
+// nodePoolUpdateDispatchConfigFromRP projects RP desired state into the dispatch canonical form.
+func nodePoolUpdateDispatchConfigFromRP(nodePool *api.HCPOpenShiftClusterNodePool) *nodePoolUpdateDispatchConfig {
+	config := &nodePoolUpdateDispatchConfig{
+		Labels:                  nodePool.Properties.Labels,
+		Taints:                  NodePoolUpdateDispatchConfigTaintsFromRP(nodePool.Properties.Taints),
+		NodeDrainTimeoutMinutes: nodePool.Properties.NodeDrainTimeoutMinutes,
+	}
+
+	if nodePool.Properties.AutoScaling != nil {
+		config.AutoScaling = &nodePoolUpdateDispatchConfigAutoScaling{
+			Min: nodePool.Properties.AutoScaling.Min,
+			Max: nodePool.Properties.AutoScaling.Max,
+		}
+	} else {
+		config.Replicas = nodePool.Properties.Replicas
+	}
+
+	return config
+}
+
+// NodePoolUpdateDispatchConfigTaintsFromRP copies taints from RP into the dispatch canonical form.
+func NodePoolUpdateDispatchConfigTaintsFromRP(taints []api.Taint) []NodePoolUpdateDispatchConfigTaint {
+	if len(taints) == 0 {
+		return nil
+	}
+
+	out := make([]NodePoolUpdateDispatchConfigTaint, 0, len(taints))
+	for _, t := range taints {
+		out = append(out, NodePoolUpdateDispatchConfigTaint{
+			Effect: string(t.Effect),
+			Key:    t.Key,
+			Value:  t.Value,
+		})
+	}
+	return out
+}
+
+// nodePoolUpdateDispatchConfigFromCS projects a Cluster Service node pool into the dispatch
+// canonical form.
+func nodePoolUpdateDispatchConfigFromCS(csNodePool *arohcpv1alpha1.NodePool) *nodePoolUpdateDispatchConfig {
+	config := &nodePoolUpdateDispatchConfig{
+		Labels: NodePoolUpdateDispatchConfigLabelsFromCS(csNodePool),
+	}
+
+	if autoscaling, ok := csNodePool.GetAutoscaling(); ok && autoscaling != nil {
+		config.AutoScaling = &nodePoolUpdateDispatchConfigAutoScaling{
+			Min: int32(autoscaling.MinReplica()),
+			Max: int32(autoscaling.MaxReplica()),
+		}
+	} else {
+		config.Replicas = int32(csNodePool.Replicas())
+	}
+
+	config.Taints = NodePoolUpdateDispatchConfigTaintsFromCS(csNodePool)
+	config.NodeDrainTimeoutMinutes = NodePoolUpdateDispatchConfigNodeDrainTimeoutFromCS(csNodePool)
+
+	return config
+}
+
+// NodePoolUpdateDispatchConfigEffectiveNodeDrainTimeoutMinutes returns the drain timeout
+// Hypershift reconciliation should expect. When RP stores an explicit override, that
+// value is returned. When RP stores nil (no override), the live Cluster Service node pool
+// value is returned because CS PATCH omit/null cannot clear or re-inherit cluster default.
+func NodePoolUpdateDispatchConfigEffectiveNodeDrainTimeoutMinutes(nodePool *api.HCPOpenShiftClusterNodePool, csNodePool *arohcpv1alpha1.NodePool) *int32 {
+	if nodePool.Properties.NodeDrainTimeoutMinutes != nil {
+		return nodePool.Properties.NodeDrainTimeoutMinutes
+	}
+	return NodePoolUpdateDispatchConfigNodeDrainTimeoutFromCS(csNodePool)
+}
+
+// NodePoolUpdateDispatchConfigNodeDrainTimeoutFromCS extracts the node drain timeout in
+// minutes from a Cluster Service node pool object. Returns nil when unset.
+func NodePoolUpdateDispatchConfigNodeDrainTimeoutFromCS(in *arohcpv1alpha1.NodePool) *int32 {
+	if nodeDrainGracePeriod, ok := in.GetNodeDrainGracePeriod(); ok {
+		if unit, ok := nodeDrainGracePeriod.GetUnit(); ok && unit == csNodeDrainGracePeriodUnit {
+			v := int32(nodeDrainGracePeriod.Value())
+			return &v
+		}
+	}
+	return nil
+}
+
+// NodePoolUpdateDispatchConfigLabelsFromCS extracts labels from a Cluster Service node pool.
+func NodePoolUpdateDispatchConfigLabelsFromCS(csNodePool *arohcpv1alpha1.NodePool) map[string]string {
+	if labels, ok := csNodePool.GetLabels(); ok {
+		return labels
+	}
+	return nil
+}
+
+// NodePoolUpdateDispatchConfigTaintsFromCS extracts taints from a Cluster Service node pool
+// into the dispatch canonical form.
+func NodePoolUpdateDispatchConfigTaintsFromCS(csNodePool *arohcpv1alpha1.NodePool) []NodePoolUpdateDispatchConfigTaint {
+	csTaints, ok := csNodePool.GetTaints()
+	if !ok || len(csTaints) == 0 {
+		return nil
+	}
+
+	out := make([]NodePoolUpdateDispatchConfigTaint, 0, len(csTaints))
+	for _, t := range csTaints {
+		out = append(out, NodePoolUpdateDispatchConfigTaint{
+			Effect: t.Effect(),
+			Key:    t.Key(),
+			Value:  t.Value(),
+		})
+	}
+	return out
+}
+
+// nodePoolUpdateDispatchConfigHash returns a SHA-256 hex digest of the dispatch config
+// projected from RP desired state. The digest is computed from canonical JSON (sorted object
+// keys at every level), not from a raw json.Marshal of the struct.
+func nodePoolUpdateDispatchConfigHash(nodePool *api.HCPOpenShiftClusterNodePool) (string, error) {
+	return nodePoolUpdateDispatchConfigFromRP(nodePool).hash()
+}
+
+// hash returns a SHA-256 hex digest of c's canonical JSON.
+func (c *nodePoolUpdateDispatchConfig) hash() (string, error) {
+	return hashUpdateDispatchConfig(c)
+}
+
+// canonicalJSON returns the deterministic JSON encoding of c used for hashing and comparison.
+// Keys are sorted at every object level and the payload is indented with two spaces; see
+// canonicalJSONForUpdateDispatchConfig.
+func (c *nodePoolUpdateDispatchConfig) canonicalJSON() ([]byte, error) {
+	return canonicalJSONForUpdateDispatchConfig(c)
+}
+
+// applyToCSBuilder maps the dispatch config onto a Cluster Service node pool builder.
+func (c *nodePoolUpdateDispatchConfig) applyToCSBuilder(nodePoolBuilder *arohcpv1alpha1.NodePoolBuilder) {
+	nodePoolBuilder.Labels(c.Labels)
+
+	if c.AutoScaling != nil {
+		nodePoolBuilder.Autoscaling(arohcpv1alpha1.NewNodePoolAutoscaling().
+			MinReplica(int(c.AutoScaling.Min)).
+			MaxReplica(int(c.AutoScaling.Max)))
+	} else {
+		nodePoolBuilder.Replicas(int(c.Replicas))
+	}
+
+	if c.Taints != nil {
+		taintBuilders := make([]*arohcpv1alpha1.TaintBuilder, 0, len(c.Taints))
+		for _, t := range c.Taints {
+			taintBuilders = append(taintBuilders, arohcpv1alpha1.NewTaint().
+				Effect(t.Effect).
+				Key(t.Key).
+				Value(t.Value))
+		}
+		nodePoolBuilder.Taints(taintBuilders...)
+	}
+
+	if c.NodeDrainTimeoutMinutes != nil {
+		nodePoolBuilder.NodeDrainGracePeriod(arohcpv1alpha1.NewValue().
+			Unit(csNodeDrainGracePeriodUnit).
+			Value(float64(*c.NodeDrainTimeoutMinutes)))
+	}
+}

--- a/internal/ocm/node_pool_update_dispatch_config_test.go
+++ b/internal/ocm/node_pool_update_dispatch_config_test.go
@@ -1,0 +1,661 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocm
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/utils/ptr"
+
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+)
+
+func TestNodePoolUpdateDispatchConfigHash(t *testing.T) {
+	baseProperties := api.HCPOpenShiftClusterNodePoolProperties{
+		Labels:   map[string]string{"env": "prod"},
+		Replicas: 3,
+		Taints: []api.Taint{
+			{Effect: api.EffectNoSchedule, Key: "key1", Value: "val1"},
+		},
+		NodeDrainTimeoutMinutes: ptr.To(int32(30)),
+	}
+
+	base := &api.HCPOpenShiftClusterNodePool{Properties: baseProperties}
+
+	baseHash, err := nodePoolUpdateDispatchConfigHash(base)
+	require.NoError(t, err)
+	require.NotEmpty(t, baseHash)
+
+	hashAgain, err := nodePoolUpdateDispatchConfigHash(base)
+	require.NoError(t, err)
+	assert.Equal(t, baseHash, hashAgain)
+
+	tests := []struct {
+		name     string
+		nodePool *api.HCPOpenShiftClusterNodePool
+	}{
+		{
+			name: "different labels",
+			nodePool: &api.HCPOpenShiftClusterNodePool{
+				Properties: api.HCPOpenShiftClusterNodePoolProperties{
+					Labels:                  map[string]string{"env": "staging"},
+					Replicas:                baseProperties.Replicas,
+					Taints:                  baseProperties.Taints,
+					NodeDrainTimeoutMinutes: baseProperties.NodeDrainTimeoutMinutes,
+				},
+			},
+		},
+		{
+			name: "different replicas",
+			nodePool: &api.HCPOpenShiftClusterNodePool{
+				Properties: api.HCPOpenShiftClusterNodePoolProperties{
+					Labels:                  baseProperties.Labels,
+					Replicas:                5,
+					Taints:                  baseProperties.Taints,
+					NodeDrainTimeoutMinutes: baseProperties.NodeDrainTimeoutMinutes,
+				},
+			},
+		},
+		{
+			name: "autoscaling instead of replicas",
+			nodePool: &api.HCPOpenShiftClusterNodePool{
+				Properties: api.HCPOpenShiftClusterNodePoolProperties{
+					Labels:                  baseProperties.Labels,
+					AutoScaling:             &api.NodePoolAutoScaling{Min: 1, Max: 10},
+					Taints:                  baseProperties.Taints,
+					NodeDrainTimeoutMinutes: baseProperties.NodeDrainTimeoutMinutes,
+				},
+			},
+		},
+		{
+			name: "different taints",
+			nodePool: &api.HCPOpenShiftClusterNodePool{
+				Properties: api.HCPOpenShiftClusterNodePoolProperties{
+					Labels:   baseProperties.Labels,
+					Replicas: baseProperties.Replicas,
+					Taints: []api.Taint{
+						{Effect: api.EffectNoExecute, Key: "key2", Value: "val2"},
+					},
+					NodeDrainTimeoutMinutes: baseProperties.NodeDrainTimeoutMinutes,
+				},
+			},
+		},
+		{
+			name: "different node drain timeout",
+			nodePool: &api.HCPOpenShiftClusterNodePool{
+				Properties: api.HCPOpenShiftClusterNodePoolProperties{
+					Labels:                  baseProperties.Labels,
+					Replicas:                baseProperties.Replicas,
+					Taints:                  baseProperties.Taints,
+					NodeDrainTimeoutMinutes: ptr.To(int32(60)),
+				},
+			},
+		},
+	}
+
+	// Each row changes one dispatch-managed field from the baseline above. Comparing against
+	// baseHash checks that the field is included in the canonical hash. It does not prove the
+	// field mapped correctly. See FromCS round-trip and per-helper tests for that.
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hash, err := nodePoolUpdateDispatchConfigHash(tt.nodePool)
+			require.NoError(t, err)
+			assert.NotEqual(t, baseHash, hash, "changing %q should change the dispatch config hash", tt.name)
+		})
+	}
+}
+
+func TestNodePoolUpdateDispatchConfigHashExcludesNonUpdatableFields(t *testing.T) {
+	np1 := &api.HCPOpenShiftClusterNodePool{
+		Properties: api.HCPOpenShiftClusterNodePoolProperties{
+			Replicas: 3,
+			Version:  api.NodePoolVersionProfile{ID: "4.19.1", ChannelGroup: "stable"},
+			Platform: api.NodePoolPlatformProfile{
+				VMSize: "Standard_D4s_v3",
+			},
+		},
+	}
+
+	np2 := &api.HCPOpenShiftClusterNodePool{
+		Properties: api.HCPOpenShiftClusterNodePoolProperties{
+			Replicas: 3,
+			Version:  api.NodePoolVersionProfile{ID: "4.19.2", ChannelGroup: "candidate"},
+			Platform: api.NodePoolPlatformProfile{
+				VMSize: "Standard_D8s_v3",
+			},
+		},
+	}
+
+	hash1, err := nodePoolUpdateDispatchConfigHash(np1)
+	require.NoError(t, err)
+	hash2, err := nodePoolUpdateDispatchConfigHash(np2)
+	require.NoError(t, err)
+	assert.Equal(t, hash1, hash2)
+}
+
+func TestNodePoolUpdateDispatchConfigHashExcludesAutoRepair(t *testing.T) {
+	np1 := &api.HCPOpenShiftClusterNodePool{
+		Properties: api.HCPOpenShiftClusterNodePoolProperties{
+			Replicas:   3,
+			AutoRepair: true,
+		},
+	}
+	np2 := &api.HCPOpenShiftClusterNodePool{
+		Properties: api.HCPOpenShiftClusterNodePoolProperties{
+			Replicas:   3,
+			AutoRepair: false,
+		},
+	}
+
+	hash1, err := nodePoolUpdateDispatchConfigHash(np1)
+	require.NoError(t, err)
+	hash2, err := nodePoolUpdateDispatchConfigHash(np2)
+	require.NoError(t, err)
+	assert.Equal(t, hash1, hash2)
+}
+
+// TestNodePoolUpdateDispatchConfigFromCSRoundTrip checks that RP and Cluster Service agree on
+// dispatch-managed config after materializing RP desired state onto a Cluster Service node pool
+// via BuildCSNodePool (update path: updating=true). nodePoolUpdateDispatchConfigFromCS and
+// nodePoolUpdateDispatchConfigFromRP must then produce the same canonical hash.
+func TestNodePoolUpdateDispatchConfigFromCSRoundTrip(t *testing.T) {
+	nodePool := &api.HCPOpenShiftClusterNodePool{
+		Properties: api.HCPOpenShiftClusterNodePoolProperties{
+			Labels:   map[string]string{"env": "prod", "team": "platform"},
+			Replicas: 5,
+			Taints: []api.Taint{
+				{Effect: api.EffectNoSchedule, Key: "dedicated", Value: "infra"},
+			},
+			NodeDrainTimeoutMinutes: ptr.To(int32(45)),
+			AutoRepair:              true,
+			Version:                 api.NodePoolVersionProfile{ID: "4.19.1", ChannelGroup: "stable"},
+			Platform: api.NodePoolPlatformProfile{
+				VMSize: "Standard_D4s_v3",
+			},
+		},
+	}
+
+	csNodePoolBuilder, err := BuildCSNodePool(context.Background(), nodePool, true)
+	require.NoError(t, err)
+
+	csNodePool, err := csNodePoolBuilder.Build()
+	require.NoError(t, err)
+
+	actualConfig := nodePoolUpdateDispatchConfigFromCS(csNodePool)
+
+	desiredHash, err := nodePoolUpdateDispatchConfigFromRP(nodePool).hash()
+	require.NoError(t, err)
+	actualHash, err := actualConfig.hash()
+	require.NoError(t, err)
+	assert.Equal(t, desiredHash, actualHash)
+}
+
+// TestNodePoolUpdateDispatchConfigFromCSRoundTripAutoScaling checks that RP desired state with
+// autoscaling (instead of fixed replicas) round-trips through BuildCSNodePool and
+// nodePoolUpdateDispatchConfigFromCS with matching hash.
+func TestNodePoolUpdateDispatchConfigFromCSRoundTripAutoScaling(t *testing.T) {
+	nodePool := &api.HCPOpenShiftClusterNodePool{
+		Properties: api.HCPOpenShiftClusterNodePoolProperties{
+			AutoScaling:             &api.NodePoolAutoScaling{Min: 2, Max: 10},
+			NodeDrainTimeoutMinutes: ptr.To(int32(30)),
+		},
+	}
+
+	csNodePoolBuilder, err := BuildCSNodePool(context.Background(), nodePool, true)
+	require.NoError(t, err)
+
+	csNodePool, err := csNodePoolBuilder.Build()
+	require.NoError(t, err)
+
+	actualConfig := nodePoolUpdateDispatchConfigFromCS(csNodePool)
+
+	desiredHash, err := nodePoolUpdateDispatchConfigFromRP(nodePool).hash()
+	require.NoError(t, err)
+	actualHash, err := actualConfig.hash()
+	require.NoError(t, err)
+	assert.Equal(t, desiredHash, actualHash)
+}
+
+func TestNodePoolUpdateDispatchConfigFromCS(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		csNodePool func(t *testing.T) *arohcpv1alpha1.NodePool
+		want       *nodePoolUpdateDispatchConfig
+	}{
+		{
+			name: "fixed replicas without autoscaling",
+			csNodePool: func(t *testing.T) *arohcpv1alpha1.NodePool {
+				t.Helper()
+				csNodePool, err := arohcpv1alpha1.NewNodePool().Replicas(5).Build()
+				require.NoError(t, err)
+				return csNodePool
+			},
+			want: &nodePoolUpdateDispatchConfig{
+				Replicas: 5,
+			},
+		},
+		{
+			name: "autoscaling maps min and max instead of replicas",
+			csNodePool: func(t *testing.T) *arohcpv1alpha1.NodePool {
+				t.Helper()
+				csNodePool, err := arohcpv1alpha1.NewNodePool().
+					Autoscaling(arohcpv1alpha1.NewNodePoolAutoscaling().
+						MinReplica(2).
+						MaxReplica(10)).
+					Build()
+				require.NoError(t, err)
+				return csNodePool
+			},
+			want: &nodePoolUpdateDispatchConfig{
+				AutoScaling: &nodePoolUpdateDispatchConfigAutoScaling{
+					Min: 2,
+					Max: 10,
+				},
+			},
+		},
+		{
+			name: "labels are copied when set",
+			csNodePool: func(t *testing.T) *arohcpv1alpha1.NodePool {
+				t.Helper()
+				csNodePool, err := arohcpv1alpha1.NewNodePool().
+					Labels(map[string]string{"env": "prod"}).
+					Build()
+				require.NoError(t, err)
+				return csNodePool
+			},
+			want: &nodePoolUpdateDispatchConfig{
+				Labels: map[string]string{"env": "prod"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := nodePoolUpdateDispatchConfigFromCS(tt.csNodePool(t))
+			if tt.want.Replicas != 0 {
+				assert.Equal(t, tt.want.Replicas, got.Replicas)
+			}
+			if tt.want.AutoScaling != nil {
+				require.NotNil(t, got.AutoScaling)
+				assert.Equal(t, *tt.want.AutoScaling, *got.AutoScaling)
+			}
+			if tt.want.Labels != nil {
+				assert.Equal(t, tt.want.Labels, got.Labels)
+			}
+		})
+	}
+}
+
+func TestNodePoolUpdateDispatchConfigNodeDrainTimeoutFromCS(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		csNodePool *arohcpv1alpha1.NodePool
+		want       *int32
+	}{
+		{
+			name: "unset cs node drain grace period returns nil",
+			csNodePool: func() *arohcpv1alpha1.NodePool {
+				csNodePool, err := arohcpv1alpha1.NewNodePool().Build()
+				require.NoError(t, err)
+				return csNodePool
+			}(),
+			want: nil,
+		},
+		{
+			name: "cs node drain grace period set in minutes unit returns the set value",
+			csNodePool: func() *arohcpv1alpha1.NodePool {
+				csNodePool, err := arohcpv1alpha1.NewNodePool().
+					NodeDrainGracePeriod(arohcpv1alpha1.NewValue().
+						Unit(csNodeDrainGracePeriodUnit).
+						Value(float64(45))).
+					Build()
+				require.NoError(t, err)
+				return csNodePool
+			}(),
+			want: ptr.To(int32(45)),
+		},
+		{
+			name: "cs node drain grace period set in non-minutes unit returns nil",
+			csNodePool: func() *arohcpv1alpha1.NodePool {
+				csNodePool, err := arohcpv1alpha1.NewNodePool().
+					NodeDrainGracePeriod(arohcpv1alpha1.NewValue().
+						Unit("hours").
+						Value(float64(1))).
+					Build()
+				require.NoError(t, err)
+				return csNodePool
+			}(),
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, NodePoolUpdateDispatchConfigNodeDrainTimeoutFromCS(tt.csNodePool))
+		})
+	}
+}
+
+func TestNodePoolUpdateDispatchConfigEffectiveNodeDrainTimeoutMinutes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		nodePool   *api.HCPOpenShiftClusterNodePool
+		csNodePool func(t *testing.T) *arohcpv1alpha1.NodePool
+		want       *int32
+	}{
+		{
+			name: "explicit RP override",
+			nodePool: &api.HCPOpenShiftClusterNodePool{
+				Properties: api.HCPOpenShiftClusterNodePoolProperties{
+					NodeDrainTimeoutMinutes: ptr.To(int32(15)),
+				},
+			},
+			csNodePool: func(t *testing.T) *arohcpv1alpha1.NodePool {
+				t.Helper()
+				csNodePoolBuilder, err := BuildCSNodePool(context.Background(), &api.HCPOpenShiftClusterNodePool{
+					Properties: api.HCPOpenShiftClusterNodePoolProperties{
+						NodeDrainTimeoutMinutes: ptr.To(int32(4)),
+					},
+				}, true)
+				require.NoError(t, err)
+				csNodePool, err := csNodePoolBuilder.Build()
+				require.NoError(t, err)
+				return csNodePool
+			},
+			want: ptr.To(int32(15)),
+		},
+		{
+			name: "RP set uses RP when CS unset",
+			nodePool: &api.HCPOpenShiftClusterNodePool{
+				Properties: api.HCPOpenShiftClusterNodePoolProperties{
+					NodeDrainTimeoutMinutes: ptr.To(int32(15)),
+				},
+			},
+			csNodePool: func(t *testing.T) *arohcpv1alpha1.NodePool {
+				t.Helper()
+				csNodePool, err := arohcpv1alpha1.NewNodePool().Build()
+				require.NoError(t, err)
+				return csNodePool
+			},
+			want: ptr.To(int32(15)),
+		},
+		{
+			name:     "RP unset uses CS",
+			nodePool: &api.HCPOpenShiftClusterNodePool{},
+			csNodePool: func(t *testing.T) *arohcpv1alpha1.NodePool {
+				t.Helper()
+				csNodePoolBuilder, err := BuildCSNodePool(context.Background(), &api.HCPOpenShiftClusterNodePool{
+					Properties: api.HCPOpenShiftClusterNodePoolProperties{
+						NodeDrainTimeoutMinutes: ptr.To(int32(4)),
+					},
+				}, true)
+				require.NoError(t, err)
+				csNodePool, err := csNodePoolBuilder.Build()
+				require.NoError(t, err)
+				return csNodePool
+			},
+			want: ptr.To(int32(4)),
+		},
+		{
+			name:     "RP unset and CS unset returns nil",
+			nodePool: &api.HCPOpenShiftClusterNodePool{},
+			csNodePool: func(t *testing.T) *arohcpv1alpha1.NodePool {
+				t.Helper()
+				csNodePool, err := arohcpv1alpha1.NewNodePool().Build()
+				require.NoError(t, err)
+				return csNodePool
+			},
+			want: nil,
+		},
+		{
+			name: "RP explicit zero overrides CS",
+			nodePool: &api.HCPOpenShiftClusterNodePool{
+				Properties: api.HCPOpenShiftClusterNodePoolProperties{
+					NodeDrainTimeoutMinutes: ptr.To(int32(0)),
+				},
+			},
+			csNodePool: func(t *testing.T) *arohcpv1alpha1.NodePool {
+				t.Helper()
+				csNodePoolBuilder, err := BuildCSNodePool(context.Background(), &api.HCPOpenShiftClusterNodePool{
+					Properties: api.HCPOpenShiftClusterNodePoolProperties{
+						NodeDrainTimeoutMinutes: ptr.To(int32(4)),
+					},
+				}, true)
+				require.NoError(t, err)
+				csNodePool, err := csNodePoolBuilder.Build()
+				require.NoError(t, err)
+				return csNodePool
+			},
+			want: ptr.To(int32(0)),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := NodePoolUpdateDispatchConfigEffectiveNodeDrainTimeoutMinutes(tt.nodePool, tt.csNodePool(t))
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestNodePoolUpdateDispatchConfigDiffJSONIgnoresCSDrainTimeoutWhenRPUnset(t *testing.T) {
+	nodePool := &api.HCPOpenShiftClusterNodePool{
+		Properties: api.HCPOpenShiftClusterNodePoolProperties{
+			Replicas: 3,
+		},
+	}
+
+	csNodePool := &api.HCPOpenShiftClusterNodePool{
+		Properties: api.HCPOpenShiftClusterNodePoolProperties{
+			Replicas:                3,
+			NodeDrainTimeoutMinutes: ptr.To(int32(4)),
+		},
+	}
+	csNodePoolBuilder, err := BuildCSNodePool(context.Background(), csNodePool, true)
+	require.NoError(t, err)
+	csNodePoolBuilt, err := csNodePoolBuilder.Build()
+	require.NoError(t, err)
+
+	desiredJSON, actualJSON, err := NodePoolUpdateDispatchConfigDiffJSON(nodePool, csNodePoolBuilt)
+	require.NoError(t, err)
+	assert.JSONEq(t, desiredJSON, actualJSON)
+	assert.Equal(t, desiredJSON, actualJSON)
+	assert.NotContains(t, actualJSON, "nodeDrainTimeoutMinutes")
+}
+
+func TestNodePoolUpdateDispatchConfigJSONFromRPAndCS(t *testing.T) {
+	nodePool := &api.HCPOpenShiftClusterNodePool{
+		Properties: api.HCPOpenShiftClusterNodePoolProperties{
+			Labels:                  map[string]string{"env": "prod"},
+			Replicas:                3,
+			NodeDrainTimeoutMinutes: ptr.To(int32(45)),
+		},
+	}
+
+	csNodePoolBuilder, err := BuildCSNodePool(context.Background(), nodePool, true)
+	require.NoError(t, err)
+	csNodePool, err := csNodePoolBuilder.Build()
+	require.NoError(t, err)
+
+	desiredJSON, err := NodePoolUpdateDispatchConfigJSONFromRP(nodePool)
+	require.NoError(t, err)
+	actualJSON, err := NodePoolUpdateDispatchConfigJSONFromCS(csNodePool)
+	require.NoError(t, err)
+
+	// We assert both semantic and byte-for-byte JSON equality on purpose:
+	//   - JSONEq checks that RP and CS projections represent the same config (values and structure).
+	//   - Equal checks that canonicalJSON produces identical strings on both sides. The node pool
+	//     service update dispatch controller uses string equality (==) for drift detection, so
+	//     this must hold whenever the configs match; JSONEq alone would not catch encoding
+	//     differences such as key ordering or whitespace that would cause a false drift signal.
+	assert.JSONEq(t, desiredJSON, actualJSON)
+	assert.Equal(t, desiredJSON, actualJSON)
+	assert.Contains(t, desiredJSON, `"nodeDrainTimeoutMinutes": 45`)
+	assert.Contains(t, desiredJSON, `"replicas": 3`)
+
+	nodePool.Properties.Replicas = 5
+	desiredJSON, actualJSON, err = NodePoolUpdateDispatchConfigDiffJSON(nodePool, csNodePool)
+	require.NoError(t, err)
+	assert.NotEqual(t, desiredJSON, actualJSON)
+}
+
+func TestNodePoolUpdateDispatchConfigTaintsFromCS(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		csNodePool func(t *testing.T) *arohcpv1alpha1.NodePool
+		want       []NodePoolUpdateDispatchConfigTaint
+	}{
+		{
+			name: "no taints returns nil",
+			csNodePool: func(t *testing.T) *arohcpv1alpha1.NodePool {
+				t.Helper()
+				csNodePool, err := arohcpv1alpha1.NewNodePool().Build()
+				require.NoError(t, err)
+				return csNodePool
+			},
+			want: nil,
+		},
+		{
+			name: "taints with effect key and value are copied",
+			csNodePool: func(t *testing.T) *arohcpv1alpha1.NodePool {
+				t.Helper()
+				csNodePool, err := arohcpv1alpha1.NewNodePool().
+					Taints(
+						arohcpv1alpha1.NewTaint().
+							Effect(string(api.EffectNoSchedule)).
+							Key("dedicated").
+							Value("infra"),
+					).
+					Build()
+				require.NoError(t, err)
+				return csNodePool
+			},
+			want: []NodePoolUpdateDispatchConfigTaint{
+				{Effect: string(api.EffectNoSchedule), Key: "dedicated", Value: "infra"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, NodePoolUpdateDispatchConfigTaintsFromCS(tt.csNodePool(t)))
+		})
+	}
+}
+
+func TestNodePoolUpdateDispatchConfigApplyToCSBuilder(t *testing.T) {
+	tests := []struct {
+		name   string
+		config nodePoolUpdateDispatchConfig
+		verify func(t *testing.T, csNodePool *arohcpv1alpha1.NodePool)
+	}{
+		{
+			name: "sets labels replicas and taints",
+			config: nodePoolUpdateDispatchConfig{
+				Labels:   map[string]string{"env": "prod"},
+				Replicas: 5,
+				Taints: []NodePoolUpdateDispatchConfigTaint{
+					{Effect: string(api.EffectNoSchedule), Key: "dedicated", Value: "infra"},
+				},
+			},
+			verify: func(t *testing.T, csNodePool *arohcpv1alpha1.NodePool) {
+				t.Helper()
+				got := nodePoolUpdateDispatchConfigFromCS(csNodePool)
+				assert.Equal(t, map[string]string{"env": "prod"}, got.Labels)
+				assert.Equal(t, int32(5), got.Replicas)
+				require.Len(t, got.Taints, 1)
+				assert.Equal(t, NodePoolUpdateDispatchConfigTaint{
+					Effect: string(api.EffectNoSchedule),
+					Key:    "dedicated",
+					Value:  "infra",
+				}, got.Taints[0])
+			},
+		},
+		{
+			name: "sets autoscaling instead of replicas",
+			config: nodePoolUpdateDispatchConfig{
+				AutoScaling: &nodePoolUpdateDispatchConfigAutoScaling{
+					Min: 2,
+					Max: 10,
+				},
+			},
+			verify: func(t *testing.T, csNodePool *arohcpv1alpha1.NodePool) {
+				t.Helper()
+				got := nodePoolUpdateDispatchConfigFromCS(csNodePool)
+				require.NotNil(t, got.AutoScaling)
+				assert.Equal(t, nodePoolUpdateDispatchConfigAutoScaling{Min: 2, Max: 10}, *got.AutoScaling)
+			},
+		},
+		{
+			name: "sets node drain grace period in minutes",
+			config: nodePoolUpdateDispatchConfig{
+				NodeDrainTimeoutMinutes: ptr.To(int32(45)),
+			},
+			verify: func(t *testing.T, csNodePool *arohcpv1alpha1.NodePool) {
+				t.Helper()
+				got := NodePoolUpdateDispatchConfigNodeDrainTimeoutFromCS(csNodePool)
+				require.NotNil(t, got)
+				assert.Equal(t, int32(45), *got)
+			},
+		},
+		{
+			name:   "nil taints does not set taints on builder",
+			config: nodePoolUpdateDispatchConfig{Replicas: 3},
+			verify: func(t *testing.T, csNodePool *arohcpv1alpha1.NodePool) {
+				t.Helper()
+				assert.Nil(t, NodePoolUpdateDispatchConfigTaintsFromCS(csNodePool))
+			},
+		},
+		{
+			name: "nil drain timeout does not set node drain grace period",
+			config: nodePoolUpdateDispatchConfig{
+				Replicas: 3,
+			},
+			verify: func(t *testing.T, csNodePool *arohcpv1alpha1.NodePool) {
+				t.Helper()
+				assert.Nil(t, NodePoolUpdateDispatchConfigNodeDrainTimeoutFromCS(csNodePool))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodePoolBuilder := arohcpv1alpha1.NewNodePool()
+			tt.config.applyToCSBuilder(nodePoolBuilder)
+
+			csNodePool, err := nodePoolBuilder.Build()
+			require.NoError(t, err)
+			tt.verify(t, csNodePool)
+		})
+	}
+}

--- a/internal/ocm/update_dispatch_config.go
+++ b/internal/ocm/update_dispatch_config.go
@@ -1,0 +1,60 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocm
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// canonicalJSONForUpdateDispatchConfig returns canonical JSON for hashing any
+// update-dispatch config struct. The value is marshaled first so json tags and
+// omitempty apply, then round-tripped through map[string]any so object keys
+// are emitted in sorted order at every level, and finally marshaled with
+// json.MarshalIndent (pretty-printed) using two-space indentation.
+func canonicalJSONForUpdateDispatchConfig(v any) ([]byte, error) {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return nil, utils.TrackError(fmt.Errorf("failed to marshal update dispatch config: %w", err))
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return nil, utils.TrackError(fmt.Errorf("failed to unmarshal update dispatch config: %w", err))
+	}
+
+	raw, err = json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return nil, utils.TrackError(fmt.Errorf("failed to marshal update dispatch config payload: %w", err))
+	}
+	return raw, nil
+}
+
+// hashUpdateDispatchConfig takes any update-dispatch config, it converts it to
+// its canonical JSON form and then hashes it using SHA-256 sum encoded to a
+// hex string.
+func hashUpdateDispatchConfig(v any) (string, error) {
+	raw, err := canonicalJSONForUpdateDispatchConfig(v)
+	if err != nil {
+		return "", err
+	}
+
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:]), nil
+}

--- a/internal/ocm/update_dispatch_config_test.go
+++ b/internal/ocm/update_dispatch_config_test.go
@@ -1,0 +1,121 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocm
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateDispatchConfigCanonicalJSONAndHash(t *testing.T) {
+	type fieldOrderProbe struct {
+		Zebra string `json:"zebra"`
+		Alpha string `json:"alpha"`
+	}
+
+	type nestedInner struct {
+		Z string `json:"z"`
+		A string `json:"a"`
+	}
+
+	type nestedProbe struct {
+		Zebra nestedInner `json:"zebra"`
+		Alpha nestedInner `json:"alpha"`
+	}
+
+	type omitProbe struct {
+		Zebra string `json:"zebra,omitempty"`
+		Alpha string `json:"alpha"`
+	}
+
+	tests := []struct {
+		name  string
+		input func(t *testing.T) any
+		want  string
+	}{
+		{
+			name: "sorts top-level struct keys",
+			input: func(t *testing.T) any {
+				return fieldOrderProbe{Zebra: "z", Alpha: "a"}
+			},
+			want: "{\n  \"alpha\": \"a\",\n  \"zebra\": \"z\"\n}",
+		},
+		{
+			name: "sorts nested object keys too",
+			input: func(t *testing.T) any {
+				return nestedProbe{
+					Zebra: nestedInner{Z: "z", A: "a"},
+					Alpha: nestedInner{A: "1", Z: "2"},
+				}
+			},
+			want: "{\n  \"alpha\": {\n    \"a\": \"1\",\n    \"z\": \"2\"\n  },\n  \"zebra\": {\n    \"a\": \"a\",\n    \"z\": \"z\"\n  }\n}",
+		},
+		{
+			name: "honors omitempty before sorting",
+			input: func(t *testing.T) any {
+				return omitProbe{Alpha: "a"}
+			},
+			want: "{\n  \"alpha\": \"a\"\n}",
+		},
+		{
+			name: "JSON fixture loaded into struct",
+			input: func(t *testing.T) any {
+				var probe fieldOrderProbe
+				require.NoError(t, json.Unmarshal([]byte(`{"zebra":"from-json","alpha":"fixture"}`), &probe))
+				return probe
+			},
+			want: "{\n  \"alpha\": \"fixture\",\n  \"zebra\": \"from-json\"\n}",
+		},
+		{
+			name: "map input round-trips with sorted keys",
+			input: func(t *testing.T) any {
+				return map[string]any{
+					"zebra": "from-map",
+					"alpha": "input",
+				}
+			},
+			want: "{\n  \"alpha\": \"input\",\n  \"zebra\": \"from-map\"\n}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := tt.input(t)
+
+			got, err := canonicalJSONForUpdateDispatchConfig(input)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, string(got))
+
+			hash, err := hashUpdateDispatchConfig(input)
+			require.NoError(t, err)
+			require.NotEmpty(t, hash)
+
+			hashAgain, err := hashUpdateDispatchConfig(input)
+			require.NoError(t, err)
+			assert.Equal(t, hash, hashAgain)
+		})
+	}
+
+	t.Run("different values produce different hash", func(t *testing.T) {
+		hashA, err := hashUpdateDispatchConfig(fieldOrderProbe{Zebra: "z", Alpha: "a"})
+		require.NoError(t, err)
+		hashB, err := hashUpdateDispatchConfig(fieldOrderProbe{Zebra: "z", Alpha: "b"})
+		require.NoError(t, err)
+		assert.NotEqual(t, hashA, hashB)
+	})
+}


### PR DESCRIPTION
As part of the process of moving CS update calls for clusters, nodepools and externalauths, we need to introduce the controllers that will dispatch the Update calls in backend. Additionally, we also need to improve the update operation controllers to calculate the state of the updates, making sure they do not mark the operation as completed before the update is fully finished. The operation update controllers have been updated to at least compare the desired state in cosmos with parts of the spec in the management cluster side and/or CS side if that's not possible for now.

The controllers will already be active even though we are not removing the CS update call from frontend. This should be fine because the update should not be dispatched to CS as we calculate whether there are differences between Cosmos desired state and the returned content in CS. An exception to this is if the cluster's control plane size has been updated via the SRE mechanism through the admin API. If that occurs, the cluster update dispatch controller will act too.