### PR TITLE
feat: add maestro alert for events stuck in unreconciled state

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
@@ -1371,6 +1371,33 @@ resource maestro 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
         for: 'PT10M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'MaestroEventStuckUnreconciled'
+        enabled: true
+        labels: {
+          severity: 'warning'
+        }
+        annotations: {
+          correlationId: 'MaestroEventStuckUnreconciled/{{ $labels.cluster }}'
+          description: 'A Maestro event has been unreconciled for {{ $value | humanizeDuration }}. This likely indicates a lost Postgres NOTIFY message. The event will not be processed until the periodic sync runs (default 10 hours).'
+          info: 'A Maestro event has been unreconciled for {{ $value | humanizeDuration }}. This likely indicates a lost Postgres NOTIFY message. The event will not be processed until the periodic sync runs (default 10 hours).'
+          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/maestro/index.html'
+          summary: 'Maestro unreconciled event age is too high — possible lost NOTIFY'
+          title: 'Maestro unreconciled event age is too high — possible lost NOTIFY'
+        }
+        expression: 'max(spec_controller_event_oldest_unreconciled_age_seconds{namespace="maestro"}) > 300'
+        for: 'PT1M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
     ]
     scopes: [
       azureMonitoring

--- a/maestro/alerts/maestro-prometheusRule.yaml
+++ b/maestro/alerts/maestro-prometheusRule.yaml
@@ -148,3 +148,17 @@ spec:
         description: 'Maestro workqueue {{ $labels.queue_name }} depth is {{ $value }}, sustained above 100 for 10 minutes. Events are not being processed fast enough.'
         runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/maestro/index.html'
         summary: 'Maestro workqueue depth is high'
+    - alert: MaestroEventStuckUnreconciled
+      # Fires when a spec event has been in the database unreconciled
+      # for more than 5 minutes. Potential causes for old unreconciled events
+      # are lost Postgres NOTIFY messages, or slow/stuck processing of the
+      # work queue.
+      expr: |
+        max(spec_controller_event_oldest_unreconciled_age_seconds{namespace="maestro"}) > 300
+      for: 1m
+      labels:
+        severity: warning
+      annotations:
+        description: 'A Maestro event has been unreconciled for {{ $value | humanizeDuration }}. This likely indicates a lost Postgres NOTIFY message. The event will not be processed until the periodic sync runs (default 10 hours).'
+        runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/maestro/index.html'
+        summary: 'Maestro unreconciled event age is too high — possible lost NOTIFY'

--- a/maestro/alerts/maestro-prometheusRule_test.yaml
+++ b/maestro/alerts/maestro-prometheusRule_test.yaml
@@ -229,3 +229,27 @@ tests:
   - eval_time: 11m
     alertname: MaestroWorkqueueDepthHigh
     exp_alerts: []
+# Test: MaestroEventStuckUnreconciled fires when age > 300s
+- interval: 1m
+  input_series:
+  - series: 'spec_controller_event_oldest_unreconciled_age_seconds{namespace="maestro"}'
+    values: "360x5" # 360 seconds (6 minutes) sustained
+  alert_rule_test:
+  - eval_time: 2m
+    alertname: MaestroEventStuckUnreconciled
+    exp_alerts:
+    - exp_labels:
+        severity: warning
+      exp_annotations:
+        description: 'A Maestro event has been unreconciled for 6m 0s. This likely indicates a lost Postgres NOTIFY message. The event will not be processed until the periodic sync runs (default 10 hours).'
+        runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/maestro/index.html'
+        summary: 'Maestro unreconciled event age is too high — possible lost NOTIFY'
+# Test: MaestroEventStuckUnreconciled does not fire when age <= 300s
+- interval: 1m
+  input_series:
+  - series: 'spec_controller_event_oldest_unreconciled_age_seconds{namespace="maestro"}'
+    values: "120x5" # 120 seconds (within normal range)
+  alert_rule_test:
+  - eval_time: 2m
+    alertname: MaestroEventStuckUnreconciled
+    exp_alerts: []

--- a/observability/grafana-dashboards/maestro/maestro-server.json
+++ b/observability/grafana-dashboards/maestro/maestro-server.json
@@ -1192,6 +1192,104 @@
       ],
       "title": "Work Queue Depth",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 300
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 35
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "max(spec_controller_event_oldest_unreconciled_age_seconds)",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Oldest Unreconciled Spec Event Age",
+      "type": "timeseries"
     }
   ],
   "preload": false,


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-26755

### What

Adds alert and dashboard panel for maestro spec events that are stuck in an unreconciled state for an extended period.
<img width="1522" height="917" alt="image" src="https://github.com/user-attachments/assets/206ba4ba-e56a-42a4-82f4-c1aa9e4aa424" />


### Why

Maestro server uses postgres NOTIFY messages to deliver spec events to the agent.  Delivery of these messages is best effort and certain failure modes can results in dropped events, resulting in "stuck" resource creation/updates.

### Testing

Alerts are unit tested.
Dashboard panel was manually tested in a personal dev environment.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [x] All comment threads resolved before merge

If E2E tests are included:

- [x] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [x] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
