### PR TITLE
test(e2e): verbose ingress strict-TLS wait + on-failure cert diagnostics (AROSLSRE-1495)

### DIFF
--- a/test/util/verifiers/serving_app.go
+++ b/test/util/verifiers/serving_app.go
@@ -527,7 +527,10 @@ func collectIngressCertDiagnostics(ctx context.Context, kubeClient kubernetes.In
 
 	// 4) Warning events in the ingress namespace (e.g. FailedMount of the
 	// managed secret).
-	events, err := kubeClient.CoreV1().Events(ingressNamespace).List(ctx, metav1.ListOptions{})
+	events, err := kubeClient.CoreV1().Events(ingressNamespace).List(ctx, metav1.ListOptions{
+		FieldSelector: "type=Warning",
+		Limit:         50,
+	})
 	if err != nil {
 		out.Printf("[strict-tls][diag] events: error listing: %v\n", err)
 	} else {

--- a/test/util/verifiers/serving_app.go
+++ b/test/util/verifiers/serving_app.go
@@ -22,6 +22,8 @@ import (
 	"net"
 	"net/http"
 	"net/http/httputil"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -180,12 +182,127 @@ func (v verifySimpleWebApp) Verify(ctx context.Context, adminRESTConfig *rest.Co
 		return nil
 	}
 	secureTransport := http.DefaultTransport.(*http.Transport).Clone()
-	if err := waitForRouteReachability(ctx, &http.Client{Transport: secureTransport}, url, 10*time.Minute); err != nil {
+	if err := waitForTrustedRouteReachability(ctx, &http.Client{Transport: secureTransport}, url, host, 10*time.Minute); err != nil {
 		printNegotiatedCertificate(ctx, host)
+		collectIngressCertDiagnostics(ctx, kubeClient, dynamicClient)
 		return err
 	}
 
 	return nil
+}
+
+// servedCertificate describes the leaf certificate currently served by the
+// router, and whether it is still the operator-generated self-signed default
+// ingress certificate rather than the managed OneCert-issued certificate.
+type servedCertificate struct {
+	desc       string
+	selfSigned bool
+	served     bool
+}
+
+// classifyServedCertificate dials host:443 (skipping verification) and reports
+// the leaf certificate currently served. The managed ingress certificate is
+// delivered asynchronously (OneCert -> Key Vault -> ACM -> IngressController),
+// so until it lands the router serves a self-signed default certificate
+// (subject CN=openshift-ingress, issuer CN=root-ca). Distinguishing the two
+// lets the strict TLS wait log the self-signed -> managed transition.
+func classifyServedCertificate(ctx context.Context, host string) servedCertificate {
+	dialCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	dialer := &tls.Dialer{
+		NetDialer: &net.Dialer{Timeout: 10 * time.Second},
+		Config:    &tls.Config{InsecureSkipVerify: true},
+	}
+	conn, err := dialer.DialContext(dialCtx, "tcp", host+":443")
+	if err != nil {
+		return servedCertificate{desc: fmt.Sprintf("dial failed: %v", err)}
+	}
+	defer conn.Close()
+
+	certs := conn.(*tls.Conn).ConnectionState().PeerCertificates
+	if len(certs) == 0 {
+		return servedCertificate{desc: "no certificate served", served: true}
+	}
+	leaf := certs[0]
+	selfSigned := strings.Contains(leaf.Issuer.CommonName, "root-ca") ||
+		strings.EqualFold(leaf.Subject.CommonName, "openshift-ingress")
+	return servedCertificate{
+		desc: fmt.Sprintf("subject=%q issuer=%q notBefore=%s notAfter=%s",
+			leaf.Subject, leaf.Issuer,
+			leaf.NotBefore.Format(time.RFC3339), leaf.NotAfter.Format(time.RFC3339)),
+		selfSigned: selfSigned,
+		served:     true,
+	}
+}
+
+// certKindLabel returns a human-readable label for a served certificate.
+func certKindLabel(c servedCertificate) string {
+	if c.selfSigned {
+		return "self-signed default"
+	}
+	return "managed (OneCert)"
+}
+
+// waitForTrustedRouteReachability polls url requiring strict TLS trust, logging
+// each observed certificate state so the progression self-signed default ->
+// waiting -> managed (OneCert) trusted certificate is visible in the test
+// output. Managed ingress-cert delivery occasionally stalls (the guest
+// cluster-ingress-cert secret is never created), and this makes such a stall
+// diagnosable inline rather than surfacing only as a generic x509 "unknown
+// authority" error.
+func waitForTrustedRouteReachability(ctx context.Context, client *http.Client, url, host string, timeout time.Duration) error {
+	var lastErr error
+	startTime := time.Now()
+	lastDesc := ""
+	lastStatusLog := time.Time{}
+
+	// Record the certificate served before strict verification begins so the
+	// starting point (typically the self-signed default) is captured.
+	if initial := classifyServedCertificate(ctx, host); initial.served {
+		lastDesc = initial.desc
+		ginkgo.GinkgoWriter.Printf("[strict-tls] initial certificate served by %s is the %s certificate: %s\n",
+			host, certKindLabel(initial), initial.desc)
+	}
+
+	err := wait.PollUntilContextTimeout(ctx, 10*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		elapsed := time.Since(startTime).Round(time.Second)
+
+		resp, err := client.Get(url)
+		if err != nil {
+			lastErr = err
+			// Surface which certificate is currently served whenever it changes,
+			// or at least once a minute, while waiting for the managed cert.
+			c := classifyServedCertificate(ctx, host)
+			if c.served && (c.desc != lastDesc || time.Since(lastStatusLog) >= time.Minute) {
+				ginkgo.GinkgoWriter.Printf("[strict-tls] waiting for trusted managed certificate (elapsed=%v): route not yet trusted (%v); currently serving %s certificate: %s\n",
+					elapsed, err, certKindLabel(c), c.desc)
+				lastDesc = c.desc
+				lastStatusLog = time.Now()
+			}
+			return false, nil
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != 200 {
+			lastErr = fmt.Errorf("received non-success status code: %d %s", resp.StatusCode, resp.Status)
+			return false, nil
+		}
+
+		c := classifyServedCertificate(ctx, host)
+		ginkgo.GinkgoWriter.Printf("[strict-tls] route reachable with trusted %s certificate after %v: %s\n",
+			certKindLabel(c), elapsed, c.desc)
+		return true, nil
+	})
+
+	switch {
+	case err == nil:
+		return nil
+	case lastErr != nil:
+		return fmt.Errorf("route was never reachable with a trusted certificate: %w", lastErr)
+	default:
+		return fmt.Errorf("route was never reachable with a trusted certificate: %w", err)
+	}
 }
 
 // waitForRouteReachability polls the URL with the provided client until a
@@ -293,6 +410,143 @@ func printNegotiatedCertificate(ctx context.Context, host string) {
 		certs[0].NotBefore,
 		certs[0].NotAfter,
 	)
+}
+
+const (
+	ingressNamespace         = "openshift-ingress"
+	ingressOperatorNamespace = "openshift-ingress-operator"
+	managedIngressCertSecret = "cluster-ingress-cert"
+	defaultIngressCertSecret = "default-ingress-cert"
+)
+
+// collectIngressCertDiagnostics inspects the guest cluster's ingress serving
+// certificate delivery chain and logs its state. It runs when the strict TLS
+// wait fails so CI captures why the managed certificate never became trusted.
+//
+// The managed serving certificate (openshift-ingress/cluster-ingress-cert) is
+// delivered from the ACM hub by a ConfigurationPolicy; its absence leaves the
+// router serving the ingress operator's self-signed default certificate, which
+// fails strict verification with "x509: certificate signed by unknown
+// authority". Dumping the managed-vs-default secret presence, the
+// IngressController spec/status, the router pod states, and the ingress
+// namespace warning events distinguishes a stalled secret delivery (the
+// observed failure mode) from an IngressController that never reconciled or a
+// router that never rolled out.
+func collectIngressCertDiagnostics(ctx context.Context, kubeClient kubernetes.Interface, dynamicClient dynamic.Interface) {
+	out := ginkgo.GinkgoWriter
+	out.Printf("[strict-tls][diag] collecting guest ingress certificate delivery diagnostics\n")
+
+	// 1) Serving-cert secrets in the ingress namespace. The managed secret is
+	// expected once delivery succeeds; the self-signed default is what the
+	// router falls back to while the managed secret is missing.
+	for _, name := range []string{managedIngressCertSecret, defaultIngressCertSecret} {
+		secret, err := kubeClient.CoreV1().Secrets(ingressNamespace).Get(ctx, name, metav1.GetOptions{})
+		switch {
+		case apierrors.IsNotFound(err):
+			out.Printf("[strict-tls][diag] secret %s/%s: NOT FOUND\n", ingressNamespace, name)
+		case err != nil:
+			out.Printf("[strict-tls][diag] secret %s/%s: error getting: %v\n", ingressNamespace, name, err)
+		default:
+			keys := make([]string, 0, len(secret.Data))
+			for k := range secret.Data {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			out.Printf("[strict-tls][diag] secret %s/%s: PRESENT type=%s dataKeys=%v created=%s\n",
+				ingressNamespace, name, secret.Type, keys, secret.CreationTimestamp.Format(time.RFC3339))
+		}
+	}
+
+	// 2) IngressController/default: the configured default certificate and any
+	// not-ready status conditions.
+	ic, err := dynamicClient.Resource(gvr("operator.openshift.io", "v1", "ingresscontrollers")).
+		Namespace(ingressOperatorNamespace).Get(ctx, "default", metav1.GetOptions{})
+	if err != nil {
+		out.Printf("[strict-tls][diag] ingresscontroller %s/default: error getting: %v\n", ingressOperatorNamespace, err)
+	} else {
+		defaultCert, _, _ := unstructured.NestedString(ic.Object, "spec", "defaultCertificate", "name")
+		if defaultCert == "" {
+			out.Printf("[strict-tls][diag] ingresscontroller default: spec.defaultCertificate.name is UNSET (operator self-signed default in use)\n")
+		} else {
+			out.Printf("[strict-tls][diag] ingresscontroller default: spec.defaultCertificate.name=%q\n", defaultCert)
+		}
+		conditions, _, _ := unstructured.NestedSlice(ic.Object, "status", "conditions")
+		for _, c := range conditions {
+			cm, ok := c.(map[string]any)
+			if !ok {
+				continue
+			}
+			ctype, _, _ := unstructured.NestedString(cm, "type")
+			cstatus, _, _ := unstructured.NestedString(cm, "status")
+			// Only surface conditions that indicate a not-ready/degraded state.
+			switch ctype {
+			case "Available":
+				if cstatus == "True" {
+					continue
+				}
+			case "Degraded", "Progressing":
+				if cstatus == "False" {
+					continue
+				}
+			default:
+				continue
+			}
+			creason, _, _ := unstructured.NestedString(cm, "reason")
+			cmsg, _, _ := unstructured.NestedString(cm, "message")
+			out.Printf("[strict-tls][diag] ingresscontroller default condition %s=%s reason=%q message=%q\n",
+				ctype, cstatus, creason, cmsg)
+		}
+	}
+
+	// 3) Router pods: a missing managed secret keeps the rolled-out router
+	// replicaset in ContainerCreating with FailedMount, so report any container
+	// stuck waiting.
+	pods, err := kubeClient.CoreV1().Pods(ingressNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "ingresscontroller.operator.openshift.io/deployment-ingresscontroller=default",
+	})
+	if err != nil {
+		out.Printf("[strict-tls][diag] router pods: error listing: %v\n", err)
+	} else {
+		out.Printf("[strict-tls][diag] router pods: %d found\n", len(pods.Items))
+		for i := range pods.Items {
+			pod := &pods.Items[i]
+			out.Printf("[strict-tls][diag]   pod %s phase=%s created=%s\n",
+				pod.Name, pod.Status.Phase, pod.CreationTimestamp.Format(time.RFC3339))
+			for _, cs := range pod.Status.ContainerStatuses {
+				if cs.State.Waiting != nil {
+					out.Printf("[strict-tls][diag]     container %s waiting: reason=%s message=%q\n",
+						cs.Name, cs.State.Waiting.Reason, cs.State.Waiting.Message)
+				}
+			}
+		}
+	}
+
+	// 4) Warning events in the ingress namespace (e.g. FailedMount of the
+	// managed secret).
+	events, err := kubeClient.CoreV1().Events(ingressNamespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		out.Printf("[strict-tls][diag] events: error listing: %v\n", err)
+	} else {
+		const maxWarnings = 20
+		printed := 0
+		for i := range events.Items {
+			e := &events.Items[i]
+			if e.Type != corev1.EventTypeWarning {
+				continue
+			}
+			out.Printf("[strict-tls][diag]   event %s/%s reason=%s count=%d lastSeen=%s message=%q\n",
+				e.InvolvedObject.Kind, e.InvolvedObject.Name, e.Reason, e.Count,
+				e.LastTimestamp.Format(time.RFC3339), e.Message)
+			printed++
+			if printed >= maxWarnings {
+				out.Printf("[strict-tls][diag]   (truncated additional warning events)\n")
+				break
+			}
+		}
+		if printed == 0 {
+			out.Printf("[strict-tls][diag] events: no warning events in %s\n", ingressNamespace)
+		}
+	}
 }
 
 func gvr(group, version, resource string) schema.GroupVersionResource {

--- a/test/util/verifiers/serving_app.go
+++ b/test/util/verifiers/serving_app.go
@@ -268,7 +268,11 @@ func waitForTrustedRouteReachability(ctx context.Context, client *http.Client, u
 	err := wait.PollUntilContextTimeout(ctx, 10*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 		elapsed := time.Since(startTime).Round(time.Second)
 
-		resp, err := client.Get(url)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return false, fmt.Errorf("failed to build request: %w", err)
+		}
+		resp, err := client.Do(req)
 		if err != nil {
 			lastErr = err
 			// Surface which certificate is currently served whenever it changes,
@@ -534,9 +538,10 @@ func collectIngressCertDiagnostics(ctx context.Context, kubeClient kubernetes.In
 			if e.Type != corev1.EventTypeWarning {
 				continue
 			}
-			out.Printf("[strict-tls][diag]   event %s/%s reason=%s count=%d lastSeen=%s message=%q\n",
+			ts, age := eventTimestamp(e)
+			out.Printf("[strict-tls][diag]   event %s/%s reason=%s count=%d lastSeen=%s age=%s message=%q\n",
 				e.InvolvedObject.Kind, e.InvolvedObject.Name, e.Reason, e.Count,
-				e.LastTimestamp.Format(time.RFC3339), e.Message)
+				ts, age, e.Message)
 			printed++
 			if printed >= maxWarnings {
 				out.Printf("[strict-tls][diag]   (truncated additional warning events)\n")
@@ -547,6 +552,24 @@ func collectIngressCertDiagnostics(ctx context.Context, kubeClient kubernetes.In
 			out.Printf("[strict-tls][diag] events: no warning events in %s\n", ingressNamespace)
 		}
 	}
+}
+
+// eventTimestamp returns a formatted best-available timestamp for an event and
+// its age. LastTimestamp is frequently zero on modern clusters (events API), so
+// it falls back to EventTime then CreationTimestamp to keep the output
+// actionable instead of printing 0001-01-01.
+func eventTimestamp(e *corev1.Event) (string, string) {
+	t := e.LastTimestamp.Time
+	if t.IsZero() {
+		t = e.EventTime.Time
+	}
+	if t.IsZero() {
+		t = e.CreationTimestamp.Time
+	}
+	if t.IsZero() {
+		return "unknown", "unknown"
+	}
+	return t.Format(time.RFC3339), time.Since(t).Round(time.Second).String()
 }
 
 func gvr(group, version, resource string) schema.GroupVersionResource {

--- a/test/util/verifiers/serving_app.go
+++ b/test/util/verifiers/serving_app.go
@@ -222,7 +222,7 @@ func classifyServedCertificate(ctx context.Context, host string) servedCertifica
 
 	certs := conn.(*tls.Conn).ConnectionState().PeerCertificates
 	if len(certs) == 0 {
-		return servedCertificate{desc: "no certificate served", served: true}
+		return servedCertificate{desc: "no certificate served"}
 	}
 	leaf := certs[0]
 	selfSigned := strings.Contains(leaf.Issuer.CommonName, "root-ca") ||
@@ -294,8 +294,13 @@ func waitForTrustedRouteReachability(ctx context.Context, client *http.Client, u
 		}
 
 		c := classifyServedCertificate(ctx, host)
-		ginkgo.GinkgoWriter.Printf("[strict-tls] route reachable with trusted %s certificate after %v: %s\n",
-			certKindLabel(c), elapsed, c.desc)
+		if c.served {
+			ginkgo.GinkgoWriter.Printf("[strict-tls] route reachable with trusted %s certificate after %v: %s\n",
+				certKindLabel(c), elapsed, c.desc)
+		} else {
+			ginkgo.GinkgoWriter.Printf("[strict-tls] route reachable with a trusted certificate after %v, but re-classifying the served certificate failed: %s\n",
+				elapsed, c.desc)
+		}
 		return true, nil
 	})
 
@@ -439,6 +444,12 @@ const (
 func collectIngressCertDiagnostics(ctx context.Context, kubeClient kubernetes.Interface, dynamicClient dynamic.Interface) {
 	out := ginkgo.GinkgoWriter
 	out.Printf("[strict-tls][diag] collecting guest ingress certificate delivery diagnostics\n")
+
+	// Bound the best-effort diagnostics so a slow/unresponsive apiserver cannot
+	// delay returning the original strict-TLS failure. All API calls below reuse
+	// this short-lived context.
+	ctx, cancel := context.WithTimeout(ctx, 45*time.Second)
+	defer cancel()
 
 	// 1) Serving-cert secrets in the ingress namespace. The managed secret is
 	// expected once delivery succeeds; the self-signed default is what the


### PR DESCRIPTION
[AROSLSRE-1495](https://redhat.atlassian.net/browse/AROSLSRE-1495) — related [AROSLSRE-848](https://redhat.atlassian.net/browse/AROSLSRE-848)

### What

Makes the `VerifySimpleWebApp` strict-TLS route check observable:

- While waiting for strict TLS trust, logs each observed certificate state (`[strict-tls]` lines): the initial self-signed default, per-change/per-minute "waiting for trusted managed certificate", and the final trusted managed (OneCert) certificate.
- On timeout, dumps the guest ingress serving-certificate delivery chain (`[strict-tls][diag]` lines): managed vs default serving-cert secrets in `openshift-ingress`, `IngressController/default` `spec.defaultCertificate` + not-ready conditions, router pod/container waiting states, and ingress-namespace warning events.

No behavior change to the check itself — the strict wait window stays at 10 minutes and strict TLS verification is preserved (nothing is skipped).

### Why

The cilium no-CNI + private-KV e2e test intermittently fails the strict-TLS check with `x509: certificate signed by unknown authority`. The managed ingress serving certificate (`openshift-ingress/cluster-ingress-cert`, delivered from the ACM hub) never lands, so the router keeps serving the operator self-signed default.

Kusto metrics show OneCert issuance is fast (p99 44s, max 85s over 945 clusters / 7d), so the stall is downstream in the ACM policy → guest-secret delivery, not OneCert latency. Today the failure surfaces only as a bare x509 error with no evidence of where the `OneCert → Key Vault → ACM → IngressController` chain broke. This change captures that evidence inline so the next CI failure is diagnosable without a live cluster.

### Testing

- `go build ./util/verifiers/`, `go vet ./util/verifiers/`, `gofmt -l` — all clean (go1.25.7).
- Logging-only change to an existing e2e verifier; no new pass/fail behavior. The verbose output and diagnostics are exercised by the existing cilium-KV e2e path on the next run.

#### Sample failure output

Below is what a strict-TLS failure now prints. The `[strict-tls][diag]` block is a real capture of the current code against fake clients reproducing the observed signature (managed secret never delivered, router stuck on `FailedMount`); the `[strict-tls]` wait lines are shown as they are emitted for the same run.

```text
[strict-tls] initial certificate served by agnhost-e2e-serving-app-bxb9f.apps.aro.cilium-cluster.h044.uksouth.aroapp-hcp.azure-test.net is the self-signed default certificate: subject="CN=openshift-ingress" issuer="CN=root-ca" notBefore=2026-07-15T08:20:11Z notAfter=2026-08-14T08:20:11Z
[strict-tls] waiting for trusted managed certificate (elapsed=1m0s): route not yet trusted (Get "https://agnhost-e2e-serving-app-bxb9f.apps.aro.cilium-cluster.h044.uksouth.aroapp-hcp.azure-test.net": tls: failed to verify certificate: x509: certificate signed by unknown authority); currently serving self-signed default certificate: subject="CN=openshift-ingress" issuer="CN=root-ca" notBefore=2026-07-15T08:20:11Z notAfter=2026-08-14T08:20:11Z
... (repeats each minute until the 10m window elapses) ...
route was never reachable with a trusted certificate: Get "https://agnhost-e2e-serving-app-bxb9f.apps.aro.cilium-cluster.h044.uksouth.aroapp-hcp.azure-test.net": tls: failed to verify certificate: x509: certificate signed by unknown authority
Negotiated certificate: host=agnhost-e2e-serving-app-bxb9f.apps.aro.cilium-cluster.h044.uksouth.aroapp-hcp.azure-test.net subject=CN=openshift-ingress issuer=CN=root-ca dnsNames=[*.apps.aro.cilium-cluster.h044.uksouth.aroapp-hcp.azure-test.net] notBefore=2026-07-15 08:20:11 +0000 UTC notAfter=2026-08-14 08:20:11 +0000 UTC
[strict-tls][diag] collecting guest ingress certificate delivery diagnostics
[strict-tls][diag] secret openshift-ingress/cluster-ingress-cert: NOT FOUND
[strict-tls][diag] secret openshift-ingress/default-ingress-cert: PRESENT type=kubernetes.io/tls dataKeys=[tls.crt tls.key] created=2026-07-15T08:32:10Z
[strict-tls][diag] ingresscontroller default: spec.defaultCertificate.name="cluster-ingress-cert"
[strict-tls][diag] ingresscontroller default condition Available=False reason="IngressControllerUnavailable" message="One or more status conditions indicate unavailable: DeploymentAvailable=False (DeploymentUnavailable: The deployment has Available status condition set to False)"
[strict-tls][diag] ingresscontroller default condition Progressing=True reason="DeploymentRollingOut" message="Waiting for router deployment rollout to finish"
[strict-tls][diag] router pods: 2 found
[strict-tls][diag]   pod router-default-5c9bd7d6c8-4nv2k phase=Running created=2026-07-15T08:32:10Z
[strict-tls][diag]   pod router-default-6984bf7b77-h8dwx phase=Pending created=2026-07-15T08:32:10Z
[strict-tls][diag]     container router waiting: reason=ContainerCreating message=""
[strict-tls][diag]   event Pod/router-default-6984bf7b77-h8dwx reason=FailedMount count=14 lastSeen=2026-07-15T08:46:20Z age=23m10s message="MountVolume.SetUp failed for volume \"default-certificate\" : secret \"cluster-ingress-cert\" not found"
```

How to read it against the cert delivery chain (`OneCert → Key Vault → ACM → IngressController`):

- `cluster-ingress-cert: NOT FOUND` + `default-ingress-cert: PRESENT` → the ACM-delivered managed secret never landed (hop 3); the router falls back to the self-signed default.
- `spec.defaultCertificate.name="cluster-ingress-cert"` → the IngressController was already pointed at the managed secret (hop 4 configured), so the missing secret is the gap.
- router pod `Pending` + `container router waiting: ContainerCreating` + `FailedMount ... secret "cluster-ingress-cert" not found` → the new router replicaset cannot roll out because the managed secret is absent.

This pinpoints the stall at hop 3 (ACM policy → guest secret) rather than leaving a bare `x509` error.

### Special notes for your reviewer

Diagnostics reuse the `kubeClient`/`dynamicClient` already built in `Verify`; they run only on strict-TLS failure, are read-only, best-effort (errors are logged, never returned), and bounded by a 45s timeout so a slow apiserver cannot delay returning the original failure. This is an observability change to help root-cause [AROSLSRE-1495](https://redhat.atlassian.net/browse/AROSLSRE-1495) — the product fix (guest `cluster-ingress-cert` never created by the ACM ConfigurationPolicy) is tracked separately. Related follow-ups discussed with the team: an `oc adm inspect` of the HostedCluster in E2E artifacts ([AROSLSRE-846](https://redhat.atlassian.net/browse/AROSLSRE-846)) and an explicit ingress-cert wait step ([AROSLSRE-847](https://redhat.atlassian.net/browse/AROSLSRE-847)) — both out of scope here.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
