### PR TITLE
fix(swift-vnet): raise ACI readiness budget from 300s to 480s

### DIFF
--- a/dev-infrastructure/scripts/swift-vnet.sh
+++ b/dev-infrastructure/scripts/swift-vnet.sh
@@ -63,7 +63,13 @@ az container delete \
 read -r -d '' CONTAINER_SCRIPT <<EOF || true
 set -euo pipefail
 
-MAX_WAIT=300
+# MAX_WAIT is the per-stage readiness budget used by retry() below (DNS gate, az
+# login, vnet existence check). A freshly-created ACI in a delegated subnet has
+# been observed to take just over 300s for its resolver / RBAC to become ready
+# (DEV CI provision failures giving up at 302-306s), so 300s was too tight. 480s
+# absorbs that tail while staying well under the outer container TIMEOUT (900s):
+# only the first cold-start stage is slow, later stages succeed once warm.
+MAX_WAIT=480
 POLL_INTERVAL=5
 
 # retry <description> <command...>: run the command, polling at a fixed POLL_INTERVAL until it

--- a/dev-infrastructure/scripts/swift-vnet.sh
+++ b/dev-infrastructure/scripts/swift-vnet.sh
@@ -63,12 +63,16 @@ az container delete \
 read -r -d '' CONTAINER_SCRIPT <<EOF || true
 set -euo pipefail
 
-# MAX_WAIT is the per-stage readiness budget used by retry() below (DNS gate, az
-# login, vnet existence check). A freshly-created ACI in a delegated subnet has
-# been observed to take just over 300s for its resolver / RBAC to become ready
-# (DEV CI provision failures giving up at 302-306s), so 300s was too tight. 480s
-# absorbs that tail while staying well under the outer container TIMEOUT (900s):
-# only the first cold-start stage is slow, later stages succeed once warm.
+# MAX_WAIT is the readiness budget applied *per* retry() stage below (DNS gate,
+# az login, vnet existence check), not to the container as a whole. A freshly-
+# created ACI in a delegated subnet has been observed to take just over 300s for
+# its resolver / RBAC to become ready (DEV CI provision failures giving up at
+# 302-306s), so 300s was too tight; 480s covers that single cold-start tail. In
+# practice only the first stage is cold (later stages succeed immediately once
+# the resolver/token is warm), so real runtime is far below the sum of the
+# per-stage limits. Total container runtime is bounded independently by the
+# outer container-group TIMEOUT (900s), which terminates the ACI regardless of
+# how the per-stage budgets add up.
 MAX_WAIT=480
 POLL_INTERVAL=5
 

--- a/dev-infrastructure/scripts/swift-vnet.sh
+++ b/dev-infrastructure/scripts/swift-vnet.sh
@@ -63,16 +63,12 @@ az container delete \
 read -r -d '' CONTAINER_SCRIPT <<EOF || true
 set -euo pipefail
 
-# MAX_WAIT is the readiness budget applied *per* retry() stage below (DNS gate,
-# az login, vnet existence check), not to the container as a whole. A freshly-
-# created ACI in a delegated subnet has been observed to take just over 300s for
-# its resolver / RBAC to become ready (DEV CI provision failures giving up at
-# 302-306s), so 300s was too tight; 480s covers that single cold-start tail. In
-# practice only the first stage is cold (later stages succeed immediately once
-# the resolver/token is warm), so real runtime is far below the sum of the
-# per-stage limits. Total container runtime is bounded independently by the
-# outer container-group TIMEOUT (900s), which terminates the ACI regardless of
-# how the per-stage budgets add up.
+# Per-stage readiness budget for retry() below (DNS gate, az login, vnet check),
+# not a whole-container limit. Sized to absorb the one-off ACI network cold-start
+# (resolver / RBAC readiness), which can run several minutes on the first stage
+# but is warm thereafter. Total container runtime is bounded independently by the
+# outer container-group TIMEOUT, which terminates the ACI regardless of how the
+# per-stage budgets add up.
 MAX_WAIT=480
 POLL_INTERVAL=5
 


### PR DESCRIPTION
## What

Raise the inner `swift-vnet` ACI container's per-stage readiness budget (`MAX_WAIT`) from **300s → 480s**.

## Why

The `management`/`swift-vnet` step accounted for **2 of 14** DEV `e2e-parallel` provision failures on **2026-07-13**. In both cases the `swift-vnet-aks-net` ACI container group started, but its network cold-start exceeded the 300s per-stage readiness budget by only a few seconds:

| Failure | Stage | Gave up at |
|---|---|---|
| Job A | DNS readiness (`login.microsoftonline.com`) | ~306s |
| Job B | `az login` (globalMSI, IMDS/MSI unreachable) | ~302s |

These are legitimately slow-but-eventual readiness waits (freshly-created ACI in a delegated subnet: resolver cold-start + RBAC/MSI propagation), not hard errors. The retry loop was already doing the right thing — it just ran out of budget by a hair. The fix is simply **more headroom**, no behavioral change.

480s is chosen so a single slow cold-start stage still finishes comfortably under:
- the outer container-group wait (`TIMEOUT=900`), and
- the 30m pipeline step timeout.

Only the first stage is cold; subsequent stages resolve immediately once the container's resolver is warm, so total container runtime stays well under 900s.

## Testing

- `bash -n dev-infrastructure/scripts/swift-vnet.sh` — syntax OK
- `shellcheck dev-infrastructure/scripts/swift-vnet.sh` — clean

## Checklist
- [x] Change is scoped to a single readiness-timeout constant + explanatory comment
- [x] No behavioral change beyond additional wait headroom
- [x] Validated with `bash -n` and `shellcheck`