### PR TITLE
observability: Add cluster deletion SLO, prometheus alerting rules and grafana dashboard (ARO-26216)

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
@@ -17,15 +17,13 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
     interval: 'PT1M'
     rules: [
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyAccessClusterErrors1h5m'
         enabled: true
         labels: {
@@ -48,15 +46,13 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyAccessClusterErrors6h30m'
         enabled: true
         labels: {
@@ -79,15 +75,13 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyAccessClusterErrors3d'
         enabled: true
         labels: {
@@ -109,15 +103,13 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyAccessClusterErrorsDegradation'
         enabled: true
         labels: {
@@ -138,15 +130,13 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyAccessClusterStuckOperation'
         enabled: true
         labels: {
@@ -179,15 +169,13 @@ resource arohcpAccessClusterSaturationAlerts 'Microsoft.AlertsManagement/prometh
     interval: 'PT1M'
     rules: [
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyAccessClusterSaturationQueueDepth'
         enabled: true
         labels: {
@@ -207,15 +195,13 @@ resource arohcpAccessClusterSaturationAlerts 'Microsoft.AlertsManagement/prometh
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyAccessClusterSaturationRetryHotLoop'
         enabled: true
         labels: {
@@ -382,15 +368,13 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
     interval: 'PT1M'
     rules: [
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'UJNodePoolErrors1h5m'
         enabled: true
         labels: {
@@ -413,15 +397,13 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'UJNodePoolErrors6h30m'
         enabled: true
         labels: {
@@ -444,15 +426,13 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'UJNodePoolErrors3d'
         enabled: true
         labels: {
@@ -474,15 +454,13 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'UJNodePoolErrorsDegradation'
         enabled: true
         labels: {
@@ -503,15 +481,13 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'UJNodePoolStuckOperation'
         enabled: true
         labels: {
@@ -544,15 +520,13 @@ resource arohcpNodepoolSaturationAlerts 'Microsoft.AlertsManagement/prometheusRu
     interval: 'PT1M'
     rules: [
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'UJNodePoolSaturationQueueDepth'
         enabled: true
         labels: {
@@ -569,6 +543,243 @@ resource arohcpNodepoolSaturationAlerts 'Microsoft.AlertsManagement/prometheusRu
         }
         expression: 'max by (name, cluster) (max without (prometheus_replica) (workqueue_depth{name=~".*NodePool.*",namespace="aro-hcp"})) > 10'
         for: 'PT5M'
+        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
+      }
+    ]
+    scopes: [
+      azureMonitoring
+    ]
+  }
+}
+
+resource arohcpClusterDeletionSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'arohcp_cluster_deletion_slo_error_alerts'
+  location: location
+  properties: {
+    interval: 'PT1M'
+    rules: [
+      {
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
+          }
+        }]
+        alert: 'userJourneyClusterDeletionErrors1h5m'
+        enabled: true
+        labels: {
+          long_window: '1h'
+          severity: 'info'
+          short_window: '5m'
+          slo: 'cluster-deletion-errors'
+        }
+        annotations: {
+          correlationId: 'userJourneyClusterDeletionErrors1h5m/{{ $labels.cluster }}'
+          description: 'More than 72% of cluster delete operations are in failed or canceled state, indicating a fast error budget burn (14.4x) that would exhaust the 95% SLO budget in ~12 hours.'
+          info: 'More than 72% of cluster delete operations are in failed or canceled state, indicating a fast error budget burn (14.4x) that would exhaust the 95% SLO budget in ~12 hours.'
+          runbook_url: 'TBD'
+          summary: 'Cluster deletion operation error rate high (>72%)'
+          title: 'Cluster deletion operation error rate high (>72%)'
+        }
+        expression: 'errors:backend_cluster_deletion_operation:error_rate > 0.72 and clamp_min(count by (cluster) (backend_resource_operation_phase_info{operation_type="delete",phase=~"succeeded|failed|canceled",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters"}) or vector(0), 0) >= 5'
+        for: 'PT5M'
+        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
+      }
+      {
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
+          }
+        }]
+        alert: 'userJourneyClusterDeletionErrors6h30m'
+        enabled: true
+        labels: {
+          long_window: '6h'
+          severity: 'info'
+          short_window: '30m'
+          slo: 'cluster-deletion-errors'
+        }
+        annotations: {
+          correlationId: 'userJourneyClusterDeletionErrors6h30m/{{ $labels.cluster }}'
+          description: 'More than 30% of cluster delete operations are in failed or canceled state sustained over 30 minutes, indicating a medium error budget burn (6x) that would exhaust the 95% SLO budget in ~28 hours.'
+          info: 'More than 30% of cluster delete operations are in failed or canceled state sustained over 30 minutes, indicating a medium error budget burn (6x) that would exhaust the 95% SLO budget in ~28 hours.'
+          runbook_url: 'TBD'
+          summary: 'Cluster deletion operation error rate elevated (>30%) for 30+ minutes'
+          title: 'Cluster deletion operation error rate elevated (>30%) for 30+ minutes'
+        }
+        expression: 'errors:backend_cluster_deletion_operation:error_rate > 0.3 and clamp_min(count by (cluster) (backend_resource_operation_phase_info{operation_type="delete",phase=~"succeeded|failed|canceled",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters"}) or vector(0), 0) >= 5'
+        for: 'PT30M'
+        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
+      }
+      {
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
+          }
+        }]
+        alert: 'userJourneyClusterDeletionErrors3d'
+        enabled: true
+        labels: {
+          long_window: '3d'
+          severity: 'info'
+          slo: 'cluster-deletion-errors'
+        }
+        annotations: {
+          correlationId: 'userJourneyClusterDeletionErrors3d/{{ $labels.cluster }}'
+          description: 'More than 5% of cluster delete operations are in failed or canceled state sustained over 6 hours, indicating persistent degradation at the 95% SLO boundary that would exhaust the error budget in ~7 days.'
+          info: 'More than 5% of cluster delete operations are in failed or canceled state sustained over 6 hours, indicating persistent degradation at the 95% SLO boundary that would exhaust the error budget in ~7 days.'
+          runbook_url: 'TBD'
+          summary: 'Cluster deletion operation error rate exceeds SLO target (>5%) for 6+ hours'
+          title: 'Cluster deletion operation error rate exceeds SLO target (>5%) for 6+ hours'
+        }
+        expression: 'errors:backend_cluster_deletion_operation:error_rate > 0.05 and clamp_min(count by (cluster) (backend_resource_operation_phase_info{operation_type="delete",phase=~"succeeded|failed|canceled",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters"}) or vector(0), 0) >= 5'
+        for: 'PT6H'
+        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
+      }
+      {
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
+          }
+        }]
+        alert: 'userJourneyClusterDeletionErrorsDegradation'
+        enabled: true
+        labels: {
+          severity: 'info'
+          slo: 'cluster-deletion-errors'
+        }
+        annotations: {
+          correlationId: 'userJourneyClusterDeletionErrorsDegradation/{{ $labels.cluster }}'
+          description: 'The cluster deletion operation failure rate has been above 15% for 30 minutes. This provides early warning of degradation before SLO-based burn rate alerts fire.'
+          info: 'The cluster deletion operation failure rate has been above 15% for 30 minutes. This provides early warning of degradation before SLO-based burn rate alerts fire.'
+          runbook_url: 'TBD'
+          summary: 'Cluster deletion operation failure rate exceeds 15% for 30 minutes'
+          title: 'Cluster deletion operation failure rate exceeds 15% for 30 minutes'
+        }
+        expression: 'errors:backend_cluster_deletion_operation:error_rate > 0.15 and clamp_min(count by (cluster) (backend_resource_operation_phase_info{operation_type="delete",phase=~"succeeded|failed|canceled",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters"}) or vector(0), 0) >= 5'
+        for: 'PT30M'
+        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
+      }
+      {
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
+          }
+        }]
+        alert: 'userJourneyClusterDeletionLatencySLOBreach'
+        enabled: true
+        labels: {
+          severity: 'info'
+          slo: 'cluster-deletion-timeliness'
+        }
+        annotations: {
+          correlationId: 'userJourneyClusterDeletionLatencySLOBreach/{{ $labels.cluster }}'
+          description: 'More than 5% of successful cluster delete operations took longer than 30 minutes, sustained over 30 minutes. This violates the Timeliness SLO target of ≥95% completion within 30 minutes.'
+          info: 'More than 5% of successful cluster delete operations took longer than 30 minutes, sustained over 30 minutes. This violates the Timeliness SLO target of ≥95% completion within 30 minutes.'
+          runbook_url: 'TBD'
+          summary: 'Cluster deletion Timeliness SLO breach: >5% of deletes exceed 30 minutes'
+          title: 'Cluster deletion Timeliness SLO breach: >5% of deletes exceed 30 minutes'
+        }
+        expression: 'errors:backend_cluster_deletion_operation:timeliness_error_rate > 0.05'
+        for: 'PT30M'
+        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
+      }
+      {
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
+          }
+        }]
+        alert: 'userJourneyClusterDeletionStuckOperation'
+        enabled: true
+        labels: {
+          severity: 'info'
+          slo: 'cluster-deletion-stuck'
+        }
+        annotations: {
+          correlationId: 'userJourneyClusterDeletionStuckOperation/{{ $labels.cluster }}/{{ $labels.resource_id }}'
+          description: 'Cluster delete operation for {{ $labels.resource_id }} has been in {{ $labels.phase }} phase for over 1 hour. Stuck operations are invisible to success/failure SLIs and require investigation.'
+          info: 'Cluster delete operation for {{ $labels.resource_id }} has been in {{ $labels.phase }} phase for over 1 hour. Stuck operations are invisible to success/failure SLIs and require investigation.'
+          runbook_url: 'TBD'
+          summary: 'Cluster deletion operation stuck in non-terminal phase for over 1 hour'
+          title: 'Cluster deletion operation stuck in non-terminal phase for over 1 hour resource_id:{{ $labels.resource_id }} phase:{{ $labels.phase }}'
+        }
+        expression: '(max without (prometheus_replica) (backend_resource_operation_phase_info{operation_type="delete",phase=~"accepted|awaitingsecret|provisioning|updating|deleting",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters"} == 1) and (time() - max without (prometheus_replica) (backend_resource_operation_last_transition_time_seconds{operation_type="delete",phase=~"accepted|awaitingsecret|provisioning|updating|deleting",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters"})) > 3600)'
+        for: 'PT15M'
+        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
+      }
+    ]
+    scopes: [
+      azureMonitoring
+    ]
+  }
+}
+
+resource arohcpClusterDeletionSaturationAlerts 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'arohcp_cluster_deletion_saturation_alerts'
+  location: location
+  properties: {
+    interval: 'PT1M'
+    rules: [
+      {
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
+          }
+        }]
+        alert: 'userJourneyClusterDeletionQueueDepth'
+        enabled: true
+        labels: {
+          severity: 'info'
+        }
+        annotations: {
+          correlationId: 'userJourneyClusterDeletionQueueDepth/{{ $labels.cluster }}/{{ $labels.name }}'
+          description: 'Cluster deletion controller workqueue {{ $labels.name }} has had a depth > 10 for more than 5 minutes, indicating work is accumulating faster than it can be processed.'
+          info: 'Cluster deletion controller workqueue {{ $labels.name }} has had a depth > 10 for more than 5 minutes, indicating work is accumulating faster than it can be processed.'
+          runbook_url: 'TBD'
+          summary: 'Cluster deletion controller workqueue depth is high'
+          title: 'Cluster deletion controller workqueue depth is high name:{{ $labels.name }}'
+        }
+        expression: 'max by (name, cluster) (max without (prometheus_replica) (workqueue_depth{name="OperationClusterDelete",namespace="aro-hcp"})) > 10'
+        for: 'PT5M'
+        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
+      }
+      {
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
+          }
+        }]
+        alert: 'userJourneyClusterDeletionRetryHotLoop'
+        enabled: true
+        labels: {
+          severity: 'info'
+        }
+        annotations: {
+          correlationId: 'userJourneyClusterDeletionRetryHotLoop/{{ $labels.cluster }}/{{ $labels.name }}'
+          description: 'Cluster deletion controller workqueue {{ $labels.name }} has a retry ratio > 50% sustained over 10 minutes, indicating most queue activity is failed retries rather than fresh work.'
+          info: 'Cluster deletion controller workqueue {{ $labels.name }} has a retry ratio > 50% sustained over 10 minutes, indicating most queue activity is failed retries rather than fresh work.'
+          runbook_url: 'TBD'
+          summary: 'Cluster deletion controller workqueue in retry hot loop'
+          title: 'Cluster deletion controller workqueue in retry hot loop name:{{ $labels.name }}'
+        }
+        expression: '(sum by (name, cluster) (max without (prometheus_replica) (rate(workqueue_retries_total{name="OperationClusterDelete",namespace="aro-hcp"}[10m]))) / sum by (name, cluster) (max without (prometheus_replica) (rate(workqueue_adds_total{name="OperationClusterDelete",namespace="aro-hcp"}[10m])))) > 0.5'
+        for: 'PT10M'
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
     ]

--- a/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
@@ -570,7 +570,7 @@ resource arohcpClusterDeletionSloErrorAlerts 'Microsoft.AlertsManagement/prometh
         enabled: true
         labels: {
           long_window: '1h'
-          severity: 'info'
+          severity: '3'
           short_window: '5m'
           slo: 'cluster-deletion-errors'
         }
@@ -578,13 +578,13 @@ resource arohcpClusterDeletionSloErrorAlerts 'Microsoft.AlertsManagement/prometh
           correlationId: 'userJourneyClusterDeletionErrors1h5m/{{ $labels.cluster }}'
           description: 'More than 72% of cluster delete operations are in failed or canceled state, indicating a fast error budget burn (14.4x) that would exhaust the 95% SLO budget in ~12 hours.'
           info: 'More than 72% of cluster delete operations are in failed or canceled state, indicating a fast error budget burn (14.4x) that would exhaust the 95% SLO budget in ~12 hours.'
-          runbook_url: 'TBD'
-          summary: 'Cluster deletion operation error rate high (>72%)'
-          title: 'Cluster deletion operation error rate high (>72%)'
+          runbook_url: 'aka.ms/arohcp-runbook-cluster-deletion'
+          summary: '{{ $labels.cluster }}: Cluster deletion operation error rate high (>72%)'
+          title: '{{ $labels.cluster }}: Cluster deletion operation error rate high (>72%)'
         }
         expression: 'errors:backend_cluster_deletion_operation:error_rate > 0.72 and clamp_min(count by (cluster) (backend_resource_operation_phase_info{operation_type="delete",phase=~"succeeded|failed|canceled",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters"}) or vector(0), 0) >= 5'
         for: 'PT5M'
-        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
         actions: [for g in actionGroups: {
@@ -598,7 +598,7 @@ resource arohcpClusterDeletionSloErrorAlerts 'Microsoft.AlertsManagement/prometh
         enabled: true
         labels: {
           long_window: '6h'
-          severity: 'info'
+          severity: '3'
           short_window: '30m'
           slo: 'cluster-deletion-errors'
         }
@@ -606,13 +606,13 @@ resource arohcpClusterDeletionSloErrorAlerts 'Microsoft.AlertsManagement/prometh
           correlationId: 'userJourneyClusterDeletionErrors6h30m/{{ $labels.cluster }}'
           description: 'More than 30% of cluster delete operations are in failed or canceled state sustained over 30 minutes, indicating a medium error budget burn (6x) that would exhaust the 95% SLO budget in ~28 hours.'
           info: 'More than 30% of cluster delete operations are in failed or canceled state sustained over 30 minutes, indicating a medium error budget burn (6x) that would exhaust the 95% SLO budget in ~28 hours.'
-          runbook_url: 'TBD'
-          summary: 'Cluster deletion operation error rate elevated (>30%) for 30+ minutes'
-          title: 'Cluster deletion operation error rate elevated (>30%) for 30+ minutes'
+          runbook_url: 'aka.ms/arohcp-runbook-cluster-deletion'
+          summary: '{{ $labels.cluster }}: Cluster deletion operation error rate elevated (>30%) for 30+ minutes'
+          title: '{{ $labels.cluster }}: Cluster deletion operation error rate elevated (>30%) for 30+ minutes'
         }
         expression: 'errors:backend_cluster_deletion_operation:error_rate > 0.3 and clamp_min(count by (cluster) (backend_resource_operation_phase_info{operation_type="delete",phase=~"succeeded|failed|canceled",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters"}) or vector(0), 0) >= 5'
         for: 'PT30M'
-        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
         actions: [for g in actionGroups: {
@@ -626,20 +626,20 @@ resource arohcpClusterDeletionSloErrorAlerts 'Microsoft.AlertsManagement/prometh
         enabled: true
         labels: {
           long_window: '3d'
-          severity: 'info'
+          severity: '3'
           slo: 'cluster-deletion-errors'
         }
         annotations: {
           correlationId: 'userJourneyClusterDeletionErrors3d/{{ $labels.cluster }}'
           description: 'More than 5% of cluster delete operations are in failed or canceled state sustained over 6 hours, indicating persistent degradation at the 95% SLO boundary that would exhaust the error budget in ~7 days.'
           info: 'More than 5% of cluster delete operations are in failed or canceled state sustained over 6 hours, indicating persistent degradation at the 95% SLO boundary that would exhaust the error budget in ~7 days.'
-          runbook_url: 'TBD'
-          summary: 'Cluster deletion operation error rate exceeds SLO target (>5%) for 6+ hours'
-          title: 'Cluster deletion operation error rate exceeds SLO target (>5%) for 6+ hours'
+          runbook_url: 'aka.ms/arohcp-runbook-cluster-deletion'
+          summary: '{{ $labels.cluster }}: Cluster deletion operation error rate exceeds SLO target (>5%) for 6+ hours'
+          title: '{{ $labels.cluster }}: Cluster deletion operation error rate exceeds SLO target (>5%) for 6+ hours'
         }
         expression: 'errors:backend_cluster_deletion_operation:error_rate > 0.05 and clamp_min(count by (cluster) (backend_resource_operation_phase_info{operation_type="delete",phase=~"succeeded|failed|canceled",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters"}) or vector(0), 0) >= 5'
         for: 'PT6H'
-        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
         actions: [for g in actionGroups: {
@@ -652,20 +652,20 @@ resource arohcpClusterDeletionSloErrorAlerts 'Microsoft.AlertsManagement/prometh
         alert: 'userJourneyClusterDeletionErrorsDegradation'
         enabled: true
         labels: {
-          severity: 'info'
+          severity: '3'
           slo: 'cluster-deletion-errors'
         }
         annotations: {
           correlationId: 'userJourneyClusterDeletionErrorsDegradation/{{ $labels.cluster }}'
           description: 'The cluster deletion operation failure rate has been above 15% for 30 minutes. This provides early warning of degradation before SLO-based burn rate alerts fire.'
           info: 'The cluster deletion operation failure rate has been above 15% for 30 minutes. This provides early warning of degradation before SLO-based burn rate alerts fire.'
-          runbook_url: 'TBD'
-          summary: 'Cluster deletion operation failure rate exceeds 15% for 30 minutes'
-          title: 'Cluster deletion operation failure rate exceeds 15% for 30 minutes'
+          runbook_url: 'aka.ms/arohcp-runbook-cluster-deletion'
+          summary: '{{ $labels.cluster }}: Cluster deletion operation failure rate exceeds 15% for 30 minutes'
+          title: '{{ $labels.cluster }}: Cluster deletion operation failure rate exceeds 15% for 30 minutes'
         }
         expression: 'errors:backend_cluster_deletion_operation:error_rate > 0.15 and clamp_min(count by (cluster) (backend_resource_operation_phase_info{operation_type="delete",phase=~"succeeded|failed|canceled",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters"}) or vector(0), 0) >= 5'
         for: 'PT30M'
-        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
         actions: [for g in actionGroups: {
@@ -675,23 +675,80 @@ resource arohcpClusterDeletionSloErrorAlerts 'Microsoft.AlertsManagement/prometh
             'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
         }]
-        alert: 'userJourneyClusterDeletionLatencySLOBreach'
+        alert: 'userJourneyClusterDeletionLatency1h5m'
         enabled: true
         labels: {
-          severity: 'info'
+          long_window: '1h'
+          severity: '3'
+          short_window: '5m'
           slo: 'cluster-deletion-timeliness'
         }
         annotations: {
-          correlationId: 'userJourneyClusterDeletionLatencySLOBreach/{{ $labels.cluster }}'
-          description: 'More than 5% of successful cluster delete operations took longer than 30 minutes, sustained over 30 minutes. This violates the Timeliness SLO target of ≥95% completion within 30 minutes.'
-          info: 'More than 5% of successful cluster delete operations took longer than 30 minutes, sustained over 30 minutes. This violates the Timeliness SLO target of ≥95% completion within 30 minutes.'
-          runbook_url: 'TBD'
-          summary: 'Cluster deletion Timeliness SLO breach: >5% of deletes exceed 30 minutes'
-          title: 'Cluster deletion Timeliness SLO breach: >5% of deletes exceed 30 minutes'
+          correlationId: 'userJourneyClusterDeletionLatency1h5m/{{ $labels.cluster }}'
+          description: 'More than 72% of successful cluster deletes exceeded 30 minutes, sustained for 5 minutes. Fast burn rate (14.4x) against the 95% Timeliness SLO — on track to exhaust the budget in ~12 hours.'
+          info: 'More than 72% of successful cluster deletes exceeded 30 minutes, sustained for 5 minutes. Fast burn rate (14.4x) against the 95% Timeliness SLO — on track to exhaust the budget in ~12 hours.'
+          runbook_url: 'aka.ms/arohcp-runbook-cluster-deletion'
+          summary: '{{ $labels.cluster }}: Cluster deletion Timeliness SLO fast burn (>72% slow for 5m)'
+          title: '{{ $labels.cluster }}: Cluster deletion Timeliness SLO fast burn (>72% slow for 5m)'
+        }
+        expression: 'errors:backend_cluster_deletion_operation:timeliness_error_rate > 0.72'
+        for: 'PT5M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+      {
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
+          }
+        }]
+        alert: 'userJourneyClusterDeletionLatency6h30m'
+        enabled: true
+        labels: {
+          long_window: '6h'
+          severity: '3'
+          short_window: '30m'
+          slo: 'cluster-deletion-timeliness'
+        }
+        annotations: {
+          correlationId: 'userJourneyClusterDeletionLatency6h30m/{{ $labels.cluster }}'
+          description: 'More than 30% of successful cluster deletes exceeded 30 minutes, sustained for 30 minutes. Medium burn rate (6x) against the 95% Timeliness SLO — on track to exhaust the budget in ~28 hours.'
+          info: 'More than 30% of successful cluster deletes exceeded 30 minutes, sustained for 30 minutes. Medium burn rate (6x) against the 95% Timeliness SLO — on track to exhaust the budget in ~28 hours.'
+          runbook_url: 'aka.ms/arohcp-runbook-cluster-deletion'
+          summary: '{{ $labels.cluster }}: Cluster deletion Timeliness SLO medium burn (>30% slow for 30m)'
+          title: '{{ $labels.cluster }}: Cluster deletion Timeliness SLO medium burn (>30% slow for 30m)'
+        }
+        expression: 'errors:backend_cluster_deletion_operation:timeliness_error_rate > 0.3'
+        for: 'PT30M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+      {
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
+          }
+        }]
+        alert: 'userJourneyClusterDeletionLatency3d'
+        enabled: true
+        labels: {
+          long_window: '3d'
+          severity: '3'
+          slo: 'cluster-deletion-timeliness'
+        }
+        annotations: {
+          correlationId: 'userJourneyClusterDeletionLatency3d/{{ $labels.cluster }}'
+          description: 'More than 5% of successful cluster deletes exceeded 30 minutes, sustained for 6 hours. Slow burn rate (1x) against the 95% Timeliness SLO — budget will be exhausted in ~7 days.'
+          info: 'More than 5% of successful cluster deletes exceeded 30 minutes, sustained for 6 hours. Slow burn rate (1x) against the 95% Timeliness SLO — budget will be exhausted in ~7 days.'
+          runbook_url: 'aka.ms/arohcp-runbook-cluster-deletion'
+          summary: '{{ $labels.cluster }}: Cluster deletion Timeliness SLO slow burn (>5% slow for 6h)'
+          title: '{{ $labels.cluster }}: Cluster deletion Timeliness SLO slow burn (>5% slow for 6h)'
         }
         expression: 'errors:backend_cluster_deletion_operation:timeliness_error_rate > 0.05'
-        for: 'PT30M'
-        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
+        for: 'PT6H'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
         actions: [for g in actionGroups: {
@@ -704,20 +761,20 @@ resource arohcpClusterDeletionSloErrorAlerts 'Microsoft.AlertsManagement/prometh
         alert: 'userJourneyClusterDeletionStuckOperation'
         enabled: true
         labels: {
-          severity: 'info'
+          severity: '3'
           slo: 'cluster-deletion-stuck'
         }
         annotations: {
           correlationId: 'userJourneyClusterDeletionStuckOperation/{{ $labels.cluster }}/{{ $labels.resource_id }}'
           description: 'Cluster delete operation for {{ $labels.resource_id }} has been in {{ $labels.phase }} phase for over 1 hour. Stuck operations are invisible to success/failure SLIs and require investigation.'
           info: 'Cluster delete operation for {{ $labels.resource_id }} has been in {{ $labels.phase }} phase for over 1 hour. Stuck operations are invisible to success/failure SLIs and require investigation.'
-          runbook_url: 'TBD'
-          summary: 'Cluster deletion operation stuck in non-terminal phase for over 1 hour'
-          title: 'Cluster deletion operation stuck in non-terminal phase for over 1 hour resource_id:{{ $labels.resource_id }} phase:{{ $labels.phase }}'
+          runbook_url: 'aka.ms/arohcp-runbook-cluster-deletion'
+          summary: '{{ $labels.cluster }}: Cluster deletion operation stuck in {{ $labels.phase }} for over 1 hour'
+          title: '{{ $labels.cluster }}: Cluster deletion operation stuck in {{ $labels.phase }} for over 1 hour resource_id:{{ $labels.resource_id }}'
         }
         expression: '(max without (prometheus_replica) (backend_resource_operation_phase_info{operation_type="delete",phase=~"accepted|awaitingsecret|provisioning|updating|deleting",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters"} == 1) and (time() - max without (prometheus_replica) (backend_resource_operation_last_transition_time_seconds{operation_type="delete",phase=~"accepted|awaitingsecret|provisioning|updating|deleting",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters"})) > 3600)'
         for: 'PT15M'
-        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
     ]
     scopes: [
@@ -743,15 +800,15 @@ resource arohcpClusterDeletionSaturationAlerts 'Microsoft.AlertsManagement/prome
         alert: 'userJourneyClusterDeletionQueueDepth'
         enabled: true
         labels: {
-          severity: 'info'
+          severity: '4'
         }
         annotations: {
           correlationId: 'userJourneyClusterDeletionQueueDepth/{{ $labels.cluster }}/{{ $labels.name }}'
           description: 'Cluster deletion controller workqueue {{ $labels.name }} has had a depth > 10 for more than 5 minutes, indicating work is accumulating faster than it can be processed.'
           info: 'Cluster deletion controller workqueue {{ $labels.name }} has had a depth > 10 for more than 5 minutes, indicating work is accumulating faster than it can be processed.'
-          runbook_url: 'TBD'
-          summary: 'Cluster deletion controller workqueue depth is high'
-          title: 'Cluster deletion controller workqueue depth is high name:{{ $labels.name }}'
+          runbook_url: 'aka.ms/arohcp-runbook-cluster-deletion'
+          summary: '{{ $labels.cluster }}: Cluster deletion controller workqueue {{ $labels.name }} depth is high'
+          title: '{{ $labels.cluster }}: Cluster deletion controller workqueue {{ $labels.name }} depth is high'
         }
         expression: 'max by (name, cluster) (max without (prometheus_replica) (workqueue_depth{name="OperationClusterDelete",namespace="aro-hcp"})) > 10'
         for: 'PT5M'
@@ -768,15 +825,15 @@ resource arohcpClusterDeletionSaturationAlerts 'Microsoft.AlertsManagement/prome
         alert: 'userJourneyClusterDeletionRetryHotLoop'
         enabled: true
         labels: {
-          severity: 'info'
+          severity: '4'
         }
         annotations: {
           correlationId: 'userJourneyClusterDeletionRetryHotLoop/{{ $labels.cluster }}/{{ $labels.name }}'
           description: 'Cluster deletion controller workqueue {{ $labels.name }} has a retry ratio > 50% sustained over 10 minutes, indicating most queue activity is failed retries rather than fresh work.'
           info: 'Cluster deletion controller workqueue {{ $labels.name }} has a retry ratio > 50% sustained over 10 minutes, indicating most queue activity is failed retries rather than fresh work.'
-          runbook_url: 'TBD'
-          summary: 'Cluster deletion controller workqueue in retry hot loop'
-          title: 'Cluster deletion controller workqueue in retry hot loop name:{{ $labels.name }}'
+          runbook_url: 'aka.ms/arohcp-runbook-cluster-deletion'
+          summary: '{{ $labels.cluster }}: Cluster deletion controller workqueue {{ $labels.name }} retry hot loop'
+          title: '{{ $labels.cluster }}: Cluster deletion controller workqueue {{ $labels.name }} retry hot loop'
         }
         expression: '(sum by (name, cluster) (max without (prometheus_replica) (rate(workqueue_retries_total{name="OperationClusterDelete",namespace="aro-hcp"}[10m]))) / sum by (name, cluster) (max without (prometheus_replica) (rate(workqueue_adds_total{name="OperationClusterDelete",namespace="aro-hcp"}[10m])))) > 0.5'
         for: 'PT10M'

--- a/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
@@ -569,6 +569,7 @@ resource arohcpClusterDeletionSloErrorAlerts 'Microsoft.AlertsManagement/prometh
         alert: 'userJourneyClusterDeletionErrors1h5m'
         enabled: true
         labels: {
+          component: 'slo'
           long_window: '1h'
           severity: '3'
           short_window: '5m'
@@ -597,6 +598,7 @@ resource arohcpClusterDeletionSloErrorAlerts 'Microsoft.AlertsManagement/prometh
         alert: 'userJourneyClusterDeletionErrors6h30m'
         enabled: true
         labels: {
+          component: 'slo'
           long_window: '6h'
           severity: '3'
           short_window: '30m'
@@ -625,6 +627,7 @@ resource arohcpClusterDeletionSloErrorAlerts 'Microsoft.AlertsManagement/prometh
         alert: 'userJourneyClusterDeletionErrors3d'
         enabled: true
         labels: {
+          component: 'slo'
           long_window: '3d'
           severity: '3'
           slo: 'cluster-deletion-errors'
@@ -652,6 +655,7 @@ resource arohcpClusterDeletionSloErrorAlerts 'Microsoft.AlertsManagement/prometh
         alert: 'userJourneyClusterDeletionErrorsDegradation'
         enabled: true
         labels: {
+          component: 'slo'
           severity: '3'
           slo: 'cluster-deletion-errors'
         }
@@ -678,6 +682,7 @@ resource arohcpClusterDeletionSloErrorAlerts 'Microsoft.AlertsManagement/prometh
         alert: 'userJourneyClusterDeletionLatency1h5m'
         enabled: true
         labels: {
+          component: 'slo'
           long_window: '1h'
           severity: '3'
           short_window: '5m'
@@ -706,6 +711,7 @@ resource arohcpClusterDeletionSloErrorAlerts 'Microsoft.AlertsManagement/prometh
         alert: 'userJourneyClusterDeletionLatency6h30m'
         enabled: true
         labels: {
+          component: 'slo'
           long_window: '6h'
           severity: '3'
           short_window: '30m'
@@ -734,6 +740,7 @@ resource arohcpClusterDeletionSloErrorAlerts 'Microsoft.AlertsManagement/prometh
         alert: 'userJourneyClusterDeletionLatency3d'
         enabled: true
         labels: {
+          component: 'slo'
           long_window: '3d'
           severity: '3'
           slo: 'cluster-deletion-timeliness'
@@ -761,6 +768,7 @@ resource arohcpClusterDeletionSloErrorAlerts 'Microsoft.AlertsManagement/prometh
         alert: 'userJourneyClusterDeletionStuckOperation'
         enabled: true
         labels: {
+          component: 'slo'
           severity: '3'
           slo: 'cluster-deletion-stuck'
         }
@@ -769,8 +777,8 @@ resource arohcpClusterDeletionSloErrorAlerts 'Microsoft.AlertsManagement/prometh
           description: 'Cluster delete operation for {{ $labels.resource_id }} has been in {{ $labels.phase }} phase for over 1 hour. Stuck operations are invisible to success/failure SLIs and require investigation.'
           info: 'Cluster delete operation for {{ $labels.resource_id }} has been in {{ $labels.phase }} phase for over 1 hour. Stuck operations are invisible to success/failure SLIs and require investigation.'
           runbook_url: 'aka.ms/arohcp-runbook-cluster-deletion'
-          summary: '{{ $labels.cluster }}: Cluster deletion operation stuck in {{ $labels.phase }} for over 1 hour'
-          title: '{{ $labels.cluster }}: Cluster deletion operation stuck in {{ $labels.phase }} for over 1 hour resource_id:{{ $labels.resource_id }}'
+          summary: '{{ $labels.cluster }}: Cluster deletion operation {{ $labels.resource_id }} stuck in {{ $labels.phase }} for over 1 hour'
+          title: '{{ $labels.cluster }}: Cluster deletion operation {{ $labels.resource_id }} stuck in {{ $labels.phase }} for over 1 hour'
         }
         expression: '(max without (prometheus_replica) (backend_resource_operation_phase_info{operation_type="delete",phase=~"accepted|awaitingsecret|provisioning|updating|deleting",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters"} == 1) and (time() - max without (prometheus_replica) (backend_resource_operation_last_transition_time_seconds{operation_type="delete",phase=~"accepted|awaitingsecret|provisioning|updating|deleting",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters"})) > 3600)'
         for: 'PT15M'
@@ -800,6 +808,7 @@ resource arohcpClusterDeletionSaturationAlerts 'Microsoft.AlertsManagement/prome
         alert: 'userJourneyClusterDeletionQueueDepth'
         enabled: true
         labels: {
+          component: 'slo'
           severity: '4'
         }
         annotations: {
@@ -825,6 +834,7 @@ resource arohcpClusterDeletionSaturationAlerts 'Microsoft.AlertsManagement/prome
         alert: 'userJourneyClusterDeletionRetryHotLoop'
         enabled: true
         labels: {
+          component: 'slo'
           severity: '4'
         }
         annotations: {

--- a/dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep
@@ -1,3 +1,4 @@
+
 param azureMonitoring string
 
 param location string = resourceGroup().location
@@ -49,6 +50,28 @@ resource arohcpClusterProvisionSloRecordingRules 'Microsoft.AlertsManagement/pro
       {
         record: 'errors:backend_cluster_provision:error_rate'
         expression: '(count by (cluster) (backend_resource_operation_phase_info{operation_type="create",phase="failed",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters"}) or 0 * count by (cluster) (backend_resource_operation_phase_info{operation_type="create",phase=~"succeeded|failed|canceled",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters"})) / clamp_min(count by (cluster) (backend_resource_operation_phase_info{operation_type="create",phase=~"succeeded|failed|canceled",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters"}), 1)'
+      }
+    ]
+  }
+}
+
+resource arohcpClusterDeletionSloRecordingRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'arohcp_cluster_deletion_slo_recording_rules'
+  location: location
+  properties: {
+    scopes: [
+      azureMonitoring
+    ]
+    enabled: true
+    interval: 'PT1M'
+    rules: [
+      {
+        record: 'errors:backend_cluster_deletion_operation:error_rate'
+        expression: '(count by (cluster) (backend_resource_operation_phase_info{operation_type="delete",phase=~"failed|canceled",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters"}) or 0 * count by (cluster) (backend_resource_operation_phase_info{operation_type="delete",phase=~"succeeded|failed|canceled",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters"})) / clamp_min(count by (cluster) (backend_resource_operation_phase_info{operation_type="delete",phase=~"succeeded|failed|canceled",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters"}), 1)'
+      }
+      {
+        record: 'errors:backend_cluster_deletion_operation:timeliness_error_rate'
+        expression: '(count by (cluster) ((backend_resource_operation_last_transition_time_seconds{operation_type="delete",phase="succeeded",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters"} - backend_resource_operation_start_time_seconds{operation_type="delete",phase="succeeded",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters"}) >= 1800 and backend_resource_operation_phase_info{operation_type="delete",phase="succeeded",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters"} == 1) or 0 * count by (cluster) (backend_resource_operation_phase_info{operation_type="delete",phase="succeeded",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters"} == 1)) / clamp_min(count by (cluster) (backend_resource_operation_phase_info{operation_type="delete",phase="succeeded",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters"} == 1), 1)'
       }
     ]
   }

--- a/observability/alerts-rp-services.yaml
+++ b/observability/alerts-rp-services.yaml
@@ -3,6 +3,7 @@ prometheusRules:
   - alerts/access-cluster-slo-prometheusRule.yaml
   - alerts/cluster-provision-slo-prometheusRule.yaml
   - alerts/nodepool-slo-prometheusRule.yaml
+  - alerts/HCPClusterDeletion-prometheusRule.yaml
   untestedRules: []
   testDependencies:
   - recording-rules-services.yaml

--- a/observability/alerts/HCPClusterDeletion-prometheusRule.yaml
+++ b/observability/alerts/HCPClusterDeletion-prometheusRule.yaml
@@ -1,0 +1,329 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app.kubernetes.io/name: kube-prometheus
+    app.kubernetes.io/part-of: kube-prometheus
+    prometheus: k8s
+    role: alert-rules
+  name: cluster-deletion-slo-rules
+  namespace: monitoring
+spec:
+  groups:
+  # ========================================
+  # Cluster Deletion SLO Recording Rules
+  # ========================================
+  # These rules track the Errors and Timeliness SLOs for cluster delete operations.
+  # SLO: 95% of cluster delete operations should succeed (not reach "failed" or "canceled" terminal phase)
+  # Error Budget: 5% (1 - 0.95)
+  # Scope: covers cluster delete operations only.
+  - name: arohcp_cluster_deletion_slo_recording_rules
+    interval: 1m
+    rules:
+    # Instantaneous error rate: fraction of terminal operations that failed or were canceled.
+    # Uses count by (cluster) to preserve the cluster label per nodepool production pattern.
+    # The "or 0 * count by (cluster)" fallback returns zero with the cluster label when
+    # there are no failures, avoiding lost label context (vs "or vector(0)").
+    - record: errors:backend_cluster_deletion_operation:error_rate
+      expr: |
+        (
+          count by (cluster) (backend_resource_operation_phase_info{
+            resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
+            operation_type="delete",
+            phase=~"failed|canceled"
+          })
+          or
+          0 * count by (cluster) (backend_resource_operation_phase_info{
+            resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
+            operation_type="delete",
+            phase=~"succeeded|failed|canceled"
+          })
+        )
+        /
+        clamp_min(
+          count by (cluster) (backend_resource_operation_phase_info{
+            resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
+            operation_type="delete",
+            phase=~"succeeded|failed|canceled"
+          }),
+          1
+        )
+
+    # Timeliness error rate: fraction of succeeded operations that exceeded the 30-minute target.
+    # Uses count by (cluster) to preserve the cluster label per nodepool production pattern.
+    - record: errors:backend_cluster_deletion_operation:timeliness_error_rate
+      expr: |
+        (
+          count by (cluster) (
+            (
+              backend_resource_operation_last_transition_time_seconds{
+                resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
+                operation_type="delete",
+                phase="succeeded"
+              }
+              -
+              backend_resource_operation_start_time_seconds{
+                resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
+                operation_type="delete",
+                phase="succeeded"
+              }
+            ) >= 1800
+            and
+            backend_resource_operation_phase_info{
+              resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
+              operation_type="delete",
+              phase="succeeded"
+            } == 1
+          )
+          or
+          0 * count by (cluster) (backend_resource_operation_phase_info{
+            resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
+            operation_type="delete",
+            phase="succeeded"
+          } == 1)
+        )
+        /
+        clamp_min(
+          count by (cluster) (backend_resource_operation_phase_info{
+            resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
+            operation_type="delete",
+            phase="succeeded"
+          } == 1),
+          1
+        )
+
+  # ========================================
+  # Cluster Deletion SLO Alerts — Errors
+  # ========================================
+  # Multi-window burn-rate-style alerting adapted for gauge metrics.
+  #
+  # Burn rate thresholds calculated from 95% SLO (5% error budget):
+  #   Fast (14.4x):  14.4 * 0.05 = 0.72 → 72% error rate
+  #   Medium (6x):   6   * 0.05 = 0.30 → 30% error rate
+  #   Slow (1x):     1   * 0.05 = 0.05 →  5% error rate
+  #
+  # The 'for' duration enforces sustained observation, approximating the
+  # short window of multi-window burn rate alerting.
+  - name: arohcp_cluster_deletion_slo_error_alerts
+    rules:
+    # ----------------------------------------
+    # Fast Burn Alert (info)
+    # ----------------------------------------
+    # 14.4x burn rate → >72% failure rate sustained for 5 minutes
+    # Would exhaust 7-day error budget in ~12 hours
+    - alert: userJourneyClusterDeletionErrors1h5m
+      expr: |
+        errors:backend_cluster_deletion_operation:error_rate > 0.72
+        and
+        clamp_min(
+          count by (cluster) (backend_resource_operation_phase_info{
+            resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
+            operation_type="delete",
+            phase=~"succeeded|failed|canceled"
+          }) or vector(0),
+          0
+        ) >= 5
+      for: 5m
+      labels:
+        severity: info
+        slo: cluster-deletion-errors
+        short_window: 5m
+        long_window: 1h
+      annotations:
+        title: "Cluster deletion operation error rate high (>72%)"
+        summary: "Cluster deletion operation error rate high (>72%)"
+        description: "More than 72% of cluster delete operations are in failed or canceled state, indicating a fast error budget burn (14.4x) that would exhaust the 95% SLO budget in ~12 hours."
+        runbook_url: "TBD"
+
+    # ----------------------------------------
+    # Medium Burn Alert (info)
+    # ----------------------------------------
+    # 6x burn rate → >30% failure rate sustained for 30 minutes
+    # Would exhaust 7-day error budget in ~28 hours
+    - alert: userJourneyClusterDeletionErrors6h30m
+      expr: |
+        errors:backend_cluster_deletion_operation:error_rate > 0.30
+        and
+        clamp_min(
+          count by (cluster) (backend_resource_operation_phase_info{
+            resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
+            operation_type="delete",
+            phase=~"succeeded|failed|canceled"
+          }) or vector(0),
+          0
+        ) >= 5
+      for: 30m
+      labels:
+        severity: info
+        slo: cluster-deletion-errors
+        short_window: 30m
+        long_window: 6h
+      annotations:
+        title: "Cluster deletion operation error rate elevated (>30%) for 30+ minutes"
+        summary: "Cluster deletion operation error rate elevated (>30%) for 30+ minutes"
+        description: "More than 30% of cluster delete operations are in failed or canceled state sustained over 30 minutes, indicating a medium error budget burn (6x) that would exhaust the 95% SLO budget in ~28 hours."
+        runbook_url: "TBD"
+
+    # ----------------------------------------
+    # Slow Burn Alert (info — creates Jira ticket, no page)
+    # ----------------------------------------
+    # Slow burn alerts generate Jira ticket for investigation.
+    # 1x burn rate → >5% failure rate sustained for 6 hours
+    # Would exhaust 7-day error budget in ~7 days
+    - alert: userJourneyClusterDeletionErrors3d
+      expr: |
+        errors:backend_cluster_deletion_operation:error_rate > 0.05
+        and
+        clamp_min(
+          count by (cluster) (backend_resource_operation_phase_info{
+            resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
+            operation_type="delete",
+            phase=~"succeeded|failed|canceled"
+          }) or vector(0),
+          0
+        ) >= 5
+      for: 6h
+      labels:
+        severity: info
+        slo: cluster-deletion-errors
+        long_window: 3d
+      annotations:
+        title: "Cluster deletion operation error rate exceeds SLO target (>5%) for 6+ hours"
+        summary: "Cluster deletion operation error rate exceeds SLO target (>5%) for 6+ hours"
+        description: "More than 5% of cluster delete operations are in failed or canceled state sustained over 6 hours, indicating persistent degradation at the 95% SLO boundary that would exhaust the error budget in ~7 days."
+        runbook_url: "TBD"
+
+    # ----------------------------------------
+    # Degradation Alert (info)
+    # ----------------------------------------
+    # With a 95% SLO, the fast-burn threshold only fires at ~72% failure rate.
+    # This provides early warning at 15% failure rate before burn-rate alerts fire.
+    - alert: userJourneyClusterDeletionErrorsDegradation
+      expr: |
+        errors:backend_cluster_deletion_operation:error_rate > 0.15
+        and
+        clamp_min(
+          count by (cluster) (backend_resource_operation_phase_info{
+            resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
+            operation_type="delete",
+            phase=~"succeeded|failed|canceled"
+          }) or vector(0),
+          0
+        ) >= 5
+      for: 30m
+      labels:
+        severity: info
+        slo: cluster-deletion-errors
+      annotations:
+        title: "Cluster deletion operation failure rate exceeds 15% for 30 minutes"
+        summary: "Cluster deletion operation failure rate exceeds 15% for 30 minutes"
+        description: "The cluster deletion operation failure rate has been above 15% for 30 minutes. This provides early warning of degradation before SLO-based burn rate alerts fire."
+        runbook_url: "TBD"
+
+    # ----------------------------------------
+    # Timeliness SLO Breach (info)
+    # ----------------------------------------
+    # Fires when >5% of successful deletes exceeded the 30-minute latency target,
+    # sustained for 30 minutes.
+    - alert: userJourneyClusterDeletionLatencySLOBreach
+      expr: |
+        errors:backend_cluster_deletion_operation:timeliness_error_rate > 0.05
+      for: 30m
+      labels:
+        severity: info
+        slo: cluster-deletion-timeliness
+      annotations:
+        title: "Cluster deletion Timeliness SLO breach: >5% of deletes exceed 30 minutes"
+        summary: "Cluster deletion Timeliness SLO breach: >5% of deletes exceed 30 minutes"
+        description: "More than 5% of successful cluster delete operations took longer than 30 minutes, sustained over 30 minutes. This violates the Timeliness SLO target of ≥95% completion within 30 minutes."
+        runbook_url: "TBD"
+
+    # ----------------------------------------
+    # Stuck Operations Alert (info)
+    # ----------------------------------------
+    # Operations stuck in non-terminal phases are invisible to success/failure SLIs.
+    # Uses last_transition_time_seconds (time in current phase) to match the dashboard
+    # panel exactly and avoid premature firing when earlier phases are still in progress.
+    #
+    # This alert fires when time in the CURRENT phase
+    #     (last_transition_time_seconds) > 1h, monitors all 5 active phases.
+    # 
+    - alert: userJourneyClusterDeletionStuckOperation
+      expr: |
+        (
+          max without(prometheus_replica) (
+            backend_resource_operation_phase_info{
+              resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
+              operation_type="delete",
+              phase=~"accepted|awaitingsecret|provisioning|updating|deleting"
+            } == 1
+          )
+          and
+          (
+            time() - max without(prometheus_replica) (
+              backend_resource_operation_last_transition_time_seconds{
+                resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
+                operation_type="delete",
+                phase=~"accepted|awaitingsecret|provisioning|updating|deleting"
+              }
+            )
+          ) > 3600
+        )
+      for: 15m
+      labels:
+        severity: info
+        slo: cluster-deletion-stuck
+      annotations:
+        title: "Cluster deletion operation stuck in non-terminal phase for over 1 hour"
+        summary: "Cluster deletion operation stuck in non-terminal phase for over 1 hour"
+        description: "Cluster delete operation for {{ $labels.resource_id }} has been in {{ $labels.phase }} phase for over 1 hour. Stuck operations are invisible to success/failure SLIs and require investigation."
+        runbook_url: "TBD"
+        correlationId: "userJourneyClusterDeletionStuckOperation/{{ $labels.cluster }}/{{ $labels.resource_id }}"
+
+  # ========================================
+  # Cluster Deletion Saturation Alerts — Saturation
+  # ========================================
+  # Threshold-based alerting for component-level metrics per ADR.
+  - name: arohcp_cluster_deletion_saturation_alerts
+    rules:
+    # Queue depth: cluster deletion controller workqueue accumulating work
+    - alert: userJourneyClusterDeletionQueueDepth
+      expr: |
+        max by (name, cluster) (
+          max without(prometheus_replica) (
+            workqueue_depth{namespace="aro-hcp", name="OperationClusterDelete"}
+          )
+        ) > 10
+      for: 5m
+      labels:
+        severity: info
+      annotations:
+        title: "Cluster deletion controller workqueue depth is high"
+        summary: "Cluster deletion controller workqueue depth is high"
+        description: "Cluster deletion controller workqueue {{ $labels.name }} has had a depth > 10 for more than 5 minutes, indicating work is accumulating faster than it can be processed."
+        runbook_url: "TBD"
+
+    # Retry hot loop: high retry ratio on cluster deletion workqueue
+    - alert: userJourneyClusterDeletionRetryHotLoop
+      expr: |
+        (
+          sum by (name, cluster) (
+            max without(prometheus_replica) (
+              rate(workqueue_retries_total{namespace="aro-hcp", name="OperationClusterDelete"}[10m])
+            )
+          )
+          /
+          sum by (name, cluster) (
+            max without(prometheus_replica) (
+              rate(workqueue_adds_total{namespace="aro-hcp", name="OperationClusterDelete"}[10m])
+            )
+          )
+        ) > 0.5
+      for: 10m
+      labels:
+        severity: info
+      annotations:
+        title: "Cluster deletion controller workqueue in retry hot loop"
+        summary: "Cluster deletion controller workqueue in retry hot loop"
+        description: "Cluster deletion controller workqueue {{ $labels.name }} has a retry ratio > 50% sustained over 10 minutes, indicating most queue activity is failed retries rather than fresh work."
+        runbook_url: "TBD"

--- a/observability/alerts/HCPClusterDeletion-prometheusRule.yaml
+++ b/observability/alerts/HCPClusterDeletion-prometheusRule.yaml
@@ -11,88 +11,6 @@ metadata:
 spec:
   groups:
   # ========================================
-  # Cluster Deletion SLO Recording Rules
-  # ========================================
-  # These rules track the Errors and Timeliness SLOs for cluster delete operations.
-  # SLO: 95% of cluster delete operations should succeed (not reach "failed" or "canceled" terminal phase)
-  # Error Budget: 5% (1 - 0.95)
-  # Scope: covers cluster delete operations only.
-  - name: arohcp_cluster_deletion_slo_recording_rules
-    interval: 1m
-    rules:
-    # Instantaneous error rate: fraction of terminal operations that failed or were canceled.
-    # Uses count by (cluster) to preserve the cluster label per nodepool production pattern.
-    # The "or 0 * count by (cluster)" fallback returns zero with the cluster label when
-    # there are no failures, avoiding lost label context (vs "or vector(0)").
-    - record: errors:backend_cluster_deletion_operation:error_rate
-      expr: |
-        (
-          count by (cluster) (backend_resource_operation_phase_info{
-            resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
-            operation_type="delete",
-            phase=~"failed|canceled"
-          })
-          or
-          0 * count by (cluster) (backend_resource_operation_phase_info{
-            resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
-            operation_type="delete",
-            phase=~"succeeded|failed|canceled"
-          })
-        )
-        /
-        clamp_min(
-          count by (cluster) (backend_resource_operation_phase_info{
-            resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
-            operation_type="delete",
-            phase=~"succeeded|failed|canceled"
-          }),
-          1
-        )
-
-    # Timeliness error rate: fraction of succeeded operations that exceeded the 30-minute target.
-    # Uses count by (cluster) to preserve the cluster label per nodepool production pattern.
-    - record: errors:backend_cluster_deletion_operation:timeliness_error_rate
-      expr: |
-        (
-          count by (cluster) (
-            (
-              backend_resource_operation_last_transition_time_seconds{
-                resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
-                operation_type="delete",
-                phase="succeeded"
-              }
-              -
-              backend_resource_operation_start_time_seconds{
-                resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
-                operation_type="delete",
-                phase="succeeded"
-              }
-            ) >= 1800
-            and
-            backend_resource_operation_phase_info{
-              resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
-              operation_type="delete",
-              phase="succeeded"
-            } == 1
-          )
-          or
-          0 * count by (cluster) (backend_resource_operation_phase_info{
-            resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
-            operation_type="delete",
-            phase="succeeded"
-          } == 1)
-        )
-        /
-        clamp_min(
-          count by (cluster) (backend_resource_operation_phase_info{
-            resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
-            operation_type="delete",
-            phase="succeeded"
-          } == 1),
-          1
-        )
-
-  # ========================================
   # Cluster Deletion SLO Alerts — Errors
   # ========================================
   # Multi-window burn-rate-style alerting adapted for gauge metrics.
@@ -125,16 +43,16 @@ spec:
         ) >= 5
       for: 5m
       labels:
-        severity: info
+        severity: "3"
         slo: cluster-deletion-errors
         short_window: 5m
         long_window: 1h
       annotations:
         title: "Cluster deletion operation error rate high (>72%)"
-        summary: "Cluster deletion operation error rate high (>72%)"
+        summary: "{{ $labels.cluster }}: Cluster deletion operation error rate high (>72%)"
         description: "More than 72% of cluster delete operations are in failed or canceled state, indicating a fast error budget burn (14.4x) that would exhaust the 95% SLO budget in ~12 hours."
-        runbook_url: "TBD"
-
+        runbook_url: "aka.ms/arohcp-runbook-cluster-deletion"
+        correlationId: "userJourneyClusterDeletionErrors1h5m/{{ $labels.cluster }}"
     # ----------------------------------------
     # Medium Burn Alert (info)
     # ----------------------------------------
@@ -154,16 +72,16 @@ spec:
         ) >= 5
       for: 30m
       labels:
-        severity: info
+        severity: "3"
         slo: cluster-deletion-errors
         short_window: 30m
         long_window: 6h
       annotations:
         title: "Cluster deletion operation error rate elevated (>30%) for 30+ minutes"
-        summary: "Cluster deletion operation error rate elevated (>30%) for 30+ minutes"
+        summary: "{{ $labels.cluster }}: Cluster deletion operation error rate elevated (>30%) for 30+ minutes"
         description: "More than 30% of cluster delete operations are in failed or canceled state sustained over 30 minutes, indicating a medium error budget burn (6x) that would exhaust the 95% SLO budget in ~28 hours."
-        runbook_url: "TBD"
-
+        runbook_url: "aka.ms/arohcp-runbook-cluster-deletion"
+        correlationId: "userJourneyClusterDeletionErrors6h30m/{{ $labels.cluster }}"
     # ----------------------------------------
     # Slow Burn Alert (info — creates Jira ticket, no page)
     # ----------------------------------------
@@ -184,15 +102,15 @@ spec:
         ) >= 5
       for: 6h
       labels:
-        severity: info
+        severity: "3"
         slo: cluster-deletion-errors
         long_window: 3d
       annotations:
         title: "Cluster deletion operation error rate exceeds SLO target (>5%) for 6+ hours"
-        summary: "Cluster deletion operation error rate exceeds SLO target (>5%) for 6+ hours"
+        summary: "{{ $labels.cluster }}: Cluster deletion operation error rate exceeds SLO target (>5%) for 6+ hours"
         description: "More than 5% of cluster delete operations are in failed or canceled state sustained over 6 hours, indicating persistent degradation at the 95% SLO boundary that would exhaust the error budget in ~7 days."
-        runbook_url: "TBD"
-
+        runbook_url: "aka.ms/arohcp-runbook-cluster-deletion"
+        correlationId: "userJourneyClusterDeletionErrors3d/{{ $labels.cluster }}"
     # ----------------------------------------
     # Degradation Alert (info)
     # ----------------------------------------
@@ -212,32 +130,70 @@ spec:
         ) >= 5
       for: 30m
       labels:
-        severity: info
+        severity: "3"
         slo: cluster-deletion-errors
       annotations:
         title: "Cluster deletion operation failure rate exceeds 15% for 30 minutes"
-        summary: "Cluster deletion operation failure rate exceeds 15% for 30 minutes"
+        summary: "{{ $labels.cluster }}: Cluster deletion operation failure rate exceeds 15% for 30 minutes"
         description: "The cluster deletion operation failure rate has been above 15% for 30 minutes. This provides early warning of degradation before SLO-based burn rate alerts fire."
-        runbook_url: "TBD"
-
+        runbook_url: "aka.ms/arohcp-runbook-cluster-deletion"
+        correlationId: "userJourneyClusterDeletionErrorsDegradation/{{ $labels.cluster }}"
     # ----------------------------------------
-    # Timeliness SLO Breach (info)
+    # Timeliness SLO — Fast Burn (info)
     # ----------------------------------------
-    # Fires when >5% of successful deletes exceeded the 30-minute latency target,
-    # sustained for 30 minutes.
-    - alert: userJourneyClusterDeletionLatencySLOBreach
+    # 14.4x burn rate → >72% of successful deletes exceeded 30m, sustained 5m
+    - alert: userJourneyClusterDeletionLatency1h5m
       expr: |
-        errors:backend_cluster_deletion_operation:timeliness_error_rate > 0.05
+        errors:backend_cluster_deletion_operation:timeliness_error_rate > 0.72
+      for: 5m
+      labels:
+        severity: "3"
+        slo: cluster-deletion-timeliness
+        short_window: 5m
+        long_window: 1h
+      annotations:
+        title: "Cluster deletion Timeliness SLO fast burn (>72% slow for 5m)"
+        summary: "{{ $labels.cluster }}: Cluster deletion Timeliness SLO fast burn (>72% slow for 5m)"
+        description: "More than 72% of successful cluster deletes exceeded 30 minutes, sustained for 5 minutes. Fast burn rate (14.4x) against the 95% Timeliness SLO — on track to exhaust the budget in ~12 hours."
+        runbook_url: "aka.ms/arohcp-runbook-cluster-deletion"
+        correlationId: "userJourneyClusterDeletionLatency1h5m/{{ $labels.cluster }}"
+    # ----------------------------------------
+    # Timeliness SLO — Medium Burn (info)
+    # ----------------------------------------
+    # 6x burn rate → >30% of successful deletes exceeded 30m, sustained 30m
+    - alert: userJourneyClusterDeletionLatency6h30m
+      expr: |
+        errors:backend_cluster_deletion_operation:timeliness_error_rate > 0.30
       for: 30m
       labels:
-        severity: info
+        severity: "3"
         slo: cluster-deletion-timeliness
+        short_window: 30m
+        long_window: 6h
       annotations:
-        title: "Cluster deletion Timeliness SLO breach: >5% of deletes exceed 30 minutes"
-        summary: "Cluster deletion Timeliness SLO breach: >5% of deletes exceed 30 minutes"
-        description: "More than 5% of successful cluster delete operations took longer than 30 minutes, sustained over 30 minutes. This violates the Timeliness SLO target of ≥95% completion within 30 minutes."
-        runbook_url: "TBD"
-
+        title: "Cluster deletion Timeliness SLO medium burn (>30% slow for 30m)"
+        summary: "{{ $labels.cluster }}: Cluster deletion Timeliness SLO medium burn (>30% slow for 30m)"
+        description: "More than 30% of successful cluster deletes exceeded 30 minutes, sustained for 30 minutes. Medium burn rate (6x) against the 95% Timeliness SLO — on track to exhaust the budget in ~28 hours."
+        runbook_url: "aka.ms/arohcp-runbook-cluster-deletion"
+        correlationId: "userJourneyClusterDeletionLatency6h30m/{{ $labels.cluster }}"
+    # ----------------------------------------
+    # Timeliness SLO — Slow Burn (info)
+    # ----------------------------------------
+    # 1x burn rate → >5% of successful deletes exceeded 30m, sustained 6h
+    - alert: userJourneyClusterDeletionLatency3d
+      expr: |
+        errors:backend_cluster_deletion_operation:timeliness_error_rate > 0.05
+      for: 6h
+      labels:
+        severity: "3"
+        slo: cluster-deletion-timeliness
+        long_window: 3d
+      annotations:
+        title: "Cluster deletion Timeliness SLO slow burn (>5% slow for 6h)"
+        summary: "{{ $labels.cluster }}: Cluster deletion Timeliness SLO slow burn (>5% slow for 6h)"
+        description: "More than 5% of successful cluster deletes exceeded 30 minutes, sustained for 6 hours. Slow burn rate (1x) against the 95% Timeliness SLO — budget will be exhausted in ~7 days."
+        runbook_url: "aka.ms/arohcp-runbook-cluster-deletion"
+        correlationId: "userJourneyClusterDeletionLatency3d/{{ $labels.cluster }}"
     # ----------------------------------------
     # Stuck Operations Alert (info)
     # ----------------------------------------
@@ -271,15 +227,14 @@ spec:
         )
       for: 15m
       labels:
-        severity: info
+        severity: "3"
         slo: cluster-deletion-stuck
       annotations:
         title: "Cluster deletion operation stuck in non-terminal phase for over 1 hour"
-        summary: "Cluster deletion operation stuck in non-terminal phase for over 1 hour"
+        summary: "{{ $labels.cluster }}: Cluster deletion operation stuck in {{ $labels.phase }} for over 1 hour"
         description: "Cluster delete operation for {{ $labels.resource_id }} has been in {{ $labels.phase }} phase for over 1 hour. Stuck operations are invisible to success/failure SLIs and require investigation."
-        runbook_url: "TBD"
+        runbook_url: "aka.ms/arohcp-runbook-cluster-deletion"
         correlationId: "userJourneyClusterDeletionStuckOperation/{{ $labels.cluster }}/{{ $labels.resource_id }}"
-
   # ========================================
   # Cluster Deletion Saturation Alerts — Saturation
   # ========================================
@@ -296,13 +251,13 @@ spec:
         ) > 10
       for: 5m
       labels:
-        severity: info
+        severity: "4"
       annotations:
         title: "Cluster deletion controller workqueue depth is high"
-        summary: "Cluster deletion controller workqueue depth is high"
+        summary: "{{ $labels.cluster }}: Cluster deletion controller workqueue {{ $labels.name }} depth is high"
         description: "Cluster deletion controller workqueue {{ $labels.name }} has had a depth > 10 for more than 5 minutes, indicating work is accumulating faster than it can be processed."
-        runbook_url: "TBD"
-
+        runbook_url: "aka.ms/arohcp-runbook-cluster-deletion"
+        correlationId: "userJourneyClusterDeletionQueueDepth/{{ $labels.cluster }}/{{ $labels.name }}"
     # Retry hot loop: high retry ratio on cluster deletion workqueue
     - alert: userJourneyClusterDeletionRetryHotLoop
       expr: |
@@ -321,9 +276,10 @@ spec:
         ) > 0.5
       for: 10m
       labels:
-        severity: info
+        severity: "4"
       annotations:
         title: "Cluster deletion controller workqueue in retry hot loop"
-        summary: "Cluster deletion controller workqueue in retry hot loop"
+        summary: "{{ $labels.cluster }}: Cluster deletion controller workqueue {{ $labels.name }} retry hot loop"
         description: "Cluster deletion controller workqueue {{ $labels.name }} has a retry ratio > 50% sustained over 10 minutes, indicating most queue activity is failed retries rather than fresh work."
-        runbook_url: "TBD"
+        runbook_url: "aka.ms/arohcp-runbook-cluster-deletion"
+        correlationId: "userJourneyClusterDeletionRetryHotLoop/{{ $labels.cluster }}/{{ $labels.name }}"

--- a/observability/alerts/HCPClusterDeletion-prometheusRule.yaml
+++ b/observability/alerts/HCPClusterDeletion-prometheusRule.yaml
@@ -47,6 +47,7 @@ spec:
         slo: cluster-deletion-errors
         short_window: 5m
         long_window: 1h
+        component: slo
       annotations:
         title: "Cluster deletion operation error rate high (>72%)"
         summary: "{{ $labels.cluster }}: Cluster deletion operation error rate high (>72%)"
@@ -76,6 +77,7 @@ spec:
         slo: cluster-deletion-errors
         short_window: 30m
         long_window: 6h
+        component: slo
       annotations:
         title: "Cluster deletion operation error rate elevated (>30%) for 30+ minutes"
         summary: "{{ $labels.cluster }}: Cluster deletion operation error rate elevated (>30%) for 30+ minutes"
@@ -105,6 +107,7 @@ spec:
         severity: "3"
         slo: cluster-deletion-errors
         long_window: 3d
+        component: slo
       annotations:
         title: "Cluster deletion operation error rate exceeds SLO target (>5%) for 6+ hours"
         summary: "{{ $labels.cluster }}: Cluster deletion operation error rate exceeds SLO target (>5%) for 6+ hours"
@@ -132,6 +135,7 @@ spec:
       labels:
         severity: "3"
         slo: cluster-deletion-errors
+        component: slo
       annotations:
         title: "Cluster deletion operation failure rate exceeds 15% for 30 minutes"
         summary: "{{ $labels.cluster }}: Cluster deletion operation failure rate exceeds 15% for 30 minutes"
@@ -151,6 +155,7 @@ spec:
         slo: cluster-deletion-timeliness
         short_window: 5m
         long_window: 1h
+        component: slo
       annotations:
         title: "Cluster deletion Timeliness SLO fast burn (>72% slow for 5m)"
         summary: "{{ $labels.cluster }}: Cluster deletion Timeliness SLO fast burn (>72% slow for 5m)"
@@ -170,6 +175,7 @@ spec:
         slo: cluster-deletion-timeliness
         short_window: 30m
         long_window: 6h
+        component: slo
       annotations:
         title: "Cluster deletion Timeliness SLO medium burn (>30% slow for 30m)"
         summary: "{{ $labels.cluster }}: Cluster deletion Timeliness SLO medium burn (>30% slow for 30m)"
@@ -188,6 +194,7 @@ spec:
         severity: "3"
         slo: cluster-deletion-timeliness
         long_window: 3d
+        component: slo
       annotations:
         title: "Cluster deletion Timeliness SLO slow burn (>5% slow for 6h)"
         summary: "{{ $labels.cluster }}: Cluster deletion Timeliness SLO slow burn (>5% slow for 6h)"
@@ -229,9 +236,10 @@ spec:
       labels:
         severity: "3"
         slo: cluster-deletion-stuck
+        component: slo
       annotations:
         title: "Cluster deletion operation stuck in non-terminal phase for over 1 hour"
-        summary: "{{ $labels.cluster }}: Cluster deletion operation stuck in {{ $labels.phase }} for over 1 hour"
+        summary: "{{ $labels.cluster }}: Cluster deletion operation {{ $labels.resource_id }} stuck in {{ $labels.phase }} for over 1 hour"
         description: "Cluster delete operation for {{ $labels.resource_id }} has been in {{ $labels.phase }} phase for over 1 hour. Stuck operations are invisible to success/failure SLIs and require investigation."
         runbook_url: "aka.ms/arohcp-runbook-cluster-deletion"
         correlationId: "userJourneyClusterDeletionStuckOperation/{{ $labels.cluster }}/{{ $labels.resource_id }}"
@@ -252,6 +260,7 @@ spec:
       for: 5m
       labels:
         severity: "4"
+        component: slo
       annotations:
         title: "Cluster deletion controller workqueue depth is high"
         summary: "{{ $labels.cluster }}: Cluster deletion controller workqueue {{ $labels.name }} depth is high"
@@ -277,6 +286,7 @@ spec:
       for: 10m
       labels:
         severity: "4"
+        component: slo
       annotations:
         title: "Cluster deletion controller workqueue in retry hot loop"
         summary: "{{ $labels.cluster }}: Cluster deletion controller workqueue {{ $labels.name }} retry hot loop"

--- a/observability/alerts/HCPClusterDeletion-prometheusRule_test.yaml
+++ b/observability/alerts/HCPClusterDeletion-prometheusRule_test.yaml
@@ -1,0 +1,728 @@
+# promtool unit tests for cluster-deletion-slo-prometheusRule.yaml
+#
+# Design notes:
+# - backend_resource_operation_phase_info is a gauge always equal to 1.
+#   count() over N such series returns N (one per operation).
+# - Recording rules (error_rate, timeliness_error_rate) are evaluated first
+#   at each step; alert expressions then reference those results.
+# - time() at eval_time Nm = N * 60 seconds (promtool starts at Unix epoch 0).
+#   This matters for the stuck-operations alert which compares time() to
+#   last_transition_time_seconds.
+
+rule_files:
+- HCPClusterDeletion-prometheusRule.yaml
+
+evaluation_interval: 1m
+
+tests:
+
+# ─────────────────────────────────────────────────────────────────────────────
+# userJourneyClusterDeletionErrors1h5m
+# Fast burn: error_rate > 0.72 sustained for 5 minutes (14.4× budget burn).
+# Setup: 8 failed + 3 succeeded = 8/11 = 72.7 % > 72 % threshold.
+# ─────────────────────────────────────────────────────────────────────────────
+- name: fast_burn_fires_above_72pct
+  interval: 1m
+  input_series:
+  # 8 failed operations
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="failed",resource_id="r1",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x20"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="failed",resource_id="r2",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x20"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="failed",resource_id="r3",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x20"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="failed",resource_id="r4",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x20"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="failed",resource_id="r5",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x20"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="failed",resource_id="r6",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x20"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="failed",resource_id="r7",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x20"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="failed",resource_id="r8",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x20"
+  # 3 succeeded operations
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s1",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x20"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s2",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x20"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s3",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x20"
+  alert_rule_test:
+  - eval_time: 10m
+    alertname: userJourneyClusterDeletionErrors1h5m
+    exp_alerts:
+    - exp_labels:
+        cluster: svc-1
+        severity: info
+        slo: cluster-deletion-errors
+        short_window: 5m
+        long_window: 1h
+      exp_annotations:
+        title: "Cluster deletion operation error rate high (>72%)"
+        summary: "Cluster deletion operation error rate high (>72%)"
+        description: "More than 72% of cluster delete operations are in failed or canceled state, indicating a fast error budget burn (14.4x) that would exhaust the 95% SLO budget in ~12 hours."
+        runbook_url: "TBD"
+
+# Fast burn does NOT fire when error rate is below 72 %
+# Setup: 5 failed + 8 succeeded = 5/13 = 38.5 % < 72 %
+- name: fast_burn_no_fire_below_72pct
+  interval: 1m
+  input_series:
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="failed",resource_id="r1",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x20"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="failed",resource_id="r2",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x20"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="failed",resource_id="r3",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x20"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="failed",resource_id="r4",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x20"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="failed",resource_id="r5",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x20"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s1",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x20"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s2",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x20"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s3",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x20"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s4",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x20"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s5",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x20"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s6",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x20"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s7",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x20"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s8",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x20"
+  alert_rule_test:
+  - eval_time: 10m
+    alertname: userJourneyClusterDeletionErrors1h5m
+    exp_alerts: []
+
+# ─────────────────────────────────────────────────────────────────────────────
+# userJourneyClusterDeletionErrors6h30m
+# Medium burn: error_rate > 0.30 sustained for 30 minutes (6× budget burn).
+# Setup: 4 failed + 9 succeeded = 4/13 = 30.8 % > 30 % threshold.
+# ─────────────────────────────────────────────────────────────────────────────
+- name: medium_burn_fires_above_30pct
+  interval: 1m
+  input_series:
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="failed",resource_id="r1",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="failed",resource_id="r2",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="failed",resource_id="r3",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="failed",resource_id="r4",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s1",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s2",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s3",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s4",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s5",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s6",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s7",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s8",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s9",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  alert_rule_test:
+  - eval_time: 35m
+    alertname: userJourneyClusterDeletionErrors6h30m
+    exp_alerts:
+    - exp_labels:
+        cluster: svc-1
+        severity: info
+        slo: cluster-deletion-errors
+        short_window: 30m
+        long_window: 6h
+      exp_annotations:
+        title: "Cluster deletion operation error rate elevated (>30%) for 30+ minutes"
+        summary: "Cluster deletion operation error rate elevated (>30%) for 30+ minutes"
+        description: "More than 30% of cluster delete operations are in failed or canceled state sustained over 30 minutes, indicating a medium error budget burn (6x) that would exhaust the 95% SLO budget in ~28 hours."
+        runbook_url: "TBD"
+
+# Medium burn does NOT fire when error rate is below 30 %
+# Setup: 2 failed + 13 succeeded = 2/15 = 13.3 % < 30 %
+- name: medium_burn_no_fire_below_30pct
+  interval: 1m
+  input_series:
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="failed",resource_id="r1",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="failed",resource_id="r2",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s1",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s2",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s3",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s4",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s5",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s6",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s7",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s8",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s9",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s10",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s11",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s12",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s13",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  alert_rule_test:
+  - eval_time: 35m
+    alertname: userJourneyClusterDeletionErrors6h30m
+    exp_alerts: []
+
+# ─────────────────────────────────────────────────────────────────────────────
+# userJourneyClusterDeletionErrors3d
+# Slow burn: error_rate > 0.05 sustained for 6 hours (at SLO boundary).
+# Setup: 2 failed + 19 succeeded = 2/21 = 9.5 % > 5 % threshold.
+# for: 6h = 360 min → fires at eval_time 365m.
+# ─────────────────────────────────────────────────────────────────────────────
+- name: slow_burn_fires_above_5pct
+  interval: 1m
+  input_series:
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="failed",resource_id="r1",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x400"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="failed",resource_id="r2",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x400"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s1",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x400"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s2",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x400"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s3",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x400"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s4",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x400"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s5",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x400"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s6",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x400"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s7",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x400"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s8",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x400"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s9",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x400"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s10",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x400"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s11",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x400"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s12",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x400"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s13",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x400"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s14",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x400"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s15",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x400"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s16",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x400"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s17",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x400"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s18",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x400"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s19",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x400"
+  alert_rule_test:
+  - eval_time: 365m
+    alertname: userJourneyClusterDeletionErrors3d
+    exp_alerts:
+    - exp_labels:
+        cluster: svc-1
+        severity: info
+        slo: cluster-deletion-errors
+        long_window: 3d
+      exp_annotations:
+        title: "Cluster deletion operation error rate exceeds SLO target (>5%) for 6+ hours"
+        summary: "Cluster deletion operation error rate exceeds SLO target (>5%) for 6+ hours"
+        description: "More than 5% of cluster delete operations are in failed or canceled state sustained over 6 hours, indicating persistent degradation at the 95% SLO boundary that would exhaust the error budget in ~7 days."
+        runbook_url: "TBD"
+
+# Slow burn does NOT fire when error rate is at or below 5 %
+# Setup: 1 failed + 19 succeeded = 1/20 = 5% — exactly at boundary, not above
+- name: slow_burn_no_fire_at_boundary
+  interval: 1m
+  input_series:
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="failed",resource_id="r1",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x400"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s1",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x400"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s2",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x400"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s3",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x400"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s4",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x400"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s5",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x400"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s6",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x400"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s7",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x400"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s8",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x400"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s9",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x400"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s10",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x400"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s11",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x400"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s12",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x400"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s13",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x400"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s14",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x400"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s15",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x400"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s16",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x400"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s17",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x400"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s18",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x400"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s19",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x400"
+  alert_rule_test:
+  - eval_time: 365m
+    alertname: userJourneyClusterDeletionErrors3d
+    exp_alerts: []
+
+# ─────────────────────────────────────────────────────────────────────────────
+# userJourneyClusterDeletionErrorsDegradation
+# Early warning: error_rate > 0.15 sustained for 30 minutes.
+# Setup: 2 failed + 11 succeeded = 2/13 = 15.4 % > 15 % threshold.
+# ─────────────────────────────────────────────────────────────────────────────
+- name: degradation_fires_above_15pct
+  interval: 1m
+  input_series:
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="failed",resource_id="r1",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="failed",resource_id="r2",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s1",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s2",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s3",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s4",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s5",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s6",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s7",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s8",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s9",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s10",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s11",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  alert_rule_test:
+  - eval_time: 35m
+    alertname: userJourneyClusterDeletionErrorsDegradation
+    exp_alerts:
+    - exp_labels:
+        cluster: svc-1
+        severity: info
+        slo: cluster-deletion-errors
+      exp_annotations:
+        title: "Cluster deletion operation failure rate exceeds 15% for 30 minutes"
+        summary: "Cluster deletion operation failure rate exceeds 15% for 30 minutes"
+        description: "The cluster deletion operation failure rate has been above 15% for 30 minutes. This provides early warning of degradation before SLO-based burn rate alerts fire."
+        runbook_url: "TBD"
+
+# Degradation does NOT fire when error rate is healthy (below 15 %)
+# Setup: 0 failed + 10 succeeded = 0 %
+- name: degradation_no_fire_healthy
+  interval: 1m
+  input_series:
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s1",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s2",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  alert_rule_test:
+  - eval_time: 35m
+    alertname: userJourneyClusterDeletionErrorsDegradation
+    exp_alerts: []
+
+# ─────────────────────────────────────────────────────────────────────────────
+# userJourneyClusterDeletionLatencySLOBreach
+# Timeliness SLO: timeliness_error_rate > 0.05 sustained for 30 minutes.
+# Setup: 2 slow ops (duration=1900s > 1800s) + 18 fast ops (duration=600s) = 10 % > 5 %.
+# start_time and last_transition_time are set as constant gauge values.
+# Their difference gives operation duration independently of time().
+# ─────────────────────────────────────────────────────────────────────────────
+- name: timeliness_breach_fires
+  interval: 1m
+  input_series:
+  # 2 slow operations: last_transition - start = 1900 - 0 = 1900s (31.7 min > 30 min threshold)
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="slow1",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_start_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="slow1",subscription_id="sub1", cluster="svc-1"}'
+    values: "0+0x40"
+  - series: 'backend_resource_operation_last_transition_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="slow1",subscription_id="sub1", cluster="svc-1"}'
+    values: "1900+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="slow2",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_start_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="slow2",subscription_id="sub1", cluster="svc-1"}'
+    values: "0+0x40"
+  - series: 'backend_resource_operation_last_transition_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="slow2",subscription_id="sub1", cluster="svc-1"}'
+    values: "1900+0x40"
+  # 18 fast operations: last_transition - start = 600 - 0 = 600s (10 min < 30 min)
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast1",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_start_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast1",subscription_id="sub1", cluster="svc-1"}'
+    values: "0+0x40"
+  - series: 'backend_resource_operation_last_transition_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast1",subscription_id="sub1", cluster="svc-1"}'
+    values: "600+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast2",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_start_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast2",subscription_id="sub1", cluster="svc-1"}'
+    values: "0+0x40"
+  - series: 'backend_resource_operation_last_transition_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast2",subscription_id="sub1", cluster="svc-1"}'
+    values: "600+0x40"
+  alert_rule_test:
+  - eval_time: 35m
+    alertname: userJourneyClusterDeletionLatencySLOBreach
+    exp_alerts:
+    - exp_labels:
+        cluster: svc-1
+        severity: info
+        slo: cluster-deletion-timeliness
+      exp_annotations:
+        title: "Cluster deletion Timeliness SLO breach: >5% of deletes exceed 30 minutes"
+        summary: "Cluster deletion Timeliness SLO breach: >5% of deletes exceed 30 minutes"
+        description: "More than 5% of successful cluster delete operations took longer than 30 minutes, sustained over 30 minutes. This violates the Timeliness SLO target of ≥95% completion within 30 minutes."
+        runbook_url: "TBD"
+
+# Timeliness does NOT fire when all operations are fast (all <30 min)
+- name: timeliness_no_fire_all_fast
+  interval: 1m
+  input_series:
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast1",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_start_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast1",subscription_id="sub1", cluster="svc-1"}'
+    values: "0+0x40"
+  - series: 'backend_resource_operation_last_transition_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast1",subscription_id="sub1", cluster="svc-1"}'
+    values: "600+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast2",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_start_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast2",subscription_id="sub1", cluster="svc-1"}'
+    values: "0+0x40"
+  - series: 'backend_resource_operation_last_transition_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast2",subscription_id="sub1", cluster="svc-1"}'
+    values: "600+0x40"
+  alert_rule_test:
+  - eval_time: 35m
+    alertname: userJourneyClusterDeletionLatencySLOBreach
+    exp_alerts: []
+
+# ─────────────────────────────────────────────────────────────────────────────
+# userJourneyClusterDeletionStuckOperation
+# Fires when an operation has been in the same non-terminal phase for >1 hour,
+# sustained for 15 minutes (for: 15m).
+#
+# time() at eval_time Nm = N * 60 seconds (promtool starts at Unix epoch 0).
+# last_transition_time = 0 → at eval_time 61m, time()-0 = 3660 > 3600.
+# for: 15m → alert fires at eval_time 61+15 = 76m. Test at 80m.
+# ─────────────────────────────────────────────────────────────────────────────
+- name: stuck_operation_fires_after_1_hour
+  interval: 1m
+  input_series:
+  # Operation stuck in "deleting" phase since epoch (last_transition_time=0)
+  # Two Prometheus replicas — max without(prometheus_replica) deduplicates to one alert
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="deleting",resource_id="stuck1",subscription_id="sub1",cluster="svc-1",prometheus_replica="prom-0"}'
+    values: "1+0x100"
+  - series: 'backend_resource_operation_last_transition_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="deleting",resource_id="stuck1",subscription_id="sub1",cluster="svc-1",prometheus_replica="prom-0"}'
+    values: "0+0x100"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="deleting",resource_id="stuck1",subscription_id="sub1",cluster="svc-1",prometheus_replica="prom-1"}'
+    values: "1+0x100"
+  - series: 'backend_resource_operation_last_transition_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="deleting",resource_id="stuck1",subscription_id="sub1",cluster="svc-1",prometheus_replica="prom-1"}'
+    values: "0+0x100"
+  alert_rule_test:
+  - eval_time: 80m
+    alertname: userJourneyClusterDeletionStuckOperation
+    exp_alerts:
+    - exp_labels:
+        cluster: svc-1
+        severity: info
+        slo: cluster-deletion-stuck
+        operation_type: delete
+        phase: deleting
+        resource_id: stuck1
+        resource_type: microsoft.redhatopenshift/hcpopenshiftclusters
+        subscription_id: sub1
+      exp_annotations:
+        title: "Cluster deletion operation stuck in non-terminal phase for over 1 hour"
+        summary: "Cluster deletion operation stuck in non-terminal phase for over 1 hour"
+        correlationId: "userJourneyClusterDeletionStuckOperation/svc-1/stuck1"
+        description: "Cluster delete operation for stuck1 has been in deleting phase for over 1 hour. Stuck operations are invisible to success/failure SLIs and require investigation."
+        runbook_url: "TBD"
+
+# Stuck does NOT fire for operations that are less than 1 hour old
+# last_transition_time = 0, eval at 30m → time()-0 = 1800 < 3600
+- name: stuck_no_fire_operation_under_1_hour
+  interval: 1m
+  input_series:
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="deleting",resource_id="new1",subscription_id="sub1",cluster="svc-1",prometheus_replica="prom-0"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_last_transition_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="deleting",resource_id="new1",subscription_id="sub1",cluster="svc-1",prometheus_replica="prom-0"}'
+    values: "0+0x40"
+  alert_rule_test:
+  - eval_time: 30m
+    alertname: userJourneyClusterDeletionStuckOperation
+    exp_alerts: []
+
+# ─────────────────────────────────────────────────────────────────────────────
+# userJourneyClusterDeletionQueueDepth
+# Fires when workqueue depth > 10 sustained for 5 minutes.
+# ─────────────────────────────────────────────────────────────────────────────
+- name: queue_depth_fires_above_10
+  interval: 1m
+  input_series:
+  - series: 'workqueue_depth{namespace="aro-hcp",name="OperationClusterDelete",cluster="svc-1"}'
+    values: "15+0x15"
+  alert_rule_test:
+  - eval_time: 10m
+    alertname: userJourneyClusterDeletionQueueDepth
+    exp_alerts:
+    - exp_labels:
+        cluster: svc-1
+        name: OperationClusterDelete
+        severity: info
+      exp_annotations:
+        title: "Cluster deletion controller workqueue depth is high"
+        summary: "Cluster deletion controller workqueue depth is high"
+        description: "Cluster deletion controller workqueue OperationClusterDelete has had a depth > 10 for more than 5 minutes, indicating work is accumulating faster than it can be processed."
+        runbook_url: "TBD"
+
+# Queue depth does NOT fire when depth is at or below threshold
+- name: queue_depth_no_fire_at_threshold
+  interval: 1m
+  input_series:
+  - series: 'workqueue_depth{namespace="aro-hcp",name="OperationClusterDelete",cluster="svc-1"}'
+    values: "10+0x15"
+  alert_rule_test:
+  - eval_time: 10m
+    alertname: userJourneyClusterDeletionQueueDepth
+    exp_alerts: []
+
+# ─────────────────────────────────────────────────────────────────────────────
+# userJourneyClusterDeletionRetryHotLoop
+# Fires when retry ratio > 50% sustained for 10 minutes.
+# retries grow at 3/min, adds grow at 4/min → rate ratio = 3/4 = 75 % > 50 %.
+# rate([10m]) needs 10+ data points; for: 10m → eval_time: 25m.
+# ─────────────────────────────────────────────────────────────────────────────
+- name: retry_hot_loop_fires_above_50pct
+  interval: 1m
+  input_series:
+  - series: 'workqueue_retries_total{namespace="aro-hcp",name="OperationClusterDelete",cluster="svc-1"}'
+    values: "0+3x30"
+  - series: 'workqueue_adds_total{namespace="aro-hcp",name="OperationClusterDelete",cluster="svc-1"}'
+    values: "0+4x30"
+  alert_rule_test:
+  - eval_time: 25m
+    alertname: userJourneyClusterDeletionRetryHotLoop
+    exp_alerts:
+    - exp_labels:
+        cluster: svc-1
+        name: OperationClusterDelete
+        severity: info
+      exp_annotations:
+        title: "Cluster deletion controller workqueue in retry hot loop"
+        summary: "Cluster deletion controller workqueue in retry hot loop"
+        description: "Cluster deletion controller workqueue OperationClusterDelete has a retry ratio > 50% sustained over 10 minutes, indicating most queue activity is failed retries rather than fresh work."
+        runbook_url: "TBD"
+
+# Retry hot loop does NOT fire when retry ratio is healthy (below 50 %)
+# retries grow at 1/min, adds grow at 4/min → ratio = 25 % < 50 %
+- name: retry_hot_loop_no_fire_healthy_ratio
+  interval: 1m
+  input_series:
+  - series: 'workqueue_retries_total{namespace="aro-hcp",name="OperationClusterDelete",cluster="svc-1"}'
+    values: "0+1x30"
+  - series: 'workqueue_adds_total{namespace="aro-hcp",name="OperationClusterDelete",cluster="svc-1"}'
+    values: "0+4x30"
+  alert_rule_test:
+  - eval_time: 25m
+    alertname: userJourneyClusterDeletionRetryHotLoop
+    exp_alerts: []
+
+# ─────────────────────────────────────────────────────────────────────────────
+# All succeeded, no failures, all fast operations.
+# Verifies:
+#   - error_rate recording rule = 0
+#   - timeliness_error_rate recording rule = 0
+#   - Every SLO and component alert is silent
+# ─────────────────────────────────────────────────────────────────────────────
+- name: all_clear_healthy_baseline
+  interval: 1m
+  input_series:
+  # 5 successful fast operations — all three metrics provided so both
+  # recording rules can evaluate correctly.
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="h1",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_start_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="h1",subscription_id="sub1", cluster="svc-1"}'
+    values: "0+0x15"
+  - series: 'backend_resource_operation_last_transition_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="h1",subscription_id="sub1", cluster="svc-1"}'
+    values: "600+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="h2",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_start_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="h2",subscription_id="sub1", cluster="svc-1"}'
+    values: "0+0x15"
+  - series: 'backend_resource_operation_last_transition_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="h2",subscription_id="sub1", cluster="svc-1"}'
+    values: "600+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="h3",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_start_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="h3",subscription_id="sub1", cluster="svc-1"}'
+    values: "0+0x15"
+  - series: 'backend_resource_operation_last_transition_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="h3",subscription_id="sub1", cluster="svc-1"}'
+    values: "600+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="h4",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_start_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="h4",subscription_id="sub1", cluster="svc-1"}'
+    values: "0+0x15"
+  - series: 'backend_resource_operation_last_transition_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="h4",subscription_id="sub1", cluster="svc-1"}'
+    values: "600+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="h5",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_start_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="h5",subscription_id="sub1", cluster="svc-1"}'
+    values: "0+0x15"
+  - series: 'backend_resource_operation_last_transition_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="h5",subscription_id="sub1", cluster="svc-1"}'
+    values: "600+0x15"
+  promql_expr_test:
+  # error_rate: 0 failed out of 5 terminal = 0
+  - expr: errors:backend_cluster_deletion_operation:error_rate
+    eval_time: 10m
+    exp_samples:
+    - labels: 'errors:backend_cluster_deletion_operation:error_rate{cluster="svc-1"}'
+      value: 0
+  # timeliness_error_rate: 0 slow out of 5 succeeded = 0
+  - expr: errors:backend_cluster_deletion_operation:timeliness_error_rate
+    eval_time: 10m
+    exp_samples:
+    - labels: 'errors:backend_cluster_deletion_operation:timeliness_error_rate{cluster="svc-1"}'
+      value: 0
+  alert_rule_test:
+  - eval_time: 10m
+    alertname: userJourneyClusterDeletionErrors1h5m
+  - eval_time: 10m
+    alertname: userJourneyClusterDeletionErrors6h30m
+  - eval_time: 10m
+    alertname: userJourneyClusterDeletionErrors3d
+  - eval_time: 10m
+    alertname: userJourneyClusterDeletionErrorsDegradation
+  - eval_time: 10m
+    alertname: userJourneyClusterDeletionLatencySLOBreach
+  - eval_time: 10m
+    alertname: userJourneyClusterDeletionStuckOperation
+  - eval_time: 10m
+    alertname: userJourneyClusterDeletionQueueDepth
+  - eval_time: 10m
+    alertname: userJourneyClusterDeletionRetryHotLoop
+
+# ─────────────────────────────────────────────────────────────────────────────
+# error_rate recording rule math
+# 8 failed + 2 succeeded = 8/10 = 0.8 (clean decimal, easy to verify)
+# Confirms the count() formula produces the correct ratio.
+# ─────────────────────────────────────────────────────────────────────────────
+- name: error_rate_recording_rule_math
+  interval: 1m
+  input_series:
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="failed",resource_id="f1",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="failed",resource_id="f2",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="failed",resource_id="f3",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="failed",resource_id="f4",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="failed",resource_id="f5",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="failed",resource_id="f6",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="failed",resource_id="f7",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="failed",resource_id="f8",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s1",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s2",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x15"
+  promql_expr_test:
+  - expr: errors:backend_cluster_deletion_operation:error_rate
+    eval_time: 10m
+    exp_samples:
+    - labels: 'errors:backend_cluster_deletion_operation:error_rate{cluster="svc-1"}'
+      value: 0.8
+
+# ─────────────────────────────────────────────────────────────────────────────
+# timeliness_error_rate recording rule
+# 1 slow op (duration=1900s > 1800s) + 4 fast ops (duration=600s < 1800s)
+# = 1/5 = 0.2 (clean decimal, easy to verify)
+# Confirms that last_transition_time - start_time is correctly compared
+# against the 1800-second (30-minute) threshold.
+# ─────────────────────────────────────────────────────────────────────────────
+- name: timeliness_error_rate_recording_rule_math
+  interval: 1m
+  input_series:
+  # 1 slow operation: duration = 1900 - 0 = 1900s (31.7 min, exceeds 30-min threshold)
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="slow1",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_start_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="slow1",subscription_id="sub1", cluster="svc-1"}'
+    values: "0+0x15"
+  - series: 'backend_resource_operation_last_transition_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="slow1",subscription_id="sub1", cluster="svc-1"}'
+    values: "1900+0x15"
+  # 4 fast operations: duration = 600 - 0 = 600s (10 min, under threshold)
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast1",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_start_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast1",subscription_id="sub1", cluster="svc-1"}'
+    values: "0+0x15"
+  - series: 'backend_resource_operation_last_transition_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast1",subscription_id="sub1", cluster="svc-1"}'
+    values: "600+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast2",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_start_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast2",subscription_id="sub1", cluster="svc-1"}'
+    values: "0+0x15"
+  - series: 'backend_resource_operation_last_transition_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast2",subscription_id="sub1", cluster="svc-1"}'
+    values: "600+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast3",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_start_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast3",subscription_id="sub1", cluster="svc-1"}'
+    values: "0+0x15"
+  - series: 'backend_resource_operation_last_transition_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast3",subscription_id="sub1", cluster="svc-1"}'
+    values: "600+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast4",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_start_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast4",subscription_id="sub1", cluster="svc-1"}'
+    values: "0+0x15"
+  - series: 'backend_resource_operation_last_transition_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast4",subscription_id="sub1", cluster="svc-1"}'
+    values: "600+0x15"
+  promql_expr_test:
+  - expr: errors:backend_cluster_deletion_operation:timeliness_error_rate
+    eval_time: 10m
+    exp_samples:
+    - labels: 'errors:backend_cluster_deletion_operation:timeliness_error_rate{cluster="svc-1"}'
+      value: 0.2

--- a/observability/alerts/HCPClusterDeletion-prometheusRule_test.yaml
+++ b/observability/alerts/HCPClusterDeletion-prometheusRule_test.yaml
@@ -56,6 +56,7 @@ tests:
         slo: cluster-deletion-errors
         short_window: 5m
         long_window: 1h
+        component: slo
       exp_annotations:
         title: "Cluster deletion operation error rate high (>72%)"
         summary: "svc-1: Cluster deletion operation error rate high (>72%)"
@@ -141,6 +142,7 @@ tests:
         slo: cluster-deletion-errors
         short_window: 30m
         long_window: 6h
+        component: slo
       exp_annotations:
         title: "Cluster deletion operation error rate elevated (>30%) for 30+ minutes"
         summary: "svc-1: Cluster deletion operation error rate elevated (>30%) for 30+ minutes"
@@ -246,6 +248,7 @@ tests:
         severity: "3"
         slo: cluster-deletion-errors
         long_window: 3d
+        component: slo
       exp_annotations:
         title: "Cluster deletion operation error rate exceeds SLO target (>5%) for 6+ hours"
         summary: "svc-1: Cluster deletion operation error rate exceeds SLO target (>5%) for 6+ hours"
@@ -343,6 +346,7 @@ tests:
         cluster: svc-1
         severity: "3"
         slo: cluster-deletion-errors
+        component: slo
       exp_annotations:
         title: "Cluster deletion operation failure rate exceeds 15% for 30 minutes"
         summary: "svc-1: Cluster deletion operation failure rate exceeds 15% for 30 minutes"
@@ -442,6 +446,7 @@ tests:
         slo: cluster-deletion-timeliness
         short_window: 5m
         long_window: 1h
+        component: slo
       exp_annotations:
         title: "Cluster deletion Timeliness SLO fast burn (>72% slow for 5m)"
         summary: "svc-1: Cluster deletion Timeliness SLO fast burn (>72% slow for 5m)"
@@ -492,6 +497,7 @@ tests:
         slo: cluster-deletion-timeliness
         short_window: 30m
         long_window: 6h
+        component: slo
       exp_annotations:
         title: "Cluster deletion Timeliness SLO medium burn (>30% slow for 30m)"
         summary: "svc-1: Cluster deletion Timeliness SLO medium burn (>30% slow for 30m)"
@@ -548,6 +554,7 @@ tests:
         cluster: svc-1
         severity: "3"
         slo: cluster-deletion-stuck
+        component: slo
         operation_type: delete
         phase: deleting
         resource_id: stuck1
@@ -555,7 +562,7 @@ tests:
         subscription_id: sub1
       exp_annotations:
         title: "Cluster deletion operation stuck in non-terminal phase for over 1 hour"
-        summary: "svc-1: Cluster deletion operation stuck in deleting for over 1 hour"
+        summary: "svc-1: Cluster deletion operation stuck1 stuck in deleting for over 1 hour"
         correlationId: "userJourneyClusterDeletionStuckOperation/svc-1/stuck1"
         description: "Cluster delete operation for stuck1 has been in deleting phase for over 1 hour. Stuck operations are invisible to success/failure SLIs and require investigation."
         runbook_url: "aka.ms/arohcp-runbook-cluster-deletion"
@@ -589,6 +596,7 @@ tests:
         cluster: svc-1
         name: OperationClusterDelete
         severity: "4"
+        component: slo
       exp_annotations:
         title: "Cluster deletion controller workqueue depth is high"
         summary: "svc-1: Cluster deletion controller workqueue OperationClusterDelete depth is high"
@@ -626,6 +634,7 @@ tests:
         cluster: svc-1
         name: OperationClusterDelete
         severity: "4"
+        component: slo
       exp_annotations:
         title: "Cluster deletion controller workqueue in retry hot loop"
         summary: "svc-1: Cluster deletion controller workqueue OperationClusterDelete retry hot loop"

--- a/observability/alerts/HCPClusterDeletion-prometheusRule_test.yaml
+++ b/observability/alerts/HCPClusterDeletion-prometheusRule_test.yaml
@@ -1,4 +1,5 @@
 # promtool unit tests for cluster-deletion-slo-prometheusRule.yaml
+# Run with: promtool test rules cluster-deletion-slo-prometheusRule_test.yaml
 #
 # Design notes:
 # - backend_resource_operation_phase_info is a gauge always equal to 1.
@@ -8,14 +9,11 @@
 # - time() at eval_time Nm = N * 60 seconds (promtool starts at Unix epoch 0).
 #   This matters for the stuck-operations alert which compares time() to
 #   last_transition_time_seconds.
-
 rule_files:
 - HCPClusterDeletion-prometheusRule.yaml
-
+- cluster-deletion-slo-recordingRule.yaml
 evaluation_interval: 1m
-
 tests:
-
 # ─────────────────────────────────────────────────────────────────────────────
 # userJourneyClusterDeletionErrors1h5m
 # Fast burn: error_rate > 0.72 sustained for 5 minutes (14.4× budget burn).
@@ -54,16 +52,16 @@ tests:
     exp_alerts:
     - exp_labels:
         cluster: svc-1
-        severity: info
+        severity: "3"
         slo: cluster-deletion-errors
         short_window: 5m
         long_window: 1h
       exp_annotations:
         title: "Cluster deletion operation error rate high (>72%)"
-        summary: "Cluster deletion operation error rate high (>72%)"
+        summary: "svc-1: Cluster deletion operation error rate high (>72%)"
         description: "More than 72% of cluster delete operations are in failed or canceled state, indicating a fast error budget burn (14.4x) that would exhaust the 95% SLO budget in ~12 hours."
-        runbook_url: "TBD"
-
+        runbook_url: "aka.ms/arohcp-runbook-cluster-deletion"
+        correlationId: "userJourneyClusterDeletionErrors1h5m/svc-1"
 # Fast burn does NOT fire when error rate is below 72 %
 # Setup: 5 failed + 8 succeeded = 5/13 = 38.5 % < 72 %
 - name: fast_burn_no_fire_below_72pct
@@ -99,7 +97,6 @@ tests:
   - eval_time: 10m
     alertname: userJourneyClusterDeletionErrors1h5m
     exp_alerts: []
-
 # ─────────────────────────────────────────────────────────────────────────────
 # userJourneyClusterDeletionErrors6h30m
 # Medium burn: error_rate > 0.30 sustained for 30 minutes (6× budget burn).
@@ -140,16 +137,16 @@ tests:
     exp_alerts:
     - exp_labels:
         cluster: svc-1
-        severity: info
+        severity: "3"
         slo: cluster-deletion-errors
         short_window: 30m
         long_window: 6h
       exp_annotations:
         title: "Cluster deletion operation error rate elevated (>30%) for 30+ minutes"
-        summary: "Cluster deletion operation error rate elevated (>30%) for 30+ minutes"
+        summary: "svc-1: Cluster deletion operation error rate elevated (>30%) for 30+ minutes"
         description: "More than 30% of cluster delete operations are in failed or canceled state sustained over 30 minutes, indicating a medium error budget burn (6x) that would exhaust the 95% SLO budget in ~28 hours."
-        runbook_url: "TBD"
-
+        runbook_url: "aka.ms/arohcp-runbook-cluster-deletion"
+        correlationId: "userJourneyClusterDeletionErrors6h30m/svc-1"
 # Medium burn does NOT fire when error rate is below 30 %
 # Setup: 2 failed + 13 succeeded = 2/15 = 13.3 % < 30 %
 - name: medium_burn_no_fire_below_30pct
@@ -189,7 +186,6 @@ tests:
   - eval_time: 35m
     alertname: userJourneyClusterDeletionErrors6h30m
     exp_alerts: []
-
 # ─────────────────────────────────────────────────────────────────────────────
 # userJourneyClusterDeletionErrors3d
 # Slow burn: error_rate > 0.05 sustained for 6 hours (at SLO boundary).
@@ -247,15 +243,15 @@ tests:
     exp_alerts:
     - exp_labels:
         cluster: svc-1
-        severity: info
+        severity: "3"
         slo: cluster-deletion-errors
         long_window: 3d
       exp_annotations:
         title: "Cluster deletion operation error rate exceeds SLO target (>5%) for 6+ hours"
-        summary: "Cluster deletion operation error rate exceeds SLO target (>5%) for 6+ hours"
+        summary: "svc-1: Cluster deletion operation error rate exceeds SLO target (>5%) for 6+ hours"
         description: "More than 5% of cluster delete operations are in failed or canceled state sustained over 6 hours, indicating persistent degradation at the 95% SLO boundary that would exhaust the error budget in ~7 days."
-        runbook_url: "TBD"
-
+        runbook_url: "aka.ms/arohcp-runbook-cluster-deletion"
+        correlationId: "userJourneyClusterDeletionErrors3d/svc-1"
 # Slow burn does NOT fire when error rate is at or below 5 %
 # Setup: 1 failed + 19 succeeded = 1/20 = 5% — exactly at boundary, not above
 - name: slow_burn_no_fire_at_boundary
@@ -305,7 +301,6 @@ tests:
   - eval_time: 365m
     alertname: userJourneyClusterDeletionErrors3d
     exp_alerts: []
-
 # ─────────────────────────────────────────────────────────────────────────────
 # userJourneyClusterDeletionErrorsDegradation
 # Early warning: error_rate > 0.15 sustained for 30 minutes.
@@ -346,14 +341,14 @@ tests:
     exp_alerts:
     - exp_labels:
         cluster: svc-1
-        severity: info
+        severity: "3"
         slo: cluster-deletion-errors
       exp_annotations:
         title: "Cluster deletion operation failure rate exceeds 15% for 30 minutes"
-        summary: "Cluster deletion operation failure rate exceeds 15% for 30 minutes"
+        summary: "svc-1: Cluster deletion operation failure rate exceeds 15% for 30 minutes"
         description: "The cluster deletion operation failure rate has been above 15% for 30 minutes. This provides early warning of degradation before SLO-based burn rate alerts fire."
-        runbook_url: "TBD"
-
+        runbook_url: "aka.ms/arohcp-runbook-cluster-deletion"
+        correlationId: "userJourneyClusterDeletionErrorsDegradation/svc-1"
 # Degradation does NOT fire when error rate is healthy (below 15 %)
 # Setup: 0 failed + 10 succeeded = 0 %
 - name: degradation_no_fire_healthy
@@ -367,15 +362,98 @@ tests:
   - eval_time: 35m
     alertname: userJourneyClusterDeletionErrorsDegradation
     exp_alerts: []
-
 # ─────────────────────────────────────────────────────────────────────────────
-# userJourneyClusterDeletionLatencySLOBreach
-# Timeliness SLO: timeliness_error_rate > 0.05 sustained for 30 minutes.
-# Setup: 2 slow ops (duration=1900s > 1800s) + 18 fast ops (duration=600s) = 10 % > 5 %.
-# start_time and last_transition_time are set as constant gauge values.
-# Their difference gives operation duration independently of time().
+# userJourneyClusterDeletionLatency1h5m
+# Timeliness fast burn: timeliness_error_rate > 0.72 sustained for 5 minutes.
+# Setup: 8 slow ops + 2 fast ops = 8/10 = 80% > 72% threshold.
 # ─────────────────────────────────────────────────────────────────────────────
-- name: timeliness_breach_fires
+- name: timeliness_fast_burn_fires
+  interval: 1m
+  input_series:
+  # 8 slow operations: duration = 1900s > 1800s (30 min threshold)
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="slow1",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x20"
+  - series: 'backend_resource_operation_start_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="slow1",subscription_id="sub1", cluster="svc-1"}'
+    values: "0+0x20"
+  - series: 'backend_resource_operation_last_transition_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="slow1",subscription_id="sub1", cluster="svc-1"}'
+    values: "1900+0x20"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="slow2",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x20"
+  - series: 'backend_resource_operation_start_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="slow2",subscription_id="sub1", cluster="svc-1"}'
+    values: "0+0x20"
+  - series: 'backend_resource_operation_last_transition_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="slow2",subscription_id="sub1", cluster="svc-1"}'
+    values: "1900+0x20"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="slow3",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x20"
+  - series: 'backend_resource_operation_start_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="slow3",subscription_id="sub1", cluster="svc-1"}'
+    values: "0+0x20"
+  - series: 'backend_resource_operation_last_transition_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="slow3",subscription_id="sub1", cluster="svc-1"}'
+    values: "1900+0x20"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="slow4",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x20"
+  - series: 'backend_resource_operation_start_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="slow4",subscription_id="sub1", cluster="svc-1"}'
+    values: "0+0x20"
+  - series: 'backend_resource_operation_last_transition_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="slow4",subscription_id="sub1", cluster="svc-1"}'
+    values: "1900+0x20"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="slow5",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x20"
+  - series: 'backend_resource_operation_start_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="slow5",subscription_id="sub1", cluster="svc-1"}'
+    values: "0+0x20"
+  - series: 'backend_resource_operation_last_transition_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="slow5",subscription_id="sub1", cluster="svc-1"}'
+    values: "1900+0x20"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="slow6",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x20"
+  - series: 'backend_resource_operation_start_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="slow6",subscription_id="sub1", cluster="svc-1"}'
+    values: "0+0x20"
+  - series: 'backend_resource_operation_last_transition_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="slow6",subscription_id="sub1", cluster="svc-1"}'
+    values: "1900+0x20"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="slow7",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x20"
+  - series: 'backend_resource_operation_start_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="slow7",subscription_id="sub1", cluster="svc-1"}'
+    values: "0+0x20"
+  - series: 'backend_resource_operation_last_transition_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="slow7",subscription_id="sub1", cluster="svc-1"}'
+    values: "1900+0x20"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="slow8",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x20"
+  - series: 'backend_resource_operation_start_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="slow8",subscription_id="sub1", cluster="svc-1"}'
+    values: "0+0x20"
+  - series: 'backend_resource_operation_last_transition_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="slow8",subscription_id="sub1", cluster="svc-1"}'
+    values: "1900+0x20"
+  # 2 fast operations: duration = 600s < 1800s
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast1",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x20"
+  - series: 'backend_resource_operation_start_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast1",subscription_id="sub1", cluster="svc-1"}'
+    values: "0+0x20"
+  - series: 'backend_resource_operation_last_transition_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast1",subscription_id="sub1", cluster="svc-1"}'
+    values: "600+0x20"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast2",subscription_id="sub1", cluster="svc-1"}'
+    values: "1+0x20"
+  - series: 'backend_resource_operation_start_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast2",subscription_id="sub1", cluster="svc-1"}'
+    values: "0+0x20"
+  - series: 'backend_resource_operation_last_transition_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast2",subscription_id="sub1", cluster="svc-1"}'
+    values: "600+0x20"
+  alert_rule_test:
+  - eval_time: 10m
+    alertname: userJourneyClusterDeletionLatency1h5m
+    exp_alerts:
+    - exp_labels:
+        cluster: svc-1
+        severity: "3"
+        slo: cluster-deletion-timeliness
+        short_window: 5m
+        long_window: 1h
+      exp_annotations:
+        title: "Cluster deletion Timeliness SLO fast burn (>72% slow for 5m)"
+        summary: "svc-1: Cluster deletion Timeliness SLO fast burn (>72% slow for 5m)"
+        description: "More than 72% of successful cluster deletes exceeded 30 minutes, sustained for 5 minutes. Fast burn rate (14.4x) against the 95% Timeliness SLO — on track to exhaust the budget in ~12 hours."
+        runbook_url: "aka.ms/arohcp-runbook-cluster-deletion"
+        correlationId: "userJourneyClusterDeletionLatency1h5m/svc-1"
+# ─────────────────────────────────────────────────────────────────────────────
+# userJourneyClusterDeletionLatency6h30m
+# Timeliness medium burn: timeliness_error_rate > 0.30 sustained for 30 minutes.
+# Setup: 2 slow ops + 2 fast ops = 2/4 = 50% > 30% threshold.
+# ─────────────────────────────────────────────────────────────────────────────
+- name: timeliness_medium_burn_fires
   interval: 1m
   input_series:
   # 2 slow operations: last_transition - start = 1900 - 0 = 1900s (31.7 min > 30 min threshold)
@@ -391,7 +469,7 @@ tests:
     values: "0+0x40"
   - series: 'backend_resource_operation_last_transition_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="slow2",subscription_id="sub1", cluster="svc-1"}'
     values: "1900+0x40"
-  # 18 fast operations: last_transition - start = 600 - 0 = 600s (10 min < 30 min)
+  # 2 fast operations: last_transition - start = 600 - 0 = 600s (10 min < 30 min)
   - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast1",subscription_id="sub1", cluster="svc-1"}'
     values: "1+0x40"
   - series: 'backend_resource_operation_start_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast1",subscription_id="sub1", cluster="svc-1"}'
@@ -406,18 +484,20 @@ tests:
     values: "600+0x40"
   alert_rule_test:
   - eval_time: 35m
-    alertname: userJourneyClusterDeletionLatencySLOBreach
+    alertname: userJourneyClusterDeletionLatency6h30m
     exp_alerts:
     - exp_labels:
         cluster: svc-1
-        severity: info
+        severity: "3"
         slo: cluster-deletion-timeliness
+        short_window: 30m
+        long_window: 6h
       exp_annotations:
-        title: "Cluster deletion Timeliness SLO breach: >5% of deletes exceed 30 minutes"
-        summary: "Cluster deletion Timeliness SLO breach: >5% of deletes exceed 30 minutes"
-        description: "More than 5% of successful cluster delete operations took longer than 30 minutes, sustained over 30 minutes. This violates the Timeliness SLO target of ≥95% completion within 30 minutes."
-        runbook_url: "TBD"
-
+        title: "Cluster deletion Timeliness SLO medium burn (>30% slow for 30m)"
+        summary: "svc-1: Cluster deletion Timeliness SLO medium burn (>30% slow for 30m)"
+        description: "More than 30% of successful cluster deletes exceeded 30 minutes, sustained for 30 minutes. Medium burn rate (6x) against the 95% Timeliness SLO — on track to exhaust the budget in ~28 hours."
+        runbook_url: "aka.ms/arohcp-runbook-cluster-deletion"
+        correlationId: "userJourneyClusterDeletionLatency6h30m/svc-1"
 # Timeliness does NOT fire when all operations are fast (all <30 min)
 - name: timeliness_no_fire_all_fast
   interval: 1m
@@ -436,9 +516,8 @@ tests:
     values: "600+0x40"
   alert_rule_test:
   - eval_time: 35m
-    alertname: userJourneyClusterDeletionLatencySLOBreach
+    alertname: userJourneyClusterDeletionLatency6h30m
     exp_alerts: []
-
 # ─────────────────────────────────────────────────────────────────────────────
 # userJourneyClusterDeletionStuckOperation
 # Fires when an operation has been in the same non-terminal phase for >1 hour,
@@ -467,7 +546,7 @@ tests:
     exp_alerts:
     - exp_labels:
         cluster: svc-1
-        severity: info
+        severity: "3"
         slo: cluster-deletion-stuck
         operation_type: delete
         phase: deleting
@@ -476,11 +555,10 @@ tests:
         subscription_id: sub1
       exp_annotations:
         title: "Cluster deletion operation stuck in non-terminal phase for over 1 hour"
-        summary: "Cluster deletion operation stuck in non-terminal phase for over 1 hour"
+        summary: "svc-1: Cluster deletion operation stuck in deleting for over 1 hour"
         correlationId: "userJourneyClusterDeletionStuckOperation/svc-1/stuck1"
         description: "Cluster delete operation for stuck1 has been in deleting phase for over 1 hour. Stuck operations are invisible to success/failure SLIs and require investigation."
-        runbook_url: "TBD"
-
+        runbook_url: "aka.ms/arohcp-runbook-cluster-deletion"
 # Stuck does NOT fire for operations that are less than 1 hour old
 # last_transition_time = 0, eval at 30m → time()-0 = 1800 < 3600
 - name: stuck_no_fire_operation_under_1_hour
@@ -494,7 +572,6 @@ tests:
   - eval_time: 30m
     alertname: userJourneyClusterDeletionStuckOperation
     exp_alerts: []
-
 # ─────────────────────────────────────────────────────────────────────────────
 # userJourneyClusterDeletionQueueDepth
 # Fires when workqueue depth > 10 sustained for 5 minutes.
@@ -511,13 +588,13 @@ tests:
     - exp_labels:
         cluster: svc-1
         name: OperationClusterDelete
-        severity: info
+        severity: "4"
       exp_annotations:
         title: "Cluster deletion controller workqueue depth is high"
-        summary: "Cluster deletion controller workqueue depth is high"
+        summary: "svc-1: Cluster deletion controller workqueue OperationClusterDelete depth is high"
         description: "Cluster deletion controller workqueue OperationClusterDelete has had a depth > 10 for more than 5 minutes, indicating work is accumulating faster than it can be processed."
-        runbook_url: "TBD"
-
+        runbook_url: "aka.ms/arohcp-runbook-cluster-deletion"
+        correlationId: "userJourneyClusterDeletionQueueDepth/svc-1/OperationClusterDelete"
 # Queue depth does NOT fire when depth is at or below threshold
 - name: queue_depth_no_fire_at_threshold
   interval: 1m
@@ -528,7 +605,6 @@ tests:
   - eval_time: 10m
     alertname: userJourneyClusterDeletionQueueDepth
     exp_alerts: []
-
 # ─────────────────────────────────────────────────────────────────────────────
 # userJourneyClusterDeletionRetryHotLoop
 # Fires when retry ratio > 50% sustained for 10 minutes.
@@ -549,13 +625,13 @@ tests:
     - exp_labels:
         cluster: svc-1
         name: OperationClusterDelete
-        severity: info
+        severity: "4"
       exp_annotations:
         title: "Cluster deletion controller workqueue in retry hot loop"
-        summary: "Cluster deletion controller workqueue in retry hot loop"
+        summary: "svc-1: Cluster deletion controller workqueue OperationClusterDelete retry hot loop"
         description: "Cluster deletion controller workqueue OperationClusterDelete has a retry ratio > 50% sustained over 10 minutes, indicating most queue activity is failed retries rather than fresh work."
-        runbook_url: "TBD"
-
+        runbook_url: "aka.ms/arohcp-runbook-cluster-deletion"
+        correlationId: "userJourneyClusterDeletionRetryHotLoop/svc-1/OperationClusterDelete"
 # Retry hot loop does NOT fire when retry ratio is healthy (below 50 %)
 # retries grow at 1/min, adds grow at 4/min → ratio = 25 % < 50 %
 - name: retry_hot_loop_no_fire_healthy_ratio
@@ -569,8 +645,15 @@ tests:
   - eval_time: 25m
     alertname: userJourneyClusterDeletionRetryHotLoop
     exp_alerts: []
+# ─────────────────────────────────────────────────────────────────────────────
+# RECORDING RULE VALIDATION
+# These tests verify recording rule intermediate values directly using
+# promql_expr_test, independent of alert thresholds.
+# Mirrors the nodepool test approach for completeness.
+# ─────────────────────────────────────────────────────────────────────────────
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Combined healthy baseline
 # All succeeded, no failures, all fast operations.
 # Verifies:
 #   - error_rate recording rule = 0
@@ -635,14 +718,17 @@ tests:
   - eval_time: 10m
     alertname: userJourneyClusterDeletionErrorsDegradation
   - eval_time: 10m
-    alertname: userJourneyClusterDeletionLatencySLOBreach
+    alertname: userJourneyClusterDeletionLatency1h5m
+  - eval_time: 10m
+    alertname: userJourneyClusterDeletionLatency6h30m
+  - eval_time: 10m
+    alertname: userJourneyClusterDeletionLatency3d
   - eval_time: 10m
     alertname: userJourneyClusterDeletionStuckOperation
   - eval_time: 10m
     alertname: userJourneyClusterDeletionQueueDepth
   - eval_time: 10m
     alertname: userJourneyClusterDeletionRetryHotLoop
-
 # ─────────────────────────────────────────────────────────────────────────────
 # error_rate recording rule math
 # 8 failed + 2 succeeded = 8/10 = 0.8 (clean decimal, easy to verify)
@@ -677,9 +763,8 @@ tests:
     exp_samples:
     - labels: 'errors:backend_cluster_deletion_operation:error_rate{cluster="svc-1"}'
       value: 0.8
-
 # ─────────────────────────────────────────────────────────────────────────────
-# timeliness_error_rate recording rule
+# timeliness_error_rate recording rule math
 # 1 slow op (duration=1900s > 1800s) + 4 fast ops (duration=600s < 1800s)
 # = 1/5 = 0.2 (clean decimal, easy to verify)
 # Confirms that last_transition_time - start_time is correctly compared

--- a/observability/grafana-dashboards/sre/user-journey/cluster-deletion.json
+++ b/observability/grafana-dashboards/sre/user-journey/cluster-deletion.json
@@ -1,0 +1,1896 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "### Cluster Deletion SLO - Fleet Wide\n\nFleet-wide view of HCP cluster deletion health from backend delete-operation and cluster provisioning-state metrics.\n\n**SLO targets**\n- `Success SLO: Successful Deletes` target is **95%** successful completed deletes in the selected lookback window.\n- `Timeliness SLO: Successful Deletes Within 30m` target is **95%** of successful deletes completing within 30 minutes.\n- Delete latency target is **p95 within 30 minutes** for successful deletes.\n\n**How the time range works**\n- The dashboard time picker is the lookback window (default `last 24 hours`).\n- `Completed`, `Successful`, `Failed / Canceled`, `Success SLO`, `Timeliness SLO`, and `Delete Duration p50/p95/p99` use cluster `operation_type=delete` attempts that reached a terminal phase within the selected window.\n- `Successful` means `phase=\"succeeded\"`; `Failed / Canceled` means `phase=~\"failed|canceled\"`.\n- `24h` is the normal default; `7d` is the practical upper bound for the current retained operation history.\n\n**Top-level panels**\n- The top summary rows show fleet size, completed attempts, failed/canceled attempts, fleet-weighted success and timeliness SLOs, and delete-duration percentiles.\n- `Clusters by Provisioning State` shows the current cluster fleet mix over time.\n- `Delete Ops Stuck > 1 Hour` highlights in-flight delete operations that may be hung.\n- `Subscription Breakdown` highlights where failed or canceled attempts are concentrated.\n- `Detail Tables` provides the exact terminal and active delete operations behind the summary panels.\n\n**Datasource**\n- Select a single service-cluster Prometheus datasource from the top bar, or choose `All` to fan out across all matching service-cluster datasources.\n- Top-level fleet SLO panels sum raw counts across the selected datasources before calculating ratios.\n- Metrics come from backend service clusters (`Managed_Prometheus_services-*`).",
+        "mode": "markdown"
+      },
+      "pluginVersion": "11.6.9",
+      "title": "Dashboard Info",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Mixed --"
+      },
+      "description": "Total number of living clusters in the fleet",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue"
+              }
+            ]
+          },
+          "unit": "none",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 6,
+        "y": 0
+      },
+      "id": 29,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "count(backend_cluster_created_time_seconds) or vector(0)",
+          "instant": true,
+          "range": false,
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Fleet Size",
+      "transformations": [
+        {
+          "id": "seriesToRows",
+          "options": {}
+        },
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "Metric": {
+                "operation": "groupby",
+                "aggregations": []
+              },
+              "Value": {
+                "operation": "aggregate",
+                "aggregations": [
+                  "sum"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "rowsToFields",
+          "options": {
+            "mappings": [
+              {
+                "fieldName": "Metric",
+                "handlerKey": "field.name"
+              },
+              {
+                "fieldName": "Value (sum)",
+                "handlerKey": "field.value"
+              }
+            ]
+          }
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Mixed --"
+      },
+      "description": "Terminal cluster delete attempts that completed within the selected dashboard time window. This is the denominator for the lookback SLO panels.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue"
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 5,
+        "x": 10,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "count((backend_resource_operation_phase_info{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=~\"succeeded|failed|canceled\", subscription_id!~\"${exclude_subs:raw}\"} == 1) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=~\"succeeded|failed|canceled\", subscription_id!~\"${exclude_subs:raw}\"}) < $__range_s)) or vector(0)",
+          "instant": true,
+          "legendFormat": "Completed",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Completed Delete Attempts (Window)",
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "reduce",
+          "options": {
+            "reducers": [
+              "sum"
+            ]
+          }
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Mixed --"
+      },
+      "description": "Fleet-weighted Success SLO: successful terminal delete attempts divided by all terminal delete attempts across the selected service-cluster datasources.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 1,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "noValue": "No operations to measure",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red"
+              },
+              {
+                "color": "orange",
+                "value": 90
+              },
+              {
+                "color": "green",
+                "value": 95
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 5,
+        "x": 15,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "count((backend_resource_operation_phase_info{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"} == 1) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"}) < $__range_s)) * 100",
+          "instant": true,
+          "legendFormat": "Successful x100",
+          "range": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "count((backend_resource_operation_phase_info{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=~\"succeeded|failed|canceled\", subscription_id!~\"${exclude_subs:raw}\"} == 1) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=~\"succeeded|failed|canceled\", subscription_id!~\"${exclude_subs:raw}\"}) < $__range_s))",
+          "instant": true,
+          "legendFormat": "Completed",
+          "range": false,
+          "refId": "B"
+        }
+      ],
+      "title": "Success SLO: Successful Deletes",
+      "transformations": [
+        {
+          "id": "seriesToRows",
+          "options": {}
+        },
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "Metric": {
+                "operation": "groupby",
+                "aggregations": []
+              },
+              "Value": {
+                "operation": "aggregate",
+                "aggregations": [
+                  "sum"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "rowsToFields",
+          "options": {
+            "mappings": [
+              {
+                "fieldName": "Metric",
+                "handlerKey": "field.name"
+              },
+              {
+                "fieldName": "Value (sum)",
+                "handlerKey": "field.value"
+              }
+            ]
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Success SLO %",
+            "binary": {
+              "left": "Successful x100",
+              "operator": "/",
+              "reducer": "sum",
+              "right": "Completed"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": true
+          }
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Mixed --"
+      },
+      "description": "Failed or canceled cluster delete attempts that completed within the selected dashboard time window. Any non-zero value means there were unsuccessful deletes in the window.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 20,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "count((backend_resource_operation_phase_info{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=~\"failed|canceled\", subscription_id!~\"${exclude_subs:raw}\"} == 1) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=~\"failed|canceled\", subscription_id!~\"${exclude_subs:raw}\"}) < $__range_s)) or vector(0)",
+          "instant": true,
+          "legendFormat": "Unsuccessful",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Failed / Canceled Delete Attempts (Window)",
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "reduce",
+          "options": {
+            "reducers": [
+              "sum"
+            ]
+          }
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 20,
+      "panels": [],
+      "title": "Cluster Deletion Lookback SLOs",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Mixed --"
+      },
+      "description": "Fleet-weighted Timeliness SLO: successful deletes under 30 minutes divided by all successful deletes across the selected service-cluster datasources.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 1,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "noValue": "No operations to measure",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red"
+              },
+              {
+                "color": "orange",
+                "value": 90
+              },
+              {
+                "color": "green",
+                "value": 95
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "count((((backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"} - backend_resource_operation_start_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"}) < 1800) and (backend_resource_operation_phase_info{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"} == 1) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"}) < $__range_s))) * 100",
+          "instant": true,
+          "legendFormat": "Timely x100",
+          "range": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "count((backend_resource_operation_phase_info{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"} == 1) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"}) < $__range_s))",
+          "instant": true,
+          "legendFormat": "Successful",
+          "range": false,
+          "refId": "B"
+        }
+      ],
+      "title": "Timeliness SLO: Successful Deletes Within 30m",
+      "transformations": [
+        {
+          "id": "seriesToRows",
+          "options": {}
+        },
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "Metric": {
+                "operation": "groupby",
+                "aggregations": []
+              },
+              "Value": {
+                "operation": "aggregate",
+                "aggregations": [
+                  "sum"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "rowsToFields",
+          "options": {
+            "mappings": [
+              {
+                "fieldName": "Metric",
+                "handlerKey": "field.name"
+              },
+              {
+                "fieldName": "Value (sum)",
+                "handlerKey": "field.value"
+              }
+            ]
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Timeliness SLO %",
+            "binary": {
+              "left": "Timely x100",
+              "operator": "/",
+              "reducer": "sum",
+              "right": "Successful"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": true
+          }
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Mixed --"
+      },
+      "description": "Fleet p50 delete duration in minutes for successful delete attempts that completed within the selected dashboard time window.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 1,
+          "mappings": [],
+          "min": 0,
+          "noValue": "No operations to measure",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "m"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 0,
+        "y": 19
+      },
+      "id": 7,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "p50"
+          ],
+          "fields": "Value",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "((backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"} - backend_resource_operation_start_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"}) / 60) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"}) < $__range_s)",
+          "instant": true,
+          "legendFormat": "p50",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Delete Duration p50 (min)",
+      "transformations": [
+        {
+          "id": "seriesToRows",
+          "options": {}
+        },
+        {
+          "id": "merge",
+          "options": {}
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Mixed --"
+      },
+      "description": "Fleet p95 delete duration in minutes for successful delete attempts that completed within the selected dashboard time window.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 1,
+          "mappings": [],
+          "min": 0,
+          "noValue": "No operations to measure",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "m"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 8,
+        "y": 19
+      },
+      "id": 24,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "p95"
+          ],
+          "fields": "Value",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "((backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"} - backend_resource_operation_start_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"}) / 60) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"}) < $__range_s)",
+          "instant": true,
+          "legendFormat": "p95",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Delete Duration p95 (min)",
+      "transformations": [
+        {
+          "id": "seriesToRows",
+          "options": {}
+        },
+        {
+          "id": "merge",
+          "options": {}
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Mixed --"
+      },
+      "description": "Fleet p99 delete duration in minutes for successful delete attempts that completed within the selected dashboard time window.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 1,
+          "mappings": [],
+          "min": 0,
+          "noValue": "No operations to measure",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "m"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 16,
+        "y": 19
+      },
+      "id": 25,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "p99"
+          ],
+          "fields": "Value",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "((backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"} - backend_resource_operation_start_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"}) / 60) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"}) < $__range_s)",
+          "instant": true,
+          "legendFormat": "p99",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Delete Duration p99 (min)",
+      "transformations": [
+        {
+          "id": "seriesToRows",
+          "options": {}
+        },
+        {
+          "id": "merge",
+          "options": {}
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Mixed --"
+      },
+      "description": "Distribution of clusters across all provisioning states over time.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Cluster Count",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "succeeded"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "failed"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "provisioning"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "deleting"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 29
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "count by (phase) (backend_cluster_provision_state == 1)",
+          "instant": false,
+          "legendFormat": "{{phase}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Clusters by Provisioning State",
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Mixed --"
+      },
+      "description": "Number of delete operations stuck in a non-terminal phase (accepted, awaitingsecret, provisioning, updating, deleting) for more than 1 hour, summed across the selected service-cluster datasources. Target: 0. Indicates operations that may be hung.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 29
+      },
+      "id": 9,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "count((backend_resource_operation_phase_info{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=~\"accepted|awaitingsecret|provisioning|updating|deleting\", subscription_id!~\"${exclude_subs:raw}\"} == 1) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=~\"accepted|awaitingsecret|provisioning|updating|deleting\", subscription_id!~\"${exclude_subs:raw}\"}) > 3600)) or vector(0)",
+          "instant": true,
+          "legendFormat": "Stuck",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Delete Ops Stuck > 1 Hour",
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "reduce",
+          "options": {
+            "reducers": [
+              "sum"
+            ]
+          }
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 40
+      },
+      "id": 22,
+      "panels": [],
+      "title": "Subscription Breakdown",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Mixed --"
+      },
+      "description": "Failed or canceled delete attempts that completed within the selected dashboard time window, grouped by subscription and summed across the selected service-cluster datasources.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Attempt Count",
+            "axisPlacement": "auto",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 41
+      },
+      "id": 13,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "orientation": "auto",
+        "showValue": "auto",
+        "stacking": "none",
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "count by (subscription_id) ((backend_resource_operation_phase_info{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=~\"failed|canceled\", subscription_id!~\"${exclude_subs:raw}\"} == 1) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=~\"failed|canceled\", subscription_id!~\"${exclude_subs:raw}\"}) < $__range_s))",
+          "instant": true,
+          "legendFormat": "{{subscription_id}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Failed / Canceled Attempts by Subscription (Window)",
+      "transformations": [
+        {
+          "id": "seriesToRows",
+          "options": {}
+        },
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "Metric": {
+                "operation": "groupby",
+                "aggregations": []
+              },
+              "Value": {
+                "operation": "aggregate",
+                "aggregations": [
+                  "sum"
+                ]
+              }
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 51
+      },
+      "id": 23,
+      "panels": [],
+      "title": "Detail Tables",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Mixed --"
+      },
+      "description": "Terminal cluster delete attempts that completed within the selected dashboard time window. Shows resource ID, subscription, and terminal phase.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Phase"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "accepted": {
+                        "color": "blue",
+                        "index": 4,
+                        "text": "accepted"
+                      },
+                      "awaitingsecret": {
+                        "color": "light-orange",
+                        "index": 7,
+                        "text": "awaitingsecret"
+                      },
+                      "canceled": {
+                        "color": "semi-dark-purple",
+                        "index": 6,
+                        "text": "canceled"
+                      },
+                      "deleting": {
+                        "color": "orange",
+                        "index": 3,
+                        "text": "deleting"
+                      },
+                      "failed": {
+                        "color": "red",
+                        "index": 1,
+                        "text": "failed"
+                      },
+                      "provisioning": {
+                        "color": "yellow",
+                        "index": 2,
+                        "text": "provisioning"
+                      },
+                      "succeeded": {
+                        "color": "green",
+                        "index": 0,
+                        "text": "succeeded"
+                      },
+                      "updating": {
+                        "color": "purple",
+                        "index": 5,
+                        "text": "updating"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 52
+      },
+      "id": 15,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": true,
+          "enablePagination": true,
+          "fields": "",
+          "reducer": [
+            "count"
+          ],
+          "show": true
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "Phase"
+          }
+        ]
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "(backend_resource_operation_phase_info{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=~\"succeeded|failed|canceled\", subscription_id!~\"${exclude_subs:raw}\"} == 1) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=~\"succeeded|failed|canceled\", subscription_id!~\"${exclude_subs:raw}\"}) < $__range_s)",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Terminal Delete Attempts (Window)",
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "__name__": true,
+              "operation_type": true,
+              "resource_type": true
+            },
+            "indexByName": {
+              "phase": 2,
+              "resource_id": 0,
+              "subscription_id": 1
+            },
+            "renameByName": {
+              "phase": "Phase",
+              "resource_id": "Resource ID",
+              "subscription_id": "Subscription"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Mixed --"
+      },
+      "description": "All active delete operations across the fleet. Shows resource ID, subscription, and current phase.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Phase"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "basic",
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "accepted": {
+                        "color": "blue",
+                        "index": 1,
+                        "text": "accepted"
+                      },
+                      "awaitingsecret": {
+                        "color": "light-orange",
+                        "index": 4,
+                        "text": "awaitingsecret"
+                      },
+                      "deleting": {
+                        "color": "orange",
+                        "index": 3,
+                        "text": "deleting"
+                      },
+                      "provisioning": {
+                        "color": "yellow",
+                        "index": 0,
+                        "text": "provisioning"
+                      },
+                      "updating": {
+                        "color": "purple",
+                        "index": 2,
+                        "text": "updating"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 62
+      },
+      "id": 16,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": true,
+          "enablePagination": true,
+          "fields": "",
+          "reducer": [
+            "count"
+          ],
+          "show": true
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "Phase"
+          }
+        ]
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "backend_resource_operation_phase_info{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=~\"accepted|awaitingsecret|provisioning|updating|deleting\", subscription_id!~\"${exclude_subs:raw}\"} == 1",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Active Delete Operations (Details)",
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "__name__": true,
+              "resource_type": true
+            },
+            "indexByName": {
+              "phase": 2,
+              "resource_id": 0,
+              "subscription_id": 1
+            },
+            "renameByName": {
+              "phase": "Phase",
+              "resource_id": "Resource ID",
+              "subscription_id": "Subscription"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 72
+      },
+      "id": 26,
+      "title": "Duration & Failure Trends",
+      "type": "row",
+      "panels": []
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Mixed --"
+      },
+      "description": "Rolling 1h successful delete duration percentiles. With datasource=All, each selected service-cluster datasource computes its own percentiles; use the top-level duration stat panels for the fleet snapshot. Red line = 30m SLO target.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false,
+            "axisPlacement": "auto",
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "mappings": [],
+          "unit": "m",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "transparent"
+              },
+              {
+                "color": "red",
+                "value": 30
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 73
+      },
+      "id": 27,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "quantile(0.50, ((backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"} - backend_resource_operation_start_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"}) / 60) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"}) < 3600)) or vector(0)",
+          "legendFormat": "p50 (per datasource)",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "quantile(0.95, ((backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"} - backend_resource_operation_start_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"}) / 60) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"}) < 3600)) or vector(0)",
+          "legendFormat": "p95 — SLO boundary (per datasource)",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "quantile(0.99, ((backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"} - backend_resource_operation_start_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"}) / 60) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"}) < 3600)) or vector(0)",
+          "legendFormat": "p99 (per datasource)",
+          "refId": "C"
+        }
+      ],
+      "title": "Delete Duration by Service Cluster (Rolling 1h)",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Mixed --"
+      },
+      "description": "Rolling 1h: failed / (succeeded + failed), with canceled operations excluded. With datasource=All, each selected service-cluster datasource computes its own ratio; use top-level panels for fleet reporting.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false,
+            "axisPlacement": "auto",
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "mappings": [],
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "yellow",
+                "value": 5
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 73
+      },
+      "id": 28,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "((count((backend_resource_operation_phase_info{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"failed\", subscription_id!~\"${exclude_subs:raw}\"} == 1) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"failed\", subscription_id!~\"${exclude_subs:raw}\"}) < 3600)) or vector(0)) / clamp_min(((count((backend_resource_operation_phase_info{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"} == 1) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"}) < 3600)) or vector(0)) + (count((backend_resource_operation_phase_info{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"failed\", subscription_id!~\"${exclude_subs:raw}\"} == 1) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"failed\", subscription_id!~\"${exclude_subs:raw}\"}) < 3600)) or vector(0))), 1)) * 100",
+          "legendFormat": "Failure Ratio (per datasource)",
+          "refId": "A"
+        }
+      ],
+      "title": "Failure Ratio by Service Cluster (Rolling 1h)",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Mixed --"
+      },
+      "description": "Distribution of cluster ages in the fleet",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 81
+      },
+      "id": 30,
+      "options": {
+        "bucketSize": "",
+        "combine": false,
+        "fillOpacity": 80,
+        "gradientMode": "none",
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "(time() - backend_cluster_created_time_seconds) / 86400",
+          "instant": true,
+          "range": false,
+          "legendFormat": "Cluster Age (days)",
+          "refId": "A"
+        }
+      ],
+      "title": "Fleet Cluster Age Distribution",
+      "transformations": [
+        {
+          "id": "seriesToRows",
+          "options": {}
+        }
+      ],
+      "type": "histogram"
+    }
+  ],
+  "preload": false,
+  "refresh": "5m",
+  "schemaVersion": 41,
+  "tags": [
+    "cluster",
+    "deletion",
+    "health",
+    "backend",
+    "user-journey"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "includeAll": true,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "^Managed_Prometheus_services-.*$",
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "description": "Pipe-separated subscription IDs to exclude from SLO calculations (e.g. internal/test subs)",
+        "hide": 0,
+        "label": "Exclude Subscriptions",
+        "name": "exclude_subs",
+        "options": [],
+        "query": "",
+        "skipUrlSync": false,
+        "type": "textbox"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Cluster Deletion SLO - Fleet Wide",
+  "uid": "cluster-deletion",
+  "version": 1
+}

--- a/observability/grafana-dashboards/sre/user-journey/cluster-deletion.json
+++ b/observability/grafana-dashboards/sre/user-journey/cluster-deletion.json
@@ -104,7 +104,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "count(backend_cluster_created_time_seconds) or vector(0)",
+          "expr": "count(backend_cluster_created_time_seconds{cluster=~\"$cluster\"}) or vector(0)",
           "instant": true,
           "range": false,
           "legendFormat": "__auto",
@@ -208,7 +208,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "count((backend_resource_operation_phase_info{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=~\"succeeded|failed|canceled\", subscription_id!~\"${exclude_subs:raw}\"} == 1) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=~\"succeeded|failed|canceled\", subscription_id!~\"${exclude_subs:raw}\"}) < $__range_s)) or vector(0)",
+          "expr": "count((backend_resource_operation_phase_info{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=~\"succeeded|failed|canceled\", cluster=~\"$cluster\", subscription_id!~\"${exclude_subs:raw}\"} == 1) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=~\"succeeded|failed|canceled\", cluster=~\"$cluster\", subscription_id!~\"${exclude_subs:raw}\"}) < $__range_s)) or vector(0)",
           "instant": true,
           "legendFormat": "Completed",
           "range": false,
@@ -297,7 +297,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "count((backend_resource_operation_phase_info{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"} == 1) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"}) < $__range_s)) * 100",
+          "expr": "count((backend_resource_operation_phase_info{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", cluster=~\"$cluster\", subscription_id!~\"${exclude_subs:raw}\"} == 1) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", cluster=~\"$cluster\", subscription_id!~\"${exclude_subs:raw}\"}) < $__range_s)) * 100",
           "instant": true,
           "legendFormat": "Successful x100",
           "range": false,
@@ -309,7 +309,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "count((backend_resource_operation_phase_info{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=~\"succeeded|failed|canceled\", subscription_id!~\"${exclude_subs:raw}\"} == 1) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=~\"succeeded|failed|canceled\", subscription_id!~\"${exclude_subs:raw}\"}) < $__range_s))",
+          "expr": "count((backend_resource_operation_phase_info{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=~\"succeeded|failed|canceled\", cluster=~\"$cluster\", subscription_id!~\"${exclude_subs:raw}\"} == 1) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=~\"succeeded|failed|canceled\", cluster=~\"$cluster\", subscription_id!~\"${exclude_subs:raw}\"}) < $__range_s))",
           "instant": true,
           "legendFormat": "Completed",
           "range": false,
@@ -434,7 +434,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "count((backend_resource_operation_phase_info{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=~\"failed|canceled\", subscription_id!~\"${exclude_subs:raw}\"} == 1) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=~\"failed|canceled\", subscription_id!~\"${exclude_subs:raw}\"}) < $__range_s)) or vector(0)",
+          "expr": "count((backend_resource_operation_phase_info{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=~\"failed|canceled\", cluster=~\"$cluster\", subscription_id!~\"${exclude_subs:raw}\"} == 1) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=~\"failed|canceled\", cluster=~\"$cluster\", subscription_id!~\"${exclude_subs:raw}\"}) < $__range_s)) or vector(0)",
           "instant": true,
           "legendFormat": "Unsuccessful",
           "range": false,
@@ -536,7 +536,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "count((((backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"} - backend_resource_operation_start_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"}) < 1800) and (backend_resource_operation_phase_info{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"} == 1) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"}) < $__range_s))) * 100",
+          "expr": "count((((backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", cluster=~\"$cluster\", subscription_id!~\"${exclude_subs:raw}\"} - backend_resource_operation_start_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", cluster=~\"$cluster\", subscription_id!~\"${exclude_subs:raw}\"}) < 1800) and (backend_resource_operation_phase_info{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", cluster=~\"$cluster\", subscription_id!~\"${exclude_subs:raw}\"} == 1) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", cluster=~\"$cluster\", subscription_id!~\"${exclude_subs:raw}\"}) < $__range_s))) * 100",
           "instant": true,
           "legendFormat": "Timely x100",
           "range": false,
@@ -548,7 +548,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "count((backend_resource_operation_phase_info{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"} == 1) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"}) < $__range_s))",
+          "expr": "count((backend_resource_operation_phase_info{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", cluster=~\"$cluster\", subscription_id!~\"${exclude_subs:raw}\"} == 1) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", cluster=~\"$cluster\", subscription_id!~\"${exclude_subs:raw}\"}) < $__range_s))",
           "instant": true,
           "legendFormat": "Successful",
           "range": false,
@@ -672,7 +672,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "((backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"} - backend_resource_operation_start_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"}) / 60) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"}) < $__range_s)",
+          "expr": "((backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", cluster=~\"$cluster\", subscription_id!~\"${exclude_subs:raw}\"} - backend_resource_operation_start_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", cluster=~\"$cluster\", subscription_id!~\"${exclude_subs:raw}\"}) / 60) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", cluster=~\"$cluster\", subscription_id!~\"${exclude_subs:raw}\"}) < $__range_s)",
           "instant": true,
           "legendFormat": "p50",
           "range": false,
@@ -751,7 +751,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "((backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"} - backend_resource_operation_start_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"}) / 60) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"}) < $__range_s)",
+          "expr": "((backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", cluster=~\"$cluster\", subscription_id!~\"${exclude_subs:raw}\"} - backend_resource_operation_start_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", cluster=~\"$cluster\", subscription_id!~\"${exclude_subs:raw}\"}) / 60) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", cluster=~\"$cluster\", subscription_id!~\"${exclude_subs:raw}\"}) < $__range_s)",
           "instant": true,
           "legendFormat": "p95",
           "range": false,
@@ -830,7 +830,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "((backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"} - backend_resource_operation_start_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"}) / 60) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"}) < $__range_s)",
+          "expr": "((backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", cluster=~\"$cluster\", subscription_id!~\"${exclude_subs:raw}\"} - backend_resource_operation_start_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", cluster=~\"$cluster\", subscription_id!~\"${exclude_subs:raw}\"}) / 60) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", cluster=~\"$cluster\", subscription_id!~\"${exclude_subs:raw}\"}) < $__range_s)",
           "instant": true,
           "legendFormat": "p99",
           "range": false,
@@ -1000,7 +1000,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "count by (phase) (backend_cluster_provision_state == 1)",
+          "expr": "count by (phase) (backend_cluster_provision_state{cluster=~\"$cluster\"} == 1)",
           "instant": false,
           "legendFormat": "{{phase}}",
           "range": true,
@@ -1080,7 +1080,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "count((backend_resource_operation_phase_info{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=~\"accepted|awaitingsecret|provisioning|updating|deleting\", subscription_id!~\"${exclude_subs:raw}\"} == 1) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=~\"accepted|awaitingsecret|provisioning|updating|deleting\", subscription_id!~\"${exclude_subs:raw}\"}) > 3600)) or vector(0)",
+          "expr": "count((backend_resource_operation_phase_info{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=~\"accepted|awaitingsecret|provisioning|updating|deleting\", cluster=~\"$cluster\", subscription_id!~\"${exclude_subs:raw}\"} == 1) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=~\"accepted|awaitingsecret|provisioning|updating|deleting\", cluster=~\"$cluster\", subscription_id!~\"${exclude_subs:raw}\"}) > 3600)) or vector(0)",
           "instant": true,
           "legendFormat": "Stuck",
           "range": false,
@@ -1199,7 +1199,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "count by (subscription_id) ((backend_resource_operation_phase_info{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=~\"failed|canceled\", subscription_id!~\"${exclude_subs:raw}\"} == 1) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=~\"failed|canceled\", subscription_id!~\"${exclude_subs:raw}\"}) < $__range_s))",
+          "expr": "count by (subscription_id) ((backend_resource_operation_phase_info{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=~\"failed|canceled\", cluster=~\"$cluster\", subscription_id!~\"${exclude_subs:raw}\"} == 1) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=~\"failed|canceled\", cluster=~\"$cluster\", subscription_id!~\"${exclude_subs:raw}\"}) < $__range_s))",
           "instant": true,
           "legendFormat": "{{subscription_id}}",
           "range": false,
@@ -1375,7 +1375,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "(backend_resource_operation_phase_info{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=~\"succeeded|failed|canceled\", subscription_id!~\"${exclude_subs:raw}\"} == 1) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=~\"succeeded|failed|canceled\", subscription_id!~\"${exclude_subs:raw}\"}) < $__range_s)",
+          "expr": "(backend_resource_operation_phase_info{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=~\"succeeded|failed|canceled\", cluster=~\"$cluster\", subscription_id!~\"${exclude_subs:raw}\"} == 1) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=~\"succeeded|failed|canceled\", cluster=~\"$cluster\", subscription_id!~\"${exclude_subs:raw}\"}) < $__range_s)",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -1529,7 +1529,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "backend_resource_operation_phase_info{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=~\"accepted|awaitingsecret|provisioning|updating|deleting\", subscription_id!~\"${exclude_subs:raw}\"} == 1",
+          "expr": "backend_resource_operation_phase_info{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=~\"accepted|awaitingsecret|provisioning|updating|deleting\", cluster=~\"$cluster\", subscription_id!~\"${exclude_subs:raw}\"} == 1",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -1649,7 +1649,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "quantile(0.50, ((backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"} - backend_resource_operation_start_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"}) / 60) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"}) < 3600)) or vector(0)",
+          "expr": "quantile(0.50, ((backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", cluster=~\"$cluster\", subscription_id!~\"${exclude_subs:raw}\"} - backend_resource_operation_start_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", cluster=~\"$cluster\", subscription_id!~\"${exclude_subs:raw}\"}) / 60) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", cluster=~\"$cluster\", subscription_id!~\"${exclude_subs:raw}\"}) < 3600)) or vector(0)",
           "legendFormat": "p50 (per datasource)",
           "refId": "A"
         },
@@ -1659,8 +1659,8 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "quantile(0.95, ((backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"} - backend_resource_operation_start_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"}) / 60) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"}) < 3600)) or vector(0)",
-          "legendFormat": "p95 — SLO boundary (per datasource)",
+          "expr": "quantile(0.95, ((backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", cluster=~\"$cluster\", subscription_id!~\"${exclude_subs:raw}\"} - backend_resource_operation_start_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", cluster=~\"$cluster\", subscription_id!~\"${exclude_subs:raw}\"}) / 60) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", cluster=~\"$cluster\", subscription_id!~\"${exclude_subs:raw}\"}) < 3600)) or vector(0)",
+          "legendFormat": "p95 \u2014 SLO boundary (per datasource)",
           "refId": "B"
         },
         {
@@ -1669,7 +1669,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "quantile(0.99, ((backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"} - backend_resource_operation_start_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"}) / 60) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"}) < 3600)) or vector(0)",
+          "expr": "quantile(0.99, ((backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", cluster=~\"$cluster\", subscription_id!~\"${exclude_subs:raw}\"} - backend_resource_operation_start_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", cluster=~\"$cluster\", subscription_id!~\"${exclude_subs:raw}\"}) / 60) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", cluster=~\"$cluster\", subscription_id!~\"${exclude_subs:raw}\"}) < 3600)) or vector(0)",
           "legendFormat": "p99 (per datasource)",
           "refId": "C"
         }
@@ -1751,7 +1751,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "((count((backend_resource_operation_phase_info{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"failed\", subscription_id!~\"${exclude_subs:raw}\"} == 1) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"failed\", subscription_id!~\"${exclude_subs:raw}\"}) < 3600)) or vector(0)) / clamp_min(((count((backend_resource_operation_phase_info{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"} == 1) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", subscription_id!~\"${exclude_subs:raw}\"}) < 3600)) or vector(0)) + (count((backend_resource_operation_phase_info{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"failed\", subscription_id!~\"${exclude_subs:raw}\"} == 1) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"failed\", subscription_id!~\"${exclude_subs:raw}\"}) < 3600)) or vector(0))), 1)) * 100",
+          "expr": "((count((backend_resource_operation_phase_info{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"failed\", cluster=~\"$cluster\", subscription_id!~\"${exclude_subs:raw}\"} == 1) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"failed\", cluster=~\"$cluster\", subscription_id!~\"${exclude_subs:raw}\"}) < 3600)) or vector(0)) / clamp_min(((count((backend_resource_operation_phase_info{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", cluster=~\"$cluster\", subscription_id!~\"${exclude_subs:raw}\"} == 1) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"succeeded\", cluster=~\"$cluster\", subscription_id!~\"${exclude_subs:raw}\"}) < 3600)) or vector(0)) + (count((backend_resource_operation_phase_info{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"failed\", cluster=~\"$cluster\", subscription_id!~\"${exclude_subs:raw}\"} == 1) and ((time() - backend_resource_operation_last_transition_time_seconds{resource_type=\"microsoft.redhatopenshift/hcpopenshiftclusters\", operation_type=\"delete\", phase=\"failed\", cluster=~\"$cluster\", subscription_id!~\"${exclude_subs:raw}\"}) < 3600)) or vector(0))), 1)) * 100",
           "legendFormat": "Failure Ratio (per datasource)",
           "refId": "A"
         }
@@ -1826,7 +1826,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "(time() - backend_cluster_created_time_seconds) / 86400",
+          "expr": "(time() - backend_cluster_created_time_seconds{cluster=~\"$cluster\"}) / 86400",
           "instant": true,
           "range": false,
           "legendFormat": "Cluster Age (days)",
@@ -1856,17 +1856,42 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "text": "All",
-          "value": "$__all"
-        },
+        "current": {},
+        "hide": 0,
         "includeAll": true,
+        "multi": false,
         "name": "datasource",
         "options": [],
         "query": "prometheus",
+        "queryValue": "",
         "refresh": 1,
         "regex": "^Managed_Prometheus_services-.*$",
+        "skipUrlSync": false,
         "type": "datasource"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(up,cluster)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Cluster",
+        "multi": false,
+        "name": "cluster",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(up,cluster)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "^.*-svc-\\d+$",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
       },
       {
         "current": {

--- a/observability/recording-rules-services.yaml
+++ b/observability/recording-rules-services.yaml
@@ -2,5 +2,6 @@ prometheusRules:
   rulesFolders:
   - recording-rules/access-cluster-slo-recordingRule.yaml
   - recording-rules/cluster-provision-slo-recordingRule.yaml
+  - recording-rules/cluster-deletion-slo-recordingRule.yaml
   untestedRules: []
   outputBicep: ../dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep

--- a/observability/recording-rules/cluster-deletion-slo-recordingRule.yaml
+++ b/observability/recording-rules/cluster-deletion-slo-recordingRule.yaml
@@ -1,0 +1,95 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app.kubernetes.io/name: kube-prometheus
+    app.kubernetes.io/part-of: kube-prometheus
+    prometheus: k8s
+    role: recording-rules
+  name: cluster-deletion-slo-recording-rules
+  namespace: monitoring
+spec:
+  groups:
+  # ========================================
+  # Cluster Deletion SLO Recording Rules
+  # ========================================
+  # These rules track the Errors and Timeliness SLOs for cluster delete operations.
+  # SLO: 95% of cluster delete operations should succeed (not reach "failed" or "canceled" terminal phase)
+  # Error Budget: 5% (1 - 0.95)
+  # Scope: covers cluster delete operations only.
+  #
+  # Metrics are gauge-based (backend_resource_operation_phase_info) from Cosmos DB,
+  # so we use count() aggregations rather than rate() on counters.
+  - name: arohcp_cluster_deletion_slo_recording_rules
+    interval: 1m
+    rules:
+    # Instantaneous error rate: fraction of terminal operations that failed or were canceled.
+    # Uses count by (cluster) to preserve the cluster label per nodepool production pattern.
+    # The "or 0 * count by (cluster)" fallback returns zero with the cluster label when
+    # there are no failures, avoiding lost label context (vs "or vector(0)").
+    - record: errors:backend_cluster_deletion_operation:error_rate
+      expr: |
+        (
+          count by (cluster) (backend_resource_operation_phase_info{
+            resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
+            operation_type="delete",
+            phase=~"failed|canceled"
+          })
+          or
+          0 * count by (cluster) (backend_resource_operation_phase_info{
+            resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
+            operation_type="delete",
+            phase=~"succeeded|failed|canceled"
+          })
+        )
+        /
+        clamp_min(
+          count by (cluster) (backend_resource_operation_phase_info{
+            resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
+            operation_type="delete",
+            phase=~"succeeded|failed|canceled"
+          }),
+          1
+        )
+    # Timeliness error rate: fraction of succeeded operations that exceeded the 30-minute target.
+    # Uses count by (cluster) to preserve the cluster label per nodepool production pattern.
+    - record: errors:backend_cluster_deletion_operation:timeliness_error_rate
+      expr: |
+        (
+          count by (cluster) (
+            (
+              backend_resource_operation_last_transition_time_seconds{
+                resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
+                operation_type="delete",
+                phase="succeeded"
+              }
+              -
+              backend_resource_operation_start_time_seconds{
+                resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
+                operation_type="delete",
+                phase="succeeded"
+              }
+            ) >= 1800
+            and
+            backend_resource_operation_phase_info{
+              resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
+              operation_type="delete",
+              phase="succeeded"
+            } == 1
+          )
+          or
+          0 * count by (cluster) (backend_resource_operation_phase_info{
+            resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
+            operation_type="delete",
+            phase="succeeded"
+          } == 1)
+        )
+        /
+        clamp_min(
+          count by (cluster) (backend_resource_operation_phase_info{
+            resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
+            operation_type="delete",
+            phase="succeeded"
+          } == 1),
+          1
+        )

--- a/observability/recording-rules/cluster-deletion-slo-recordingRule_test.yaml
+++ b/observability/recording-rules/cluster-deletion-slo-recordingRule_test.yaml
@@ -1,0 +1,209 @@
+rule_files:
+- cluster-deletion-slo-recordingRule.yaml
+evaluation_interval: 1m
+tests:
+# ─────────────────────────────────────────────────────────────────────────────
+# errors:backend_cluster_deletion_operation:error_rate
+#
+# Rule: count(failed|canceled) / clamp_min(count(succeeded|failed|canceled), 1)
+# The "or 0 * count(...)" fallback preserves the cluster label when there are
+# no failures, producing 0 rather than an empty result set.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Zero-fallback: all succeeded → error_rate = 0 with cluster label preserved.
+# Exercises the "or 0 *" branch: no failed/canceled series, so the main
+# numerator arm is empty and the fallback produces 0 * 5 = 0.
+- name: error_rate_zero_when_all_succeeded
+  interval: 1m
+  input_series:
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s1",subscription_id="sub1",cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s2",subscription_id="sub1",cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s3",subscription_id="sub1",cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s4",subscription_id="sub1",cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s5",subscription_id="sub1",cluster="svc-1"}'
+    values: "1+0x15"
+  promql_expr_test:
+  - expr: errors:backend_cluster_deletion_operation:error_rate
+    eval_time: 5m
+    exp_samples:
+    - labels: 'errors:backend_cluster_deletion_operation:error_rate{cluster="svc-1"}'
+      value: 0
+# Arithmetic: 8 failed + 2 succeeded = 8/10 = 0.8
+- name: error_rate_arithmetic
+  interval: 1m
+  input_series:
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="failed",resource_id="f1",subscription_id="sub1",cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="failed",resource_id="f2",subscription_id="sub1",cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="failed",resource_id="f3",subscription_id="sub1",cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="failed",resource_id="f4",subscription_id="sub1",cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="failed",resource_id="f5",subscription_id="sub1",cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="failed",resource_id="f6",subscription_id="sub1",cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="failed",resource_id="f7",subscription_id="sub1",cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="failed",resource_id="f8",subscription_id="sub1",cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s1",subscription_id="sub1",cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s2",subscription_id="sub1",cluster="svc-1"}'
+    values: "1+0x15"
+  promql_expr_test:
+  - expr: errors:backend_cluster_deletion_operation:error_rate
+    eval_time: 5m
+    exp_samples:
+    - labels: 'errors:backend_cluster_deletion_operation:error_rate{cluster="svc-1"}'
+      value: 0.8
+# Canceled counts as error: 3 canceled + 2 succeeded = 3/5 = 0.6.
+# Confirms the phase=~"failed|canceled" numerator selector includes canceled.
+- name: error_rate_canceled_counts_as_error
+  interval: 1m
+  input_series:
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="canceled",resource_id="c1",subscription_id="sub1",cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="canceled",resource_id="c2",subscription_id="sub1",cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="canceled",resource_id="c3",subscription_id="sub1",cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s1",subscription_id="sub1",cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="s2",subscription_id="sub1",cluster="svc-1"}'
+    values: "1+0x15"
+  promql_expr_test:
+  - expr: errors:backend_cluster_deletion_operation:error_rate
+    eval_time: 5m
+    exp_samples:
+    - labels: 'errors:backend_cluster_deletion_operation:error_rate{cluster="svc-1"}'
+      value: 0.6
+# ─────────────────────────────────────────────────────────────────────────────
+# errors:backend_cluster_deletion_operation:timeliness_error_rate
+#
+# Rule: count(succeeded where duration >= 1800s) / clamp_min(count(succeeded), 1)
+# Duration = last_transition_time_seconds - start_time_seconds.
+# The "or 0 * count(...)" fallback preserves the cluster label when all
+# operations are fast, producing 0 rather than an empty result set.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Zero-fallback: all fast (600s < 1800s) → timeliness_error_rate = 0 with
+# cluster label preserved.
+- name: timeliness_error_rate_zero_when_all_fast
+  interval: 1m
+  input_series:
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="f1",subscription_id="sub1",cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_start_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="f1",subscription_id="sub1",cluster="svc-1"}'
+    values: "0+0x15"
+  - series: 'backend_resource_operation_last_transition_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="f1",subscription_id="sub1",cluster="svc-1"}'
+    values: "600+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="f2",subscription_id="sub1",cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_start_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="f2",subscription_id="sub1",cluster="svc-1"}'
+    values: "0+0x15"
+  - series: 'backend_resource_operation_last_transition_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="f2",subscription_id="sub1",cluster="svc-1"}'
+    values: "600+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="f3",subscription_id="sub1",cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_start_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="f3",subscription_id="sub1",cluster="svc-1"}'
+    values: "0+0x15"
+  - series: 'backend_resource_operation_last_transition_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="f3",subscription_id="sub1",cluster="svc-1"}'
+    values: "600+0x15"
+  promql_expr_test:
+  - expr: errors:backend_cluster_deletion_operation:timeliness_error_rate
+    eval_time: 5m
+    exp_samples:
+    - labels: 'errors:backend_cluster_deletion_operation:timeliness_error_rate{cluster="svc-1"}'
+      value: 0
+# Arithmetic: 1 slow (1900s > 1800s) + 4 fast (600s) = 1/5 = 0.2
+- name: timeliness_error_rate_arithmetic
+  interval: 1m
+  input_series:
+  # 1 slow operation: duration = 1900 - 0 = 1900s (31.7 min, exceeds 30-min threshold)
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="slow1",subscription_id="sub1",cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_start_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="slow1",subscription_id="sub1",cluster="svc-1"}'
+    values: "0+0x15"
+  - series: 'backend_resource_operation_last_transition_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="slow1",subscription_id="sub1",cluster="svc-1"}'
+    values: "1900+0x15"
+  # 4 fast operations: duration = 600 - 0 = 600s (10 min, under threshold)
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast1",subscription_id="sub1",cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_start_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast1",subscription_id="sub1",cluster="svc-1"}'
+    values: "0+0x15"
+  - series: 'backend_resource_operation_last_transition_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast1",subscription_id="sub1",cluster="svc-1"}'
+    values: "600+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast2",subscription_id="sub1",cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_start_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast2",subscription_id="sub1",cluster="svc-1"}'
+    values: "0+0x15"
+  - series: 'backend_resource_operation_last_transition_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast2",subscription_id="sub1",cluster="svc-1"}'
+    values: "600+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast3",subscription_id="sub1",cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_start_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast3",subscription_id="sub1",cluster="svc-1"}'
+    values: "0+0x15"
+  - series: 'backend_resource_operation_last_transition_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast3",subscription_id="sub1",cluster="svc-1"}'
+    values: "600+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast4",subscription_id="sub1",cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_start_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast4",subscription_id="sub1",cluster="svc-1"}'
+    values: "0+0x15"
+  - series: 'backend_resource_operation_last_transition_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast4",subscription_id="sub1",cluster="svc-1"}'
+    values: "600+0x15"
+  promql_expr_test:
+  - expr: errors:backend_cluster_deletion_operation:timeliness_error_rate
+    eval_time: 5m
+    exp_samples:
+    - labels: 'errors:backend_cluster_deletion_operation:timeliness_error_rate{cluster="svc-1"}'
+      value: 0.2
+# Boundary: exactly 1800s (30 min) counts as slow because the threshold is >= 1800.
+# 1 boundary op (1800s) + 4 fast (600s) = 1/5 = 0.2.
+# A value of 1799s would NOT be counted as slow.
+- name: timeliness_error_rate_exactly_30min_counts_as_slow
+  interval: 1m
+  input_series:
+  # 1 operation at exactly the threshold: duration = 1800 - 0 = 1800s (>= 1800 → slow)
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="boundary1",subscription_id="sub1",cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_start_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="boundary1",subscription_id="sub1",cluster="svc-1"}'
+    values: "0+0x15"
+  - series: 'backend_resource_operation_last_transition_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="boundary1",subscription_id="sub1",cluster="svc-1"}'
+    values: "1800+0x15"
+  # 4 fast operations: duration = 600s (under threshold)
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast1",subscription_id="sub1",cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_start_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast1",subscription_id="sub1",cluster="svc-1"}'
+    values: "0+0x15"
+  - series: 'backend_resource_operation_last_transition_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast1",subscription_id="sub1",cluster="svc-1"}'
+    values: "600+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast2",subscription_id="sub1",cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_start_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast2",subscription_id="sub1",cluster="svc-1"}'
+    values: "0+0x15"
+  - series: 'backend_resource_operation_last_transition_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast2",subscription_id="sub1",cluster="svc-1"}'
+    values: "600+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast3",subscription_id="sub1",cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_start_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast3",subscription_id="sub1",cluster="svc-1"}'
+    values: "0+0x15"
+  - series: 'backend_resource_operation_last_transition_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast3",subscription_id="sub1",cluster="svc-1"}'
+    values: "600+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast4",subscription_id="sub1",cluster="svc-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_start_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast4",subscription_id="sub1",cluster="svc-1"}'
+    values: "0+0x15"
+  - series: 'backend_resource_operation_last_transition_time_seconds{resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",operation_type="delete",phase="succeeded",resource_id="fast4",subscription_id="sub1",cluster="svc-1"}'
+    values: "600+0x15"
+  promql_expr_test:
+  - expr: errors:backend_cluster_deletion_operation:timeliness_error_rate
+    eval_time: 5m
+    exp_samples:
+    - labels: 'errors:backend_cluster_deletion_operation:timeliness_error_rate{cluster="svc-1"}'
+      value: 0.2


### PR DESCRIPTION
Adds Prometheus alerting and recording rules for Cluster Deletion monitoring as part of [ARO-26216](https://redhat.atlassian.net/browse/ARO-26216). Rules follow [ADR-001: ARO HCP Alerting Recommendation](https://github.com/openshift-online/architecture/pull/79).

runbook_url: aka.ms/arohcp-runbook-cluster-deletion — placeholder short-link; will be pointed to the TSG once published.

Alerts

userJourneyClusterDeletionErrors1h5m — Fast burn, >72% failure rate for 5m (14.4× budget burn)
userJourneyClusterDeletionErrors6h30m — Medium burn, >30% failure rate for 30m (6× budget burn)
userJourneyClusterDeletionErrors3d — Slow burn, >5% failure rate for 6h (1× budget burn)
userJourneyClusterDeletionErrorsDegradation — Early warning, >15% failure rate for 30m
userJourneyClusterDeletionLatency1h5m — Timeliness fast burn, >72% of deletes exceed 30m for 5m
userJourneyClusterDeletionLatency6h30m — Timeliness medium burn, >30% of deletes exceed 30m for 30m
userJourneyClusterDeletionLatency3d — Timeliness slow burn, >5% of deletes exceed 30m for 6h
userJourneyClusterDeletionStuckOperation — Operation stuck in same phase >1 hour; HA deduplication via max without(prometheus_replica)
userJourneyClusterDeletionQueueDepth — Workqueue depth >10 for 5m
All alerts use CEN numeric severity (Sev 3: Errors1h5m, Errors6h30m, Latency1h5m, Latency6h30m (fast + medium burns) Sev 4: Errors3d, ErrorsDegradation, Latency3d, StuckOperation, QueueDepth (slow burns + stuck + saturation)) and include correlationId per [ADR-001](https://redhat.atlassian.net/browse/ADR-001).

Recording Rules

errors:backend_cluster_deletion_operation:error_rate
errors:backend_cluster_deletion_operation:latency_error_rate
Registered in recording-rules-services.yaml and regenerated into generatedRecordingRules.bicep.

Dashboard

Grafana dashboard cluster-deletion.json — fleet-wide SLO visibility covering success SLO, timeliness SLO, stuck operations, duration percentiles (p50/p95/p99), failure ratio trend, and per-subscription breakdown. Includes cluster template variable for per-cluster drill-down.

Testing

25 promtool test scenarios covering all 9 alerts (fire + no-fire pairs), recording rule math, and a combined healthy baseline.
make -C tooling/prometheus-rules run-rp-services and run-recording-rules-services pass. Generated Bicep committed.

Note: HCPdeletionStuck-prometheusRule.yaml is a pre-existing unregistered legacy file. userJourneyClusterDeletionStuckOperation supersedes it with a 1h threshold and CEN-compliant severity.
Jira: [ARO-26216](https://redhat.atlassian.net/browse/ARO-26216)
ADR: ARO HCP Alerting Recommendation ([ADR-001](https://redhat.atlassian.net/browse/ADR-001))