### PR TITLE
fix: clamp chart slider default to Y-axis maximum

### DIFF
--- a/test/cmd/aro-hcp-tests/gather-observability/artifacts/metricspanel.html.tmpl
+++ b/test/cmd/aro-hcp-tests/gather-observability/artifacts/metricspanel.html.tmpl
@@ -178,8 +178,8 @@
 
         slider.addEventListener('input', applyThreshold);
 
-        if (initialThreshold > 0 && initialThreshold <= yExtent[1]) {
-            slider.value = String(initialThreshold);
+        if (initialThreshold > 0) {
+            slider.value = String(Math.min(initialThreshold, yExtent[1]));
             applyThreshold();
         }
     }


### PR DESCRIPTION
### What

When a query's minPeakThreshold exceeds the chart's Y-axis maximum (e.g. all series peak below the configured threshold), the slider was silently falling back to 0 because the guard condition rejected the value entirely. This hid all series instead of showing only those near the top of the actual data range.

Clamp the initial slider value to yExtent[1] so the slider starts at the chart maximum when the configured default is out of range.

### Why

<!-- Briefly explain why this change is needed -->

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
