### PR TITLE
feature: adding absent alert for credential refresher

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedMsftPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedMsftPrometheusAlertingRules.bicep
@@ -752,6 +752,33 @@ resource msftMsiCredentialRefresher 'Microsoft.AlertsManagement/prometheusRuleGr
             }
           }
         ]
+        alert: 'ClusterCredentialMetricMissing'
+        enabled: true
+        labels: {
+          severity: 'warning'
+        }
+        annotations: {
+          correlationId: 'ClusterCredentialMetricMissing/{{ $labels.cluster }}'
+          description: 'Credential refresher expiration metric is missing for service cluster {{ $labels.cluster }}.'
+          info: 'Credential refresher expiration metric is missing for service cluster {{ $labels.cluster }}.'
+          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/troubleshooting/tsgs/credential-refresher-expiring-cert'
+          summary: 'Credential refresher metric missing for cluster {{ $labels.cluster }}'
+          title: 'Credential refresher metric missing for cluster {{ $labels.cluster }}'
+        }
+        expression: 'group by (cluster) (up{cluster=~".*-svc(-[0-9]+)?$",job="kubelet"}) unless on (cluster) group by (cluster) (credential_refresher_days_until_msi_credential_expiration_bucket{cluster=~".*-svc(-[0-9]+)?$"})'
+        for: 'PT30M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
         alert: 'ClusterCredentialExpiringSoon'
         enabled: true
         labels: {

--- a/observability/alerts-msft-services.yaml
+++ b/observability/alerts-msft-services.yaml
@@ -51,6 +51,7 @@ prometheusRules:
     - KubePersistentVolumeErrors
   - groupName: msi-credential-refresher
     alerts:
+    - ClusterCredentialMetricMissing
     - ClusterCredentialExpiringSoon
     - ClusterCredentialExpired
     - ClusterCredentialNotRenewable

--- a/observability/alerts/msi-credential-refresher-prometheusRule.yaml
+++ b/observability/alerts/msi-credential-refresher-prometheusRule.yaml
@@ -8,6 +8,16 @@ spec:
   - name: msi-credential-refresher
     interval: 1m
     rules:
+    - alert: ClusterCredentialMetricMissing
+      expr: group by (cluster) (up{job="kubelet",cluster=~".*-svc(-[0-9]+)?$"}) unless on(cluster) group by (cluster) (credential_refresher_days_until_msi_credential_expiration_bucket{cluster=~".*-svc(-[0-9]+)?$"})
+      for: 30m
+      labels:
+        severity: warning
+      annotations:
+        description: 'Credential refresher expiration metric is missing for service cluster {{ $labels.cluster }}.'
+        summary: 'Credential refresher metric missing for cluster {{ $labels.cluster }}'
+        runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/troubleshooting/tsgs/credential-refresher-expiring-cert'
+        correlationId: 'ClusterCredentialMetricMissing/{{ $labels.cluster }}'
     - alert: ClusterCredentialExpiringSoon
       expr: sum by (cluster) (increase(credential_refresher_days_until_msi_credential_expiration_bucket{le=~"^30([.]0)?$"}[30m])) - sum by (cluster) (increase(credential_refresher_days_until_msi_credential_expiration_bucket{le=~"^0([.]0)?$"}[30m])) > 0
       for: 5m

--- a/observability/alerts/msi-credential-refresher-prometheusRule_test.yaml
+++ b/observability/alerts/msi-credential-refresher-prometheusRule_test.yaml
@@ -4,6 +4,47 @@ evaluation_interval: 1m
 tests:
 - interval: 1m
   input_series:
+  - series: 'up{job="kubelet",cluster="test-svc"}'
+    # Service cluster is being scraped (up present), but credential refresher metric is absent.
+    # With group-by/unless and for: 30m, the alert fires once up has been present without the
+    # credential metric for 30 consecutive minutes.
+    values: '1+0x35'
+  alert_rule_test:
+  - eval_time: 35m
+    alertname: ClusterCredentialMetricMissing
+    exp_alerts:
+    - exp_labels:
+        severity: warning
+        cluster: test-svc
+      exp_annotations:
+        description: 'Credential refresher expiration metric is missing for service cluster test-svc.'
+        summary: 'Credential refresher metric missing for cluster test-svc'
+        runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/troubleshooting/tsgs/credential-refresher-expiring-cert'
+        correlationId: 'ClusterCredentialMetricMissing/test-svc'
+- interval: 1m
+  input_series:
+  - series: 'up{job="kubelet",cluster="test-svc"}'
+    # Service cluster is being scraped
+    values: '1+0x35'
+  - series: 'credential_refresher_days_until_msi_credential_expiration_bucket{cluster="test-svc",le="30"}'
+    # Credential metric is present; the unless clause removes the cluster from the result, so no alert
+    values: '0+0x35'
+  alert_rule_test:
+  - eval_time: 35m
+    alertname: ClusterCredentialMetricMissing
+    exp_alerts: []
+- interval: 1m
+  input_series:
+  - series: 'up{job="kubelet",cluster="test-cluster"}'
+    # Cluster name does not include -svc, so the cluster=~".*-svc.*" filter excludes it from both
+    # sides of the unless; no alert should fire
+    values: '1+0x35'
+  alert_rule_test:
+  - eval_time: 35m
+    alertname: ClusterCredentialMetricMissing
+    exp_alerts: []
+- interval: 1m
+  input_series:
   - series: 'credential_refresher_days_until_msi_credential_expiration_bucket{cluster="test-cluster",le="30"}'
     # Values need to increase over 30 minutes window for the increase() function to work
     # Starting from 0 and increasing by 1 every minute for 35 minutes


### PR DESCRIPTION
[ARO-28431](https://redhat.atlassian.net/browse/ARO-28431)

### What
Adding absent alert for credential refresher on svc clusters

### Why
This is our only alerting for expiring customer cluster credentials. We need to be alerted if we aren't getting this signal.

### Testing

Added unit test for the new alert

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [x] All comment threads resolved before merge

If E2E tests are included:

- [x] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [x] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
