### PR TITLE
fix: validate node pool osDisk sizeGiB maximum by disk type

### DIFF
--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/hcpCluster-models.tsp
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/hcpCluster-models.tsp
@@ -831,9 +831,13 @@ model NodePoolPlatformProfile {
 
 /** The settings and configuration options for OSDisk */
 model OsDiskProfile {
-  /** The OS disk size in GiB */
+  /** The OS disk size in GiB. Maximum is 4095 GiB for Managed disks. For Ephemeral disks,
+   * the maximum is 2040 GiB; Azure may enforce a lower effective limit based on the
+   * selected VM size's local cache, temp, or NVMe capacity.
+   */
   @visibility(Lifecycle.Read, Lifecycle.Create)
   @minValue(64)
+  @maxValue(4095)
   sizeGiB?: int32 = 64;
 
   /** The type of the disk storage account

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2024-06-10-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2024-06-10-preview/openapi.json
@@ -3062,9 +3062,10 @@
         "sizeGiB": {
           "type": "integer",
           "format": "int32",
-          "description": "The OS disk size in GiB",
+          "description": "The OS disk size in GiB. Maximum is 4095 GiB for Managed disks. For Ephemeral disks,\nthe maximum is 2040 GiB; Azure may enforce a lower effective limit based on the\nselected VM size's local cache, temp, or NVMe capacity.",
           "default": 64,
           "minimum": 64,
+          "maximum": 4095,
           "x-ms-mutability": [
             "read",
             "create"

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2025-12-23-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2025-12-23-preview/openapi.json
@@ -3187,9 +3187,10 @@
         "sizeGiB": {
           "type": "integer",
           "format": "int32",
-          "description": "The OS disk size in GiB",
+          "description": "The OS disk size in GiB. Maximum is 4095 GiB for Managed disks. For Ephemeral disks,\nthe maximum is 2040 GiB; Azure may enforce a lower effective limit based on the\nselected VM size's local cache, temp, or NVMe capacity.",
           "default": 64,
           "minimum": 64,
+          "maximum": 4095,
           "x-ms-mutability": [
             "read",
             "create"

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2026-06-30-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2026-06-30-preview/openapi.json
@@ -3252,9 +3252,10 @@
         "sizeGiB": {
           "type": "integer",
           "format": "int32",
-          "description": "The OS disk size in GiB",
+          "description": "The OS disk size in GiB. Maximum is 4095 GiB for Managed disks. For Ephemeral disks,\nthe maximum is 2040 GiB; Azure may enforce a lower effective limit based on the\nselected VM size's local cache, temp, or NVMe capacity.",
           "default": 64,
           "minimum": 64,
+          "maximum": 4095,
           "x-ms-mutability": [
             "read",
             "create"

--- a/internal/api/v20240610preview/generated/models.go
+++ b/internal/api/v20240610preview/generated/models.go
@@ -821,7 +821,9 @@ type OsDiskProfile struct {
 	// Details on how to create a Disk Encryption Set can be found here: https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-customer-managed-keys-portal#set-up-your-disk-encryption-set
 	EncryptionSetID *string
 
-	// The OS disk size in GiB
+	// The OS disk size in GiB. Maximum is 4095 GiB for Managed disks. For Ephemeral disks, the maximum is 2040 GiB; Azure may
+	// enforce a lower effective limit based on the selected VM size's local cache,
+	// temp, or NVMe capacity.
 	SizeGiB *int32
 }
 

--- a/internal/api/v20251223preview/generated/models.go
+++ b/internal/api/v20251223preview/generated/models.go
@@ -882,7 +882,9 @@ type OsDiskProfile struct {
 	// Details on how to create a Disk Encryption Set can be found here: https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-customer-managed-keys-portal#set-up-your-disk-encryption-set
 	EncryptionSetID *string
 
-	// The OS disk size in GiB
+	// The OS disk size in GiB. Maximum is 4095 GiB for Managed disks. For Ephemeral disks, the maximum is 2040 GiB; Azure may
+	// enforce a lower effective limit based on the selected VM size's local cache,
+	// temp, or NVMe capacity.
 	SizeGiB *int32
 }
 

--- a/internal/api/v20260630preview/generated/models.go
+++ b/internal/api/v20260630preview/generated/models.go
@@ -898,7 +898,9 @@ type OsDiskProfile struct {
 	// Details on how to create a Disk Encryption Set can be found here: https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-customer-managed-keys-portal#set-up-your-disk-encryption-set
 	EncryptionSetID *string
 
-	// The OS disk size in GiB
+	// The OS disk size in GiB. Maximum is 4095 GiB for Managed disks. For Ephemeral disks, the maximum is 2040 GiB; Azure may
+	// enforce a lower effective limit based on the selected VM size's local cache,
+	// temp, or NVMe capacity.
 	SizeGiB *int32
 }
 

--- a/internal/validation/validate_nodepools.go
+++ b/internal/validation/validate_nodepools.go
@@ -38,6 +38,17 @@ const (
 	nodePoolK8sLabelKeyNodeRoleWorker = "node-role.kubernetes.io/worker"
 	nodePoolK8sLabelKeyMachineRole    = "machine.openshift.io/cluster-api-machine-role"
 	nodePoolK8sLabelKeyMachineType    = "machine.openshift.io/cluster-api-machine-type"
+
+	// MaxManagedOSDiskSizeGiB is the maximum allowed OS disk size (GiB) for Managed (persistent) OS disks.
+	// See https://learn.microsoft.com/en-us/azure/virtual-machines/managed-disks-overview#os-disk
+	MaxManagedOSDiskSizeGiB int32 = 4095
+	// MaxEphemeralOSDiskSizeGiB is the absolute maximum allowed OS disk size (GiB) for Ephemeral OS disks.
+	// Azure may enforce a lower effective limit per VM size based on local cache/temp/NVMe capacity.
+	// Values above this absolute cap are rejected here; values within this cap but above the selected
+	// VM size's local disk capacity are accepted by this validator and fail later during Azure
+	// provisioning.
+	// See https://learn.microsoft.com/en-us/azure/virtual-machines/ephemeral-os-disks
+	MaxEphemeralOSDiskSizeGiB int32 = 2040
 )
 
 // nodePoolForbiddenK8sLabelValuesByKey maps Kubernetes label keys to forbidden values.
@@ -331,6 +342,13 @@ func validateOSDiskProfile(ctx context.Context, op operation.Operation, fldPath 
 	//DiskType               OsDiskType             `json:"diskType"`
 	errs = append(errs, validate.RequiredValue(ctx, op, fldPath.Child("diskType"), &newObj.DiskType, safe.Field(oldObj, toOSDiskProfileDiskType))...)
 	errs = append(errs, validate.Enum(ctx, op, fldPath.Child("diskType"), &newObj.DiskType, safe.Field(oldObj, toOSDiskProfileDiskType), api.ValidOsDiskTypes, nil)...)
+
+	switch newObj.DiskType {
+	case api.OsDiskTypeManaged:
+		errs = append(errs, Maximum(ctx, op, fldPath.Child("sizeGiB"), newObj.SizeGiB, safe.Field(oldObj, toOSDiskProfileSizeGiB), MaxManagedOSDiskSizeGiB)...)
+	case api.OsDiskTypeEphemeral:
+		errs = append(errs, Maximum(ctx, op, fldPath.Child("sizeGiB"), newObj.SizeGiB, safe.Field(oldObj, toOSDiskProfileSizeGiB), MaxEphemeralOSDiskSizeGiB)...)
+	}
 
 	//EncryptionSetID        string                 `json:"encryptionSetId,omitempty"`
 	errs = append(errs, RestrictedResourceIDWithResourceGroup(ctx, op, fldPath.Child("encryptionSetId"), newObj.EncryptionSetID, safe.Field(oldObj, toOSDiskProfileEncryptionSetID), "Microsoft.Compute/diskEncryptionSets")...)

--- a/internal/validation/validate_nodepools_comprehensive_test.go
+++ b/internal/validation/validate_nodepools_comprehensive_test.go
@@ -348,6 +348,53 @@ func TestValidateNodePoolCreate(t *testing.T) {
 			},
 		},
 		{
+			name: "managed OS disk size at maximum - valid - create",
+			nodePool: func() *api.HCPOpenShiftClusterNodePool {
+				np := createValidNodePool()
+				np.Properties.Platform.OSDisk.DiskType = api.OsDiskTypeManaged
+				np.Properties.Platform.OSDisk.SizeGiB = ptr.To[int32](MaxManagedOSDiskSizeGiB)
+				return np
+			}(),
+			expectErrors: []utils.ExpectedError{},
+		},
+		{
+			name: "managed OS disk size over maximum - create",
+			nodePool: func() *api.HCPOpenShiftClusterNodePool {
+				np := createValidNodePool()
+				np.Properties.Platform.OSDisk.DiskType = api.OsDiskTypeManaged
+				np.Properties.Platform.OSDisk.DiskStorageAccountType = api.DiskStorageAccountTypeStandardSSD_LRS
+				np.Properties.Platform.OSDisk.SizeGiB = ptr.To[int32](MaxManagedOSDiskSizeGiB + 1)
+				return np
+			}(),
+			expectErrors: []utils.ExpectedError{
+				{Message: "must be less than or equal to 4095", FieldPath: "properties.platform.osDisk.sizeGiB"},
+			},
+		},
+		{
+			name: "ephemeral OS disk size at maximum - valid - create",
+			nodePool: func() *api.HCPOpenShiftClusterNodePool {
+				np := createValidNodePool()
+				np.Properties.Platform.OSDisk.DiskType = api.OsDiskTypeEphemeral
+				np.Properties.AutoRepair = true
+				np.Properties.Platform.OSDisk.SizeGiB = ptr.To[int32](MaxEphemeralOSDiskSizeGiB)
+				return np
+			}(),
+			expectErrors: []utils.ExpectedError{},
+		},
+		{
+			name: "ephemeral OS disk size over maximum - create",
+			nodePool: func() *api.HCPOpenShiftClusterNodePool {
+				np := createValidNodePool()
+				np.Properties.Platform.OSDisk.DiskType = api.OsDiskTypeEphemeral
+				np.Properties.AutoRepair = true
+				np.Properties.Platform.OSDisk.SizeGiB = ptr.To[int32](MaxEphemeralOSDiskSizeGiB + 1)
+				return np
+			}(),
+			expectErrors: []utils.ExpectedError{
+				{Message: "must be less than or equal to 2040", FieldPath: "properties.platform.osDisk.sizeGiB"},
+			},
+		},
+		{
 			name: "invalid disk storage account type - create",
 			nodePool: func() *api.HCPOpenShiftClusterNodePool {
 				np := createValidNodePool()


### PR DESCRIPTION
 Jira issue :
https://redhat.atlassian.net/browse/ARO-22496

### What

- Add maximum sizeGiB validation for node pool OS disks: 4095 GiB for Managed (persistent) disks and 2040 GiB for Ephemeral disks
- Document limits in TypeSpec and OpenAPI (@maxValue(4095) with description noting the ephemeral cap)
- Add unit tests for at-max and over-max cases for both disk types

### Why

Users could create node pools with sizeGiB values above Azure’s limits (e.g. 5000 with StandardSSD_LRS). The request passed RP validation and failed later during VM provisioning with Azure errors like:

  - Managed: The value 5000 of parameter 'osDisk.diskSizeGB' is out of range. The value must be between '1' and '4095', inclusive.
  - Ephemeral: The value 4000 of parameter 'osDisk.diskSizeGB' is out of range. The value must be between '1' and '2040', inclusive.

This change rejects invalid sizes at the ARM API during node pool create and preflight, so customers get an immediate validation error instead of an async provisioning failure.

Limits align with Azure documentation:

  - Managed OS disk max: 4,095 GiB — [Managed disks overview (OS disk)](https://learn.microsoft.com/en-us/azure/virtual-machines/managed-disks-overview#os-disk)
  - Ephemeral OS disk max: 2,040 GiB (or VM local cache/temp/NVMe size, whichever is smaller) — [Ephemeral OS disks](https://learn.microsoft.com/en-us/azure/virtual-machines/ephemeral-os-disks)

Fixes [ARO-22496](https://redhat.atlassian.net/browse/ARO-22496)

### Testing
- Added unit tests and followed below plan:

1. go test -run TestValidateNodePoolCreate ./internal/validation/...

 -  Managed at max (4095) — valid 
 -  Managed over max (4096) — rejected
 -  Ephemeral at max (2040) — valid
 -  Ephemeral over max (2041) — rejected

2. Manual test scenarios:

 -  sizeGiB: 5000 (Managed) → must be less than or equal to 4095
 -  sizeGiB: 4000 (Ephemeral) → must be less than or equal to 2040
 -  Valid sizes → preflight Succeeded

3.  make -C api swagger — OpenAPI regenerated and matches TypeSpec
 
### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
