### PR TITLE
refactor: replace error-based validation with structured ValidationResult

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ _artifacts
 must-gather-*
 /hcpctl
 timing-metadata-*
+/.claude/

--- a/backend/pkg/controllers/controllerutils/generic_watching_controller.go
+++ b/backend/pkg/controllers/controllerutils/generic_watching_controller.go
@@ -42,6 +42,13 @@ type GenericSyncer[T comparable] interface {
 	MakeKey(resourceID *azcorearm.ResourceID) T
 }
 
+// AfterEnqueuer allows scheduling a workqueue item for processing after an
+// explicit delay. Validation controllers use this to implement
+// EarliestRetryAfter semantics.
+type AfterEnqueuer interface {
+	EnqueueAfter(keyObj any, duration time.Duration)
+}
+
 type Notifier interface {
 	AddEventHandlerWithOptions(handler cache.ResourceEventHandler, options cache.HandlerOptions) (cache.ResourceEventHandlerRegistration, error)
 }
@@ -75,6 +82,14 @@ func newGenericWatchingController[T comparable](name string, resourceType azcore
 	}
 
 	return c
+}
+
+func (c *genericWatchingController[T]) EnqueueAfter(keyObj any, duration time.Duration) {
+	key, ok := keyObj.(T)
+	if !ok {
+		return
+	}
+	c.queue.AddAfter(key, duration)
 }
 
 func (c *genericWatchingController[T]) SyncOnce(ctx context.Context, keyObj any) error {

--- a/backend/pkg/controllers/validationcontrollers/cluster_validation_controller.go
+++ b/backend/pkg/controllers/validationcontrollers/cluster_validation_controller.go
@@ -19,8 +19,10 @@ import (
 	"fmt"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/lru"
 
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/validationcontrollers/validations"
@@ -36,12 +38,22 @@ import (
 // clusterValidationSyncer is a Cluster syncer that performs a Cluster
 // validation.
 type clusterValidationSyncer struct {
-	cooldownChecker   controllerutil.CooldownChecker
-	resourcesDBClient database.ResourcesDBClient
+	cooldownChecker      controllerutil.CooldownChecker
+	retryCooldownChecker *controllerutil.SettableCooldownChecker
+	enqueueAfter         controllerutils.AfterEnqueuer
+	resourcesDBClient    database.ResourcesDBClient
+
+	// consecutiveUnknownCounts tracks how many consecutive Unknown results
+	// each key has produced. When a previous condition exists and the
+	// result is Unknown, the stored condition is preserved for the first
+	// maxConsecutiveUnknownsBeforeWrite attempts.
+	consecutiveUnknownCounts *lru.Cache
 
 	// validation is the validation to perform on the cluster.
 	validation validations.ClusterValidation
 }
+
+const maxConsecutiveUnknownsBeforeWrite = 10
 
 var _ controllerutils.ClusterSyncer = (*clusterValidationSyncer)(nil)
 
@@ -56,9 +68,11 @@ func NewClusterValidationController(
 ) controllerutils.Controller {
 
 	syncer := &clusterValidationSyncer{
-		cooldownChecker:   controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
-		resourcesDBClient: resourcesDBClient,
-		validation:        validation,
+		cooldownChecker:          controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		retryCooldownChecker:     controllerutil.NewSettableCooldownChecker(),
+		resourcesDBClient:        resourcesDBClient,
+		consecutiveUnknownCounts: lru.New(1000000),
+		validation:               validation,
 	}
 
 	controller := controllerutils.NewClusterWatchingController(
@@ -70,10 +84,18 @@ func NewClusterValidationController(
 		syncer,
 	)
 
+	if enqueuer, ok := controller.(controllerutils.AfterEnqueuer); ok {
+		syncer.enqueueAfter = enqueuer
+	} else {
+		panic("ClusterValidationController must implement AfterEnqueuer")
+	}
+
 	return controller
 }
 
 func (c *clusterValidationSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPClusterKey) error {
+	logger := utils.LoggerFromContext(ctx)
+
 	existingCluster, err := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).Get(ctx, key.HCPClusterName)
 	if database.IsNotFoundError(err) {
 		return nil // cluster doesn't exist, no work to do
@@ -90,47 +112,97 @@ func (c *clusterValidationSyncer) SyncOnce(ctx context.Context, key controllerut
 		return utils.TrackError(fmt.Errorf("failed to get or create ServiceProviderCluster: %w", err))
 	}
 
-	shouldProcess := c.shouldProcess(existingServiceProviderCluster)
-	if !shouldProcess {
-		return nil // no work to do
+	if !c.shouldProcess(existingServiceProviderCluster) {
+		return nil
+	}
+	if !c.retryCooldownChecker.CanSync(ctx, key) {
+		if c.enqueueAfter != nil {
+			c.enqueueAfter.EnqueueAfter(key, c.retryCooldownChecker.TimeUntilReady(key)+time.Second)
+		}
+		return nil
 	}
 	subscription, err := c.resourcesDBClient.Subscriptions().Get(ctx, existingCluster.ID.SubscriptionID)
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to get Subscription: %w", err))
 	}
 
-	// We store the validation error in a separate variable and we use that as the
-	// error to return to the caller. This allows us to perform other remaining
-	// tasks in the syncer even if the validation fails, and we ultimately
-	// drive the behavior of its controller through the outcome of the validation.
-	validationErr := c.validation.Validate(ctx, subscription, existingCluster)
+	result := c.validation.Validate(ctx, subscription, existingCluster)
+	result = validations.DefaultResult(result)
 
-	validationCondition := metav1.Condition{
-		Type: c.validation.Name(),
+	validationCondition := validations.BuildCondition(c.validation.Name(), result)
+	switch result.Outcome {
+	case validations.OutcomeTypeUnknown:
+		count := c.incrementUnknownCount(key)
+		if existingCondition := meta.FindStatusCondition(existingServiceProviderCluster.Status.Validations, c.validation.Name()); existingCondition != nil && existingCondition.Status != metav1.ConditionUnknown && count <= maxConsecutiveUnknownsBeforeWrite {
+			logger.Info("Validation returned Unknown but previous condition exists, so preserving previous state for a few attempts",
+				"previousStatus", existingCondition.Status,
+				"previousReason", existingCondition.Reason,
+				"unknownReason", validationCondition.Reason,
+				"unknownMessage", validationCondition.Message,
+				"serviceProviderMessage", result.Unknown.ServiceProviderMessage,
+				"consecutiveUnknownCount", count,
+			)
+			c.handleRequeue(key, result)
+			return nil
+		}
+		logger.Info("Writing unknown state",
+			"reason", validationCondition.Reason,
+			"serviceProviderMessage", result.Unknown.ServiceProviderMessage,
+			"consecutiveUnknownCount", count,
+		)
+	case validations.OutcomeTypeFailed:
+		logger.Info("Writing failed state",
+			"reason", result.Failed.Reason,
+			"serviceProviderMessage", result.Failed.ServiceProviderMessage,
+		)
+	case validations.OutcomeTypePassed:
+		logger.Info("Writing passed state")
 	}
-	if validationErr != nil {
-		validationCondition.Status = metav1.ConditionFalse
-		validationCondition.Reason = "Failed"
-		validationCondition.Message = fmt.Sprintf("Validation failed: %s", validationErr.Error())
-	} else {
-		validationCondition.Status = metav1.ConditionTrue
-		validationCondition.Reason = "Succeeded"
-		validationCondition.Message = "Validation succeeded"
-	}
+	// if we get here, we're going to overwrite the previous status
+	c.resetUnknownCount(key)
+
 	replacement := existingServiceProviderCluster.DeepCopy()
 	meta.SetStatusCondition(&replacement.Status.Validations, validationCondition)
 
-	serviceProviderClustersCosmosClient := c.resourcesDBClient.ServiceProviderClusters(key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
-	_, err = serviceProviderClustersCosmosClient.Replace(ctx, replacement, nil)
-	if database.IsPreconditionFailedError(err) {
-		// if we have a conflict error, then we're guaranteed that our informer will eventually see an update and trigger us again.
-		return nil
-	}
-	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to replace ServiceProviderCluster: %w", err))
+	if !equality.Semantic.DeepEqual(existingServiceProviderCluster, replacement) {
+		serviceProviderClustersCosmosClient := c.resourcesDBClient.ServiceProviderClusters(key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+		_, err = serviceProviderClustersCosmosClient.Replace(ctx, replacement, nil)
+		if database.IsPreconditionFailedError(err) {
+			return nil
+		}
+		if err != nil {
+			return utils.TrackError(fmt.Errorf("failed to replace ServiceProviderCluster: %w", err))
+		}
 	}
 
-	return validationErr
+	c.handleRequeue(key, result)
+	return nil
+}
+
+func (c *clusterValidationSyncer) handleRequeue(key controllerutils.HCPClusterKey, result *validations.ValidationResult) {
+	if result.EarliestRetryAfter != nil {
+		c.retryCooldownChecker.SetCooldown(key, *result.EarliestRetryAfter)
+	}
+
+	if result.Outcome == validations.OutcomeTypePassed {
+		return
+	}
+
+	retryAfter := *result.EarliestRetryAfter + time.Second
+	c.enqueueAfter.EnqueueAfter(key, retryAfter)
+}
+
+func (c *clusterValidationSyncer) incrementUnknownCount(key controllerutils.HCPClusterKey) int {
+	count := 1
+	if existing, ok := c.consecutiveUnknownCounts.Get(key); ok {
+		count = existing.(int) + 1
+	}
+	c.consecutiveUnknownCounts.Add(key, count)
+	return count
+}
+
+func (c *clusterValidationSyncer) resetUnknownCount(key controllerutils.HCPClusterKey) {
+	c.consecutiveUnknownCounts.Remove(key)
 }
 
 // shouldProcess returns true when the condition associated to the validation does not exist or when it exists but

--- a/backend/pkg/controllers/validationcontrollers/nodepool_validation_controller.go
+++ b/backend/pkg/controllers/validationcontrollers/nodepool_validation_controller.go
@@ -19,8 +19,10 @@ import (
 	"fmt"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/lru"
 
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/validationcontrollers/validations"
@@ -36,8 +38,11 @@ import (
 // nodePoolValidationSyncer is a NodePool syncer that performs a NodePool
 // validation.
 type nodePoolValidationSyncer struct {
-	cooldownChecker   controllerutil.CooldownChecker
-	resourcesDBClient database.ResourcesDBClient
+	cooldownChecker          controllerutil.CooldownChecker
+	retryCooldownChecker     *controllerutil.SettableCooldownChecker
+	enqueueAfter             controllerutils.AfterEnqueuer
+	resourcesDBClient        database.ResourcesDBClient
+	consecutiveUnknownCounts *lru.Cache
 
 	// validation is the validation to perform on the node pool.
 	validation validations.NodePoolValidation
@@ -56,9 +61,11 @@ func NewNodePoolValidationController(
 ) controllerutils.Controller {
 
 	syncer := &nodePoolValidationSyncer{
-		cooldownChecker:   controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
-		resourcesDBClient: resourcesDBClient,
-		validation:        validation,
+		cooldownChecker:          controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
+		retryCooldownChecker:     controllerutil.NewSettableCooldownChecker(),
+		resourcesDBClient:        resourcesDBClient,
+		consecutiveUnknownCounts: lru.New(1000000),
+		validation:               validation,
 	}
 
 	controller := controllerutils.NewNodePoolWatchingController(
@@ -69,6 +76,12 @@ func NewNodePoolValidationController(
 		1*time.Minute,
 		syncer,
 	)
+
+	if enqueuer, ok := controller.(controllerutils.AfterEnqueuer); ok {
+		syncer.enqueueAfter = enqueuer
+	} else {
+		panic("ClusterValidationController must implement AfterEnqueuer")
+	}
 
 	return controller
 }
@@ -101,46 +114,97 @@ func (c *nodePoolValidationSyncer) SyncOnce(ctx context.Context, key controlleru
 		return utils.TrackError(fmt.Errorf("failed to get or create ServiceProviderNodePool: %w", err))
 	}
 
-	shouldProcess := c.shouldProcess(existingServiceProviderNodePool)
-	if !shouldProcess {
-		return nil // no work to do
+	if !c.shouldProcess(existingServiceProviderNodePool) {
+		return nil
+	}
+	if !c.retryCooldownChecker.CanSync(ctx, key) {
+		c.enqueueAfter.EnqueueAfter(key, c.retryCooldownChecker.TimeUntilReady(key)+time.Second)
+		return nil
 	}
 	subscription, err := c.resourcesDBClient.Subscriptions().Get(ctx, existingNodePool.ID.SubscriptionID)
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to get Subscription: %w", err))
 	}
 
-	// We store the validation error in a separate variable and we use that as the
-	// error to return to the caller. This allows us to perform other remaining
-	// tasks in the syncer even if the validation fails, and we ultimately
-	// drive the behavior of its controller through the outcome of the validation.
-	validationErr := c.validation.Validate(ctx, existingCluster, subscription, existingNodePool)
+	result := c.validation.Validate(ctx, existingCluster, subscription, existingNodePool)
+	result = validations.DefaultResult(result)
 
-	validationCondition := metav1.Condition{
-		Type: c.validation.Name(),
+	logger := utils.LoggerFromContext(ctx)
+	validationCondition := validations.BuildCondition(c.validation.Name(), result)
+	switch result.Outcome {
+	case validations.OutcomeTypeUnknown:
+		count := c.incrementUnknownCount(key)
+		if existingCondition := meta.FindStatusCondition(existingServiceProviderNodePool.Status.Validations, c.validation.Name()); existingCondition != nil && existingCondition.Status != metav1.ConditionUnknown && count <= maxConsecutiveUnknownsBeforeWrite {
+			logger.Info("Validation returned Unknown but previous condition exists, so preserving previous state for a few attempts",
+				"previousStatus", existingCondition.Status,
+				"previousReason", existingCondition.Reason,
+				"unknownReason", validationCondition.Reason,
+				"unknownMessage", validationCondition.Message,
+				"serviceProviderMessage", result.Unknown.ServiceProviderMessage,
+				"consecutiveUnknownCount", count,
+			)
+			c.handleRequeue(key, result)
+			return nil
+		}
+		logger.Info("Writing unknown state",
+			"reason", validationCondition.Reason,
+			"serviceProviderMessage", result.Unknown.ServiceProviderMessage,
+			"consecutiveUnknownCount", count,
+		)
+	case validations.OutcomeTypeFailed:
+		logger.Info("Writing failed state",
+			"reason", result.Failed.Reason,
+			"userMessage", result.Failed.UserMessage,
+			"serviceProviderMessage", result.Failed.ServiceProviderMessage,
+		)
+	case validations.OutcomeTypePassed:
+		logger.Info("Writing passed state")
 	}
-	if validationErr != nil {
-		validationCondition.Status = metav1.ConditionFalse
-		validationCondition.Reason = "Failed"
-		validationCondition.Message = fmt.Sprintf("Validation failed: %s", validationErr.Error())
-	} else {
-		validationCondition.Status = metav1.ConditionTrue
-		validationCondition.Reason = "Succeeded"
-		validationCondition.Message = "Validation succeeded"
-	}
-	meta.SetStatusCondition(&existingServiceProviderNodePool.Status.Validations, validationCondition)
+	// if we get here, we're going to overwrite the previous status
+	c.resetUnknownCount(key)
 
-	serviceProviderNodePoolsCosmosClient := c.resourcesDBClient.ServiceProviderNodePools(key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
-	_, err = serviceProviderNodePoolsCosmosClient.Replace(ctx, existingServiceProviderNodePool, nil)
-	if database.IsPreconditionFailedError(err) {
-		// if we have a conflict error, then we're guaranteed that our informer will eventually see an update and trigger us again.
-		return nil
-	}
-	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to replace ServiceProviderNodePool: %w", err))
+	replacement := existingServiceProviderNodePool.DeepCopy()
+	meta.SetStatusCondition(&replacement.Status.Validations, validationCondition)
+
+	if !equality.Semantic.DeepEqual(existingServiceProviderNodePool, replacement) {
+		serviceProviderNodePoolsCosmosClient := c.resourcesDBClient.ServiceProviderNodePools(key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
+		_, err = serviceProviderNodePoolsCosmosClient.Replace(ctx, replacement, nil)
+		if database.IsPreconditionFailedError(err) {
+			return nil
+		}
+		if err != nil {
+			return utils.TrackError(fmt.Errorf("failed to replace ServiceProviderNodePool: %w", err))
+		}
 	}
 
-	return validationErr
+	c.handleRequeue(key, result)
+	return nil
+}
+
+func (c *nodePoolValidationSyncer) handleRequeue(key controllerutils.HCPNodePoolKey, result *validations.ValidationResult) {
+	if result.EarliestRetryAfter != nil {
+		c.retryCooldownChecker.SetCooldown(key, *result.EarliestRetryAfter)
+	}
+
+	if result.Outcome == validations.OutcomeTypePassed {
+		return
+	}
+
+	retryAfter := *result.EarliestRetryAfter + time.Second
+	c.enqueueAfter.EnqueueAfter(key, retryAfter)
+}
+
+func (c *nodePoolValidationSyncer) incrementUnknownCount(key controllerutils.HCPNodePoolKey) int {
+	count := 1
+	if existing, ok := c.consecutiveUnknownCounts.Get(key); ok {
+		count = existing.(int) + 1
+	}
+	c.consecutiveUnknownCounts.Add(key, count)
+	return count
+}
+
+func (c *nodePoolValidationSyncer) resetUnknownCount(key controllerutils.HCPNodePoolKey) {
+	c.consecutiveUnknownCounts.Remove(key)
 }
 
 // shouldProcess returns true when the condition associated to the validation does not exist or when it exists but

--- a/backend/pkg/controllers/validationcontrollers/nodepool_validation_controller_test.go
+++ b/backend/pkg/controllers/validationcontrollers/nodepool_validation_controller_test.go
@@ -16,9 +16,9 @@ package validationcontrollers
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr/testr"
 	"github.com/stretchr/testify/assert"
@@ -26,6 +26,8 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/lru"
+	"k8s.io/utils/ptr"
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
@@ -113,6 +115,20 @@ func newTestSubscription() *arm.Subscription {
 	}
 }
 
+// mockNodePoolValidation implements validations.NodePoolValidation for tests.
+type mockNodePoolValidation struct {
+	name   string
+	result *validations.ValidationResult
+}
+
+var _ validations.NodePoolValidation = (*mockNodePoolValidation)(nil)
+
+func (m *mockNodePoolValidation) Name() string { return m.name }
+
+func (m *mockNodePoolValidation) Validate(_ context.Context, _ *api.HCPOpenShiftCluster, _ *arm.Subscription, _ *api.HCPOpenShiftClusterNodePool) *validations.ValidationResult {
+	return m.result
+}
+
 // alwaysSyncCooldownChecker always allows syncing.
 type alwaysSyncCooldownChecker struct{}
 
@@ -120,18 +136,18 @@ func (a *alwaysSyncCooldownChecker) CanSync(_ context.Context, _ any) bool { ret
 
 var _ controllerutil.CooldownChecker = (*alwaysSyncCooldownChecker)(nil)
 
-// mockNodePoolValidation implements validations.NodePoolValidation for tests.
-type mockNodePoolValidation struct {
-	name        string
-	validateErr error
+// mockAfterEnqueuer records EnqueueAfter calls.
+type mockAfterEnqueuer struct {
+	calls []enqueueAfterCall
 }
 
-var _ validations.NodePoolValidation = (*mockNodePoolValidation)(nil)
+type enqueueAfterCall struct {
+	key      any
+	duration time.Duration
+}
 
-func (m *mockNodePoolValidation) Name() string { return m.name }
-
-func (m *mockNodePoolValidation) Validate(_ context.Context, _ *api.HCPOpenShiftCluster, _ *arm.Subscription, _ *api.HCPOpenShiftClusterNodePool) error {
-	return m.validateErr
+func (m *mockAfterEnqueuer) EnqueueAfter(keyObj any, duration time.Duration) {
+	m.calls = append(m.calls, enqueueAfterCall{key: keyObj, duration: duration})
 }
 
 func TestNodePoolValidationSyncer_SyncOnce(t *testing.T) {
@@ -150,8 +166,9 @@ func TestNodePoolValidationSyncer_SyncOnce(t *testing.T) {
 		name                string
 		setupDB             func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient)
 		validation          *mockNodePoolValidation
-		wantErr             bool
+		wantEnqueueCount    int
 		wantConditionStatus *metav1.ConditionStatus
+		wantConditionReason string
 	}{
 		{
 			name: "cluster not found -- no-op",
@@ -179,19 +196,61 @@ func TestNodePoolValidationSyncer_SyncOnce(t *testing.T) {
 			name:    "validation succeeds -- condition set to True",
 			setupDB: defaultSetupDB,
 			validation: &mockNodePoolValidation{
-				name: testValidationName,
+				name:   testValidationName,
+				result: &validations.ValidationResult{Outcome: validations.OutcomeTypePassed},
 			},
 			wantConditionStatus: api.Ptr(metav1.ConditionTrue),
+			wantConditionReason: "AsExpected",
 		},
 		{
-			name:    "validation fails -- condition set to False and error returned",
+			name:    "validation fails -- condition set to False and enqueued for retry",
 			setupDB: defaultSetupDB,
 			validation: &mockNodePoolValidation{
-				name:        testValidationName,
-				validateErr: fmt.Errorf("quota exceeded"),
+				name: testValidationName,
+				result: &validations.ValidationResult{
+					Outcome: validations.OutcomeTypeFailed,
+					Failed: &validations.FailedResult{
+						Reason:                 "QuotaExceeded",
+						ServiceProviderMessage: "quota exceeded",
+						UserMessage:            "Quota exceeded.",
+					},
+					EarliestRetryAfter: ptr.To(60 * time.Second),
+				},
 			},
-			wantErr:             true,
+			wantEnqueueCount:    1,
 			wantConditionStatus: api.Ptr(metav1.ConditionFalse),
+			wantConditionReason: "QuotaExceeded",
+		},
+		{
+			name:    "nil validation result -- treated as Unknown and enqueued for retry",
+			setupDB: defaultSetupDB,
+			validation: &mockNodePoolValidation{
+				name:   testValidationName,
+				result: nil,
+			},
+			wantEnqueueCount:    1,
+			wantConditionStatus: api.Ptr(metav1.ConditionUnknown),
+			wantConditionReason: "NilResult",
+		},
+		{
+			name:    "unknown with LogOnly -- condition set to Unknown, enqueued for retry",
+			setupDB: defaultSetupDB,
+			validation: &mockNodePoolValidation{
+				name: testValidationName,
+				result: &validations.ValidationResult{
+					Outcome: validations.OutcomeTypeUnknown,
+					Unknown: &validations.UnknownResult{
+						Reason:                 "Transient",
+						ServiceProviderMessage: "transient issue",
+						UserMessage:            "Validation status is unknown.",
+						ReportingPolicy:        validations.ReportingPolicyTypeLogOnly,
+					},
+					EarliestRetryAfter: ptr.To(60 * time.Second),
+				},
+			},
+			wantEnqueueCount:    1,
+			wantConditionStatus: api.Ptr(metav1.ConditionUnknown),
+			wantConditionReason: "Transient",
 		},
 		{
 			name: "already-succeeded validation -- skipped",
@@ -223,8 +282,15 @@ func TestNodePoolValidationSyncer_SyncOnce(t *testing.T) {
 				require.NoError(t, err)
 			},
 			validation: &mockNodePoolValidation{
-				name:        testValidationName,
-				validateErr: fmt.Errorf("should not be called"),
+				name: testValidationName,
+				result: &validations.ValidationResult{
+					Outcome: validations.OutcomeTypeFailed,
+					Failed: &validations.FailedResult{
+						Reason:                 "ShouldNotBeCalled",
+						ServiceProviderMessage: "should not be called",
+						UserMessage:            "should not be called",
+					},
+				},
 			},
 		},
 	}
@@ -238,18 +304,20 @@ func TestNodePoolValidationSyncer_SyncOnce(t *testing.T) {
 				tc.setupDB(t, ctx, mockDB)
 			}
 
+			mockEnqueuer := &mockAfterEnqueuer{}
 			syncer := &nodePoolValidationSyncer{
-				cooldownChecker:   &alwaysSyncCooldownChecker{},
-				resourcesDBClient: mockDB,
-				validation:        tc.validation,
+				cooldownChecker:          &alwaysSyncCooldownChecker{},
+				retryCooldownChecker:     controllerutil.NewSettableCooldownChecker(),
+				enqueueAfter:             mockEnqueuer,
+				resourcesDBClient:        mockDB,
+				consecutiveUnknownCounts: lru.New(100),
+				validation:               tc.validation,
 			}
 
 			err := syncer.SyncOnce(ctx, newTestNodePoolKey())
-			if tc.wantErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
+			require.NoError(t, err)
+
+			assert.Len(t, mockEnqueuer.calls, tc.wantEnqueueCount)
 
 			if tc.wantConditionStatus != nil {
 				spnp, spnpErr := mockDB.ServiceProviderNodePools(
@@ -261,13 +329,165 @@ func TestNodePoolValidationSyncer_SyncOnce(t *testing.T) {
 				require.NotNil(t, cond, "expected validation condition to be set")
 				assert.Equal(t, *tc.wantConditionStatus, cond.Status)
 
-				if tc.validation.validateErr != nil {
-					assert.Equal(t, "Failed", cond.Reason)
-					assert.Contains(t, cond.Message, tc.validation.validateErr.Error())
-				} else {
-					assert.Equal(t, "Succeeded", cond.Reason)
+				if tc.wantConditionReason != "" {
+					assert.Equal(t, tc.wantConditionReason, cond.Reason)
 				}
 			}
 		})
 	}
+}
+
+func TestNodePoolValidationSyncer_EnqueueAfterTiming(t *testing.T) {
+	ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+
+	mockDB := databasetesting.NewMockResourcesDBClient()
+	_, err := mockDB.HCPClusters(testSubscriptionID, testResourceGroup).Create(ctx, newTestCluster(t), nil)
+	require.NoError(t, err)
+	_, err = mockDB.HCPClusters(testSubscriptionID, testResourceGroup).NodePools(testClusterName).Create(ctx, newTestNodePool(t), nil)
+	require.NoError(t, err)
+	_, err = mockDB.Subscriptions().Create(ctx, newTestSubscription(), nil)
+	require.NoError(t, err)
+
+	mockEnqueuer := &mockAfterEnqueuer{}
+	syncer := &nodePoolValidationSyncer{
+		cooldownChecker:          &alwaysSyncCooldownChecker{},
+		retryCooldownChecker:     controllerutil.NewSettableCooldownChecker(),
+		enqueueAfter:             mockEnqueuer,
+		resourcesDBClient:        mockDB,
+		consecutiveUnknownCounts: lru.New(100),
+		validation: &mockNodePoolValidation{
+			name: testValidationName,
+			result: &validations.ValidationResult{
+				Outcome: validations.OutcomeTypeFailed,
+				Failed: &validations.FailedResult{
+					Reason:                 "QuotaExceeded",
+					ServiceProviderMessage: "quota exceeded",
+					UserMessage:            "Quota exceeded.",
+				},
+				EarliestRetryAfter: ptr.To(120 * time.Second),
+			},
+		},
+	}
+
+	err = syncer.SyncOnce(ctx, newTestNodePoolKey())
+	require.NoError(t, err)
+	require.Len(t, mockEnqueuer.calls, 1)
+	assert.Equal(t, 121*time.Second, mockEnqueuer.calls[0].duration)
+}
+
+func TestClusterValidationSyncer_SyncOnce(t *testing.T) {
+	newTestClusterKey := func() controllerutils.HCPClusterKey {
+		return controllerutils.HCPClusterKey{
+			SubscriptionID:    testSubscriptionID,
+			ResourceGroupName: testResourceGroup,
+			HCPClusterName:    testClusterName,
+		}
+	}
+
+	defaultSetupDB := func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
+		t.Helper()
+		_, err := mockDB.HCPClusters(testSubscriptionID, testResourceGroup).Create(ctx, newTestCluster(t), nil)
+		require.NoError(t, err)
+		_, err = mockDB.Subscriptions().Create(ctx, newTestSubscription(), nil)
+		require.NoError(t, err)
+	}
+
+	testCases := []struct {
+		name                string
+		setupDB             func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient)
+		result              *validations.ValidationResult
+		wantEnqueueCount    int
+		wantConditionStatus *metav1.ConditionStatus
+		wantConditionReason string
+	}{
+		{
+			name: "cluster not found -- no-op",
+			setupDB: func(t *testing.T, ctx context.Context, mockDB *databasetesting.MockResourcesDBClient) {
+				t.Helper()
+				_, err := mockDB.Subscriptions().Create(ctx, newTestSubscription(), nil)
+				require.NoError(t, err)
+			},
+		},
+		{
+			name:                "validation succeeds -- condition set to True",
+			setupDB:             defaultSetupDB,
+			result:              &validations.ValidationResult{Outcome: validations.OutcomeTypePassed},
+			wantConditionStatus: api.Ptr(metav1.ConditionTrue),
+			wantConditionReason: "AsExpected",
+		},
+		{
+			name:    "validation fails -- condition set to False, enqueued for retry",
+			setupDB: defaultSetupDB,
+			result: &validations.ValidationResult{
+				Outcome: validations.OutcomeTypeFailed,
+				Failed: &validations.FailedResult{
+					Reason:                 "QuotaExceeded",
+					ServiceProviderMessage: "quota exceeded",
+					UserMessage:            "Quota exceeded.",
+				},
+				EarliestRetryAfter: ptr.To(60 * time.Second),
+			},
+			wantEnqueueCount:    1,
+			wantConditionStatus: api.Ptr(metav1.ConditionFalse),
+			wantConditionReason: "QuotaExceeded",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+
+			mockDB := databasetesting.NewMockResourcesDBClient()
+			if tc.setupDB != nil {
+				tc.setupDB(t, ctx, mockDB)
+			}
+
+			mockEnqueuer := &mockAfterEnqueuer{}
+			syncer := &clusterValidationSyncer{
+				cooldownChecker:          &alwaysSyncCooldownChecker{},
+				retryCooldownChecker:     controllerutil.NewSettableCooldownChecker(),
+				enqueueAfter:             mockEnqueuer,
+				resourcesDBClient:        mockDB,
+				consecutiveUnknownCounts: lru.New(100),
+				validation: &mockClusterValidation{
+					name:   testValidationName,
+					result: tc.result,
+				},
+			}
+
+			err := syncer.SyncOnce(ctx, newTestClusterKey())
+			require.NoError(t, err)
+
+			assert.Len(t, mockEnqueuer.calls, tc.wantEnqueueCount)
+
+			if tc.wantConditionStatus != nil {
+				spc, spcErr := mockDB.ServiceProviderClusters(
+					testSubscriptionID, testResourceGroup, testClusterName,
+				).Get(ctx, "default")
+				require.NoError(t, spcErr)
+
+				cond := meta.FindStatusCondition(spc.Status.Validations, testValidationName)
+				require.NotNil(t, cond, "expected validation condition to be set")
+				assert.Equal(t, *tc.wantConditionStatus, cond.Status)
+
+				if tc.wantConditionReason != "" {
+					assert.Equal(t, tc.wantConditionReason, cond.Reason)
+				}
+			}
+		})
+	}
+}
+
+// mockClusterValidation implements validations.ClusterValidation for tests.
+type mockClusterValidation struct {
+	name   string
+	result *validations.ValidationResult
+}
+
+var _ validations.ClusterValidation = (*mockClusterValidation)(nil)
+
+func (m *mockClusterValidation) Name() string { return m.name }
+
+func (m *mockClusterValidation) Validate(_ context.Context, _ *arm.Subscription, _ *api.HCPOpenShiftCluster) *validations.ValidationResult {
+	return m.result
 }

--- a/backend/pkg/controllers/validationcontrollers/validations/always_success_validation.go
+++ b/backend/pkg/controllers/validationcontrollers/validations/always_success_validation.go
@@ -21,8 +21,7 @@ import (
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 )
 
-// AlwaysSuccessValidation is a validation that always succeeds. This is,
-// it returns no error.
+// AlwaysSuccessValidation is a validation that always succeeds.
 type AlwaysSuccessValidation struct {
 }
 
@@ -30,8 +29,8 @@ func (v *AlwaysSuccessValidation) Name() string {
 	return "AlwaysSuccessValidation"
 }
 
-func (v *AlwaysSuccessValidation) Validate(ctx context.Context, clusterSubscription *arm.Subscription, cluster *api.HCPOpenShiftCluster) error {
-	return nil
+func (v *AlwaysSuccessValidation) Validate(ctx context.Context, clusterSubscription *arm.Subscription, cluster *api.HCPOpenShiftCluster) *ValidationResult {
+	return &ValidationResult{Outcome: OutcomeTypePassed}
 }
 
 func NewAlwaysSuccessValidation() ClusterValidation {

--- a/backend/pkg/controllers/validationcontrollers/validations/azure_cluster_mis_existence_validation.go
+++ b/backend/pkg/controllers/validationcontrollers/validations/azure_cluster_mis_existence_validation.go
@@ -18,13 +18,15 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
+
+	"k8s.io/utils/ptr"
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
 	azureclient "github.com/Azure/ARO-HCP/backend/pkg/azure/client"
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
-	"github.com/Azure/ARO-HCP/internal/utils"
 )
 
 // AzureClusterManagedIdentitiesExistenceValidation validates the existence of all managed identities defined in the cluster.
@@ -45,7 +47,7 @@ func (v *AzureClusterManagedIdentitiesExistenceValidation) Name() string {
 	return "AzureClusterManagedIdentitiesExistenceValidation"
 }
 
-func (v *AzureClusterManagedIdentitiesExistenceValidation) Validate(ctx context.Context, clusterSubscription *arm.Subscription, cluster *api.HCPOpenShiftCluster) error {
+func (v *AzureClusterManagedIdentitiesExistenceValidation) Validate(ctx context.Context, clusterSubscription *arm.Subscription, cluster *api.HCPOpenShiftCluster) *ValidationResult {
 	smiResourceID := cluster.CustomerProperties.Platform.OperatorsAuthentication.UserAssignedIdentities.ServiceManagedIdentity
 	clusterIdentityURL := cluster.ServiceProviderProperties.ManagedIdentitiesDataPlaneIdentityURL
 	// We check the existence of the Cluster's Service Managed Identity by
@@ -55,7 +57,16 @@ func (v *AzureClusterManagedIdentitiesExistenceValidation) Validate(ctx context.
 	// service managed identity does not exist the request will fail.
 	uaisClient, err := v.smiClientBuilder.UserAssignedIdentitiesClient(ctx, clusterIdentityURL, smiResourceID, cluster.ID.SubscriptionID)
 	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to get user assigned identities client: %w", err))
+		return &ValidationResult{
+			Outcome: OutcomeTypeUnknown,
+			Unknown: &UnknownResult{
+				Reason:                 "ClientError",
+				ServiceProviderMessage: fmt.Sprintf("failed to get user assigned identities client: %s", err),
+				UserMessage:            "Failed to check managed identity existence.",
+				ReportingPolicy:        ReportingPolicyTypeError,
+			},
+			EarliestRetryAfter: ptr.To(60 * time.Second),
+		}
 	}
 
 	clusterUAIsProfile := &cluster.CustomerProperties.Platform.OperatorsAuthentication.UserAssignedIdentities
@@ -66,18 +77,35 @@ func (v *AzureClusterManagedIdentitiesExistenceValidation) Validate(ctx context.
 		_, err := uaisClient.Get(ctx, resourceID.ResourceGroupName, resourceID.Name, nil)
 		if azureclient.IsResourceNotFoundErr(err) {
 			notFoundMIsStrs = append(notFoundMIsStrs, resourceID.String())
+			continue
 		}
 		if err != nil {
-			// TODO is it ok to error when one of them fails to get when the error is not a resource not found error?
-			return utils.TrackError(fmt.Errorf("failed to get managed identity '%s': %w", resourceID, err))
+			return &ValidationResult{
+				Outcome: OutcomeTypeUnknown,
+				Unknown: &UnknownResult{
+					Reason:                 "APIError",
+					ServiceProviderMessage: fmt.Sprintf("failed to get managed identity %q: %s", resourceID, err),
+					UserMessage:            "Failed to check managed identity existence.",
+					ReportingPolicy:        ReportingPolicyTypeError,
+				},
+				EarliestRetryAfter: ptr.To(60 * time.Second),
+			}
 		}
 	}
 
 	if len(notFoundMIsStrs) > 0 {
-		return utils.TrackError(fmt.Errorf("managed identities not found: %s", strings.Join(notFoundMIsStrs, ", ")))
+		return &ValidationResult{
+			Outcome: OutcomeTypeFailed,
+			Failed: &FailedResult{
+				Reason:                 "ManagedIdentitiesNotFound",
+				ServiceProviderMessage: fmt.Sprintf("managed identities not found: %s", strings.Join(notFoundMIsStrs, ", ")),
+				UserMessage:            fmt.Sprintf("The following managed identities were not found: %s", strings.Join(notFoundMIsStrs, ", ")),
+			},
+			EarliestRetryAfter: ptr.To(60 * time.Second),
+		}
 	}
 
-	return nil
+	return &ValidationResult{Outcome: OutcomeTypePassed}
 }
 
 // clusterOperatorsManagedIdentities returns a list of the control and data plane identities defined in the cluster.

--- a/backend/pkg/controllers/validationcontrollers/validations/azure_cluster_resource_group_existence_validation.go
+++ b/backend/pkg/controllers/validationcontrollers/validations/azure_cluster_resource_group_existence_validation.go
@@ -17,11 +17,13 @@ package validations
 import (
 	"context"
 	"fmt"
+	"time"
+
+	"k8s.io/utils/ptr"
 
 	azureclient "github.com/Azure/ARO-HCP/backend/pkg/azure/client"
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
-	"github.com/Azure/ARO-HCP/internal/utils"
 )
 
 // AzureClusterResourceGroupExistenceValidation validates that the Azure Resource
@@ -44,22 +46,48 @@ func (a *AzureClusterResourceGroupExistenceValidation) Name() string {
 
 func (a *AzureClusterResourceGroupExistenceValidation) Validate(
 	ctx context.Context, clusterSubscription *arm.Subscription, cluster *api.HCPOpenShiftCluster,
-) error {
+) *ValidationResult {
 	rgClient, err := a.azureFPAClientBuilder.ResourceGroupsClient(
 		*clusterSubscription.Properties.TenantId,
 		cluster.ID.SubscriptionID,
 	)
 	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to get resource groups client: %w", err))
+		return &ValidationResult{
+			Outcome: OutcomeTypeUnknown,
+			Unknown: &UnknownResult{
+				Reason:                 "ClientError",
+				ServiceProviderMessage: fmt.Sprintf("failed to get resource groups client: %s", err),
+				UserMessage:            "Failed to check resource group existence.",
+				ReportingPolicy:        ReportingPolicyTypeError,
+			},
+			EarliestRetryAfter: ptr.To(60 * time.Second),
+		}
 	}
 
 	_, err = rgClient.Get(ctx, cluster.ID.ResourceGroupName, nil)
 	if azureclient.IsResourceGroupNotFoundErr(err) {
-		return utils.TrackError(fmt.Errorf("resource group does not exist: %w", err))
+		return &ValidationResult{
+			Outcome: OutcomeTypeFailed,
+			Failed: &FailedResult{
+				Reason:                 "ResourceGroupNotFound",
+				ServiceProviderMessage: fmt.Sprintf("resource group %q does not exist: %s", cluster.ID.ResourceGroupName, err),
+				UserMessage:            fmt.Sprintf("Resource group %q does not exist.", cluster.ID.ResourceGroupName),
+			},
+			EarliestRetryAfter: ptr.To(60 * time.Second),
+		}
 	}
 	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to get resource group: %w", err))
+		return &ValidationResult{
+			Outcome: OutcomeTypeUnknown,
+			Unknown: &UnknownResult{
+				Reason:                 "APIError",
+				ServiceProviderMessage: fmt.Sprintf("failed to get resource group: %s", err),
+				UserMessage:            "Failed to check resource group existence.",
+				ReportingPolicy:        ReportingPolicyTypeError,
+			},
+			EarliestRetryAfter: ptr.To(60 * time.Second),
+		}
 	}
 
-	return nil
+	return &ValidationResult{Outcome: OutcomeTypePassed}
 }

--- a/backend/pkg/controllers/validationcontrollers/validations/azure_rp_registration_validation.go
+++ b/backend/pkg/controllers/validationcontrollers/validations/azure_rp_registration_validation.go
@@ -18,11 +18,13 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
+
+	"k8s.io/utils/ptr"
 
 	azureclient "github.com/Azure/ARO-HCP/backend/pkg/azure/client"
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
-	"github.com/Azure/ARO-HCP/internal/utils"
 )
 
 // The RpRegistrationValidation struct validates the states of several
@@ -45,7 +47,7 @@ func (v *AzureResourceProvidersRegistrationValidation) Name() string {
 
 func (v *AzureResourceProvidersRegistrationValidation) Validate(
 	ctx context.Context, clusterSubscription *arm.Subscription, cluster *api.HCPOpenShiftCluster,
-) error {
+) *ValidationResult {
 	resourceProvidersToCheck := []string{
 		"Microsoft.Authorization",
 		"Microsoft.Compute",
@@ -53,20 +55,37 @@ func (v *AzureResourceProvidersRegistrationValidation) Validate(
 		"Microsoft.Storage",
 	}
 
-	missingResourcesProviders := []string{}
-
 	rpClient, err := v.azureFPAClientBuilder.ResourceProvidersClient(
 		*clusterSubscription.Properties.TenantId,
 		cluster.ID.SubscriptionID,
 	)
 	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to get resource providers client: %w", err))
+		return &ValidationResult{
+			Outcome: OutcomeTypeUnknown,
+			Unknown: &UnknownResult{
+				Reason:                 "ClientError",
+				ServiceProviderMessage: fmt.Sprintf("failed to get resource providers client: %s", err),
+				UserMessage:            "Failed to check resource provider registration status.",
+				ReportingPolicy:        ReportingPolicyTypeError,
+			},
+			EarliestRetryAfter: ptr.To(60 * time.Second),
+		}
 	}
 
+	var missingResourcesProviders []string
 	for _, rp := range resourceProvidersToCheck {
 		providerResp, err := rpClient.Get(ctx, rp, nil)
 		if err != nil {
-			return err
+			return &ValidationResult{
+				Outcome: OutcomeTypeUnknown,
+				Unknown: &UnknownResult{
+					Reason:                 "APIError",
+					ServiceProviderMessage: fmt.Sprintf("failed to get resource provider %s: %s", rp, err),
+					UserMessage:            "Failed to check resource provider registration status.",
+					ReportingPolicy:        ReportingPolicyTypeError,
+				},
+				EarliestRetryAfter: ptr.To(60 * time.Second),
+			}
 		}
 		if providerResp.RegistrationState == nil ||
 			*providerResp.RegistrationState != "Registered" {
@@ -75,9 +94,16 @@ func (v *AzureResourceProvidersRegistrationValidation) Validate(
 	}
 
 	if len(missingResourcesProviders) > 0 {
-		return utils.TrackError(fmt.Errorf("%v of the resource providers are not registered, or their state is empty: %s",
-			len(missingResourcesProviders), strings.Join(missingResourcesProviders, ", ")))
+		return &ValidationResult{
+			Outcome: OutcomeTypeFailed,
+			Failed: &FailedResult{
+				Reason:                 "ResourceProvidersNotRegistered",
+				ServiceProviderMessage: fmt.Sprintf("%d resource providers not registered: %s", len(missingResourcesProviders), strings.Join(missingResourcesProviders, ", ")),
+				UserMessage:            fmt.Sprintf("The following Azure resource providers must be registered in the subscription: %s", strings.Join(missingResourcesProviders, ", ")),
+			},
+			EarliestRetryAfter: ptr.To(60 * time.Second),
+		}
 	}
 
-	return nil
+	return &ValidationResult{Outcome: OutcomeTypePassed}
 }

--- a/backend/pkg/controllers/validationcontrollers/validations/cluster_validation.go
+++ b/backend/pkg/controllers/validationcontrollers/validations/cluster_validation.go
@@ -18,6 +18,9 @@ import (
 	"context"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 )
@@ -49,11 +52,11 @@ type OutcomeType string
 
 var (
 	// OutcomeTypePassed becomes a .status.validation.status = True, .reason=AsExpected, .message=As expected.
-	OutcomeTypePassed = "Passed"
+	OutcomeTypePassed OutcomeType = "Passed"
 	// OutcomeTypeFailed becomes a .status.validation.status=False, .reason= validationResult.Failed.Reason, .message=validationResult.Failed.UserMessage
-	OutcomeTypeFailed = "Failed"
-	// OutcomeTypeFailed becomes a .status.validation.status=Unknown, .reason= validationResult.Unknown.Reason, .message=validationResult.Unknown.UserMessage
-	OutcomeTypeUnknown = "Unknown"
+	OutcomeTypeFailed OutcomeType = "Failed"
+	// OutcomeTypeUnknown becomes a .status.validation.status=Unknown, .reason= validationResult.Unknown.Reason, .message=validationResult.Unknown.UserMessage
+	OutcomeTypeUnknown OutcomeType = "Unknown"
 )
 
 type FailedResult struct {
@@ -82,7 +85,63 @@ type ReportingPolicyType string
 var (
 
 	// ReportingPolicyTypeLogOnly means to return nil from the controller so it doesn't count in metrics.  Useful for certain types of failures.
-	ReportingPolicyTypeLogOnly = "LogOnly"
+	ReportingPolicyTypeLogOnly ReportingPolicyType = "LogOnly"
 	// ReportingPolicyTypeError will return an error for rapid retry, but the EarliestRetryAfter will prevent rapid retry and queue (without error) for a time after that.
-	ReportingPolicyTypeError = "ReportError"
+	ReportingPolicyTypeError ReportingPolicyType = "ReportError"
 )
+
+// DefaultResult returns a non-nil result with defaults applied. A nil input
+// is treated as Unknown with a 60s retry. A non-nil input with no
+// EarliestRetryAfter gets a 60s default.
+func DefaultResult(result *ValidationResult) *ValidationResult {
+	if result == nil {
+		return &ValidationResult{
+			Outcome: OutcomeTypeUnknown,
+			Unknown: &UnknownResult{
+				Reason:                 "NilResult",
+				ServiceProviderMessage: "Validation returned nil result.",
+				UserMessage:            "Validation status is unknown.",
+				ReportingPolicy:        ReportingPolicyTypeError,
+			},
+			EarliestRetryAfter: ptr.To(60 * time.Second),
+		}
+	}
+	if result.EarliestRetryAfter == nil {
+		result.EarliestRetryAfter = ptr.To(60 * time.Second)
+	}
+	return result
+}
+
+// BuildCondition converts a ValidationResult into a metav1.Condition with the
+// given condition type (typically the validation's Name()).
+func BuildCondition(conditionType string, result *ValidationResult) metav1.Condition {
+	switch result.Outcome {
+	case OutcomeTypePassed:
+		return metav1.Condition{
+			Type:    conditionType,
+			Status:  metav1.ConditionTrue,
+			Reason:  "AsExpected",
+			Message: "As expected.",
+		}
+	case OutcomeTypeFailed:
+		return metav1.Condition{
+			Type:    conditionType,
+			Status:  metav1.ConditionFalse,
+			Reason:  result.Failed.Reason,
+			Message: result.Failed.UserMessage,
+		}
+	default:
+		reason := "Unknown"
+		message := "Validation status is unknown."
+		if result.Unknown != nil {
+			reason = result.Unknown.Reason
+			message = result.Unknown.UserMessage
+		}
+		return metav1.Condition{
+			Type:    conditionType,
+			Status:  metav1.ConditionUnknown,
+			Reason:  reason,
+			Message: message,
+		}
+	}
+}

--- a/backend/pkg/controllers/validationcontrollers/validations/cluster_validation.go
+++ b/backend/pkg/controllers/validationcontrollers/validations/cluster_validation.go
@@ -16,6 +16,7 @@ package validations
 
 import (
 	"context"
+	"time"
 
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
@@ -25,6 +26,63 @@ import (
 type ClusterValidation interface {
 	// Name returns the name of the validation.
 	Name() string
-	// Validate validates the Cluster. It returns nil if the validation succeeds and an error otherwise.
-	Validate(ctx context.Context, clusterSubscription *arm.Subscription, cluster *api.HCPOpenShiftCluster) error
+	// Validate validates the Cluster.
+	// nil validation result is treated as a validation Unknown, Reason nil result, EarliestRetryAfter 60s
+	Validate(ctx context.Context, clusterSubscription *arm.Subscription, cluster *api.HCPOpenShiftCluster) *ValidationResult
 }
+
+type ValidationResult struct {
+	Outcome OutcomeType
+
+	Failed *FailedResult
+
+	Unknown *UnknownResult
+
+	// EarliestRetryAfter is the earliest time that a retry is allowed.  It is enforced.
+	// Recommended for all OutcomeTypes.
+	// For all Failed and Unknown, we will queue this plus one second
+	// For Pass, we will get it on the next resync
+	EarliestRetryAfter *time.Duration
+}
+
+type OutcomeType string
+
+var (
+	// OutcomeTypePassed becomes a .status.validation.status = True, .reason=AsExpected, .message=As expected.
+	OutcomeTypePassed = "Passed"
+	// OutcomeTypeFailed becomes a .status.validation.status=False, .reason= validationResult.Failed.Reason, .message=validationResult.Failed.UserMessage
+	OutcomeTypeFailed = "Failed"
+	// OutcomeTypeFailed becomes a .status.validation.status=Unknown, .reason= validationResult.Unknown.Reason, .message=validationResult.Unknown.UserMessage
+	OutcomeTypeUnknown = "Unknown"
+)
+
+type FailedResult struct {
+	// machine readable, must not be sensitive
+	Reason string
+	// human readable for serviceProvider
+	ServiceProviderMessage string
+	// human readable for user
+	UserMessage string
+}
+
+type UnknownResult struct {
+	// machine readable, must not be sensitive
+	Reason string
+	// human readable for serviceProvider
+	ServiceProviderMessage string
+	// human readable for user
+	UserMessage string
+
+	// ReportingPolicy indicates how the error should be treated.
+	ReportingPolicy ReportingPolicyType
+}
+
+type ReportingPolicyType string
+
+var (
+
+	// ReportingPolicyTypeLogOnly means to return nil from the controller so it doesn't count in metrics.  Useful for certain types of failures.
+	ReportingPolicyTypeLogOnly = "LogOnly"
+	// ReportingPolicyTypeError will return an error for rapid retry, but the EarliestRetryAfter will prevent rapid retry and queue (without error) for a time after that.
+	ReportingPolicyTypeError = "ReportError"
+)

--- a/backend/pkg/controllers/validationcontrollers/validations/nodepool_validation.go
+++ b/backend/pkg/controllers/validationcontrollers/validations/nodepool_validation.go
@@ -26,5 +26,5 @@ type NodePoolValidation interface {
 	// Name returns the name of the validation.
 	Name() string
 	// Validate validates the NodePool. It returns nil if the validation succeeds and an error otherwise.
-	Validate(ctx context.Context, cluster *api.HCPOpenShiftCluster, nodePoolSubscription *arm.Subscription, nodePool *api.HCPOpenShiftClusterNodePool) error
+	Validate(ctx context.Context, cluster *api.HCPOpenShiftCluster, nodePoolSubscription *arm.Subscription, nodePool *api.HCPOpenShiftClusterNodePool) *ValidationResult
 }

--- a/internal/controllerutils/cooldown.go
+++ b/internal/controllerutils/cooldown.go
@@ -88,3 +88,52 @@ func (c *TimeBasedCooldownChecker) CanSync(_ context.Context, key any) bool {
 	}
 	return false
 }
+
+// SettableCooldownChecker is a cooldown gate where the per-key cooldown
+// duration is set explicitly by the caller via SetCooldown, rather than
+// being fixed at construction time. A key with no cooldown set is always
+// allowed.
+type SettableCooldownChecker struct {
+	clock        utilsclock.PassiveClock
+	nextExecTime *lru.Cache
+}
+
+func NewSettableCooldownChecker() *SettableCooldownChecker {
+	return &SettableCooldownChecker{
+		clock:        utilsclock.RealClock{},
+		nextExecTime: lru.New(1000000),
+	}
+}
+
+func (c *SettableCooldownChecker) SetClock(clock utilsclock.PassiveClock) {
+	c.clock = clock
+}
+
+// SetCooldown records that the given key should not be re-synced until
+// now+duration has elapsed.
+func (c *SettableCooldownChecker) SetCooldown(key any, duration time.Duration) {
+	c.nextExecTime.Add(key, c.clock.Now().Add(duration))
+}
+
+func (c *SettableCooldownChecker) CanSync(_ context.Context, key any) bool {
+	now := c.clock.Now()
+	nextExecTime, ok := c.nextExecTime.Get(key)
+	if !ok {
+		return true
+	}
+	return now.After(nextExecTime.(time.Time))
+}
+
+// TimeUntilReady returns the duration until the key's cooldown expires.
+// Returns 0 if the key has no cooldown set or the cooldown has already expired.
+func (c *SettableCooldownChecker) TimeUntilReady(key any) time.Duration {
+	nextExecTime, ok := c.nextExecTime.Get(key)
+	if !ok {
+		return 0
+	}
+	d := nextExecTime.(time.Time).Sub(c.clock.Now())
+	if d < 0 {
+		return 0
+	}
+	return d
+}


### PR DESCRIPTION
Validation controllers now return *ValidationResult (Passed/Failed/Unknown)
instead of error, giving each outcome explicit retry timing, user-facing
messages, and service-provider diagnostics.
    
Key changes:
- Validate() returns *ValidationResult with Outcome, Failed/Unknown details,
  and EarliestRetryAfter
- SettableCooldownChecker enforces per-key retry timing inside SyncOnce
- AfterEnqueuer exposes workqueue AddAfter for explicit requeue scheduling
- Unknown results preserve the previous stored condition for up to 10
  consecutive attempts before overwriting
- DeepEqual guard skips Cosmos Replace when the condition hasn't changed
- DefaultResult and BuildCondition extracted as shared helpers
