### PR TITLE
fix(config): type AKS upgradeSettings maxSurge/maxUnavailable as string

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -507,27 +507,11 @@
       "properties": {
         "maxSurge": {
           "description": "Maximum number or percentage of nodes surged during upgrade.",
-          "oneOf": [
-            {
-              "type": "integer",
-              "minimum": 0
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "type": "string"
         },
         "maxUnavailable": {
           "description": "Maximum number or percentage of nodes unavailable during upgrade.",
-          "oneOf": [
-            {
-              "type": "integer",
-              "minimum": 0
-            },
-            {
-              "type": "string"
-            }
-          ]
+          "type": "string"
         }
       },
       "required": [

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -509,7 +509,7 @@ defaults:
       networkPolicy: "cilium"
       upgradeSettings:
         maxSurge: "10%"
-        maxUnavailable: 0
+        maxUnavailable: "0"
       systemAgentPool:
         name: 'system'
         minCount: 1
@@ -642,7 +642,7 @@ defaults:
       networkPolicy: "azure"
       upgradeSettings:
         maxSurge: "10%"
-        maxUnavailable: 0
+        maxUnavailable: "0"
       etcd:
         name: "ah-{{ .ctx.environment }}-me-{{ .ctx.regionShort }}-{{ .ctx.stamp }}" # [globally-unique]
         softDelete: true

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -637,7 +637,7 @@ mgmt:
       zones: ""
     upgradeSettings:
       maxSurge: 10%
-      maxUnavailable: 0
+      maxUnavailable: "0"
     userAgentPool:
       maxCount: 14
       minCount: 7
@@ -985,7 +985,7 @@ svc:
       zones: ""
     upgradeSettings:
       maxSurge: 10%
-      maxUnavailable: 0
+      maxUnavailable: "0"
     userAgentPool:
       maxCount: 3
       minCount: 1

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -637,7 +637,7 @@ mgmt:
       zones: ""
     upgradeSettings:
       maxSurge: 10%
-      maxUnavailable: 0
+      maxUnavailable: "0"
     userAgentPool:
       maxCount: 14
       minCount: 7
@@ -985,7 +985,7 @@ svc:
       zones: ""
     upgradeSettings:
       maxSurge: 10%
-      maxUnavailable: 0
+      maxUnavailable: "0"
     userAgentPool:
       maxCount: 3
       minCount: 1

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -637,7 +637,7 @@ mgmt:
       zones: ""
     upgradeSettings:
       maxSurge: 10%
-      maxUnavailable: 0
+      maxUnavailable: "0"
     userAgentPool:
       maxCount: 3
       minCount: 1
@@ -983,7 +983,7 @@ svc:
       zones: ""
     upgradeSettings:
       maxSurge: 10%
-      maxUnavailable: 0
+      maxUnavailable: "0"
     userAgentPool:
       maxCount: 12
       minCount: 2

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -637,7 +637,7 @@ mgmt:
       zones: ""
     upgradeSettings:
       maxSurge: 10%
-      maxUnavailable: 0
+      maxUnavailable: "0"
     userAgentPool:
       maxCount: 3
       minCount: 1
@@ -983,7 +983,7 @@ svc:
       zones: ""
     upgradeSettings:
       maxSurge: 10%
-      maxUnavailable: 0
+      maxUnavailable: "0"
     userAgentPool:
       maxCount: 3
       minCount: 1

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -637,7 +637,7 @@ mgmt:
       zones: ""
     upgradeSettings:
       maxSurge: 10%
-      maxUnavailable: 0
+      maxUnavailable: "0"
     userAgentPool:
       maxCount: 3
       minCount: 1
@@ -983,7 +983,7 @@ svc:
       zones: ""
     upgradeSettings:
       maxSurge: 10%
-      maxUnavailable: 0
+      maxUnavailable: "0"
     userAgentPool:
       maxCount: 3
       minCount: 1

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -637,7 +637,7 @@ mgmt:
       zones: ""
     upgradeSettings:
       maxSurge: 10%
-      maxUnavailable: 0
+      maxUnavailable: "0"
     userAgentPool:
       maxCount: 6
       minCount: 1
@@ -985,7 +985,7 @@ svc:
       zones: ""
     upgradeSettings:
       maxSurge: 10%
-      maxUnavailable: 0
+      maxUnavailable: "0"
     userAgentPool:
       maxCount: 3
       minCount: 1


### PR DESCRIPTION
The  bump-aro-hcp  job (and the sdp-pipelines merge validation) fails during EV2 manifest generation with:
```
step Service.Infra.service.cluster: failed to compile bicepparam: 1 errors
BCP019: Expected a new line character at this location.
  svc-cluster.tmpl.public-int.bicepparam L45
```

This blocks every ARO-HCP → sdp-pipelines bump, so the AKS upgrade-settings feature can't ship.

Root cause

 aksUpgradeSettings.maxSurge / maxUnavailable  were schema-typed as  oneOf [integer, string] , and  maxUnavailable  was set to the integer  0  in config. But every consumer treats these as strings:

•  svc-cluster.bicep  /  pool.bicep  declare both params as  string 
• the bicepparam template quotes them:  '{{ .svc.aks.upgradeSettings.maxUnavailable }}' 
• the Azure AKS ARM  upgradeSettings  properties are strings (count or percentage), which is why  maxSurge  already had to be  "10%" 

In EV2 "generate-only" mode, config values in bicepparams are replaced with EV2 placeholders: string →  '__path__' , non-string →  any('__path__') . Because  maxUnavailable  was an integer, the  any()  wrapper rendered inside the template's quotes:

`param aksUpgradeSettingsMaxUnavailable = 'any('__svc.aks.upgradeSettings.maxUnavailable__')'   // invalid → BCP019`

 maxSurge  was unaffected only because  "10%"  is already a string. (The same  oneOf  on  clustersService.k8s.deploymentStrategy.rollingUpdate  is harmless because that value is consumed by a Helm chart, not a bicepparam — no  any()  placeholder pass.)

Fix

•  config/config.schema.json :  aksUpgradeSettings.maxSurge  and  maxUnavailable  →  "type": "string"  (drop the integer branch so an unquoted value can't reintroduce this).
•  config/config.yaml :  maxUnavailable: "0"  (quoted), matching  maxSurge: "10%" , in both the  svc.aks  and  mgmt.aks  blocks.
• Re-ran  cd config && make materialize ; rendered output committed.

Validation

• Reproduced the exact  BCP019 @ Service.Infra.service.cluster  failure against ARO-HCP  a05bb664 .
• Confirmed the string form compiles clean end-to-end ( az bicep build-params  through the AKS resource, no errors).



### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
