### PR TITLE
test/aro-hcp-tests: pass MonitoringEventsDatabase to Kusto queries

### DIFF
--- a/test/cmd/aro-hcp-tests/gather-snapshot/options.go
+++ b/test/cmd/aro-hcp-tests/gather-snapshot/options.go
@@ -61,12 +61,13 @@ type ValidatedOptions struct {
 }
 
 type completedOptions struct {
-	OutputDir      string
-	KustoEndpoint  string
-	ServiceDB      string
-	HCPDB          string
-	TestTimingInfo map[string]timing.TimingInfo
-	kustoClient    *azkustodata.Client
+	OutputDir          string
+	KustoEndpoint      string
+	ServiceDB          string
+	HCPDB              string
+	MonitoringEventsDB string
+	TestTimingInfo     map[string]timing.TimingInfo
+	kustoClient        *azkustodata.Client
 }
 
 type Options struct {
@@ -144,6 +145,10 @@ func (o *ValidatedOptions) Complete(ctx context.Context) (*Options, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get hosted control plane logs database from config: %w", err)
 	}
+	monitoringEventsDB, err := testutil.ConfigGetString(cfg, "kusto.monitoringEventsDatabase")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get monitoring events database from config: %w", err)
+	}
 
 	kustoRegion, err := resolveKustoRegion(kustoName)
 	if err != nil {
@@ -161,6 +166,7 @@ func (o *ValidatedOptions) Complete(ctx context.Context) (*Options, error) {
 		"endpoint", kustoEndpoint.String(),
 		"serviceDB", serviceDB,
 		"hcpDB", hcpDB,
+		"monitoringEventsDB", monitoringEventsDB,
 	)
 
 	testTimingInfo, err := timing.LoadTestTimingInfo(ctx, o.TimingInputDir)
@@ -184,12 +190,13 @@ func (o *ValidatedOptions) Complete(ctx context.Context) (*Options, error) {
 	}
 
 	return &Options{completedOptions: &completedOptions{
-		OutputDir:      o.OutputDir,
-		KustoEndpoint:  kustoEndpoint.String(),
-		ServiceDB:      serviceDB,
-		HCPDB:          hcpDB,
-		TestTimingInfo: testTimingInfo,
-		kustoClient:    kustoClient,
+		OutputDir:          o.OutputDir,
+		KustoEndpoint:      kustoEndpoint.String(),
+		ServiceDB:          serviceDB,
+		HCPDB:              hcpDB,
+		MonitoringEventsDB: monitoringEventsDB,
+		TestTimingInfo:     testTimingInfo,
+		kustoClient:        kustoClient,
 	}}, nil
 }
 
@@ -230,10 +237,11 @@ func (o Options) Run(ctx context.Context) error {
 			)
 
 			input := snapshot.GatherInput{
-				ClusterURI:      o.KustoEndpoint,
-				ServiceDatabase: o.ServiceDB,
-				HCPDatabase:     o.HCPDB,
-				ResourceGroup:   rg,
+				ClusterURI:               o.KustoEndpoint,
+				ServiceDatabase:          o.ServiceDB,
+				HCPDatabase:              o.HCPDB,
+				MonitoringEventsDatabase: o.MonitoringEventsDB,
+				ResourceGroup:            rg,
 				TimeWindow: snapshot.TimeWindow{
 					Start:           ti.StartTime,
 					End:             ti.EndTime,

--- a/test/cmd/aro-hcp-tests/gather-snapshot/options.go
+++ b/test/cmd/aro-hcp-tests/gather-snapshot/options.go
@@ -254,6 +254,16 @@ func (o Options) Run(ctx context.Context) error {
 			manifest, report, err := gatherer.Gather(ctx, input, testOutputDir)
 			if err != nil {
 				logger.Error(err, "Failed to gather snapshot", "test", testName, "resourceGroup", rg)
+				allReports = append(allReports, &snapshot.VerificationReport{
+					Cases: []snapshot.VerificationCase{{
+						Suite:        fmt.Sprintf("gather/%s", rg),
+						Query:        "gather",
+						Category:     "infrastructure",
+						ResourceType: "gather",
+						Status:       snapshot.VerificationFail,
+						Message:      fmt.Sprintf("failed to gather snapshot for test %q resource group %q: %v", testName, rg, err),
+					}},
+				})
 				if ctx.Err() != nil {
 					break
 				}


### PR DESCRIPTION
test/aro-hcp-tests: emit failed jUnit when snapshot gathering errors

Previously, when gatherer.Gather() failed (e.g. due to a Kusto query
error), the error was logged but no jUnit test case was emitted. This
meant CI saw 0 tests / 0 failures and reported success, completely
hiding the problem.

Synthesize a failed VerificationReport for each Gather failure so it
flows through the normal jUnit aggregation path and surfaces in CI.

---

test/aro-hcp-tests: pass MonitoringEventsDatabase to Kusto queries

The GatherInput struct was missing MonitoringEventsDatabase, leaving it
as an empty string. The alert queries use this database via the
alertEvents.kql template partial, which rendered as
`.database('')` — causing Kusto to look up 'NetDefaultDB' which
does not exist, failing every alert query.

Read the value from the rendered config key
kusto.monitoringEventsDatabase and pass it through.

---

