### PR TITLE
fix(grafana): comment out grafana-reconcile step (EV2 rejects empty SKU)

### DIFF
--- a/dev-infrastructure/global-pipeline.yaml
+++ b/dev-infrastructure/global-pipeline.yaml
@@ -40,34 +40,44 @@ resourceGroups:
     template: templates/global-infra.bicep
     parameters: configurations/global-infra.tmpl.bicepparam
     deploymentLevel: ResourceGroup
-  - name: grafana-reconcile
-    action: GrafanaManage
-    grafanaName:
-      configRef: monitoring.grafanaName
-    location:
-      configRef: global.region
-    majorVersion:
-      configRef: monitoring.grafanaMajorVersion
-    zoneRedundancy:
-      configRef: monitoring.grafanaZoneRedundantMode
-    crossTenantSecurityGroup:
-      configRef: monitoring.crossTenantSecurityGroup
-    timeout: "15m"
-    identityFrom:
-      resourceGroup: singleton
-      step: infra
-      name: globalMSIId
-    dependsOn:
-    - resourceGroup: singleton
-      step: infra
+  # TEMPORARILY DISABLED: the SDP EV2 generator emits an unconditional `SKU` shell
+  # env var for the GrafanaManage action, but this step provides no `sku`, so EV2
+  # rejects the empty env var at artifact registration:
+  #   "Value or Reference must be provided for environment variable 'SKU'".
+  # SKU is optional in the pipeline schema and in templatize; the divergence is in the
+  # downstream sdp-pipelines EV2 generator, which emits `--sku` unconditionally.
+  # Re-enable once that tooling emits `--sku` only when set.
+  # Tracked by ARO-28445 (caused by ARO-28040 / ARO-28041).
+  # - name: grafana-reconcile
+  #   action: GrafanaManage
+  #   grafanaName:
+  #     configRef: monitoring.grafanaName
+  #   location:
+  #     configRef: global.region
+  #   majorVersion:
+  #     configRef: monitoring.grafanaMajorVersion
+  #   zoneRedundancy:
+  #     configRef: monitoring.grafanaZoneRedundantMode
+  #   crossTenantSecurityGroup:
+  #     configRef: monitoring.crossTenantSecurityGroup
+  #   timeout: "15m"
+  #   identityFrom:
+  #     resourceGroup: singleton
+  #     step: infra
+  #     name: globalMSIId
+  #   dependsOn:
+  #   - resourceGroup: singleton
+  #     step: infra
   - name: grafana-roles
     action: ARM
     template: templates/grafana-roles.bicep
     parameters: configurations/grafana-roles.tmpl.bicepparam
     deploymentLevel: ResourceGroup
     dependsOn:
+    # was: grafana-reconcile (temporarily disabled) -> depend on infra instead so the
+    # DAG stays valid; grafana-roles runs against the existing Grafana instance.
     - resourceGroup: singleton
-      step: grafana-reconcile
+      step: infra
   - name: output
     action: ARM
     template: templates/output-global.bicep
@@ -82,8 +92,6 @@ resourceGroups:
     # with ResourceNotFound before acrs creates them.
     - resourceGroup: singleton
       step: acrs
-    - resourceGroup: singleton
-      step: grafana-reconcile
   - name: grafana-monitoring-reader
     action: ARM
     template: templates/grafana-monitoring-reader.bicep

--- a/dev-infrastructure/global-pipeline.yaml
+++ b/dev-infrastructure/global-pipeline.yaml
@@ -47,6 +47,9 @@ resourceGroups:
   # SKU is optional in the pipeline schema and in templatize; the divergence is in the
   # downstream sdp-pipelines EV2 generator, which emits `--sku` unconditionally.
   # Re-enable once that tooling emits `--sku` only when set.
+  # PREREQUISITE: with this disabled, no step here provisions/updates the Grafana
+  # workspace (the remaining ARM templates only read it as `existing`), so this is safe
+  # only where the workspace already exists (INT/STG/PROD), not on a greenfield sub.
   # Tracked by ARO-28445 (caused by ARO-28040 / ARO-28041).
   # - name: grafana-reconcile
   #   action: GrafanaManage

--- a/dev-infrastructure/grafana-pipeline.yaml
+++ b/dev-infrastructure/grafana-pipeline.yaml
@@ -18,30 +18,40 @@ resourceGroups:
     parameters: configurations/output-grafana.tmpl.bicepparam
     deploymentLevel: ResourceGroup
     outputOnly: true
-  - name: grafana-reconcile
-    action: GrafanaManage
-    grafanaName:
-      configRef: monitoring.grafanaName
-    location:
-      configRef: global.region
-    majorVersion:
-      configRef: monitoring.grafanaMajorVersion
-    zoneRedundancy:
-      configRef: monitoring.grafanaZoneRedundantMode
-    crossTenantSecurityGroup:
-      configRef: monitoring.crossTenantSecurityGroup
-    identityFrom:
-      resourceGroup: singleton
-      step: output
-      name: globalMSIId
+  # TEMPORARILY DISABLED: the SDP EV2 generator emits an unconditional `SKU` shell
+  # env var for the GrafanaManage action, but this step provides no `sku`, so EV2
+  # rejects the empty env var at artifact registration:
+  #   "Value or Reference must be provided for environment variable 'SKU'".
+  # SKU is optional in the pipeline schema and in templatize; the divergence is in the
+  # downstream sdp-pipelines EV2 generator, which emits `--sku` unconditionally.
+  # Re-enable once that tooling emits `--sku` only when set.
+  # Tracked by ARO-28445 (caused by ARO-28040 / ARO-28041).
+  # - name: grafana-reconcile
+  #   action: GrafanaManage
+  #   grafanaName:
+  #     configRef: monitoring.grafanaName
+  #   location:
+  #     configRef: global.region
+  #   majorVersion:
+  #     configRef: monitoring.grafanaMajorVersion
+  #   zoneRedundancy:
+  #     configRef: monitoring.grafanaZoneRedundantMode
+  #   crossTenantSecurityGroup:
+  #     configRef: monitoring.crossTenantSecurityGroup
+  #   identityFrom:
+  #     resourceGroup: singleton
+  #     step: output
+  #     name: globalMSIId
   - name: grafana-roles
     action: ARM
     template: templates/grafana-roles.bicep
     parameters: configurations/grafana-roles.tmpl.bicepparam
     deploymentLevel: ResourceGroup
     dependsOn:
+    # was: grafana-reconcile (temporarily disabled) -> depend on output instead so the
+    # DAG stays valid; grafana-roles runs against the existing Grafana instance.
     - resourceGroup: singleton
-      step: grafana-reconcile
+      step: output
   - name: grafana-monitoring-reader
     action: ARM
     template: templates/grafana-monitoring-reader.bicep

--- a/dev-infrastructure/grafana-pipeline.yaml
+++ b/dev-infrastructure/grafana-pipeline.yaml
@@ -25,6 +25,9 @@ resourceGroups:
   # SKU is optional in the pipeline schema and in templatize; the divergence is in the
   # downstream sdp-pipelines EV2 generator, which emits `--sku` unconditionally.
   # Re-enable once that tooling emits `--sku` only when set.
+  # PREREQUISITE: with this disabled, no step here provisions/updates the Grafana
+  # workspace (the remaining ARM templates only read it as `existing`), so this is safe
+  # only where the workspace already exists (INT/STG/PROD), not on a greenfield sub.
   # Tracked by ARO-28445 (caused by ARO-28040 / ARO-28041).
   # - name: grafana-reconcile
   #   action: GrafanaManage


### PR DESCRIPTION
## What

Temporarily comments out the `grafana-reconcile` (`GrafanaManage`) step in the two pipelines that operate on the **existing** Grafana instance, keeping each DAG valid:

- **`dev-infrastructure/global-pipeline.yaml`** (`Global` service group): repoint `grafana-roles` `dependsOn` → `infra`; drop `grafana-reconcile` from `output` `dependsOn`.
- **`dev-infrastructure/grafana-pipeline.yaml`** (`Grafana` service group): repoint `grafana-roles` `dependsOn` → `output`.

`grafana-roles`, `output`, and `grafana-monitoring-reader` are left intact in both.

> Out of scope: `dev-infrastructure/global-pipeline-stg.yaml` (`Global.StgGlobal`, transient V2) has the same step, but there `grafana-reconcile` *creates* the greenfield `arohcp-stg2` workspace — a plain disable would just move the failure to `output` (reads Grafana as `existing`). That pipeline needs the proper tooling fix instead. Tracked under ARO-28445.

## Why

The `grafana-reconcile` step fails EV2 artifact registration on INT/STG/PROD incremental rollouts:

```
For Resource 'Global.singleton.grafana-reconcile' ... action 'shell/grafana-reconcile' failed:
Error validation Shell with Name 'grafana-reconcile': Value or Reference must be
provided for environment variable 'SKU'.
```

Root cause: the downstream sdp-pipelines EV2 generator adds the `--sku` / `SKU` shell env var **unconditionally**. This step provides no `sku` (it's `omitempty` in `types.GrafanaManageStep`, optional in the pipeline schema, and `templatize` only emits `--sku` when set), so the generated `grafana-reconcile/rolloutParameters.json` carries `SKU: "__SKU__"` — an unresolvable EV2 substitution token — which EV2 `UploadArtifacts` rejects.

This is an interim unblock. The proper fix lives in the SDP tooling: emit `--sku` only when `sku` is set (then re-enable the steps).

## Testing

Reproduced and verified the fix locally against the pinned revision, for **both** service groups:

- **Before**: `make -C hcp generate-ev2-manifests SERVICE_GROUP=<Global|Grafana> TOPOLOGY_PATH=ARO-HCP/topology.yaml` generates `grafana-reconcile/rolloutParameters.json` with env var `SKU` = `"__SKU__"` plus `--sku="${SKU}"` in the command.
- **After**: regenerating produces **no** `grafana-reconcile` artifact, so there is nothing for EV2 to reject. Remaining grafana steps still generate; topology DAG validates (no dangling `dependsOn`); generation exits 0.
- `yamlfmt v0.16.0` (matching CI) reports no changes on either file.
- Note: `output-global.bicep` / `output-grafana.bicep` read Grafana as `existing`, so removing reconcile is safe on INT/STG/PROD where the instance already exists.

## Tracking

- Bug: **ARO-28445**
- Caused by the grafana-reconcile refactor: **ARO-28040** / **ARO-28041**
- Same mitigation pattern as: **ARO-28044**