### PR TITLE
feat: add more externalauth validations in frontend

### DIFF
--- a/internal/api/types_externalauth.go
+++ b/internal/api/types_externalauth.go
@@ -129,6 +129,13 @@ type ExternalAuthClientComponentProfile struct {
 	AuthClientNamespace string `json:"authClientNamespace"`
 }
 
+const (
+	// ExternalAuthConsoleClientComponentName is the name of the OpenShift console component to be configured to use the identity provider for authentication.
+	ExternalAuthConsoleClientComponentName = "console"
+	// ExternalAuthConsoleClientComponentNamespace is the namespace where the OpenShift console is deployed.
+	ExternalAuthConsoleClientComponentNamespace = "openshift-console"
+)
+
 // External Auth claim profile
 // Visibility for the entire struct is "read create update".
 type ExternalAuthClaimProfile struct {

--- a/internal/validation/hcpopenshiftclusterexternalauth_test.go
+++ b/internal/validation/hcpopenshiftclusterexternalauth_test.go
@@ -314,7 +314,7 @@ func TestExternalAuthValidate(t *testing.T) {
 								Name:                ClientComponentName,
 								AuthClientNamespace: ClientComponentNamespace,
 							},
-							Type: api.ExternalAuthClientTypeConfidential,
+							Type: api.ExternalAuthClientTypePublic,
 						},
 					},
 					Claim: api.ExternalAuthClaimProfile{
@@ -342,7 +342,7 @@ func TestExternalAuthValidate(t *testing.T) {
 								AuthClientNamespace: ClientComponentNamespace,
 							},
 							ExtraScopes: []string{""},
-							Type:        api.ExternalAuthClientTypeConfidential,
+							Type:        api.ExternalAuthClientTypePublic,
 						},
 					},
 					Claim: api.ExternalAuthClaimProfile{
@@ -374,7 +374,7 @@ func TestExternalAuthValidate(t *testing.T) {
 								Name:                ClientComponentName,
 								AuthClientNamespace: ClientComponentNamespace,
 							},
-							Type: api.ExternalAuthClientTypeConfidential,
+							Type: api.ExternalAuthClientTypePublic,
 						},
 					},
 					Claim: api.ExternalAuthClaimProfile{
@@ -406,7 +406,7 @@ func TestExternalAuthValidate(t *testing.T) {
 								Name:                ClientComponentName,
 								AuthClientNamespace: ClientComponentNamespace,
 							},
-							Type: api.ExternalAuthClientTypeConfidential,
+							Type: api.ExternalAuthClientTypePublic,
 						},
 						{
 							ClientID: ClientID2,
@@ -414,7 +414,7 @@ func TestExternalAuthValidate(t *testing.T) {
 								Name:                ClientComponentName,
 								AuthClientNamespace: ClientComponentNamespace,
 							},
-							Type: api.ExternalAuthClientTypeConfidential,
+							Type: api.ExternalAuthClientTypePublic,
 						},
 					},
 					Claim: api.ExternalAuthClaimProfile{

--- a/internal/validation/hcpopenshiftclusterexternalauth_test.go
+++ b/internal/validation/hcpopenshiftclusterexternalauth_test.go
@@ -135,7 +135,12 @@ func TestExternalAuthValidate(t *testing.T) {
 					},
 				},
 			},
-			expectErrors: []utils.ExpectedError{}, // This field is not being validated for length in the actual function
+			expectErrors: []utils.ExpectedError{
+				{
+					Message:   "may not be more than 256 bytes",
+					FieldPath: "properties.claim.mappings.username.claim",
+				},
+			},
 		},
 		{
 			name: "Max not satisfied for properties.claim.mappings.groups.claim",

--- a/internal/validation/hcpopenshiftclusterexternalauth_test.go
+++ b/internal/validation/hcpopenshiftclusterexternalauth_test.go
@@ -327,6 +327,39 @@ func TestExternalAuthValidate(t *testing.T) {
 			expectErrors: nil,
 		},
 		{
+			name: "Bad properties.clients.extraScopes - empty extraScope value",
+			tweaks: &api.HCPOpenShiftClusterExternalAuth{
+				Properties: api.HCPOpenShiftClusterExternalAuthProperties{
+					Issuer: api.TokenIssuerProfile{
+						URL:       "https://example.com",
+						Audiences: []string{ClientID1},
+					},
+					Clients: []api.ExternalAuthClientProfile{
+						{
+							ClientID: ClientID1,
+							Component: api.ExternalAuthClientComponentProfile{
+								Name:                ClientComponentName,
+								AuthClientNamespace: ClientComponentNamespace,
+							},
+							ExtraScopes: []string{""},
+							Type:        api.ExternalAuthClientTypeConfidential,
+						},
+					},
+					Claim: api.ExternalAuthClaimProfile{
+						Mappings: api.TokenClaimMappingsProfile{
+							Username: api.UsernameClaimProfile{Claim: "email"},
+						},
+					},
+				},
+			},
+			expectErrors: []utils.ExpectedError{
+				{
+					Message:   "Required value",
+					FieldPath: "properties.clients[0].extraScopes[0]",
+				},
+			},
+		},
+		{
 			name: "Invalid ClientID not in audiences",
 			tweaks: &api.HCPOpenShiftClusterExternalAuth{
 				Properties: api.HCPOpenShiftClusterExternalAuthProperties{

--- a/internal/validation/hcpopenshiftclusterexternalauth_test.go
+++ b/internal/validation/hcpopenshiftclusterexternalauth_test.go
@@ -216,15 +216,21 @@ func TestExternalAuthValidate(t *testing.T) {
 			},
 		},
 		{
-			name: "Bad properties.issuer.audiences",
+			name: "Bad properties.issuer.audiences - empty audience value",
 			tweaks: &api.HCPOpenShiftClusterExternalAuth{
 				Properties: api.HCPOpenShiftClusterExternalAuthProperties{
 					Issuer: api.TokenIssuerProfile{
-						Audiences: []string{"omitempty"},
+						URL:       "https://example.com",
+						Audiences: []string{""},
 					},
 				},
 			},
-			expectErrors: nil,
+			expectErrors: []utils.ExpectedError{
+				{
+					Message:   "Required value",
+					FieldPath: "properties.issuer.audiences[0]",
+				},
+			},
 		},
 		{
 			name: "Missing prefix when policy is Prefix",

--- a/internal/validation/validate_externalauth.go
+++ b/internal/validation/validate_externalauth.go
@@ -179,13 +179,13 @@ func validateTokenIssuerProfile(ctx context.Context, op operation.Operation, fld
 	errs = append(errs, validate.RequiredSlice(ctx, op, fldPath.Child("audiences"), newObj.Audiences, safe.Field(oldObj, toTokenIssuerProfileAudiences))...)
 	errs = append(errs, MinItems(ctx, op, fldPath.Child("audiences"), newObj.Audiences, safe.Field(oldObj, toTokenIssuerProfileAudiences), 1)...)
 	errs = append(errs, MaxItems(ctx, op, fldPath.Child("audiences"), newObj.Audiences, safe.Field(oldObj, toTokenIssuerProfileAudiences), 10)...)
+	errs = append(errs, validate.EachSliceVal(
+		ctx, op, fldPath.Child("audiences"),
+		newObj.Audiences, safe.Field(oldObj, toTokenIssuerProfileAudiences),
+		nil, nil,
+		validate.RequiredValue,
+	)...)
 	// TODO I bet these were forgotten
-	//errs = append(errs, validate.EachSliceVal(
-	//	ctx, op, fldPath.Child("audiences"),
-	//	newObj.Audiences, safe.Field(oldObj, toTokenIssuerProfileAudiences),
-	//	nil, nil,
-	//	validate.RequiredValue,
-	//)...)
 	//errs = append(errs, validate.EachSliceVal(
 	//	ctx, op, fldPath.Child("audiences"),
 	//	newObj.Audiences, safe.Field(oldObj, toTokenIssuerProfileAudiences),

--- a/internal/validation/validate_externalauth.go
+++ b/internal/validation/validate_externalauth.go
@@ -348,6 +348,7 @@ func validateUsernameClaimProfile(ctx context.Context, op operation.Operation, f
 
 	//Claim        string                    `json:"claim"`
 	errs = append(errs, validate.RequiredValue(ctx, op, fldPath.Child("claim"), &newObj.Claim, safe.Field(oldObj, toUsernameClaimProfileClaim))...)
+	errs = append(errs, MaxLen(ctx, op, fldPath.Child("claim"), &newObj.Claim, safe.Field(oldObj, toUsernameClaimProfileClaim), 256)...)
 
 	//Prefix       string                    `json:"prefix"`
 

--- a/internal/validation/validate_externalauth.go
+++ b/internal/validation/validate_externalauth.go
@@ -203,8 +203,9 @@ var (
 	toExternalAuthClientProfileComponent = func(oldObj *api.ExternalAuthClientProfile) *api.ExternalAuthClientComponentProfile {
 		return &oldObj.Component
 	}
-	toExternalAuthClientProfileClientID = func(oldObj *api.ExternalAuthClientProfile) *string { return &oldObj.ClientID }
-	toExternalAuthClientProfileType     = func(oldObj *api.ExternalAuthClientProfile) *api.ExternalAuthClientType { return &oldObj.Type }
+	toExternalAuthClientProfileClientID    = func(oldObj *api.ExternalAuthClientProfile) *string { return &oldObj.ClientID }
+	toExternalAuthClientProfileType        = func(oldObj *api.ExternalAuthClientProfile) *api.ExternalAuthClientType { return &oldObj.Type }
+	toExternalAuthClientProfileExtraScopes = func(oldObj *api.ExternalAuthClientProfile) []string { return oldObj.ExtraScopes }
 )
 
 func validateExternalAuthClientProfile(ctx context.Context, op operation.Operation, fldPath *field.Path, newObj, oldObj *api.ExternalAuthClientProfile) field.ErrorList {
@@ -218,6 +219,12 @@ func validateExternalAuthClientProfile(ctx context.Context, op operation.Operati
 	errs = append(errs, validate.RequiredValue(ctx, op, fldPath.Child("clientId"), &newObj.ClientID, safe.Field(oldObj, toExternalAuthClientProfileClientID))...)
 
 	//ExtraScopes []string                           `json:"extraScopes"`
+	errs = append(errs, validate.EachSliceVal(
+		ctx, op, fldPath.Child("extraScopes"),
+		newObj.ExtraScopes, safe.Field(oldObj, toExternalAuthClientProfileExtraScopes),
+		nil, nil,
+		validate.RequiredValue,
+	)...)
 
 	//Type        ExternalAuthClientType             `json:"type"`
 	errs = append(errs, validate.RequiredValue(ctx, op, fldPath.Child("type"), &newObj.Type, safe.Field(oldObj, toExternalAuthClientProfileType))...)

--- a/internal/validation/validate_externalauth.go
+++ b/internal/validation/validate_externalauth.go
@@ -209,6 +209,18 @@ var (
 	toExternalAuthClientProfileExtraScopes = func(oldObj *api.ExternalAuthClientProfile) []string { return oldObj.ExtraScopes }
 )
 
+// confidentialExternalAuthClientComponentKey is the map key for validConfidentialExternalAuthClientComponents.
+type confidentialExternalAuthClientComponentKey struct {
+	name      string
+	namespace string
+}
+
+// validConfidentialExternalAuthClientComponents lists component name and namespace
+// pairs that may use the Confidential client type.
+var validConfidentialExternalAuthClientComponents = map[confidentialExternalAuthClientComponentKey]struct{}{
+	{name: api.ExternalAuthConsoleClientComponentName, namespace: api.ExternalAuthConsoleClientComponentNamespace}: {},
+}
+
 func validateExternalAuthClientProfile(ctx context.Context, op operation.Operation, fldPath *field.Path, newObj, oldObj *api.ExternalAuthClientProfile) field.ErrorList {
 	errs := field.ErrorList{}
 
@@ -243,6 +255,21 @@ func validateExternalAuthClientProfile(ctx context.Context, op operation.Operati
 				api.ExternalAuthConsoleClientComponentName,
 				api.ExternalAuthConsoleClientComponentNamespace,
 			),
+		))
+	}
+
+	// Confidential clients are restricted to platform components listed in
+	// validConfidentialExternalAuthClientComponents. This is independent of the
+	// console-specific type requirement above.
+	_, isAllowedConfidentialComponent := validConfidentialExternalAuthClientComponents[confidentialExternalAuthClientComponentKey{
+		name:      newObj.Component.Name,
+		namespace: newObj.Component.AuthClientNamespace,
+	}]
+	if newObj.Type == api.ExternalAuthClientTypeConfidential && !isAllowedConfidentialComponent {
+		errs = append(errs, field.Invalid(
+			fldPath.Child("type"),
+			newObj.Type,
+			"confidential client type is not allowed for this component",
 		))
 	}
 

--- a/internal/validation/validate_externalauth.go
+++ b/internal/validation/validate_externalauth.go
@@ -16,6 +16,7 @@ package validation
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"regexp"
 
@@ -229,6 +230,21 @@ func validateExternalAuthClientProfile(ctx context.Context, op operation.Operati
 	//Type        ExternalAuthClientType             `json:"type"`
 	errs = append(errs, validate.RequiredValue(ctx, op, fldPath.Child("type"), &newObj.Type, safe.Field(oldObj, toExternalAuthClientProfileType))...)
 	errs = append(errs, validate.Enum(ctx, op, fldPath.Child("type"), &newObj.Type, safe.Field(oldObj, toExternalAuthClientProfileType), api.ValidExternalAuthClientTypes, nil)...)
+
+	// The OpenShift console component must use the Confidential client type.
+	if newObj.Component.Name == api.ExternalAuthConsoleClientComponentName &&
+		newObj.Component.AuthClientNamespace == api.ExternalAuthConsoleClientComponentNamespace &&
+		newObj.Type != api.ExternalAuthClientTypeConfidential {
+		errs = append(errs, field.Invalid(
+			fldPath.Child("type"),
+			newObj.Type,
+			fmt.Sprintf("must be %s when component name is %s and component namespace is %s",
+				api.ExternalAuthClientTypeConfidential,
+				api.ExternalAuthConsoleClientComponentName,
+				api.ExternalAuthConsoleClientComponentNamespace,
+			),
+		))
+	}
 
 	return errs
 }

--- a/internal/validation/validate_externalauth_comprehensive_test.go
+++ b/internal/validation/validate_externalauth_comprehensive_test.go
@@ -16,6 +16,7 @@ package validation
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -564,6 +565,58 @@ func TestValidateExternalAuth(t *testing.T) {
 				{FieldPath: "properties.provisioningState", Message: "field is immutable"},
 			},
 		},
+		{
+			name: "update rejects changing console client type to Public",
+			newObj: testExternalAuthWithClients(
+				[]string{"console-client"},
+				testExternalAuthClientProfile(
+					api.ExternalAuthConsoleClientComponentName,
+					api.ExternalAuthConsoleClientComponentNamespace,
+					"console-client",
+					api.ExternalAuthClientTypePublic,
+				),
+			),
+			oldObj: testExternalAuthWithClients(
+				[]string{"console-client"},
+				testExternalAuthClientProfile(
+					api.ExternalAuthConsoleClientComponentName,
+					api.ExternalAuthConsoleClientComponentNamespace,
+					"console-client",
+					api.ExternalAuthClientTypeConfidential,
+				),
+			),
+			op: operation.Operation{Type: operation.Update},
+			expectErrors: []utils.ExpectedError{
+				{FieldPath: "properties.clients[0].type", Message: fmt.Sprintf("must be %s when component name is %s and component namespace is %s",
+					api.ExternalAuthClientTypeConfidential,
+					api.ExternalAuthConsoleClientComponentName,
+					api.ExternalAuthConsoleClientComponentNamespace,
+				)},
+			},
+		},
+		{
+			name: "update accepts keeping console client Confidential",
+			newObj: testExternalAuthWithClients(
+				[]string{"console-client"},
+				testExternalAuthClientProfile(
+					api.ExternalAuthConsoleClientComponentName,
+					api.ExternalAuthConsoleClientComponentNamespace,
+					"console-client",
+					api.ExternalAuthClientTypeConfidential,
+				),
+			),
+			oldObj: testExternalAuthWithClients(
+				[]string{"console-client"},
+				testExternalAuthClientProfile(
+					api.ExternalAuthConsoleClientComponentName,
+					api.ExternalAuthConsoleClientComponentNamespace,
+					"console-client",
+					api.ExternalAuthClientTypeConfidential,
+				),
+			),
+			op:           operation.Operation{Type: operation.Update},
+			expectErrors: nil,
+		},
 	}
 
 	for _, tt := range tests {
@@ -862,6 +915,96 @@ func TestValidateExternalAuthCustomValidation(t *testing.T) {
 			expectErrors: nil,
 		},
 		{
+			name: "console client must be Confidential",
+			newObj: testExternalAuthWithClients(
+				[]string{"console-client"},
+				testExternalAuthClientProfile(
+					api.ExternalAuthConsoleClientComponentName,
+					api.ExternalAuthConsoleClientComponentNamespace,
+					"console-client",
+					api.ExternalAuthClientTypeConfidential,
+				),
+			),
+			expectErrors: nil,
+		},
+		{
+			name: "console client rejects Public type",
+			newObj: testExternalAuthWithClients(
+				[]string{"console-client"},
+				testExternalAuthClientProfile(
+					api.ExternalAuthConsoleClientComponentName,
+					api.ExternalAuthConsoleClientComponentNamespace,
+					"console-client",
+					api.ExternalAuthClientTypePublic,
+				),
+			),
+			expectErrors: []utils.ExpectedError{
+				{FieldPath: "properties.clients[0].type", Message: fmt.Sprintf("must be %s when component name is %s and component namespace is %s",
+					api.ExternalAuthClientTypeConfidential,
+					api.ExternalAuthConsoleClientComponentName,
+					api.ExternalAuthConsoleClientComponentNamespace,
+				)},
+			},
+		},
+		{
+			name: "cli client in openshift-console namespace may be Public",
+			newObj: testExternalAuthWithClients(
+				[]string{"cli-client"},
+				testExternalAuthClientProfile(
+					"cli",
+					api.ExternalAuthConsoleClientComponentNamespace,
+					"cli-client",
+					api.ExternalAuthClientTypePublic,
+				),
+			),
+			expectErrors: nil,
+		},
+		{
+			name: "console name in different namespace may be Public",
+			newObj: testExternalAuthWithClients(
+				[]string{"console-client"},
+				testExternalAuthClientProfile(
+					api.ExternalAuthConsoleClientComponentName,
+					"other-namespace",
+					"console-client",
+					api.ExternalAuthClientTypePublic,
+				),
+			),
+			expectErrors: nil,
+		},
+		{
+			name: "openshift-console namespace with different name may be Public",
+			newObj: testExternalAuthWithClients(
+				[]string{"oauth-client"},
+				testExternalAuthClientProfile(
+					"oauth",
+					api.ExternalAuthConsoleClientComponentNamespace,
+					"oauth-client",
+					api.ExternalAuthClientTypePublic,
+				),
+			),
+			expectErrors: nil,
+		},
+		{
+			name: "default console and cli client pair",
+			newObj: testExternalAuthWithClients(
+				[]string{"shared-client-id"},
+				testExternalAuthClientProfile(
+					api.ExternalAuthConsoleClientComponentName,
+					api.ExternalAuthConsoleClientComponentNamespace,
+					"shared-client-id",
+					api.ExternalAuthClientTypeConfidential,
+				),
+				testExternalAuthClientProfile(
+					"cli",
+					api.ExternalAuthConsoleClientComponentNamespace,
+					"shared-client-id",
+					api.ExternalAuthClientTypePublic,
+				),
+			),
+			expectErrors: nil,
+		},
+		{
 			name: "duplicate client identifiers",
 			newObj: func() *api.HCPOpenShiftClusterExternalAuth {
 				obj := createValidExternalAuth()
@@ -900,6 +1043,26 @@ func TestValidateExternalAuthCustomValidation(t *testing.T) {
 			utils.VerifyErrorsMatch(t, tt.expectErrors, errs)
 		})
 	}
+}
+
+func testExternalAuthClientProfile(name, namespace, clientID string, clientType api.ExternalAuthClientType) api.ExternalAuthClientProfile {
+	return api.ExternalAuthClientProfile{
+		Component: api.ExternalAuthClientComponentProfile{
+			Name:                name,
+			AuthClientNamespace: namespace,
+		},
+		ClientID: clientID,
+		Type:     clientType,
+	}
+}
+
+func testExternalAuthWithClients(audiences []string, clients ...api.ExternalAuthClientProfile) *api.HCPOpenShiftClusterExternalAuth {
+	obj := createValidExternalAuth()
+	obj.Properties.Issuer.Audiences = audiences
+	obj.Properties.Clients = clients
+	// Avoid nil pointer issues in discriminated union validation during update tests.
+	obj.Properties.Claim.ValidationRules = []api.TokenClaimValidationRule{}
+	return obj
 }
 
 func createMinimalExternalAuth() *api.HCPOpenShiftClusterExternalAuth {

--- a/internal/validation/validate_externalauth_comprehensive_test.go
+++ b/internal/validation/validate_externalauth_comprehensive_test.go
@@ -47,6 +47,20 @@ func TestValidateExternalAuth(t *testing.T) {
 			expectErrors: nil,
 		},
 		{
+			name: "valid external auth with console confidential client",
+			newObj: testExternalAuthWithClients(
+				[]string{"console-client"},
+				testExternalAuthClientProfile(
+					api.ExternalAuthConsoleClientComponentName,
+					api.ExternalAuthConsoleClientComponentNamespace,
+					"console-client",
+					api.ExternalAuthClientTypeConfidential,
+				),
+			),
+			op:           operation.Operation{Type: operation.Create},
+			expectErrors: nil,
+		},
+		{
 			name: "valid external auth with multiple unique clients",
 			newObj: func() *api.HCPOpenShiftClusterExternalAuth {
 				obj := createValidExternalAuth()
@@ -58,7 +72,7 @@ func TestValidateExternalAuth(t *testing.T) {
 							AuthClientNamespace: "namespace1",
 						},
 						ClientID: "client1",
-						Type:     api.ExternalAuthClientTypeConfidential,
+						Type:     api.ExternalAuthClientTypePublic,
 					},
 					{
 						Component: api.ExternalAuthClientComponentProfile{
@@ -74,7 +88,7 @@ func TestValidateExternalAuth(t *testing.T) {
 							AuthClientNamespace: "namespace3",
 						},
 						ClientID: "client3",
-						Type:     api.ExternalAuthClientTypeConfidential,
+						Type:     api.ExternalAuthClientTypePublic,
 					},
 				}
 				return obj
@@ -212,7 +226,7 @@ func TestValidateExternalAuth(t *testing.T) {
 							AuthClientNamespace: "namespace" + string(rune('0'+i)),
 						},
 						ClientID: "audience1",
-						Type:     api.ExternalAuthClientTypeConfidential,
+						Type:     api.ExternalAuthClientTypePublic,
 					}
 				}
 				return obj
@@ -235,7 +249,7 @@ func TestValidateExternalAuth(t *testing.T) {
 							AuthClientNamespace: "test-namespace",
 						},
 						ClientID: "audience1",
-						Type:     api.ExternalAuthClientTypeConfidential,
+						Type:     api.ExternalAuthClientTypePublic,
 					},
 				}
 				return obj
@@ -301,7 +315,7 @@ func TestValidateExternalAuth(t *testing.T) {
 							AuthClientNamespace: "same-namespace",
 						},
 						ClientID: "client1",
-						Type:     api.ExternalAuthClientTypeConfidential,
+						Type:     api.ExternalAuthClientTypePublic,
 					},
 					{
 						Component: api.ExternalAuthClientComponentProfile{
@@ -331,7 +345,7 @@ func TestValidateExternalAuth(t *testing.T) {
 							AuthClientNamespace: "test-namespace",
 						},
 						ClientID: "nonexistent-client", // This doesn't match any audience
-						Type:     api.ExternalAuthClientTypeConfidential,
+						Type:     api.ExternalAuthClientTypePublic,
 					},
 				}
 				return obj
@@ -353,7 +367,7 @@ func TestValidateExternalAuth(t *testing.T) {
 							AuthClientNamespace: "namespace1",
 						},
 						ClientID: "audience1", // This matches
-						Type:     api.ExternalAuthClientTypeConfidential,
+						Type:     api.ExternalAuthClientTypePublic,
 					},
 					{
 						Component: api.ExternalAuthClientComponentProfile{
@@ -617,6 +631,31 @@ func TestValidateExternalAuth(t *testing.T) {
 			op:           operation.Operation{Type: operation.Update},
 			expectErrors: nil,
 		},
+		{
+			name: "update rejects confidential on unsupported component",
+			newObj: testExternalAuthWithClients(
+				[]string{"other-client"},
+				testExternalAuthClientProfile(
+					"component1",
+					"namespace1",
+					"other-client",
+					api.ExternalAuthClientTypeConfidential,
+				),
+			),
+			oldObj: testExternalAuthWithClients(
+				[]string{"other-client"},
+				testExternalAuthClientProfile(
+					"component1",
+					"namespace1",
+					"other-client",
+					api.ExternalAuthClientTypePublic,
+				),
+			),
+			op: operation.Operation{Type: operation.Update},
+			expectErrors: []utils.ExpectedError{
+				{FieldPath: "properties.clients[0].type", Message: "confidential client type is not allowed for this component"},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -859,7 +898,7 @@ func TestValidateExternalAuthCustomValidation(t *testing.T) {
 							AuthClientNamespace: "namespace1",
 						},
 						ClientID: "client1",
-						Type:     api.ExternalAuthClientTypeConfidential,
+						Type:     api.ExternalAuthClientTypePublic,
 					},
 				}
 				return obj
@@ -878,7 +917,7 @@ func TestValidateExternalAuthCustomValidation(t *testing.T) {
 							AuthClientNamespace: "namespace1",
 						},
 						ClientID: "nonexistent-client",
-						Type:     api.ExternalAuthClientTypeConfidential,
+						Type:     api.ExternalAuthClientTypePublic,
 					},
 				}
 				return obj
@@ -899,7 +938,7 @@ func TestValidateExternalAuthCustomValidation(t *testing.T) {
 							AuthClientNamespace: "namespace1",
 						},
 						ClientID: "client1",
-						Type:     api.ExternalAuthClientTypeConfidential,
+						Type:     api.ExternalAuthClientTypePublic,
 					},
 					{
 						Component: api.ExternalAuthClientComponentProfile{
@@ -944,6 +983,21 @@ func TestValidateExternalAuthCustomValidation(t *testing.T) {
 					api.ExternalAuthConsoleClientComponentName,
 					api.ExternalAuthConsoleClientComponentNamespace,
 				)},
+			},
+		},
+		{
+			name: "confidential client rejects unsupported component",
+			newObj: testExternalAuthWithClients(
+				[]string{"other-client"},
+				testExternalAuthClientProfile(
+					"component1",
+					"namespace1",
+					"other-client",
+					api.ExternalAuthClientTypeConfidential,
+				),
+			),
+			expectErrors: []utils.ExpectedError{
+				{FieldPath: "properties.clients[0].type", Message: "confidential client type is not allowed for this component"},
 			},
 		},
 		{
@@ -1016,7 +1070,7 @@ func TestValidateExternalAuthCustomValidation(t *testing.T) {
 							AuthClientNamespace: "same-namespace",
 						},
 						ClientID: "client1-a",
-						Type:     api.ExternalAuthClientTypeConfidential,
+						Type:     api.ExternalAuthClientTypePublic,
 					},
 					{
 						Component: api.ExternalAuthClientComponentProfile{
@@ -1108,7 +1162,7 @@ func createValidExternalAuth() *api.HCPOpenShiftClusterExternalAuth {
 						AuthClientNamespace: "test-namespace",
 					},
 					ClientID: "audience1",
-					Type:     api.ExternalAuthClientTypeConfidential,
+					Type:     api.ExternalAuthClientTypePublic,
 				},
 			},
 			Claim: api.ExternalAuthClaimProfile{

--- a/internal/validation/validate_externalauth_comprehensive_test.go
+++ b/internal/validation/validate_externalauth_comprehensive_test.go
@@ -276,6 +276,22 @@ func TestValidateExternalAuth(t *testing.T) {
 			},
 		},
 		{
+			name: "username claim too long",
+			newObj: func() *api.HCPOpenShiftClusterExternalAuth {
+				obj := createValidExternalAuth()
+				longClaim := make([]byte, 257)
+				for i := range longClaim {
+					longClaim[i] = 'a'
+				}
+				obj.Properties.Claim.Mappings.Username.Claim = string(longClaim)
+				return obj
+			}(),
+			op: operation.Operation{Type: operation.Create},
+			expectErrors: []utils.ExpectedError{
+				{FieldPath: "properties.claim.mappings.username.claim", Message: "may not be more than 256 bytes"},
+			},
+		},
+		{
 			name: "group claim too long",
 			newObj: func() *api.HCPOpenShiftClusterExternalAuth {
 				obj := createValidExternalAuth()

--- a/internal/validation/validate_externalauth_comprehensive_test.go
+++ b/internal/validation/validate_externalauth_comprehensive_test.go
@@ -383,6 +383,53 @@ func TestValidateExternalAuth(t *testing.T) {
 			},
 		},
 		{
+			name: "valid client extraScopes",
+			newObj: func() *api.HCPOpenShiftClusterExternalAuth {
+				obj := createValidExternalAuth()
+				obj.Properties.Clients[0].ExtraScopes = []string{"email", "profile"}
+				return obj
+			}(),
+			op:           operation.Operation{Type: operation.Create},
+			expectErrors: nil,
+		},
+		{
+			name: "empty client extraScope",
+			newObj: func() *api.HCPOpenShiftClusterExternalAuth {
+				obj := createValidExternalAuth()
+				obj.Properties.Clients[0].ExtraScopes = []string{""}
+				return obj
+			}(),
+			op: operation.Operation{Type: operation.Create},
+			expectErrors: []utils.ExpectedError{
+				{FieldPath: "properties.clients[0].extraScopes[0]", Message: "Required value"},
+			},
+		},
+		{
+			name: "empty client extraScope among valid extraScopes",
+			newObj: func() *api.HCPOpenShiftClusterExternalAuth {
+				obj := createValidExternalAuth()
+				obj.Properties.Clients[0].ExtraScopes = []string{"email", ""}
+				return obj
+			}(),
+			op: operation.Operation{Type: operation.Create},
+			expectErrors: []utils.ExpectedError{
+				{FieldPath: "properties.clients[0].extraScopes[1]", Message: "Required value"},
+			},
+		},
+		{
+			name: "multiple empty client extraScopes",
+			newObj: func() *api.HCPOpenShiftClusterExternalAuth {
+				obj := createValidExternalAuth()
+				obj.Properties.Clients[0].ExtraScopes = []string{"", ""}
+				return obj
+			}(),
+			op: operation.Operation{Type: operation.Create},
+			expectErrors: []utils.ExpectedError{
+				{FieldPath: "properties.clients[0].extraScopes[0]", Message: "Required value"},
+				{FieldPath: "properties.clients[0].extraScopes[1]", Message: "Required value"},
+			},
+		},
+		{
 			name: "invalid external auth resource name - empty",
 			newObj: func() *api.HCPOpenShiftClusterExternalAuth {
 				obj := createValidExternalAuth()

--- a/internal/validation/validate_externalauth_comprehensive_test.go
+++ b/internal/validation/validate_externalauth_comprehensive_test.go
@@ -144,6 +144,46 @@ func TestValidateExternalAuth(t *testing.T) {
 			},
 		},
 		{
+			name: "empty issuer audience",
+			newObj: func() *api.HCPOpenShiftClusterExternalAuth {
+				obj := createMinimalExternalAuth()
+				obj.Properties.Issuer.URL = "https://valid.example.com"
+				obj.Properties.Issuer.Audiences = []string{""}
+				return obj
+			}(),
+			op: operation.Operation{Type: operation.Create},
+			expectErrors: []utils.ExpectedError{
+				{FieldPath: "properties.issuer.audiences[0]", Message: "Required value"},
+			},
+		},
+		{
+			name: "empty issuer audience among valid audiences",
+			newObj: func() *api.HCPOpenShiftClusterExternalAuth {
+				obj := createMinimalExternalAuth()
+				obj.Properties.Issuer.URL = "https://valid.example.com"
+				obj.Properties.Issuer.Audiences = []string{"audience1", ""}
+				return obj
+			}(),
+			op: operation.Operation{Type: operation.Create},
+			expectErrors: []utils.ExpectedError{
+				{FieldPath: "properties.issuer.audiences[1]", Message: "Required value"},
+			},
+		},
+		{
+			name: "multiple empty issuer audiences",
+			newObj: func() *api.HCPOpenShiftClusterExternalAuth {
+				obj := createMinimalExternalAuth()
+				obj.Properties.Issuer.URL = "https://valid.example.com"
+				obj.Properties.Issuer.Audiences = []string{"", ""}
+				return obj
+			}(),
+			op: operation.Operation{Type: operation.Create},
+			expectErrors: []utils.ExpectedError{
+				{FieldPath: "properties.issuer.audiences[0]", Message: "Required value"},
+				{FieldPath: "properties.issuer.audiences[1]", Message: "Required value"},
+			},
+		},
+		{
 			name: "invalid CA certificate",
 			newObj: func() *api.HCPOpenShiftClusterExternalAuth {
 				obj := createMinimalExternalAuth()

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/duplicate-client-components/03-httpCreate-externalauth/externalauth.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/duplicate-client-components/03-httpCreate-externalauth/externalauth.json
@@ -16,7 +16,7 @@
 					"authClientNamespace": "openshift-console",
 					"name": "duplicate-component"
 				},
-				"type": "Confidential"
+				"type": "Public"
 			},
 			{
 				"clientId": "client-2",


### PR DESCRIPTION
I did a general review of static validations that are performed in CS. This PR contains validations that are being performed in CS, implemented in Frontend.

This should not impact existing resources because CS is already enforcing the validation.