### PR TITLE
chore(config): add stgGlobalV2.billingKusto{Name,Sku} to de-hardcode STG billing Kusto (AROSLSRE-1482)

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -52,6 +52,14 @@ clouds:
             # creation on 2026-06-15, so only major versions 12/13 are accepted.
             # The live grandfathered workspace stays on 11 (shared monitoring value).
             grafanaMajorVersion: "13"
+            # Dedicated STG billing Kusto in the new hcp-stg-global sub. Distinct from
+            # the shared billing.kusto.* (which Billing.Global keeps managing for stg),
+            # so the shared cluster is never touched. The SKU is E8a_v4 because the
+            # shared billing.kusto.sku (E8ads_v5) is not offered in uksouth, where this
+            # dedicated cluster lives. Consumed only by the transient Billing.StgGlobal
+            # bicepparam; promoted into stg.defaults billing.kusto.* at cutover.
+            billingKustoName: "arohcpHoBo{{ .ctx.environment }}"
+            billingKustoSku: "Standard_E8a_v4"
           # E2E
           e2e:
             regionTest:

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -3522,6 +3522,12 @@
         },
         "grafanaMajorVersion": {
           "type": "string"
+        },
+        "billingKustoName": {
+          "type": "string"
+        },
+        "billingKustoSku": {
+          "type": "string"
         }
       },
       "additionalProperties": false,
@@ -3537,7 +3543,9 @@
         "cxParentZoneName",
         "kustoName",
         "grafanaName",
-        "grafanaMajorVersion"
+        "grafanaMajorVersion",
+        "billingKustoName",
+        "billingKustoSku"
       ]
     },
     "releaseApprover": {

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -121,6 +121,8 @@ defaults:
     kustoName: "empty-sentinel"
     grafanaName: "empty-sentinel"
     grafanaMajorVersion: "empty-sentinel"
+    billingKustoName: "empty-sentinel"
+    billingKustoSku: "empty-sentinel"
   # Image Registry Policy
   imageRegistryPolicy:
     extraAllowedRegistries: ""

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -940,6 +940,8 @@ sessiongate:
 stgGlobalV2:
   acrOcpName: empty-sentinel
   acrSvcName: empty-sentinel
+  billingKustoName: empty-sentinel
+  billingKustoSku: empty-sentinel
   cxParentZoneName: empty-sentinel
   frontDoorKeyVaultName: empty-sentinel
   frontDoorName: empty-sentinel

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -940,6 +940,8 @@ sessiongate:
 stgGlobalV2:
   acrOcpName: empty-sentinel
   acrSvcName: empty-sentinel
+  billingKustoName: empty-sentinel
+  billingKustoSku: empty-sentinel
   cxParentZoneName: empty-sentinel
   frontDoorKeyVaultName: empty-sentinel
   frontDoorName: empty-sentinel

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -938,6 +938,8 @@ sessiongate:
 stgGlobalV2:
   acrOcpName: empty-sentinel
   acrSvcName: empty-sentinel
+  billingKustoName: empty-sentinel
+  billingKustoSku: empty-sentinel
   cxParentZoneName: empty-sentinel
   frontDoorKeyVaultName: empty-sentinel
   frontDoorName: empty-sentinel

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -938,6 +938,8 @@ sessiongate:
 stgGlobalV2:
   acrOcpName: empty-sentinel
   acrSvcName: empty-sentinel
+  billingKustoName: empty-sentinel
+  billingKustoSku: empty-sentinel
   cxParentZoneName: empty-sentinel
   frontDoorKeyVaultName: empty-sentinel
   frontDoorName: empty-sentinel

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -938,6 +938,8 @@ sessiongate:
 stgGlobalV2:
   acrOcpName: empty-sentinel
   acrSvcName: empty-sentinel
+  billingKustoName: empty-sentinel
+  billingKustoSku: empty-sentinel
   cxParentZoneName: empty-sentinel
   frontDoorKeyVaultName: empty-sentinel
   frontDoorName: empty-sentinel

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -940,6 +940,8 @@ sessiongate:
 stgGlobalV2:
   acrOcpName: empty-sentinel
   acrSvcName: empty-sentinel
+  billingKustoName: empty-sentinel
+  billingKustoSku: empty-sentinel
   cxParentZoneName: empty-sentinel
   frontDoorKeyVaultName: empty-sentinel
   frontDoorName: empty-sentinel


### PR DESCRIPTION
Fixes [AROSLSRE-1482](https://redhat.atlassian.net/browse/AROSLSRE-1482)

### What

Add dedicated `stgGlobalV2.billingKustoName` and `stgGlobalV2.billingKustoSku` config keys (empty-sentinel defaults; real values only for `public/stg`) plus their schema entries, and re-materialize.

```yaml
# config.msft.clouds-overlay.yaml (stg only)
stgGlobalV2:
  billingKustoName: "arohcpHoBo{{ .ctx.environment }}"   # arohcpHoBostg
  billingKustoSku: "Standard_E8a_v4"
```

### Why

The transient `Billing.StgGlobal` V2 bicepparam in `sdp-pipelines` currently **hardcodes** the billing Kusto cluster name and SKU as string literals. It has to, because `billing.kusto.clusterName` / `billing.kusto.sku` are shared configRefs also consumed by `Billing.Global` — which keeps managing the shared `arohcpHoBoprod` cluster for `stg/uksouth` during coexistence — so a cloud/env-scoped overlay override of those shared keys would also resize the shared cluster.

Introducing distinct `stgGlobalV2.billingKusto*` keys (a **new** key read only by the V2 param) lets the pipeline reference schema-validated, versioned config instead of literals, without touching the shared cluster. `Standard_E8a_v4` is used because the shared `Standard_E8ads_v5` is not offered in `uksouth`, where the dedicated cluster lives. These keys are removed with the rest of `stgGlobalV2` at cutover ([AROSLSRE-1202](https://redhat.atlassian.net/browse/AROSLSRE-1202)).

A follow-up `sdp-pipelines` PR will switch the bicepparam to `{{ .stgGlobalV2.billingKustoName }}` / `{{ .stgGlobalV2.billingKustoSku }}` once this merges and the pinned ARO-HCP revision is bumped. This replaces the literal-hardcoding approach in sdp-pipelines PR 16421393.

### Testing

- `cd config && make materialize` — rendered dev configs updated (empty-sentinel).
- `make verify-schema` — passes.
- `templatize configuration render --cloud public --environment stg --region uksouth` confirms `stgGlobalV2.billingKustoName=arohcpHoBostg`, `billingKustoSku=Standard_E8a_v4`.

### Special notes for your reviewer

No behavior change on its own — these keys are inert until the follow-up sdp-pipelines PR consumes them, and only ever resolve to real values for `public/stg`. All other clouds/envs stay `empty-sentinel`.
