### PR TITLE
test: add E2E tests to validate node pool creation for various availability zone scenarios

### DIFF
--- a/test/e2e/cluster_create_nodepool_osdisk.go
+++ b/test/e2e/cluster_create_nodepool_osdisk.go
@@ -122,5 +122,7 @@ var _ = Describe("Customer", func() {
 			Expect(created.Properties.Platform).ToNot(BeNil(), "nodepool Properties.Platform was nil")
 			Expect(created.Properties.Platform.OSDisk).ToNot(BeNil(), "nodepool Properties.Platform.OSDisk was nil")
 			Expect(*created.Properties.Platform.OSDisk.SizeGiB).To(Equal(customerNodeOsDiskSizeGiB), "nodepool OS disk size should be %d GiB", customerNodeOsDiskSizeGiB)
+			Expect(created.Properties.Platform.AvailabilityZone).To(BeNil(),
+				"expected availability zone to be unset when not specified on nodepool create")
 		})
 })

--- a/test/e2e/nodepool_autoscaling.go
+++ b/test/e2e/nodepool_autoscaling.go
@@ -160,6 +160,10 @@ var _ = Describe("Customer", func() {
 					azNodePoolName)
 				Expect(err).NotTo(HaveOccurred(), "failed to get AZ nodepool %s", azNodePoolName)
 				Expect(azNodePoolResp.Properties).NotTo(BeNil(), "nodepool response Properties was nil")
+				Expect(azNodePoolResp.Properties.Platform).NotTo(BeNil(), "nodepool response Properties.Platform was nil")
+				Expect(azNodePoolResp.Properties.Platform.AvailabilityZone).NotTo(BeNil(), "nodepool response Properties.Platform.AvailabilityZone was nil")
+				Expect(*azNodePoolResp.Properties.Platform.AvailabilityZone).To(Equal(availabilityZone),
+					"expected nodepool availability zone to match requested zone %s", availabilityZone)
 				Expect(azNodePoolResp.Properties.AutoScaling).NotTo(BeNil(), "Expected nodepool to have autoscaling configuration")
 				Expect(azNodePoolResp.Properties.AutoScaling.Min).To(Equal(to.Ptr(azAutoscalingMin)), "expected AZ nodepool autoscaling min to equal %d", azAutoscalingMin)
 				Expect(azNodePoolResp.Properties.AutoScaling.Max).To(Equal(to.Ptr(azAutoscalingMax)), "expected AZ nodepool autoscaling max to equal %d", azAutoscalingMax)

--- a/test/e2e/nodepool_availability_zone.go
+++ b/test/e2e/nodepool_availability_zone.go
@@ -1,0 +1,166 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	hcpsdk20240610preview "github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
+	"github.com/Azure/ARO-HCP/test/util/framework"
+	"github.com/Azure/ARO-HCP/test/util/labels"
+)
+
+const nonExistentAvailabilityZone = "99"
+
+type availabilityZoneTestCluster struct {
+	resourceGroupName        string
+	managedResourceGroupName string
+	clusterName              string
+	nodePoolsClient          *hcpsdk20240610preview.NodePoolsClient
+	tc                       *framework.E2ETestContext
+}
+
+func createAvailabilityZoneTestCluster(ctx context.Context) availabilityZoneTestCluster {
+	const customerClusterName = "np-az-cluster"
+
+	tc := framework.NewTestContext()
+
+	if tc.UsePooledIdentities() {
+		err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
+		Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
+	}
+
+	By("creating a resource group")
+	resourceGroup, err := tc.NewResourceGroup(ctx, "np-az", tc.Location())
+	Expect(err).NotTo(HaveOccurred(), "failed to create resource group for nodepool availability zone tests")
+
+	clusterParams := framework.NewDefaultClusterParams20240610()
+	clusterParams.ClusterName = customerClusterName
+	managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
+	clusterParams.ManagedResourceGroupName = managedResourceGroupName
+
+	By("creating customer resources")
+	clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,
+		resourceGroup,
+		clusterParams,
+		map[string]any{},
+		TestArtifactsFS,
+		framework.RBACScopeResourceGroup,
+	)
+	Expect(err).NotTo(HaveOccurred(), "failed to create customer resources for availability zone tests")
+
+	By("creating the HCP cluster")
+	err = tc.CreateHCPClusterFromParam20240610(ctx,
+		GinkgoLogr,
+		*resourceGroup.Name,
+		clusterParams,
+		framework.ClusterCreationTimeout,
+	)
+	Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster %s", customerClusterName)
+
+	return availabilityZoneTestCluster{
+		resourceGroupName:        *resourceGroup.Name,
+		managedResourceGroupName: managedResourceGroupName,
+		clusterName:              customerClusterName,
+		nodePoolsClient:          tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient(),
+		tc:                       tc,
+	}
+}
+
+var _ = Describe("Nodepool Availability Zone", func() {
+	It("should reject nodepool creation for invalid availability zone configurations",
+		labels.RequireNothing,
+		labels.Medium,
+		labels.Negative,
+		labels.AroRpApiCompatible,
+		func(ctx context.Context) {
+			cluster := createAvailabilityZoneTestCluster(ctx)
+
+			By("resolving a worker VM size that supports availability zones")
+			selector := framework.DefaultWorkerVMSizeSelector()
+			selector.RequireZones = true
+			workerVMSize, err := cluster.tc.SelectVMSize(ctx, selector)
+			if errors.Is(err, framework.ErrNoUsableVMSize) {
+				Skip(fmt.Sprintf("no zone-capable worker VM size found in region %s", cluster.tc.Location()))
+			}
+			Expect(err).NotTo(HaveOccurred(), "failed to resolve a worker VM size with availability zone support")
+			availableZones, err := cluster.tc.AvailableZones(ctx, workerVMSize)
+			Expect(err).NotTo(HaveOccurred(), "failed to resolve usable availability zones for worker VM size %s", workerVMSize)
+			Expect(availableZones).NotTo(BeEmpty(),
+				"expected worker VM size %s selected with RequireZones to have usable availability zones in %s",
+				workerVMSize, cluster.tc.Location())
+			supportedAvailabilityZone := availableZones[0]
+
+			By("attempting to create a nodepool with a non-existing availability zone")
+			invalidZoneNodePoolParams := framework.NewDefaultNodePoolParams20240610()
+			invalidZoneNodePoolParams.ClusterName = cluster.clusterName
+			invalidZoneNodePoolParams.NodePoolName = "np-bad-az"
+			invalidZoneNodePoolParams.VMSize = workerVMSize
+			invalidZoneNodePoolParams.AvailabilityZone = nonExistentAvailabilityZone
+			err = cluster.tc.CreateNodePoolFromParam20240610(ctx,
+				GinkgoLogr,
+				cluster.resourceGroupName,
+				cluster.managedResourceGroupName,
+				cluster.clusterName,
+				invalidZoneNodePoolParams,
+				framework.NodePoolCreationTimeout,
+			)
+			Expect(err).To(HaveOccurred(), "expected nodepool creation to fail for non-existing availability zone %s", nonExistentAvailabilityZone)
+			errMsg := strings.ToLower(err.Error())
+			Expect(errMsg).To(ContainSubstring("does not support availability zone"),
+				"error should indicate the availability zone is not supported")
+			Expect(errMsg).To(ContainSubstring(nonExistentAvailabilityZone),
+				"error should reference the invalid availability zone %s", nonExistentAvailabilityZone)
+
+			failedNodePool, err := framework.GetNodePool20240610(ctx, cluster.nodePoolsClient, cluster.resourceGroupName, cluster.clusterName, invalidZoneNodePoolParams.NodePoolName)
+			Expect(err).NotTo(HaveOccurred(), "failed to get nodepool %s after expected availability zone failure", invalidZoneNodePoolParams.NodePoolName)
+			Expect(failedNodePool.Properties).NotTo(BeNil(), "nodepool response Properties was nil")
+			Expect(failedNodePool.Properties.ProvisioningState).NotTo(BeNil(), "nodepool Properties.ProvisioningState was nil")
+			Expect(*failedNodePool.Properties.ProvisioningState).To(Equal(hcpsdk20240610preview.ProvisioningStateFailed),
+				"expected nodepool %s provisioning state to be Failed", invalidZoneNodePoolParams.NodePoolName)
+
+			By("attempting to create a nodepool with an availability zone on a VM size that does not support zone deployment")
+			vmSizeWithoutZones, err := cluster.tc.FindVMSizeWithoutAvailabilityZones(ctx)
+			Expect(err).NotTo(HaveOccurred(), "failed to search for VM size without availability zone support")
+			if vmSizeWithoutZones == "" {
+				Skip(fmt.Sprintf("no Azure VM size without availability zone support found in region %s", cluster.tc.Location()))
+			}
+
+			noZoneVMNodePoolParams := framework.NewDefaultNodePoolParams20240610()
+			noZoneVMNodePoolParams.ClusterName = cluster.clusterName
+			noZoneVMNodePoolParams.NodePoolName = "np-vm-no-az"
+			noZoneVMNodePoolParams.VMSize = vmSizeWithoutZones
+			noZoneVMNodePoolParams.AvailabilityZone = supportedAvailabilityZone
+			err = cluster.tc.CreateNodePoolFromParam20240610(ctx,
+				GinkgoLogr,
+				cluster.resourceGroupName,
+				cluster.managedResourceGroupName,
+				cluster.clusterName,
+				noZoneVMNodePoolParams,
+				framework.NodePoolCreationTimeout,
+			)
+			Expect(err).To(HaveOccurred(),
+				"expected nodepool creation to fail when VM size %s does not support availability zone deployment", vmSizeWithoutZones)
+			Expect(strings.ToLower(err.Error())).To(ContainSubstring(
+				"does not support to be deployed to a specific availability zone"),
+				"error should indicate the VM size does not support availability zone deployment")
+		})
+})

--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -129,6 +129,9 @@ func setupAzureLogging(logDirPath string) *os.File {
 	return azureLogFile
 }
 
+// E2ETestContext is the per-test context returned by NewTestContext.
+type E2ETestContext = perItOrDescribeTestContext
+
 func NewTestContext() *perItOrDescribeTestContext {
 	logDirPath := setupTestLogDir(artifactDir())
 	azureLogFile := setupAzureLogging(logDirPath)

--- a/test/util/framework/vm_sku_selection.go
+++ b/test/util/framework/vm_sku_selection.go
@@ -114,6 +114,77 @@ func (tc *perItOrDescribeTestContext) SelectVMSize(ctx context.Context, selector
 	return selected, nil
 }
 
+// FindVMSizeWithoutAvailabilityZones returns the first RP-allowlisted worker-class
+// VM size in the test location that is unrestricted for the subscription but advertises
+// no availability zones in the Azure Resource SKUs API. An empty string means no such
+// SKU was found (callers typically Skip the test).
+func (tc *perItOrDescribeTestContext) FindVMSizeWithoutAvailabilityZones(ctx context.Context) (string, error) {
+	location := tc.Location()
+	selector := DefaultWorkerVMSizeSelector()
+
+	skus, err := tc.listVirtualMachineResourceSKUs(ctx, location)
+	if err != nil {
+		return "", err
+	}
+
+	skuByName := make(map[string]*armcompute.ResourceSKU, len(skus))
+	for _, sku := range skus {
+		if sku == nil || sku.Name == nil {
+			continue
+		}
+		skuByName[*sku.Name] = sku
+	}
+
+	for _, name := range selector.Preferred {
+		if vmSize, ok := vmSizeWithoutAvailabilityZones(skuByName[name], location, selector); ok {
+			return vmSize, nil
+		}
+	}
+
+	var candidates []string
+	for _, sku := range skus {
+		if vmSize, ok := vmSizeWithoutAvailabilityZones(sku, location, selector); ok {
+			candidates = append(candidates, vmSize)
+		}
+	}
+	sort.Strings(candidates)
+	if len(candidates) == 0 {
+		return "", nil
+	}
+	return candidates[0], nil
+}
+
+func vmSizeWithoutAvailabilityZones(sku *armcompute.ResourceSKU, location string, selector VMSizeSelector) (string, bool) {
+	if sku == nil || sku.Name == nil {
+		return "", false
+	}
+	if selector.NamePattern != nil && !selector.NamePattern.MatchString(*sku.Name) {
+		return "", false
+	}
+	if !skuUsable(sku, location, selector) {
+		return "", false
+	}
+	if skuAdvertisesAvailabilityZones(sku, location) {
+		return "", false
+	}
+	return *sku.Name, true
+}
+
+// skuAdvertisesAvailabilityZones reports whether the SKU advertises any
+// availability zones for the location in the Azure Resource SKUs API, regardless
+// of subscription-specific zone restrictions.
+func skuAdvertisesAvailabilityZones(sku *armcompute.ResourceSKU, location string) bool {
+	for _, info := range sku.LocationInfo {
+		if info == nil || info.Location == nil || !strings.EqualFold(*info.Location, location) {
+			continue
+		}
+		if len(info.Zones) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // vmSizeSelectionTrace records how SelectVMSize reached its decision so it can
 // be logged. It makes it obvious in CI output when a preferred candidate was
 // unavailable and selection fell through to the next entry (or the fallback).

--- a/test/util/framework/vm_sku_selection_test.go
+++ b/test/util/framework/vm_sku_selection_test.go
@@ -514,6 +514,39 @@ func TestEphemeralSelectorSelectsDifferentFamily(t *testing.T) {
 	}
 }
 
+func TestVMSizeWithoutAvailabilityZones(t *testing.T) {
+	selector := DefaultWorkerVMSizeSelector()
+
+	skuWithZones := makeSKU("Standard_D8s_v3", testLocation,
+		withCapability(capabilityVCPUs, "8"),
+		withZones(testLocation, "1", "2", "3"),
+	)
+	if name, ok := vmSizeWithoutAvailabilityZones(skuWithZones, testLocation, selector); ok {
+		t.Fatalf("expected SKU with zones to be rejected, got %q", name)
+	}
+
+	withoutZones := makeSKU("Standard_D8s_v3", testLocation, withCapability(capabilityVCPUs, "8"))
+	if name, ok := vmSizeWithoutAvailabilityZones(withoutZones, testLocation, selector); !ok || name != "Standard_D8s_v3" {
+		t.Fatalf("expected Standard_D8s_v3 without zones to match, got name=%q ok=%v", name, ok)
+	}
+
+	// A zone-capable SKU with all zones subscription-restricted must not be
+	// treated as lacking zone support.
+	withZonesAllRestricted := makeSKU("Standard_D8s_v5", testLocation,
+		withCapability(capabilityVCPUs, "8"),
+		withZones(testLocation, "1", "2", "3"),
+		withZoneRestriction(testLocation, "1", "2", "3"),
+	)
+	if name, ok := vmSizeWithoutAvailabilityZones(withZonesAllRestricted, testLocation, selector); ok {
+		t.Fatalf("expected zone-capable SKU with all zones restricted to be rejected, got %q", name)
+	}
+
+	nonAllowlisted := makeSKU("Standard_D8ds_v5", testLocation, withCapability(capabilityVCPUs, "8"))
+	if name, ok := vmSizeWithoutAvailabilityZones(nonAllowlisted, testLocation, selector); ok {
+		t.Fatalf("expected non-allowlisted SKU to be rejected, got %q", name)
+	}
+}
+
 // TestWorkerSelectorPreferredEntriesAreAllowlisted closes the Preferred-list
 // gap in the allowlist-boundary guard. selectVMSize tries Preferred SKUs before
 // discovery and intentionally does NOT constrain them by NamePattern, so a


### PR DESCRIPTION
Jira issue: 
https://redhat.atlassian.net/browse/ARO-13378

### What

Adds ARO-HCP E2E tests for node pool creation for various availability zone behavior.

**Scenarios covered:**
- **Positive:** nodepool without AZ; nodepool with a valid AZ (Updated existing tests to add Explicit assertion for AZ to avoid reduntant tests)
- **Negative:** non-existing AZ (`"99"`) fails inflight with expected error
- **Negative:** VM size that does not support AZ deployment fails inflight (Skips when no such SKU exists in the region)

### Testing

- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [x] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.mhttps://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [x] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
