### PR TITLE
fix: use hostedcontrolplane label for HCP identity in KSM metrics

### DIFF
--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arohcp_monitor.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arohcp_monitor.yaml
@@ -68650,6 +68650,11 @@ spec:
       maxBackoff: 256s
     metadataConfig:
       send: false
+    # Both drop rules are needed: the namespace rule catches HCP metrics where
+    # namespace is still ocm-* (cluster-scoped like nodes, plus non-KSM HCP metrics),
+    # while the hostedcontrolplane rule catches per-HCP KSM metrics for namespaced
+    # resources where namespace has been promoted to the actual resource namespace
+    # (e.g. openshift-ingress-operator) and no longer matches ocm-*.
     writeRelabelConfigs:
       - sourceLabels: [namespace]
         regex: '^ocm-arohcpdev.*'
@@ -68671,6 +68676,10 @@ spec:
       maxBackoff: 256s
     metadataConfig:
       send: false
+    # Combined into a single rule because sequential keep rules are AND
+    # (a metric must match all rules to survive), but we need OR — keep if
+    # either namespace or hostedcontrolplane matches ocm-*.
+    # See https://github.com/prometheus/prometheus/issues/3996
     writeRelabelConfigs:
       - sourceLabels: [namespace, hostedcontrolplane]
         separator: ;

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arohcp_monitor.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arohcp_monitor.yaml
@@ -68654,6 +68654,9 @@ spec:
       - sourceLabels: [namespace]
         regex: '^ocm-arohcpdev.*'
         action: drop
+      - sourceLabels: [hostedcontrolplane]
+        regex: '^ocm-arohcpdev.*'
+        action: drop
   - url: '__hcpDcrRemoteWriteUrl__'
     azureAd:
       cloud: AzurePublic
@@ -68669,8 +68672,9 @@ spec:
     metadataConfig:
       send: false
     writeRelabelConfigs:
-      - sourceLabels: [namespace]
-        regex: '^ocm-arohcpdev.*'
+      - sourceLabels: [namespace, hostedcontrolplane]
+        separator: ;
+        regex: '(ocm-arohcpdev[^;]*;.*|.*;ocm-arohcpdev.*)'
         action: keep
 ---
 # Source: hcp-prometheus/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/alertmanager.rules.yaml

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_arohcp_monitor.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_arohcp_monitor.yaml
@@ -68531,6 +68531,11 @@ spec:
       maxBackoff: 256s
     metadataConfig:
       send: false
+    # Both drop rules are needed: the namespace rule catches HCP metrics where
+    # namespace is still ocm-* (cluster-scoped like nodes, plus non-KSM HCP metrics),
+    # while the hostedcontrolplane rule catches per-HCP KSM metrics for namespaced
+    # resources where namespace has been promoted to the actual resource namespace
+    # (e.g. openshift-ingress-operator) and no longer matches ocm-*.
     writeRelabelConfigs:
       - sourceLabels: [namespace]
         regex: '^ocm-arohcpdev.*'
@@ -68552,6 +68557,10 @@ spec:
       maxBackoff: 256s
     metadataConfig:
       send: false
+    # Combined into a single rule because sequential keep rules are AND
+    # (a metric must match all rules to survive), but we need OR — keep if
+    # either namespace or hostedcontrolplane matches ocm-*.
+    # See https://github.com/prometheus/prometheus/issues/3996
     writeRelabelConfigs:
       - sourceLabels: [namespace, hostedcontrolplane]
         separator: ;

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_arohcp_monitor.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_arohcp_monitor.yaml
@@ -68535,6 +68535,9 @@ spec:
       - sourceLabels: [namespace]
         regex: '^ocm-arohcpdev.*'
         action: drop
+      - sourceLabels: [hostedcontrolplane]
+        regex: '^ocm-arohcpdev.*'
+        action: drop
   - url: '__hcpDcrRemoteWriteUrl__'
     azureAd:
       cloud: AzurePublic
@@ -68550,8 +68553,9 @@ spec:
     metadataConfig:
       send: false
     writeRelabelConfigs:
-      - sourceLabels: [namespace]
-        regex: '^ocm-arohcpdev.*'
+      - sourceLabels: [namespace, hostedcontrolplane]
+        separator: ;
+        regex: '(ocm-arohcpdev[^;]*;.*|.*;ocm-arohcpdev.*)'
         action: keep
 ---
 # Source: hcp-prometheus/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/alertmanager.rules.yaml

--- a/mgmt-agent/pkg/controller/ksmhcp/resources.go
+++ b/mgmt-agent/pkg/controller/ksmhcp/resources.go
@@ -156,9 +156,15 @@ func buildServiceMonitor(namespace string, ownerRef metav1.OwnerReference) (*uns
 					Interval: "30s",
 					MetricRelabelConfigs: []monitoringv1.RelabelConfig{
 						{
-							TargetLabel: "namespace",
+							TargetLabel: "hostedcontrolplane",
 							Replacement: ptr.To(namespace),
 							Action:      "replace",
+						},
+						{
+							SourceLabels: []monitoringv1.LabelName{"exported_namespace"},
+							TargetLabel:  "namespace",
+							Regex:        "(.+)",
+							Action:       "replace",
 						},
 					},
 				},

--- a/mgmt-agent/pkg/controller/ksmhcp/testdata/zz_fixture_TestBuildServiceMonitor.yaml
+++ b/mgmt-agent/pkg/controller/ksmhcp/testdata/zz_fixture_TestBuildServiceMonitor.yaml
@@ -16,6 +16,11 @@ spec:
     metricRelabelings:
     - action: replace
       replacement: ocm-arohcppers-abc123-xyz
+      targetLabel: hostedcontrolplane
+    - action: replace
+      regex: (.+)
+      sourceLabels:
+      - exported_namespace
       targetLabel: namespace
     port: http-metrics
   namespaceSelector:

--- a/observability/prometheus/deploy/templates/prometheus.yaml
+++ b/observability/prometheus/deploy/templates/prometheus.yaml
@@ -122,6 +122,9 @@ spec:
       - sourceLabels: [namespace]
         regex: '^ocm-{{ .Values.environment }}.*'
         action: drop
+      - sourceLabels: [hostedcontrolplane]
+        regex: '^ocm-{{ .Values.environment }}.*'
+        action: drop
     {{- end -}}
   {{- if ne .Values.prometheusSpec.hcpRemoteWriteUrl "NONE" }}
   - url: '{{ .Values.prometheusSpec.hcpRemoteWriteUrl }}'
@@ -140,8 +143,9 @@ spec:
       send: false
     {{- if .Values.environment }}
     writeRelabelConfigs:
-      - sourceLabels: [namespace]
-        regex: '^ocm-{{ .Values.environment }}.*'
+      - sourceLabels: [namespace, hostedcontrolplane]
+        separator: ;
+        regex: '(ocm-{{ .Values.environment }}[^;]*;.*|.*;ocm-{{ .Values.environment }}.*)'
         action: keep
     {{- end }}
   {{- end }}

--- a/observability/prometheus/deploy/templates/prometheus.yaml
+++ b/observability/prometheus/deploy/templates/prometheus.yaml
@@ -118,6 +118,11 @@ spec:
     metadataConfig:
       send: false
     {{- if .Values.environment }}
+    # Both drop rules are needed: the namespace rule catches HCP metrics where
+    # namespace is still ocm-* (cluster-scoped like nodes, plus non-KSM HCP metrics),
+    # while the hostedcontrolplane rule catches per-HCP KSM metrics for namespaced
+    # resources where namespace has been promoted to the actual resource namespace
+    # (e.g. openshift-ingress-operator) and no longer matches ocm-*.
     writeRelabelConfigs:
       - sourceLabels: [namespace]
         regex: '^ocm-{{ .Values.environment }}.*'
@@ -142,6 +147,10 @@ spec:
     metadataConfig:
       send: false
     {{- if .Values.environment }}
+    # Combined into a single rule because sequential keep rules are AND
+    # (a metric must match all rules to survive), but we need OR — keep if
+    # either namespace or hostedcontrolplane matches ocm-*.
+    # See https://github.com/prometheus/prometheus/issues/3996
     writeRelabelConfigs:
       - sourceLabels: [namespace, hostedcontrolplane]
         separator: ;

--- a/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_mgmt_resources.yaml
+++ b/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_mgmt_resources.yaml
@@ -68660,6 +68660,9 @@ spec:
       - sourceLabels: [namespace]
         regex: '^ocm-arohcpdev.*'
         action: drop
+      - sourceLabels: [hostedcontrolplane]
+        regex: '^ocm-arohcpdev.*'
+        action: drop
   - url: '__hcpDcrRemoteWriteUrl__'
     azureAd:
       cloud: AzurePublic
@@ -68675,8 +68678,9 @@ spec:
     metadataConfig:
       send: false
     writeRelabelConfigs:
-      - sourceLabels: [namespace]
-        regex: '^ocm-arohcpdev.*'
+      - sourceLabels: [namespace, hostedcontrolplane]
+        separator: ;
+        regex: '(ocm-arohcpdev[^;]*;.*|.*;ocm-arohcpdev.*)'
         action: keep
 ---
 # Source: hcp-prometheus/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/alertmanager.rules.yaml

--- a/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_mgmt_resources.yaml
+++ b/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_mgmt_resources.yaml
@@ -68656,6 +68656,11 @@ spec:
       maxBackoff: 256s
     metadataConfig:
       send: false
+    # Both drop rules are needed: the namespace rule catches HCP metrics where
+    # namespace is still ocm-* (cluster-scoped like nodes, plus non-KSM HCP metrics),
+    # while the hostedcontrolplane rule catches per-HCP KSM metrics for namespaced
+    # resources where namespace has been promoted to the actual resource namespace
+    # (e.g. openshift-ingress-operator) and no longer matches ocm-*.
     writeRelabelConfigs:
       - sourceLabels: [namespace]
         regex: '^ocm-arohcpdev.*'
@@ -68677,6 +68682,10 @@ spec:
       maxBackoff: 256s
     metadataConfig:
       send: false
+    # Combined into a single rule because sequential keep rules are AND
+    # (a metric must match all rules to survive), but we need OR — keep if
+    # either namespace or hostedcontrolplane matches ocm-*.
+    # See https://github.com/prometheus/prometheus/issues/3996
     writeRelabelConfigs:
       - sourceLabels: [namespace, hostedcontrolplane]
         separator: ;

--- a/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_mgmt_resources_unset.yaml
+++ b/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_mgmt_resources_unset.yaml
@@ -68650,6 +68650,11 @@ spec:
       maxBackoff: 256s
     metadataConfig:
       send: false
+    # Both drop rules are needed: the namespace rule catches HCP metrics where
+    # namespace is still ocm-* (cluster-scoped like nodes, plus non-KSM HCP metrics),
+    # while the hostedcontrolplane rule catches per-HCP KSM metrics for namespaced
+    # resources where namespace has been promoted to the actual resource namespace
+    # (e.g. openshift-ingress-operator) and no longer matches ocm-*.
     writeRelabelConfigs:
       - sourceLabels: [namespace]
         regex: '^ocm-arohcpdev.*'
@@ -68671,6 +68676,10 @@ spec:
       maxBackoff: 256s
     metadataConfig:
       send: false
+    # Combined into a single rule because sequential keep rules are AND
+    # (a metric must match all rules to survive), but we need OR — keep if
+    # either namespace or hostedcontrolplane matches ocm-*.
+    # See https://github.com/prometheus/prometheus/issues/3996
     writeRelabelConfigs:
       - sourceLabels: [namespace, hostedcontrolplane]
         separator: ;

--- a/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_mgmt_resources_unset.yaml
+++ b/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_mgmt_resources_unset.yaml
@@ -68654,6 +68654,9 @@ spec:
       - sourceLabels: [namespace]
         regex: '^ocm-arohcpdev.*'
         action: drop
+      - sourceLabels: [hostedcontrolplane]
+        regex: '^ocm-arohcpdev.*'
+        action: drop
   - url: '__hcpDcrRemoteWriteUrl__'
     azureAd:
       cloud: AzurePublic
@@ -68669,8 +68672,9 @@ spec:
     metadataConfig:
       send: false
     writeRelabelConfigs:
-      - sourceLabels: [namespace]
-        regex: '^ocm-arohcpdev.*'
+      - sourceLabels: [namespace, hostedcontrolplane]
+        separator: ;
+        regex: '(ocm-arohcpdev[^;]*;.*|.*;ocm-arohcpdev.*)'
         action: keep
 ---
 # Source: hcp-prometheus/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/alertmanager.rules.yaml

--- a/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_svc_resources.yaml
+++ b/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_svc_resources.yaml
@@ -68541,6 +68541,9 @@ spec:
       - sourceLabels: [namespace]
         regex: '^ocm-arohcpdev.*'
         action: drop
+      - sourceLabels: [hostedcontrolplane]
+        regex: '^ocm-arohcpdev.*'
+        action: drop
   - url: '__hcpDcrRemoteWriteUrl__'
     azureAd:
       cloud: AzurePublic
@@ -68556,8 +68559,9 @@ spec:
     metadataConfig:
       send: false
     writeRelabelConfigs:
-      - sourceLabels: [namespace]
-        regex: '^ocm-arohcpdev.*'
+      - sourceLabels: [namespace, hostedcontrolplane]
+        separator: ;
+        regex: '(ocm-arohcpdev[^;]*;.*|.*;ocm-arohcpdev.*)'
         action: keep
 ---
 # Source: hcp-prometheus/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/alertmanager.rules.yaml

--- a/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_svc_resources.yaml
+++ b/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_svc_resources.yaml
@@ -68537,6 +68537,11 @@ spec:
       maxBackoff: 256s
     metadataConfig:
       send: false
+    # Both drop rules are needed: the namespace rule catches HCP metrics where
+    # namespace is still ocm-* (cluster-scoped like nodes, plus non-KSM HCP metrics),
+    # while the hostedcontrolplane rule catches per-HCP KSM metrics for namespaced
+    # resources where namespace has been promoted to the actual resource namespace
+    # (e.g. openshift-ingress-operator) and no longer matches ocm-*.
     writeRelabelConfigs:
       - sourceLabels: [namespace]
         regex: '^ocm-arohcpdev.*'
@@ -68558,6 +68563,10 @@ spec:
       maxBackoff: 256s
     metadataConfig:
       send: false
+    # Combined into a single rule because sequential keep rules are AND
+    # (a metric must match all rules to survive), but we need OR — keep if
+    # either namespace or hostedcontrolplane matches ocm-*.
+    # See https://github.com/prometheus/prometheus/issues/3996
     writeRelabelConfigs:
       - sourceLabels: [namespace, hostedcontrolplane]
         separator: ;

--- a/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_svc_resources_unset.yaml
+++ b/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_svc_resources_unset.yaml
@@ -68531,6 +68531,11 @@ spec:
       maxBackoff: 256s
     metadataConfig:
       send: false
+    # Both drop rules are needed: the namespace rule catches HCP metrics where
+    # namespace is still ocm-* (cluster-scoped like nodes, plus non-KSM HCP metrics),
+    # while the hostedcontrolplane rule catches per-HCP KSM metrics for namespaced
+    # resources where namespace has been promoted to the actual resource namespace
+    # (e.g. openshift-ingress-operator) and no longer matches ocm-*.
     writeRelabelConfigs:
       - sourceLabels: [namespace]
         regex: '^ocm-arohcpdev.*'
@@ -68552,6 +68557,10 @@ spec:
       maxBackoff: 256s
     metadataConfig:
       send: false
+    # Combined into a single rule because sequential keep rules are AND
+    # (a metric must match all rules to survive), but we need OR — keep if
+    # either namespace or hostedcontrolplane matches ocm-*.
+    # See https://github.com/prometheus/prometheus/issues/3996
     writeRelabelConfigs:
       - sourceLabels: [namespace, hostedcontrolplane]
         separator: ;

--- a/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_svc_resources_unset.yaml
+++ b/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_svc_resources_unset.yaml
@@ -68535,6 +68535,9 @@ spec:
       - sourceLabels: [namespace]
         regex: '^ocm-arohcpdev.*'
         action: drop
+      - sourceLabels: [hostedcontrolplane]
+        regex: '^ocm-arohcpdev.*'
+        action: drop
   - url: '__hcpDcrRemoteWriteUrl__'
     azureAd:
       cloud: AzurePublic
@@ -68550,8 +68553,9 @@ spec:
     metadataConfig:
       send: false
     writeRelabelConfigs:
-      - sourceLabels: [namespace]
-        regex: '^ocm-arohcpdev.*'
+      - sourceLabels: [namespace, hostedcontrolplane]
+        separator: ;
+        regex: '(ocm-arohcpdev[^;]*;.*|.*;ocm-arohcpdev.*)'
         action: keep
 ---
 # Source: hcp-prometheus/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/alertmanager.rules.yaml


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-1491

## Why

The per-HCP KSM ServiceMonitor previously overwrote the `namespace` label with the HCP control plane namespace. This was:
- **Redundant** for cluster-scoped metrics (nodes) — Prometheus service discovery already injects `namespace=ocm-*` via `__meta_kubernetes_namespace`
- **Destructive** for namespaced metrics (e.g. IngressController) — it discards the actual resource namespace (e.g. `openshift-ingress-operator`), making it impossible to distinguish which component inside the HCP is failing

When Prometheus scrapes a target with `honorLabels: false` (the default), a label collision between the scraped metric's `namespace` and the service discovery's `namespace` is resolved by renaming the metric's label to `exported_namespace`. The previous `metricRelabelConfigs` then overwrote `namespace` with the same `ocm-*` value — losing the original resource namespace entirely.

## What

- Adds a `hostedcontrolplane` label set to the HCP control plane namespace for unambiguous HCP identity
- Promotes `exported_namespace` into `namespace` (when non-empty) so namespaced resource metrics retain their original namespace
- Uses `regex: (.+)` guard so cluster-scoped metrics (where `exported_namespace` is absent) keep `namespace=ocm-*` for routing
- Updates remote write `writeRelabelConfigs` to route HCP metrics based on either `namespace` or `hostedcontrolplane` matching `ocm-*`

## Query model

```promql
# All ingress across all clusters
ingresscontroller_info{namespace="openshift-ingress-operator"}

# Ingress in one cluster
ingresscontroller_info{hostedcontrolplane="ocm-arohcpci01-...", namespace="openshift-ingress-operator"}

# All metrics in one cluster
{hostedcontrolplane="ocm-arohcpci01-..."}
```

| Resource type | `hostedcontrolplane` | `namespace` |
|---|---|---|
| Namespaced (IngressController) | `ocm-*` (HCP identity) | `openshift-ingress-operator` (actual resource ns) |
| Cluster-scoped (nodes) | `ocm-*` (HCP identity) | `ocm-*` (from service discovery, no override) |

## Testing

Verified on pers dev cluster (`pers-usw3iman-mgmt-1`) by deploying the mgmt-agent and querying the HCP AMW (`hcps-usw3iman`).

kube_node_info
```json
{
                    "__name__": "kube_node_info",
                    "cluster": "pers-usw3iman-mgmt-1",
                    "container": "kube-state-metrics",
                    "container_runtime_version": "cri-o://1.33.13-2.rhaos4.20.git3c4da7a.el9",
                    "endpoint": "http-metrics",
                    "environment": "pers",
                    "hostedcontrolplane": "ocm-arohcppers-2riaginb3qd89hngotreo4rk07q4btt2-y7s2w4q1k4s2r2t",
                    "instance": "10.128.64.193:8080",
                    "internal_ip": "10.0.0.4",
                    "job": "kube-state-metrics-hcp",
                    "kernel_version": "5.14.0-570.126.1.el9_6.x86_64",
                    "kubelet_version": "v1.33.13",
                    "kubeproxy_version": "deprecated",
                    "microsoft.amwresourceid": "/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourcegroups/hcp-underlay-pers-usw3iman/providers/microsoft.monitor/accounts/hcps-usw3iman",
                    "namespace": "ocm-arohcppers-2riaginb3qd89hngotreo4rk07q4btt2-y7s2w4q1k4s2r2t",
                    "node": "y7s2w4q1k4s2r2t-np-1-bnm6h-26cdl",
                    "os_image": "red hat enterprise linux coreos 9.6.20260702-0 (plow)",
                    "pod": "kube-state-metrics-hcp-9bd877fd4-cqzdv",
                    "prometheus": "prometheus/prometheus",
                    "prometheus_replica": "prom-agent-prometheus-0",
                    "provider_id": "azure:///subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourcegroups/autoscaling-cluster-4qrhq9--managed/providers/microsoft.compute/virtualmachines/y7s2w4q1k4s2r2t-np-1-bnm6h-26cdl",
                    "region": "westus3",
                    "service": "kube-state-metrics-hcp",
                    "system_uuid": "324fdb51-229a-44b0-9032-42ba20569ef6"
                }
```

ingresscontroller_info
```json
{
                    "__name__": "ingresscontroller_info",
                    "cluster": "pers-usw3iman-mgmt-1",
                    "container": "kube-state-metrics",
                    "customresource_group": "operator.openshift.io",
                    "customresource_kind": "ingresscontroller",
                    "customresource_version": "v1",
                    "default_certificate_name": "cluster-ingress-cert",
                    "dns_management_policy": "managed",
                    "endpoint": "http-metrics",
                    "endpoint_publishing_strategy_type": "loadbalancerservice",
                    "environment": "pers",
                    "exported_namespace": "openshift-ingress-operator",
                    "hostedcontrolplane": "ocm-arohcppers-2riaginb3qd89hngotreo4rk07q4btt2-y7s2w4q1k4s2r2t",
                    "instance": "10.128.64.193:8080",
                    "job": "kube-state-metrics-hcp",
                    "load_balancer_scope": "external",
                    "microsoft.amwresourceid": "/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourcegroups/hcp-underlay-pers-usw3iman/providers/microsoft.monitor/accounts/hcps-usw3iman",
                    "name": "default",
                    "namespace": "openshift-ingress-operator",
                    "pod": "kube-state-metrics-hcp-9bd877fd4-cqzdv",
                    "prometheus": "prometheus/prometheus",
                    "prometheus_replica": "prom-agent-prometheus-0",
                    "region": "westus3",
                    "service": "kube-state-metrics-hcp"
                }
```

kube_node_status_condition
```json
{
                    "__name__": "kube_node_status_condition",
                    "cluster": "pers-usw3iman-mgmt-1",
                    "condition": "ready",
                    "container": "kube-state-metrics",
                    "endpoint": "http-metrics",
                    "environment": "pers",
                    "hostedcontrolplane": "ocm-arohcppers-2riaginb3qd89hngotreo4rk07q4btt2-y7s2w4q1k4s2r2t",
                    "instance": "10.128.64.193:8080",
                    "job": "kube-state-metrics-hcp",
                    "microsoft.amwresourceid": "/subscriptions/1d3378d3-5a3f-4712-85a1-2485495dfc4b/resourcegroups/hcp-underlay-pers-usw3iman/providers/microsoft.monitor/accounts/hcps-usw3iman",
                    "namespace": "ocm-arohcppers-2riaginb3qd89hngotreo4rk07q4btt2-y7s2w4q1k4s2r2t",
                    "node": "y7s2w4q1k4s2r2t-np-1-bnm6h-sdnfk",
                    "pod": "kube-state-metrics-hcp-9bd877fd4-cqzdv",
                    "prometheus": "prometheus/prometheus",
                    "prometheus_replica": "prom-agent-prometheus-0",
                    "region": "westus3",
                    "service": "kube-state-metrics-hcp",
                    "status": "true"
                }
```