### PR TITLE
hcpctl snapshot analyze: teach the agents about alerts

### DIFF
--- a/tooling/hcpctl/cmd/snapshot/from_prow_job_cmd.go
+++ b/tooling/hcpctl/cmd/snapshot/from_prow_job_cmd.go
@@ -195,19 +195,20 @@ func (o *validatedFromProwJobOptions) run(ctx context.Context) error {
 		}
 
 		result, err := snapshotpkg.GatherForTest(ctx, snapshotpkg.GatherForTestOptions{
-			Gatherer:              gatherer,
-			Test:                  test,
-			ProwJobURL:            o.prowInfo.URL,
-			KustoEndpoint:         kustoEndpoint.String(),
-			ServiceDatabase:       jobConfig.ServiceDatabase,
-			HCPDatabase:           jobConfig.HCPDatabase,
-			ServiceClusterName:    jobConfig.ServiceClusterName,
-			ManagementClusterName: jobConfig.ManagementClusterName,
-			SiblingTests:          siblingTests,
-			OutputDir:             testOutputDir,
-			QueryTimeout:          o.queryTimeout,
-			Concurrency:           o.concurrency,
-			NodeConsoleLogs:       nodeConsoleLogs,
+			Gatherer:                 gatherer,
+			Test:                     test,
+			ProwJobURL:               o.prowInfo.URL,
+			KustoEndpoint:            kustoEndpoint.String(),
+			ServiceDatabase:          jobConfig.ServiceDatabase,
+			HCPDatabase:              jobConfig.HCPDatabase,
+			MonitoringEventsDatabase: jobConfig.MonitoringEventsDatabase,
+			ServiceClusterName:       jobConfig.ServiceClusterName,
+			ManagementClusterName:    jobConfig.ManagementClusterName,
+			SiblingTests:             siblingTests,
+			OutputDir:                testOutputDir,
+			QueryTimeout:             o.queryTimeout,
+			Concurrency:              o.concurrency,
+			NodeConsoleLogs:          nodeConsoleLogs,
 		})
 		if err != nil {
 			logger.Error(err, "Failed to gather snapshot for test", "test", test.Name)

--- a/tooling/hcpctl/cmd/snapshot/from_resource_cmd.go
+++ b/tooling/hcpctl/cmd/snapshot/from_resource_cmd.go
@@ -32,24 +32,26 @@ import (
 
 // RawFromResourceOptions holds the unvalidated CLI options for from-resource.
 type RawFromResourceOptions struct {
-	Kusto           string
-	Region          string
-	ServiceDatabase string
-	HCPDatabase     string
-	ResourceGroup   string
-	StartTime       string
-	EndTime         string
-	OutputDir       string
-	QueryTimeout    time.Duration
-	Concurrency     int
+	Kusto                    string
+	Region                   string
+	ServiceDatabase          string
+	HCPDatabase              string
+	MonitoringEventsDatabase string
+	ResourceGroup            string
+	StartTime                string
+	EndTime                  string
+	OutputDir                string
+	QueryTimeout             time.Duration
+	Concurrency              int
 }
 
 func defaultFromResourceOptions() *RawFromResourceOptions {
 	return &RawFromResourceOptions{
-		ServiceDatabase: "intSVCLogs",
-		HCPDatabase:     "intHCPLogs",
-		QueryTimeout:    5 * time.Minute,
-		OutputDir:       fmt.Sprintf("snapshot-%s", time.Now().Format("20060102-150405")),
+		ServiceDatabase:          "ServiceLogs",
+		HCPDatabase:              "HostedControlPlaneLogs",
+		MonitoringEventsDatabase: "MonitoringEvents",
+		QueryTimeout:             5 * time.Minute,
+		OutputDir:                fmt.Sprintf("snapshot-%s", time.Now().Format("20060102-150405")),
 	}
 }
 
@@ -58,6 +60,7 @@ func bindFromResourceOptions(opts *RawFromResourceOptions, cmd *cobra.Command) e
 	cmd.Flags().StringVar(&opts.Region, "region", opts.Region, "Azure Data Explorer cluster region (required)")
 	cmd.Flags().StringVar(&opts.ServiceDatabase, "service-database", opts.ServiceDatabase, "Kusto database for service logs")
 	cmd.Flags().StringVar(&opts.HCPDatabase, "hcp-database", opts.HCPDatabase, "Kusto database for hosted control plane logs")
+	cmd.Flags().StringVar(&opts.MonitoringEventsDatabase, "monitoring-events-database", opts.MonitoringEventsDatabase, "Kusto database for monitoring events (alerts)")
 	cmd.Flags().StringVar(&opts.ResourceGroup, "resource-group", opts.ResourceGroup, "Azure resource group name (required)")
 	cmd.Flags().StringVar(&opts.StartTime, "start-time", opts.StartTime, "Query start time in RFC3339 format (required)")
 	cmd.Flags().StringVar(&opts.EndTime, "end-time", opts.EndTime, "Query end time in RFC3339 format (required)")
@@ -74,15 +77,16 @@ func bindFromResourceOptions(opts *RawFromResourceOptions, cmd *cobra.Command) e
 }
 
 type validatedFromResourceOptions struct {
-	kustoEndpoint   *url.URL
-	serviceDatabase string
-	hcpDatabase     string
-	resourceGroup   string
-	startTime       time.Time
-	endTime         time.Time
-	outputDir       string
-	queryTimeout    time.Duration
-	concurrency     int
+	kustoEndpoint            *url.URL
+	serviceDatabase          string
+	hcpDatabase              string
+	monitoringEventsDatabase string
+	resourceGroup            string
+	startTime                time.Time
+	endTime                  time.Time
+	outputDir                string
+	queryTimeout             time.Duration
+	concurrency              int
 }
 
 func (o *RawFromResourceOptions) validate() (*validatedFromResourceOptions, error) {
@@ -104,15 +108,16 @@ func (o *RawFromResourceOptions) validate() (*validatedFromResourceOptions, erro
 	}
 
 	return &validatedFromResourceOptions{
-		kustoEndpoint:   kustoEndpoint,
-		serviceDatabase: o.ServiceDatabase,
-		hcpDatabase:     o.HCPDatabase,
-		resourceGroup:   o.ResourceGroup,
-		startTime:       startTime,
-		endTime:         endTime,
-		outputDir:       o.OutputDir,
-		queryTimeout:    o.QueryTimeout,
-		concurrency:     o.Concurrency,
+		kustoEndpoint:            kustoEndpoint,
+		serviceDatabase:          o.ServiceDatabase,
+		hcpDatabase:              o.HCPDatabase,
+		monitoringEventsDatabase: o.MonitoringEventsDatabase,
+		resourceGroup:            o.ResourceGroup,
+		startTime:                startTime,
+		endTime:                  endTime,
+		outputDir:                o.OutputDir,
+		queryTimeout:             o.QueryTimeout,
+		concurrency:              o.Concurrency,
 	}, nil
 }
 
@@ -151,10 +156,11 @@ func (o *completedFromResourceOptions) run(ctx context.Context) error {
 
 	gatherer := snapshotpkg.NewGatherer(o.kustoClient)
 	input := snapshotpkg.GatherInput{
-		ClusterURI:      o.kustoEndpoint.String(),
-		ServiceDatabase: o.serviceDatabase,
-		HCPDatabase:     o.hcpDatabase,
-		ResourceGroup:   o.resourceGroup,
+		ClusterURI:               o.kustoEndpoint.String(),
+		ServiceDatabase:          o.serviceDatabase,
+		HCPDatabase:              o.hcpDatabase,
+		MonitoringEventsDatabase: o.monitoringEventsDatabase,
+		ResourceGroup:            o.resourceGroup,
 		TimeWindow: snapshotpkg.TimeWindow{
 			Start: o.startTime,
 			End:   o.endTime,

--- a/tooling/hcpctl/pkg/agent/prompts/system.md
+++ b/tooling/hcpctl/pkg/agent/prompts/system.md
@@ -219,6 +219,12 @@ Each environment has two databases:
   (mgmt-agent, HyperShift operator) is also in this database — filter by `cluster`.
 - **`HostedControlPlaneLogs`**: Per-cluster hosted control plane container logs
   (`containerLogs`) — kube-apiserver, etcd, control-plane-operator, etc.
+- **`MonitoringEvents`**: Alert events from Prometheus/metric alerting. The
+  `alertEvents` table contains fired/resolved alerts with columns: `alertId`,
+  `alertRule`, `severity`, `monitorCondition`, `firedDateTime`, `resolvedDateTime`,
+  `alertContext` (dynamic — contains `labels` and `annotations` with the full
+  Prometheus alert payload). When investigating alerts, always expand `alertContext`
+  for the full detail — `alertContext.labels`, `alertContext.annotations`, etc.
 
 Hosted cluster namespaces: `ocm-arohcp<env>-<cid>-<id>`. Use `distinct pod_name,
 container_name` within a namespace to discover available logs.

--- a/tooling/hcpctl/pkg/snapshot/gather_enriched.go
+++ b/tooling/hcpctl/pkg/snapshot/gather_enriched.go
@@ -46,6 +46,9 @@ type GatherForTestOptions struct {
 	// HCPDatabase is the Kusto database name for HCP-side data.
 	HCPDatabase string
 
+	// MonitoringEventsDatabase is the Kusto database name for monitoring events (alerts).
+	MonitoringEventsDatabase string
+
 	// ServiceClusterName and ManagementClusterName are AKS cluster names
 	// used to filter Kusto queries to only relevant clusters for PR jobs.
 	ServiceClusterName    string
@@ -130,12 +133,13 @@ func GatherForTest(ctx context.Context, opts GatherForTestOptions) (*GatherForTe
 	}
 
 	input := GatherInput{
-		ClusterURI:            opts.KustoEndpoint,
-		ServiceDatabase:       opts.ServiceDatabase,
-		HCPDatabase:           opts.HCPDatabase,
-		ResourceGroup:         test.ResourceGroup,
-		ServiceClusterName:    opts.ServiceClusterName,
-		ManagementClusterName: opts.ManagementClusterName,
+		ClusterURI:               opts.KustoEndpoint,
+		ServiceDatabase:          opts.ServiceDatabase,
+		HCPDatabase:              opts.HCPDatabase,
+		MonitoringEventsDatabase: opts.MonitoringEventsDatabase,
+		ResourceGroup:            test.ResourceGroup,
+		ServiceClusterName:       opts.ServiceClusterName,
+		ManagementClusterName:    opts.ManagementClusterName,
 		TimeWindow: TimeWindow{
 			Start:           startTime,
 			End:             endTime,

--- a/tooling/hcpctl/pkg/snapshot/gatherer.go
+++ b/tooling/hcpctl/pkg/snapshot/gatherer.go
@@ -44,6 +44,8 @@ type GatherInput struct {
 	ServiceDatabase string
 	// HCPDatabase is the Kusto database containing hosted control plane logs.
 	HCPDatabase string
+	// MonitoringEventsDatabase is the Kusto database containing monitoring events (alerts).
+	MonitoringEventsDatabase string
 	// ResourceGroup is the Azure resource group to scope queries to.
 	ResourceGroup string
 	// TimeWindow is the full time range to query.
@@ -74,6 +76,18 @@ func (g GatherInput) concurrency() int {
 		return g.Concurrency
 	}
 	return 4 * runtime.NumCPU()
+}
+
+// databaseFor returns the Kusto database name for the given database key.
+func (g GatherInput) databaseFor(database string) string {
+	switch database {
+	case "hcp":
+		return g.HCPDatabase
+	case "monitoringEvents":
+		return g.MonitoringEventsDatabase
+	default:
+		return g.ServiceDatabase
+	}
 }
 
 // phaseSpec describes a single phase (test or cleanup) with its time boundaries.
@@ -215,14 +229,15 @@ func (g *Gatherer) Gather(ctx context.Context, input GatherInput, outputDir stri
 
 	// Build seed queryData for discovery (full time window).
 	seedData := queryData{
-		ClusterURI:            input.ClusterURI,
-		ServiceDatabase:       input.ServiceDatabase,
-		HCPDatabase:           input.HCPDatabase,
-		ResourceGroup:         input.ResourceGroup,
-		ServiceClusterName:    input.ServiceClusterName,
-		ManagementClusterName: input.ManagementClusterName,
-		FullStartTime:         input.TimeWindow.Start,
-		FullEndTime:           input.TimeWindow.End,
+		ClusterURI:               input.ClusterURI,
+		ServiceDatabase:          input.ServiceDatabase,
+		HCPDatabase:              input.HCPDatabase,
+		MonitoringEventsDatabase: input.MonitoringEventsDatabase,
+		ResourceGroup:            input.ResourceGroup,
+		ServiceClusterName:       input.ServiceClusterName,
+		ManagementClusterName:    input.ManagementClusterName,
+		FullStartTime:            input.TimeWindow.Start,
+		FullEndTime:              input.TimeWindow.End,
 		// Discovery queries use the full window for phase fields too.
 		PhaseStartTime: input.TimeWindow.Start,
 		PhaseEndTime:   input.TimeWindow.End,
@@ -882,10 +897,7 @@ func (g *Gatherer) executeQuery(ctx context.Context, q querySpec, data *queryDat
 		return nil, fmt.Errorf("query %s: %w", q.key(), err)
 	}
 
-	db := input.ServiceDatabase
-	if q.database == "hcp" {
-		db = input.HCPDatabase
-	}
+	db := input.databaseFor(q.database)
 
 	rows, err := g.executeKQL(ctx, rendered, db, input.QueryTimeout)
 	if err != nil {
@@ -925,10 +937,7 @@ func (g *Gatherer) executeQueryToDir(ctx context.Context, q querySpec, data *que
 		return nil, fmt.Errorf("query %s: %w", q.key(), err)
 	}
 
-	db := input.ServiceDatabase
-	if q.database == "hcp" {
-		db = input.HCPDatabase
-	}
+	db := input.databaseFor(q.database)
 
 	rows, err := g.executeKQL(ctx, rendered, db, input.QueryTimeout)
 	if err != nil {

--- a/tooling/hcpctl/pkg/snapshot/prow.go
+++ b/tooling/hcpctl/pkg/snapshot/prow.go
@@ -65,10 +65,11 @@ func (p *ProwJobInfo) IsPullRequest() bool {
 
 // ProwJobConfig holds the Kusto connection info extracted from a Prow job's config.yaml.
 type ProwJobConfig struct {
-	Region          string
-	KustoName       string
-	HCPDatabase     string
-	ServiceDatabase string
+	Region                   string
+	KustoName                string
+	HCPDatabase              string
+	ServiceDatabase          string
+	MonitoringEventsDatabase string
 
 	// ServiceClusterName and ManagementClusterName are the AKS cluster names
 	// used to filter Kusto queries to only relevant clusters. These are only
@@ -578,6 +579,7 @@ type sourceKusto struct {
 	Location                       string `json:"location"`
 	HostedControlPlaneLogsDatabase string `json:"hostedControlPlaneLogsDatabase"`
 	ServiceLogsDatabase            string `json:"serviceLogsDatabase"`
+	MonitoringEventsDatabase       string `json:"monitoringEventsDatabase"`
 }
 
 type sourceAKS struct {
@@ -595,12 +597,13 @@ func parseConfig(data []byte) (*ProwJobConfig, error) {
 	}
 
 	return &ProwJobConfig{
-		Region:                src.Kusto.Location,
-		KustoName:             src.Kusto.KustoName,
-		HCPDatabase:           src.Kusto.HostedControlPlaneLogsDatabase,
-		ServiceDatabase:       src.Kusto.ServiceLogsDatabase,
-		ServiceClusterName:    src.Svc.AKS.Name,
-		ManagementClusterName: src.Mgmt.AKS.Name,
+		Region:                   src.Kusto.Location,
+		KustoName:                src.Kusto.KustoName,
+		HCPDatabase:              src.Kusto.HostedControlPlaneLogsDatabase,
+		ServiceDatabase:          src.Kusto.ServiceLogsDatabase,
+		MonitoringEventsDatabase: src.Kusto.MonitoringEventsDatabase,
+		ServiceClusterName:       src.Svc.AKS.Name,
+		ManagementClusterName:    src.Mgmt.AKS.Name,
 	}, nil
 }
 

--- a/tooling/hcpctl/pkg/snapshot/queries.go
+++ b/tooling/hcpctl/pkg/snapshot/queries.go
@@ -112,10 +112,11 @@ func (q querySpec) key() string {
 // queryData holds all context accumulated across the query chain.
 type queryData struct {
 	// Seed values — provided by the caller.
-	ClusterURI      string
-	ServiceDatabase string
-	HCPDatabase     string
-	ResourceGroup   string
+	ClusterURI               string
+	ServiceDatabase          string
+	HCPDatabase              string
+	MonitoringEventsDatabase string
+	ResourceGroup            string
 
 	// ServiceClusterName and ManagementClusterName are AKS cluster names
 	// used to filter queries for PR jobs. When both are non-empty, queries
@@ -718,6 +719,28 @@ var allQueries = []querySpec{
 		},
 		prerequisites: "HostedControlPlaneNamespace, ResourceType is cluster",
 	},
+	{
+		component:    "alerts",
+		queryName:    "cluster",
+		templatePath: "queries/alerts/cluster/query.kql",
+		database:     "monitoringEvents",
+		category:     categoryResourceEvents,
+		ready: func(d queryData) bool {
+			return d.HostedControlPlaneNamespace != "" && strings.EqualFold(d.ResourceType, "microsoft.redhatopenshift/hcpopenshiftclusters")
+		},
+		prerequisites: "HostedControlPlaneNamespace, ResourceType is cluster",
+	},
+	{
+		component:    "alerts",
+		queryName:    "acm",
+		templatePath: "queries/alerts/acm/query.kql",
+		database:     "monitoringEvents",
+		category:     categoryResourceEvents,
+		ready: func(d queryData) bool {
+			return d.ClusterID != "" && strings.EqualFold(d.ResourceType, "microsoft.redhatopenshift/hcpopenshiftclusters")
+		},
+		prerequisites: "ClusterID, ResourceType is cluster",
+	},
 }
 
 // contextQueries are broader queries not tied to a specific correlation ID.
@@ -729,6 +752,20 @@ var contextQueries = []querySpec{
 		queryName:    "frontendRequests",
 		templatePath: "queries/frontend/frontendRequests/query.kql",
 		database:     "service",
+		category:     categoryContext,
+	},
+	{
+		component:    "alerts",
+		queryName:    "uncategorized",
+		templatePath: "queries/alerts/uncategorized/query.kql",
+		database:     "monitoringEvents",
+		category:     categoryContext,
+	},
+	{
+		component:    "alerts",
+		queryName:    "service",
+		templatePath: "queries/alerts/service/query.kql",
+		database:     "monitoringEvents",
 		category:     categoryContext,
 	},
 }

--- a/tooling/hcpctl/pkg/snapshot/queries/alerts/acm/README.md
+++ b/tooling/hcpctl/pkg/snapshot/queries/alerts/acm/README.md
@@ -1,0 +1,15 @@
+# alerts / acm
+
+## Summary
+
+Lists fired or active Prometheus/metric alerts during the time window for the ACM klusterlet namespace (`klusterlet-<cluster-id>`) associated with the cluster under test.
+
+ACM is used by clusters-service to inject ingress and manage a few things, so it's unlikely to be important - but failures here can block deletions.
+
+## What to Look For
+
+Registration failures, agent connectivity issues, or work-agent errors that would prevent ManifestWork delivery to the hosted cluster — blocking cluster ingress provisioning or deletion.
+
+## Where to Go Next
+
+Review `clustersService/logs/` for any errors. Use the `kusto_query` tool to expand `alertContext` for full alert detail.

--- a/tooling/hcpctl/pkg/snapshot/queries/alerts/acm/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/alerts/acm/query.kql
@@ -1,0 +1,4 @@
+{{ template "alertEventsBase" . }}
+| where isnotnull(alertContext.labels.namespace) and
+    alertContext.labels.namespace == 'klusterlet-{{ .ClusterID }}'
+{{ template "alertEventsProject" . }}

--- a/tooling/hcpctl/pkg/snapshot/queries/alerts/cluster/README.md
+++ b/tooling/hcpctl/pkg/snapshot/queries/alerts/cluster/README.md
@@ -1,0 +1,13 @@
+# alerts / cluster
+
+## Summary
+
+Lists fired or active Prometheus/metric alerts during the time window for the hosted control plane namespace of the cluster under test.
+
+## What to Look For
+
+Control plane alerts — etcd leader loss, kube-apiserver latency, OOM kills, certificate rotation failures — that directly impact cluster health and may explain test timeouts or failures.
+
+## Where to Go Next
+
+Cross-reference with `events/hypershift/controlPlaneEvents` and `conditions/hypershift/hostedClusterConditions` to build a timeline. Use the `kusto_query` tool to expand `alertContext` for full alert detail.

--- a/tooling/hcpctl/pkg/snapshot/queries/alerts/cluster/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/alerts/cluster/query.kql
@@ -1,0 +1,4 @@
+{{ template "alertEventsBase" . }}
+| where isnotnull(alertContext.labels.namespace) and
+    alertContext.labels.namespace == '{{ .HostedControlPlaneNamespace }}'
+{{ template "alertEventsProject" . }}

--- a/tooling/hcpctl/pkg/snapshot/queries/alerts/service/README.md
+++ b/tooling/hcpctl/pkg/snapshot/queries/alerts/service/README.md
@@ -1,0 +1,13 @@
+# alerts / service
+
+## Summary
+
+Lists fired or active Prometheus/metric alerts during the time window for ARO-HCP service namespaces (clusters-service, maestro, hypershift, fleet, etc.).
+
+## What to Look For
+
+Alerts indicating service-level degradation — pod restarts, resource exhaustion, failed reconciliations, or connectivity issues in service components that could cause test failures.
+
+## Where to Go Next
+
+Correlate with service component logs (e.g. `logs/clustersService/`, `logs/maestro/`) to determine whether the alert was a symptom or a root cause. Use the `kusto_query` tool to expand `alertContext` for full detail.

--- a/tooling/hcpctl/pkg/snapshot/queries/alerts/service/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/alerts/service/query.kql
@@ -1,0 +1,8 @@
+{{ template "alertEventsBase" . }}
+| where isnotnull(alertContext.labels.namespace) and
+    alertContext.labels.namespace in (
+        'sessiongate', 'maestro', 'fleet', 'clusters-service',
+        'aro-hcp-admin-api', 'aro-hcp', 'acrpull', 'velero',
+        'mgmt-agent', 'kube-applier', 'hypershift-sharedingress', 'hypershift'
+    )
+{{ template "alertEventsProject" . }}

--- a/tooling/hcpctl/pkg/snapshot/queries/alerts/uncategorized/README.md
+++ b/tooling/hcpctl/pkg/snapshot/queries/alerts/uncategorized/README.md
@@ -1,0 +1,15 @@
+# alerts / uncategorized
+
+## Summary
+
+Lists fired or active Prometheus/metric alerts during the time window that do not belong to a known service namespace or a per-cluster namespace (hosted control plane, klusterlet).
+
+**Be aware that alerts in here may only pertain to *other clusters* that happened to be running at this time. Proceed with caution.**
+
+## What to Look For
+
+Unexpected infrastructure alerts (node pressure, etcd issues, certificate expiry) that may indicate environmental instability affecting the test.
+
+## Where to Go Next
+
+Use the `kusto_query` tool to expand `alertContext` for any interesting alerts to see the full label set and annotations.

--- a/tooling/hcpctl/pkg/snapshot/queries/alerts/uncategorized/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/alerts/uncategorized/query.kql
@@ -1,0 +1,11 @@
+{{ template "alertEventsBase" . }}
+| where isnull(alertContext.labels.namespace) or
+    isnotnull(alertContext.labels.namespace) and
+    alertContext.labels.namespace !startswith 'ocm-arohcp' and
+    alertContext.labels.namespace !startswith 'klusterlet' and
+    alertContext.labels.namespace !in (
+        'sessiongate', 'maestro', 'fleet', 'clusters-service',
+        'aro-hcp-admin-api', 'aro-hcp', 'acrpull', 'velero',
+        'mgmt-agent', 'kube-applier', 'hypershift-sharedingress', 'hypershift'
+    )
+{{ template "alertEventsProject" . }}

--- a/tooling/hcpctl/pkg/snapshot/queries/partials/alertEvents.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/partials/alertEvents.kql
@@ -1,0 +1,15 @@
+{{- define "alertEventsBase" -}}
+cluster('{{ .ClusterURI }}').database('{{ .MonitoringEventsDatabase }}').table('alertEvents')
+| where firedDateTime > {{ kqlDatetime .FullStartTime }}
+    and (
+        isnull(resolvedDateTime) or
+        (isnotnull(resolvedDateTime) and resolvedDateTime < {{ kqlDatetime .FullEndTime }})
+    )
+{{- if and .ServiceClusterName .ManagementClusterName }}
+| where alertContext.labels.cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
+{{- end }}
+{{- end -}}
+
+{{- define "alertEventsProject" -}}
+| project alert=alertContext.labels.alertname, firedDateTime, resolvedDateTime, description=alertContext.annotations.description
+{{- end -}}


### PR DESCRIPTION
We store all of our alert data in Kusto, so the agent can query for them as normal and use this as signal when investigating.

/label lgtm