### PR TITLE
fix(pipeline): retry svc cluster deploy on transient NSP association errors

### DIFF
--- a/dev-infrastructure/svc-pipeline.yaml
+++ b/dev-infrastructure/svc-pipeline.yaml
@@ -467,6 +467,11 @@ resourceGroups:
       - "There was a problem communicating with the identity service"
       - "DeploymentScriptExceededMaxAllowedTime"
       - "was not found in the AAD tenant"
+      # Transient Network Security Perimeter association failures against the RP
+      # Cosmos DB account (exclusive-lock contention / backend retry exhaustion).
+      - "AnmPreconditionFailedException"
+      - "MaxRetryCountReached"
+      - "ServiceUnavailable"
       maximumRetryCount: 3
       durationBetweenRetries: 2m
   - name: upgrade-aks-cluster


### PR DESCRIPTION
<!-- No Jira issue; triage-driven CI reliability fix. -->

### What

Add three transient Network Security Perimeter (NSP) error codes to the
`automatedRetry.errorContainsAny` list on the `service/cluster` ARM step in
`dev-infrastructure/svc-pipeline.yaml`:

- `AnmPreconditionFailedException`
- `MaxRetryCountReached`
- `ServiceUnavailable`

### Why

The `service/cluster` step was the single biggest provision-failure cause in
DEV CI on 2026-07-13 (**6 of 14** provision failures). All six failed on the
NSP resource association against the RP Cosmos DB account with transient,
retryable errors:

- `AnmPreconditionFailedException` — *"already an operation in progress which
  requires exclusive lock on this service `arohcpci01-rp-*`. Please retry the
  operation after sometime."*
- `MaxRetryCountReached` — Azure ANM backend's own retry exhaustion.
- `ServiceUnavailable` — *"Error while processing request for association …
  Service Unavailable"*.

The step **already** has an `automatedRetry` block, but none of these strings
were in `errorContainsAny`, so the pipeline retry never fired and the step
failed on the first attempt. Azure's own error message asks the caller to
"retry the operation after sometime" — i.e. the lock contention is transient —
so a pipeline-level retry is the appropriate mitigation.

Note on budget: the single-step timeout (30m) is shared across all retry
attempts + the `durationBetweenRetries` sleeps (not reset per attempt), and an
observed failed attempt costs ~11.5m. In practice ~1 retry fits within the
budget rather than the configured 3 — still strictly better than the current
zero retries.

### Testing

No unit/integration/E2E tests — this is a declarative pipeline config change
(retry match list). Validated with:

- `make yamlfmt` — no changes to the file (formatting clean).
- `make validate-config-pipelines` — passes (pipeline schema/topology valid).

The behavior is exercised by the existing templatize retry mechanism
(`tooling/templatize/pkg/pipeline/run.go`); no code path changed, only which
error strings trigger the existing retry.

### Special notes for your reviewer

`ServiceUnavailable` is the most generic of the three, but retrying on a 503-class
transient is standard and only fires when the step has already errored. Happy to
drop it and keep only the two NSP-specific codes if you'd prefer a narrower match.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [x] Screenshots included (if graph/UI/metrics changes) — N/A
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable) — N/A
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
