### PR TITLE
fix: add sku for grafana to config

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -2976,6 +2976,10 @@
         "grafanaName": {
           "type": "string"
         },
+        "grafanaSku": {
+          "type": "string",
+          "description": "The SKU of the Azure Managed Grafana instance (e.g. Standard, Essential)."
+        },
         "grafanaMajorVersion": {
           "type": "string"
         },
@@ -3090,6 +3094,7 @@
       "additionalProperties": false,
       "required": [
         "grafanaName",
+        "grafanaSku",
         "grafanaRoles",
         "grafanaMajorVersion",
         "crossTenantSecurityGroup",

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -380,6 +380,7 @@ defaults:
   # Monitoring
   monitoring:
     grafanaName: "arohcp-{{ .ctx.environment }}"
+    grafanaSku: "Standard"
     # Format:
     #   Multiline string using '>-' YAML block scalar
     #   One item per line, formatted as: UUID/PrincipalType/RoleName

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -799,6 +799,7 @@ monitoring:
   grafanaMajorVersion: "12"
   grafanaName: arohcp-dev
   grafanaRoles: 6b6d3adf-8476-4727-9812-20ffdef2b85c/Group/Admin
+  grafanaSku: Standard
   grafanaZoneRedundantMode: Disabled
   hcpWorkspaceName: hcps-j7654321
   icm:

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -799,6 +799,7 @@ monitoring:
   grafanaMajorVersion: "12"
   grafanaName: arohcp-dev
   grafanaRoles: 6b6d3adf-8476-4727-9812-20ffdef2b85c/Group/Admin
+  grafanaSku: Standard
   grafanaZoneRedundantMode: Disabled
   hcpWorkspaceName: hcps-j7654321
   icm:

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -797,6 +797,7 @@ monitoring:
   grafanaMajorVersion: "12"
   grafanaName: arohcp-dev
   grafanaRoles: 6b6d3adf-8476-4727-9812-20ffdef2b85c/Group/Admin
+  grafanaSku: Standard
   grafanaZoneRedundantMode: Disabled
   hcpWorkspaceName: hcps-cspr-usw3
   icm:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -797,6 +797,7 @@ monitoring:
   grafanaMajorVersion: "12"
   grafanaName: arohcp-dev
   grafanaRoles: 6b6d3adf-8476-4727-9812-20ffdef2b85c/Group/Admin
+  grafanaSku: Standard
   grafanaZoneRedundantMode: Disabled
   hcpWorkspaceName: hcps-usw3
   icm:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -797,6 +797,7 @@ monitoring:
   grafanaMajorVersion: "12"
   grafanaName: arohcp-dev
   grafanaRoles: 6b6d3adf-8476-4727-9812-20ffdef2b85c/Group/Admin
+  grafanaSku: Standard
   grafanaZoneRedundantMode: Disabled
   hcpWorkspaceName: hcps-usw3ptest
   icm:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -799,6 +799,7 @@ monitoring:
   grafanaMajorVersion: "12"
   grafanaName: arohcp-dev
   grafanaRoles: 6b6d3adf-8476-4727-9812-20ffdef2b85c/Group/Admin
+  grafanaSku: Standard
   grafanaZoneRedundantMode: Disabled
   hcpWorkspaceName: hcps-usw3test
   icm:

--- a/dev-infrastructure/global-pipeline-stg.yaml
+++ b/dev-infrastructure/global-pipeline-stg.yaml
@@ -50,6 +50,8 @@ resourceGroups:
       configRef: stgGlobalV2.grafanaName
     location:
       configRef: global.region
+    sku:
+      configRef: monitoring.grafanaSku
     majorVersion:
       configRef: monitoring.grafanaMajorVersion
     zoneRedundancy:

--- a/dev-infrastructure/global-pipeline.yaml
+++ b/dev-infrastructure/global-pipeline.yaml
@@ -46,6 +46,8 @@ resourceGroups:
       configRef: monitoring.grafanaName
     location:
       configRef: global.region
+    sku:
+      configRef: monitoring.grafanaSku
     majorVersion:
       configRef: monitoring.grafanaMajorVersion
     zoneRedundancy:

--- a/dev-infrastructure/grafana-pipeline.yaml
+++ b/dev-infrastructure/grafana-pipeline.yaml
@@ -24,6 +24,8 @@ resourceGroups:
       configRef: monitoring.grafanaName
     location:
       configRef: global.region
+    sku:
+      configRef: monitoring.grafanaSku
     majorVersion:
       configRef: monitoring.grafanaMajorVersion
     zoneRedundancy:


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-28040

### What
Set the Azure Managed Grafana **SKU** for the `grafana-reconcile` (`GrafanaManage`) pipeline steps.

• Add a `grafanaSku` config value (default `"Standard"`) to `defaults.monitoring` in `config/config.yaml`, plus the property and `required` entry in `config/config.schema.json`.
• Reference it via `sku: { configRef: monitoring.grafanaSku }` in the three `grafana-reconcile` steps: `dev-infrastructure/global-pipeline.yaml`, `global-pipeline-stg.yaml`, and `grafana-pipeline.yaml`.
• Regenerate rendered dev configs (`make -C config/ materialize`).

### Why

The `GrafanaManage` action always emits a `SKU` environment variable for the generated EV2 shell step (`grafanactl manage reconcile` requires `--sku`). Because the steps didn't set `sku`, sdp-pipelines EV2 generation produced an unbound `__SKU__` placeholder with no scope binding, and EV2 artifact validation failed:

> Error validation Shell with Name 'grafana-reconcile': Value or Reference must be provided for environment variable 'SKU'.

This blocks bumping sdp-pipelines to newer ARO-HCP revisions. Making it config-driven (rather than a literal) matches the sibling knobs (`grafanaMajorVersion`, `grafanaZoneRedundantMode`) and allows per-cloud/env/region override. The default `"Standard"` matches what the pre-reconcile bicep hard-coded for every instance and grafanactl's own default, so reconcile is a no-op on SKU for existing instances.

### Testing

• `make -C config/ materialize` — rendered configs + helm fixtures regenerate cleanly; `detect-change` gate stays green (no stray artifacts).
• Config schema validation passes (`grafanaSku` present in every rendered config via base defaults).
• sdp-pipelines EV2 **generate-only** preflight against this local tree for `Global`, `Global.StgGlobal`, and `Grafana` — all `PREFLIGHT OK`.
• Inspected the generated `ScopeBindings.json`: with the fix, `__SKU__` → `$config(monitoring.grafanaSku)` (matching its `__MAJOR_VERSION__` sibling); reverting the `sku` line reproduced the failure (no `__SKU__` binding), confirming the fix addresses the exact EV2 error.

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
