### PR TITLE
observability: alert on Pods not running after 5min

### DIFF
--- a/admin/alerts/admin-prometheusRule.yaml
+++ b/admin/alerts/admin-prometheusRule.yaml
@@ -11,6 +11,8 @@ metadata:
 spec:
   groups:
   - name: admin-api
+    labels:
+      component: admin
     rules:
     - alert: AdminHighAuditLogErrorRate
       expr: |

--- a/admin/alerts/admin-prometheusRule_test.yaml
+++ b/admin/alerts/admin-prometheusRule_test.yaml
@@ -14,6 +14,7 @@ tests:
     alertname: AdminHighAuditLogErrorRate
     exp_alerts:
     - exp_labels:
+        component: admin
         severity: info
       exp_annotations:
         summary: "High Admin API audit log error rate."
@@ -40,6 +41,7 @@ tests:
     alertname: AdminAuditLogConnectionDegraded
     exp_alerts:
     - exp_labels:
+        component: admin
         job: aro-hcp-admin-api-metrics
         severity: info
       exp_annotations:

--- a/backend/alerts/backend-async-operations-prometheusRule.yaml
+++ b/backend/alerts/backend-async-operations-prometheusRule.yaml
@@ -31,6 +31,8 @@ spec:
   # duplicate alerting — e2e test failures are already surfaced by
   # dedicated e2e alerts.
   - name: backend-async-operations
+    labels:
+      component: backend
     rules:
     # ----------------------------------------
     # Cluster operations

--- a/backend/alerts/backend-async-operations-prometheusRule_test.yaml
+++ b/backend/alerts/backend-async-operations-prometheusRule_test.yaml
@@ -18,13 +18,14 @@ tests:
     alertname: BackendAsyncOperationClusterCreateStuck
     exp_alerts:
     - exp_labels:
-        resource_id: "/sub/1/cluster/a"
-        subscription_id: "sub-1"
-        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters"
+        cluster: "mgmt-1"
+        component: backend
         operation_type: "create"
         phase: "provisioning"
-        cluster: "mgmt-1"
+        resource_id: "/sub/1/cluster/a"
+        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters"
         severity: "3"
+        subscription_id: "sub-1"
       exp_annotations:
         correlationId: 'BackendAsyncOperationStuck/mgmt-1//sub/1/cluster/a'
         summary: 'Cluster create operation stuck'
@@ -69,13 +70,14 @@ tests:
     alertname: BackendAsyncOperationClusterCreateStuck
     exp_alerts:
     - exp_labels:
-        resource_id: "/sub/1/cluster/d"
-        subscription_id: "sub-1"
-        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters"
+        cluster: "mgmt-1"
+        component: backend
         operation_type: "create"
         phase: "provisioning"
-        cluster: "mgmt-1"
+        resource_id: "/sub/1/cluster/d"
+        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters"
         severity: "3"
+        subscription_id: "sub-1"
       exp_annotations:
         correlationId: 'BackendAsyncOperationStuck/mgmt-1//sub/1/cluster/d'
         summary: 'Cluster create operation stuck'
@@ -97,13 +99,14 @@ tests:
     alertname: BackendAsyncOperationClusterUpdateStuck
     exp_alerts:
     - exp_labels:
-        resource_id: "/sub/2/cluster/a"
-        subscription_id: "sub-2"
-        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters"
+        cluster: "mgmt-1"
+        component: backend
         operation_type: "update"
         phase: "updating"
-        cluster: "mgmt-1"
+        resource_id: "/sub/2/cluster/a"
+        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters"
         severity: "3"
+        subscription_id: "sub-2"
       exp_annotations:
         correlationId: 'BackendAsyncOperationStuck/mgmt-1//sub/2/cluster/a'
         summary: 'Cluster update operation stuck'
@@ -136,13 +139,14 @@ tests:
     alertname: BackendAsyncOperationClusterDeleteStuck
     exp_alerts:
     - exp_labels:
-        resource_id: "/sub/3/cluster/a"
-        subscription_id: "sub-3"
-        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters"
+        cluster: "mgmt-1"
+        component: backend
         operation_type: "delete"
         phase: "deleting"
-        cluster: "mgmt-1"
+        resource_id: "/sub/3/cluster/a"
+        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters"
         severity: "3"
+        subscription_id: "sub-3"
       exp_annotations:
         correlationId: 'BackendAsyncOperationStuck/mgmt-1//sub/3/cluster/a'
         summary: 'Cluster delete operation stuck'
@@ -175,13 +179,14 @@ tests:
     alertname: BackendAsyncOperationCredentialRequestStuck
     exp_alerts:
     - exp_labels:
-        resource_id: "/sub/4/cluster/a"
-        subscription_id: "sub-4"
-        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters"
+        cluster: "mgmt-1"
+        component: backend
         operation_type: "requestcredential"
         phase: "provisioning"
-        cluster: "mgmt-1"
+        resource_id: "/sub/4/cluster/a"
+        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters"
         severity: "3"
+        subscription_id: "sub-4"
       exp_annotations:
         correlationId: 'BackendAsyncOperationStuck/mgmt-1//sub/4/cluster/a'
         summary: 'Credential request operation stuck'
@@ -214,13 +219,14 @@ tests:
     alertname: BackendAsyncOperationCredentialRequestStuck
     exp_alerts:
     - exp_labels:
-        resource_id: "/sub/4/cluster/c"
-        subscription_id: "sub-4"
-        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters"
+        cluster: "mgmt-1"
+        component: backend
         operation_type: "requestcredential"
         phase: "provisioning"
-        cluster: "mgmt-1"
+        resource_id: "/sub/4/cluster/c"
+        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters"
         severity: "3"
+        subscription_id: "sub-4"
       exp_annotations:
         correlationId: 'BackendAsyncOperationStuck/mgmt-1//sub/4/cluster/c'
         summary: 'Credential request operation stuck'
@@ -242,13 +248,14 @@ tests:
     alertname: BackendAsyncOperationCredentialRevokeStuck
     exp_alerts:
     - exp_labels:
-        resource_id: "/sub/5/cluster/a"
-        subscription_id: "sub-5"
-        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters"
+        cluster: "mgmt-1"
+        component: backend
         operation_type: "revokecredentials"
         phase: "deleting"
-        cluster: "mgmt-1"
+        resource_id: "/sub/5/cluster/a"
+        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters"
         severity: "3"
+        subscription_id: "sub-5"
       exp_annotations:
         correlationId: 'BackendAsyncOperationStuck/mgmt-1//sub/5/cluster/a'
         summary: 'Credential revoke operation stuck'
@@ -280,13 +287,14 @@ tests:
     alertname: BackendAsyncOperationNodePoolCreateStuck
     exp_alerts:
     - exp_labels:
-        resource_id: "/sub/6/np/a"
-        subscription_id: "sub-6"
-        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters/nodepools"
+        cluster: "mgmt-1"
+        component: backend
         operation_type: "create"
         phase: "provisioning"
-        cluster: "mgmt-1"
+        resource_id: "/sub/6/np/a"
+        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters/nodepools"
         severity: "3"
+        subscription_id: "sub-6"
       exp_annotations:
         correlationId: 'BackendAsyncOperationStuck/mgmt-1//sub/6/np/a'
         summary: 'Node pool create operation stuck'
@@ -319,13 +327,14 @@ tests:
     alertname: BackendAsyncOperationNodePoolCreateStuck
     exp_alerts:
     - exp_labels:
-        resource_id: "/sub/6/np/c"
-        subscription_id: "sub-6"
-        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters/nodepools"
+        cluster: "mgmt-1"
+        component: backend
         operation_type: "create"
         phase: "provisioning"
-        cluster: "mgmt-1"
+        resource_id: "/sub/6/np/c"
+        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters/nodepools"
         severity: "3"
+        subscription_id: "sub-6"
       exp_annotations:
         correlationId: 'BackendAsyncOperationStuck/mgmt-1//sub/6/np/c'
         summary: 'Node pool create operation stuck'
@@ -346,13 +355,14 @@ tests:
     alertname: BackendAsyncOperationNodePoolUpdateStuck
     exp_alerts:
     - exp_labels:
-        resource_id: "/sub/7/np/a"
-        subscription_id: "sub-7"
-        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters/nodepools"
+        cluster: "mgmt-1"
+        component: backend
         operation_type: "update"
         phase: "updating"
-        cluster: "mgmt-1"
+        resource_id: "/sub/7/np/a"
+        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters/nodepools"
         severity: "3"
+        subscription_id: "sub-7"
       exp_annotations:
         correlationId: 'BackendAsyncOperationStuck/mgmt-1//sub/7/np/a'
         summary: 'Node pool update operation stuck'
@@ -384,13 +394,14 @@ tests:
     alertname: BackendAsyncOperationNodePoolDeleteStuck
     exp_alerts:
     - exp_labels:
-        resource_id: "/sub/8/np/a"
-        subscription_id: "sub-8"
-        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters/nodepools"
+        cluster: "mgmt-1"
+        component: backend
         operation_type: "delete"
         phase: "deleting"
-        cluster: "mgmt-1"
+        resource_id: "/sub/8/np/a"
+        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters/nodepools"
         severity: "3"
+        subscription_id: "sub-8"
       exp_annotations:
         correlationId: 'BackendAsyncOperationStuck/mgmt-1//sub/8/np/a'
         summary: 'Node pool delete operation stuck'
@@ -423,13 +434,14 @@ tests:
     alertname: BackendAsyncOperationExternalAuthCreateStuck
     exp_alerts:
     - exp_labels:
-        resource_id: "/sub/9/ea/a"
-        subscription_id: "sub-9"
-        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters/externalauths"
+        cluster: "mgmt-1"
+        component: backend
         operation_type: "create"
         phase: "awaitingsecret"
-        cluster: "mgmt-1"
+        resource_id: "/sub/9/ea/a"
+        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters/externalauths"
         severity: "3"
+        subscription_id: "sub-9"
       exp_annotations:
         correlationId: 'BackendAsyncOperationStuck/mgmt-1//sub/9/ea/a'
         summary: 'External auth create operation stuck'
@@ -462,13 +474,14 @@ tests:
     alertname: BackendAsyncOperationExternalAuthCreateStuck
     exp_alerts:
     - exp_labels:
-        resource_id: "/sub/9/ea/c"
-        subscription_id: "sub-9"
-        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters/externalauths"
+        cluster: "mgmt-1"
+        component: backend
         operation_type: "create"
         phase: "awaitingsecret"
-        cluster: "mgmt-1"
+        resource_id: "/sub/9/ea/c"
+        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters/externalauths"
         severity: "3"
+        subscription_id: "sub-9"
       exp_annotations:
         correlationId: 'BackendAsyncOperationStuck/mgmt-1//sub/9/ea/c'
         summary: 'External auth create operation stuck'
@@ -490,13 +503,14 @@ tests:
     alertname: BackendAsyncOperationExternalAuthUpdateStuck
     exp_alerts:
     - exp_labels:
-        resource_id: "/sub/10/ea/a"
-        subscription_id: "sub-10"
-        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters/externalauths"
+        cluster: "mgmt-1"
+        component: backend
         operation_type: "update"
         phase: "updating"
-        cluster: "mgmt-1"
+        resource_id: "/sub/10/ea/a"
+        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters/externalauths"
         severity: "3"
+        subscription_id: "sub-10"
       exp_annotations:
         correlationId: 'BackendAsyncOperationStuck/mgmt-1//sub/10/ea/a'
         summary: 'External auth update operation stuck'
@@ -529,13 +543,14 @@ tests:
     alertname: BackendAsyncOperationExternalAuthDeleteStuck
     exp_alerts:
     - exp_labels:
-        resource_id: "/sub/11/ea/a"
-        subscription_id: "sub-11"
-        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters/externalauths"
+        cluster: "mgmt-1"
+        component: backend
         operation_type: "delete"
         phase: "deleting"
-        cluster: "mgmt-1"
+        resource_id: "/sub/11/ea/a"
+        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters/externalauths"
         severity: "3"
+        subscription_id: "sub-11"
       exp_annotations:
         correlationId: 'BackendAsyncOperationStuck/mgmt-1//sub/11/ea/a'
         summary: 'External auth delete operation stuck'
@@ -568,13 +583,14 @@ tests:
     alertname: BackendAsyncOperationStuck
     exp_alerts:
     - exp_labels:
-        resource_id: "/sub/12/cluster/a"
-        subscription_id: "sub-12"
-        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters"
+        cluster: "mgmt-1"
+        component: backend
         operation_type: "create"
         phase: "provisioning"
-        cluster: "mgmt-1"
+        resource_id: "/sub/12/cluster/a"
+        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters"
         severity: "3"
+        subscription_id: "sub-12"
       exp_annotations:
         correlationId: 'BackendAsyncOperationStuck/mgmt-1//sub/12/cluster/a'
         summary: 'Async operation stuck'
@@ -607,13 +623,14 @@ tests:
     alertname: BackendAsyncOperationStuck
     exp_alerts:
     - exp_labels:
-        resource_id: "/sub/12/cluster/d"
-        subscription_id: "sub-12"
-        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters"
+        cluster: "mgmt-1"
+        component: backend
         operation_type: "create"
         phase: "provisioning"
-        cluster: "mgmt-1"
+        resource_id: "/sub/12/cluster/d"
+        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters"
         severity: "3"
+        subscription_id: "sub-12"
       exp_annotations:
         correlationId: 'BackendAsyncOperationStuck/mgmt-1//sub/12/cluster/d'
         summary: 'Async operation stuck'

--- a/backend/alerts/backend-prometheusRule.yaml
+++ b/backend/alerts/backend-prometheusRule.yaml
@@ -11,6 +11,8 @@ metadata:
 spec:
   groups:
   - name: backend
+    labels:
+      component: backend
     rules:
     - alert: BackendControllerQueueDepthHigh
       expr: |

--- a/backend/alerts/backend-prometheusRule_test.yaml
+++ b/backend/alerts/backend-prometheusRule_test.yaml
@@ -12,6 +12,7 @@ tests:
     alertname: BackendControllerQueueDepthHigh
     exp_alerts:
     - exp_labels:
+        component: backend
         name: OperationClusterCreate
         severity: warning
       exp_annotations:
@@ -37,6 +38,7 @@ tests:
     alertname: BackendControllerPanic
     exp_alerts:
     - exp_labels:
+        component: backend
         controller: DoNothingExample
         severity: warning
       exp_annotations:
@@ -62,6 +64,7 @@ tests:
     alertname: OrphanedMRGDetected
     exp_alerts:
     - exp_labels:
+        component: backend
         location: eastus
         severity: warning
       exp_annotations:
@@ -87,6 +90,7 @@ tests:
     alertname: OrphanedMRGDeletionFailing
     exp_alerts:
     - exp_labels:
+        component: backend
         location: eastus
         severity: warning
       exp_annotations:

--- a/backend/alerts/backend-retryhotloop-prometheusRule.yaml
+++ b/backend/alerts/backend-retryhotloop-prometheusRule.yaml
@@ -11,6 +11,8 @@ metadata:
 spec:
   groups:
   - name: backend-retryhotloop
+    labels:
+      component: backend
     rules:
     - alert: BackendControllerRetryHotLoop
       # A ratio of retries to total adds that is rate-independent:

--- a/backend/alerts/backend-retryhotloop-prometheusRule_test.yaml
+++ b/backend/alerts/backend-retryhotloop-prometheusRule_test.yaml
@@ -14,6 +14,7 @@ tests:
     alertname: BackendControllerRetryHotLoop
     exp_alerts:
     - exp_labels:
+        component: backend
         name: OperationClusterCreate
         severity: warning
       exp_annotations:

--- a/dev-infrastructure/modules/metrics/rules/generatedHCPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedHCPPrometheusAlertingRules.bicep
@@ -29,6 +29,7 @@ resource mgmtCapacityRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
         alert: 'MgmtClusterHCPCapacityWarning'
         enabled: true
         labels: {
+          component: 'capacity'
           severity: 'info'
           team: 'hcp-sl'
         }
@@ -58,6 +59,7 @@ resource mgmtCapacityRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
         alert: 'MgmtClusterNodeSwiftNICCapacityZero'
         enabled: true
         labels: {
+          component: 'capacity'
           severity: 'critical'
           team: 'hcp-sl'
         }
@@ -87,6 +89,7 @@ resource mgmtCapacityRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
         alert: 'MgmtClusterHCPCapacityCritical'
         enabled: true
         labels: {
+          component: 'capacity'
           severity: 'info'
           team: 'hcp-sl'
         }

--- a/dev-infrastructure/modules/metrics/rules/generatedKustoOnlyHCPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedKustoOnlyHCPPrometheusAlertingRules.bicep
@@ -60,14 +60,14 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
         }
         annotations: {
           correlationId: 'KubePodNotReady/{{ $labels.cluster }}/{{ $labels.namespace }}/{{ $labels.pod }}'
-          description: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready state for longer than 15 minutes.'
-          info: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready state for longer than 15 minutes.'
+          description: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready state for longer than 5 minutes.'
+          info: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready state for longer than 5 minutes.'
           runbook_url: 'https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubepodnotready'
-          summary: 'Pod has been in a non-ready state for more than 15 minutes.'
-          title: 'Pod has been in a non-ready state for more than 15 minutes. namespace:{{ $labels.namespace }} pod:{{ $labels.pod }}'
+          summary: 'Pod has been in a non-ready state for more than 5 minutes.'
+          title: 'Pod has been in a non-ready state for more than 5 minutes. namespace:{{ $labels.namespace }} pod:{{ $labels.pod }}'
         }
-        expression: 'sum by (namespace, pod, cluster) (max by (namespace, pod, cluster) (kube_pod_status_phase{job="kube-state-metrics",phase=~"Pending|Unknown|Failed"}) * on (namespace, pod, cluster) group_left (owner_kind) topk by (namespace, pod, cluster) (1, max by (namespace, pod, owner_kind, cluster) (kube_pod_owner{owner_kind!="Job"}))) > 0'
-        for: 'PT15M'
+        expression: 'sum by (namespace, pod, cluster) (max by (namespace, pod, cluster) (kube_pod_status_phase{job="kube-state-metrics",namespace!~"klusterlet-.*",phase=~"Pending|Unknown|Failed"}) * on (namespace, pod, cluster) group_left (owner_kind) topk by (namespace, pod, cluster) (1, max by (namespace, pod, owner_kind, cluster) (kube_pod_owner{owner_kind!="Job"}))) > 0'
+        for: 'PT5M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {

--- a/dev-infrastructure/modules/metrics/rules/generatedKustoOnlyHCPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedKustoOnlyHCPPrometheusAlertingRules.bicep
@@ -29,6 +29,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
         alert: 'KubePodCrashLooping'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -56,6 +57,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
         alert: 'KubePodNotReady'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -83,6 +85,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
         alert: 'KubeDeploymentGenerationMismatch'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -110,6 +113,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
         alert: 'KubeDeploymentReplicasMismatch'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -137,6 +141,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
         alert: 'KubeDeploymentRolloutStuck'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -164,6 +169,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
         alert: 'KubeStatefulSetReplicasMismatch'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -191,6 +197,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
         alert: 'KubeStatefulSetGenerationMismatch'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -218,6 +225,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
         alert: 'KubeStatefulSetUpdateNotRolledOut'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -245,6 +253,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
         alert: 'KubeDaemonSetRolloutStuck'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -272,6 +281,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
         alert: 'KubeContainerWaiting'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -299,6 +309,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
         alert: 'KubeDaemonSetNotScheduled'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -326,6 +337,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
         alert: 'KubeDaemonSetMisScheduled'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -353,6 +365,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
         alert: 'KubeJobNotCompleted'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -379,6 +392,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
         alert: 'KubeJobFailed'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -406,6 +420,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
         alert: 'KubeHpaReplicasMismatch'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -433,6 +448,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
         alert: 'KubeHpaMaxedOut'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -473,6 +489,7 @@ resource kubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups@20
         alert: 'KubeCPUOvercommit'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -500,6 +517,7 @@ resource kubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups@20
         alert: 'KubeMemoryOvercommit'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -527,6 +545,7 @@ resource kubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups@20
         alert: 'KubeCPUQuotaOvercommit'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -554,6 +573,7 @@ resource kubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups@20
         alert: 'KubeMemoryQuotaOvercommit'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -581,6 +601,7 @@ resource kubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups@20
         alert: 'KubeQuotaAlmostFull'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'info'
         }
         annotations: {
@@ -608,6 +629,7 @@ resource kubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups@20
         alert: 'KubeQuotaFullyUsed'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'info'
         }
         annotations: {
@@ -635,6 +657,7 @@ resource kubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups@20
         alert: 'KubeQuotaExceeded'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -662,6 +685,7 @@ resource kubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups@20
         alert: 'CPUThrottlingHigh'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'info'
         }
         annotations: {
@@ -702,6 +726,7 @@ resource kubernetesStorage 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
         alert: 'KubePersistentVolumeFillingUp'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'critical'
         }
         annotations: {
@@ -729,6 +754,7 @@ resource kubernetesStorage 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
         alert: 'KubePersistentVolumeFillingUp'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -756,6 +782,7 @@ resource kubernetesStorage 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
         alert: 'KubePersistentVolumeInodesFillingUp'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'critical'
         }
         annotations: {
@@ -783,6 +810,7 @@ resource kubernetesStorage 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
         alert: 'KubePersistentVolumeInodesFillingUp'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -810,6 +838,7 @@ resource kubernetesStorage 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
         alert: 'KubePersistentVolumeErrors'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'critical'
         }
         annotations: {
@@ -850,6 +879,7 @@ resource kubernetesSystem 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-
         alert: 'KubeVersionMismatch'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -877,6 +907,7 @@ resource kubernetesSystem 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-
         alert: 'KubeClientErrors'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -917,6 +948,7 @@ resource kubeApiserverSlos 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
         alert: 'KubeAPIErrorBudgetBurn'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           long: '1h'
           severity: 'critical'
           short: '5m'
@@ -946,6 +978,7 @@ resource kubeApiserverSlos 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
         alert: 'KubeAPIErrorBudgetBurn'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           long: '6h'
           severity: 'critical'
           short: '30m'
@@ -975,6 +1008,7 @@ resource kubeApiserverSlos 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
         alert: 'KubeAPIErrorBudgetBurn'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           long: '1d'
           severity: 'warning'
           short: '2h'
@@ -1004,6 +1038,7 @@ resource kubeApiserverSlos 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
         alert: 'KubeAPIErrorBudgetBurn'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           long: '3d'
           severity: 'warning'
           short: '6h'
@@ -1046,6 +1081,7 @@ resource kubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRuleGro
         alert: 'KubeClientCertificateExpiration'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -1073,6 +1109,7 @@ resource kubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRuleGro
         alert: 'KubeClientCertificateExpiration'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'critical'
         }
         annotations: {
@@ -1100,6 +1137,7 @@ resource kubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRuleGro
         alert: 'KubeAggregatedAPIErrors'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -1126,6 +1164,7 @@ resource kubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRuleGro
         alert: 'KubeAggregatedAPIDown'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -1153,6 +1192,7 @@ resource kubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRuleGro
         alert: 'KubeAPIDown'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'critical'
         }
         annotations: {
@@ -1180,6 +1220,7 @@ resource kubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRuleGro
         alert: 'KubeAPITerminatedRequests'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -1220,6 +1261,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
         alert: 'KubeNodeNotReady'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -1247,6 +1289,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
         alert: 'KubeNodeUnreachable'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -1274,6 +1317,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
         alert: 'KubeletTooManyPods'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'info'
         }
         annotations: {
@@ -1301,6 +1345,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
         alert: 'KubeNodeReadinessFlapping'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -1328,6 +1373,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
         alert: 'KubeletPlegDurationHigh'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -1355,6 +1401,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
         alert: 'KubeletPodStartUpLatencyHigh'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -1382,6 +1429,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
         alert: 'KubeletClientCertificateExpiration'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -1408,6 +1456,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
         alert: 'KubeletClientCertificateExpiration'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'critical'
         }
         annotations: {
@@ -1434,6 +1483,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
         alert: 'KubeletServerCertificateExpiration'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -1460,6 +1510,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
         alert: 'KubeletServerCertificateExpiration'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'critical'
         }
         annotations: {
@@ -1486,6 +1537,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
         alert: 'KubeletClientCertificateRenewalErrors'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -1513,6 +1565,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
         alert: 'KubeletServerCertificateRenewalErrors'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -1540,6 +1593,7 @@ resource kubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGroup
         alert: 'KubeletDown'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'critical'
         }
         annotations: {
@@ -1580,6 +1634,7 @@ resource kubernetesSystemScheduler 'Microsoft.AlertsManagement/prometheusRuleGro
         alert: 'KubeSchedulerDown'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'critical'
         }
         annotations: {
@@ -1620,6 +1675,7 @@ resource kubernetesSystemControllerManager 'Microsoft.AlertsManagement/prometheu
         alert: 'KubeControllerManagerDown'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'critical'
         }
         annotations: {

--- a/dev-infrastructure/modules/metrics/rules/generatedKustoOnlyServicePrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedKustoOnlyServicePrometheusAlertingRules.bicep
@@ -29,6 +29,7 @@ resource svcKubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
         alert: 'KubePodCrashLooping'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -56,6 +57,7 @@ resource svcKubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
         alert: 'KubePodNotReady'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -83,6 +85,7 @@ resource svcKubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
         alert: 'KubeDeploymentGenerationMismatch'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -110,6 +113,7 @@ resource svcKubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
         alert: 'KubeDeploymentReplicasMismatch'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -137,6 +141,7 @@ resource svcKubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
         alert: 'KubeDeploymentRolloutStuck'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -164,6 +169,7 @@ resource svcKubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
         alert: 'KubeStatefulSetReplicasMismatch'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -191,6 +197,7 @@ resource svcKubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
         alert: 'KubeStatefulSetGenerationMismatch'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -218,6 +225,7 @@ resource svcKubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
         alert: 'KubeStatefulSetUpdateNotRolledOut'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -245,6 +253,7 @@ resource svcKubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
         alert: 'KubeDaemonSetRolloutStuck'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -272,6 +281,7 @@ resource svcKubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
         alert: 'KubeContainerWaiting'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -299,6 +309,7 @@ resource svcKubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
         alert: 'KubeDaemonSetNotScheduled'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -326,6 +337,7 @@ resource svcKubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
         alert: 'KubeDaemonSetMisScheduled'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -353,6 +365,7 @@ resource svcKubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
         alert: 'KubeJobNotCompleted'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -379,6 +392,7 @@ resource svcKubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
         alert: 'KubeJobFailed'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -406,6 +420,7 @@ resource svcKubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
         alert: 'KubeHpaReplicasMismatch'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -433,6 +448,7 @@ resource svcKubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
         alert: 'KubeHpaMaxedOut'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -473,6 +489,7 @@ resource svcKubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups
         alert: 'KubeCPUOvercommit'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -500,6 +517,7 @@ resource svcKubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups
         alert: 'KubeMemoryOvercommit'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -527,6 +545,7 @@ resource svcKubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups
         alert: 'KubeCPUQuotaOvercommit'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -554,6 +573,7 @@ resource svcKubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups
         alert: 'KubeMemoryQuotaOvercommit'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -581,6 +601,7 @@ resource svcKubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups
         alert: 'KubeQuotaAlmostFull'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'info'
         }
         annotations: {
@@ -608,6 +629,7 @@ resource svcKubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups
         alert: 'KubeQuotaFullyUsed'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'info'
         }
         annotations: {
@@ -635,6 +657,7 @@ resource svcKubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups
         alert: 'KubeQuotaExceeded'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -662,6 +685,7 @@ resource svcKubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroups
         alert: 'CPUThrottlingHigh'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'info'
         }
         annotations: {
@@ -702,6 +726,7 @@ resource svcKubernetesStorage 'Microsoft.AlertsManagement/prometheusRuleGroups@2
         alert: 'KubePersistentVolumeFillingUp'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'critical'
         }
         annotations: {
@@ -729,6 +754,7 @@ resource svcKubernetesStorage 'Microsoft.AlertsManagement/prometheusRuleGroups@2
         alert: 'KubePersistentVolumeFillingUp'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -756,6 +782,7 @@ resource svcKubernetesStorage 'Microsoft.AlertsManagement/prometheusRuleGroups@2
         alert: 'KubePersistentVolumeInodesFillingUp'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'critical'
         }
         annotations: {
@@ -783,6 +810,7 @@ resource svcKubernetesStorage 'Microsoft.AlertsManagement/prometheusRuleGroups@2
         alert: 'KubePersistentVolumeInodesFillingUp'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -810,6 +838,7 @@ resource svcKubernetesStorage 'Microsoft.AlertsManagement/prometheusRuleGroups@2
         alert: 'KubePersistentVolumeErrors'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'critical'
         }
         annotations: {
@@ -850,6 +879,7 @@ resource svcKubernetesSystem 'Microsoft.AlertsManagement/prometheusRuleGroups@20
         alert: 'KubeVersionMismatch'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -877,6 +907,7 @@ resource svcKubernetesSystem 'Microsoft.AlertsManagement/prometheusRuleGroups@20
         alert: 'KubeClientErrors'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -917,6 +948,7 @@ resource svcKubeApiserverSlos 'Microsoft.AlertsManagement/prometheusRuleGroups@2
         alert: 'KubeAPIErrorBudgetBurn'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           long: '1h'
           severity: 'critical'
           short: '5m'
@@ -946,6 +978,7 @@ resource svcKubeApiserverSlos 'Microsoft.AlertsManagement/prometheusRuleGroups@2
         alert: 'KubeAPIErrorBudgetBurn'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           long: '6h'
           severity: 'critical'
           short: '30m'
@@ -975,6 +1008,7 @@ resource svcKubeApiserverSlos 'Microsoft.AlertsManagement/prometheusRuleGroups@2
         alert: 'KubeAPIErrorBudgetBurn'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           long: '1d'
           severity: 'warning'
           short: '2h'
@@ -1004,6 +1038,7 @@ resource svcKubeApiserverSlos 'Microsoft.AlertsManagement/prometheusRuleGroups@2
         alert: 'KubeAPIErrorBudgetBurn'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           long: '3d'
           severity: 'warning'
           short: '6h'
@@ -1046,6 +1081,7 @@ resource svcKubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRule
         alert: 'KubeClientCertificateExpiration'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -1073,6 +1109,7 @@ resource svcKubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRule
         alert: 'KubeClientCertificateExpiration'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'critical'
         }
         annotations: {
@@ -1100,6 +1137,7 @@ resource svcKubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRule
         alert: 'KubeAggregatedAPIErrors'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -1126,6 +1164,7 @@ resource svcKubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRule
         alert: 'KubeAggregatedAPIDown'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -1153,6 +1192,7 @@ resource svcKubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRule
         alert: 'KubeAPIDown'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'critical'
         }
         annotations: {
@@ -1180,6 +1220,7 @@ resource svcKubernetesSystemApiserver 'Microsoft.AlertsManagement/prometheusRule
         alert: 'KubeAPITerminatedRequests'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -1220,6 +1261,7 @@ resource svcKubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGr
         alert: 'KubeNodeNotReady'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -1247,6 +1289,7 @@ resource svcKubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGr
         alert: 'KubeNodeUnreachable'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -1274,6 +1317,7 @@ resource svcKubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGr
         alert: 'KubeletTooManyPods'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'info'
         }
         annotations: {
@@ -1301,6 +1345,7 @@ resource svcKubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGr
         alert: 'KubeNodeReadinessFlapping'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -1328,6 +1373,7 @@ resource svcKubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGr
         alert: 'KubeletPlegDurationHigh'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -1355,6 +1401,7 @@ resource svcKubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGr
         alert: 'KubeletPodStartUpLatencyHigh'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -1382,6 +1429,7 @@ resource svcKubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGr
         alert: 'KubeletClientCertificateExpiration'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -1408,6 +1456,7 @@ resource svcKubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGr
         alert: 'KubeletClientCertificateExpiration'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'critical'
         }
         annotations: {
@@ -1434,6 +1483,7 @@ resource svcKubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGr
         alert: 'KubeletServerCertificateExpiration'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -1460,6 +1510,7 @@ resource svcKubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGr
         alert: 'KubeletServerCertificateExpiration'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'critical'
         }
         annotations: {
@@ -1486,6 +1537,7 @@ resource svcKubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGr
         alert: 'KubeletClientCertificateRenewalErrors'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -1513,6 +1565,7 @@ resource svcKubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGr
         alert: 'KubeletServerCertificateRenewalErrors'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -1540,6 +1593,7 @@ resource svcKubernetesSystemKubelet 'Microsoft.AlertsManagement/prometheusRuleGr
         alert: 'KubeletDown'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'critical'
         }
         annotations: {
@@ -1580,6 +1634,7 @@ resource svcKubernetesSystemScheduler 'Microsoft.AlertsManagement/prometheusRule
         alert: 'KubeSchedulerDown'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'critical'
         }
         annotations: {
@@ -1620,6 +1675,7 @@ resource svcKubernetesSystemControllerManager 'Microsoft.AlertsManagement/promet
         alert: 'KubeControllerManagerDown'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'critical'
         }
         annotations: {
@@ -1660,6 +1716,7 @@ resource svcFrontendPathLatency 'Microsoft.AlertsManagement/prometheusRuleGroups
         alert: 'FrontendPathLatency'
         enabled: true
         labels: {
+          component: 'frontend'
           severity: 'info'
         }
         annotations: {

--- a/dev-infrastructure/modules/metrics/rules/generatedKustoOnlyServicePrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedKustoOnlyServicePrometheusAlertingRules.bicep
@@ -60,14 +60,14 @@ resource svcKubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
         }
         annotations: {
           correlationId: 'KubePodNotReady/{{ $labels.cluster }}/{{ $labels.namespace }}/{{ $labels.pod }}'
-          description: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready state for longer than 15 minutes.'
-          info: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready state for longer than 15 minutes.'
+          description: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready state for longer than 5 minutes.'
+          info: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready state for longer than 5 minutes.'
           runbook_url: 'https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubepodnotready'
-          summary: 'Pod has been in a non-ready state for more than 15 minutes.'
-          title: 'Pod has been in a non-ready state for more than 15 minutes. namespace:{{ $labels.namespace }} pod:{{ $labels.pod }}'
+          summary: 'Pod has been in a non-ready state for more than 5 minutes.'
+          title: 'Pod has been in a non-ready state for more than 5 minutes. namespace:{{ $labels.namespace }} pod:{{ $labels.pod }}'
         }
-        expression: 'sum by (namespace, pod, cluster) (max by (namespace, pod, cluster) (kube_pod_status_phase{job="kube-state-metrics",phase=~"Pending|Unknown|Failed"}) * on (namespace, pod, cluster) group_left (owner_kind) topk by (namespace, pod, cluster) (1, max by (namespace, pod, owner_kind, cluster) (kube_pod_owner{owner_kind!="Job"}))) > 0'
-        for: 'PT15M'
+        expression: 'sum by (namespace, pod, cluster) (max by (namespace, pod, cluster) (kube_pod_status_phase{job="kube-state-metrics",namespace!~"klusterlet-.*",phase=~"Pending|Unknown|Failed"}) * on (namespace, pod, cluster) group_left (owner_kind) topk by (namespace, pod, cluster) (1, max by (namespace, pod, owner_kind, cluster) (kube_pod_owner{owner_kind!="Job"}))) > 0'
+        for: 'PT5M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {

--- a/dev-infrastructure/modules/metrics/rules/generatedMsftPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedMsftPrometheusAlertingRules.bicep
@@ -29,6 +29,7 @@ resource msftKubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@202
         alert: 'KubePodCrashLooping'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -56,6 +57,7 @@ resource msftKubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@202
         alert: 'KubePodNotReady'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -83,6 +85,7 @@ resource msftKubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@202
         alert: 'KubeDeploymentGenerationMismatch'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -110,6 +113,7 @@ resource msftKubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@202
         alert: 'KubeDeploymentReplicasMismatch'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -137,6 +141,7 @@ resource msftKubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@202
         alert: 'KubeDeploymentRolloutStuck'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -164,6 +169,7 @@ resource msftKubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@202
         alert: 'KubeStatefulSetReplicasMismatch'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -191,6 +197,7 @@ resource msftKubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@202
         alert: 'KubeStatefulSetGenerationMismatch'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -218,6 +225,7 @@ resource msftKubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@202
         alert: 'KubeStatefulSetUpdateNotRolledOut'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -245,6 +253,7 @@ resource msftKubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@202
         alert: 'KubeDaemonSetRolloutStuck'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -272,6 +281,7 @@ resource msftKubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@202
         alert: 'KubeContainerWaiting'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -299,6 +309,7 @@ resource msftKubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@202
         alert: 'KubeDaemonSetNotScheduled'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -326,6 +337,7 @@ resource msftKubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@202
         alert: 'KubeDaemonSetMisScheduled'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -353,6 +365,7 @@ resource msftKubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@202
         alert: 'KubeJobNotCompleted'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -379,6 +392,7 @@ resource msftKubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@202
         alert: 'KubeJobFailed'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -406,6 +420,7 @@ resource msftKubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@202
         alert: 'KubeHpaReplicasMismatch'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -433,6 +448,7 @@ resource msftKubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@202
         alert: 'KubeHpaMaxedOut'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -473,6 +489,7 @@ resource msftKubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroup
         alert: 'KubeQuotaAlmostFull'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'info'
         }
         annotations: {
@@ -500,6 +517,7 @@ resource msftKubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroup
         alert: 'KubeQuotaFullyUsed'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'info'
         }
         annotations: {
@@ -527,6 +545,7 @@ resource msftKubernetesResources 'Microsoft.AlertsManagement/prometheusRuleGroup
         alert: 'KubeQuotaExceeded'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -567,6 +586,7 @@ resource msftKubernetesStorage 'Microsoft.AlertsManagement/prometheusRuleGroups@
         alert: 'KubePersistentVolumeFillingUp'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'critical'
         }
         annotations: {
@@ -594,6 +614,7 @@ resource msftKubernetesStorage 'Microsoft.AlertsManagement/prometheusRuleGroups@
         alert: 'KubePersistentVolumeFillingUp'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -621,6 +642,7 @@ resource msftKubernetesStorage 'Microsoft.AlertsManagement/prometheusRuleGroups@
         alert: 'KubePersistentVolumeInodesFillingUp'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'critical'
         }
         annotations: {
@@ -648,6 +670,7 @@ resource msftKubernetesStorage 'Microsoft.AlertsManagement/prometheusRuleGroups@
         alert: 'KubePersistentVolumeInodesFillingUp'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -675,6 +698,7 @@ resource msftKubernetesStorage 'Microsoft.AlertsManagement/prometheusRuleGroups@
         alert: 'KubePersistentVolumeErrors'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'critical'
         }
         annotations: {
@@ -715,6 +739,7 @@ resource msftPrometheusWipRules 'Microsoft.AlertsManagement/prometheusRuleGroups
         alert: 'PrometheusMetricsAbsentPerCluster'
         enabled: true
         labels: {
+          component: 'monitoring-infrastructure'
           severity: 'critical'
         }
         annotations: {
@@ -761,6 +786,7 @@ resource msftMise 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' =
         alert: 'MiseEnvoyScrapeDown'
         enabled: true
         labels: {
+          component: 'frontend'
           severity: 'info'
         }
         annotations: {
@@ -801,6 +827,7 @@ resource msftMsiCredentialRefresher 'Microsoft.AlertsManagement/prometheusRuleGr
         alert: 'ClusterCredentialExpiringSoon'
         enabled: true
         labels: {
+          component: 'credential-refresher'
           severity: 'warning'
         }
         annotations: {
@@ -828,6 +855,7 @@ resource msftMsiCredentialRefresher 'Microsoft.AlertsManagement/prometheusRuleGr
         alert: 'ClusterCredentialExpired'
         enabled: true
         labels: {
+          component: 'credential-refresher'
           severity: 'warning'
         }
         annotations: {
@@ -855,6 +883,7 @@ resource msftMsiCredentialRefresher 'Microsoft.AlertsManagement/prometheusRuleGr
         alert: 'ClusterCredentialNotRenewable'
         enabled: true
         labels: {
+          component: 'credential-refresher'
           severity: 'warning'
         }
         annotations: {

--- a/dev-infrastructure/modules/metrics/rules/generatedMsftPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedMsftPrometheusAlertingRules.bicep
@@ -60,14 +60,14 @@ resource msftKubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@202
         }
         annotations: {
           correlationId: 'KubePodNotReady/{{ $labels.cluster }}/{{ $labels.namespace }}/{{ $labels.pod }}'
-          description: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready state for longer than 15 minutes.'
-          info: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready state for longer than 15 minutes.'
+          description: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready state for longer than 5 minutes.'
+          info: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready state for longer than 5 minutes.'
           runbook_url: 'https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubepodnotready'
-          summary: 'Pod has been in a non-ready state for more than 15 minutes.'
-          title: 'Pod has been in a non-ready state for more than 15 minutes. namespace:{{ $labels.namespace }} pod:{{ $labels.pod }}'
+          summary: 'Pod has been in a non-ready state for more than 5 minutes.'
+          title: 'Pod has been in a non-ready state for more than 5 minutes. namespace:{{ $labels.namespace }} pod:{{ $labels.pod }}'
         }
-        expression: 'sum by (namespace, pod, cluster) (max by (namespace, pod, cluster) (kube_pod_status_phase{job="kube-state-metrics",namespace=~"billing|credential-refresher",phase=~"Pending|Unknown|Failed"}) * on (namespace, pod, cluster) group_left (owner_kind) topk by (namespace, pod, cluster) (1, max by (namespace, pod, owner_kind, cluster) (kube_pod_owner{namespace=~"billing|credential-refresher",owner_kind!="Job"}))) > 0'
-        for: 'PT15M'
+        expression: 'sum by (namespace, pod, cluster) (max by (namespace, pod, cluster) (kube_pod_status_phase{job="kube-state-metrics",namespace!~"klusterlet-.*",phase=~"Pending|Unknown|Failed"}) * on (namespace, pod, cluster) group_left (owner_kind) topk by (namespace, pod, cluster) (1, max by (namespace, pod, owner_kind, cluster) (kube_pod_owner{namespace=~"billing|credential-refresher",owner_kind!="Job"}))) > 0'
+        for: 'PT5M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {

--- a/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
@@ -29,6 +29,7 @@ resource prometheusWipRules 'Microsoft.AlertsManagement/prometheusRuleGroups@202
         alert: 'PrometheusJobUp'
         enabled: true
         labels: {
+          component: 'monitoring-infrastructure'
           severity: 'critical'
         }
         annotations: {
@@ -62,6 +63,7 @@ Check the status of the Prometheus pods, service endpoints, and network connecti
         alert: 'PrometheusUptime'
         enabled: true
         labels: {
+          component: 'monitoring-infrastructure'
           severity: 'critical'
         }
         annotations: {
@@ -97,6 +99,7 @@ Please check the status of the Prometheus pods, service endpoints, and network c
         alert: 'PrometheusUptimeSampleCount'
         enabled: true
         labels: {
+          component: 'monitoring-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -132,6 +135,7 @@ Check the PrometheusAgent pod status, remote write pipeline, and PodMonitor conf
         alert: 'PrometheusMetricsAbsentPerCluster'
         enabled: true
         labels: {
+          component: 'monitoring-infrastructure'
           severity: 'critical'
         }
         annotations: {
@@ -165,6 +169,7 @@ Check the PrometheusAgent pod status and remote write configuration on the affec
         alert: 'PrometheusPendingRate'
         enabled: true
         labels: {
+          component: 'monitoring-infrastructure'
           severity: 'critical'
         }
         annotations: {
@@ -202,6 +207,7 @@ Investigate the health and performance of the remote storage endpoint, network l
         alert: 'PrometheusFailedRate'
         enabled: true
         labels: {
+          component: 'monitoring-infrastructure'
           severity: 'critical'
         }
         annotations: {
@@ -252,6 +258,7 @@ resource prometheusRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
         alert: 'PrometheusRemoteStorageFailures'
         enabled: true
         labels: {
+          component: 'monitoring-infrastructure'
           severity: 'critical'
         }
         annotations: {
@@ -279,6 +286,7 @@ resource prometheusRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
         alert: 'PrometheusNotIngestingSamples'
         enabled: true
         labels: {
+          component: 'monitoring-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -306,6 +314,7 @@ resource prometheusRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
         alert: 'PrometheusBadConfig'
         enabled: true
         labels: {
+          component: 'monitoring-infrastructure'
           severity: 'critical'
         }
         annotations: {
@@ -333,6 +342,7 @@ resource prometheusRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
         alert: 'PrometheusScrapeSampleLimitHit'
         enabled: true
         labels: {
+          component: 'monitoring-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -373,6 +383,7 @@ resource prometheusOperatorRules 'Microsoft.AlertsManagement/prometheusRuleGroup
         alert: 'PrometheusOperatorNotReady'
         enabled: true
         labels: {
+          component: 'monitoring-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -400,6 +411,7 @@ resource prometheusOperatorRules 'Microsoft.AlertsManagement/prometheusRuleGroup
         alert: 'PrometheusOperatorRejectedResources'
         enabled: true
         labels: {
+          component: 'monitoring-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -440,6 +452,7 @@ resource frontend 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' =
         alert: 'FrontendClusterServiceErrorRate'
         enabled: true
         labels: {
+          component: 'frontend'
           severity: 'info'
         }
         annotations: {
@@ -467,6 +480,7 @@ resource frontend 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' =
         alert: 'FrontendHighAuditLogErrorRate'
         enabled: true
         labels: {
+          component: 'frontend'
           severity: 'info'
         }
         annotations: {
@@ -494,6 +508,7 @@ resource frontend 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' =
         alert: 'FrontendAuditLogConnectionDegraded'
         enabled: true
         labels: {
+          component: 'frontend'
           severity: 'info'
         }
         annotations: {
@@ -521,6 +536,7 @@ resource frontend 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' =
         alert: 'FrontendHttpRequestPanics'
         enabled: true
         labels: {
+          component: 'frontend'
           severity: 'warning'
         }
         annotations: {
@@ -561,6 +577,7 @@ resource backend 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
         alert: 'BackendControllerQueueDepthHigh'
         enabled: true
         labels: {
+          component: 'backend'
           severity: 'warning'
         }
         annotations: {
@@ -588,6 +605,7 @@ resource backend 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
         alert: 'BackendControllerPanic'
         enabled: true
         labels: {
+          component: 'backend'
           severity: 'warning'
         }
         annotations: {
@@ -615,6 +633,7 @@ resource backend 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
         alert: 'OrphanedMRGDetected'
         enabled: true
         labels: {
+          component: 'backend'
           severity: 'warning'
         }
         annotations: {
@@ -642,6 +661,7 @@ resource backend 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
         alert: 'OrphanedMRGDeletionFailing'
         enabled: true
         labels: {
+          component: 'backend'
           severity: 'warning'
         }
         annotations: {
@@ -682,6 +702,7 @@ resource backendAsyncOperations 'Microsoft.AlertsManagement/prometheusRuleGroups
         alert: 'BackendAsyncOperationClusterCreateStuck'
         enabled: true
         labels: {
+          component: 'backend'
           severity: '3'
         }
         annotations: {
@@ -708,6 +729,7 @@ resource backendAsyncOperations 'Microsoft.AlertsManagement/prometheusRuleGroups
         alert: 'BackendAsyncOperationClusterUpdateStuck'
         enabled: true
         labels: {
+          component: 'backend'
           severity: '3'
         }
         annotations: {
@@ -734,6 +756,7 @@ resource backendAsyncOperations 'Microsoft.AlertsManagement/prometheusRuleGroups
         alert: 'BackendAsyncOperationClusterDeleteStuck'
         enabled: true
         labels: {
+          component: 'backend'
           severity: '3'
         }
         annotations: {
@@ -760,6 +783,7 @@ resource backendAsyncOperations 'Microsoft.AlertsManagement/prometheusRuleGroups
         alert: 'BackendAsyncOperationCredentialRequestStuck'
         enabled: true
         labels: {
+          component: 'backend'
           severity: '3'
         }
         annotations: {
@@ -786,6 +810,7 @@ resource backendAsyncOperations 'Microsoft.AlertsManagement/prometheusRuleGroups
         alert: 'BackendAsyncOperationCredentialRevokeStuck'
         enabled: true
         labels: {
+          component: 'backend'
           severity: '3'
         }
         annotations: {
@@ -812,6 +837,7 @@ resource backendAsyncOperations 'Microsoft.AlertsManagement/prometheusRuleGroups
         alert: 'BackendAsyncOperationNodePoolCreateStuck'
         enabled: true
         labels: {
+          component: 'backend'
           severity: '3'
         }
         annotations: {
@@ -838,6 +864,7 @@ resource backendAsyncOperations 'Microsoft.AlertsManagement/prometheusRuleGroups
         alert: 'BackendAsyncOperationNodePoolUpdateStuck'
         enabled: true
         labels: {
+          component: 'backend'
           severity: '3'
         }
         annotations: {
@@ -864,6 +891,7 @@ resource backendAsyncOperations 'Microsoft.AlertsManagement/prometheusRuleGroups
         alert: 'BackendAsyncOperationNodePoolDeleteStuck'
         enabled: true
         labels: {
+          component: 'backend'
           severity: '3'
         }
         annotations: {
@@ -890,6 +918,7 @@ resource backendAsyncOperations 'Microsoft.AlertsManagement/prometheusRuleGroups
         alert: 'BackendAsyncOperationExternalAuthCreateStuck'
         enabled: true
         labels: {
+          component: 'backend'
           severity: '3'
         }
         annotations: {
@@ -916,6 +945,7 @@ resource backendAsyncOperations 'Microsoft.AlertsManagement/prometheusRuleGroups
         alert: 'BackendAsyncOperationExternalAuthUpdateStuck'
         enabled: true
         labels: {
+          component: 'backend'
           severity: '3'
         }
         annotations: {
@@ -942,6 +972,7 @@ resource backendAsyncOperations 'Microsoft.AlertsManagement/prometheusRuleGroups
         alert: 'BackendAsyncOperationExternalAuthDeleteStuck'
         enabled: true
         labels: {
+          component: 'backend'
           severity: '3'
         }
         annotations: {
@@ -968,6 +999,7 @@ resource backendAsyncOperations 'Microsoft.AlertsManagement/prometheusRuleGroups
         alert: 'BackendAsyncOperationStuck'
         enabled: true
         labels: {
+          component: 'backend'
           severity: '3'
         }
         annotations: {
@@ -1007,6 +1039,7 @@ resource fleet 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
         alert: 'FleetControllerRetryHotLoop'
         enabled: true
         labels: {
+          component: 'fleet'
           severity: 'warning'
         }
         annotations: {
@@ -1034,6 +1067,7 @@ resource fleet 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
         alert: 'FleetControllerQueueDepthHigh'
         enabled: true
         labels: {
+          component: 'fleet'
           severity: 'warning'
         }
         annotations: {
@@ -1061,6 +1095,7 @@ resource fleet 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
         alert: 'FleetControllerPanic'
         enabled: true
         labels: {
+          component: 'fleet'
           severity: 'warning'
         }
         annotations: {
@@ -1101,6 +1136,7 @@ resource adminApi 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' =
         alert: 'AdminHighAuditLogErrorRate'
         enabled: true
         labels: {
+          component: 'admin'
           severity: 'info'
         }
         annotations: {
@@ -1128,6 +1164,7 @@ resource adminApi 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' =
         alert: 'AdminAuditLogConnectionDegraded'
         enabled: true
         labels: {
+          component: 'admin'
           severity: 'info'
         }
         annotations: {
@@ -1168,6 +1205,7 @@ resource maestro 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
         alert: 'MaestroGRPCSourceClientExcessConnections'
         enabled: true
         labels: {
+          component: 'maestro'
           severity: 'warning'
         }
         annotations: {
@@ -1195,6 +1233,7 @@ resource maestro 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
         alert: 'MaestroRESTAPIErrorRate'
         enabled: true
         labels: {
+          component: 'maestro'
           severity: 'warning'
         }
         annotations: {
@@ -1222,6 +1261,7 @@ resource maestro 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
         alert: 'MaestroGRPCServerErrorRate'
         enabled: true
         labels: {
+          component: 'maestro'
           severity: 'warning'
         }
         annotations: {
@@ -1249,6 +1289,7 @@ resource maestro 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
         alert: 'MaestroSpecControllerReconcileErrors'
         enabled: true
         labels: {
+          component: 'maestro'
           severity: 'warning'
         }
         annotations: {
@@ -1276,6 +1317,7 @@ resource maestro 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
         alert: 'MaestroServerNoReadyReplicas'
         enabled: true
         labels: {
+          component: 'maestro'
           severity: 'critical'
         }
         annotations: {
@@ -1303,6 +1345,7 @@ resource maestro 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
         alert: 'MaestroServerReplicaNotReady'
         enabled: true
         labels: {
+          component: 'maestro'
           severity: 'warning'
         }
         annotations: {
@@ -1330,6 +1373,7 @@ resource maestro 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
         alert: 'MaestroPostgresNotificationQueueUsageHigh'
         enabled: true
         labels: {
+          component: 'maestro'
           severity: 'warning'
         }
         annotations: {
@@ -1357,6 +1401,7 @@ resource maestro 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
         alert: 'MaestroWorkqueueDepthHigh'
         enabled: true
         labels: {
+          component: 'maestro'
           severity: 'warning'
         }
         annotations: {
@@ -1384,6 +1429,7 @@ resource maestro 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = 
         alert: 'MaestroEventStuckUnreconciled'
         enabled: true
         labels: {
+          component: 'maestro'
           severity: 'warning'
         }
         annotations: {
@@ -1424,6 +1470,7 @@ resource arobitRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01
         alert: 'ArobitForwarderJobUp'
         enabled: true
         labels: {
+          component: 'monitoring-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -1453,6 +1500,7 @@ resource arobitRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01
         alert: 'FluentBitIngestionPaused'
         enabled: true
         labels: {
+          component: 'monitoring-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -1486,6 +1534,7 @@ Investigate the Fluent Bit logs for the specific error details and check the Kus
         alert: 'FluentBitHighOutputRetries'
         enabled: true
         labels: {
+          component: 'monitoring-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -1519,6 +1568,7 @@ Investigate the Fluent Bit logs for the specific error details and check the Kus
         alert: 'FluentBitOutputErrors'
         enabled: true
         labels: {
+          component: 'monitoring-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -1550,6 +1600,7 @@ Investigate the Fluent Bit logs for the specific error details and check the Kus
         alert: 'FluentBitOutputRetriesExhausted'
         enabled: true
         labels: {
+          component: 'monitoring-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -1594,6 +1645,7 @@ resource serviceTagCapacityRules 'Microsoft.AlertsManagement/prometheusRuleGroup
         alert: 'AroHcpNonprodInboundCustomerapiCapacity'
         enabled: true
         labels: {
+          component: 'network-capacity'
           severity: 'info'
           team: 'hcp-sl'
         }
@@ -1623,6 +1675,7 @@ resource serviceTagCapacityRules 'Microsoft.AlertsManagement/prometheusRuleGroup
         alert: 'AroHcpNonprodInboundSvcCapacity'
         enabled: true
         labels: {
+          component: 'network-capacity'
           severity: 'info'
           team: 'hcp-sl'
         }
@@ -1652,6 +1705,7 @@ resource serviceTagCapacityRules 'Microsoft.AlertsManagement/prometheusRuleGroup
         alert: 'AroHcpNonprodOutboundCxCapacity'
         enabled: true
         labels: {
+          component: 'network-capacity'
           severity: 'info'
           team: 'hcp-sl'
         }
@@ -1681,6 +1735,7 @@ resource serviceTagCapacityRules 'Microsoft.AlertsManagement/prometheusRuleGroup
         alert: 'AroHcpNonprodOutboundSvcCapacity'
         enabled: true
         labels: {
+          component: 'network-capacity'
           severity: 'info'
           team: 'hcp-sl'
         }
@@ -1710,6 +1765,7 @@ resource serviceTagCapacityRules 'Microsoft.AlertsManagement/prometheusRuleGroup
         alert: 'AroHcpProdInboundCustomerapiCapacity'
         enabled: true
         labels: {
+          component: 'network-capacity'
           severity: 'info'
           team: 'hcp-sl'
         }
@@ -1739,6 +1795,7 @@ resource serviceTagCapacityRules 'Microsoft.AlertsManagement/prometheusRuleGroup
         alert: 'AroHcpProdInboundCustomerapiUswest2Capacity'
         enabled: true
         labels: {
+          component: 'network-capacity'
           severity: 'info'
           team: 'hcp-sl'
         }
@@ -1768,6 +1825,7 @@ resource serviceTagCapacityRules 'Microsoft.AlertsManagement/prometheusRuleGroup
         alert: 'AroHcpProdInboundCxCapacity'
         enabled: true
         labels: {
+          component: 'network-capacity'
           severity: 'info'
           team: 'hcp-sl'
         }
@@ -1797,6 +1855,7 @@ resource serviceTagCapacityRules 'Microsoft.AlertsManagement/prometheusRuleGroup
         alert: 'AroHcpProdInboundSvcCapacity'
         enabled: true
         labels: {
+          component: 'network-capacity'
           severity: 'info'
           team: 'hcp-sl'
         }
@@ -1826,6 +1885,7 @@ resource serviceTagCapacityRules 'Microsoft.AlertsManagement/prometheusRuleGroup
         alert: 'AroHcpProdOutboundCxCapacity'
         enabled: true
         labels: {
+          component: 'network-capacity'
           severity: 'info'
           team: 'hcp-sl'
         }
@@ -1855,6 +1915,7 @@ resource serviceTagCapacityRules 'Microsoft.AlertsManagement/prometheusRuleGroup
         alert: 'AroHcpProdOutboundSvcCapacity'
         enabled: true
         labels: {
+          component: 'network-capacity'
           severity: 'info'
           team: 'hcp-sl'
         }
@@ -1897,6 +1958,7 @@ resource hcpTestClustersRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2
         alert: 'HCPClusterOlderThan3Hours'
         enabled: true
         labels: {
+          component: 'test-clusters'
           severity: '3'
         }
         annotations: {
@@ -1926,6 +1988,7 @@ resource hcpTestClustersRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2
         alert: 'ProdE2EHCPClusterOlderThan3Hours'
         enabled: true
         labels: {
+          component: 'test-clusters'
           severity: '3'
         }
         annotations: {
@@ -1968,6 +2031,7 @@ resource kubeContainerOomRules 'Microsoft.AlertsManagement/prometheusRuleGroups@
         alert: 'KubeContainerOOMKilled'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -2007,6 +2071,7 @@ resource kubeNodeRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-
         alert: 'KubeMemoryPressure'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -2033,6 +2098,7 @@ resource kubeNodeRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-
         alert: 'NodeConntrackTableSaturation'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -2072,6 +2138,7 @@ resource imageRegistryPolicy 'Microsoft.AlertsManagement/prometheusRuleGroups@20
         alert: 'ImageRegistryPolicyDenied'
         enabled: true
         labels: {
+          component: 'image-registry-policy'
           severity: 'warning'
         }
         annotations: {
@@ -2099,6 +2166,7 @@ resource imageRegistryPolicy 'Microsoft.AlertsManagement/prometheusRuleGroups@20
         alert: 'ImageRegistryPolicyAuditViolation'
         enabled: true
         labels: {
+          component: 'image-registry-policy'
           severity: 'info'
         }
         annotations: {
@@ -2139,6 +2207,7 @@ resource kustoLogsAgeRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
         alert: 'KustoLogsDataStale'
         enabled: true
         labels: {
+          component: 'kusto'
           severity: 'warning'
         }
         annotations: {
@@ -2181,6 +2250,7 @@ resource leaderelection 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
         alert: 'LeaderElectionLeaseStale'
         enabled: true
         labels: {
+          component: 'leader-election'
           severity: 'warning'
         }
         annotations: {
@@ -2208,6 +2278,7 @@ resource leaderelection 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
         alert: 'LeaderElectionLeaseStaleCritical'
         enabled: true
         labels: {
+          component: 'leader-election'
           severity: 'critical'
         }
         annotations: {

--- a/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
@@ -29,6 +29,7 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         alert: 'userJourneyAccessClusterErrors1h5m'
         enabled: true
         labels: {
+          component: 'slo'
           long_window: '1h'
           severity: '3'
           short_window: '5m'
@@ -59,6 +60,7 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         alert: 'userJourneyAccessClusterErrors6h30m'
         enabled: true
         labels: {
+          component: 'slo'
           long_window: '6h'
           severity: '3'
           short_window: '30m'
@@ -89,6 +91,7 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         alert: 'userJourneyAccessClusterErrors3d'
         enabled: true
         labels: {
+          component: 'slo'
           long_window: '3d'
           severity: '4'
           slo: 'access-cluster-errors'
@@ -118,6 +121,7 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         alert: 'userJourneyAccessClusterErrorsDegradation'
         enabled: true
         labels: {
+          component: 'slo'
           severity: '4'
           slo: 'access-cluster-errors'
         }
@@ -146,6 +150,7 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         alert: 'userJourneyAccessClusterStuckOperation'
         enabled: true
         labels: {
+          component: 'slo'
           severity: '4'
         }
         annotations: {
@@ -186,6 +191,7 @@ resource arohcpAccessClusterSaturationAlerts 'Microsoft.AlertsManagement/prometh
         alert: 'userJourneyAccessClusterSaturationQueueDepth'
         enabled: true
         labels: {
+          component: 'slo'
           severity: '4'
         }
         annotations: {
@@ -213,6 +219,7 @@ resource arohcpAccessClusterSaturationAlerts 'Microsoft.AlertsManagement/prometh
         alert: 'userJourneyAccessClusterSaturationRetryHotLoop'
         enabled: true
         labels: {
+          component: 'slo'
           severity: '4'
         }
         annotations: {
@@ -253,6 +260,7 @@ resource arohcpClusterProvisionSloErrorAlerts 'Microsoft.AlertsManagement/promet
         alert: 'UJClusterProvisionErrors1h5m'
         enabled: true
         labels: {
+          component: 'slo'
           long_window: '1h'
           severity: '3'
           short_window: '5m'
@@ -283,6 +291,7 @@ resource arohcpClusterProvisionSloErrorAlerts 'Microsoft.AlertsManagement/promet
         alert: 'UJClusterProvisionErrors6h30m'
         enabled: true
         labels: {
+          component: 'slo'
           long_window: '6h'
           severity: '3'
           short_window: '30m'
@@ -313,6 +322,7 @@ resource arohcpClusterProvisionSloErrorAlerts 'Microsoft.AlertsManagement/promet
         alert: 'UJClusterProvisionErrors3d'
         enabled: true
         labels: {
+          component: 'slo'
           long_window: '3d'
           severity: '4'
           slo: 'cluster-provision-errors'
@@ -342,6 +352,7 @@ resource arohcpClusterProvisionSloErrorAlerts 'Microsoft.AlertsManagement/promet
         alert: 'UJClusterProvisionErrorsDegradation'
         enabled: true
         labels: {
+          component: 'slo'
           severity: '4'
           slo: 'cluster-provision-errors'
         }
@@ -383,6 +394,7 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
         alert: 'UJNodePoolErrors1h5m'
         enabled: true
         labels: {
+          component: 'slo'
           long_window: '1h'
           severity: 'info'
           short_window: '5m'
@@ -413,6 +425,7 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
         alert: 'UJNodePoolErrors6h30m'
         enabled: true
         labels: {
+          component: 'slo'
           long_window: '6h'
           severity: 'info'
           short_window: '30m'
@@ -443,6 +456,7 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
         alert: 'UJNodePoolErrors3d'
         enabled: true
         labels: {
+          component: 'slo'
           long_window: '3d'
           severity: 'info'
           slo: 'nodepool-errors'
@@ -472,6 +486,7 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
         alert: 'UJNodePoolErrorsDegradation'
         enabled: true
         labels: {
+          component: 'slo'
           severity: 'info'
           slo: 'nodepool-errors'
         }
@@ -500,6 +515,7 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
         alert: 'UJNodePoolStuckOperation'
         enabled: true
         labels: {
+          component: 'slo'
           severity: 'info'
         }
         annotations: {
@@ -540,6 +556,7 @@ resource arohcpNodepoolSaturationAlerts 'Microsoft.AlertsManagement/prometheusRu
         alert: 'UJNodePoolSaturationQueueDepth'
         enabled: true
         labels: {
+          component: 'slo'
           severity: 'info'
         }
         annotations: {
@@ -567,6 +584,7 @@ resource arohcpNodepoolSaturationAlerts 'Microsoft.AlertsManagement/prometheusRu
         alert: 'UJNodePoolSaturationRetryHotLoop'
         enabled: true
         labels: {
+          component: 'slo'
           severity: 'info'
         }
         annotations: {

--- a/dev-infrastructure/modules/metrics/rules/generatedSLHCPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedSLHCPPrometheusAlertingRules.bicep
@@ -29,6 +29,7 @@ resource hcpClusterOperatorsRules 'Microsoft.AlertsManagement/prometheusRuleGrou
         alert: 'HCPClusterOperatorUnavailable'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -58,6 +59,7 @@ resource hcpClusterOperatorsRules 'Microsoft.AlertsManagement/prometheusRuleGrou
         alert: 'HCPClusterOperatorDegraded'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'info'
         }
         annotations: {
@@ -87,6 +89,7 @@ resource hcpClusterOperatorsRules 'Microsoft.AlertsManagement/prometheusRuleGrou
         alert: 'HCPClusterVersionFailing'
         enabled: true
         labels: {
+          component: 'kubernetes-infrastructure'
           severity: 'warning'
         }
         annotations: {
@@ -129,6 +132,7 @@ resource kubeApplier 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01
         alert: 'KubeApplierDesiresMetricNotPresent'
         enabled: true
         labels: {
+          component: 'kube-applier'
           severity: 'warning'
         }
         annotations: {

--- a/dev-infrastructure/modules/metrics/rules/generatedSREServicePrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedSREServicePrometheusAlertingRules.bicep
@@ -29,6 +29,7 @@ resource frontendLatency 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
         alert: 'FrontendLatency'
         enabled: true
         labels: {
+          component: 'frontend'
           severity: 'info'
         }
         annotations: {
@@ -69,6 +70,7 @@ resource backendRetryhotloop 'Microsoft.AlertsManagement/prometheusRuleGroups@20
         alert: 'BackendControllerRetryHotLoop'
         enabled: true
         labels: {
+          component: 'backend'
           severity: 'warning'
         }
         annotations: {

--- a/fleet/alerts/fleet-prometheusRule.yaml
+++ b/fleet/alerts/fleet-prometheusRule.yaml
@@ -11,6 +11,8 @@ metadata:
 spec:
   groups:
   - name: fleet
+    labels:
+      component: fleet
     rules:
     - alert: FleetControllerRetryHotLoop
       # A ratio of retries to total adds that is rate-independent:

--- a/fleet/alerts/fleet-prometheusRule_test.yaml
+++ b/fleet/alerts/fleet-prometheusRule_test.yaml
@@ -14,6 +14,7 @@ tests:
     alertname: FleetControllerRetryHotLoop
     exp_alerts:
     - exp_labels:
+        component: fleet
         name: ClustersServiceRegistrationController
         severity: warning
       exp_annotations:
@@ -41,6 +42,7 @@ tests:
     alertname: FleetControllerQueueDepthHigh
     exp_alerts:
     - exp_labels:
+        component: fleet
         name: ClustersServiceRegistrationController
         severity: warning
       exp_annotations:
@@ -66,6 +68,7 @@ tests:
     alertname: FleetControllerPanic
     exp_alerts:
     - exp_labels:
+        component: fleet
         controller: ClustersServiceRegistrationController
         severity: warning
       exp_annotations:

--- a/frontend/alerts/frontend-latency-prometheusRule.yaml
+++ b/frontend/alerts/frontend-latency-prometheusRule.yaml
@@ -11,6 +11,8 @@ metadata:
 spec:
   groups:
   - name: frontend-latency
+    labels:
+      component: frontend
     rules:
     - alert: FrontendLatency
       expr: |

--- a/frontend/alerts/frontend-path-latency-prometheusRule.yaml
+++ b/frontend/alerts/frontend-path-latency-prometheusRule.yaml
@@ -11,6 +11,8 @@ metadata:
 spec:
   groups:
   - name: frontend-path-latency
+    labels:
+      component: frontend
     rules:
     - alert: FrontendPathLatency
       expr: |

--- a/frontend/alerts/frontend-prometheusRule.yaml
+++ b/frontend/alerts/frontend-prometheusRule.yaml
@@ -11,6 +11,8 @@ metadata:
 spec:
   groups:
   - name: frontend
+    labels:
+      component: frontend
     rules:
     - alert: FrontendClusterServiceErrorRate
       expr: |

--- a/frontend/alerts/frontend-prometheusRule_test.yaml
+++ b/frontend/alerts/frontend-prometheusRule_test.yaml
@@ -14,6 +14,7 @@ tests:
     alertname: FrontendClusterServiceErrorRate
     exp_alerts:
     - exp_labels:
+        component: frontend
         severity: info
       exp_annotations:
         description: 'The Frontend Cluster Service 5xx error rate is above 5% for the last hour. Current value: 5.66%.'
@@ -42,6 +43,7 @@ tests:
     alertname: FrontendHighAuditLogErrorRate
     exp_alerts:
     - exp_labels:
+        component: frontend
         severity: info
       exp_annotations:
         summary: "High Frontend audit log error rate."
@@ -68,6 +70,7 @@ tests:
     alertname: FrontendAuditLogConnectionDegraded
     exp_alerts:
     - exp_labels:
+        component: frontend
         job: aro-hcp-frontend-metrics
         severity: info
       exp_annotations:
@@ -93,6 +96,7 @@ tests:
     alertname: FrontendHttpRequestPanics
     exp_alerts:
     - exp_labels:
+        component: frontend
         severity: warning
       exp_annotations:
         description: 'Frontend HTTP request handler has panicked 5 time(s) in the last 5 minutes.'

--- a/frontend/alerts/mise-prometheusRule.yaml
+++ b/frontend/alerts/mise-prometheusRule.yaml
@@ -11,6 +11,8 @@ metadata:
 spec:
   groups:
   - name: mise
+    labels:
+      component: frontend
     rules:
     - alert: MiseEnvoyScrapeDown
       # Get list of all `svc` clusters (returns 1 for each)

--- a/frontend/alerts/mise-prometheusRule_test.yaml
+++ b/frontend/alerts/mise-prometheusRule_test.yaml
@@ -13,8 +13,9 @@ tests:
     exp_alerts:
     - exp_labels:
         alertname: MiseEnvoyScrapeDown
-        severity: info
         cluster: test-svc-1
+        component: frontend
+        severity: info
       exp_annotations:
         summary: "Envoy scrape target down for namespace=mise"
         description: "Prometheus scrape for envoy-stats job in namespace mise is failing or missing."
@@ -43,8 +44,9 @@ tests:
     exp_alerts:
     - exp_labels:
         alertname: MiseEnvoyScrapeDown
-        severity: info
         cluster: test-svc-2
+        component: frontend
+        severity: info
       exp_annotations:
         summary: "Envoy scrape target down for namespace=mise"
         description: "Prometheus scrape for envoy-stats job in namespace mise is failing or missing."

--- a/kube-applier/alerts/kube-applier-prometheusRule.yaml
+++ b/kube-applier/alerts/kube-applier-prometheusRule.yaml
@@ -11,6 +11,8 @@ metadata:
 spec:
   groups:
   - name: kube-applier
+    labels:
+      component: kube-applier
     rules:
     - alert: KubeApplierDesiresMetricNotPresent
       # Fires when at least one instance of kube-applier is running but the kube_applier_desires metric is not present for 5 minutes.

--- a/kube-applier/alerts/kube-applier-prometheusRule_test.yaml
+++ b/kube-applier/alerts/kube-applier-prometheusRule_test.yaml
@@ -13,6 +13,7 @@ tests:
     exp_alerts:
     - exp_labels:
         cluster: test-cluster
+        component: kube-applier
         namespace: kube-applier
         severity: warning
       exp_annotations:

--- a/maestro/alerts/maestro-prometheusRule.yaml
+++ b/maestro/alerts/maestro-prometheusRule.yaml
@@ -11,6 +11,8 @@ metadata:
 spec:
   groups:
   - name: maestro
+    labels:
+      component: maestro
     rules:
     - alert: MaestroGRPCSourceClientExcessConnections
       # Fires when the number of registered gRPC source clients is

--- a/maestro/alerts/maestro-prometheusRule_test.yaml
+++ b/maestro/alerts/maestro-prometheusRule_test.yaml
@@ -12,6 +12,7 @@ tests:
     alertname: MaestroGRPCSourceClientExcessConnections
     exp_alerts:
     - exp_labels:
+        component: maestro
         severity: warning
       exp_annotations:
         description: 'Maestro gRPC server has 125 registered source clients, which is unusually high. Only clusters-service and backend are expected as source clients. This may indicate a connection leak or clients failing to unregister.'
@@ -38,6 +39,7 @@ tests:
     alertname: MaestroRESTAPIErrorRate
     exp_alerts:
     - exp_labels:
+        component: maestro
         severity: warning
       exp_annotations:
         description: 'Maestro REST API 5xx error rate is above 5% for the last 5 minutes. Current value: 6%.'
@@ -66,6 +68,7 @@ tests:
     alertname: MaestroGRPCServerErrorRate
     exp_alerts:
     - exp_labels:
+        component: maestro
         severity: warning
       exp_annotations:
         description: 'Maestro gRPC server error rate is above 5% for the last 5 minutes. Current value: 8%.'
@@ -94,6 +97,7 @@ tests:
     alertname: MaestroSpecControllerReconcileErrors
     exp_alerts:
     - exp_labels:
+        component: maestro
         severity: warning
       exp_annotations:
         description: 'Maestro spec controller reconcile error rate is above 10% for the last 10 minutes. Resources may not be reaching management clusters. Current value: 15%.'
@@ -122,9 +126,10 @@ tests:
     alertname: MaestroServerNoReadyReplicas
     exp_alerts:
     - exp_labels:
-        severity: critical
-        namespace: maestro
+        component: maestro
         deployment: maestro
+        namespace: maestro
+        severity: critical
       exp_annotations:
         description: 'No maestro-server replicas have been Ready for 10 minutes. Readiness is gated on Postgres connectivity, so maestro is likely unable to reach its database; Clusters Service will get 503 and HCP cluster provisioning will stall.'
         runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/maestro/index.html'
@@ -152,9 +157,10 @@ tests:
     alertname: MaestroServerReplicaNotReady
     exp_alerts:
     - exp_labels:
-        severity: warning
-        namespace: maestro
+        component: maestro
         deployment: maestro
+        namespace: maestro
+        severity: warning
       exp_annotations:
         description: 'At least one maestro-server replica has been NotReady for 15 minutes (available 1 below desired). Readiness is gated on Postgres connectivity, so a persistently NotReady replica usually indicates database connectivity problems.'
         runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/maestro/index.html'
@@ -190,6 +196,7 @@ tests:
     alertname: MaestroPostgresNotificationQueueUsageHigh
     exp_alerts:
     - exp_labels:
+        component: maestro
         severity: warning
       exp_annotations:
         description: 'Maestro PostgreSQL notification queue usage is above 50% for the last 5 minutes. Current value: 60%. If the queue fills up, NOTIFY calls will block and event processing will stall.'
@@ -214,8 +221,9 @@ tests:
     alertname: MaestroWorkqueueDepthHigh
     exp_alerts:
     - exp_labels:
-        severity: warning
+        component: maestro
         queue_name: event-controller
+        severity: warning
       exp_annotations:
         description: 'Maestro workqueue event-controller depth is 150, sustained above 100 for 10 minutes. Events are not being processed fast enough.'
         runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/maestro/index.html'
@@ -239,6 +247,7 @@ tests:
     alertname: MaestroEventStuckUnreconciled
     exp_alerts:
     - exp_labels:
+        component: maestro
         severity: warning
       exp_annotations:
         description: 'A Maestro event has been unreconciled for 6m 0s. This likely indicates a lost Postgres NOTIFY message. The event will not be processed until the periodic sync runs (default 10 hours).'

--- a/observability/alerts-kusto-hcps.yaml
+++ b/observability/alerts-kusto-hcps.yaml
@@ -14,9 +14,4 @@ prometheusRules:
     to: 'job="controlplane-cluster-autoscaler"'
   - from: 'job="kube-controller-manager"'
     to: 'job="controlplane-kube-controller-manager"'
-  regexOutputReplacements:
-  # absent alerts don't work correctly because they aren't associated with a specific cluster
-  # The alert ends up firing with {{target.cluster}} in the title and correlation id instead of
-  # an actual cluster name
-  - from: 'absent\(up{job="(.+)"} == 1\)'
-    to: 'count by (cluster) (up{job="$1"} == 1) == 0'
+

--- a/observability/alerts-kusto-hcps.yaml
+++ b/observability/alerts-kusto-hcps.yaml
@@ -14,4 +14,3 @@ prometheusRules:
     to: 'job="controlplane-cluster-autoscaler"'
   - from: 'job="kube-controller-manager"'
     to: 'job="controlplane-kube-controller-manager"'
-

--- a/observability/alerts-kusto-services.yaml
+++ b/observability/alerts-kusto-services.yaml
@@ -16,9 +16,4 @@ prometheusRules:
     to: 'job="controlplane-cluster-autoscaler"'
   - from: 'job="kube-controller-manager"'
     to: 'job="controlplane-kube-controller-manager"'
-  regexOutputReplacements:
-  # absent alerts don't work correctly because they aren't associated with a specific cluster
-  # The alert ends up firing with {{target.cluster}} in the title and correlation id instead of
-  # an actual cluster name
-  - from: 'absent\(up{job="(.+)"} == 1\)'
-    to: 'count by (cluster) (up{job="$1"} == 1) == 0'
+

--- a/observability/alerts-kusto-services.yaml
+++ b/observability/alerts-kusto-services.yaml
@@ -16,4 +16,3 @@ prometheusRules:
     to: 'job="controlplane-cluster-autoscaler"'
   - from: 'job="kube-controller-manager"'
     to: 'job="controlplane-kube-controller-manager"'
-

--- a/observability/alerts/HCPclusterOperators-prometheusRule.yaml
+++ b/observability/alerts/HCPclusterOperators-prometheusRule.yaml
@@ -6,6 +6,8 @@ metadata:
 spec:
   groups:
   - name: hcp-cluster-operators-rules
+    labels:
+      component: kubernetes-infrastructure
     rules:
     # Fires when one or more cluster operators (EXCLUDING the version and console
     # operators) report Available=false on a hosted cluster that has worker nodes.

--- a/observability/alerts/HCPclusterOperators-prometheusRule_test.yaml
+++ b/observability/alerts/HCPclusterOperators-prometheusRule_test.yaml
@@ -62,18 +62,20 @@ tests:
     alertname: HCPClusterOperatorUnavailable
     exp_alerts:
     - exp_labels:
-        severity: warning
         cluster: mgmt-1
+        component: kubernetes-infrastructure
         namespace: hcp-ingress-down
+        severity: warning
       exp_annotations:
         summary: "HCP cluster operator unavailable on hcp-ingress-down"
         description: "1 cluster operator(s) on hosted cluster hcp-ingress-down (management cluster mgmt-1) have been reporting Available=false for more than 30 minutes. The version and console operators are excluded from this alert; the affected cluster has worker nodes present. An unavailable operator means the component it manages is down, not merely degraded.\n"
         correlationId: 'HCPClusterOperatorUnavailable/mgmt-1/hcp-ingress-down'
         runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/hcp-cluster-operators.md
     - exp_labels:
-        severity: warning
         cluster: mgmt-1
+        component: kubernetes-infrastructure
         namespace: hcp-version-and-ingress
+        severity: warning
       exp_annotations:
         summary: "HCP cluster operator unavailable on hcp-version-and-ingress"
         description: "1 cluster operator(s) on hosted cluster hcp-version-and-ingress (management cluster mgmt-1) have been reporting Available=false for more than 30 minutes. The version and console operators are excluded from this alert; the affected cluster has worker nodes present. An unavailable operator means the component it manages is down, not merely degraded.\n"
@@ -88,9 +90,10 @@ tests:
     alertname: HCPClusterVersionFailing
     exp_alerts:
     - exp_labels:
-        severity: warning
         cluster: mgmt-1
+        component: kubernetes-infrastructure
         namespace: hcp-version-only
+        severity: warning
       exp_annotations:
         summary: "HCP version operator failing on hcp-version-only"
         description: "The version operator (ClusterVersion) on hosted cluster hcp-version-only (management cluster mgmt-1) has been Failing for more than 1 hour while NO other cluster operator is unavailable or degraded. This points at a version-operator-specific failure -- payload image retrieval, release signature verification, an upgrade precondition, or a cluster-scoped manifest apply -- rather than a problem any individual component operator reports.\n"
@@ -105,9 +108,10 @@ tests:
     alertname: HCPClusterOperatorDegraded
     exp_alerts:
     - exp_labels:
-        severity: info
         cluster: mgmt-1
+        component: kubernetes-infrastructure
         namespace: hcp-storage-degraded
+        severity: info
       exp_annotations:
         summary: "HCP cluster operator degraded on hcp-storage-degraded"
         description: "1 cluster operator(s) on hosted cluster hcp-storage-degraded (management cluster mgmt-1) have been reporting Degraded=true for more than 2 hours. The version and console operators are excluded from this alert; the affected cluster has worker nodes present. A degraded operator is reporting reduced quality of service.\n"

--- a/observability/alerts/access-cluster-slo-prometheusRule.yaml
+++ b/observability/alerts/access-cluster-slo-prometheusRule.yaml
@@ -26,6 +26,8 @@ spec:
   # (point-in-time state rather than event rates), this provides equivalent
   # protection against transient spikes.
   - name: arohcp_access_cluster_slo_error_alerts
+    labels:
+      component: slo
     rules:
     # ----------------------------------------
     # Fast Burn Alert (IcM Sev 3 — RP lane / customer-facing UJ)
@@ -133,6 +135,8 @@ spec:
   # Queue depth and retry rates for credential controllers.
   # IcM Sev 4 (precursor).
   - name: arohcp_access_cluster_saturation_alerts
+    labels:
+      component: slo
     rules:
     # Queue depth: credential controller workqueue accumulating work
     - alert: userJourneyAccessClusterSaturationQueueDepth

--- a/observability/alerts/access-cluster-slo-prometheusRule_test.yaml
+++ b/observability/alerts/access-cluster-slo-prometheusRule_test.yaml
@@ -99,10 +99,11 @@ tests:
     exp_alerts:
     - exp_labels:
         cluster: "mgmt-1"
-        severity: "3"
-        slo: access-cluster-errors
+        component: slo
         long_window: 1h
+        severity: "3"
         short_window: 5m
+        slo: access-cluster-errors
       exp_annotations:
         summary: "mgmt-1: Credential operation error rate critically high (>72%)"
         description: "More than 72% of credential operations (requestcredential/revokecredentials) are in failed state, indicating a fast error budget burn (14.4x) that would exhaust the 95% SLO budget in ~12 hours."
@@ -113,6 +114,7 @@ tests:
     exp_alerts:
     - exp_labels:
         cluster: "mgmt-1"
+        component: slo
         severity: "4"
         slo: access-cluster-errors
       exp_annotations:
@@ -164,6 +166,7 @@ tests:
     exp_alerts:
     - exp_labels:
         cluster: "mgmt-1"
+        component: slo
         severity: "4"
         slo: access-cluster-errors
       exp_annotations:
@@ -188,13 +191,14 @@ tests:
     alertname: userJourneyAccessClusterStuckOperation
     exp_alerts:
     - exp_labels:
-        resource_id: "/sub/3/cluster/stuck"
-        subscription_id: "sub-3"
-        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters"
+        cluster: "mgmt-1"
+        component: slo
         operation_type: "requestcredential"
         phase: "accepted"
-        cluster: "mgmt-1"
+        resource_id: "/sub/3/cluster/stuck"
+        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters"
         severity: "4"
+        subscription_id: "sub-3"
       exp_annotations:
         summary: "mgmt-1: Credential operation stuck in accepted for over 1 hour"
         description: "Credential operation for /sub/3/cluster/stuck has been in accepted phase for over 1 hour. Stuck operations are invisible to success/failure SLIs and require investigation."
@@ -249,8 +253,9 @@ tests:
     alertname: userJourneyAccessClusterSaturationQueueDepth
     exp_alerts:
     - exp_labels:
-        name: "OperationRequestCredential"
         cluster: "mgmt-1"
+        component: slo
+        name: "OperationRequestCredential"
         severity: "4"
       exp_annotations:
         summary: "mgmt-1: Credential controller workqueue OperationRequestCredential depth is high"
@@ -280,8 +285,9 @@ tests:
     alertname: userJourneyAccessClusterSaturationRetryHotLoop
     exp_alerts:
     - exp_labels:
-        name: "OperationRequestCredential"
         cluster: "mgmt-1"
+        component: slo
+        name: "OperationRequestCredential"
         severity: "4"
       exp_annotations:
         summary: "mgmt-1: Credential controller workqueue OperationRequestCredential retry hot loop"
@@ -355,10 +361,11 @@ tests:
     exp_alerts:
     - exp_labels:
         cluster: "mgmt-1"
-        severity: "3"
-        slo: access-cluster-errors
+        component: slo
         long_window: 6h
+        severity: "3"
         short_window: 30m
+        slo: access-cluster-errors
       exp_annotations:
         summary: "mgmt-1: Credential operation error rate elevated (>30%) for 30+ minutes"
         description: "More than 30% of credential operations are in failed state sustained over 30 minutes, indicating a medium error budget burn (6x) that would exhaust the 95% SLO budget in ~28 hours."
@@ -381,13 +388,14 @@ tests:
     alertname: userJourneyAccessClusterStuckOperation
     exp_alerts:
     - exp_labels:
-        resource_id: "/sub/7/cluster/stuck-revoke"
-        subscription_id: "sub-7"
-        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters"
+        cluster: "mgmt-1"
+        component: slo
         operation_type: "revokecredentials"
         phase: "deleting"
-        cluster: "mgmt-1"
+        resource_id: "/sub/7/cluster/stuck-revoke"
+        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters"
         severity: "4"
+        subscription_id: "sub-7"
       exp_annotations:
         summary: "mgmt-1: Credential operation stuck in deleting for over 1 hour"
         description: "Credential operation for /sub/7/cluster/stuck-revoke has been in deleting phase for over 1 hour. Stuck operations are invisible to success/failure SLIs and require investigation."

--- a/observability/alerts/arobit-prometheusRule.yaml
+++ b/observability/alerts/arobit-prometheusRule.yaml
@@ -6,6 +6,8 @@ metadata:
 spec:
   groups:
   - name: arobit-rules
+    labels:
+      component: monitoring-infrastructure
     rules:
     - alert: ArobitForwarderJobUp
       expr: group by (cluster) (up{job="kube-state-metrics"}) unless on(cluster) group by (cluster) (up{job="arobit-forwarder",namespace="arobit"} == 1)

--- a/observability/alerts/arobit-prometheusRule_test.yaml
+++ b/observability/alerts/arobit-prometheusRule_test.yaml
@@ -15,8 +15,9 @@ tests:
     exp_alerts:
     - exp_labels:
         alertname: ArobitForwarderJobUp
-        severity: warning
         cluster: test
+        component: monitoring-infrastructure
+        severity: warning
       exp_annotations:
         description: |
           The Arobit forwarder metrics endpoint on cluster test has been unreachable for 15 minutes.
@@ -33,9 +34,10 @@ tests:
     exp_alerts:
     - exp_labels:
         alertname: FluentBitIngestionPaused
-        severity: warning
         cluster: test
+        component: monitoring-infrastructure
         pod: arobit-paused
+        severity: warning
       exp_annotations:
         runbook_url: https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/troubleshooting/arobit.html
         description: |
@@ -63,9 +65,10 @@ tests:
     exp_alerts:
     - exp_labels:
         alertname: FluentBitHighOutputRetries
-        severity: warning
         cluster: test
+        component: monitoring-infrastructure
         pod: arobit-retrying
+        severity: warning
       exp_annotations:
         runbook_url: https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/troubleshooting/arobit.html
         description: |
@@ -102,9 +105,10 @@ tests:
     exp_alerts:
     - exp_labels:
         alertname: FluentBitOutputErrors
-        severity: warning
         cluster: test
+        component: monitoring-infrastructure
         pod: arobit-errors
+        severity: warning
       exp_annotations:
         runbook_url: https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/troubleshooting/arobit.html
         description: |
@@ -140,9 +144,10 @@ tests:
     exp_alerts:
     - exp_labels:
         alertname: FluentBitOutputRetriesExhausted
-        severity: warning
         cluster: test
+        component: monitoring-infrastructure
         pod: arobit-exhausted
+        severity: warning
       exp_annotations:
         runbook_url: https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/troubleshooting/arobit.html
         description: |

--- a/observability/alerts/cluster-provision-slo-prometheusRule.yaml
+++ b/observability/alerts/cluster-provision-slo-prometheusRule.yaml
@@ -32,6 +32,8 @@ spec:
   # journey, so fast/medium burn page at IcM Sev 3 and slow/degradation raise a
   # Sev 4 ticket, mirroring the access-cluster SLO severity model.
   - name: arohcp_cluster_provision_slo_error_alerts
+    labels:
+      component: slo
     rules:
     # ----------------------------------------
     # Fast Burn Alert (IcM Sev 3 — RP lane / customer-facing UJ)

--- a/observability/alerts/cluster-provision-slo-prometheusRule_test.yaml
+++ b/observability/alerts/cluster-provision-slo-prometheusRule_test.yaml
@@ -94,10 +94,11 @@ tests:
     exp_alerts:
     - exp_labels:
         cluster: "mgmt-1"
-        severity: "3"
-        slo: cluster-provision-errors
+        component: slo
         long_window: 1h
+        severity: "3"
         short_window: 5m
+        slo: cluster-provision-errors
       exp_annotations:
         summary: "mgmt-1: Cluster provisioning error rate critically high (>72%)"
         description: "More than 72% of cluster create (install) operations are in failed state, indicating a fast error budget burn (14.4x) that would exhaust the 95% SLO budget in ~12 hours. A regional install failure of this magnitude typically points at a shared dependency (e.g. registry, DNS, or ARM) rather than individual clusters."
@@ -108,6 +109,7 @@ tests:
     exp_alerts:
     - exp_labels:
         cluster: "mgmt-1"
+        component: slo
         severity: "4"
         slo: cluster-provision-errors
       exp_annotations:
@@ -153,6 +155,7 @@ tests:
     exp_alerts:
     - exp_labels:
         cluster: "mgmt-1"
+        component: slo
         severity: "4"
         slo: cluster-provision-errors
       exp_annotations:
@@ -203,10 +206,11 @@ tests:
     exp_alerts:
     - exp_labels:
         cluster: "mgmt-1"
-        severity: "3"
-        slo: cluster-provision-errors
+        component: slo
         long_window: 6h
+        severity: "3"
         short_window: 30m
+        slo: cluster-provision-errors
       exp_annotations:
         summary: "mgmt-1: Cluster provisioning error rate elevated (>30%) for 30+ minutes"
         description: "More than 30% of cluster create (install) operations are in failed state sustained over 30 minutes, indicating a medium error budget burn (6x) that would exhaust the 95% SLO budget in ~28 hours."

--- a/observability/alerts/hcp-test-clusters-prometheusRule.yaml
+++ b/observability/alerts/hcp-test-clusters-prometheusRule.yaml
@@ -6,6 +6,8 @@ metadata:
 spec:
   groups:
   - name: hcp-test-clusters-rules
+    labels:
+      component: test-clusters
     rules:
     - alert: HCPClusterOlderThan3Hours
       expr: |

--- a/observability/alerts/hcp-test-clusters-prometheusRule_test.yaml
+++ b/observability/alerts/hcp-test-clusters-prometheusRule_test.yaml
@@ -13,10 +13,11 @@ tests:
     exp_alerts:
     - exp_labels:
         alertname: HCPClusterOlderThan3Hours
-        severity: "3"
         cluster: int-uksouth-svc-1
+        component: test-clusters
         environment: int
         resource_id: /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/test-cluster
+        severity: "3"
       exp_annotations:
         correlationId: 'IntStgClusterOlderThan3Hours/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/test-cluster'
         description: |
@@ -34,10 +35,11 @@ tests:
     exp_alerts:
     - exp_labels:
         alertname: HCPClusterOlderThan3Hours
-        severity: "3"
         cluster: stg-uksouth-svc-1
+        component: test-clusters
         environment: stg
         resource_id: /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/test-cluster
+        severity: "3"
       exp_annotations:
         correlationId: 'IntStgClusterOlderThan3Hours/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/test-cluster'
         description: |
@@ -73,11 +75,12 @@ tests:
     exp_alerts:
     - exp_labels:
         alertname: ProdE2EHCPClusterOlderThan3Hours
-        severity: "3"
         cluster: prod-uksouth-svc-1
+        component: test-clusters
         environment: prod
-        subscription_id: 403d9de9-132b-4974-94a5-5b78bdfa191e
         resource_id: /subscriptions/403d9de9-132b-4974-94a5-5b78bdfa191e/resourcegroups/test-rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/test-cluster
+        severity: "3"
+        subscription_id: 403d9de9-132b-4974-94a5-5b78bdfa191e
       exp_annotations:
         correlationId: 'ProdE2EClusterOlderThan3Hours/subscriptions/403d9de9-132b-4974-94a5-5b78bdfa191e/resourcegroups/test-rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/test-cluster'
         description: |
@@ -97,11 +100,12 @@ tests:
     exp_alerts:
     - exp_labels:
         alertname: ProdE2EHCPClusterOlderThan3Hours
-        severity: "3"
         cluster: prod-uksouth-svc-1
+        component: test-clusters
         environment: prod
-        subscription_id: 8d696692-794f-4cdb-ba25-9250c9e9ec4c
         resource_id: /subscriptions/8d696692-794f-4cdb-ba25-9250c9e9ec4c/resourcegroups/test-rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/test-cluster
+        severity: "3"
+        subscription_id: 8d696692-794f-4cdb-ba25-9250c9e9ec4c
       exp_annotations:
         correlationId: 'ProdE2EClusterOlderThan3Hours/subscriptions/8d696692-794f-4cdb-ba25-9250c9e9ec4c/resourcegroups/test-rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/test-cluster'
         description: |
@@ -110,11 +114,12 @@ tests:
         summary: Prod e2e HCP is older than 3h
     - exp_labels:
         alertname: ProdE2EHCPClusterOlderThan3Hours
-        severity: "3"
         cluster: prod-uksouth-svc-1
+        component: test-clusters
         environment: prod
-        subscription_id: ec435068-e722-475f-8504-c91b72a5dc51
         resource_id: /subscriptions/ec435068-e722-475f-8504-c91b72a5dc51/resourcegroups/test-rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/test-cluster
+        severity: "3"
+        subscription_id: ec435068-e722-475f-8504-c91b72a5dc51
       exp_annotations:
         correlationId: 'ProdE2EClusterOlderThan3Hours/subscriptions/ec435068-e722-475f-8504-c91b72a5dc51/resourcegroups/test-rg/providers/microsoft.redhatopenshift/hcpopenshiftclusters/test-cluster'
         description: |

--- a/observability/alerts/imageRegistryPolicy-prometheusRule.yaml
+++ b/observability/alerts/imageRegistryPolicy-prometheusRule.yaml
@@ -6,6 +6,8 @@ metadata:
 spec:
   groups:
   - name: image-registry-policy
+    labels:
+      component: image-registry-policy
     interval: 1m
     rules:
     - alert: ImageRegistryPolicyDenied

--- a/observability/alerts/imageRegistryPolicy-prometheusRule_test.yaml
+++ b/observability/alerts/imageRegistryPolicy-prometheusRule_test.yaml
@@ -12,10 +12,11 @@ tests:
     alertname: ImageRegistryPolicyDenied
     exp_alerts:
     - exp_labels:
-        severity: warning
         cluster: svc-1
+        component: image-registry-policy
         policy: image-registry-allowlist-policy
         policy_binding: image-registry-allowlist-policy-binding
+        severity: warning
       exp_annotations:
         summary: "Image registry policy denied pod admission"
         description: "The image-registry-allowlist-policy on cluster svc-1 has denied 45 pod admission(s) in the last 15 minutes. This means pods with images from non-approved registries were blocked from running."
@@ -40,10 +41,11 @@ tests:
     alertname: ImageRegistryPolicyAuditViolation
     exp_alerts:
     - exp_labels:
-        severity: info
         cluster: mgmt-1
+        component: image-registry-policy
         policy: image-registry-allowlist-policy
         policy_binding: image-registry-allowlist-policy-binding
+        severity: info
       exp_annotations:
         summary: "Image registry policy audit violation detected"
         description: "The image-registry-allowlist-policy on cluster mgmt-1 has logged 30 audit violation(s) in the last 15 minutes. Pods with images from non-approved registries are running but not blocked. Review kubernetesEvents in Kusto for details."

--- a/observability/alerts/kubeContainerOOM-prometheusRule.yaml
+++ b/observability/alerts/kubeContainerOOM-prometheusRule.yaml
@@ -6,6 +6,8 @@ metadata:
 spec:
   groups:
   - name: kube-container-oom-rules
+    labels:
+      component: kubernetes-infrastructure
     rules:
     - alert: KubeContainerOOMKilled
       expr: |

--- a/observability/alerts/kubeContainerOOM-prometheusRule_test.yaml
+++ b/observability/alerts/kubeContainerOOM-prometheusRule_test.yaml
@@ -13,13 +13,14 @@ tests:
     exp_alerts:
     - exp_labels:
         alertname: KubeContainerOOMKilled
-        severity: warning
         cluster: svc-1
+        component: kubernetes-infrastructure
+        container: frontend
+        job: kube-state-metrics
         namespace: aro-hcp
         pod: frontend-abc-12345
-        container: frontend
         reason: OOMKilled
-        job: kube-state-metrics
+        severity: warning
       exp_annotations:
         summary: "Container frontend was OOMKilled"
         description: "Container frontend in pod aro-hcp/frontend-abc-12345 on cluster svc-1 has been OOMKilled. This indicates the container exceeded its memory limit and was terminated by the kernel."

--- a/observability/alerts/kubeNode-prometheusRule.yaml
+++ b/observability/alerts/kubeNode-prometheusRule.yaml
@@ -6,6 +6,8 @@ metadata:
 spec:
   groups:
   - name: kube-node-rules
+    labels:
+      component: kubernetes-infrastructure
     rules:
     - alert: KubeMemoryPressure
       annotations:

--- a/observability/alerts/kubeNode-prometheusRule_test.yaml
+++ b/observability/alerts/kubeNode-prometheusRule_test.yaml
@@ -13,10 +13,11 @@ tests:
     exp_alerts:
     - exp_labels:
         alertname: KubeMemoryPressure
-        severity: warning
         cluster: svc-1
-        node: node-1
+        component: kubernetes-infrastructure
         condition: MemoryPressure
+        node: node-1
+        severity: warning
         status: "true"
       exp_annotations:
         summary: "Node under memory pressure"
@@ -52,10 +53,11 @@ tests:
     exp_alerts:
     - exp_labels:
         alertname: NodeConntrackTableSaturation
-        severity: warning
         cluster: mgmt-1
+        component: kubernetes-infrastructure
         instance: 10.0.0.4:9100
         job: node
+        severity: warning
       exp_annotations:
         summary: "Node conntrack table approaching capacity"
         description: "Node 10.0.0.4:9100 on cluster mgmt-1 has its netfilter conntrack table 90% full (nf_conntrack_max). Sustained saturation leads to 'nf_conntrack: table full, dropping packet' (ConntrackFull), which times out kubelet/DNS/IMDS traffic and degrades node health. Consider a larger SKU (nf_conntrack_max = 32768 x vCPU) or scaling the pool out."

--- a/observability/alerts/kubernetesControlPlane-prometheusRule.upstream.yaml
+++ b/observability/alerts/kubernetesControlPlane-prometheusRule.upstream.yaml
@@ -24,18 +24,18 @@ spec:
         severity: warning
     - alert: KubePodNotReady
       annotations:
-        description: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready state for longer than 5 minutes.
+        description: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready state for longer than 15 minutes.
         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubepodnotready
-        summary: Pod has been in a non-ready state for more than 5 minutes.
+        summary: Pod has been in a non-ready state for more than 15 minutes.
       expr: |
         sum by (namespace, pod, cluster) (
           max by(namespace, pod, cluster) (
-            kube_pod_status_phase{job="kube-state-metrics", phase=~"Pending|Unknown|Failed", namespace!~"klusterlet-.*"}
+            kube_pod_status_phase{job="kube-state-metrics", phase=~"Pending|Unknown|Failed"}
           ) * on(namespace, pod, cluster) group_left(owner_kind) topk by(namespace, pod, cluster) (
             1, max by(namespace, pod, owner_kind, cluster) (kube_pod_owner{owner_kind!="Job"})
           )
         ) > 0
-      for: 5m
+      for: 15m
       labels:
         severity: warning
     - alert: KubeDeploymentGenerationMismatch
@@ -52,7 +52,7 @@ spec:
         severity: warning
     - alert: KubeDeploymentReplicasMismatch
       annotations:
-        description: Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has not matched the expected number of replicas for longer than 30 minutes.
+        description: Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has not matched the expected number of replicas for longer than 15 minutes.
         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubedeploymentreplicasmismatch
         summary: Deployment has not matched the expected number of replicas.
       expr: |
@@ -65,18 +65,18 @@ spec:
             ==
           0
         )
-      for: 30m
+      for: 15m
       labels:
         severity: warning
     - alert: KubeDeploymentRolloutStuck
       annotations:
-        description: Rollout of deployment {{ $labels.namespace }}/{{ $labels.deployment }} is not progressing for longer than 30 minutes.
+        description: Rollout of deployment {{ $labels.namespace }}/{{ $labels.deployment }} is not progressing for longer than 15 minutes.
         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubedeploymentrolloutstuck
         summary: Deployment rollout is not progressing.
       expr: |
         kube_deployment_status_condition{condition="Progressing", status="false",job="kube-state-metrics"}
         != 0
-      for: 30m
+      for: 15m
       labels:
         severity: warning
     - alert: KubeStatefulSetReplicasMismatch
@@ -463,7 +463,7 @@ spec:
         summary: Different semantic versions of Kubernetes components running.
       expr: |
         count by (cluster) (count by (git_version, cluster) (label_replace(kubernetes_build_info{job!~"kube-dns|coredns"},"git_version","$1","git_version","(v[0-9]*.[0-9]*).*"))) > 1
-      for: 90m
+      for: 15m
       labels:
         severity: warning
     - alert: KubeClientErrors
@@ -602,12 +602,12 @@ spec:
     rules:
     - alert: KubeNodeNotReady
       annotations:
-        description: '{{ $labels.node }} has been unready for more than 30 minutes.'
+        description: '{{ $labels.node }} has been unready for more than 15 minutes.'
         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubenodenotready
         summary: Node is not ready.
       expr: |
         kube_node_status_condition{job="kube-state-metrics",condition="Ready",status="true"} == 0
-      for: 30m
+      for: 15m
       labels:
         severity: warning
     - alert: KubeNodeUnreachable

--- a/observability/alerts/kubernetesControlPlane-prometheusRule.yaml
+++ b/observability/alerts/kubernetesControlPlane-prometheusRule.yaml
@@ -584,7 +584,7 @@ spec:
         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeapidown
         summary: Target disappeared from Prometheus target discovery.
       expr: |
-        absent(up{job="apiserver"} == 1)
+        count by (cluster) (up{job="apiserver"} == 1) == 0
       for: 15m
       labels:
         severity: critical
@@ -728,7 +728,7 @@ spec:
         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeletdown
         summary: Target disappeared from Prometheus target discovery.
       expr: |
-        absent(up{job="kubelet", metrics_path="/metrics"} == 1)
+        count by (cluster) (up{job="kubelet", metrics_path="/metrics"} == 1) == 0
       for: 15m
       labels:
         severity: critical
@@ -740,7 +740,7 @@ spec:
         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeschedulerdown
         summary: Target disappeared from Prometheus target discovery.
       expr: |
-        absent(up{job="kube-scheduler"} == 1)
+        count by (cluster) (up{job="kube-scheduler"} == 1) == 0
       for: 15m
       labels:
         severity: critical
@@ -752,7 +752,7 @@ spec:
         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubecontrollermanagerdown
         summary: Target disappeared from Prometheus target discovery.
       expr: |
-        absent(up{job="kube-controller-manager"} == 1)
+        count by (cluster) (up{job="kube-controller-manager"} == 1) == 0
       for: 15m
       labels:
         severity: critical

--- a/observability/alerts/kubernetesControlPlane-prometheusRule.yaml
+++ b/observability/alerts/kubernetesControlPlane-prometheusRule.yaml
@@ -11,6 +11,8 @@ metadata:
 spec:
   groups:
   - name: kubernetes-apps
+    labels:
+      component: kubernetes-infrastructure
     rules:
     - alert: KubePodCrashLooping
       annotations:
@@ -255,6 +257,8 @@ spec:
       labels:
         severity: warning
   - name: kubernetes-resources
+    labels:
+      component: kubernetes-infrastructure
     rules:
     - alert: KubeCPUOvercommit
       annotations:
@@ -359,6 +363,8 @@ spec:
       labels:
         severity: info
   - name: kubernetes-storage
+    labels:
+      component: kubernetes-infrastructure
     rules:
     - alert: KubePersistentVolumeFillingUp
       annotations:
@@ -455,6 +461,8 @@ spec:
       labels:
         severity: critical
   - name: kubernetes-system
+    labels:
+      component: kubernetes-infrastructure
     rules:
     - alert: KubeVersionMismatch
       annotations:
@@ -480,6 +488,8 @@ spec:
       labels:
         severity: warning
   - name: kube-apiserver-slos
+    labels:
+      component: kubernetes-infrastructure
     rules:
     - alert: KubeAPIErrorBudgetBurn
       annotations:
@@ -538,6 +548,8 @@ spec:
         severity: warning
         short: 6h
   - name: kubernetes-system-apiserver
+    labels:
+      component: kubernetes-infrastructure
     rules:
     - alert: KubeClientCertificateExpiration
       annotations:
@@ -599,6 +611,8 @@ spec:
       labels:
         severity: warning
   - name: kubernetes-system-kubelet
+    labels:
+      component: kubernetes-infrastructure
     rules:
     - alert: KubeNodeNotReady
       annotations:
@@ -733,6 +747,8 @@ spec:
       labels:
         severity: critical
   - name: kubernetes-system-scheduler
+    labels:
+      component: kubernetes-infrastructure
     rules:
     - alert: KubeSchedulerDown
       annotations:
@@ -745,6 +761,8 @@ spec:
       labels:
         severity: critical
   - name: kubernetes-system-controller-manager
+    labels:
+      component: kubernetes-infrastructure
     rules:
     - alert: KubeControllerManagerDown
       annotations:

--- a/observability/alerts/kubernetesControlPlane-prometheusRule.yaml.diff
+++ b/observability/alerts/kubernetesControlPlane-prometheusRule.yaml.diff
@@ -1,5 +1,28 @@
 --- upstream/kubernetesControlPlane-prometheusRule.yaml
 +++ alerts/kubernetesControlPlane-prometheusRule.yaml
+@@ -24,18 +24,18 @@
+         severity: warning
+     - alert: KubePodNotReady
+       annotations:
+-        description: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready state for longer than 15 minutes.
++        description: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready state for longer than 5 minutes.
+         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubepodnotready
+-        summary: Pod has been in a non-ready state for more than 15 minutes.
++        summary: Pod has been in a non-ready state for more than 5 minutes.
+       expr: |
+         sum by (namespace, pod, cluster) (
+           max by(namespace, pod, cluster) (
+-            kube_pod_status_phase{job="kube-state-metrics", phase=~"Pending|Unknown|Failed"}
++            kube_pod_status_phase{job="kube-state-metrics", phase=~"Pending|Unknown|Failed", namespace!~"klusterlet-.*"}
+           ) * on(namespace, pod, cluster) group_left(owner_kind) topk by(namespace, pod, cluster) (
+             1, max by(namespace, pod, owner_kind, cluster) (kube_pod_owner{owner_kind!="Job"})
+           )
+         ) > 0
+-      for: 15m
++      for: 5m
+       labels:
+         severity: warning
+     - alert: KubeDeploymentGenerationMismatch
 @@ -52,7 +52,7 @@
          severity: warning
      - alert: KubeDeploymentReplicasMismatch

--- a/observability/alerts/kubernetesControlPlane-prometheusRule.yaml.diff
+++ b/observability/alerts/kubernetesControlPlane-prometheusRule.yaml.diff
@@ -1,6 +1,15 @@
 --- upstream/kubernetesControlPlane-prometheusRule.yaml
 +++ alerts/kubernetesControlPlane-prometheusRule.yaml
-@@ -24,18 +24,18 @@
+@@ -11,6 +11,8 @@
+ spec:
+   groups:
+   - name: kubernetes-apps
++    labels:
++      component: kubernetes-infrastructure
+     rules:
+     - alert: KubePodCrashLooping
+       annotations:
+@@ -24,18 +26,18 @@
          severity: warning
      - alert: KubePodNotReady
        annotations:
@@ -23,7 +32,7 @@
        labels:
          severity: warning
      - alert: KubeDeploymentGenerationMismatch
-@@ -52,7 +52,7 @@
+@@ -52,7 +54,7 @@
          severity: warning
      - alert: KubeDeploymentReplicasMismatch
        annotations:
@@ -32,7 +41,7 @@
          runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubedeploymentreplicasmismatch
          summary: Deployment has not matched the expected number of replicas.
        expr: |
-@@ -65,18 +65,18 @@
+@@ -65,18 +67,18 @@
              ==
            0
          )
@@ -54,7 +63,34 @@
        labels:
          severity: warning
      - alert: KubeStatefulSetReplicasMismatch
-@@ -463,7 +463,7 @@
+@@ -255,6 +257,8 @@
+       labels:
+         severity: warning
+   - name: kubernetes-resources
++    labels:
++      component: kubernetes-infrastructure
+     rules:
+     - alert: KubeCPUOvercommit
+       annotations:
+@@ -359,6 +363,8 @@
+       labels:
+         severity: info
+   - name: kubernetes-storage
++    labels:
++      component: kubernetes-infrastructure
+     rules:
+     - alert: KubePersistentVolumeFillingUp
+       annotations:
+@@ -455,6 +461,8 @@
+       labels:
+         severity: critical
+   - name: kubernetes-system
++    labels:
++      component: kubernetes-infrastructure
+     rules:
+     - alert: KubeVersionMismatch
+       annotations:
+@@ -463,7 +471,7 @@
          summary: Different semantic versions of Kubernetes components running.
        expr: |
          count by (cluster) (count by (git_version, cluster) (label_replace(kubernetes_build_info{job!~"kube-dns|coredns"},"git_version","$1","git_version","(v[0-9]*.[0-9]*).*"))) > 1
@@ -63,7 +99,25 @@
        labels:
          severity: warning
      - alert: KubeClientErrors
-@@ -584,7 +584,7 @@
+@@ -480,6 +488,8 @@
+       labels:
+         severity: warning
+   - name: kube-apiserver-slos
++    labels:
++      component: kubernetes-infrastructure
+     rules:
+     - alert: KubeAPIErrorBudgetBurn
+       annotations:
+@@ -538,6 +548,8 @@
+         severity: warning
+         short: 6h
+   - name: kubernetes-system-apiserver
++    labels:
++      component: kubernetes-infrastructure
+     rules:
+     - alert: KubeClientCertificateExpiration
+       annotations:
+@@ -584,7 +596,7 @@
          runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeapidown
          summary: Target disappeared from Prometheus target discovery.
        expr: |
@@ -72,7 +126,12 @@
        for: 15m
        labels:
          severity: critical
-@@ -602,12 +602,12 @@
+@@ -599,15 +611,17 @@
+       labels:
+         severity: warning
+   - name: kubernetes-system-kubelet
++    labels:
++      component: kubernetes-infrastructure
      rules:
      - alert: KubeNodeNotReady
        annotations:
@@ -87,7 +146,7 @@
        labels:
          severity: warning
      - alert: KubeNodeUnreachable
-@@ -728,7 +728,7 @@
+@@ -728,11 +742,13 @@
          runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeletdown
          summary: Target disappeared from Prometheus target discovery.
        expr: |
@@ -96,7 +155,13 @@
        for: 15m
        labels:
          severity: critical
-@@ -740,7 +740,7 @@
+   - name: kubernetes-system-scheduler
++    labels:
++      component: kubernetes-infrastructure
+     rules:
+     - alert: KubeSchedulerDown
+       annotations:
+@@ -740,11 +756,13 @@
          runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeschedulerdown
          summary: Target disappeared from Prometheus target discovery.
        expr: |
@@ -105,7 +170,13 @@
        for: 15m
        labels:
          severity: critical
-@@ -752,7 +752,7 @@
+   - name: kubernetes-system-controller-manager
++    labels:
++      component: kubernetes-infrastructure
+     rules:
+     - alert: KubeControllerManagerDown
+       annotations:
+@@ -752,7 +770,7 @@
          runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubecontrollermanagerdown
          summary: Target disappeared from Prometheus target discovery.
        expr: |

--- a/observability/alerts/kubernetesControlPlane-prometheusRule.yaml.diff
+++ b/observability/alerts/kubernetesControlPlane-prometheusRule.yaml.diff
@@ -63,6 +63,15 @@
        labels:
          severity: warning
      - alert: KubeClientErrors
+@@ -584,7 +584,7 @@
+         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeapidown
+         summary: Target disappeared from Prometheus target discovery.
+       expr: |
+-        absent(up{job="apiserver"} == 1)
++        count by (cluster) (up{job="apiserver"} == 1) == 0
+       for: 15m
+       labels:
+         severity: critical
 @@ -602,12 +602,12 @@
      rules:
      - alert: KubeNodeNotReady
@@ -78,3 +87,30 @@
        labels:
          severity: warning
      - alert: KubeNodeUnreachable
+@@ -728,7 +728,7 @@
+         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeletdown
+         summary: Target disappeared from Prometheus target discovery.
+       expr: |
+-        absent(up{job="kubelet", metrics_path="/metrics"} == 1)
++        count by (cluster) (up{job="kubelet", metrics_path="/metrics"} == 1) == 0
+       for: 15m
+       labels:
+         severity: critical
+@@ -740,7 +740,7 @@
+         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeschedulerdown
+         summary: Target disappeared from Prometheus target discovery.
+       expr: |
+-        absent(up{job="kube-scheduler"} == 1)
++        count by (cluster) (up{job="kube-scheduler"} == 1) == 0
+       for: 15m
+       labels:
+         severity: critical
+@@ -752,7 +752,7 @@
+         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubecontrollermanagerdown
+         summary: Target disappeared from Prometheus target discovery.
+       expr: |
+-        absent(up{job="kube-controller-manager"} == 1)
++        count by (cluster) (up{job="kube-controller-manager"} == 1) == 0
+       for: 15m
+       labels:
+         severity: critical

--- a/observability/alerts/kusto-logs-age-prometheusRule.yaml
+++ b/observability/alerts/kusto-logs-age-prometheusRule.yaml
@@ -6,6 +6,8 @@ metadata:
 spec:
   groups:
   - name: kusto-logs-age-rules
+    labels:
+      component: kusto
     rules:
     - alert: KustoLogsDataStale
       expr: kusto_logs_age_in_seconds{table!="systemdlogs"} > 3600 or kusto_logs_age_in_seconds{table="systemdlogs",cluster!~".*-svc-.*"} > 3600 or kusto_logs_age_in_seconds{table="systemdlogs",cluster=~".*-svc-.*"} > 7200

--- a/observability/alerts/kusto-logs-age-prometheusRule_test.yaml
+++ b/observability/alerts/kusto-logs-age-prometheusRule_test.yaml
@@ -13,9 +13,10 @@ tests:
     exp_alerts:
     - exp_labels:
         alertname: KustoLogsDataStale
-        severity: warning
-        kusto_cluster: testcluster
         cluster: sc-test
+        component: kusto
+        kusto_cluster: testcluster
+        severity: warning
         table: ContainerLog
       exp_annotations:
         description: |
@@ -51,9 +52,10 @@ tests:
     exp_alerts:
     - exp_labels:
         alertname: KustoLogsDataStale
-        severity: warning
-        kusto_cluster: testcluster
         cluster: aro-hcp-region-svc-1
+        component: kusto
+        kusto_cluster: testcluster
+        severity: warning
         table: systemdlogs
       exp_annotations:
         description: |
@@ -71,9 +73,10 @@ tests:
     exp_alerts:
     - exp_labels:
         alertname: KustoLogsDataStale
-        severity: warning
-        kusto_cluster: testcluster
         cluster: aro-hcp-region-mgmt-1
+        component: kusto
+        kusto_cluster: testcluster
+        severity: warning
         table: systemdlogs
       exp_annotations:
         description: |
@@ -91,9 +94,10 @@ tests:
     exp_alerts:
     - exp_labels:
         alertname: KustoLogsDataStale
-        severity: warning
-        kusto_cluster: testcluster
         cluster: aro-hcp-region-svc-1
+        component: kusto
+        kusto_cluster: testcluster
+        severity: warning
         table: ContainerLog
       exp_annotations:
         description: |

--- a/observability/alerts/leaderelection-prometheusRule.yaml
+++ b/observability/alerts/leaderelection-prometheusRule.yaml
@@ -11,6 +11,8 @@ metadata:
 spec:
   groups:
   - name: leaderelection
+    labels:
+      component: leader-election
     rules:
     - alert: LeaderElectionLeaseStale
       # Fires when a leader election lease has not been renewed for >37m (12m expr threshold + 25m for:); excludes namespaces covered by LeaderElectionLeaseStaleCritical and standard k8s system namespaces (kube-node-lease has node heartbeat leases that are not leader election).

--- a/observability/alerts/leaderelection-prometheusRule_test.yaml
+++ b/observability/alerts/leaderelection-prometheusRule_test.yaml
@@ -16,10 +16,11 @@ tests:
     alertname: LeaderElectionLeaseStale
     exp_alerts:
     - exp_labels:
-        severity: warning
         cluster: test-cluster
+        component: leader-election
         lease: test-lease
         namespace: test-namespace
+        severity: warning
       exp_annotations:
         description: 'Leader election lease test-lease in namespace test-namespace on cluster test-cluster has not been renewed for more than 37 minutes. The leadership election might be broken or the component stopped running.'
         runbook_url: 'TBD'
@@ -75,10 +76,11 @@ tests:
     alertname: LeaderElectionLeaseStaleCritical
     exp_alerts:
     - exp_labels:
-        severity: critical
         cluster: test-cluster
+        component: leader-election
         lease: kube-applier
         namespace: kube-applier
+        severity: critical
       exp_annotations:
         description: 'Leader election lease kube-applier in namespace kube-applier on cluster test-cluster has not been renewed for more than 6 minutes. The leadership election might be broken or the component stopped running.'
         runbook_url: 'TBD'

--- a/observability/alerts/mgmt-capacity-prometheusRule.yaml
+++ b/observability/alerts/mgmt-capacity-prometheusRule.yaml
@@ -6,6 +6,8 @@ metadata:
 spec:
   groups:
   - name: mgmt-capacity-rules
+    labels:
+      component: capacity
     rules:
     # Management cluster HCP capacity monitoring
     # Owner: Service Lifecycle team (hcp-sl)

--- a/observability/alerts/mgmt-capacity-prometheusRule_test.yaml
+++ b/observability/alerts/mgmt-capacity-prometheusRule_test.yaml
@@ -12,11 +12,12 @@ tests:
     alertname: MgmtClusterNodeSwiftNICCapacityZero
     exp_alerts:
     - exp_labels:
-        severity: critical
-        team: hcp-sl
         cluster: mgmt-nic-zero
+        component: capacity
         node: user-pool-node-1
         resource: aro_openshift_io_swift_nic
+        severity: critical
+        team: hcp-sl
       exp_annotations:
         summary: Management cluster node has zero SWIFT NIC capacity.
         description: Node user-pool-node-1 on management cluster mgmt-nic-zero has zero SWIFT NIC capacity. No HCPs can be scheduled on this node until NIC capacity is restored.
@@ -122,9 +123,10 @@ tests:
     alertname: MgmtClusterHCPCapacityWarning
     exp_alerts:
     - exp_labels:
+        cluster: mgmt-test
+        component: capacity
         severity: info
         team: hcp-sl
-        cluster: mgmt-test
       exp_annotations:
         summary: Management cluster HCP capacity is approaching limit (60% threshold).
         description: Management cluster mgmt-test is at 61.67% of its HCP capacity (60 HCP limit). Current count exceeds warning threshold of 60%.
@@ -242,9 +244,10 @@ tests:
     alertname: MgmtClusterHCPCapacityCritical
     exp_alerts:
     - exp_labels:
+        cluster: mgmt-critical
+        component: capacity
         severity: info
         team: hcp-sl
-        cluster: mgmt-critical
       exp_annotations:
         summary: Management cluster HCP capacity is critically high (85% threshold).
         description: Management cluster mgmt-critical is at 86.67% of its HCP capacity (60 HCP limit). Current count exceeds critical threshold of 85%. Immediate action required to provision additional management cluster capacity.

--- a/observability/alerts/msi-credential-refresher-prometheusRule.yaml
+++ b/observability/alerts/msi-credential-refresher-prometheusRule.yaml
@@ -6,6 +6,8 @@ metadata:
 spec:
   groups:
   - name: msi-credential-refresher
+    labels:
+      component: credential-refresher
     interval: 1m
     rules:
     - alert: ClusterCredentialExpiringSoon

--- a/observability/alerts/msi-credential-refresher-prometheusRule_test.yaml
+++ b/observability/alerts/msi-credential-refresher-prometheusRule_test.yaml
@@ -16,8 +16,9 @@ tests:
     alertname: ClusterCredentialExpiringSoon
     exp_alerts:
     - exp_labels:
-        severity: warning
         cluster: test-cluster
+        component: credential-refresher
+        severity: warning
       exp_annotations:
         description: 'Credential(s) for customer cluster monitored by test-cluster are expiring in less than 30 days.'
         summary: 'Customer cluster credential expiring in less than 30 days'
@@ -45,8 +46,9 @@ tests:
     alertname: ClusterCredentialNotRenewable
     exp_alerts:
     - exp_labels:
-        severity: warning
         cluster: test-cluster
+        component: credential-refresher
+        severity: warning
       exp_annotations:
         description: 'Credential(s) for customer cluster monitored by test-cluster are no longer renewable.'
         summary: 'Customer cluster credential is no longer renewable'
@@ -74,8 +76,9 @@ tests:
     alertname: ClusterCredentialExpired
     exp_alerts:
     - exp_labels:
-        severity: warning
         cluster: test-cluster
+        component: credential-refresher
+        severity: warning
       exp_annotations:
         description: 'Credential(s) for customer cluster monitored by test-cluster expired.'
         summary: 'Customer cluster credential expired'
@@ -115,8 +118,9 @@ tests:
     alertname: ClusterCredentialExpiringSoon
     exp_alerts:
     - exp_labels:
-        severity: warning
         cluster: test-cluster
+        component: credential-refresher
+        severity: warning
       exp_annotations:
         description: 'Credential(s) for customer cluster monitored by test-cluster are expiring in less than 30 days.'
         summary: 'Customer cluster credential expiring in less than 30 days'
@@ -132,8 +136,9 @@ tests:
     alertname: ClusterCredentialNotRenewable
     exp_alerts:
     - exp_labels:
-        severity: warning
         cluster: test-cluster
+        component: credential-refresher
+        severity: warning
       exp_annotations:
         description: 'Credential(s) for customer cluster monitored by test-cluster are no longer renewable.'
         summary: 'Customer cluster credential is no longer renewable'
@@ -152,8 +157,9 @@ tests:
     alertname: ClusterCredentialExpired
     exp_alerts:
     - exp_labels:
-        severity: warning
         cluster: test-cluster
+        component: credential-refresher
+        severity: warning
       exp_annotations:
         description: 'Credential(s) for customer cluster monitored by test-cluster expired.'
         summary: 'Customer cluster credential expired'

--- a/observability/alerts/nodepool-slo-prometheusRule.yaml
+++ b/observability/alerts/nodepool-slo-prometheusRule.yaml
@@ -86,6 +86,8 @@ spec:
   # (point-in-time state rather than event rates), this provides equivalent
   # protection against transient spikes.
   - name: arohcp_nodepool_slo_error_alerts
+    labels:
+      component: slo
     rules:
     # ----------------------------------------
     # Fast Burn Alert (non-paging for now per approver request)
@@ -199,6 +201,8 @@ spec:
   # Queue depth and retry rates impact node pool operations directly,
   # making these user journey signals per ADR. Sev 4 (precursor).
   - name: arohcp_nodepool_saturation_alerts
+    labels:
+      component: slo
     rules:
     # Queue depth: node pool controller workqueue accumulating work
     - alert: UJNodePoolSaturationQueueDepth

--- a/observability/alerts/nodepool-slo-prometheusRule_test.yaml
+++ b/observability/alerts/nodepool-slo-prometheusRule_test.yaml
@@ -97,10 +97,11 @@ tests:
     exp_alerts:
     - exp_labels:
         cluster: "mgmt-1"
-        severity: info
-        slo: nodepool-errors
+        component: slo
         long_window: 1h
+        severity: info
         short_window: 5m
+        slo: nodepool-errors
       exp_annotations:
         summary: "mgmt-1: Node Pool operation error rate critically high (>72%)"
         description: "More than 72% of node pool operations are in failed state, indicating a fast error budget burn (14.4x) that would exhaust the 95% SLO budget in ~12 hours."
@@ -111,6 +112,7 @@ tests:
     exp_alerts:
     - exp_labels:
         cluster: "mgmt-1"
+        component: slo
         severity: info
         slo: nodepool-errors
       exp_annotations:
@@ -162,6 +164,7 @@ tests:
     exp_alerts:
     - exp_labels:
         cluster: "mgmt-1"
+        component: slo
         severity: info
         slo: nodepool-errors
       exp_annotations:
@@ -186,13 +189,14 @@ tests:
     alertname: UJNodePoolStuckOperation
     exp_alerts:
     - exp_labels:
-        resource_id: "/sub/3/np/stuck"
-        subscription_id: "sub-3"
-        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters/nodepools"
+        cluster: "mgmt-1"
+        component: slo
         operation_type: "update"
         phase: "updating"
-        cluster: "mgmt-1"
+        resource_id: "/sub/3/np/stuck"
+        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters/nodepools"
         severity: info
+        subscription_id: "sub-3"
       exp_annotations:
         summary: "mgmt-1: Node Pool operation stuck in updating for over 2 hours"
         description: "Node pool operation for /sub/3/np/stuck has been in updating phase for over 2 hours. Stuck operations are invisible to success/failure SLIs and require investigation."
@@ -247,8 +251,9 @@ tests:
     alertname: UJNodePoolSaturationQueueDepth
     exp_alerts:
     - exp_labels:
-        name: "OperationNodePoolUpdate"
         cluster: "mgmt-1"
+        component: slo
+        name: "OperationNodePoolUpdate"
         severity: info
       exp_annotations:
         summary: "mgmt-1: Node Pool controller workqueue OperationNodePoolUpdate depth is high"
@@ -278,8 +283,9 @@ tests:
     alertname: UJNodePoolSaturationRetryHotLoop
     exp_alerts:
     - exp_labels:
-        name: "OperationNodePoolUpdate"
         cluster: "mgmt-1"
+        component: slo
+        name: "OperationNodePoolUpdate"
         severity: info
       exp_annotations:
         summary: "mgmt-1: Node Pool controller workqueue OperationNodePoolUpdate retry hot loop"
@@ -352,10 +358,11 @@ tests:
     exp_alerts:
     - exp_labels:
         cluster: "mgmt-1"
-        severity: info
-        slo: nodepool-errors
+        component: slo
         long_window: 6h
+        severity: info
         short_window: 30m
+        slo: nodepool-errors
       exp_annotations:
         summary: "mgmt-1: Node Pool operation error rate elevated (>30%) for 30+ minutes"
         description: "More than 30% of node pool operations are in failed state sustained over 30 minutes, indicating a medium error budget burn (6x) that would exhaust the 95% SLO budget in ~28 hours."
@@ -378,13 +385,14 @@ tests:
     alertname: UJNodePoolStuckOperation
     exp_alerts:
     - exp_labels:
-        resource_id: "/sub/7/np/stuck-del"
-        subscription_id: "sub-7"
-        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters/nodepools"
+        cluster: "mgmt-1"
+        component: slo
         operation_type: "delete"
         phase: "deleting"
-        cluster: "mgmt-1"
+        resource_id: "/sub/7/np/stuck-del"
+        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters/nodepools"
         severity: info
+        subscription_id: "sub-7"
       exp_annotations:
         summary: "mgmt-1: Node Pool operation stuck in deleting for over 2 hours"
         description: "Node pool operation for /sub/7/np/stuck-del has been in deleting phase for over 2 hours. Stuck operations are invisible to success/failure SLIs and require investigation."
@@ -414,13 +422,14 @@ tests:
     alertname: UJNodePoolStuckOperation
     exp_alerts:
     - exp_labels:
-        resource_id: "/sub/8/np/flap-del"
-        subscription_id: "sub-8"
-        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters/nodepools"
+        cluster: "mgmt-1"
+        component: slo
         operation_type: "delete"
         phase: "deleting"
-        cluster: "mgmt-1"
+        resource_id: "/sub/8/np/flap-del"
+        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters/nodepools"
         severity: info
+        subscription_id: "sub-8"
       exp_annotations:
         summary: "mgmt-1: Node Pool operation stuck in deleting for over 2 hours"
         description: "Node pool operation for /sub/8/np/flap-del has been in deleting phase for over 2 hours. Stuck operations are invisible to success/failure SLIs and require investigation."
@@ -431,13 +440,14 @@ tests:
     alertname: UJNodePoolStuckOperation
     exp_alerts:
     - exp_labels:
-        resource_id: "/sub/8/np/flap-del"
-        subscription_id: "sub-8"
-        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters/nodepools"
+        cluster: "mgmt-1"
+        component: slo
         operation_type: "delete"
         phase: "deleting"
-        cluster: "mgmt-1"
+        resource_id: "/sub/8/np/flap-del"
+        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters/nodepools"
         severity: info
+        subscription_id: "sub-8"
       exp_annotations:
         summary: "mgmt-1: Node Pool operation stuck in deleting for over 2 hours"
         description: "Node pool operation for /sub/8/np/flap-del has been in deleting phase for over 2 hours. Stuck operations are invisible to success/failure SLIs and require investigation."
@@ -447,13 +457,14 @@ tests:
     alertname: UJNodePoolStuckOperation
     exp_alerts:
     - exp_labels:
-        resource_id: "/sub/8/np/flap-del"
-        subscription_id: "sub-8"
-        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters/nodepools"
+        cluster: "mgmt-1"
+        component: slo
         operation_type: "delete"
         phase: "deleting"
-        cluster: "mgmt-1"
+        resource_id: "/sub/8/np/flap-del"
+        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters/nodepools"
         severity: info
+        subscription_id: "sub-8"
       exp_annotations:
         summary: "mgmt-1: Node Pool operation stuck in deleting for over 2 hours"
         description: "Node pool operation for /sub/8/np/flap-del has been in deleting phase for over 2 hours. Stuck operations are invisible to success/failure SLIs and require investigation."
@@ -477,13 +488,14 @@ tests:
     alertname: UJNodePoolStuckOperation
     exp_alerts:
     - exp_labels:
-        resource_id: "/sub/9/np/done-del"
-        subscription_id: "sub-9"
-        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters/nodepools"
+        cluster: "mgmt-1"
+        component: slo
         operation_type: "delete"
         phase: "deleting"
-        cluster: "mgmt-1"
+        resource_id: "/sub/9/np/done-del"
+        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters/nodepools"
         severity: info
+        subscription_id: "sub-9"
       exp_annotations:
         summary: "mgmt-1: Node Pool operation stuck in deleting for over 2 hours"
         description: "Node pool operation for /sub/9/np/done-del has been in deleting phase for over 2 hours. Stuck operations are invisible to success/failure SLIs and require investigation."

--- a/observability/alerts/prometheus-prometheusRule.yaml
+++ b/observability/alerts/prometheus-prometheusRule.yaml
@@ -11,6 +11,8 @@ metadata:
 spec:
   groups:
   - name: prometheus-wip-rules
+    labels:
+      component: monitoring-infrastructure
     rules:
     - alert: PrometheusJobUp
       # TODO: once PR #5732 (underlay_clusters source-of-truth metric) is merged and confirmed
@@ -121,6 +123,8 @@ spec:
         runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md
         summary: Prometheus failed sample rate to remote storage is above 10%.
   - name: prometheus-rules
+    labels:
+      component: monitoring-infrastructure
     rules:
     - alert: PrometheusRemoteStorageFailures
       expr: ((rate(prometheus_remote_storage_failed_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) or rate(prometheus_remote_storage_samples_failed_total{job="prometheus/prometheus",namespace="prometheus"}[5m])) / ((rate(prometheus_remote_storage_failed_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) or rate(prometheus_remote_storage_samples_failed_total{job="prometheus/prometheus",namespace="prometheus"}[5m])) + (rate(prometheus_remote_storage_succeeded_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m]) or rate(prometheus_remote_storage_samples_total{job="prometheus/prometheus",namespace="prometheus"}[5m])))) * 100 > 1
@@ -159,6 +163,8 @@ spec:
         runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md
         summary: Prometheus has failed scrapes that have exceeded the configured sample limit.
   - name: prometheus-operator-rules
+    labels:
+      component: monitoring-infrastructure
     rules:
     - alert: PrometheusOperatorNotReady
       expr: min by (cluster, controller, namespace) (max_over_time(prometheus_operator_ready{job="prometheus-operator",namespace="prometheus"}[5m])) == 0

--- a/observability/alerts/prometheus-prometheusRule_test.yaml
+++ b/observability/alerts/prometheus-prometheusRule_test.yaml
@@ -14,8 +14,9 @@ tests:
     alertname: PrometheusJobUp
     exp_alerts:
     - exp_labels:
-        severity: critical
         cluster: test
+        component: monitoring-infrastructure
+        severity: critical
       exp_annotations:
         summary: Prometheus is unreachable for 10 minutes.
         description: |
@@ -32,9 +33,10 @@ tests:
     alertname: PrometheusUptime
     exp_alerts:
     - exp_labels:
-        severity: critical
+        component: monitoring-infrastructure
         job: prometheus/prometheus
         namespace: prometheus
+        severity: critical
       exp_annotations:
         summary: Prometheus uptime below 95% over 24 hours.
         description: |
@@ -74,11 +76,12 @@ tests:
     alertname: PrometheusFailedRate
     exp_alerts:
     - exp_labels:
-        severity: critical
         cluster: test
+        component: monitoring-infrastructure
         job: prometheus/prometheus
         namespace: prometheus
         remote_name: rw1
+        severity: critical
         url: http://rw1
       exp_annotations:
         summary: Prometheus failed sample rate to remote storage is above 10%.
@@ -101,10 +104,11 @@ tests:
     alertname: PrometheusRemoteStorageFailures
     exp_alerts:
     - exp_labels:
-        severity: critical
+        component: monitoring-infrastructure
         job: prometheus/prometheus
         namespace: prometheus
         remote_name: test
+        severity: critical
         url: http://test
       exp_annotations:
         summary: Prometheus fails to send samples to remote storage.
@@ -121,9 +125,10 @@ tests:
     alertname: PrometheusNotIngestingSamples
     exp_alerts:
     - exp_labels:
-        severity: warning
+        component: monitoring-infrastructure
         job: prometheus/prometheus
         namespace: prometheus
+        severity: warning
       exp_annotations:
         summary: Prometheus is not ingesting samples.
         description: Prometheus prometheus/ is not ingesting samples.
@@ -137,9 +142,10 @@ tests:
     alertname: PrometheusBadConfig
     exp_alerts:
     - exp_labels:
-        severity: critical
+        component: monitoring-infrastructure
         job: prometheus/prometheus
         namespace: prometheus
+        severity: critical
       exp_annotations:
         summary: Failed Prometheus configuration reload.
         description: Prometheus prometheus/ has failed to reload its configuration.
@@ -153,9 +159,10 @@ tests:
     alertname: PrometheusScrapeSampleLimitHit
     exp_alerts:
     - exp_labels:
-        severity: warning
+        component: monitoring-infrastructure
         job: prometheus/prometheus
         namespace: prometheus
+        severity: warning
       exp_annotations:
         summary: Prometheus has failed scrapes that have exceeded the configured sample limit.
         description: Prometheus prometheus/ has failed 10 scrapes in the last 5m because some targets exceeded the configured sample_limit.
@@ -170,9 +177,10 @@ tests:
     alertname: PrometheusOperatorNotReady
     exp_alerts:
     - exp_labels:
-        severity: warning
+        component: monitoring-infrastructure
         controller: prometheus
         namespace: prometheus
+        severity: warning
       exp_annotations:
         summary: Prometheus operator not ready
         description: Prometheus operator in prometheus namespace isn't ready to reconcile prometheus resources.
@@ -186,12 +194,13 @@ tests:
     alertname: PrometheusOperatorRejectedResources
     exp_alerts:
     - exp_labels:
-        severity: warning
+        component: monitoring-infrastructure
+        controller: prometheus
         job: prometheus-operator
         namespace: prometheus
-        state: rejected
-        controller: prometheus
         resource: prometheusrule
+        severity: warning
+        state: rejected
       exp_annotations:
         summary: Resources rejected by Prometheus operator
         description: Prometheus operator in prometheus namespace rejected 5 prometheus/prometheusrule resources.
@@ -210,8 +219,9 @@ tests:
     alertname: PrometheusJobUp
     exp_alerts:
     - exp_labels:
-        severity: critical
         cluster: test
+        component: monitoring-infrastructure
+        severity: critical
       exp_annotations:
         summary: Prometheus is unreachable for 10 minutes.
         description: |
@@ -262,8 +272,9 @@ tests:
     alertname: PrometheusPendingRate
     exp_alerts:
     - exp_labels:
-        severity: critical
         cluster: test-high
+        component: monitoring-infrastructure
+        severity: critical
       exp_annotations:
         summary: Prometheus pending sample rate is above 40%.
         description: |
@@ -289,10 +300,11 @@ tests:
     alertname: PrometheusRemoteStorageFailures
     exp_alerts:
     - exp_labels:
-        severity: critical
+        component: monitoring-infrastructure
         job: prometheus/prometheus
         namespace: prometheus
         remote_name: storage1
+        severity: critical
         url: http://storage1
       exp_annotations:
         summary: Prometheus fails to send samples to remote storage.
@@ -310,9 +322,10 @@ tests:
     alertname: PrometheusNotIngestingSamples
     exp_alerts:
     - exp_labels:
-        severity: warning
+        component: monitoring-infrastructure
         job: prometheus/prometheus
         namespace: prometheus
+        severity: warning
       exp_annotations:
         summary: Prometheus is not ingesting samples.
         description: Prometheus prometheus/ is not ingesting samples.
@@ -338,9 +351,10 @@ tests:
     alertname: PrometheusOperatorNotReady
     exp_alerts:
     - exp_labels:
-        severity: warning
+        component: monitoring-infrastructure
         controller: prometheus
         namespace: prometheus
+        severity: warning
       exp_annotations:
         summary: Prometheus operator not ready
         description: Prometheus operator in prometheus namespace isn't ready to reconcile prometheus resources.
@@ -357,23 +371,25 @@ tests:
     alertname: PrometheusOperatorRejectedResources
     exp_alerts:
     - exp_labels:
-        severity: warning
+        component: monitoring-infrastructure
+        controller: prometheus
         job: prometheus-operator
         namespace: prometheus
-        state: rejected
-        controller: prometheus
         resource: servicemonitor
+        severity: warning
+        state: rejected
       exp_annotations:
         summary: Resources rejected by Prometheus operator
         description: Prometheus operator in prometheus namespace rejected 3 prometheus/servicemonitor resources.
         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/prometheus-operator/prometheusoperatorrejectedresources
     - exp_labels:
-        severity: warning
+        component: monitoring-infrastructure
+        controller: prometheus
         job: prometheus-operator
         namespace: prometheus
-        state: rejected
-        controller: prometheus
         resource: podmonitor
+        severity: warning
+        state: rejected
       exp_annotations:
         summary: Resources rejected by Prometheus operator
         description: Prometheus operator in prometheus namespace rejected 2 prometheus/podmonitor resources.
@@ -439,8 +455,9 @@ tests:
     alertname: PrometheusJobUp
     exp_alerts:
     - exp_labels:
-        severity: critical
         cluster: test
+        component: monitoring-infrastructure
+        severity: critical
       exp_annotations:
         summary: Prometheus is unreachable for 10 minutes.
         description: |
@@ -458,9 +475,10 @@ tests:
     alertname: PrometheusUptime
     exp_alerts:
     - exp_labels:
-        severity: critical
+        component: monitoring-infrastructure
         job: prometheus/prometheus
         namespace: prometheus
+        severity: critical
       exp_annotations:
         summary: Prometheus uptime below 95% over 24 hours.
         description: |
@@ -503,11 +521,12 @@ tests:
     alertname: PrometheusFailedRate
     exp_alerts:
     - exp_labels:
-        severity: critical
         cluster: threshold-plus
+        component: monitoring-infrastructure
         job: prometheus/prometheus
         namespace: prometheus
         remote_name: rw1
+        severity: critical
         url: http://rw1
       exp_annotations:
         summary: Prometheus failed sample rate to remote storage is above 10%.
@@ -567,10 +586,11 @@ tests:
     alertname: PrometheusRemoteStorageFailures
     exp_alerts:
     - exp_labels:
-        severity: critical
+        component: monitoring-infrastructure
         job: prometheus/prometheus
         namespace: prometheus
         remote_name: legacy
+        severity: critical
         url: http://legacy
       exp_annotations:
         summary: Prometheus fails to send samples to remote storage.
@@ -597,9 +617,10 @@ tests:
     alertname: PrometheusBadConfig
     exp_alerts:
     - exp_labels:
-        severity: critical
+        component: monitoring-infrastructure
         job: prometheus/prometheus
         namespace: prometheus
+        severity: critical
       exp_annotations:
         summary: Failed Prometheus configuration reload.
         description: Prometheus prometheus/ has failed to reload its configuration.
@@ -616,19 +637,21 @@ tests:
     alertname: PrometheusScrapeSampleLimitHit
     exp_alerts:
     - exp_labels:
-        severity: warning
+        component: monitoring-infrastructure
+        instance: prometheus-0
         job: prometheus/prometheus
         namespace: prometheus
-        instance: prometheus-0
+        severity: warning
       exp_annotations:
         summary: Prometheus has failed scrapes that have exceeded the configured sample limit.
         description: Prometheus prometheus/ has failed 5 scrapes in the last 5m because some targets exceeded the configured sample_limit.
         runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md
     - exp_labels:
-        severity: warning
+        component: monitoring-infrastructure
+        instance: prometheus-1
         job: prometheus/prometheus
         namespace: prometheus
-        instance: prometheus-1
+        severity: warning
       exp_annotations:
         summary: Prometheus has failed scrapes that have exceeded the configured sample limit.
         description: Prometheus prometheus/ has failed 10 scrapes in the last 5m because some targets exceeded the configured sample_limit.
@@ -663,12 +686,13 @@ tests:
     alertname: PrometheusOperatorRejectedResources
     exp_alerts:
     - exp_labels:
-        severity: warning
+        component: monitoring-infrastructure
+        controller: prometheus
         job: prometheus-operator
         namespace: prometheus
-        state: rejected
-        controller: prometheus
         resource: prometheusrule
+        severity: warning
+        state: rejected
       exp_annotations:
         summary: Resources rejected by Prometheus operator
         description: Prometheus operator in prometheus namespace rejected 2 prometheus/prometheusrule resources.
@@ -696,8 +720,9 @@ tests:
     alertname: PrometheusJobUp
     exp_alerts:
     - exp_labels:
-        severity: critical
         cluster: test
+        component: monitoring-infrastructure
+        severity: critical
       exp_annotations:
         summary: Prometheus is unreachable for 10 minutes.
         description: |
@@ -717,11 +742,12 @@ tests:
     alertname: PrometheusFailedRate
     exp_alerts:
     - exp_labels:
-        severity: critical
         cluster: high-failure
+        component: monitoring-infrastructure
         job: prometheus/prometheus
         namespace: prometheus
         remote_name: rw1
+        severity: critical
         url: http://rw1
       exp_annotations:
         summary: Prometheus failed sample rate to remote storage is above 10%.
@@ -766,10 +792,11 @@ tests:
     alertname: PrometheusRemoteStorageFailures
     exp_alerts:
     - exp_labels:
-        severity: critical
+        component: monitoring-infrastructure
         job: prometheus/prometheus
         namespace: prometheus
         remote_name: minimal
+        severity: critical
         url: http://minimal
       exp_annotations:
         summary: Prometheus fails to send samples to remote storage.
@@ -787,8 +814,9 @@ tests:
     alertname: PrometheusJobUp
     exp_alerts:
     - exp_labels:
-        severity: critical
         cluster: test
+        component: monitoring-infrastructure
+        severity: critical
       exp_annotations:
         summary: Prometheus is unreachable for 10 minutes.
         description: |
@@ -822,10 +850,11 @@ tests:
     alertname: PrometheusUptimeSampleCount
     exp_alerts:
     - exp_labels:
-        severity: warning
+        cluster: gap-cluster
+        component: monitoring-infrastructure
         job: prometheus/prometheus
         namespace: prometheus
-        cluster: gap-cluster
+        severity: warning
       exp_annotations:
         summary: Prometheus sample count below 95% SLO threshold for 24 hours.
         description: |
@@ -869,8 +898,9 @@ tests:
     alertname: PrometheusMetricsAbsentPerCluster
     exp_alerts:
     - exp_labels:
-        severity: critical
         cluster: dead-cluster
+        component: monitoring-infrastructure
+        severity: critical
       exp_annotations:
         summary: Prometheus metrics absent for cluster dead-cluster.
         description: |
@@ -900,8 +930,9 @@ tests:
     alertname: PrometheusMetricsAbsentPerCluster
     exp_alerts:
     - exp_labels:
-        severity: critical
         cluster: dead
+        component: monitoring-infrastructure
+        severity: critical
       exp_annotations:
         summary: Prometheus metrics absent for cluster dead.
         description: |
@@ -942,10 +973,11 @@ tests:
     alertname: PrometheusRemoteStorageFailures
     exp_alerts:
     - exp_labels:
-        severity: critical
+        component: monitoring-infrastructure
         job: prometheus/prometheus
         namespace: prometheus
         remote_name: storage1
+        severity: critical
         url: http://storage1
       exp_annotations:
         summary: Prometheus fails to send samples to remote storage.
@@ -965,10 +997,11 @@ tests:
     alertname: PrometheusNotIngestingSamples
     exp_alerts:
     - exp_labels:
-        severity: warning
+        component: monitoring-infrastructure
         job: prometheus/prometheus
         namespace: prometheus
         pod: prometheus-server-0
+        severity: warning
       exp_annotations:
         summary: Prometheus is not ingesting samples.
         description: Prometheus prometheus/prometheus-server-0 is not ingesting samples.
@@ -989,8 +1022,9 @@ tests:
     alertname: PrometheusPendingRate
     exp_alerts:
     - exp_labels:
-        severity: critical
         cluster: prod-east
+        component: monitoring-infrastructure
+        severity: critical
       exp_annotations:
         summary: Prometheus pending sample rate is above 40%.
         description: |
@@ -1014,17 +1048,19 @@ tests:
     alertname: PrometheusOperatorNotReady
     exp_alerts:
     - exp_labels:
-        severity: warning
+        component: monitoring-infrastructure
         controller: prometheus
         namespace: prometheus
+        severity: warning
       exp_annotations:
         summary: Prometheus operator not ready
         description: Prometheus operator in prometheus namespace isn't ready to reconcile prometheus resources.
         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/prometheus-operator/prometheusoperatornotready
     - exp_labels:
-        severity: warning
+        component: monitoring-infrastructure
         controller: alertmanager
         namespace: prometheus
+        severity: warning
       exp_annotations:
         summary: Prometheus operator not ready
         description: Prometheus operator in prometheus namespace isn't ready to reconcile alertmanager resources.
@@ -1041,10 +1077,11 @@ tests:
     alertname: PrometheusBadConfig
     exp_alerts:
     - exp_labels:
-        severity: critical
+        component: monitoring-infrastructure
+        instance: 192.168.1.100:9090
         job: prometheus/prometheus
         namespace: prometheus
-        instance: 192.168.1.100:9090
+        severity: critical
       exp_annotations:
         summary: Failed Prometheus configuration reload.
         description: Prometheus prometheus/ has failed to reload its configuration.
@@ -1061,10 +1098,11 @@ tests:
     alertname: PrometheusRemoteStorageFailures
     exp_alerts:
     - exp_labels:
-        severity: critical
+        component: monitoring-infrastructure
         job: prometheus/prometheus
         namespace: prometheus
         remote_name: storage1
+        severity: critical
         url: https://storage1.company.com/api/v1/write
       exp_annotations:
         summary: Prometheus fails to send samples to remote storage.

--- a/observability/alerts/service-tag-public-ip-usage.yaml
+++ b/observability/alerts/service-tag-public-ip-usage.yaml
@@ -6,6 +6,8 @@ metadata:
 spec:
   groups:
   - name: service-tag-capacity-rules
+    labels:
+      component: network-capacity
     rules:
     - alert: AroHcpNonprodInboundCustomerapiCapacity
       annotations:

--- a/observability/alerts/service-tag-public-ip-usage_test.yaml
+++ b/observability/alerts/service-tag-public-ip-usage_test.yaml
@@ -30,13 +30,14 @@ tests:
     alertname: AroHcpNonprodInboundCustomerapiCapacity
     exp_alerts:
     - exp_labels:
-        severity: info
-        team: hcp-sl
+        cluster: test
+        component: network-capacity
         region: eastus
         service_tag_type: FirstPartyUsage
         service_tag_value: /aro-hcp-nonprod-inbound-customerapi
+        severity: info
         subscription_id: test-sub
-        cluster: test
+        team: hcp-sl
       exp_annotations:
         description: Service Tag IP Usage test is at 81.25% of its capacity. Current count exceeds warning threshold of 80%.
         runbook_url: https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/serviceiptagusage
@@ -46,13 +47,14 @@ tests:
     alertname: AroHcpNonprodInboundSvcCapacity
     exp_alerts:
     - exp_labels:
-        severity: info
-        team: hcp-sl
+        cluster: test
+        component: network-capacity
         region: eastus
         service_tag_type: FirstPartyUsage
         service_tag_value: /aro-hcp-nonprod-inbound-svc
+        severity: info
         subscription_id: test-sub
-        cluster: test
+        team: hcp-sl
       exp_annotations:
         description: Service Tag IP Usage test is at 83.33% of its capacity. Current count exceeds warning threshold of 80%.
         runbook_url: https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/serviceiptagusage
@@ -62,13 +64,14 @@ tests:
     alertname: AroHcpNonprodOutboundCxCapacity
     exp_alerts:
     - exp_labels:
-        severity: info
-        team: hcp-sl
+        cluster: test
+        component: network-capacity
         region: eastus
         service_tag_type: FirstPartyUsage
         service_tag_value: /aro-hcp-nonprod-outbound-cx
+        severity: info
         subscription_id: test-sub
-        cluster: test
+        team: hcp-sl
       exp_annotations:
         description: Service Tag IP Usage test is at 87.5% of its capacity. Current count exceeds warning threshold of 80%.
         runbook_url: https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/serviceiptagusage
@@ -78,13 +81,14 @@ tests:
     alertname: AroHcpNonprodOutboundSvcCapacity
     exp_alerts:
     - exp_labels:
-        severity: info
-        team: hcp-sl
+        cluster: test
+        component: network-capacity
         region: eastus
         service_tag_type: FirstPartyUsage
         service_tag_value: /aro-hcp-nonprod-outbound-svc
+        severity: info
         subscription_id: test-sub
-        cluster: test
+        team: hcp-sl
       exp_annotations:
         description: Service Tag IP Usage test is at 83.33% of its capacity. Current count exceeds warning threshold of 80%.
         runbook_url: https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/serviceiptagusage
@@ -94,13 +98,14 @@ tests:
     alertname: AroHcpProdInboundCustomerapiCapacity
     exp_alerts:
     - exp_labels:
-        severity: info
-        team: hcp-sl
+        cluster: test
+        component: network-capacity
         region: eastus
         service_tag_type: FirstPartyUsage
         service_tag_value: /aro-hcp-prod-inbound-customerapi
+        severity: info
         subscription_id: test-sub
-        cluster: test
+        team: hcp-sl
       exp_annotations:
         description: Service Tag IP Usage test is at 81.25% of its capacity. Current count exceeds warning threshold of 80%.
         runbook_url: https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/serviceiptagusage
@@ -110,13 +115,14 @@ tests:
     alertname: AroHcpProdInboundCustomerapiUswest2Capacity
     exp_alerts:
     - exp_labels:
-        severity: info
-        team: hcp-sl
+        cluster: test
+        component: network-capacity
         region: uswest2
         service_tag_type: FirstPartyUsage
         service_tag_value: /aro-hcp-prod-inbound-customerapi
+        severity: info
         subscription_id: test-sub
-        cluster: test
+        team: hcp-sl
       exp_annotations:
         description: Service Tag IP Usage test is at 80.47% of its capacity. Current count exceeds warning threshold of 80%.
         runbook_url: https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/serviceiptagusage
@@ -126,13 +132,14 @@ tests:
     alertname: AroHcpProdInboundCxCapacity
     exp_alerts:
     - exp_labels:
-        severity: info
-        team: hcp-sl
+        cluster: test
+        component: network-capacity
         region: eastus
         service_tag_type: FirstPartyUsage
         service_tag_value: /aro-hcp-prod-inbound-cx
+        severity: info
         subscription_id: test-sub
-        cluster: test
+        team: hcp-sl
       exp_annotations:
         description: Service Tag IP Usage test is at 81.25% of its capacity. Current count exceeds warning threshold of 80%.
         runbook_url: https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/serviceiptagusage
@@ -142,13 +149,14 @@ tests:
     alertname: AroHcpProdInboundSvcCapacity
     exp_alerts:
     - exp_labels:
-        severity: info
-        team: hcp-sl
+        cluster: test
+        component: network-capacity
         region: eastus
         service_tag_type: FirstPartyUsage
         service_tag_value: /aro-hcp-prod-inbound-svc
+        severity: info
         subscription_id: test-sub
-        cluster: test
+        team: hcp-sl
       exp_annotations:
         description: Service Tag IP Usage test is at 81.25% of its capacity. Current count exceeds warning threshold of 80%.
         runbook_url: https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/serviceiptagusage
@@ -158,13 +166,14 @@ tests:
     alertname: AroHcpProdOutboundCxCapacity
     exp_alerts:
     - exp_labels:
-        severity: info
-        team: hcp-sl
+        cluster: test
+        component: network-capacity
         region: eastus
         service_tag_type: FirstPartyUsage
         service_tag_value: /aro-hcp-prod-outbound-cx
+        severity: info
         subscription_id: test-sub
-        cluster: test
+        team: hcp-sl
       exp_annotations:
         description: Service Tag IP Usage test is at 81.25% of its capacity. Current count exceeds warning threshold of 80%.
         runbook_url: https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/serviceiptagusage
@@ -174,13 +183,14 @@ tests:
     alertname: AroHcpProdOutboundSvcCapacity
     exp_alerts:
     - exp_labels:
-        severity: info
-        team: hcp-sl
+        cluster: test
+        component: network-capacity
         region: eastus
         service_tag_type: FirstPartyUsage
         service_tag_value: /aro-hcp-prod-outbound-svc
+        severity: info
         subscription_id: test-sub
-        cluster: test
+        team: hcp-sl
       exp_annotations:
         description: Service Tag IP Usage test is at 81.25% of its capacity. Current count exceeds warning threshold of 80%.
         runbook_url: https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/serviceiptagusage

--- a/tooling/prometheus-rules/internal/generator.go
+++ b/tooling/prometheus-rules/internal/generator.go
@@ -549,6 +549,9 @@ param location string = resourceGroup().location
 					if err != nil {
 						return fmt.Errorf("alert %q: %w", rule.Alert, err)
 					}
+					if err := requireLabel(labels, "component", rule.Alert, group.Name); err != nil {
+						return err
+					}
 					armGroup.Properties.Rules = append(armGroup.Properties.Rules, &armprometheusrulegroups.PrometheusRule{
 						Alert:       ptr.To(rule.Alert),
 						Enabled:     ptr.To(true),
@@ -759,6 +762,14 @@ func parseToAzureDurationString(d *monitoringv1.Duration) *string {
 
 	// TODO: this is likely not precisely correct, but /shrug
 	return ptr.To("PT" + strings.ToUpper(parsedDuration.String()))
+}
+
+func requireLabel(labels map[string]*string, name, alert, group string) error {
+	v, ok := labels[name]
+	if !ok || v == nil || *v == "" {
+		return fmt.Errorf("alert %q in group %q: missing required %q label (set at group or rule level)", alert, group, name)
+	}
+	return nil
 }
 
 func severityFor(labels map[string]*string) (*int32, error) {

--- a/tooling/prometheus-rules/internal/generator_test.go
+++ b/tooling/prometheus-rules/internal/generator_test.go
@@ -555,7 +555,8 @@ func TestOptionsGenerate(t *testing.T) {
 											Expr:  intstr.FromString("up == 0"),
 											For:   (*monitoringv1.Duration)(ptr.To("5m")),
 											Labels: map[string]string{
-												"severity": "critical",
+												"severity":  "critical",
+												"component": "test",
 											},
 											Annotations: map[string]string{
 												"summary": "Test alert",
@@ -607,14 +608,16 @@ func TestOptionsGenerate(t *testing.T) {
 											Alert: "AllowedAlert",
 											Expr:  intstr.FromString("up == 0"),
 											Labels: map[string]string{
-												"severity": "critical",
+												"severity":  "critical",
+												"component": "test",
 											},
 										},
 										{
 											Alert: "BlockedAlert",
 											Expr:  intstr.FromString("down == 1"),
 											Labels: map[string]string{
-												"severity": "warning",
+												"severity":  "warning",
+												"component": "test",
 											},
 										},
 									},
@@ -655,7 +658,8 @@ func TestOptionsGenerate(t *testing.T) {
 											Alert: "hostedcluster-KubeAPIServer-ErrorBudgetBurn",
 											Expr:  intstr.FromString("up == 0"),
 											Labels: map[string]string{
-												"severity": "info",
+												"severity":  "info",
+												"component": "test",
 											},
 											Annotations: map[string]string{
 												"summary":       "High KubeAPIServer error budget burn for HostedCluster {{ $labels.name }}",
@@ -701,7 +705,8 @@ func TestOptionsGenerate(t *testing.T) {
 											Alert: "EnrichedAlert",
 											Expr:  intstr.FromString("up == 0"),
 											Labels: map[string]string{
-												"severity": "warning",
+												"severity":  "warning",
+												"component": "test",
 											},
 											Annotations: map[string]string{
 												"summary":     "Pod in namespace {{ $labels.namespace }} is unhealthy",
@@ -750,7 +755,8 @@ func TestOptionsGenerate(t *testing.T) {
 											Alert: "OrderingAlert",
 											Expr:  intstr.FromString("up == 0"),
 											Labels: map[string]string{
-												"severity": "warning",
+												"severity":  "warning",
+												"component": "test",
 											},
 											Annotations: map[string]string{
 												"summary":     "Something is wrong",
@@ -796,7 +802,8 @@ func TestOptionsGenerate(t *testing.T) {
 											Alert: "NoSummaryAlert",
 											Expr:  intstr.FromString("up == 0"),
 											Labels: map[string]string{
-												"severity": "warning",
+												"severity":  "warning",
+												"component": "test",
 											},
 											Annotations: map[string]string{
 												"description": "Pod {{ $labels.namespace }}/{{ $labels.pod }} has issues",
@@ -841,7 +848,8 @@ func TestOptionsGenerate(t *testing.T) {
 											Alert: "AutoExtractAlert",
 											Expr:  intstr.FromString("up == 0"),
 											Labels: map[string]string{
-												"severity": "warning",
+												"severity":  "warning",
+												"component": "test",
 											},
 											Annotations: map[string]string{
 												"summary":     "Pod {{ $labels.pod }} in namespace {{ $labels.namespace }} is down",
@@ -889,7 +897,8 @@ func TestOptionsGenerate(t *testing.T) {
 											Alert: "AutoTitleAlert",
 											Expr:  intstr.FromString("up == 0"),
 											Labels: map[string]string{
-												"severity": "warning",
+												"severity":  "warning",
+												"component": "test",
 											},
 											Annotations: map[string]string{
 												"summary":     "Instance is down",
@@ -936,7 +945,8 @@ func TestOptionsGenerate(t *testing.T) {
 											Alert: "RealAlert",
 											Expr:  intstr.FromString("up == 0"),
 											Labels: map[string]string{
-												"severity": "critical",
+												"severity":  "critical",
+												"component": "test",
 											},
 										},
 									},
@@ -958,7 +968,8 @@ func TestOptionsGenerate(t *testing.T) {
 											Alert: "DependencyAlert",
 											Expr:  intstr.FromString("sum(up)"),
 											Labels: map[string]string{
-												"severity": "warning",
+												"severity":  "warning",
+												"component": "test",
 											},
 										},
 									},
@@ -1005,7 +1016,8 @@ func TestOptionsGenerate(t *testing.T) {
 											Alert: "QuotaAlert",
 											Expr:  intstr.FromString(`kube_resourcequota{job="kube-state-metrics", type="used"} > 0.9`),
 											Labels: map[string]string{
-												"severity": "warning",
+												"severity":  "warning",
+												"component": "test",
 											},
 											Annotations: map[string]string{
 												"summary": "Quota almost full",
@@ -1055,7 +1067,8 @@ func TestOptionsGenerate(t *testing.T) {
 											Alert: "ScopedAlert",
 											Expr:  intstr.FromString(`up{namespace="already-scoped"}`),
 											Labels: map[string]string{
-												"severity": "warning",
+												"severity":  "warning",
+												"component": "test",
 											},
 											Annotations: map[string]string{
 												"summary": "Already scoped alert",

--- a/tooling/prometheus-rules/main_test.go
+++ b/tooling/prometheus-rules/main_test.go
@@ -121,6 +121,7 @@ spec:
       expr: up == 0
       labels:
         severity: critical
+        component: testing
     - record: test:metric:rate5m
       expr: rate(test_metric[5m])
 `

--- a/tooling/prometheus-rules/testdata/alerts/testing-prometheusRule.yaml
+++ b/tooling/prometheus-rules/testdata/alerts/testing-prometheusRule.yaml
@@ -11,6 +11,8 @@ metadata:
 spec:
   groups:
   - name: InstancesDownV1
+    labels:
+      component: testing
     rules:
     - alert: InstancesDownV1
       expr: sum(up{job="app"}) == 0

--- a/tooling/prometheus-rules/testdata/alerts/testing-prometheusRule_test.yaml
+++ b/tooling/prometheus-rules/testdata/alerts/testing-prometheusRule_test.yaml
@@ -18,6 +18,7 @@ tests:
     exp_alerts:
     - exp_labels:
         severity: critical
+        component: testing
       exp_annotations:
         summary: "All instances of the App are down"
         description: "All instances of the App are down"

--- a/tooling/prometheus-rules/testdata/generated.bicep
+++ b/tooling/prometheus-rules/testdata/generated.bicep
@@ -27,6 +27,7 @@ resource InstancesDownV1 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
         alert: 'InstancesDownV1'
         enabled: true
         labels: {
+          component: 'testing'
           severity: 'critical'
         }
         annotations: {
@@ -50,6 +51,7 @@ resource InstancesDownV1 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
         alert: 'KubePodNotReady'
         enabled: true
         labels: {
+          component: 'testing'
           severity: 'warning'
         }
         annotations: {

--- a/tooling/prometheus-rules/testdata/generated_5m.bicep
+++ b/tooling/prometheus-rules/testdata/generated_5m.bicep
@@ -27,6 +27,7 @@ resource InstancesDownV1 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
         alert: 'InstancesDownV1'
         enabled: true
         labels: {
+          component: 'testing'
           severity: 'critical'
         }
         annotations: {
@@ -50,6 +51,7 @@ resource InstancesDownV1 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
         alert: 'KubePodNotReady'
         enabled: true
         labels: {
+          component: 'testing'
           severity: 'warning'
         }
         annotations: {


### PR DESCRIPTION
Empirically we see a tiny fraction of Pods (0.01%) that fit this, and I am willing to bet they are all in some kind of failure mode for our service. We want alerting to be the useful signal that catches anomalies, and now that we are not sending this to any humans, it's ok if we have some false positives.
