### PR TITLE
fix(test): wrap Graph writes in Eventually

### DIFF
--- a/test/e2e/cluster_authorized_cidrs_connectivity.go
+++ b/test/e2e/cluster_authorized_cidrs_connectivity.go
@@ -265,8 +265,7 @@ var _ = Describe("Authorized CIDRs", func() {
 				graphClient, err := tc.GetGraphClient(ctx)
 				Expect(err).NotTo(HaveOccurred(), "failed to get graph client")
 
-				pass, err := graphClient.AddPassword(ctx, app.ID, "cidr-external-auth-pass", time.Now(), time.Now().Add(24*time.Hour))
-				Expect(err).NotTo(HaveOccurred(), "failed to add password to app registration")
+				passSecret := framework.AddAppRegistrationPassword(ctx, graphClient, app.ID, "cidr-external-auth-pass")
 
 				By("creating an external auth config with a prefix")
 				extAuth := hcpsdk20240610preview.ExternalAuth{
@@ -329,7 +328,7 @@ var _ = Describe("Authorized CIDRs", func() {
 
 				By("creating a rest config using OIDC authentication")
 				Expect(tc.TenantID()).NotTo(BeEmpty(), "tenant ID should not be empty for OIDC authentication")
-				cred, err := azidentity.NewClientSecretCredential(tc.TenantID(), app.AppID, pass.SecretText, nil)
+				cred, err := azidentity.NewClientSecretCredential(tc.TenantID(), app.AppID, passSecret, nil)
 				Expect(err).NotTo(HaveOccurred(), "failed to create client secret credential for OIDC authentication")
 
 				// MSGraph is eventually consistent, wait up to 2 minutes for the token to be valid
@@ -385,7 +384,7 @@ var _ = Describe("Authorized CIDRs", func() {
 
 				By("creating the console OAuth client secret for external auth via VM")
 				consoleOAuthSecretName := fmt.Sprintf("%s-console-openshift-console", customerExternalAuthName)
-				clientSecretB64 := base64.StdEncoding.EncodeToString([]byte(pass.SecretText))
+				clientSecretB64 := base64.StdEncoding.EncodeToString([]byte(passSecret))
 				createSecretCmd := fmt.Sprintf(
 					`echo '%s' | base64 -d > /tmp/kubeconfig && kubectl --kubeconfig=/tmp/kubeconfig create secret generic %s --namespace=openshift-config --from-literal=clientSecret="$(echo '%s' | base64 -d)"`,
 					kubeconfigB64,

--- a/test/e2e/external_auth_create.go
+++ b/test/e2e/external_auth_create.go
@@ -128,8 +128,7 @@ var _ = Describe("Customer", func() {
 			graphClient, err := tc.GetGraphClient(ctx)
 			Expect(err).NotTo(HaveOccurred(), "failed to get Microsoft Graph client")
 
-			pass, err := graphClient.AddPassword(ctx, app.ID, "external-auth-pass", time.Now(), time.Now().Add(24*time.Hour))
-			Expect(err).NotTo(HaveOccurred(), "failed to add password to app registration")
+			passSecret := framework.AddAppRegistrationPassword(ctx, graphClient, app.ID, "external-auth-pass")
 
 			By("creating an external auth config with a prefix")
 			extAuth := hcpsdk20240610preview.ExternalAuth{
@@ -184,7 +183,7 @@ var _ = Describe("Customer", func() {
 
 			By("creating a rest config using OIDC authentication")
 			Expect(tc.TenantID()).NotTo(BeEmpty(), "tenant ID must not be empty for OIDC authentication")
-			cred, err := azidentity.NewClientSecretCredential(tc.TenantID(), app.AppID, pass.SecretText, nil)
+			cred, err := azidentity.NewClientSecretCredential(tc.TenantID(), app.AppID, passSecret, nil)
 			Expect(err).NotTo(HaveOccurred(), "failed to create client secret credential for OIDC authentication")
 
 			// MSGraph is eventually consistent, wait up to 2 minutes for the token to be valid
@@ -237,7 +236,7 @@ var _ = Describe("Customer", func() {
 					Namespace: "openshift-config",
 				},
 				StringData: map[string]string{
-					"clientSecret": pass.SecretText,
+					"clientSecret": passSecret,
 				},
 			}
 			_, err = adminClient.CoreV1().Secrets("openshift-config").Create(ctx, consoleOAuthSecret, metav1.CreateOptions{})

--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -795,10 +795,12 @@ func (tc *perItOrDescribeTestContext) NewAppRegistrationWithServicePrincipal(ctx
 		return nil, nil, fmt.Errorf("failed to get graph client: %w", err)
 	}
 
-	app, err := graphClient.CreateApplication(ctx, appName, []string{})
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create app registration: %w", err)
-	}
+	var app *graphutil.Application
+	gomega.Eventually(func() error {
+		var err error
+		app, err = graphClient.CreateApplication(ctx, appName, []string{})
+		return err
+	}, 2*time.Minute, 5*time.Second).Should(gomega.Succeed(), "failed to create app registration")
 
 	func() {
 		tc.contextLock.Lock()
@@ -807,12 +809,28 @@ func (tc *perItOrDescribeTestContext) NewAppRegistrationWithServicePrincipal(ctx
 		tc.knownAppRegistrationIDs = append(tc.knownAppRegistrationIDs, app.ID)
 	}()
 
-	sp, err := graphClient.CreateServicePrincipal(ctx, app.AppID)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create service principal: %w", err)
-	}
+	var sp *graphutil.ServicePrincipal
+	gomega.Eventually(func() error {
+		var err error
+		sp, err = graphClient.CreateServicePrincipal(ctx, app.AppID)
+		return err
+	}, 2*time.Minute, 5*time.Second).Should(gomega.Succeed(), "failed to create service principal")
 
 	return app, sp, nil
+}
+
+func AddAppRegistrationPassword(ctx context.Context, graphClient *graphutil.Client, appID, displayName string) string {
+	var passSecret string
+	gomega.Eventually(func() error {
+		pass, err := graphClient.AddPassword(ctx, appID, displayName, time.Now(), time.Now().Add(24*time.Hour))
+		if err != nil {
+			return err
+		}
+		passSecret = pass.SecretText
+		return nil
+	}, 2*time.Minute, 5*time.Second).Should(gomega.Succeed(), "failed to add password to app registration")
+
+	return passSecret
 }
 
 func CleanupAppRegistrations(ctx context.Context, graphClient *graphutil.Client, appRegistrationIDs []string) error {


### PR DESCRIPTION
[ARO-27423](https://redhat.atlassian.net/browse/ARO-27423)

### What

Wrap Graph writes in Eventually with a 2‑minute budget and 5‑second poll interval, matching the existing convention. 

### Why

A newly‑created application object is not immediately visible on every Graph replica, write operations against it can return 404 ResourceNotFound or 403 RequestDenied fo tens of seconds (or even longer) after the create.

### Testing

The PR modifies existing test framework functions and their 2 callers. 

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
