### PR TITLE
feat: ensure azmonitoring.coreos.com ServiceMonitors exist alongside coreos

### DIFF
--- a/acm/deploy/helm/multicluster-engine/templates/clusterlifecycle-state-metrics-v2.servicemonitor-azmonitor.yaml
+++ b/acm/deploy/helm/multicluster-engine/templates/clusterlifecycle-state-metrics-v2.servicemonitor-azmonitor.yaml
@@ -1,0 +1,18 @@
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clusterlifecycle-state-metrics-v2
+  namespace: '{{ .Release.Namespace }}'
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 60s
+    port: https
+    scheme: https
+    scrapeTimeout: 10s
+    tlsConfig:
+      insecureSkipVerify: true
+  jobLabel: clc-app
+  selector:
+    matchLabels:
+      clc-app: clusterlifecycle-state-metrics-v2

--- a/acm/scaffold/metrics-servicemonitor-azmonitor.yaml
+++ b/acm/scaffold/metrics-servicemonitor-azmonitor.yaml
@@ -1,0 +1,18 @@
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clusterlifecycle-state-metrics-v2
+  namespace: '{{ .Release.Namespace }}'
+spec:
+  endpoints:
+  - interval: 60s
+    port: https
+    scheme: https
+    scrapeTimeout: 10s
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    tlsConfig:
+      insecureSkipVerify: true
+  jobLabel: clc-app
+  selector:
+    matchLabels:
+      clc-app: clusterlifecycle-state-metrics-v2

--- a/acm/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_mce.yaml
+++ b/acm/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_mce.yaml
@@ -3682,6 +3682,26 @@ spec:
     operator: Equal
     value: "true"
 ---
+# Source: multicluster-engine/templates/clusterlifecycle-state-metrics-v2.servicemonitor-azmonitor.yaml
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clusterlifecycle-state-metrics-v2
+  namespace: 'multicluster-engine'
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 60s
+    port: https
+    scheme: https
+    scrapeTimeout: 10s
+    tlsConfig:
+      insecureSkipVerify: true
+  jobLabel: clc-app
+  selector:
+    matchLabels:
+      clc-app: clusterlifecycle-state-metrics-v2
+---
 # Source: multicluster-engine/templates/clusterlifecycle-state-metrics-v2.servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/acrpull/deploy/templates/podmonitor-azmonitor.yaml
+++ b/acrpull/deploy/templates/podmonitor-azmonitor.yaml
@@ -1,0 +1,15 @@
+apiVersion: azmonitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: acrpull
+    app.kubernetes.io/managed-by: Helm
+  name: acrpull
+  namespace: '{{ .Values.namespace }}'
+spec:
+  podMetricsEndpoints:
+  - port: metrics
+    path: /metrics
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: acrpull

--- a/admin/deploy/templates/admin.servicemonitor-azmonitor.yaml
+++ b/admin/deploy/templates/admin.servicemonitor-azmonitor.yaml
@@ -1,0 +1,17 @@
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: aro-hcp-admin-api
+  namespace: '{{ .Release.Namespace }}'
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - '{{ .Release.Namespace }}'
+  selector:
+    matchLabels:
+      app: admin-api-metrics

--- a/admin/testdata/zz_fixture_TestHelmTemplate_admin_api_mise_enabled.yaml
+++ b/admin/testdata/zz_fixture_TestHelmTemplate_admin_api_mise_enabled.yaml
@@ -361,6 +361,25 @@ spec:
     - objectName: admin-api-cert
       key: tls.key
 ---
+# Source: ARO HCP Admin API/templates/admin.servicemonitor-azmonitor.yaml
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: aro-hcp-admin-api
+  namespace: 'aro-hcp-admin-api'
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - 'aro-hcp-admin-api'
+  selector:
+    matchLabels:
+      app: admin-api-metrics
+---
 # Source: ARO HCP Admin API/templates/admin.servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/admin/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_admin_api.yaml
+++ b/admin/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_admin_api.yaml
@@ -345,6 +345,25 @@ spec:
     - objectName: admin-api-cert
       key: tls.key
 ---
+# Source: ARO HCP Admin API/templates/admin.servicemonitor-azmonitor.yaml
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: aro-hcp-admin-api
+  namespace: 'aro-hcp-admin-api'
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - 'aro-hcp-admin-api'
+  selector:
+    matchLabels:
+      app: admin-api-metrics
+---
 # Source: ARO HCP Admin API/templates/admin.servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/backend/deploy/templates/servicemonitor-azmonitor.yaml
+++ b/backend/deploy/templates/servicemonitor-azmonitor.yaml
@@ -1,0 +1,18 @@
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: aro-hcp-backend
+  namespace: '{{ .Release.Namespace }}'
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - '{{ .Release.Namespace }}'
+  selector:
+    matchLabels:
+      app: aro-hcp-backend
+      port: metrics

--- a/backend/testdata/zz_fixture_TestHelmTemplate_backend_clstr_scoped_identities_role_set_name_public.yaml
+++ b/backend/testdata/zz_fixture_TestHelmTemplate_backend_clstr_scoped_identities_role_set_name_public.yaml
@@ -344,6 +344,26 @@ spec:
     usePodIdentity: "false"
   provider: azure
 ---
+# Source: backend/templates/servicemonitor-azmonitor.yaml
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: aro-hcp-backend
+  namespace: 'aro-hcp'
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - 'aro-hcp'
+  selector:
+    matchLabels:
+      app: aro-hcp-backend
+      port: metrics
+---
 # Source: backend/templates/servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/backend/testdata/zz_fixture_TestHelmTemplate_backend_mi_mock_and_arm_perms_mgr_identities_unset.yaml
+++ b/backend/testdata/zz_fixture_TestHelmTemplate_backend_mi_mock_and_arm_perms_mgr_identities_unset.yaml
@@ -319,6 +319,26 @@ spec:
     usePodIdentity: "false"
   provider: azure
 ---
+# Source: backend/templates/servicemonitor-azmonitor.yaml
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: aro-hcp-backend
+  namespace: 'aro-hcp'
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - 'aro-hcp'
+  selector:
+    matchLabels:
+      app: aro-hcp-backend
+      port: metrics
+---
 # Source: backend/templates/servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/backend/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_aro_hcp_backend_dev.yaml
+++ b/backend/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_aro_hcp_backend_dev.yaml
@@ -344,6 +344,26 @@ spec:
     usePodIdentity: "false"
   provider: azure
 ---
+# Source: backend/templates/servicemonitor-azmonitor.yaml
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: aro-hcp-backend
+  namespace: 'aro-hcp'
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - 'aro-hcp'
+  selector:
+    matchLabels:
+      app: aro-hcp-backend
+      port: metrics
+---
 # Source: backend/templates/servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/cluster-service/deploy/templates/servicemonitor-azmonitor.yaml
+++ b/cluster-service/deploy/templates/servicemonitor-azmonitor.yaml
@@ -1,0 +1,18 @@
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clusters-service
+  namespace: '{{ .Release.Namespace }}'
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - '{{ .Release.Namespace }}'
+  selector:
+    matchLabels:
+      app: clusters-service
+      port: metrics

--- a/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_azuredb.yaml
+++ b/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_azuredb.yaml
@@ -8414,6 +8414,26 @@ spec:
     usePodIdentity: "false"
   provider: azure
 ---
+# Source: clusters-service/templates/servicemonitor-azmonitor.yaml
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clusters-service
+  namespace: 'clusters-service'
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - 'clusters-service'
+  selector:
+    matchLabels:
+      app: clusters-service
+      port: metrics
+---
 # Source: clusters-service/templates/servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_containerdb.yaml
+++ b/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_containerdb.yaml
@@ -8515,6 +8515,26 @@ spec:
     usePodIdentity: "false"
   provider: azure
 ---
+# Source: clusters-service/templates/servicemonitor-azmonitor.yaml
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clusters-service
+  namespace: 'clusters-service'
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - 'clusters-service'
+  selector:
+    matchLabels:
+      app: clusters-service
+      port: metrics
+---
 # Source: clusters-service/templates/servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/cluster-service/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_cluster_service.yaml
+++ b/cluster-service/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_cluster_service.yaml
@@ -8414,6 +8414,26 @@ spec:
     usePodIdentity: "false"
   provider: azure
 ---
+# Source: clusters-service/templates/servicemonitor-azmonitor.yaml
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clusters-service
+  namespace: 'clusters-service'
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - 'clusters-service'
+  selector:
+    matchLabels:
+      app: clusters-service
+      port: metrics
+---
 # Source: clusters-service/templates/servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_acrpull.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_acrpull.yaml
@@ -557,6 +557,23 @@ spec:
       serviceAccountName: acrpull
       terminationGracePeriodSeconds: 10
 ---
+# Source: acrpull/templates/podmonitor-azmonitor.yaml
+apiVersion: azmonitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: acrpull
+    app.kubernetes.io/managed-by: Helm
+  name: acrpull
+  namespace: 'acrpull'
+spec:
+  podMetricsEndpoints:
+  - port: metrics
+    path: /metrics
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: acrpull
+---
 # Source: acrpull/templates/podmonitor.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arobit.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arobit.yaml
@@ -700,6 +700,25 @@ spec:
             name: arobit-forwarder
             defaultMode: 0755
 ---
+# Source: arobit/templates/forwarder-servicemonitor-azmonitor.yaml
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: arobit-forwarder
+  namespace: 'arobit'
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - 'arobit'
+  selector:
+    matchLabels:
+      app: arobit-forwarder
+---
 # Source: arobit/templates/forwarder-servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_acrpull.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_acrpull.yaml
@@ -557,6 +557,23 @@ spec:
       serviceAccountName: acrpull
       terminationGracePeriodSeconds: 10
 ---
+# Source: acrpull/templates/podmonitor-azmonitor.yaml
+apiVersion: azmonitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: acrpull
+    app.kubernetes.io/managed-by: Helm
+  name: acrpull
+  namespace: 'acrpull'
+spec:
+  podMetricsEndpoints:
+  - port: metrics
+    path: /metrics
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: acrpull
+---
 # Source: acrpull/templates/podmonitor.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_aro_hcp_exporter.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_aro_hcp_exporter.yaml
@@ -111,6 +111,25 @@ spec:
             cpu: 100m
             memory: 128Mi
 ---
+# Source: aro-hcp-exporter/templates/servicemonitor-azmonitor.yaml
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: 'aro-hcp-exporter'
+  namespace: 'aro-hcp-exporter'
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - 'aro-hcp-exporter'
+  selector:
+    matchLabels:
+      app: 'aro-hcp-exporter'
+---
 # Source: aro-hcp-exporter/templates/servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_arobit.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_arobit.yaml
@@ -676,6 +676,25 @@ spec:
             name: arobit-forwarder
             defaultMode: 0755
 ---
+# Source: arobit/templates/forwarder-servicemonitor-azmonitor.yaml
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: arobit-forwarder
+  namespace: 'arobit'
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - 'arobit'
+  selector:
+    matchLabels:
+      app: arobit-forwarder
+---
 # Source: arobit/templates/forwarder-servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_istio.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_istio.yaml
@@ -105,6 +105,32 @@ spec:
     protocol: http
   resolution: STATIC
 ---
+# Source: istio/templates/istiod.servicemonitor-azmonitor.yml
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: istiod
+  namespace: 'aks-istio-system'
+spec:
+  jobLabel: app
+  # The following limits - labelLimit, labelNameLengthLimit and labelValueLengthLimit should exist in the pod monitor CR
+  # These ensure that the metrics don't get dropped because labels/labelnames/labelvalues exceed the limits supported by the processing pipeline
+  labelLimit: 63
+  labelNameLengthLimit: 511
+  labelValueLengthLimit: 1023
+  selector:
+    matchExpressions:
+    - key: app
+      operator: In
+      values:
+      - istiod
+  namespaceSelector:
+    matchNames:
+    - aks-istio-system
+  endpoints:
+  - interval: 15s
+    port: http-monitoring
+---
 # Source: istio/templates/istiod.servicemonitor.yml
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_istio.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_istio.yaml
@@ -65,6 +65,29 @@ spec:
   mtls:
     mode: STRICT
 ---
+# Source: istio/templates/envoy-stats.podmonitor-azmonitor.yml
+apiVersion: azmonitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: envoy-stats
+  namespace: 'aks-istio-system'
+spec:
+  jobLabel: app
+  # The following limits - labelLimit, labelNameLengthLimit and labelValueLengthLimit should exist in the pod monitor CR
+  # These ensure that the metrics don't get dropped because labels/labelnames/labelvalues exceed the limits supported by the processing pipeline
+  labelLimit: 63
+  labelNameLengthLimit: 511
+  labelValueLengthLimit: 1023
+  selector:
+    matchLabels:
+      security.istio.io/tlsMode: istio
+  namespaceSelector:
+    any: true
+  podMetricsEndpoints:
+  - interval: 15s
+    path: /stats/prometheus
+    port: http-envoy-prom
+---
 # Source: istio/templates/envoy-stats.podmonitor.yml
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor

--- a/fleet/deploy/templates/servicemonitor-azmonitor.yaml
+++ b/fleet/deploy/templates/servicemonitor-azmonitor.yaml
@@ -1,0 +1,18 @@
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: fleet-controller
+  namespace: '{{ .Release.Namespace }}'
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - '{{ .Release.Namespace }}'
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: fleet-controller
+      port: metrics

--- a/fleet/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_fleet.yaml
+++ b/fleet/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_fleet.yaml
@@ -198,6 +198,26 @@ spec:
     8081:
       mode: PERMISSIVE
 ---
+# Source: fleet/templates/servicemonitor-azmonitor.yaml
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: fleet-controller
+  namespace: 'fleet'
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - 'fleet'
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: fleet-controller
+      port: metrics
+---
 # Source: fleet/templates/servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/frontend/deploy/templates/servicemonitor-azmonitor.yaml
+++ b/frontend/deploy/templates/servicemonitor-azmonitor.yaml
@@ -1,0 +1,18 @@
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: aro-hcp-frontend
+  namespace: '{{ .Release.Namespace }}'
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - '{{ .Release.Namespace }}'
+  selector:
+    matchLabels:
+      app.kubernetes.io/part-of: aro-hcp-frontend
+      port: metrics

--- a/frontend/testdata/zz_fixture_TestHelmTemplate_frontend_connect_socket.yaml
+++ b/frontend/testdata/zz_fixture_TestHelmTemplate_frontend_connect_socket.yaml
@@ -394,6 +394,26 @@ spec:
     - objectName: frontend-cert
       key: tls.key
 ---
+# Source: frontend/templates/servicemonitor-azmonitor.yaml
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: aro-hcp-frontend
+  namespace: 'aro-hcp'
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - 'aro-hcp'
+  selector:
+    matchLabels:
+      app.kubernetes.io/part-of: aro-hcp-frontend
+      port: metrics
+---
 # Source: frontend/templates/servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/frontend/testdata/zz_fixture_TestHelmTemplate_frontend_mise_enabled.yaml
+++ b/frontend/testdata/zz_fixture_TestHelmTemplate_frontend_mise_enabled.yaml
@@ -405,6 +405,26 @@ spec:
     - objectName: frontend-cert
       key: tls.key
 ---
+# Source: frontend/templates/servicemonitor-azmonitor.yaml
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: aro-hcp-frontend
+  namespace: 'aro-hcp'
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - 'aro-hcp'
+  selector:
+    matchLabels:
+      app.kubernetes.io/part-of: aro-hcp-frontend
+      port: metrics
+---
 # Source: frontend/templates/servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/frontend/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_aro_hcp_frontend_dev.yaml
+++ b/frontend/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_aro_hcp_frontend_dev.yaml
@@ -386,6 +386,26 @@ spec:
     - objectName: frontend-cert
       key: tls.key
 ---
+# Source: frontend/templates/servicemonitor-azmonitor.yaml
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: aro-hcp-frontend
+  namespace: 'aro-hcp'
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - 'aro-hcp'
+  selector:
+    matchLabels:
+      app.kubernetes.io/part-of: aro-hcp-frontend
+      port: metrics
+---
 # Source: frontend/templates/servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/istio/deploy/templates/envoy-stats.podmonitor-azmonitor.yml
+++ b/istio/deploy/templates/envoy-stats.podmonitor-azmonitor.yml
@@ -1,0 +1,21 @@
+apiVersion: azmonitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: envoy-stats
+  namespace: '{{ .Release.Namespace }}'
+spec:
+  jobLabel: app
+  # The following limits - labelLimit, labelNameLengthLimit and labelValueLengthLimit should exist in the pod monitor CR
+  # These ensure that the metrics don't get dropped because labels/labelnames/labelvalues exceed the limits supported by the processing pipeline
+  labelLimit: 63
+  labelNameLengthLimit: 511
+  labelValueLengthLimit: 1023
+  selector:
+    matchLabels:
+      security.istio.io/tlsMode: istio
+  namespaceSelector:
+    any: true
+  podMetricsEndpoints:
+  - interval: 15s
+    path: /stats/prometheus
+    port: http-envoy-prom

--- a/istio/deploy/templates/istiod.servicemonitor-azmonitor.yml
+++ b/istio/deploy/templates/istiod.servicemonitor-azmonitor.yml
@@ -1,0 +1,24 @@
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: istiod
+  namespace: '{{ .Release.Namespace }}'
+spec:
+  jobLabel: app
+  # The following limits - labelLimit, labelNameLengthLimit and labelValueLengthLimit should exist in the pod monitor CR
+  # These ensure that the metrics don't get dropped because labels/labelnames/labelvalues exceed the limits supported by the processing pipeline
+  labelLimit: 63
+  labelNameLengthLimit: 511
+  labelValueLengthLimit: 1023
+  selector:
+    matchExpressions:
+    - key: app
+      operator: In
+      values:
+      - istiod
+  namespaceSelector:
+    matchNames:
+    - aks-istio-system
+  endpoints:
+  - interval: 15s
+    port: http-monitoring

--- a/istio/testdata/zz_fixture_TestHelmTemplate_istio_mise_enabled.yaml
+++ b/istio/testdata/zz_fixture_TestHelmTemplate_istio_mise_enabled.yaml
@@ -284,6 +284,32 @@ spec:
     protocol: http
   resolution: STATIC
 ---
+# Source: istio/templates/istiod.servicemonitor-azmonitor.yml
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: istiod
+  namespace: 'aks-istio-system'
+spec:
+  jobLabel: app
+  # The following limits - labelLimit, labelNameLengthLimit and labelValueLengthLimit should exist in the pod monitor CR
+  # These ensure that the metrics don't get dropped because labels/labelnames/labelvalues exceed the limits supported by the processing pipeline
+  labelLimit: 63
+  labelNameLengthLimit: 511
+  labelValueLengthLimit: 1023
+  selector:
+    matchExpressions:
+    - key: app
+      operator: In
+      values:
+      - istiod
+  namespaceSelector:
+    matchNames:
+    - aks-istio-system
+  endpoints:
+  - interval: 15s
+    port: http-monitoring
+---
 # Source: istio/templates/istiod.servicemonitor.yml
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/istio/testdata/zz_fixture_TestHelmTemplate_istio_mise_enabled.yaml
+++ b/istio/testdata/zz_fixture_TestHelmTemplate_istio_mise_enabled.yaml
@@ -244,6 +244,29 @@ spec:
   mtls:
     mode: STRICT
 ---
+# Source: istio/templates/envoy-stats.podmonitor-azmonitor.yml
+apiVersion: azmonitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: envoy-stats
+  namespace: 'aks-istio-system'
+spec:
+  jobLabel: app
+  # The following limits - labelLimit, labelNameLengthLimit and labelValueLengthLimit should exist in the pod monitor CR
+  # These ensure that the metrics don't get dropped because labels/labelnames/labelvalues exceed the limits supported by the processing pipeline
+  labelLimit: 63
+  labelNameLengthLimit: 511
+  labelValueLengthLimit: 1023
+  selector:
+    matchLabels:
+      security.istio.io/tlsMode: istio
+  namespaceSelector:
+    any: true
+  podMetricsEndpoints:
+  - interval: 15s
+    path: /stats/prometheus
+    port: http-envoy-prom
+---
 # Source: istio/templates/envoy-stats.podmonitor.yml
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor

--- a/kube-applier/deploy/templates/servicemonitor-azmonitor.yaml
+++ b/kube-applier/deploy/templates/servicemonitor-azmonitor.yaml
@@ -1,0 +1,18 @@
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kube-applier
+  namespace: '{{ .Release.Namespace }}'
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - '{{ .Release.Namespace }}'
+  selector:
+    matchLabels:
+      app: kube-applier
+      port: metrics

--- a/kube-applier/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_kube_applier.yaml
+++ b/kube-applier/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_kube_applier.yaml
@@ -283,6 +283,26 @@ spec:
       tenantID: '__imagePullerMsiTenantId__'
   serviceAccountName: 'kube-applier'
 ---
+# Source: kube-applier/templates/servicemonitor-azmonitor.yaml
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kube-applier
+  namespace: 'kube-applier'
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - 'kube-applier'
+  selector:
+    matchLabels:
+      app: kube-applier
+      port: metrics
+---
 # Source: kube-applier/templates/servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/maestro/agent/deploy/templates/maestro-agent.podmonitor-azmonitor.yaml
+++ b/maestro/agent/deploy/templates/maestro-agent.podmonitor-azmonitor.yaml
@@ -1,0 +1,16 @@
+apiVersion: azmonitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: maestro-agent
+  namespace: '{{ .Release.Namespace }}'
+spec:
+  selector:
+    matchLabels:
+      app: maestro-agent
+  namespaceSelector:
+    matchNames:
+    - '{{ .Release.Namespace }}'
+  podMetricsEndpoints:
+  - path: /metrics
+    port: metrics
+    scheme: http

--- a/maestro/agent/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_maestro_agent.yaml
+++ b/maestro/agent/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_maestro_agent.yaml
@@ -418,6 +418,24 @@ spec:
 # Source: maestro-agent/templates/appliedmanifestworks.work.open-cluster-management.io.customresourcedefinition.yaml
 #
 ---
+# Source: maestro-agent/templates/maestro-agent.podmonitor-azmonitor.yaml
+apiVersion: azmonitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: maestro-agent
+  namespace: 'maestro'
+spec:
+  selector:
+    matchLabels:
+      app: maestro-agent
+  namespaceSelector:
+    matchNames:
+    - 'maestro'
+  podMetricsEndpoints:
+  - path: /metrics
+    port: metrics
+    scheme: http
+---
 # Source: maestro-agent/templates/maestro-agent.podmonitor.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor

--- a/maestro/server/deploy/templates/maestro.servicemonitor-azmonitor.yaml
+++ b/maestro/server/deploy/templates/maestro.servicemonitor-azmonitor.yaml
@@ -1,0 +1,18 @@
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: maestro-server
+  namespace: '{{ .Release.Namespace }}'
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - '{{ .Release.Namespace }}'
+  selector:
+    matchLabels:
+      app: maestro
+      port: metrics

--- a/maestro/server/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_maestro_server.yaml
+++ b/maestro/server/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_maestro_server.yaml
@@ -570,6 +570,26 @@ spec:
     usePodIdentity: "false"
   provider: azure
 ---
+# Source: maestro-server/templates/maestro.servicemonitor-azmonitor.yaml
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: maestro-server
+  namespace: 'maestro'
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - 'maestro'
+  selector:
+    matchLabels:
+      app: maestro
+      port: metrics
+---
 # Source: maestro-server/templates/maestro.servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/mgmt-agent/cmd/options.go
+++ b/mgmt-agent/cmd/options.go
@@ -51,6 +51,7 @@ import (
 	sharedleaderelection "github.com/Azure/ARO-HCP/internal/leaderelection"
 	"github.com/Azure/ARO-HCP/mgmt-agent/pkg/controller"
 	"github.com/Azure/ARO-HCP/mgmt-agent/pkg/controller/ksmhcp"
+	"github.com/Azure/ARO-HCP/mgmt-agent/pkg/controller/monitortranslator"
 )
 
 const (
@@ -58,18 +59,20 @@ const (
 )
 
 type RawControllerOptions struct {
-	HealthAddress string
-	Kubeconfig    string
-	Namespace     string
-	Workers       int
-	LogVerbosity  int
-	KSMImage      string
+	HealthAddress      string
+	Kubeconfig         string
+	Namespace          string
+	Workers            int
+	LogVerbosity       int
+	KSMImage           string
+	OCMNamespacePrefix string
 }
 
 func DefaultControllerOptions() *RawControllerOptions {
 	return &RawControllerOptions{
-		HealthAddress: ":8080",
-		Workers:       2,
+		HealthAddress:      ":8080",
+		Workers:            2,
+		OCMNamespacePrefix: "ocm-",
 	}
 }
 
@@ -82,6 +85,7 @@ func (o *RawControllerOptions) BindFlags(cmd *cobra.Command) error {
 		"Log verbosity. 0 is the default verbosity level, equivalent to INFO. "+
 			"It must be a value >= 0, where a higher value means more verbose output.")
 	cmd.Flags().StringVar(&o.KSMImage, "ksm-image", o.KSMImage, "Container image for kube-state-metrics deployed per HCP namespace")
+	cmd.Flags().StringVar(&o.OCMNamespacePrefix, "ocm-namespace-prefix", o.OCMNamespacePrefix, "Namespace prefix for OCM/HyperShift namespaces to translate monitors for")
 
 	return nil
 }
@@ -97,6 +101,7 @@ type ValidatedControllerOptions struct {
 type completedControllerOptions struct {
 	ctrl                     *controller.SwiftNICController
 	ksmCtrl                  *ksmhcp.KSMHCPController
+	monitorTranslatorCtrl    *monitortranslator.MonitorTranslatorController
 	resourceWatcher          *controller.ResourceWatcher
 	podWatcher               *controller.PodWatcher
 	configMapWatcher         *controller.ConfigMapWatcher
@@ -106,6 +111,7 @@ type completedControllerOptions struct {
 	cmWatcherInformers       kubeinformers.SharedInformerFactory
 	hypershiftInformers      hypershiftinformers.SharedInformerFactory
 	dynamicInformers         dynamicinformer.DynamicSharedInformerFactory
+	translatorDynInformers   dynamicinformer.DynamicSharedInformerFactory
 	workers                  int
 	healthAddress            string
 	leaderElectionLock       resourcelock.Interface
@@ -189,9 +195,11 @@ func (o *ValidatedControllerOptions) Complete(ctx context.Context) (*ControllerO
 	}
 
 	var ksmCtrl *ksmhcp.KSMHCPController
+	var monitorTranslatorCtrl *monitortranslator.MonitorTranslatorController
 	var hsInformers hypershiftinformers.SharedInformerFactory
 	var ksmKubeInformers kubeinformers.SharedInformerFactory
 	var dynInformers dynamicinformer.DynamicSharedInformerFactory
+	var translatorDynInformers dynamicinformer.DynamicSharedInformerFactory
 	if o.KSMImage != "" {
 		hsClient, err := hypershiftclient.NewForConfig(kubeConfig)
 		if err != nil {
@@ -221,6 +229,17 @@ func (o *ValidatedControllerOptions) Complete(ctx context.Context) (*ControllerO
 		if err != nil {
 			return nil, fmt.Errorf("failed to create KSM HCP controller: %w", err)
 		}
+
+		translatorDynInformers = dynamicinformer.NewDynamicSharedInformerFactory(dynamicClient, 10*time.Minute)
+		monitorTranslatorCtrl, err = monitortranslator.NewMonitorTranslatorController(
+			dynamicClient,
+			translatorDynInformers.ForResource(monitortranslator.SourceServiceMonitorGVR).Informer(),
+			translatorDynInformers.ForResource(monitortranslator.SourcePodMonitorGVR).Informer(),
+			o.OCMNamespacePrefix,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create monitor translator controller: %w", err)
+		}
 	}
 
 	hostname, err := os.Hostname()
@@ -237,6 +256,7 @@ func (o *ValidatedControllerOptions) Complete(ctx context.Context) (*ControllerO
 		completedControllerOptions: &completedControllerOptions{
 			ctrl:                     ctrl,
 			ksmCtrl:                  ksmCtrl,
+			monitorTranslatorCtrl:    monitorTranslatorCtrl,
 			resourceWatcher:          resourceWatcher,
 			podWatcher:               podWatcher,
 			configMapWatcher:         configMapWatcher,
@@ -246,6 +266,7 @@ func (o *ValidatedControllerOptions) Complete(ctx context.Context) (*ControllerO
 			cmWatcherInformers:       cmWatcherInformers,
 			hypershiftInformers:      hsInformers,
 			dynamicInformers:         dynInformers,
+			translatorDynInformers:   translatorDynInformers,
 			workers:                  o.Workers,
 			healthAddress:            o.HealthAddress,
 			leaderElectionLock:       leaderElectionLock,
@@ -356,6 +377,9 @@ func (o *ControllerOptions) runControllersUnderLeaderElection(ctx context.Contex
 				if o.dynamicInformers != nil {
 					o.dynamicInformers.Start(ctx.Done())
 				}
+				if o.translatorDynInformers != nil {
+					o.translatorDynInformers.Start(ctx.Done())
+				}
 				if o.cmWatcherInformers != nil {
 					o.cmWatcherInformers.Start(ctx.Done())
 				}
@@ -394,6 +418,14 @@ func (o *ControllerOptions) runControllersUnderLeaderElection(ctx context.Contex
 						defer utilruntime.HandleCrash()
 						if err := o.podWatcher.Run(ctx); err != nil {
 							logger.Error(err, "pod watcher failed")
+						}
+					}()
+				}
+				if o.monitorTranslatorCtrl != nil {
+					go func() {
+						defer utilruntime.HandleCrash()
+						if err := o.monitorTranslatorCtrl.Run(ctx, o.workers); err != nil {
+							logger.Error(err, "monitor translator controller failed")
 						}
 					}()
 				}

--- a/mgmt-agent/deploy/templates/clusterrole.yaml
+++ b/mgmt-agent/deploy/templates/clusterrole.yaml
@@ -59,6 +59,18 @@ rules:
   - monitoring.coreos.com
   resources:
   - servicemonitors
+  - podmonitors
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+- apiGroups:
+  - azmonitoring.coreos.com
+  resources:
+  - servicemonitors
+  - podmonitors
   verbs:
   - get
   - list

--- a/mgmt-agent/deploy/templates/servicemonitor-azmonitor.yaml
+++ b/mgmt-agent/deploy/templates/servicemonitor-azmonitor.yaml
@@ -1,0 +1,18 @@
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: mgmt-agent
+  namespace: '{{ .Release.Namespace }}'
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - '{{ .Release.Namespace }}'
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mgmt-agent
+      port: metrics

--- a/mgmt-agent/pkg/controller/monitortranslator/controller.go
+++ b/mgmt-agent/pkg/controller/monitortranslator/controller.go
@@ -1,0 +1,277 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monitortranslator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
+)
+
+const (
+	MonitorTranslatorControllerName = "MonitorTranslator"
+	fieldManager                    = "mgmt-agent-monitor-translator"
+)
+
+var (
+	SourceServiceMonitorGVR = schema.GroupVersionResource{
+		Group:    "monitoring.coreos.com",
+		Version:  "v1",
+		Resource: "servicemonitors",
+	}
+	SourcePodMonitorGVR = schema.GroupVersionResource{
+		Group:    "monitoring.coreos.com",
+		Version:  "v1",
+		Resource: "podmonitors",
+	}
+	TargetServiceMonitorGVR = schema.GroupVersionResource{
+		Group:    "azmonitoring.coreos.com",
+		Version:  "v1",
+		Resource: "servicemonitors",
+	}
+	TargetPodMonitorGVR = schema.GroupVersionResource{
+		Group:    "azmonitoring.coreos.com",
+		Version:  "v1",
+		Resource: "podmonitors",
+	}
+)
+
+// MonitorTranslatorController watches monitoring.coreos.com/v1 ServiceMonitors
+// and PodMonitors and creates equivalent azmonitoring.coreos.com/v1 resources
+// in namespaces matching a configurable prefix.
+type MonitorTranslatorController struct {
+	dynamicClient dynamic.Interface
+	hasSynced     []cache.InformerSynced
+	workqueue     workqueue.TypedRateLimitingInterface[string]
+	nsPrefix      string
+
+	smLister cache.GenericLister
+	pmLister cache.GenericLister
+}
+
+// NewMonitorTranslatorController creates a new MonitorTranslatorController.
+func NewMonitorTranslatorController(
+	dynamicClient dynamic.Interface,
+	serviceMonitorInformer cache.SharedIndexInformer,
+	podMonitorInformer cache.SharedIndexInformer,
+	nsPrefix string,
+) (*MonitorTranslatorController, error) {
+	c := &MonitorTranslatorController{
+		dynamicClient: dynamicClient,
+		hasSynced: []cache.InformerSynced{
+			serviceMonitorInformer.HasSynced,
+			podMonitorInformer.HasSynced,
+		},
+		workqueue: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{Name: MonitorTranslatorControllerName},
+		),
+		nsPrefix: nsPrefix,
+		smLister: cache.NewGenericLister(serviceMonitorInformer.GetIndexer(), schema.GroupResource{Group: SourceServiceMonitorGVR.Group, Resource: SourceServiceMonitorGVR.Resource}),
+		pmLister: cache.NewGenericLister(podMonitorInformer.GetIndexer(), schema.GroupResource{Group: SourcePodMonitorGVR.Group, Resource: SourcePodMonitorGVR.Resource}),
+	}
+
+	enqueue := func(resource string) cache.ResourceEventHandlerFuncs {
+		return cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj any) {
+				c.enqueueObject(resource, obj)
+			},
+			UpdateFunc: func(_, obj any) {
+				c.enqueueObject(resource, obj)
+			},
+			DeleteFunc: func(obj any) {
+				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+				if ok {
+					obj = tombstone.Obj
+				}
+				c.enqueueObject(resource, obj)
+			},
+		}
+	}
+
+	if _, err := serviceMonitorInformer.AddEventHandler(enqueue(SourceServiceMonitorGVR.Resource)); err != nil {
+		return nil, fmt.Errorf("failed to add ServiceMonitor event handler: %w", err)
+	}
+	if _, err := podMonitorInformer.AddEventHandler(enqueue(SourcePodMonitorGVR.Resource)); err != nil {
+		return nil, fmt.Errorf("failed to add PodMonitor event handler: %w", err)
+	}
+
+	return c, nil
+}
+
+func (c *MonitorTranslatorController) enqueueObject(resource string, obj any) {
+	key, err := cache.MetaNamespaceKeyFunc(obj)
+	if err != nil {
+		return
+	}
+	c.workqueue.Add(resource + "/" + key)
+}
+
+// Run starts the controller workers and blocks until the context is cancelled.
+func (c *MonitorTranslatorController) Run(ctx context.Context, workers int) error {
+	defer utilruntime.HandleCrash()
+	defer c.workqueue.ShutDown()
+
+	logger := klog.FromContext(ctx)
+	logger.Info("Starting MonitorTranslator controller")
+
+	logger.Info("Waiting for informer caches to sync")
+	if ok := cache.WaitForCacheSync(ctx.Done(), c.hasSynced...); !ok {
+		return fmt.Errorf("failed to wait for caches to sync")
+	}
+
+	logger.Info("Starting workers", "count", workers)
+	for range workers {
+		go wait.UntilWithContext(ctx, c.runWorker, time.Second)
+	}
+
+	logger.Info("MonitorTranslator controller started")
+	<-ctx.Done()
+	logger.Info("Shutting down MonitorTranslator controller")
+
+	return nil
+}
+
+func (c *MonitorTranslatorController) runWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
+	}
+}
+
+func (c *MonitorTranslatorController) processNextWorkItem(ctx context.Context) bool {
+	key, shutdown := c.workqueue.Get()
+	if shutdown {
+		return false
+	}
+	defer c.workqueue.Done(key)
+
+	err := c.syncHandler(ctx, key)
+	if err == nil {
+		c.workqueue.Forget(key)
+		return true
+	}
+
+	utilruntime.HandleError(fmt.Errorf("error syncing %q: %w", key, err))
+	c.workqueue.AddRateLimited(key)
+	return true
+}
+
+// syncHandler processes a single work item. The key format is "<resource>/<namespace>/<name>".
+func (c *MonitorTranslatorController) syncHandler(ctx context.Context, key string) error {
+	resource, nsName, ok := strings.Cut(key, "/")
+	if !ok {
+		return fmt.Errorf("invalid key %q: missing resource prefix", key)
+	}
+	namespace, name, err := cache.SplitMetaNamespaceKey(nsName)
+	if err != nil {
+		return fmt.Errorf("invalid key %q: %w", key, err)
+	}
+
+	if !strings.HasPrefix(namespace, c.nsPrefix) {
+		return nil
+	}
+
+	logger := klog.FromContext(ctx).WithValues("resource", resource, "namespace", namespace, "name", name)
+	ctx = klog.NewContext(ctx, logger)
+
+	var sourceGVR, targetGVR schema.GroupVersionResource
+	var lister cache.GenericLister
+	switch resource {
+	case SourceServiceMonitorGVR.Resource:
+		sourceGVR = SourceServiceMonitorGVR
+		targetGVR = TargetServiceMonitorGVR
+		lister = c.smLister
+	case SourcePodMonitorGVR.Resource:
+		sourceGVR = SourcePodMonitorGVR
+		targetGVR = TargetPodMonitorGVR
+		lister = c.pmLister
+	default:
+		return fmt.Errorf("unknown resource %q in key %q", resource, key)
+	}
+
+	obj, err := lister.ByNamespace(namespace).Get(name)
+	if err != nil {
+		logger.V(4).Info("Source resource no longer exists, translated resource will be garbage collected via OwnerReference")
+		return nil
+	}
+
+	source, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		return fmt.Errorf("expected *unstructured.Unstructured, got %T", obj)
+	}
+
+	translated := Translate(source, sourceGVR, targetGVR)
+	if err := c.applyResource(ctx, targetGVR, translated); err != nil {
+		return fmt.Errorf("failed to apply translated %s %s/%s: %w", resource, namespace, name, err)
+	}
+
+	logger.V(4).Info("Translated monitor resource")
+	return nil
+}
+
+func (c *MonitorTranslatorController) applyResource(ctx context.Context, gvr schema.GroupVersionResource, desired *unstructured.Unstructured) error {
+	data, err := json.Marshal(desired)
+	if err != nil {
+		return fmt.Errorf("failed to marshal resource: %w", err)
+	}
+	_, err = c.dynamicClient.Resource(gvr).Namespace(desired.GetNamespace()).Patch(
+		ctx, desired.GetName(), types.ApplyPatchType, data,
+		metav1.PatchOptions{FieldManager: fieldManager, Force: ptr.To(true)},
+	)
+	return err
+}
+
+// Translate creates an azmonitoring.coreos.com/v1 resource from a monitoring.coreos.com/v1 source.
+// The spec is copied verbatim. An OwnerReference is set for garbage collection.
+func Translate(source *unstructured.Unstructured, sourceGVR, targetGVR schema.GroupVersionResource) *unstructured.Unstructured {
+	target := &unstructured.Unstructured{Object: make(map[string]any)}
+	target.SetAPIVersion(targetGVR.Group + "/v1")
+	target.SetKind(source.GetKind())
+	target.SetName(source.GetName())
+	target.SetNamespace(source.GetNamespace())
+
+	if labels := source.GetLabels(); len(labels) > 0 {
+		target.SetLabels(labels)
+	}
+
+	spec, found, _ := unstructured.NestedMap(source.Object, "spec")
+	if found {
+		_ = unstructured.SetNestedMap(target.Object, spec, "spec")
+	}
+
+	target.SetOwnerReferences([]metav1.OwnerReference{
+		{
+			APIVersion: source.GetAPIVersion(),
+			Kind:       source.GetKind(),
+			Name:       source.GetName(),
+			UID:        source.GetUID(),
+		},
+	})
+
+	return target
+}

--- a/mgmt-agent/pkg/controller/monitortranslator/controller_test.go
+++ b/mgmt-agent/pkg/controller/monitortranslator/controller_test.go
@@ -1,0 +1,157 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monitortranslator
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/Azure/ARO-Tools/testutil"
+)
+
+func TestTranslateServiceMonitor(t *testing.T) {
+	source := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "monitoring.coreos.com/v1",
+			"kind":       "ServiceMonitor",
+			"metadata": map[string]any{
+				"name":      "test-service",
+				"namespace": "ocm-arohcppers-abc123-xyz",
+				"uid":       "source-uid-123",
+				"labels": map[string]any{
+					"app": "test-service",
+				},
+			},
+			"spec": map[string]any{
+				"endpoints": []any{
+					map[string]any{
+						"port":     "metrics",
+						"interval": "30s",
+						"path":     "/metrics",
+					},
+				},
+				"selector": map[string]any{
+					"matchLabels": map[string]any{
+						"app": "test-service",
+					},
+				},
+				"namespaceSelector": map[string]any{
+					"matchNames": []any{"ocm-arohcppers-abc123-xyz"},
+				},
+			},
+		},
+	}
+
+	result := Translate(source, SourceServiceMonitorGVR, TargetServiceMonitorGVR)
+	testutil.CompareWithFixture(t, result)
+}
+
+func TestTranslatePodMonitor(t *testing.T) {
+	source := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "monitoring.coreos.com/v1",
+			"kind":       "PodMonitor",
+			"metadata": map[string]any{
+				"name":      "test-pods",
+				"namespace": "ocm-arohcppers-abc123-xyz",
+				"uid":       "source-uid-456",
+				"labels": map[string]any{
+					"app": "test-pods",
+				},
+			},
+			"spec": map[string]any{
+				"podMetricsEndpoints": []any{
+					map[string]any{
+						"port": "metrics",
+						"path": "/metrics",
+					},
+				},
+				"selector": map[string]any{
+					"matchLabels": map[string]any{
+						"app": "test-pods",
+					},
+				},
+			},
+		},
+	}
+
+	result := Translate(source, SourcePodMonitorGVR, TargetPodMonitorGVR)
+	testutil.CompareWithFixture(t, result)
+}
+
+func TestTranslatePreservesOwnerReference(t *testing.T) {
+	source := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "monitoring.coreos.com/v1",
+			"kind":       "ServiceMonitor",
+			"metadata": map[string]any{
+				"name":      "owned-monitor",
+				"namespace": "ocm-test",
+				"uid":       "uid-789",
+			},
+			"spec": map[string]any{},
+		},
+	}
+
+	result := Translate(source, SourceServiceMonitorGVR, TargetServiceMonitorGVR)
+
+	ownerRefs := result.GetOwnerReferences()
+	if len(ownerRefs) != 1 {
+		t.Fatalf("expected 1 owner reference, got %d", len(ownerRefs))
+	}
+
+	expected := metav1.OwnerReference{
+		APIVersion: "monitoring.coreos.com/v1",
+		Kind:       "ServiceMonitor",
+		Name:       "owned-monitor",
+		UID:        types.UID("uid-789"),
+	}
+	if ownerRefs[0] != expected {
+		t.Errorf("owner reference mismatch:\ngot:  %+v\nwant: %+v", ownerRefs[0], expected)
+	}
+}
+
+func TestTranslateNoLabels(t *testing.T) {
+	source := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "monitoring.coreos.com/v1",
+			"kind":       "ServiceMonitor",
+			"metadata": map[string]any{
+				"name":      "no-labels",
+				"namespace": "ocm-test",
+				"uid":       "uid-nolabel",
+			},
+			"spec": map[string]any{
+				"endpoints": []any{
+					map[string]any{
+						"port": "metrics",
+					},
+				},
+			},
+		},
+	}
+
+	result := Translate(source, SourceServiceMonitorGVR, TargetServiceMonitorGVR)
+
+	if labels := result.GetLabels(); len(labels) != 0 {
+		t.Errorf("expected no labels, got %v", labels)
+	}
+	if result.GetAPIVersion() != "azmonitoring.coreos.com/v1" {
+		t.Errorf("expected apiVersion azmonitoring.coreos.com/v1, got %s", result.GetAPIVersion())
+	}
+}

--- a/mgmt-agent/pkg/controller/monitortranslator/testdata/zz_fixture_TestTranslatePodMonitor.yaml
+++ b/mgmt-agent/pkg/controller/monitortranslator/testdata/zz_fixture_TestTranslatePodMonitor.yaml
@@ -1,0 +1,19 @@
+apiVersion: azmonitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    app: test-pods
+  name: test-pods
+  namespace: ocm-arohcppers-abc123-xyz
+  ownerReferences:
+  - apiVersion: monitoring.coreos.com/v1
+    kind: PodMonitor
+    name: test-pods
+    uid: source-uid-456
+spec:
+  podMetricsEndpoints:
+  - path: /metrics
+    port: metrics
+  selector:
+    matchLabels:
+      app: test-pods

--- a/mgmt-agent/pkg/controller/monitortranslator/testdata/zz_fixture_TestTranslateServiceMonitor.yaml
+++ b/mgmt-agent/pkg/controller/monitortranslator/testdata/zz_fixture_TestTranslateServiceMonitor.yaml
@@ -1,0 +1,23 @@
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: test-service
+  name: test-service
+  namespace: ocm-arohcppers-abc123-xyz
+  ownerReferences:
+  - apiVersion: monitoring.coreos.com/v1
+    kind: ServiceMonitor
+    name: test-service
+    uid: source-uid-123
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+  namespaceSelector:
+    matchNames:
+    - ocm-arohcppers-abc123-xyz
+  selector:
+    matchLabels:
+      app: test-service

--- a/mgmt-agent/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_mgmt_agent.yaml
+++ b/mgmt-agent/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_mgmt_agent.yaml
@@ -86,6 +86,18 @@ rules:
   - monitoring.coreos.com
   resources:
   - servicemonitors
+  - podmonitors
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+- apiGroups:
+  - azmonitoring.coreos.com
+  resources:
+  - servicemonitors
+  - podmonitors
   verbs:
   - get
   - list
@@ -247,6 +259,26 @@ spec:
       serviceAccountName: mgmt-agent
       terminationGracePeriodSeconds: 10
       nodeSelector:
+---
+# Source: mgmt-agent/templates/servicemonitor-azmonitor.yaml
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: mgmt-agent
+  namespace: 'mgmt-agent'
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - 'mgmt-agent'
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mgmt-agent
+      port: metrics
 ---
 # Source: mgmt-agent/templates/servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1

--- a/observability/arobit/deploy/templates/forwarder-servicemonitor-azmonitor.yaml
+++ b/observability/arobit/deploy/templates/forwarder-servicemonitor-azmonitor.yaml
@@ -1,0 +1,17 @@
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: arobit-forwarder
+  namespace: '{{ .Release.Namespace }}'
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - '{{ .Release.Namespace }}'
+  selector:
+    matchLabels:
+      app: arobit-forwarder

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_buffering_disabled_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_buffering_disabled_svc.yaml
@@ -585,6 +585,25 @@ spec:
             name: arobit-forwarder
             defaultMode: 0755
 ---
+# Source: arobit/templates/forwarder-servicemonitor-azmonitor.yaml
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: arobit-forwarder
+  namespace: 'arobit'
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - 'arobit'
+  selector:
+    matchLabels:
+      app: arobit-forwarder
+---
 # Source: arobit/templates/forwarder-servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_disabled_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_disabled_svc.yaml
@@ -675,6 +675,25 @@ spec:
             name: arobit-forwarder
             defaultMode: 0755
 ---
+# Source: arobit/templates/forwarder-servicemonitor-azmonitor.yaml
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: arobit-forwarder
+  namespace: 'arobit'
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - 'arobit'
+  selector:
+    matchLabels:
+      app: arobit-forwarder
+---
 # Source: arobit/templates/forwarder-servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_unlimited_memory_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_unlimited_memory_svc.yaml
@@ -674,6 +674,25 @@ spec:
             name: arobit-forwarder
             defaultMode: 0755
 ---
+# Source: arobit/templates/forwarder-servicemonitor-azmonitor.yaml
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: arobit-forwarder
+  namespace: 'arobit'
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - 'arobit'
+  selector:
+    matchLabels:
+      app: arobit-forwarder
+---
 # Source: arobit/templates/forwarder-servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_mgmt.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_mgmt.yaml
@@ -1114,6 +1114,25 @@ spec:
     tenantId: "__tenantId__"
     usePodIdentity: "false"
 ---
+# Source: arobit/templates/forwarder-servicemonitor-azmonitor.yaml
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: arobit-forwarder
+  namespace: 'arobit'
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - 'arobit'
+  selector:
+    matchLabels:
+      app: arobit-forwarder
+---
 # Source: arobit/templates/forwarder-servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_svc.yaml
@@ -676,6 +676,25 @@ spec:
             name: arobit-forwarder
             defaultMode: 0755
 ---
+# Source: arobit/templates/forwarder-servicemonitor-azmonitor.yaml
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: arobit-forwarder
+  namespace: 'arobit'
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - 'arobit'
+  selector:
+    matchLabels:
+      app: arobit-forwarder
+---
 # Source: arobit/templates/forwarder-servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/tooling/aro-hcp-exporter/deploy/templates/servicemonitor-azmonitor.yaml
+++ b/tooling/aro-hcp-exporter/deploy/templates/servicemonitor-azmonitor.yaml
@@ -1,0 +1,17 @@
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: '{{ .Values.service.name }}'
+  namespace: '{{ .Release.Namespace }}'
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - '{{ .Release.Namespace }}'
+  selector:
+    matchLabels:
+      app: '{{ .Values.service.name }}'

--- a/tooling/helmtest/internal/type.go
+++ b/tooling/helmtest/internal/type.go
@@ -59,6 +59,7 @@ type Settings struct {
 	Replace                       []Replace
 	ResourceRequestsAllowlist     []string // Components exempt from requiring resources.requests.memory
 	ResourceMemoryLimitsAllowlist []string // Components exempt from requiring resources.limits.memory
+	SmonSkipNamespaces            []string // Namespaces to skip for smon checks
 }
 
 type Replace struct {

--- a/tooling/helmtest/settings.yaml
+++ b/tooling/helmtest/settings.yaml
@@ -94,3 +94,5 @@ ResourceMemoryLimitsAllowlist:
 - Deployment/clusters-service/clusters-service-server # config sets memory: unlimited (template omits limits)
 - Deployment/ocm-cs-db/postgresql # postgresql container has no resources set
 - Job/shell-script-executor-1/cs-shell-script-executor # cs-debug-jobs debug job has no resources set
+smonSkipNamespaces:
+- prometheus

--- a/tooling/helmtest/testrunner/smon_check.go
+++ b/tooling/helmtest/testrunner/smon_check.go
@@ -1,0 +1,60 @@
+package testrunner
+
+import (
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+
+	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
+)
+
+type smonMeta struct {
+	ApiVersion string `json:"apiVersion"`
+	Kind       string `json:"kind"`
+	Metadata   struct {
+		Name      string `json:"name"`
+		Namespace string `json:"namespace"`
+	} `json:"metadata"`
+}
+
+// returns (skip, azmonitorSmonExists && coreOsSmonExists, err)
+// skip is true if no smons exist in the manifest
+// azmonitorSmonExists && coreOsSmonExists is true if both smons exist in the manifest
+// err is an error if the smons are not found or the api version is unknown
+func checkAzmonitorAndCoreOsSmonsExists(manifest string, skipNamespaces []string) (bool, bool, error) {
+	var azmonitorSmonExists, coreOsSmonExists bool
+
+	decoder := utilyaml.NewYAMLToJSONDecoder(strings.NewReader(manifest))
+	for {
+		var smon smonMeta
+		if err := decoder.Decode(&smon); err != nil {
+			if err == io.EOF {
+				break
+			}
+		}
+		if slices.Contains(skipNamespaces, smon.Metadata.Namespace) {
+			return true, false, nil
+		}
+		if smon.Kind == "ServiceMonitor" {
+			switch smon.ApiVersion {
+			case "monitoring.coreos.com/v1":
+				coreOsSmonExists = true
+			case "azmonitoring.coreos.com/v1":
+				azmonitorSmonExists = true
+			default:
+				return false, false, fmt.Errorf("unknown smon api version: %s", smon.ApiVersion)
+			}
+		}
+	}
+	if !azmonitorSmonExists && !coreOsSmonExists {
+		return true, false, nil
+	}
+	if !azmonitorSmonExists {
+		return false, false, fmt.Errorf("azmonitor smon does not exist in the manifest")
+	}
+	if !coreOsSmonExists {
+		return false, false, fmt.Errorf("coreos smon does not exist in the manifest")
+	}
+	return false, true, nil
+}

--- a/tooling/helmtest/testrunner/smon_check.go
+++ b/tooling/helmtest/testrunner/smon_check.go
@@ -9,7 +9,7 @@ import (
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
 )
 
-type smonMeta struct {
+type monitorMeta struct {
 	ApiVersion string `json:"apiVersion"`
 	Kind       string `json:"kind"`
 	Metadata   struct {
@@ -18,43 +18,59 @@ type smonMeta struct {
 	} `json:"metadata"`
 }
 
-// returns (skip, azmonitorSmonExists && coreOsSmonExists, err)
-// skip is true if no smons exist in the manifest
-// azmonitorSmonExists && coreOsSmonExists is true if both smons exist in the manifest
-// err is an error if the smons are not found or the api version is unknown
-func checkAzmonitorAndCoreOsSmonsExists(manifest string, skipNamespaces []string) (bool, bool, error) {
-	var azmonitorSmonExists, coreOsSmonExists bool
+// returns (skip, err)
+// skip is true if no monitors exist in the manifest
+// err is an error if the monitors are not found or the api version is unknown
+func checkAzmonitorAndCoreOsMonitorsExist(manifest string, skipNamespaces []string) (bool, error) {
+	smonSkip, err := ensureKindsExist(manifest, "ServiceMonitor", skipNamespaces)
+	if err != nil {
+		return false, err
+	}
+	pmonSkip, err := ensureKindsExist(manifest, "PodMonitor", skipNamespaces)
+	if err != nil {
+		return false, err
+	}
+
+	if smonSkip && pmonSkip {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func ensureKindsExist(manifest string, kind string, skipNamespaces []string) (bool, error) {
+	var azmonitorExists, coreOsExists bool
 
 	decoder := utilyaml.NewYAMLToJSONDecoder(strings.NewReader(manifest))
 	for {
-		var smon smonMeta
-		if err := decoder.Decode(&smon); err != nil {
+		var m monitorMeta
+		if err := decoder.Decode(&m); err != nil {
 			if err == io.EOF {
 				break
 			}
 		}
-		if slices.Contains(skipNamespaces, smon.Metadata.Namespace) {
-			return true, false, nil
+		if slices.Contains(skipNamespaces, m.Metadata.Namespace) {
+			return true, nil
 		}
-		if smon.Kind == "ServiceMonitor" {
-			switch smon.ApiVersion {
+		if m.Kind == kind {
+			switch m.ApiVersion {
 			case "monitoring.coreos.com/v1":
-				coreOsSmonExists = true
+				coreOsExists = true
 			case "azmonitoring.coreos.com/v1":
-				azmonitorSmonExists = true
+				azmonitorExists = true
 			default:
-				return false, false, fmt.Errorf("unknown smon api version: %s", smon.ApiVersion)
+				return false, fmt.Errorf("unknown %s api version: %s", kind, m.ApiVersion)
 			}
 		}
 	}
-	if !azmonitorSmonExists && !coreOsSmonExists {
-		return true, false, nil
+	if !azmonitorExists && !coreOsExists {
+		return true, nil
 	}
-	if !azmonitorSmonExists {
-		return false, false, fmt.Errorf("azmonitor smon does not exist in the manifest")
+	if !azmonitorExists {
+		return false, fmt.Errorf("azmonitor %s does not exist in the manifest", kind)
 	}
-	if !coreOsSmonExists {
-		return false, false, fmt.Errorf("coreos smon does not exist in the manifest")
+	if !coreOsExists {
+		return false, fmt.Errorf("coreos %s does not exist in the manifest", kind)
 	}
-	return false, true, nil
+	return false, nil
 }

--- a/tooling/helmtest/testrunner/smon_check_test.go
+++ b/tooling/helmtest/testrunner/smon_check_test.go
@@ -20,81 +20,104 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCheckAzmonitorAndCoreOsSmonsExists(t *testing.T) {
+func TestCheckAzmonitorAndCoreOsMonitorsExist(t *testing.T) {
 	tests := []struct {
 		name           string
 		manifest       string
 		skipNamespaces []string
 		wantSkip       bool
-		wantBoth       bool
 		wantErr        string
 	}{
 		{
-			name:     "both smons present",
+			name:     "both servicemonitors present",
 			manifest: coreosSmon("test-smon", "test-ns") + azmonitorSmon("test-smon-azmonitor", "test-ns"),
 			wantSkip: false,
-			wantBoth: true,
 		},
 		{
-			name:     "no smons at all returns skip",
+			name:     "both podmonitors present",
+			manifest: coreosPmon("test-pmon", "test-ns") + azmonitorPmon("test-pmon-azmonitor", "test-ns"),
+			wantSkip: false,
+		},
+		{
+			name:     "both servicemonitors and podmonitors present",
+			manifest: coreosSmon("test-smon", "test-ns") + azmonitorSmon("test-smon-azmonitor", "test-ns") + coreosPmon("test-pmon", "test-ns") + azmonitorPmon("test-pmon-azmonitor", "test-ns"),
+			wantSkip: false,
+		},
+		{
+			name:     "no monitors at all returns skip",
 			manifest: nonSmonResource(),
 			wantSkip: true,
-			wantBoth: false,
 		},
 		{
 			name:     "empty manifest returns skip",
 			manifest: "",
 			wantSkip: true,
-			wantBoth: false,
 		},
 		{
-			name:     "only coreos smon returns error",
+			name:     "only coreos servicemonitor returns error",
 			manifest: coreosSmon("test-smon", "test-ns"),
 			wantSkip: false,
-			wantBoth: false,
-			wantErr:  "azmonitor smon does not exist in the manifest",
+			wantErr:  "azmonitor ServiceMonitor does not exist in the manifest",
 		},
 		{
-			name:     "only azmonitor smon returns error",
+			name:     "only azmonitor servicemonitor returns error",
 			manifest: azmonitorSmon("test-smon-azmonitor", "test-ns"),
 			wantSkip: false,
-			wantBoth: false,
-			wantErr:  "coreos smon does not exist in the manifest",
+			wantErr:  "coreos ServiceMonitor does not exist in the manifest",
 		},
 		{
-			name:     "unknown api version returns error",
-			manifest: smonWithApiVersion("test-smon", "test-ns", "monitoring.unknown.io/v1"),
+			name:     "only coreos podmonitor returns error",
+			manifest: coreosPmon("test-pmon", "test-ns"),
 			wantSkip: false,
-			wantBoth: false,
-			wantErr:  "unknown smon api version: monitoring.unknown.io/v1",
+			wantErr:  "azmonitor PodMonitor does not exist in the manifest",
 		},
 		{
-			name:           "smon in skipped namespace returns skip",
+			name:     "only azmonitor podmonitor returns error",
+			manifest: azmonitorPmon("test-pmon-azmonitor", "test-ns"),
+			wantSkip: false,
+			wantErr:  "coreos PodMonitor does not exist in the manifest",
+		},
+		{
+			name:     "unknown servicemonitor api version returns error",
+			manifest: monitorWithApiVersion("ServiceMonitor", "test-smon", "test-ns", "monitoring.unknown.io/v1"),
+			wantSkip: false,
+			wantErr:  "unknown ServiceMonitor api version: monitoring.unknown.io/v1",
+		},
+		{
+			name:     "unknown podmonitor api version returns error",
+			manifest: monitorWithApiVersion("PodMonitor", "test-pmon", "test-ns", "monitoring.unknown.io/v1"),
+			wantSkip: false,
+			wantErr:  "unknown PodMonitor api version: monitoring.unknown.io/v1",
+		},
+		{
+			name:           "servicemonitor in skipped namespace returns skip",
 			manifest:       coreosSmon("test-smon", "kube-system"),
 			skipNamespaces: []string{"kube-system"},
 			wantSkip:       true,
-			wantBoth:       false,
 		},
 		{
-			name:           "smon not in skipped namespace proceeds normally",
+			name:           "servicemonitor not in skipped namespace proceeds normally",
 			manifest:       coreosSmon("test-smon", "test-ns") + azmonitorSmon("test-smon-azmonitor", "test-ns"),
 			skipNamespaces: []string{"kube-system"},
 			wantSkip:       false,
-			wantBoth:       true,
 		},
 		{
-			name:     "mixed smons and non-smon resources",
+			name:     "mixed monitors and non-monitor resources",
 			manifest: nonSmonResource() + coreosSmon("test-smon", "test-ns") + azmonitorSmon("test-smon-azmonitor", "test-ns"),
 			wantSkip: false,
-			wantBoth: true,
+		},
+		{
+			name:     "servicemonitor error takes precedence over podmonitor skip",
+			manifest: coreosSmon("test-smon", "test-ns"),
+			wantSkip: false,
+			wantErr:  "azmonitor ServiceMonitor does not exist in the manifest",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			skip, both, err := checkAzmonitorAndCoreOsSmonsExists(tc.manifest, tc.skipNamespaces)
+			skip, err := checkAzmonitorAndCoreOsMonitorsExist(tc.manifest, tc.skipNamespaces)
 			assert.Equal(t, tc.wantSkip, skip, "skip")
-			assert.Equal(t, tc.wantBoth, both, "both")
 			if tc.wantErr != "" {
 				assert.EqualError(t, err, tc.wantErr)
 			} else {
@@ -112,8 +135,16 @@ func azmonitorSmon(name, namespace string) string {
 	return "---\napiVersion: azmonitoring.coreos.com/v1\nkind: ServiceMonitor\nmetadata:\n  name: " + name + "\n  namespace: " + namespace + "\n"
 }
 
-func smonWithApiVersion(name, namespace, apiVersion string) string {
-	return "---\napiVersion: " + apiVersion + "\nkind: ServiceMonitor\nmetadata:\n  name: " + name + "\n  namespace: " + namespace + "\n"
+func coreosPmon(name, namespace string) string {
+	return "---\napiVersion: monitoring.coreos.com/v1\nkind: PodMonitor\nmetadata:\n  name: " + name + "\n  namespace: " + namespace + "\n"
+}
+
+func azmonitorPmon(name, namespace string) string {
+	return "---\napiVersion: azmonitoring.coreos.com/v1\nkind: PodMonitor\nmetadata:\n  name: " + name + "\n  namespace: " + namespace + "\n"
+}
+
+func monitorWithApiVersion(kind, name, namespace, apiVersion string) string {
+	return "---\napiVersion: " + apiVersion + "\nkind: " + kind + "\nmetadata:\n  name: " + name + "\n  namespace: " + namespace + "\n"
 }
 
 func nonSmonResource() string {

--- a/tooling/helmtest/testrunner/smon_check_test.go
+++ b/tooling/helmtest/testrunner/smon_check_test.go
@@ -1,0 +1,121 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testrunner
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckAzmonitorAndCoreOsSmonsExists(t *testing.T) {
+	tests := []struct {
+		name           string
+		manifest       string
+		skipNamespaces []string
+		wantSkip       bool
+		wantBoth       bool
+		wantErr        string
+	}{
+		{
+			name:     "both smons present",
+			manifest: coreosSmon("test-smon", "test-ns") + azmonitorSmon("test-smon-azmonitor", "test-ns"),
+			wantSkip: false,
+			wantBoth: true,
+		},
+		{
+			name:     "no smons at all returns skip",
+			manifest: nonSmonResource(),
+			wantSkip: true,
+			wantBoth: false,
+		},
+		{
+			name:     "empty manifest returns skip",
+			manifest: "",
+			wantSkip: true,
+			wantBoth: false,
+		},
+		{
+			name:     "only coreos smon returns error",
+			manifest: coreosSmon("test-smon", "test-ns"),
+			wantSkip: false,
+			wantBoth: false,
+			wantErr:  "azmonitor smon does not exist in the manifest",
+		},
+		{
+			name:     "only azmonitor smon returns error",
+			manifest: azmonitorSmon("test-smon-azmonitor", "test-ns"),
+			wantSkip: false,
+			wantBoth: false,
+			wantErr:  "coreos smon does not exist in the manifest",
+		},
+		{
+			name:     "unknown api version returns error",
+			manifest: smonWithApiVersion("test-smon", "test-ns", "monitoring.unknown.io/v1"),
+			wantSkip: false,
+			wantBoth: false,
+			wantErr:  "unknown smon api version: monitoring.unknown.io/v1",
+		},
+		{
+			name:           "smon in skipped namespace returns skip",
+			manifest:       coreosSmon("test-smon", "kube-system"),
+			skipNamespaces: []string{"kube-system"},
+			wantSkip:       true,
+			wantBoth:       false,
+		},
+		{
+			name:           "smon not in skipped namespace proceeds normally",
+			manifest:       coreosSmon("test-smon", "test-ns") + azmonitorSmon("test-smon-azmonitor", "test-ns"),
+			skipNamespaces: []string{"kube-system"},
+			wantSkip:       false,
+			wantBoth:       true,
+		},
+		{
+			name:     "mixed smons and non-smon resources",
+			manifest: nonSmonResource() + coreosSmon("test-smon", "test-ns") + azmonitorSmon("test-smon-azmonitor", "test-ns"),
+			wantSkip: false,
+			wantBoth: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			skip, both, err := checkAzmonitorAndCoreOsSmonsExists(tc.manifest, tc.skipNamespaces)
+			assert.Equal(t, tc.wantSkip, skip, "skip")
+			assert.Equal(t, tc.wantBoth, both, "both")
+			if tc.wantErr != "" {
+				assert.EqualError(t, err, tc.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func coreosSmon(name, namespace string) string {
+	return "---\napiVersion: monitoring.coreos.com/v1\nkind: ServiceMonitor\nmetadata:\n  name: " + name + "\n  namespace: " + namespace + "\n"
+}
+
+func azmonitorSmon(name, namespace string) string {
+	return "---\napiVersion: azmonitoring.coreos.com/v1\nkind: ServiceMonitor\nmetadata:\n  name: " + name + "\n  namespace: " + namespace + "\n"
+}
+
+func smonWithApiVersion(name, namespace, apiVersion string) string {
+	return "---\napiVersion: " + apiVersion + "\nkind: ServiceMonitor\nmetadata:\n  name: " + name + "\n  namespace: " + namespace + "\n"
+}
+
+func nonSmonResource() string {
+	return "---\napiVersion: v1\nkind: Service\nmetadata:\n  name: test-svc\n  namespace: test-ns\n"
+}

--- a/tooling/helmtest/testrunner/test_runner.go
+++ b/tooling/helmtest/testrunner/test_runner.go
@@ -200,10 +200,9 @@ func RunTestHelmTemplate(t *testing.T, settingsPath string) {
 					t.Error(v)
 				}
 
-				skip, smonsExist, err := checkAzmonitorAndCoreOsSmonsExists(manifest, settings.SmonSkipNamespaces)
+				skip, err := checkAzmonitorAndCoreOsMonitorsExist(manifest, settings.SmonSkipNamespaces)
 				if !skip {
 					require.NoError(t, err)
-					require.True(t, smonsExist)
 				}
 				// we want to place implicit test cases by the pipelines that created them, not the chart they happened to render.
 				// n.b. a more correct implementation would keep track of *where* the custom test case came from and use that dir

--- a/tooling/helmtest/testrunner/test_runner.go
+++ b/tooling/helmtest/testrunner/test_runner.go
@@ -200,6 +200,11 @@ func RunTestHelmTemplate(t *testing.T, settingsPath string) {
 					t.Error(v)
 				}
 
+				skip, smonsExist, err := checkAzmonitorAndCoreOsSmonsExists(manifest, settings.SmonSkipNamespaces)
+				if !skip {
+					require.NoError(t, err)
+					require.True(t, smonsExist)
+				}
 				// we want to place implicit test cases by the pipelines that created them, not the chart they happened to render.
 				// n.b. a more correct implementation would keep track of *where* the custom test case came from and use that dir
 				// exactly as the output directory - an exercise left for the future

--- a/tooling/tenant-quota/deploy/templates/servicemonitor-azmonitor.yaml
+++ b/tooling/tenant-quota/deploy/templates/servicemonitor-azmonitor.yaml
@@ -1,0 +1,20 @@
+# Purpose: Azure Monitor scraping - tells Azure Monitor Managed Prometheus to scrape metrics from the tenant-quota-collector service
+apiVersion: azmonitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: tenant-quota-collector
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: tenant-quota-collector
+    release: arohcp-monitor
+spec:
+  selector:
+    matchLabels:
+      app: tenant-quota-collector
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  endpoints:
+  - port: metrics
+    interval: 5m
+    path: /metrics

--- a/velero/deploy/templates/node-agent-podmonitor-azmonitor.yaml
+++ b/velero/deploy/templates/node-agent-podmonitor-azmonitor.yaml
@@ -1,0 +1,17 @@
+apiVersion: azmonitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: node-agent
+  namespace: '{{ .Release.Namespace }}'
+spec:
+  selector:
+    matchLabels:
+      name: node-agent
+  namespaceSelector:
+    matchNames:
+    - '{{ .Release.Namespace }}'
+  podMetricsEndpoints:
+  - path: /metrics
+    port: metrics
+    scheme: http
+    interval: 30s

--- a/velero/deploy/templates/velero-podmonitor-azmonitor.yaml
+++ b/velero/deploy/templates/velero-podmonitor-azmonitor.yaml
@@ -1,0 +1,17 @@
+apiVersion: azmonitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: velero
+  namespace: '{{ .Release.Namespace }}'
+spec:
+  selector:
+    matchLabels:
+      deploy: velero
+  namespaceSelector:
+    matchNames:
+    - '{{ .Release.Namespace }}'
+  podMetricsEndpoints:
+  - path: /metrics
+    port: metrics
+    scheme: http
+    interval: 30s

--- a/velero/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_velero.yaml
+++ b/velero/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_velero.yaml
@@ -274,6 +274,25 @@ spec:
       tenantID: '__imagePullerMsiTenantId__'
   serviceAccountName: velero
 ---
+# Source: velero-hcp-cli/templates/node-agent-podmonitor-azmonitor.yaml
+apiVersion: azmonitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: node-agent
+  namespace: 'velero'
+spec:
+  selector:
+    matchLabels:
+      name: node-agent
+  namespaceSelector:
+    matchNames:
+    - 'velero'
+  podMetricsEndpoints:
+  - path: /metrics
+    port: metrics
+    scheme: http
+    interval: 30s
+---
 # Source: velero-hcp-cli/templates/node-agent-podmonitor.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
@@ -284,6 +303,25 @@ spec:
   selector:
     matchLabels:
       name: node-agent
+  namespaceSelector:
+    matchNames:
+    - 'velero'
+  podMetricsEndpoints:
+  - path: /metrics
+    port: metrics
+    scheme: http
+    interval: 30s
+---
+# Source: velero-hcp-cli/templates/velero-podmonitor-azmonitor.yaml
+apiVersion: azmonitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: velero
+  namespace: 'velero'
+spec:
+  selector:
+    matchLabels:
+      deploy: velero
   namespaceSelector:
     matchNames:
     - 'velero'


### PR DESCRIPTION
### What

  * Add smon_check to helmtest to enforce that every Helm chart shipping a monitoring.coreos.com/v1 ServiceMonitor also ships a matching azmonitoring.coreos.com/v1 ServiceMonitor. This runs as part of the existing TestHelmTemplate suite and fails the build if either is missing.

  * Add azmonitoring.coreos.com/v1 ServiceMonitor CRs to all service Helm charts (frontend, backend, cluster-service, fleet, admin, maestro, kube-applier, istio, observability, acm, mgmt-agent, sessiongate). These are the static counterparts required by Azure Monitor's managed Prometheus scrape pipeline.

  * Add MonitorTranslator controller to mgmt-agent that watches monitoring.coreos.com/v1 ServiceMonitors and PodMonitors in ocm-* namespaces and creates equivalent azmonitoring.coreos.com/v1 resources with an OwnerReference for automatic cleanup. This covers the dynamic per-HCP monitors that cannot ship as static Helm templates.


### Why

Want to prepare for switching to Azure Monitor agent for gathering metrics of services

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
