### PR TITLE
fix: flappy nodepoolstuckoperation alert fix

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
@@ -380,7 +380,7 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
           summary: '{{ $labels.cluster }}: Node Pool operation stuck in {{ $labels.phase }} for over 2 hours'
           title: '{{ $labels.cluster }}: Node Pool operation stuck in {{ $labels.phase }} for over 2 hours resource_id:{{ $labels.resource_id }}'
         }
-        expression: '((time() - backend_resource_operation_start_time_seconds{resource_type=~".*nodepools"}) and backend_resource_operation_phase_info{phase=~"updating|deleting",resource_type=~".*nodepools"} == 1) > 7200'
+        expression: 'max_over_time((((time() - backend_resource_operation_start_time_seconds{resource_type=~".*nodepools"}) and backend_resource_operation_phase_info{phase=~"updating|deleting",resource_type=~".*nodepools"} == 1) > 7200)[6h:5m])'
         for: 'PT15M'
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }

--- a/observability/alerts/nodepool-slo-prometheusRule.yaml
+++ b/observability/alerts/nodepool-slo-prometheusRule.yaml
@@ -164,13 +164,28 @@ spec:
     # Operations stuck in non-terminal phases are invisible to success/failure SLIs.
     # Threshold: 2 hours (7200s) with 15m sustained observation to filter
     # slow-but-completing operations from genuinely stuck ones.
+    #
+    # Stickiness (max_over_time ... [6h:]): while a resource stays wedged, the raw
+    # condition can transiently clear -- most commonly when the backend retries the
+    # operation and resets backend_resource_operation_start_time_seconds, briefly
+    # dropping (time() - start_time) below the 7200s threshold. Each clear
+    # auto-resolves the IcM incident and the next re-fire opens a brand-new one,
+    # producing roughly one new incident every ~4h for the same wedged resource.
+    # (Azure Managed Prometheus has no keep_firing_for, so we express the hold in the
+    # PromQL.) Holding the condition firing over a 6h look-back collapses a
+    # continuously-stuck resource into a single long-lived incident; genuinely
+    # distinct stuck episodes more than 6h apart still get their own incident.
     - alert: UJNodePoolStuckOperation
       expr: |
-        (
-          (time() - backend_resource_operation_start_time_seconds{resource_type=~".*nodepools"})
-          and
-          backend_resource_operation_phase_info{resource_type=~".*nodepools", phase=~"updating|deleting"} == 1
-        ) > 7200
+        max_over_time(
+          (
+            (
+              (time() - backend_resource_operation_start_time_seconds{resource_type=~".*nodepools"})
+              and
+              backend_resource_operation_phase_info{resource_type=~".*nodepools", phase=~"updating|deleting"} == 1
+            ) > 7200
+          )[6h:5m]
+        )
       for: 15m
       labels:
         severity: info

--- a/observability/alerts/nodepool-slo-prometheusRule_test.yaml
+++ b/observability/alerts/nodepool-slo-prometheusRule_test.yaml
@@ -389,3 +389,105 @@ tests:
         summary: "mgmt-1: Node Pool operation stuck in deleting for over 2 hours"
         description: "Node pool operation for /sub/7/np/stuck-del has been in deleting phase for over 2 hours. Stuck operations are invisible to success/failure SLIs and require investigation."
         runbook_url: "https://aka.ms/arohcp-runbook-nodepool"
+# ========================================
+# Test 13: Stuck delete that flaps (backend retry resets start_time)
+# ========================================
+# A genuinely-wedged delete stays in "deleting" the whole time, but the backend
+# retries the operation at t=240m and resets
+# backend_resource_operation_start_time_seconds, so (time() - start_time) briefly
+# drops below the 7200s threshold (raw condition false for t=240..360m). The
+# max_over_time(...[6h:]) hold must keep the SAME alert firing across this gap so a
+# continuously-stuck resource maps to a single long-lived IcM incident instead of a
+# fresh incident every few hours.
+- interval: 1m
+  input_series:
+  # phase stays "deleting" throughout
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/8/np/flap-del", subscription_id="sub-8", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters/nodepools", operation_type="delete", phase="deleting", cluster="mgmt-1"}'
+    values: "1+0x480"
+  # start_time=0 until t=239m (age crosses 7200s at t=120m); backend retries at
+  # t=240m so start_time jumps to 14400s and age re-crosses 7200s only at t=360m.
+  - series: 'backend_resource_operation_start_time_seconds{resource_id="/sub/8/np/flap-del", subscription_id="sub-8", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters/nodepools", operation_type="delete", phase="deleting", cluster="mgmt-1"}'
+    values: "0+0x239 14400+0x240"
+  alert_rule_test:
+  # Raw condition true (age 9000s > 7200s) → firing.
+  - eval_time: 150m
+    alertname: UJNodePoolStuckOperation
+    exp_alerts:
+    - exp_labels:
+        resource_id: "/sub/8/np/flap-del"
+        subscription_id: "sub-8"
+        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters/nodepools"
+        operation_type: "delete"
+        phase: "deleting"
+        cluster: "mgmt-1"
+        severity: info
+      exp_annotations:
+        summary: "mgmt-1: Node Pool operation stuck in deleting for over 2 hours"
+        description: "Node pool operation for /sub/8/np/flap-del has been in deleting phase for over 2 hours. Stuck operations are invisible to success/failure SLIs and require investigation."
+        runbook_url: "https://aka.ms/arohcp-runbook-nodepool"
+  # Raw condition FALSE here (start_time reset → age < 7200s) but the resource is
+  # still wedged. The 6h hold keeps the same alert firing → no resolve, no duplicate.
+  - eval_time: 300m
+    alertname: UJNodePoolStuckOperation
+    exp_alerts:
+    - exp_labels:
+        resource_id: "/sub/8/np/flap-del"
+        subscription_id: "sub-8"
+        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters/nodepools"
+        operation_type: "delete"
+        phase: "deleting"
+        cluster: "mgmt-1"
+        severity: info
+      exp_annotations:
+        summary: "mgmt-1: Node Pool operation stuck in deleting for over 2 hours"
+        description: "Node pool operation for /sub/8/np/flap-del has been in deleting phase for over 2 hours. Stuck operations are invisible to success/failure SLIs and require investigation."
+        runbook_url: "https://aka.ms/arohcp-runbook-nodepool"
+  # Raw condition true again after re-crossing 7200s — still one continuous alert.
+  - eval_time: 470m
+    alertname: UJNodePoolStuckOperation
+    exp_alerts:
+    - exp_labels:
+        resource_id: "/sub/8/np/flap-del"
+        subscription_id: "sub-8"
+        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters/nodepools"
+        operation_type: "delete"
+        phase: "deleting"
+        cluster: "mgmt-1"
+        severity: info
+      exp_annotations:
+        summary: "mgmt-1: Node Pool operation stuck in deleting for over 2 hours"
+        description: "Node pool operation for /sub/8/np/flap-del has been in deleting phase for over 2 hours. Stuck operations are invisible to success/failure SLIs and require investigation."
+        runbook_url: "https://aka.ms/arohcp-runbook-nodepool"
+# ========================================
+# Test 14: Stuck delete completes — alert clears after the 6h hold
+# ========================================
+# The resource is wedged (deleting) through t=150m, then the operation completes
+# (phase_info flips to 0). The 6h hold keeps the alert firing for a while (still
+# firing at t=300m) but it resolves once there has been no stuck sample for 6h (not
+# firing at t=520m). Confirms the stickiness is bounded and does not fire forever.
+- interval: 1m
+  input_series:
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/9/np/done-del", subscription_id="sub-9", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters/nodepools", operation_type="delete", phase="deleting", cluster="mgmt-1"}'
+    values: "1+0x150 0+0x400"
+  - series: 'backend_resource_operation_start_time_seconds{resource_id="/sub/9/np/done-del", subscription_id="sub-9", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters/nodepools", operation_type="delete", phase="deleting", cluster="mgmt-1"}'
+    values: "0+0x551"
+  alert_rule_test:
+  # Within the 6h hold after the last stuck sample (t=150m) → still firing.
+  - eval_time: 300m
+    alertname: UJNodePoolStuckOperation
+    exp_alerts:
+    - exp_labels:
+        resource_id: "/sub/9/np/done-del"
+        subscription_id: "sub-9"
+        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters/nodepools"
+        operation_type: "delete"
+        phase: "deleting"
+        cluster: "mgmt-1"
+        severity: info
+      exp_annotations:
+        summary: "mgmt-1: Node Pool operation stuck in deleting for over 2 hours"
+        description: "Node pool operation for /sub/9/np/done-del has been in deleting phase for over 2 hours. Stuck operations are invisible to success/failure SLIs and require investigation."
+        runbook_url: "https://aka.ms/arohcp-runbook-nodepool"
+  # 6h after the last stuck sample (150m + 360m = 510m) the hold expires → resolved.
+  - eval_time: 520m
+    alertname: UJNodePoolStuckOperation


### PR DESCRIPTION


### What

Wrapped the UJNodePoolStuckOperation expression in max_over_time(...)[6h:5m] so that when a backend retry resets start_time_seconds and briefly drops the age below the 7200s threshold, the alert stays firing instead of auto-resolving and creating a duplicate IcM incident. Added a comment block explaining the rationale.

### Why

 When a node pool operation is genuinely stuck, the backend periodically retries it, which resets backend_resource_operation_start_time_seconds. This briefly drops (time() - start_time) below the 7200s threshold, causing the alert to auto-resolve. When the age re-crosses the threshold a few hours later, a brand-new IcM incident is opened for the same wedged resource. In practice this produces roughly one duplicate incident every ~4 hours for a single stuck operation.

### Testing

  - Existing tests 1-12 pass unchanged (the max_over_time wrapper doesn't change behavior for continuously-stuck or non-stuck operations)
  - Added Test 13: validates a stuck delete where start_time is reset by a backend retry at t=240m — confirms the alert stays firing through the gap when the raw condition is false
  - Added Test 14: validates that the 6h hold is bounded — after the operation completes, the alert resolves once there has been no stuck sample for 6 hours
  - make alerts passes and regenerates the bicep correctly

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
