### PR TITLE
fix(config): require string aksUpgradeSettings so Ev2 bicepparam renders

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -506,28 +506,14 @@
       "additionalProperties": false,
       "properties": {
         "maxSurge": {
-          "description": "Maximum number or percentage of nodes surged during upgrade.",
-          "oneOf": [
-            {
-              "type": "integer",
-              "minimum": 0
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "description": "Maximum number or percentage of nodes surged during upgrade. Must be a string (e.g. \"1\" or \"10%\") because it is rendered into a string bicep parameter and passed through the Ev2 placeholder resolver, which cannot represent non-string scalars in the generated bicepparam.",
+          "type": "string",
+          "pattern": "^[0-9]+%?$"
         },
         "maxUnavailable": {
-          "description": "Maximum number or percentage of nodes unavailable during upgrade.",
-          "oneOf": [
-            {
-              "type": "integer",
-              "minimum": 0
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "description": "Maximum number or percentage of nodes unavailable during upgrade. Must be a string (e.g. \"0\" or \"10%\") because it is rendered into a string bicep parameter and passed through the Ev2 placeholder resolver, which cannot represent non-string scalars in the generated bicepparam.",
+          "type": "string",
+          "pattern": "^[0-9]+%?$"
         }
       },
       "required": [

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -509,7 +509,7 @@ defaults:
       networkPolicy: "cilium"
       upgradeSettings:
         maxSurge: "10%"
-        maxUnavailable: 0
+        maxUnavailable: "0"
       systemAgentPool:
         name: 'system'
         minCount: 1
@@ -642,7 +642,7 @@ defaults:
       networkPolicy: "azure"
       upgradeSettings:
         maxSurge: "10%"
-        maxUnavailable: 0
+        maxUnavailable: "0"
       etcd:
         name: "ah-{{ .ctx.environment }}-me-{{ .ctx.regionShort }}-{{ .ctx.stamp }}" # [globally-unique]
         softDelete: true

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -637,7 +637,7 @@ mgmt:
       zones: ""
     upgradeSettings:
       maxSurge: 10%
-      maxUnavailable: 0
+      maxUnavailable: "0"
     userAgentPool:
       maxCount: 14
       minCount: 7
@@ -985,7 +985,7 @@ svc:
       zones: ""
     upgradeSettings:
       maxSurge: 10%
-      maxUnavailable: 0
+      maxUnavailable: "0"
     userAgentPool:
       maxCount: 3
       minCount: 1

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -637,7 +637,7 @@ mgmt:
       zones: ""
     upgradeSettings:
       maxSurge: 10%
-      maxUnavailable: 0
+      maxUnavailable: "0"
     userAgentPool:
       maxCount: 14
       minCount: 7
@@ -985,7 +985,7 @@ svc:
       zones: ""
     upgradeSettings:
       maxSurge: 10%
-      maxUnavailable: 0
+      maxUnavailable: "0"
     userAgentPool:
       maxCount: 3
       minCount: 1

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -637,7 +637,7 @@ mgmt:
       zones: ""
     upgradeSettings:
       maxSurge: 10%
-      maxUnavailable: 0
+      maxUnavailable: "0"
     userAgentPool:
       maxCount: 3
       minCount: 1
@@ -983,7 +983,7 @@ svc:
       zones: ""
     upgradeSettings:
       maxSurge: 10%
-      maxUnavailable: 0
+      maxUnavailable: "0"
     userAgentPool:
       maxCount: 12
       minCount: 2

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -637,7 +637,7 @@ mgmt:
       zones: ""
     upgradeSettings:
       maxSurge: 10%
-      maxUnavailable: 0
+      maxUnavailable: "0"
     userAgentPool:
       maxCount: 3
       minCount: 1
@@ -983,7 +983,7 @@ svc:
       zones: ""
     upgradeSettings:
       maxSurge: 10%
-      maxUnavailable: 0
+      maxUnavailable: "0"
     userAgentPool:
       maxCount: 3
       minCount: 1

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -637,7 +637,7 @@ mgmt:
       zones: ""
     upgradeSettings:
       maxSurge: 10%
-      maxUnavailable: 0
+      maxUnavailable: "0"
     userAgentPool:
       maxCount: 3
       minCount: 1
@@ -983,7 +983,7 @@ svc:
       zones: ""
     upgradeSettings:
       maxSurge: 10%
-      maxUnavailable: 0
+      maxUnavailable: "0"
     userAgentPool:
       maxCount: 3
       minCount: 1

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -637,7 +637,7 @@ mgmt:
       zones: ""
     upgradeSettings:
       maxSurge: 10%
-      maxUnavailable: 0
+      maxUnavailable: "0"
     userAgentPool:
       maxCount: 6
       minCount: 1
@@ -985,7 +985,7 @@ svc:
       zones: ""
     upgradeSettings:
       maxSurge: 10%
-      maxUnavailable: 0
+      maxUnavailable: "0"
     userAgentPool:
       maxCount: 3
       minCount: 1


### PR DESCRIPTION
## What this PR does

Constrains the `aksUpgradeSettings.maxSurge` / `maxUnavailable` config values to **string** (schema `type: string`, `pattern: ^[0-9]+%?$`) and quotes the svc/mgmt defaults in `config.yaml` (`maxUnavailable: "0"`).

## Why

The svc-cluster and mgmt-cluster bicepparam templates wrap these placeholders in single quotes:

```bicep
param aksUpgradeSettingsMaxUnavailable = '{{ .svc.aks.upgradeSettings.maxUnavailable }}'
```

because the corresponding bicep params are typed `string` (`svc-cluster.bicep` L51/L54). When the Ev2 placeholder resolver renders a **non-string** config scalar, it wraps the value in `any('__…__')` to preserve its numeric type. Combined with the template's own quotes this produces the invalid literal:

```
param aksUpgradeSettingsMaxUnavailable = 'any('__svc.aks.upgradeSettings.maxUnavailable__')'
```

which fails bicepparam parsing with **BCP019 "Expected a new line character"** during `Generate Ev2 RA Manifests → Resolve Step Manifests` for `Service.Infra` / `Management.Infra`. This broke the ARO-HCP auto-bumper (release-candidate-creator) incremental-test-pipeline build and the sdp-pipelines umbrella build.

Making the values strings means the resolver never emits `any(...)`, so the rendered bicepparam is valid.

## Testing

- `cd config && make materialize` passes; rendered configs now emit `maxUnavailable: "0"`.
- Verified the fix against the Ev2 manifest generation path on the sdp-pipelines umbrella (`Service.Infra` + `Management.Infra` both generate cleanly with the quoted values); the failing bumper build reproduced the BCP019 before the change and passes after.

## Special notes for your reviewer

Related: AROSLSRE-1470. This is the upstream proper fix; the sdp-pipelines overlay carries an equivalent temporary stringify workaround that will be reverted once this bumps into the umbrella.
