### PR TITLE
cfg: CI use 2 mgmt clusters

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1704,16 +1704,18 @@ clouds:
               exporter: "otlp"
           # MC
           mgmt:
+            stamps:
+              count: 2
             rg: "hcp-underlay-{{ .ctx.environment }}-{{ .ctx.regionShort }}-mgmt-{{ .ctx.stamp }}"
             aks:
               name: "{{ .ctx.environment }}-{{ .ctx.regionShort }}-mgmt-{{ .ctx.stamp }}"
               systemAgentPool:
                 maxCount: 4
                 osDiskSizeGB: 32
-                vmSize: Standard_D16ds_v6
+                vmSize: Standard_D8ds_v6
               userAgentPool:
                 maxCount: 14
-                minCount: 7
+                minCount: 4
                 osDiskSizeGB: 100
                 vmSize: Standard_E16ds_v6
                 secondaryNicCount: 7
@@ -1803,6 +1805,8 @@ clouds:
               exporter: "otlp"
           # MC
           mgmt:
+            stamps:
+              count: 2
             subscription:
               key: ARO HCP E2E Infrastructure (EA Subscription)
             rg: "hcp-underlay-{{ .ctx.environment }}-{{ .ctx.regionShort }}-mgmt-{{ .ctx.stamp }}"
@@ -1811,10 +1815,10 @@ clouds:
               systemAgentPool:
                 maxCount: 4
                 osDiskSizeGB: 32
-                vmSize: Standard_D16ds_v6
+                vmSize: Standard_D8ds_v6
               userAgentPool:
                 maxCount: 14
-                minCount: 7
+                minCount: 4
                 osDiskSizeGB: 100
                 vmSize: Standard_E16ds_v6
                 secondaryNicCount: 7

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -632,7 +632,7 @@ mgmt:
       name: system
       osDiskSizeGB: 32
       poolCount: 1
-      vmSize: Standard_D16ds_v6
+      vmSize: Standard_D8ds_v6
       zoneRedundantMode: Auto
       zones: ""
     upgradeSettings:
@@ -640,7 +640,7 @@ mgmt:
       maxUnavailable: "0"
     userAgentPool:
       maxCount: 14
-      minCount: 7
+      minCount: 4
       name: userswft
       osDiskSizeGB: 100
       poolCount: 3
@@ -709,7 +709,7 @@ mgmt:
   rg: hcp-underlay-ci00-j7654321-mgmt-1
   stampIdentifier: "1"
   stamps:
-    count: 1
+    count: 2
   subscription:
     certificateDomains:
     - '*.hcp.osadev.cloud'

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -632,7 +632,7 @@ mgmt:
       name: system
       osDiskSizeGB: 32
       poolCount: 1
-      vmSize: Standard_D16ds_v6
+      vmSize: Standard_D8ds_v6
       zoneRedundantMode: Auto
       zones: ""
     upgradeSettings:
@@ -640,7 +640,7 @@ mgmt:
       maxUnavailable: "0"
     userAgentPool:
       maxCount: 14
-      minCount: 7
+      minCount: 4
       name: userswft
       osDiskSizeGB: 100
       poolCount: 3
@@ -709,7 +709,7 @@ mgmt:
   rg: hcp-underlay-ci01-j7654321-mgmt-1
   stampIdentifier: "1"
   stamps:
-    count: 1
+    count: 2
   subscription:
     certificateDomains:
     - '*.hcp.osadev.cloud'


### PR DESCRIPTION
### What

in order to test multiple management clusters, the stamp count has been bumped to 2 for ci00/ci01. system and user pools have been reduced because both mgmt clusters loadbalance the HCPs that are created during the e2e tests and should suffice in sum

### Why

<!-- Briefly explain why this change is needed -->

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
