### PR TITLE
chore(acr): add purge jobs for dev service images and enable SVC retention

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -93,8 +93,8 @@ defaults:
       name: 'arohcpsvc{{ .ctx.environment }}' # [globally-unique]
       zoneRedundantMode: Enabled
       untaggedImagesRetention:
-        enabled: false
-        days: 365
+        enabled: true
+        days: 90
     ocp:
       name: 'arohcpocp{{ .ctx.environment }}' # [globally-unique]
       zoneRedundantMode: Enabled

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -19,8 +19,8 @@ acr:
   svc:
     name: arohcpsvcdev
     untaggedImagesRetention:
-      days: 365
-      enabled: false
+      days: 90
+      enabled: true
     zoneRedundantMode: Disabled
 acrDNSSuffix: azurecr.io
 acrPull:

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -19,8 +19,8 @@ acr:
   svc:
     name: arohcpsvcdev
     untaggedImagesRetention:
-      days: 365
-      enabled: false
+      days: 90
+      enabled: true
     zoneRedundantMode: Disabled
 acrDNSSuffix: azurecr.io
 acrPull:

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -19,8 +19,8 @@ acr:
   svc:
     name: arohcpsvcdev
     untaggedImagesRetention:
-      days: 365
-      enabled: false
+      days: 90
+      enabled: true
     zoneRedundantMode: Disabled
 acrDNSSuffix: azurecr.io
 acrPull:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -19,8 +19,8 @@ acr:
   svc:
     name: arohcpsvcdev
     untaggedImagesRetention:
-      days: 365
-      enabled: false
+      days: 90
+      enabled: true
     zoneRedundantMode: Disabled
 acrDNSSuffix: azurecr.io
 acrPull:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -19,8 +19,8 @@ acr:
   svc:
     name: arohcpsvcdev
     untaggedImagesRetention:
-      days: 365
-      enabled: false
+      days: 90
+      enabled: true
     zoneRedundantMode: Disabled
 acrDNSSuffix: azurecr.io
 acrPull:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -19,8 +19,8 @@ acr:
   svc:
     name: arohcpsvcdev
     untaggedImagesRetention:
-      days: 365
-      enabled: false
+      days: 90
+      enabled: true
     zoneRedundantMode: Disabled
 acrDNSSuffix: azurecr.io
 acrPull:

--- a/dev-infrastructure/configurations/acr-svc.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/acr-svc.tmpl.bicepparam
@@ -21,20 +21,24 @@ param quayRepositoriesToCache = [
 
 param purgeJobs = [
   {
-    name: 'ocm-clusters-service-sandbox-purge'
-    purgeFilter: 'quay.io/app-sre/ocm-clusters-service-sandbox:.*'
+    name: 'sandbox-images-purge'
+    purgeFilters: [
+      'quay.io/app-sre/ocm-clusters-service-sandbox:.*'
+      'quay.io/app-sre/aro-hcp-clusters-service-sandbox:.*'
+    ]
     purgeAfter: '2d'
     imagesToKeep: 1
   }
   {
-    name: 'aro-hcp-clusters-service-sandbox-purge'
-    purgeFilter: 'quay.io/app-sre/aro-hcp-clusters-service-sandbox:.*'
-    purgeAfter: '2d'
-    imagesToKeep: 1
-  }
-  {
-    name: 'arohcpfrontend-purge'
-    purgeFilter: 'arohcpfrontend:.*'
+    name: 'service-images-purge'
+    purgeFilters: [
+      'arohcp*:.*'
+      'fleet:.*'
+      'kube-applier:.*'
+      'mgmt-agent:.*'
+      'test-*:.*'
+      'ci-op-*/*:.*'
+    ]
     purgeAfter: '7d'
     imagesToKeep: 3
   }

--- a/dev-infrastructure/templates/dev-acr.bicep
+++ b/dev-infrastructure/templates/dev-acr.bicep
@@ -97,7 +97,11 @@ steps:
     disableWorkingDirectoryOverride: true
     timeout: 3600
 ''',
-          reduce(map(purgeJob.purgeFilters, f => '--filter "${f}"'), '', (cur, next) => empty(cur) ? next : '${cur} ${next}'),
+          reduce(
+            map(purgeJob.purgeFilters, f => '--filter "${f}"'),
+            '',
+            (cur, next) => empty(cur) ? next : '${cur} ${next}'
+          ),
           purgeJob.imagesToKeep,
           purgeJob.purgeAfter
         ))

--- a/dev-infrastructure/templates/dev-acr.bicep
+++ b/dev-infrastructure/templates/dev-acr.bicep
@@ -97,11 +97,7 @@ steps:
     disableWorkingDirectoryOverride: true
     timeout: 3600
 ''',
-          reduce(
-            map(purgeJob.purgeFilters, f => '--filter "${f}"'),
-            '',
-            (cur, next) => empty(cur) ? next : '${cur} ${next}'
-          ),
+          join(map(purgeJob.purgeFilters, f => '--filter "${f}"'), ' '),
           purgeJob.imagesToKeep,
           purgeJob.purgeAfter
         ))

--- a/dev-infrastructure/templates/dev-acr.bicep
+++ b/dev-infrastructure/templates/dev-acr.bicep
@@ -93,11 +93,11 @@ resource purgeCached 'Microsoft.ContainerRegistry/registries/tasks@2019-04-01' =
           '''
 version: v1.1.0
 steps:
-  - cmd: acr purge --filter "{0}" --keep {1} --ago {2}
+  - cmd: acr purge {0} --keep {1} --ago {2}
     disableWorkingDirectoryOverride: true
     timeout: 3600
 ''',
-          purgeJob.purgeFilter,
+          reduce(map(purgeJob.purgeFilters, f => '--filter "${f}"'), '', (cur, next) => empty(cur) ? next : '${cur} ${next}'),
           purgeJob.imagesToKeep,
           purgeJob.purgeAfter
         ))


### PR DESCRIPTION
[ARO-27672](https://redhat.atlassian.net/browse/ARO-27672)

### What

- Enable SVC ACR untagged image retention (90 days, matching OCP ACR)
- Extend ACR purge jobs to cover all in-repo services, personal dev repos, and CI pipeline repos
- Change purge job template to support multiple `--filter` flags per job via a `purgeFilters` array

### Why

SVC ACR has ~9,400 repos with ~47k tagged images and ~45k untagged manifests accumulating with no cleanup. Only `arohcpfrontend` had a purge job (86 tags vs 1,000+ for unprotected repos).

### Testing

- `az bicep build` and `make materialize` pass locally
- Post-merge: verify ACR Tasks in portal, dry-run `acr purge` before first execution

### Special notes for your reviewer

- `arohcp*:.*` wildcard covers frontend, backend, adminapi, sessiongate, and metrics
- `ci-op-*/*:.*` targets multi-segment CI pipeline repos — needs verification that `*` matches path separators in `acr purge`

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if graph/UI/metrics changes) — N/A
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge