### PR TITLE
fix(hcpctl): use kubeAudit table for mgmtAuditLogs snapshot query

### DIFF
--- a/tooling/hcpctl/pkg/snapshot/queries/maestro/mgmtAuditLogs/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/maestro/mgmtAuditLogs/query.kql
@@ -1,16 +1,14 @@
 {{ template "bundleMap" . }}
 let bundleResources = bundleMap
 | summarize groupVersion = take_any(groupVersion), resourceKind = take_any(resourceKind), label = take_any(label) by resourceNamespace, resourceName;
-cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('aksEvents')
-| where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
+cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('kubeAudit')
+| where requestReceivedTimestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
 {{- if and .ServiceClusterName .ManagementClusterName }}
-| where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
+| where resourceId contains '{{ .ServiceClusterName }}' or resourceId contains '{{ .ManagementClusterName }}'
 {{- end }}
-| where operationName == 'kube-audit'
-| extend event = parse_json(log)
-| where event.stage == 'ResponseComplete'
-| extend objectNamespace = tostring(event.objectRef.namespace), objectName = tostring(event.objectRef.name)
+| where stage == 'ResponseComplete'
+| extend objectNamespace = tostring(objectRef.namespace), objectName = tostring(objectRef.name)
 | lookup bundleResources on $left.objectNamespace == $right.resourceNamespace, $left.objectName == $right.resourceName
 | where isnotempty(label)
-| project timestamp, groupVersion, resourceKind, label, objectNamespace, objectName, verb = tostring(event.verb), user = tostring(event.user.username), responseCode = toint(event.responseStatus.code)
+| project timestamp = requestReceivedTimestamp, groupVersion, resourceKind, label, objectNamespace, objectName, verb, user = tostring(user.username), responseCode = toint(responseStatus.code)
 | order by timestamp asc


### PR DESCRIPTION
## Summary
- Switch mgmtAuditLogs query from `aksEvents` to `kubeAudit` table — `aksEvents` excludes kube-audit rows via an update policy, causing a 400 error due to missing `cluster` column
- Use pre-parsed native columns (`stage`, `verb`, `user`, `objectRef`, `responseStatus`) instead of re-parsing `log` JSON
- Filter by `resourceId` instead of the non-existent `cluster` column
- Use `requestReceivedTimestamp` instead of `timestamp` for filtering/ordering, since `timestamp` reflects log ingestion time rather than when the API server received the request

## Test plan
- [x] Verified old query returns `SEM0100: Failed to resolve table or column or scalar or graph expression named 'cluster'`
- [x] Verified new query returns 770+ audit log rows (test phase) and 286 rows (cleanup phase) for prow job `pull-ci-Azure-ARO-HCP-main-e2e-parallel/2076479485393244160`
- [x] `go build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)