### PR TITLE
feat(global): associate global subscription with OneCert domain via certificateDomains (AROSLSRE-1477)

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -41,6 +41,9 @@ defaults:
     subscription:
       key: hcp-global
       displayName: "Azure Red Hat OpenShift HCP - {{ .ctx.environment }} - Global"
+      # OneCert domains this sub may request certs for; tied at provisioning.
+      certificateDomains:
+      - '*.aro-hcp-global.azure.com'
       providers:
         'Microsoft.Cdn':
           poll: true

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -409,6 +409,8 @@ global:
   rg: global
   safeDnsIntAppObjectId: ""
   subscription:
+    certificateDomains:
+    - '*.aro-hcp-global.azure.com'
     displayName: Azure Red Hat OpenShift HCP - ci00 - Global
     key: ARO Hosted Control Planes (EA Subscription 1)
     providers:

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -409,6 +409,8 @@ global:
   rg: global
   safeDnsIntAppObjectId: ""
   subscription:
+    certificateDomains:
+    - '*.aro-hcp-global.azure.com'
     displayName: Azure Red Hat OpenShift HCP - ci01 - Global
     key: ARO Hosted Control Planes (EA Subscription 1)
     providers:

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -409,6 +409,8 @@ global:
   rg: global
   safeDnsIntAppObjectId: ""
   subscription:
+    certificateDomains:
+    - '*.aro-hcp-global.azure.com'
     displayName: Azure Red Hat OpenShift HCP - cspr - Global
     key: ARO Hosted Control Planes (EA Subscription 1)
     providers:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -409,6 +409,8 @@ global:
   rg: global
   safeDnsIntAppObjectId: ""
   subscription:
+    certificateDomains:
+    - '*.aro-hcp-global.azure.com'
     displayName: Azure Red Hat OpenShift HCP - dev - Global
     key: ARO Hosted Control Planes (EA Subscription 1)
     providers:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -409,6 +409,8 @@ global:
   rg: global
   safeDnsIntAppObjectId: ""
   subscription:
+    certificateDomains:
+    - '*.aro-hcp-global.azure.com'
     displayName: Azure Red Hat OpenShift HCP - perf - Global
     key: ARO Hosted Control Planes (EA Subscription 1)
     providers:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -409,6 +409,8 @@ global:
   rg: global
   safeDnsIntAppObjectId: ""
   subscription:
+    certificateDomains:
+    - '*.aro-hcp-global.azure.com'
     displayName: Azure Red Hat OpenShift HCP - pers - Global
     key: ARO Hosted Control Planes (EA Subscription 1)
     providers:


### PR DESCRIPTION
[AROSLSRE-1477](https://redhat.atlassian.net/browse/AROSLSRE-1477)

### What

Adds `certificateDomains: ['*.aro-hcp-global.azure.com']` to the **global** subscription in `config/config.yaml` (and its regenerated dev renders).

This is the config value consumed by EV2 `subscriptionProvisioning.certificateDomains` in the global subscription bootstrap pipeline (in `sdp-pipelines`, follow-up PR), which ties a newly-created global subscription to its pre-registered OneCert domain at creation time.

### Why

The Step-3 STG-global V2 rollout (`Global.StgGlobal`) failed at the two geneva certificate steps:

```
geneva-actions-cert / geneva-logs-cert (CreateCertificate) — Failed
OneCertV2-PrivateCA ... 'InvalidWhitelistedDomainApprover':
'd63a7f3d-…' is not an approved SubscriptionId for domain
'genevaAction.aro-hcp-global.azure.com' /
'geneva-logs-admin.geneva.keyvault.aro-hcp-global.azure.com'
under the '*.aro-hcp-global.azure.com' whitelist.
```

Root cause: the **global** subscription bootstrap never associated the sub with its OneCert domain. `svc`/`mgmt` subscriptions already set `certificateDomains` (`*.hcpsvc.osadev.cloud`, `*.hcp.osadev.cloud`), but `global` omitted it. The shared `hcp-global` sub was OneCert-approved once out of band long ago, so existing envs never hit this — but the migration provisioned a brand-new global sub through a bootstrap that carries no `certificateDomains`, so it was never authorized for `*.aro-hcp-global.azure.com` and geneva `CreateCertificate` was rejected.

Per the EV2 subscription-provisioning docs, `certificateDomains` → `certificateIssuance.allowedDomains` is the supported way to constrain which subs may request certs for a pre-registered domain. This change makes every future/recreated global sub authorized at creation, with no manual OneCert step.

Env-independent: the global geneva domain (`aro-hcp-global.azure.com`) is a fixed literal across all clouds/envs, so a single value in `defaults` is correct.

> Note: this prevents recurrence for **new** subs only. Per EV2 docs, already-created/backfilled subs are not supported — the existing `hcp-stg-global` sub is unblocked separately (maintainer-approved one-time action), tracked in [AROSLSRE-1477](https://redhat.atlassian.net/browse/AROSLSRE-1477).

### Testing

- `make -C config validate` passes — schema-validates and renders all environments with the new value. `certificateDomains` is already part of the `subscriptionMetadata` schema definition (which `global.subscription` refs), so no schema change is needed.
- Rendered output confirmed: `certificateDomains: ['*.aro-hcp-global.azure.com']` now appears under `global.subscription` in the dev renders (+2 lines each), alongside the existing svc/mgmt entries. Rendered artifacts are included so `detect-change` CI stays green.
- No unit-test surface — this is a config/data change validated by the templatizer + schema.

### Special notes for your reviewer

- Mirrors the existing `svc`/`mgmt` `certificateDomains` pattern; only the global subscription was missing it.
- The pipeline wiring that consumes this value lives in `sdp-pipelines` (`hcp/subscriptions/global/pipeline.yaml` + `stgglobal` V2 copy) and lands in a follow-up PR that must merge **after** this one is pulled downstream via `Revision.mk`.
