### PR TITLE
fix(access-cluster): IcM severity 3/4 + aka.ms runbook on SLO dashboard

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
@@ -30,7 +30,7 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         enabled: true
         labels: {
           long_window: '1h'
-          severity: 'info'
+          severity: '3'
           short_window: '5m'
           slo: 'access-cluster-errors'
         }
@@ -44,7 +44,7 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         }
         expression: 'errors:backend_credential_operation:error_rate > 0.72'
         for: 'PT5M'
-        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
         actions: [
@@ -60,7 +60,7 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         enabled: true
         labels: {
           long_window: '6h'
-          severity: 'info'
+          severity: '3'
           short_window: '30m'
           slo: 'access-cluster-errors'
         }
@@ -74,7 +74,7 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         }
         expression: 'errors:backend_credential_operation:error_rate > 0.3'
         for: 'PT30M'
-        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
         actions: [
@@ -90,7 +90,7 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         enabled: true
         labels: {
           long_window: '3d'
-          severity: 'info'
+          severity: '4'
           slo: 'access-cluster-errors'
         }
         annotations: {
@@ -118,7 +118,7 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         alert: 'userJourneyAccessClusterErrorsDegradation'
         enabled: true
         labels: {
-          severity: 'info'
+          severity: '4'
           slo: 'access-cluster-errors'
         }
         annotations: {
@@ -146,7 +146,7 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         alert: 'userJourneyAccessClusterStuckOperation'
         enabled: true
         labels: {
-          severity: 'info'
+          severity: '4'
         }
         annotations: {
           correlationId: 'userJourneyAccessClusterStuckOperation/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.phase }}'
@@ -186,7 +186,7 @@ resource arohcpAccessClusterSaturationAlerts 'Microsoft.AlertsManagement/prometh
         alert: 'userJourneyAccessClusterSaturationQueueDepth'
         enabled: true
         labels: {
-          severity: 'info'
+          severity: '4'
         }
         annotations: {
           correlationId: 'userJourneyAccessClusterSaturationQueueDepth/{{ $labels.cluster }}/{{ $labels.name }}'
@@ -213,7 +213,7 @@ resource arohcpAccessClusterSaturationAlerts 'Microsoft.AlertsManagement/prometh
         alert: 'userJourneyAccessClusterSaturationRetryHotLoop'
         enabled: true
         labels: {
-          severity: 'info'
+          severity: '4'
         }
         annotations: {
           correlationId: 'userJourneyAccessClusterSaturationRetryHotLoop/{{ $labels.cluster }}/{{ $labels.name }}'

--- a/observability/alerts/access-cluster-slo-prometheusRule.yaml
+++ b/observability/alerts/access-cluster-slo-prometheusRule.yaml
@@ -28,7 +28,7 @@ spec:
   - name: arohcp_access_cluster_slo_error_alerts
     rules:
     # ----------------------------------------
-    # Fast Burn Alert (non-paging for now)
+    # Fast Burn Alert (IcM Sev 3 — RP lane / customer-facing UJ)
     # ----------------------------------------
     # 14.4x burn rate → >72% failure rate sustained for 5 minutes
     # Would exhaust 7-day error budget in ~12 hours
@@ -37,7 +37,7 @@ spec:
         errors:backend_credential_operation:error_rate > 0.72
       for: 5m
       labels:
-        severity: info
+        severity: "3"
         slo: access-cluster-errors
         long_window: 1h
         short_window: 5m
@@ -46,7 +46,7 @@ spec:
         description: "More than 72% of credential operations (requestcredential/revokecredentials) are in failed state, indicating a fast error budget burn (14.4x) that would exhaust the 95% SLO budget in ~12 hours."
         runbook_url: "aka.ms/arohcp-runbook-access-cluster"
     # ----------------------------------------
-    # Medium Burn Alert (non-paging for now)
+    # Medium Burn Alert (IcM Sev 3)
     # ----------------------------------------
     # 6x burn rate → >30% failure rate sustained for 30 minutes
     # Would exhaust 7-day error budget in ~28 hours
@@ -55,7 +55,7 @@ spec:
         errors:backend_credential_operation:error_rate > 0.30
       for: 30m
       labels:
-        severity: info
+        severity: "3"
         slo: access-cluster-errors
         long_window: 6h
         short_window: 30m
@@ -64,9 +64,9 @@ spec:
         description: "More than 30% of credential operations are in failed state sustained over 30 minutes, indicating a medium error budget burn (6x) that would exhaust the 95% SLO budget in ~28 hours."
         runbook_url: "aka.ms/arohcp-runbook-access-cluster"
     # ----------------------------------------
-    # Slow Burn Alert (Sev 4 — ticket)
+    # Slow Burn Alert (IcM Sev 4 — ticket)
     # ----------------------------------------
-    # Per ADR: slow burn alerts generate Jira ticket, not a page.
+    # Per ADR: slow burn alerts generate a ticket, not a page.
     # 1x burn rate → >5% failure rate sustained for 6 hours
     # Would exhaust 7-day error budget in ~7 days
     - alert: userJourneyAccessClusterErrors3d
@@ -74,7 +74,7 @@ spec:
         errors:backend_credential_operation:error_rate > 0.05
       for: 6h
       labels:
-        severity: info
+        severity: "4"
         slo: access-cluster-errors
         long_window: 3d
       annotations:
@@ -82,7 +82,7 @@ spec:
         description: "More than 5% of credential operations are in failed state sustained over 6 hours, indicating persistent degradation at the 95% SLO boundary that would exhaust the error budget in ~7 days."
         runbook_url: "aka.ms/arohcp-runbook-access-cluster"
     # ----------------------------------------
-    # Degradation Alert (Sev 4 — ticket)
+    # Degradation Alert (IcM Sev 4 — ticket)
     # ----------------------------------------
     # With a 95% SLO, the fast-burn threshold only fires at ~72% failure rate.
     # This provides early warning at 15% failure rate before burn-rate alerts fire.
@@ -92,7 +92,7 @@ spec:
         errors:backend_credential_operation:error_rate > 0.15
       for: 30m
       labels:
-        severity: info
+        severity: "4"
         slo: access-cluster-errors
       annotations:
         summary: "{{ $labels.cluster }}: Credential operation failure rate exceeds 15% for 30 minutes"
@@ -121,7 +121,7 @@ spec:
         ) > 3600
       for: 15m
       labels:
-        severity: info
+        severity: "4"
       annotations:
         summary: "{{ $labels.cluster }}: Credential operation stuck in {{ $labels.phase }} for over 1 hour"
         description: "Credential operation for {{ $labels.resource_id }} has been in {{ $labels.phase }} phase for over 1 hour. Stuck operations are invisible to success/failure SLIs and require investigation."
@@ -130,7 +130,7 @@ spec:
   # Access the Cluster Alerts — Saturation
   # ========================================
   # Queue depth and retry rates for credential controllers.
-  # Sev 4 (precursor).
+  # IcM Sev 4 (precursor).
   - name: arohcp_access_cluster_saturation_alerts
     rules:
     # Queue depth: credential controller workqueue accumulating work
@@ -143,7 +143,7 @@ spec:
         ) > 10
       for: 5m
       labels:
-        severity: info
+        severity: "4"
       annotations:
         summary: "{{ $labels.cluster }}: Credential controller workqueue {{ $labels.name }} depth is high"
         description: "Credential controller workqueue {{ $labels.name }} has had a depth > 10 for more than 5 minutes, indicating work is accumulating faster than it can be processed."
@@ -166,7 +166,7 @@ spec:
         ) > 0.5
       for: 10m
       labels:
-        severity: info
+        severity: "4"
       annotations:
         summary: "{{ $labels.cluster }}: Credential controller workqueue {{ $labels.name }} retry hot loop"
         description: "Credential controller workqueue {{ $labels.name }} has a retry ratio > 50% sustained over 10 minutes, indicating most queue activity is failed retries rather than fresh work."

--- a/observability/alerts/access-cluster-slo-prometheusRule_test.yaml
+++ b/observability/alerts/access-cluster-slo-prometheusRule_test.yaml
@@ -99,7 +99,7 @@ tests:
     exp_alerts:
     - exp_labels:
         cluster: "mgmt-1"
-        severity: info
+        severity: "3"
         slo: access-cluster-errors
         long_window: 1h
         short_window: 5m
@@ -113,7 +113,7 @@ tests:
     exp_alerts:
     - exp_labels:
         cluster: "mgmt-1"
-        severity: info
+        severity: "4"
         slo: access-cluster-errors
       exp_annotations:
         summary: "mgmt-1: Credential operation failure rate exceeds 15% for 30 minutes"
@@ -164,7 +164,7 @@ tests:
     exp_alerts:
     - exp_labels:
         cluster: "mgmt-1"
-        severity: info
+        severity: "4"
         slo: access-cluster-errors
       exp_annotations:
         summary: "mgmt-1: Credential operation failure rate exceeds 15% for 30 minutes"
@@ -194,7 +194,7 @@ tests:
         operation_type: "requestcredential"
         phase: "accepted"
         cluster: "mgmt-1"
-        severity: info
+        severity: "4"
       exp_annotations:
         summary: "mgmt-1: Credential operation stuck in accepted for over 1 hour"
         description: "Credential operation for /sub/3/cluster/stuck has been in accepted phase for over 1 hour. Stuck operations are invisible to success/failure SLIs and require investigation."
@@ -251,7 +251,7 @@ tests:
     - exp_labels:
         name: "OperationRequestCredential"
         cluster: "mgmt-1"
-        severity: info
+        severity: "4"
       exp_annotations:
         summary: "mgmt-1: Credential controller workqueue OperationRequestCredential depth is high"
         description: "Credential controller workqueue OperationRequestCredential has had a depth > 10 for more than 5 minutes, indicating work is accumulating faster than it can be processed."
@@ -282,7 +282,7 @@ tests:
     - exp_labels:
         name: "OperationRequestCredential"
         cluster: "mgmt-1"
-        severity: info
+        severity: "4"
       exp_annotations:
         summary: "mgmt-1: Credential controller workqueue OperationRequestCredential retry hot loop"
         description: "Credential controller workqueue OperationRequestCredential has a retry ratio > 50% sustained over 10 minutes, indicating most queue activity is failed retries rather than fresh work."
@@ -355,7 +355,7 @@ tests:
     exp_alerts:
     - exp_labels:
         cluster: "mgmt-1"
-        severity: info
+        severity: "3"
         slo: access-cluster-errors
         long_window: 6h
         short_window: 30m
@@ -387,7 +387,7 @@ tests:
         operation_type: "revokecredentials"
         phase: "deleting"
         cluster: "mgmt-1"
-        severity: info
+        severity: "4"
       exp_annotations:
         summary: "mgmt-1: Credential operation stuck in deleting for over 1 hour"
         description: "Credential operation for /sub/7/cluster/stuck-revoke has been in deleting phase for over 1 hour. Stuck operations are invisible to success/failure SLIs and require investigation."

--- a/observability/grafana-dashboards/sre/user-journey/access-cluster-slo.json
+++ b/observability/grafana-dashboards/sre/user-journey/access-cluster-slo.json
@@ -26,7 +26,7 @@
       "id": 1,
       "options": {
         "code": { "language": "plaintext", "showLineNumbers": false, "showMiniMap": false },
-        "content": "### Access the Cluster SLO Dashboard\n\nMonitors credential operation health (requestcredential, revokecredentials) against defined SLOs.\n\n**SLO Targets (Proposed — pending baseline):**\n- Credential operation success rate: 95% over 7-day rolling window\n- Stuck operations: none > 1 hour\n\n**Metrics Source:** `backend_resource_operation_phase_info`, `backend_resource_operation_start_time_seconds` (Cosmos DB-backed)\n\n**Jira:** [ARO-26191](https://redhat.atlassian.net/browse/ARO-26191) | **TSG:** [Access the ARO HCP Cluster TSG](https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/troubleshooting/access-the-aro-hcp-cluster-tsg.html)",
+        "content": "### Access the Cluster SLO Dashboard\n\nMonitors credential operation health (requestcredential, revokecredentials) against defined SLOs.\n\n**SLO Targets (Proposed — pending baseline):**\n- Credential operation success rate: 95% over 7-day rolling window\n- Stuck operations: none > 1 hour\n\n**Metrics Source:** `backend_resource_operation_phase_info`, `backend_resource_operation_start_time_seconds` (Cosmos DB-backed)\n\n**Jira:** [ARO-26191](https://redhat.atlassian.net/browse/ARO-26191) | **Runbook:** [Access the Cluster](https://aka.ms/arohcp-runbook-access-cluster)",
         "mode": "markdown"
       },
       "pluginVersion": "11.6.9",


### PR DESCRIPTION
## Summary 
Set Access Cluster journey alert severities to IcM `3` (fast/medium burn) and `4` (slow, degradation, stuck, saturation) per ADR / alerts.md / PR #5717 - Update unit test expected labels - Replace eng.ms TSG link on the Access Cluster SLO Grafana dashboard with `aka.ms/arohcp-runbook-access-cluster`  Follow-up to Simon review on Azure-Documents-Common PR 16201256.  ## Test plan - [ ] promtool / existing `access-cluster-slo-prometheusRule_test.yaml` passes - [ ] Confirm dashboard markdown shows aka.ms link 
## Dashboard link before/after (overview markdown panel)

**Before:** eng.ms Access Cluster troubleshooting guide URL in the overview text panel.
**After:** https://aka.ms/arohcp-runbook-access-cluster (canonical operator entry point).

No query/panel layout changes — text/link update only.

## Generated Bicep

Regenerated generatedRPPrometheusAlertingRules.bicep so deployed Azure Monitor rules match severity 3/4.