### PR TITLE
chore(config): bump opstool AKS to 1.35 for fleet parity (AROSLSRE-1414)

### DIFF
--- a/config/config-dev-ci.yaml
+++ b/config/config-dev-ci.yaml
@@ -38,7 +38,7 @@ clouds:
           vnetAddressPrefix: "10.0.0.0/16"
           subnetPrefix: "10.0.1.0/24"
           podSubnetPrefix: "10.0.2.0/24"
-          kubernetesVersion: "1.34"
+          kubernetesVersion: "1.35"
           networkDataplane: "cilium"
           networkPolicy: "cilium"
           clusterOutboundIPAddressIPTags: ""


### PR DESCRIPTION
[AROSLSRE-1414](https://redhat.atlassian.net/browse/AROSLSRE-1414) (parent [AROSLSRE-863](https://redhat.atlassian.net/browse/AROSLSRE-863))

### What

Bump the `opstool` AKS `kubernetesVersion` in `config/config-dev-ci.yaml` from `"1.34"` to `"1.35"` — the **final hop to fleet parity**.

### Why

`opstool-usw3` is now on `1.34` (control plane and all three node pools at `1.34.8`), while the rest of the fleet runs `1.35`. This PR closes the gap. AKS upgrades one minor at a time; `az aks get-upgrades` confirms `1.35.x` is the available target from `1.34`.

Bumping `kubernetesVersion` drives the `opstool-aks-pipeline` (`dev-infrastructure/scripts/upgrade-aks-cluster.sh` → `az aks upgrade`) to upgrade the control plane and roll the node pools onto `1.35`.

### Testing

No code paths change; this is a config version bump validated by the existing config schema (`config/config-dev-ci.schema.json` types `kubernetesVersion` as a string). `cd config && make materialize` produces no rendered-config changes (opstool config is not part of the rendered tree).

Post-deploy validation on `opstool-usw3`:

- `az aks show ... --query kubernetesVersion` → `1.35`
- `az aks nodepool list ... --query "[].currentOrchestratorVersion"` → `1.35.x` on all pools

### Special notes for your reviewer

Scope is intentionally limited to `opstool` (dev-ci). This completes the sequence `1.32` → `1.33` ([#5936](https://github.com/Azure/ARO-HCP/pull/5936), pipeline fix [#5988](https://github.com/Azure/ARO-HCP/pull/5988)) → `1.34` ([#6042](https://github.com/Azure/ARO-HCP/pull/6042)) → `1.35`, each rolled out and verified on `opstool-usw3`.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
