### PR TITLE
hcpctl/snapshot: teach the agents about new tables

### DIFF
--- a/test/cmd/aro-hcp-tests/gather-snapshot/options.go
+++ b/test/cmd/aro-hcp-tests/gather-snapshot/options.go
@@ -28,7 +28,6 @@ import (
 	"github.com/Azure/azure-kusto-go/azkustodata"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 
-	"github.com/Azure/ARO-HCP/test/cmd/aro-hcp-tests/internal/testutil"
 	"github.com/Azure/ARO-HCP/test/util/junit"
 	"github.com/Azure/ARO-HCP/test/util/timing"
 	"github.com/Azure/ARO-HCP/tooling/hcpctl/pkg/kusto"
@@ -61,13 +60,15 @@ type ValidatedOptions struct {
 }
 
 type completedOptions struct {
-	OutputDir          string
-	KustoEndpoint      string
-	ServiceDB          string
-	HCPDB              string
-	MonitoringEventsDB string
-	TestTimingInfo     map[string]timing.TimingInfo
-	kustoClient        *azkustodata.Client
+	OutputDir             string
+	KustoEndpoint         string
+	ServiceDB             string
+	HCPDB                 string
+	MonitoringEventsDB    string
+	ServiceClusterName    string
+	ManagementClusterName string
+	TestTimingInfo        map[string]timing.TimingInfo
+	kustoClient           *azkustodata.Client
 }
 
 type Options struct {
@@ -128,45 +129,35 @@ func (o *ValidatedOptions) Complete(ctx context.Context) (*Options, error) {
 		return nil, fmt.Errorf("failed to create output directory %s: %w", o.OutputDir, err)
 	}
 
-	cfg, err := testutil.LoadRenderedConfig(o.RenderedConfig)
+	rawCfg, err := os.ReadFile(o.RenderedConfig)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to read rendered config %s: %w", o.RenderedConfig, err)
 	}
 
-	kustoName, err := testutil.ConfigGetString(cfg, "kusto.kustoName")
+	jobConfig, err := snapshot.ParseConfig(rawCfg)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get kusto name from config: %w", err)
-	}
-	serviceDB, err := testutil.ConfigGetString(cfg, "kusto.serviceLogsDatabase")
-	if err != nil {
-		return nil, fmt.Errorf("failed to get service logs database from config: %w", err)
-	}
-	hcpDB, err := testutil.ConfigGetString(cfg, "kusto.hostedControlPlaneLogsDatabase")
-	if err != nil {
-		return nil, fmt.Errorf("failed to get hosted control plane logs database from config: %w", err)
-	}
-	monitoringEventsDB, err := testutil.ConfigGetString(cfg, "kusto.monitoringEventsDatabase")
-	if err != nil {
-		return nil, fmt.Errorf("failed to get monitoring events database from config: %w", err)
+		return nil, fmt.Errorf("failed to parse rendered config: %w", err)
 	}
 
-	kustoRegion, err := resolveKustoRegion(kustoName)
+	kustoRegion, err := resolveKustoRegion(jobConfig.KustoName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve kusto region: %w", err)
 	}
 
-	kustoEndpoint, err := kusto.KustoEndpoint(kustoName, kustoRegion)
+	kustoEndpoint, err := kusto.KustoEndpoint(jobConfig.KustoName, kustoRegion)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build kusto endpoint: %w", err)
 	}
 
 	logger.Info("resolved kusto config",
-		"name", kustoName,
+		"name", jobConfig.KustoName,
 		"region", kustoRegion,
 		"endpoint", kustoEndpoint.String(),
-		"serviceDB", serviceDB,
-		"hcpDB", hcpDB,
-		"monitoringEventsDB", monitoringEventsDB,
+		"serviceDB", jobConfig.ServiceDatabase,
+		"hcpDB", jobConfig.HCPDatabase,
+		"monitoringEventsDB", jobConfig.MonitoringEventsDatabase,
+		"serviceCluster", jobConfig.ServiceClusterName,
+		"managementCluster", jobConfig.ManagementClusterName,
 	)
 
 	testTimingInfo, err := timing.LoadTestTimingInfo(ctx, o.TimingInputDir)
@@ -190,13 +181,15 @@ func (o *ValidatedOptions) Complete(ctx context.Context) (*Options, error) {
 	}
 
 	return &Options{completedOptions: &completedOptions{
-		OutputDir:          o.OutputDir,
-		KustoEndpoint:      kustoEndpoint.String(),
-		ServiceDB:          serviceDB,
-		HCPDB:              hcpDB,
-		MonitoringEventsDB: monitoringEventsDB,
-		TestTimingInfo:     testTimingInfo,
-		kustoClient:        kustoClient,
+		OutputDir:             o.OutputDir,
+		KustoEndpoint:         kustoEndpoint.String(),
+		ServiceDB:             jobConfig.ServiceDatabase,
+		HCPDB:                 jobConfig.HCPDatabase,
+		MonitoringEventsDB:    jobConfig.MonitoringEventsDatabase,
+		ServiceClusterName:    jobConfig.ServiceClusterName,
+		ManagementClusterName: jobConfig.ManagementClusterName,
+		TestTimingInfo:        testTimingInfo,
+		kustoClient:           kustoClient,
 	}}, nil
 }
 
@@ -242,6 +235,8 @@ func (o Options) Run(ctx context.Context) error {
 				HCPDatabase:              o.HCPDB,
 				MonitoringEventsDatabase: o.MonitoringEventsDB,
 				ResourceGroup:            rg,
+				ServiceClusterName:       o.ServiceClusterName,
+				ManagementClusterName:    o.ManagementClusterName,
 				TimeWindow: snapshot.TimeWindow{
 					Start:           ti.StartTime,
 					End:             ti.EndTime,

--- a/tooling/hcpctl/pkg/agent/prompts/exemplars/cluster-cleanup-unknown-failure.md
+++ b/tooling/hcpctl/pkg/agent/prompts/exemplars/cluster-cleanup-unknown-failure.md
@@ -121,15 +121,13 @@ return utils.TrackError(err)
 The backend deletion controllers posted normal status during the cleanup time for this cluster:
 
 ```kql
-cluster('https://hcp-int-uk.uksouth.kusto.windows.net').database('ServiceLogs').table('backendLogs')
+cluster('https://hcp-int-uk.uksouth.kusto.windows.net').database('ServiceLogs').table('cosmosResourceSnapshots')
 | where timestamp between (datetime(2026-05-19T22:18:20Z) .. datetime(2026-05-19T23:03:20Z))
-| where container_name == 'aro-hcp-backend'
-| where log.controller_name == 'datadump'
-| where log.resource_group == 'rg-np-version-upgrade-rs22qw-sssr8k'
-| where log.resource_name == 'np-version-upgrade-cluster-rs22qw'
-| where log.content.resourceType =~ 'microsoft.redhatopenshift/hcpopenshiftclusters/hcpopenshiftcontrollers'
-| where log.content.resourceID has 'np-version-upgrade-cluster-rs22qw'
-| summarize content=take_any(log.content), observedTime=take_any(timestamp) by etag=tostring(log.content._etag)
+| where subscriptionID == '64f0619f-ebc2-4156-9d91-c4c781de7e54'
+| where resourceGroup =~ 'rg-np-version-upgrade-rs22qw-sssr8k'
+| where resourceID startswith '/subscriptions/64f0619f-ebc2-4156-9d91-c4c781de7e54/resourcegroups/rg-np-version-upgrade-rs22qw-sssr8k/providers/microsoft.redhatopenshift/hcpopenshiftclusters/np-version-upgrade-cluster-rs22qw'
+| where resourceType =~ 'microsoft.redhatopenshift/hcpopenshiftclusters/hcpopenshiftcontrollers'
+| summarize content=take_any(content), observedTime=take_any(timestamp) by etag=tostring(content._etag)
 | sort by tolong(content._ts) asc
 | extend content = parse_json(content)
 | extend controller_name = extract("/hcpOpenShiftControllers/([^\\/]+)", 1, tostring(content.resourceID))
@@ -248,14 +246,13 @@ never finished deleting, so our root-cause investigation stops here.
 The `HostedCluster` condition timeline after the test's cleanup start-time shows nothing out of the ordinary:
 
 ```kql
-cluster('https://hcp-int-uk.uksouth.kusto.windows.net').database('ServiceLogs').table('backendLogs')
+cluster('https://hcp-int-uk.uksouth.kusto.windows.net').database('ServiceLogs').table('cosmosResourceSnapshots')
 | where timestamp between (datetime(2026-05-19T22:18:20Z) .. datetime(2026-05-19T23:03:20Z))
-| where container_name == 'aro-hcp-backend'
-| where log.controller_name == 'datadump'
-| where log.resource_group == 'rg-np-version-upgrade-rs22qw-sssr8k'
-| where log.resource_name == 'np-version-upgrade-cluster-rs22qw'
-| where log.content.resourceType =~ 'microsoft.redhatopenshift/hcpopenshiftclusters/readdesires'
-| summarize content=take_any(log.content), observedTime=take_any(timestamp) by etag=tostring(log.content._etag)
+| where subscriptionID == '64f0619f-ebc2-4156-9d91-c4c781de7e54'
+| where resourceGroup =~ 'rg-np-version-upgrade-rs22qw-sssr8k'
+| where resourceID startswith '/subscriptions/64f0619f-ebc2-4156-9d91-c4c781de7e54/resourcegroups/rg-np-version-upgrade-rs22qw-sssr8k/providers/microsoft.redhatopenshift/hcpopenshiftclusters/np-version-upgrade-cluster-rs22qw'
+| where resourceType =~ 'microsoft.redhatopenshift/hcpopenshiftclusters/readdesires'
+| summarize content=take_any(content), observedTime=take_any(timestamp) by etag=tostring(content._etag)
 | sort by tolong(content._ts) asc
 | extend content = parse_json(content)
 | extend manifest = content.properties.status.kubeContent

--- a/tooling/hcpctl/pkg/agent/prompts/exemplars/cluster-creation-timeout-z-stream-upgrade.md
+++ b/tooling/hcpctl/pkg/agent/prompts/exemplars/cluster-creation-timeout-z-stream-upgrade.md
@@ -77,22 +77,20 @@ let hcNamespace = 'ocm-arohcpci01-2r4sj32f75bfmfa9m6rkupe7o982hqst';
 // manifest.json: hosted_control_plane_namespace (name suffix)
 let hcName = 'p2d8v9o7y9g8x5o';
 // manifest.json: kusto_cluster
-cluster('https://hcp-dev-us-2.eastus2.kusto.windows.net').database('ServiceLogs').table('containerLogs')
+cluster('https://hcp-dev-us-2.eastus2.kusto.windows.net').database('ServiceLogs').table('kubernetesResourceSnapshots')
 // manifest.json: time_window.start .. time_window.end
 | where timestamp between (datetime(2026-06-24T17:43:34Z) .. datetime(2026-06-24T18:49:43Z))
-| where container_name == 'mgmt-agent-controller'
-| where tostring(log.msg) == 'resource event'
-| where tostring(log.object.kind) == 'HostedCluster'
-| where tostring(log.namespace) == hcNamespace
-| where tostring(log.name) == hcName
-| extend desired = tostring(log.object.spec.release.image),
-         versionHistory = tostring(log.object.status.controlPlaneVersion.history),
-         forceUpgradeTo = tostring(log.object.metadata.annotations['hypershift.openshift.io/force-upgrade-to'])
+| where objectKind == 'HostedCluster'
+| where namespace == hcNamespace
+| where name == hcName
+| extend desired = tostring(object.spec.release.image),
+         versionHistory = tostring(object.status.controlPlaneVersion.history),
+         forceUpgradeTo = tostring(object.metadata.annotations['hypershift.openshift.io/force-upgrade-to'])
 | extend desired = replace_regex(desired, @'sha256:[a-f0-9]{64}', 'sha256:…'),
          forceUpgradeTo = replace_regex(forceUpgradeTo, @'sha256:[a-f0-9]{64}', 'sha256:…'),
          versionHistory = replace_regex(versionHistory, @'sha256:[a-f0-9]{64}', 'sha256:…')
 | summarize first_occurrence = min(timestamp), last_occurrence = max(timestamp),
-            event = arg_min(timestamp, tostring(log.event)),
+            event = arg_min(timestamp, event),
             desired = arg_min(timestamp, desired),
             forceUpgradeTo = max(forceUpgradeTo)
     by versionHistory
@@ -127,15 +125,13 @@ let hcNamespace = 'ocm-arohcpci01-2r4sj32f75bfmfa9m6rkupe7o982hqst';
 // manifest.json: hosted_control_plane_namespace (name suffix)
 let hcName = 'p2d8v9o7y9g8x5o';
 // manifest.json: kusto_cluster
-cluster('https://hcp-dev-us-2.eastus2.kusto.windows.net').database('ServiceLogs').table('containerLogs')
+cluster('https://hcp-dev-us-2.eastus2.kusto.windows.net').database('ServiceLogs').table('kubernetesResourceSnapshots')
 // manifest.json: time_window subset (CS ready .. test failure)
 | where timestamp between (csReadyAt .. probeEnd)
-| where container_name == 'mgmt-agent-controller'
-| where tostring(log.msg) == 'resource event'
-| where tostring(log.object.kind) == 'HostedCluster'
-| where tostring(log.namespace) == hcNamespace
-| where tostring(log.name) == hcName
-| extend conditions = log.object.status.conditions
+| where objectKind == 'HostedCluster'
+| where namespace == hcNamespace
+| where name == hcName
+| extend conditions = object.status.conditions
 | mv-expand condition = conditions
 | extend type = tostring(condition.type),
          status = tostring(condition.status),
@@ -169,18 +165,17 @@ kube-apiserver pods on the new ReplicaSet `54b7f655f6` cold-started while old RS
 // manifest.json: hosted_control_plane_namespace
 let hcpNamespace = 'ocm-arohcpci01-2r4sj32f75bfmfa9m6rkupe7o982hqst-p2d8v9o7y9g8x5o';
 // manifest.json: kusto_cluster
-cluster('https://hcp-dev-us-2.eastus2.kusto.windows.net').database('ServiceLogs').table('containerLogs')
+cluster('https://hcp-dev-us-2.eastus2.kusto.windows.net').database('ServiceLogs').table('kubernetesResourceSnapshots')
 // manifest.json: time_window subset (upgrade rollout window)
 | where timestamp between (datetime(2026-06-24T17:55:00Z) .. datetime(2026-06-24T18:05:00Z))
-| where container_name == 'mgmt-agent-controller'
-| where tostring(log.msg) == 'pod event'
-| where tostring(log.namespace) == hcpNamespace
-| where tostring(log.name) startswith 'kube-apiserver-'
-| extend containers = log.object.status.containerStatuses
+| where objectKind == 'Pod'
+| where namespace == hcpNamespace
+| where name startswith 'kube-apiserver-'
+| extend containers = object.status.containerStatuses
 | mv-expand container = containers
 | project timestamp,
-    event=tostring(log.event),
-    podName=tostring(log.name),
+    event,
+    podName=name,
     containerName=tostring(container.name),
     ready=tobool(container.ready),
     reason=coalesce(

--- a/tooling/hcpctl/pkg/agent/prompts/exemplars/cluster-installation-azure-disk-failure.md
+++ b/tooling/hcpctl/pkg/agent/prompts/exemplars/cluster-installation-azure-disk-failure.md
@@ -140,15 +140,13 @@ return utils.TrackError(err)
 No backend controllers posted unnatural status during the test run for this cluster.
 
 ```kql
-cluster('https://hcp-int-uk.uksouth.kusto.windows.net').database('ServiceLogs').table('backendLogs')
+cluster('https://hcp-int-uk.uksouth.kusto.windows.net').database('ServiceLogs').table('cosmosResourceSnapshots')
 | where timestamp between (datetime(2026-05-19T20:52:10Z) .. datetime(2026-05-19T21:43:55Z))
-| where container_name == 'aro-hcp-backend'
-| where log.controller_name == 'datadump'
-| where log.resource_group == 'customer-rg-crkv7p'
-| where log.resource_name == 'basic-hcp-cluster'
-| where log.content.resourceType =~ 'microsoft.redhatopenshift/hcpopenshiftclusters/hcpopenshiftcontrollers'
-| where log.content.resourceID has 'basic-hcp-cluster'
-| summarize payload=take_any(log.content) by etag=tostring(log.content._etag)
+| where subscriptionID == '64f0619f-ebc2-4156-9d91-c4c781de7e54'
+| where resourceGroup =~ 'customer-rg-crkv7p'
+| where resourceID startswith '/subscriptions/64f0619f-ebc2-4156-9d91-c4c781de7e54/resourcegroups/customer-rg-crkv7p/providers/microsoft.redhatopenshift/hcpopenshiftclusters/basic-hcp-cluster'
+| where resourceType =~ 'microsoft.redhatopenshift/hcpopenshiftclusters/hcpopenshiftcontrollers'
+| summarize payload=take_any(content) by etag=tostring(content._etag)
 | extend payload = parse_json(payload)
 | extend controller_name = extract("/hcpOpenShiftControllers/([^\\/]+)", 1, tostring(payload.resourceID))
 | extend ts = tolong(payload._ts)
@@ -217,14 +215,13 @@ return nil
 The `Available` condition on the `HostedCluster` never had a `true` status:
 
 ```kql
-cluster('https://hcp-int-uk.uksouth.kusto.windows.net').database('ServiceLogs').table('backendLogs')
+cluster('https://hcp-int-uk.uksouth.kusto.windows.net').database('ServiceLogs').table('cosmosResourceSnapshots')
 | where timestamp between (datetime(2026-05-19T20:52:10Z) .. datetime(2026-05-19T22:10:46Z))
-| where container_name == 'aro-hcp-backend'
-| where log.controller_name == 'datadump'
-| where log.resource_group == 'customer-rg-crkv7p'
-| where log.resource_name == 'basic-hcp-cluster'
-| where log.content.resourceType =~ 'microsoft.redhatopenshift/hcpopenshiftclusters/readdesires'
-| summarize content=take_any(log.content), observedTime=take_any(timestamp) by etag=tostring(log.content._etag)
+| where subscriptionID == '64f0619f-ebc2-4156-9d91-c4c781de7e54'
+| where resourceGroup =~ 'customer-rg-crkv7p'
+| where resourceID startswith '/subscriptions/64f0619f-ebc2-4156-9d91-c4c781de7e54/resourcegroups/customer-rg-crkv7p/providers/microsoft.redhatopenshift/hcpopenshiftclusters/basic-hcp-cluster'
+| where resourceType =~ 'microsoft.redhatopenshift/hcpopenshiftclusters/readdesires'
+| summarize content=take_any(content), observedTime=take_any(timestamp) by etag=tostring(content._etag)
 | sort by tolong(content._ts) asc
 | extend content = parse_json(content)
 | extend manifest = content.properties.status.kubeContent
@@ -252,14 +249,13 @@ The last snapshot of the `HostedCluster` conditions before the test cleanup bega
 present and the `kube-apiserver` deployment had not been found:
 
 ```kql
-cluster('https://hcp-int-uk.uksouth.kusto.windows.net').database('ServiceLogs').table('backendLogs')
+cluster('https://hcp-int-uk.uksouth.kusto.windows.net').database('ServiceLogs').table('cosmosResourceSnapshots')
 | where timestamp between (datetime(2026-05-19T20:52:10Z) .. datetime(2026-05-19T21:43:55Z))
-| where container_name == 'aro-hcp-backend'
-| where log.controller_name == 'datadump'
-| where log.resource_group == 'customer-rg-crkv7p'
-| where log.resource_name == 'basic-hcp-cluster'
-| where log.content.resourceType =~ 'microsoft.redhatopenshift/hcpopenshiftclusters/readdesires'
-| summarize content=take_any(log.content), observedTime=take_any(timestamp) by etag=tostring(log.content._etag)
+| where subscriptionID == '64f0619f-ebc2-4156-9d91-c4c781de7e54'
+| where resourceGroup =~ 'customer-rg-crkv7p'
+| where resourceID startswith '/subscriptions/64f0619f-ebc2-4156-9d91-c4c781de7e54/resourcegroups/customer-rg-crkv7p/providers/microsoft.redhatopenshift/hcpopenshiftclusters/basic-hcp-cluster'
+| where resourceType =~ 'microsoft.redhatopenshift/hcpopenshiftclusters/readdesires'
+| summarize content=take_any(content), observedTime=take_any(timestamp) by etag=tostring(content._etag)
 | top 1 by tolong(content._ts) desc
 | extend content = parse_json(content)
 | extend manifest = content.properties.status.kubeContent

--- a/tooling/hcpctl/pkg/agent/prompts/system.md
+++ b/tooling/hcpctl/pkg/agent/prompts/system.md
@@ -215,7 +215,9 @@ Each environment has two databases:
 
 - **`ServiceLogs`**: Frontend (`frontendLogs`), Backend (`backendLogs`), Clusters
   Service (`clustersServiceLogs`), Maestro server/agent (`containerLogs`), Kubernetes
-  events (`kubernetesEvents`), audit logs (`kubeAudit`). Management cluster data
+  events (`kubernetesEvents`), audit logs (`kubeAudit`), Kubernetes resource snapshots
+  (`kubernetesResourceSnapshots`), Cosmos DB document snapshots
+  (`cosmosResourceSnapshots`). Management cluster data
   (mgmt-agent, HyperShift operator) is also in this database — filter by `cluster`.
 - **`HostedControlPlaneLogs`**: Per-cluster hosted control plane container logs
   (`containerLogs`) — kube-apiserver, etcd, control-plane-operator, etc.
@@ -229,15 +231,82 @@ Each environment has two databases:
 Hosted cluster namespaces: `ocm-arohcp<env>-<cid>-<id>`. Use `distinct pod_name,
 container_name` within a namespace to discover available logs.
 
+#### `kubernetesEvents` (ServiceLogs)
+
 The `kubernetesEvents` table contains Kubernetes API Event objects from both service
 and management clusters. Filter by `cluster`, `eventNamespace`, `objectKind`,
-`objectName`, `reason`, `message`. This is not mgmt-agent output: K8s Events report
-API-level reasons (mount failures, scheduling, probes).
+`objectName`, `reason`, `message`.
 
-The mgmt-agent on each management cluster logs full object snapshots on changes:
-`resource event` (CR status for HyperShift, ACM, CAPI, Azure networking CRs) and
-`pod event` (container state transitions). These are in `ServiceLogs.containerLogs`
-with `container_name = 'mgmt-agent-controller'`.
+#### `kubernetesResourceSnapshots` (ServiceLogs)
+
+The mgmt-agent on each management cluster snapshots Kubernetes resources into the
+`kubernetesResourceSnapshots` table. This is a good replacement for `kubectl get` —
+it shows changes over time. **Management cluster data only** today.
+
+Columns: `timestamp`, `environment`, `region`, `cluster`, `event` (Add/Update/Delete),
+`apiVersion`, `objectKind`, `namespace`, `name`, `uid`, `object` (dynamic — the full
+Kubernetes object).
+
+**Recording semantics:**
+- Non-Pod resources (HyperShift, CAPI, ACM, Azure networking CRDs, Namespaces) emit
+  a row on every informer event (Add, Update, Delete).
+- Pods emit only on Add/Delete and when a container's **state type** transitions
+  (Waiting↔Running↔Terminated). Field-level changes within the same state type
+  (e.g., a different `Waiting.Reason`) are *not* recorded.
+
+**Discovery:** Use `| distinct objectKind` (with appropriate time/cluster filters) to
+see which resource kinds are available at runtime — the set is dynamic and grows as
+new CRDs are registered.
+
+**Example:** Get HostedCluster condition timeline:
+```kql
+kubernetesResourceSnapshots
+| where objectKind == 'HostedCluster'
+| where namespace == '<hc-namespace>'
+| where name == '<hc-name>'
+| mv-expand condition = object.status.conditions
+| project timestamp, event, type=tostring(condition.type), status=tostring(condition.status),
+    reason=tostring(condition.reason), message=tostring(condition.message)
+```
+
+#### `cosmosResourceSnapshots` (ServiceLogs)
+
+The backend's datadump controller periodically snapshots Cosmos DB documents into the
+`cosmosResourceSnapshots` table. This provides the backend's view of ARM resources,
+including readdesires (the mechanism for pulling Kubernetes resource status back to the
+backend), service provider state, and controller conditions.
+
+Columns: `timestamp`, `environment`, `region`, `cluster`, `cosmosContainer`,
+`subscriptionID`, `resourceGroup`, `resourceType`, `resourceName`, `resourceID`
+(full ARM resource ID), `content` (dynamic — the full Cosmos document including
+`_etag`, `_ts`, and `properties`).
+
+**Filtering:** Use `resourceID startswith '<cluster ARM resource ID>'` to find all
+child documents for a cluster (readdesires, service provider state, controller
+conditions, nodepools, etc.). Prepend `subscriptionID` and `resourceGroup` filters
+for best query performance.
+
+**Deduplication:** Cosmos documents are identified by `content._etag`. Use
+`summarize content=take_any(content) by etag=tostring(content._etag)` to deduplicate,
+then `sort by tolong(content._ts) asc` to order chronologically.
+
+**Discovery:** Use `| distinct resourceType` (with appropriate filters) to explore
+which document types are available — the examples in gathered data show only a subset
+of what the backend snapshots.
+
+**Example:** Get latest HostedCluster conditions from readdesire:
+```kql
+cosmosResourceSnapshots
+| where resourceID startswith '<cluster ARM ID>'
+| where resourceType =~ 'microsoft.redhatopenshift/hcpopenshiftclusters/readdesires'
+| summarize content=take_any(content) by etag=tostring(content._etag)
+| top 1 by tolong(content._ts) desc
+| extend manifest = content.properties.status.kubeContent
+| where manifest.kind == 'HostedCluster'
+| mv-expand condition = manifest.status.conditions
+| project type=tostring(condition.type), status=tostring(condition.status),
+    reason=tostring(condition.reason), message=tostring(condition.message)
+```
 
 Review ingest mappings and schemas at `dev-infrastructure/modules/logs/kusto/tables`.
 

--- a/tooling/hcpctl/pkg/snapshot/gatherer.go
+++ b/tooling/hcpctl/pkg/snapshot/gatherer.go
@@ -359,6 +359,7 @@ func (g *Gatherer) runDiscovery(
 		reqData.CorrelationID = req.CorrelationID
 		reqData.ClientRequestID = req.ClientRequestID
 		reqData.ResponseStatusCode = req.Status
+		reqData.SubscriptionID = req.SubscriptionID
 		reqData.ResourceID = req.ResourceID
 		reqData.ResourceType = req.ResourceType
 		reqData.ResourceName = req.ResourceName
@@ -401,6 +402,63 @@ func (g *Gatherer) runDiscovery(
 		}
 	}
 
+	// =========================================================================
+	// Cosmos resource discovery: find all resource types under the cluster prefix
+	// =========================================================================
+
+	// Collect the first ClusterResourceID + SubscriptionID from tracked requests.
+	var cosmosDiscoveryData queryData
+	for i := range trackedReqs {
+		if trackedReqs[i].data.ClusterResourceID != "" && trackedReqs[i].data.SubscriptionID != "" {
+			cosmosDiscoveryData = seedData
+			cosmosDiscoveryData.ClusterResourceID = trackedReqs[i].data.ClusterResourceID
+			cosmosDiscoveryData.SubscriptionID = trackedReqs[i].data.SubscriptionID
+			break
+		}
+	}
+
+	// cosmosChildTypes maps lowercased parent resource ID → set of child resource types.
+	cosmosChildTypes := make(map[string]map[string]bool)
+	// cosmosResources maps lowercased resource ID → resource type for all discovered resources.
+	cosmosResources := make(map[string]string)
+
+	if cosmosDiscoveryData.ClusterResourceID != "" {
+		rendered, err := renderQuery("queries/backend/cosmosResourceDiscovery/query.kql", cosmosDiscoveryData)
+		if err == nil {
+			rows, queryErr := g.executeKQL(ctx, rendered, cosmosDiscoveryData.ServiceDatabase, 2*time.Minute)
+			if queryErr != nil {
+				logger.Error(queryErr, "Cosmos resource discovery query failed, continuing without discovery")
+			} else {
+				for _, row := range rows {
+					if len(row.values) < 2 {
+						continue
+					}
+					resID := row.values[0]
+					resType := row.values[1]
+					cosmosResources[resID] = resType
+
+					// Determine parent resource ID by parsing and checking for a parent.
+					parsed, parseErr := azcorearm.ParseResourceID(resID)
+					if parseErr != nil {
+						continue
+					}
+					if parsed.Parent != nil && parsed.Parent.ResourceType.Type != "" {
+						parentID := strings.ToLower(parsed.Parent.String())
+						if cosmosChildTypes[parentID] == nil {
+							cosmosChildTypes[parentID] = make(map[string]bool)
+						}
+						cosmosChildTypes[parentID][resType] = true
+					}
+				}
+				logger.V(1).Info("Cosmos resource discovery complete",
+					"totalDocTypes", len(cosmosResources),
+					"parentsWithChildren", len(cosmosChildTypes))
+			}
+		} else {
+			logger.Error(err, "Failed to render cosmos resource discovery query")
+		}
+	}
+
 	// Deduplicate resources.
 	resources := make(map[string]*resourceState)
 	var resourceOrder []string
@@ -418,6 +476,68 @@ func (g *Gatherer) runDiscovery(
 			resourceOrder = append(resourceOrder, key)
 		}
 		resources[key].requests = append(resources[key].requests, tr.trackedRequest)
+	}
+
+	// Add Cosmos-discovered resources not found via frontend requests, and
+	// populate ChildResourceTypes for all resources.
+	if cosmosDiscoveryData.ClusterResourceID != "" {
+		// Identify top-level resources from Cosmos (direct children of the cluster
+		// or the cluster itself) and add them if not already tracked.
+		clusterResourceIDLower := strings.ToLower(cosmosDiscoveryData.ClusterResourceID)
+		for resID, resType := range cosmosResources {
+			parsed, err := azcorearm.ParseResourceID(resID)
+			if err != nil {
+				continue
+			}
+			// A "top-level" resource is either the cluster itself or a direct child
+			// (its parent is the cluster resource ID).
+			isClusterItself := strings.EqualFold(resID, clusterResourceIDLower)
+			isDirectChild := parsed.Parent != nil && strings.EqualFold(parsed.Parent.String(), clusterResourceIDLower)
+			if !isClusterItself && !isDirectChild {
+				continue
+			}
+			// Skip child-only resource types (hcpopenshiftcontrollers, readdesires,
+			// serviceprovider*, applydesires) — these aren't top-level resources.
+			typeParts := strings.Split(strings.ToLower(parsed.ResourceType.Type), "/")
+			lastSegment := typeParts[len(typeParts)-1]
+			if strings.HasPrefix(lastSegment, "serviceprovider") ||
+				lastSegment == "hcpopenshiftcontrollers" ||
+				lastSegment == "readdesires" ||
+				lastSegment == "applydesires" {
+				continue
+			}
+
+			key := sanitizePath(resType) + "/" + sanitizePath(parsed.Name)
+			if _, ok := resources[key]; !ok {
+				resData := seedData
+				resData.SubscriptionID = cosmosDiscoveryData.SubscriptionID
+				resData.ResourceID = resID
+				resData.ResourceType = resType
+				resData.ResourceName = parsed.Name
+				resData.ClusterResourceID = cosmosDiscoveryData.ClusterResourceID
+				if parsed.Parent != nil && parsed.Parent.ResourceType.Type != "" {
+					resData.ClusterResourceName = parsed.Parent.Name
+				} else {
+					resData.ClusterResourceName = parsed.Name
+				}
+				resData.ServiceProviderResourceType = serviceProviderResourceType(resType)
+				resources[key] = &resourceState{data: resData, mu: &sync.Mutex{}}
+				resourceOrder = append(resourceOrder, key)
+				logger.V(1).Info("Cosmos-discovered resource", "key", key, "resourceID", resID)
+			}
+		}
+
+		// Populate ChildResourceTypes on all tracked resources.
+		for _, rs := range resources {
+			resIDLower := strings.ToLower(rs.data.ResourceID)
+			if children, ok := cosmosChildTypes[resIDLower]; ok {
+				rs.data.ChildResourceTypes = children
+			}
+			// Also derive ServiceProviderResourceType dynamically if not already set.
+			if rs.data.ServiceProviderResourceType == "" && rs.data.ChildResourceTypes != nil {
+				rs.data.ServiceProviderResourceType = rs.data.childServiceProviderType()
+			}
+		}
 	}
 
 	// Pool 2: Run resource discovery queries + write cached request discovery output.
@@ -752,6 +872,7 @@ type frontendRequest struct {
 	ClientRequestID             string
 	Method                      string
 	Path                        string
+	SubscriptionID              string
 	ResourceID                  string
 	ResourceType                string
 	ResourceName                string
@@ -808,6 +929,7 @@ func (g *Gatherer) discoverRequests(ctx context.Context, input GatherInput, data
 		if req.Path != "" {
 			if res, err := azcorearm.ParseResourceID(req.Path); err == nil {
 				req.ResourceID = req.Path
+				req.SubscriptionID = res.SubscriptionID
 				req.ResourceType = res.ResourceType.String()
 				req.ResourceName = res.Name
 				req.ServiceProviderResourceType = serviceProviderResourceType(req.ResourceType)

--- a/tooling/hcpctl/pkg/snapshot/gatherer.go
+++ b/tooling/hcpctl/pkg/snapshot/gatherer.go
@@ -70,6 +70,36 @@ type GatherInput struct {
 	ManagementClusterName string
 }
 
+// validate checks that all required fields are set.
+func (g GatherInput) validate() error {
+	var missing []string
+	if g.ClusterURI == "" {
+		missing = append(missing, "ClusterURI")
+	}
+	if g.ServiceDatabase == "" {
+		missing = append(missing, "ServiceDatabase")
+	}
+	if g.HCPDatabase == "" {
+		missing = append(missing, "HCPDatabase")
+	}
+	if g.MonitoringEventsDatabase == "" {
+		missing = append(missing, "MonitoringEventsDatabase")
+	}
+	if g.ResourceGroup == "" {
+		missing = append(missing, "ResourceGroup")
+	}
+	if g.TimeWindow.Start.IsZero() {
+		missing = append(missing, "TimeWindow.Start")
+	}
+	if g.TimeWindow.End.IsZero() {
+		missing = append(missing, "TimeWindow.End")
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("missing required fields: %s", strings.Join(missing, ", "))
+	}
+	return nil
+}
+
 // concurrency returns the effective concurrency limit.
 func (g GatherInput) concurrency() int {
 	if g.Concurrency > 0 {
@@ -220,6 +250,10 @@ type resourceState struct {
 // and writes structured output to outputDir. It runs discovery queries once,
 // then per-phase (test and cleanup) queries with appropriate time boundaries.
 func (g *Gatherer) Gather(ctx context.Context, input GatherInput, outputDir string) (*Manifest, *VerificationReport, error) {
+	if err := input.validate(); err != nil {
+		return nil, nil, fmt.Errorf("invalid GatherInput: %w", err)
+	}
+
 	logger := logr.FromContextOrDiscard(ctx)
 	report := &VerificationReport{}
 

--- a/tooling/hcpctl/pkg/snapshot/prow.go
+++ b/tooling/hcpctl/pkg/snapshot/prow.go
@@ -264,7 +264,7 @@ func fetchPRJobConfig(ctx context.Context, info *ProwJobInfo, logger logr.Logger
 		return nil, fmt.Errorf("failed to download config.yaml from provision-environment: %w", err)
 	}
 
-	jobConfig, err := parseConfig(configData)
+	jobConfig, err := ParseConfig(configData)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse config.yaml: %w", err)
 	}
@@ -325,7 +325,7 @@ func fetchNonPRJobConfig(ctx context.Context, info *ProwJobInfo, sdpPipelinesDir
 		return nil, fmt.Errorf("failed to run git show in %s: %w", sdpPipelinesDir, err)
 	}
 
-	jobConfig, err := parseConfig(configData)
+	jobConfig, err := ParseConfig(configData)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse rendered config from sdp-pipelines: %w", err)
 	}
@@ -590,7 +590,12 @@ type sourceAKSName struct {
 	Name string `json:"name"`
 }
 
-func parseConfig(data []byte) (*ProwJobConfig, error) {
+// ParseConfig parses a rendered environment config YAML and extracts the
+// Kusto connection info and AKS cluster names into a ProwJobConfig. This is
+// the single source of truth for mapping config keys to ProwJobConfig fields;
+// all callers that need these values should use this function to avoid
+// independent config-key reads drifting out of sync.
+func ParseConfig(data []byte) (*ProwJobConfig, error) {
 	var src sourceConfig
 	if err := yaml.Unmarshal(data, &src); err != nil {
 		return nil, fmt.Errorf("failed to parse YAML: %w", err)

--- a/tooling/hcpctl/pkg/snapshot/queries.go
+++ b/tooling/hcpctl/pkg/snapshot/queries.go
@@ -144,6 +144,7 @@ type queryData struct {
 	ResponseStatusCode int
 
 	// Discovered by queries.
+	SubscriptionID              string
 	ResourceID                  string
 	ResourceType                string
 	ResourceName                string
@@ -156,6 +157,37 @@ type queryData struct {
 	ClusterID                   string
 	HostedClusterNamespace      string
 	HostedControlPlaneNamespace string
+
+	// ChildResourceTypes maps lowercased resource type strings to true for
+	// all child resource types that exist under this resource in
+	// cosmosResourceSnapshots. Populated by the cosmosResourceDiscovery query.
+	ChildResourceTypes map[string]bool
+}
+
+// hasChildResourceType returns true if a child resource type with the given
+// suffix (case-insensitive) exists for this resource in cosmosResourceSnapshots.
+func (d queryData) hasChildResourceType(suffix string) bool {
+	suffix = strings.ToLower(suffix)
+	for rt := range d.ChildResourceTypes {
+		if strings.HasSuffix(rt, "/"+suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+// childServiceProviderType returns the service provider child resource type if
+// one exists (e.g., ".../serviceproviderclusters" or ".../serviceprovidernodepools"),
+// or empty string if none exists.
+func (d queryData) childServiceProviderType() string {
+	for rt := range d.ChildResourceTypes {
+		parts := strings.Split(rt, "/")
+		last := parts[len(parts)-1]
+		if strings.HasPrefix(last, "serviceprovider") {
+			return rt
+		}
+	}
+	return ""
 }
 
 // serviceProviderResourceType maps an ARM resource type to its corresponding
@@ -307,9 +339,9 @@ var allQueries = []querySpec{
 		database:     "service",
 		category:     categoryResourceDiscovery,
 		ready: func(d queryData) bool {
-			return d.ResourceGroup != "" && d.ResourceType != "" && d.ResourceID != "" && d.ClusterResourceName != ""
+			return d.SubscriptionID != "" && d.ResourceGroup != "" && d.ResourceID != ""
 		},
-		prerequisites: "ResourceGroup, ResourceType, ResourceID",
+		prerequisites: "SubscriptionID, ResourceGroup, ResourceID",
 		requiredWhen:  isClusterOrNodePool,
 		storeResult: func(d *queryData, rows []resultRow) error {
 			if len(rows) > 1 {
@@ -358,9 +390,9 @@ var allQueries = []querySpec{
 		database:     "service",
 		category:     categoryResourceDiscovery,
 		ready: func(d queryData) bool {
-			return d.ResourceGroup != "" && d.ClusterResourceName != "" && d.ServiceProviderResourceType != "" && d.ResourceName != ""
+			return d.SubscriptionID != "" && d.ResourceGroup != "" && d.ClusterResourceID != "" && d.ServiceProviderResourceType != ""
 		},
-		prerequisites: "ResourceGroup, ClusterResourceName, ServiceProviderResourceType, ResourceName",
+		prerequisites: "SubscriptionID, ResourceGroup, ClusterResourceID, ServiceProviderResourceType",
 		// Maestro readonly bundles are being phased out in favor of ReadDesires,
 		// so empty results are acceptable. Query stays informational for older snapshots.
 	},
@@ -371,9 +403,9 @@ var allQueries = []querySpec{
 		database:     "service",
 		category:     categoryResourceDiscovery,
 		ready: func(d queryData) bool {
-			return d.ResourceGroup != "" && d.ClusterResourceName != ""
+			return d.SubscriptionID != "" && d.ResourceGroup != "" && d.ClusterResourceID != ""
 		},
-		prerequisites: "ResourceGroup, ClusterResourceName",
+		prerequisites: "SubscriptionID, ResourceGroup, ClusterResourceID",
 		requiredWhen:  func(d queryData) bool { return d.ClusterResourceName != "" },
 		storeResult: func(d *queryData, rows []resultRow) error {
 			if len(rows) > 1 {
@@ -393,9 +425,9 @@ var allQueries = []querySpec{
 		database:     "service",
 		category:     categoryState,
 		ready: func(d queryData) bool {
-			return d.ResourceID != ""
+			return d.SubscriptionID != "" && d.ResourceGroup != "" && d.ResourceID != ""
 		},
-		prerequisites: "ResourceID",
+		prerequisites: "SubscriptionID, ResourceGroup, ResourceID",
 		requiredWhen:  isClusterOrNodePool,
 	},
 	{
@@ -405,9 +437,9 @@ var allQueries = []querySpec{
 		database:     "service",
 		category:     categoryConditions,
 		ready: func(d queryData) bool {
-			return d.ResourceGroup != "" && d.ResourceType != "" && d.ResourceName != "" && d.ClusterResourceName != ""
+			return d.SubscriptionID != "" && d.ResourceGroup != "" && d.ClusterResourceID != "" && d.ResourceType != "" && d.hasChildResourceType("hcpopenshiftcontrollers")
 		},
-		prerequisites: "ResourceGroup, ResourceType, ResourceName, ClusterResourceName",
+		prerequisites: "SubscriptionID, ResourceGroup, ClusterResourceID, ResourceType, ChildResourceTypes includes hcpopenshiftcontrollers",
 		requiredWhen:  isClusterOrNodePool,
 	},
 	{
@@ -417,9 +449,9 @@ var allQueries = []querySpec{
 		database:     "service",
 		category:     categoryConditions,
 		ready: func(d queryData) bool {
-			return d.ResourceGroup != "" && d.ResourceType != "" && d.ResourceName != "" && d.ClusterResourceName != ""
+			return d.SubscriptionID != "" && d.ResourceGroup != "" && d.ClusterResourceID != "" && d.ResourceType != "" && d.hasChildResourceType("hcpopenshiftcontrollers")
 		},
-		prerequisites: "ResourceGroup, ResourceType, ResourceName, ClusterResourceName",
+		prerequisites: "SubscriptionID, ResourceGroup, ClusterResourceID, ResourceType, ChildResourceTypes includes hcpopenshiftcontrollers",
 		requiredWhen:  isClusterOrNodePool,
 	},
 	{
@@ -429,9 +461,9 @@ var allQueries = []querySpec{
 		database:     "service",
 		category:     categoryState,
 		ready: func(d queryData) bool {
-			return d.ResourceGroup != "" && d.ServiceProviderResourceType != "" && d.ResourceName != "" && d.ClusterResourceName != ""
+			return d.SubscriptionID != "" && d.ResourceGroup != "" && d.ClusterResourceID != "" && d.ServiceProviderResourceType != ""
 		},
-		prerequisites: "ResourceGroup, ServiceProviderResourceType, ResourceName, ClusterResourceName",
+		prerequisites: "SubscriptionID, ResourceGroup, ClusterResourceID, ServiceProviderResourceType",
 		requiredWhen:  func(d queryData) bool { return d.ServiceProviderResourceType != "" },
 	},
 	{
@@ -483,9 +515,9 @@ var allQueries = []querySpec{
 		database:     "service",
 		category:     categoryConditions,
 		ready: func(d queryData) bool {
-			return d.ResourceGroup != "" && d.ClusterResourceName != "" && strings.EqualFold(d.ResourceType, "microsoft.redhatopenshift/hcpopenshiftclusters")
+			return d.SubscriptionID != "" && d.ResourceGroup != "" && d.ClusterResourceID != "" && isClusterType(d)
 		},
-		prerequisites: "ResourceGroup, ResourceName, ResourceType is cluster",
+		prerequisites: "SubscriptionID, ResourceGroup, ClusterResourceID, ResourceType is cluster",
 		requiredWhen:  isClusterType,
 	},
 	{
@@ -495,9 +527,9 @@ var allQueries = []querySpec{
 		database:     "service",
 		category:     categoryConditions,
 		ready: func(d queryData) bool {
-			return d.ResourceGroup != "" && d.ClusterResourceName != "" && strings.EqualFold(d.ResourceType, "microsoft.redhatopenshift/hcpopenshiftclusters")
+			return d.SubscriptionID != "" && d.ResourceGroup != "" && d.ClusterResourceID != "" && isClusterType(d)
 		},
-		prerequisites: "ResourceGroup, ResourceName, ResourceType is cluster",
+		prerequisites: "SubscriptionID, ResourceGroup, ClusterResourceID, ResourceType is cluster",
 		requiredWhen:  isClusterType,
 	},
 	{
@@ -507,9 +539,9 @@ var allQueries = []querySpec{
 		database:     "service",
 		category:     categoryConditions,
 		ready: func(d queryData) bool {
-			return d.ResourceGroup != "" && d.ClusterResourceName != "" && d.ResourceName != "" && strings.EqualFold(d.ResourceType, "microsoft.redhatopenshift/hcpopenshiftclusters/nodepools")
+			return d.SubscriptionID != "" && d.ResourceGroup != "" && d.ResourceID != "" && isNodePoolType(d)
 		},
-		prerequisites: "ResourceGroup, ClusterResourceName, ResourceName, ResourceType is nodepool",
+		prerequisites: "SubscriptionID, ResourceGroup, ResourceID, ResourceType is nodepool",
 		requiredWhen:  isNodePoolType,
 	},
 	{
@@ -519,9 +551,9 @@ var allQueries = []querySpec{
 		database:     "service",
 		category:     categoryConditions,
 		ready: func(d queryData) bool {
-			return d.ResourceGroup != "" && d.ClusterResourceName != "" && d.ResourceName != "" && strings.EqualFold(d.ResourceType, "microsoft.redhatopenshift/hcpopenshiftclusters/nodepools")
+			return d.SubscriptionID != "" && d.ResourceGroup != "" && d.ResourceID != "" && isNodePoolType(d)
 		},
-		prerequisites: "ResourceGroup, ClusterResourceName, ResourceName, ResourceType is nodepool",
+		prerequisites: "SubscriptionID, ResourceGroup, ResourceID, ResourceType is nodepool",
 		requiredWhen:  isNodePoolType,
 	},
 	{
@@ -572,9 +604,9 @@ var allQueries = []querySpec{
 		database:     "service",
 		category:     categoryLogs,
 		ready: func(d queryData) bool {
-			return d.ClusterID != "" || (d.ResourceGroup != "" && d.ClusterResourceName != "" && d.ServiceProviderResourceType != "")
+			return d.ClusterID != "" || (d.SubscriptionID != "" && d.ResourceGroup != "" && d.ClusterResourceID != "" && d.ServiceProviderResourceType != "")
 		},
-		prerequisites: "ClusterID, or ResourceGroup + ClusterResourceName + ServiceProviderResourceType",
+		prerequisites: "ClusterID, or SubscriptionID + ResourceGroup + ClusterResourceID + ServiceProviderResourceType",
 		requiredWhen:  isClusterOrNodePool,
 	},
 	{
@@ -584,9 +616,9 @@ var allQueries = []querySpec{
 		database:     "service",
 		category:     categoryLogs,
 		ready: func(d queryData) bool {
-			return d.ClusterID != "" || (d.ResourceGroup != "" && d.ClusterResourceName != "" && d.ServiceProviderResourceType != "")
+			return d.ClusterID != "" || (d.SubscriptionID != "" && d.ResourceGroup != "" && d.ClusterResourceID != "" && d.ServiceProviderResourceType != "")
 		},
-		prerequisites: "ClusterID, or ResourceGroup + ClusterResourceName + ServiceProviderResourceType",
+		prerequisites: "ClusterID, or SubscriptionID + ResourceGroup + ClusterResourceID + ServiceProviderResourceType",
 		requiredWhen:  isClusterOrNodePool,
 	},
 	{
@@ -596,9 +628,9 @@ var allQueries = []querySpec{
 		database:     "service",
 		category:     categoryLogs,
 		ready: func(d queryData) bool {
-			return d.ClusterID != "" || (d.ResourceGroup != "" && d.ClusterResourceName != "" && d.ServiceProviderResourceType != "")
+			return d.ClusterID != "" || (d.SubscriptionID != "" && d.ResourceGroup != "" && d.ClusterResourceID != "" && d.ServiceProviderResourceType != "")
 		},
-		prerequisites: "ClusterID, or ResourceGroup + ClusterResourceName + ServiceProviderResourceType",
+		prerequisites: "ClusterID, or SubscriptionID + ResourceGroup + ClusterResourceID + ServiceProviderResourceType",
 	},
 	{
 		component:    "maestro",
@@ -607,9 +639,9 @@ var allQueries = []querySpec{
 		database:     "service",
 		category:     categoryState,
 		ready: func(d queryData) bool {
-			return d.ClusterID != "" || (d.ResourceGroup != "" && d.ClusterResourceName != "" && d.ServiceProviderResourceType != "")
+			return d.ClusterID != "" || (d.SubscriptionID != "" && d.ResourceGroup != "" && d.ClusterResourceID != "" && d.ServiceProviderResourceType != "")
 		},
-		prerequisites: "ClusterID, or ResourceGroup + ClusterResourceName + ServiceProviderResourceType",
+		prerequisites: "ClusterID, or SubscriptionID + ResourceGroup + ClusterResourceID + ServiceProviderResourceType",
 		requiredWhen:  isClusterOrNodePool,
 	},
 

--- a/tooling/hcpctl/pkg/snapshot/queries/backend/cosmosResourceDiscovery/README.md
+++ b/tooling/hcpctl/pkg/snapshot/queries/backend/cosmosResourceDiscovery/README.md
@@ -1,0 +1,19 @@
+# backend / cosmosResourceDiscovery
+
+## Summary
+
+Discovers all resource types that exist in Cosmos DB under the cluster's ARM resource ID prefix.
+This drives which per-resource queries are applicable (e.g., controller conditions only fire when
+`hcpopenshiftcontrollers` child documents exist).
+
+## What to Look For
+
+A list of `(resourceID, resourceType)` pairs showing all Cosmos documents related to this cluster.
+Resource types with `/hcpopenshiftcontrollers` suffixes indicate controller condition data is available.
+Resource types with `/readdesires` indicate management cluster state is available. Resource types with
+`/serviceprovider*` indicate service provider state documents exist.
+
+## Where to Go Next
+
+This query is informational — its results drive the availability of downstream queries like
+`backend/resourceControllerConditions`, `backend/serviceProviderState`, and `hypershift/hostedClusterMetadata`.

--- a/tooling/hcpctl/pkg/snapshot/queries/backend/cosmosResourceDiscovery/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/backend/cosmosResourceDiscovery/query.kql
@@ -5,6 +5,5 @@ cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('cosmosRes
 {{- end }}
 | where subscriptionID == '{{ .SubscriptionID }}'
 | where resourceGroup =~ '{{ .ResourceGroup }}'
-| where resourceID =~ '{{ .ResourceID }}'
-| extend internalId=tostring(content.properties.serviceProviderProperties.clusterServiceID)
-| distinct internalId
+| where resourceID startswith '{{ .ClusterResourceID }}'
+| distinct resourceID=tolower(resourceID), resourceType=tolower(resourceType)

--- a/tooling/hcpctl/pkg/snapshot/queries/backend/resourceControllerConditionTimeline/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/backend/resourceControllerConditionTimeline/query.kql
@@ -1,15 +1,13 @@
-cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('backendLogs')
+cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('cosmosResourceSnapshots')
 | where timestamp between ({{ kqlDatetime .FullStartTime }} .. {{ kqlDatetime .FullEndTime }})
 {{- if and .ServiceClusterName .ManagementClusterName }}
 | where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
 {{- end }}
-| where container_name == 'aro-hcp-backend'
-| where log.controller_name == 'datadump'
-| where log.resource_group == '{{ .ResourceGroup }}'
-| where log.resource_name == '{{ .ClusterResourceName }}'
-| where log.content.resourceType =~ '{{ .ResourceType }}/hcpopenshiftcontrollers'
-| where log.content.resourceID has '{{ .ResourceName }}'
-| summarize content=take_any(log.content), observedTime=take_any(timestamp) by etag=tostring(log.content._etag)
+| where subscriptionID == '{{ .SubscriptionID }}'
+| where resourceGroup =~ '{{ .ResourceGroup }}'
+| where resourceID startswith '{{ .ClusterResourceID }}'
+| where resourceType =~ '{{ .ResourceType }}/hcpopenshiftcontrollers'
+| summarize content=take_any(content), observedTime=min(timestamp) by etag=tostring(content._etag)
 | sort by tolong(content._ts) asc
 | extend content = parse_json(content)
 | extend controller_name = extract("/hcpOpenShiftControllers/([^\\/]+)", 1, tostring(content.resourceID))

--- a/tooling/hcpctl/pkg/snapshot/queries/backend/resourceControllerConditions/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/backend/resourceControllerConditions/query.kql
@@ -1,15 +1,13 @@
-cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('backendLogs')
+cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('cosmosResourceSnapshots')
 | where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
 {{- if and .ServiceClusterName .ManagementClusterName }}
 | where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
 {{- end }}
-| where container_name == 'aro-hcp-backend'
-| where log.controller_name == 'datadump'
-| where log.resource_group == '{{ .ResourceGroup }}'
-| where log.resource_name == '{{ .ClusterResourceName }}'
-| where log.content.resourceType =~ '{{ .ResourceType }}/hcpopenshiftcontrollers'
-| where log.content.resourceID has '{{ .ResourceName }}'
-| summarize payload=take_any(log.content), observedTime=take_any(timestamp) by etag=tostring(log.content._etag)
+| where subscriptionID == '{{ .SubscriptionID }}'
+| where resourceGroup =~ '{{ .ResourceGroup }}'
+| where resourceID startswith '{{ .ClusterResourceID }}'
+| where resourceType =~ '{{ .ResourceType }}/hcpopenshiftcontrollers'
+| summarize payload=take_any(content), observedTime=min(timestamp) by etag=tostring(content._etag)
 | extend payload = parse_json(payload)
 | extend controller_name = extract("/hcpOpenShiftControllers/([^\\/]+)", 1, tostring(payload.resourceID))
 | extend ts = tolong(payload._ts)

--- a/tooling/hcpctl/pkg/snapshot/queries/backend/resourceState/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/backend/resourceState/query.kql
@@ -1,11 +1,11 @@
-cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('backendLogs')
+cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('cosmosResourceSnapshots')
 | where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
 {{- if and .ServiceClusterName .ManagementClusterName }}
 | where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
 {{- end }}
-| where container_name == 'aro-hcp-backend'
-| where log.controller_name == 'datadump'
-| where log.content.resourceID =~ '{{ .ResourceID }}'
-| summarize content=take_any(log.content) by etag=tostring(log.content._etag)
+| where subscriptionID == '{{ .SubscriptionID }}'
+| where resourceGroup =~ '{{ .ResourceGroup }}'
+| where resourceID =~ '{{ .ResourceID }}'
+| summarize content=take_any(content) by etag=tostring(content._etag)
 | sort by tolong(content._ts) asc
 | project content

--- a/tooling/hcpctl/pkg/snapshot/queries/backend/serviceProviderState/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/backend/serviceProviderState/query.kql
@@ -1,14 +1,12 @@
-cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('backendLogs')
+cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('cosmosResourceSnapshots')
 | where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
 {{- if and .ServiceClusterName .ManagementClusterName }}
 | where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
 {{- end }}
-| where container_name == 'aro-hcp-backend'
-| where log.controller_name == 'datadump'
-| where log.resource_group == '{{ .ResourceGroup }}'
-| where log.resource_name == '{{ .ClusterResourceName }}'
-| where log.content.resourceType =~ '{{ .ServiceProviderResourceType }}'
-| where log.content.resourceID has '{{ .ResourceName }}'
-| summarize content=take_any(log.content) by etag=tostring(log.content._etag)
+| where subscriptionID == '{{ .SubscriptionID }}'
+| where resourceGroup =~ '{{ .ResourceGroup }}'
+| where resourceID startswith '{{ .ClusterResourceID }}'
+| where resourceType =~ '{{ .ServiceProviderResourceType }}'
+| summarize content=take_any(content) by etag=tostring(content._etag)
 | sort by tolong(content._ts) asc
 | project content

--- a/tooling/hcpctl/pkg/snapshot/queries/hypershift/hostedClusterConditionTimeline/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/hypershift/hostedClusterConditionTimeline/query.kql
@@ -1,14 +1,13 @@
-cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('backendLogs')
+cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('cosmosResourceSnapshots')
 | where timestamp between ({{ kqlDatetime .FullStartTime }} .. {{ kqlDatetime .FullEndTime }})
 {{- if and .ServiceClusterName .ManagementClusterName }}
 | where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
 {{- end }}
-| where container_name == 'aro-hcp-backend'
-| where log.controller_name == 'datadump'
-| where log.resource_group == '{{ .ResourceGroup }}'
-| where log.resource_name == '{{ .ClusterResourceName }}'
-| where log.content.resourceType =~ 'microsoft.redhatopenshift/hcpopenshiftclusters/readdesires'
-| summarize content=take_any(log.content), observedTime=take_any(timestamp) by etag=tostring(log.content._etag)
+| where subscriptionID == '{{ .SubscriptionID }}'
+| where resourceGroup =~ '{{ .ResourceGroup }}'
+| where resourceID startswith '{{ .ClusterResourceID }}'
+| where resourceType =~ 'microsoft.redhatopenshift/hcpopenshiftclusters/readdesires'
+| summarize content=take_any(content), observedTime=min(timestamp) by etag=tostring(content._etag)
 | sort by tolong(content._ts) asc
 | extend content = parse_json(content)
 | extend manifest = content.properties.status.kubeContent

--- a/tooling/hcpctl/pkg/snapshot/queries/hypershift/hostedClusterConditions/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/hypershift/hostedClusterConditions/query.kql
@@ -1,14 +1,13 @@
-cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('backendLogs')
+cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('cosmosResourceSnapshots')
 | where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
 {{- if and .ServiceClusterName .ManagementClusterName }}
 | where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
 {{- end }}
-| where container_name == 'aro-hcp-backend'
-| where log.controller_name == 'datadump'
-| where log.resource_group == '{{ .ResourceGroup }}'
-| where log.resource_name == '{{ .ClusterResourceName }}'
-| where log.content.resourceType =~ 'microsoft.redhatopenshift/hcpopenshiftclusters/readdesires'
-| summarize content=take_any(log.content), observedTime=take_any(timestamp) by etag=tostring(log.content._etag)
+| where subscriptionID == '{{ .SubscriptionID }}'
+| where resourceGroup =~ '{{ .ResourceGroup }}'
+| where resourceID startswith '{{ .ClusterResourceID }}'
+| where resourceType =~ 'microsoft.redhatopenshift/hcpopenshiftclusters/readdesires'
+| summarize content=take_any(content), observedTime=min(timestamp) by etag=tostring(content._etag)
 | top 1 by tolong(content._ts) desc
 | extend content = parse_json(content)
 | extend manifest = content.properties.status.kubeContent

--- a/tooling/hcpctl/pkg/snapshot/queries/hypershift/hostedClusterMetadata/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/hypershift/hostedClusterMetadata/query.kql
@@ -1,14 +1,13 @@
-cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('backendLogs')
+cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('cosmosResourceSnapshots')
 | where timestamp between ({{ kqlDatetime .FullStartTime }} .. {{ kqlDatetime .FullEndTime }})
 {{- if and .ServiceClusterName .ManagementClusterName }}
 | where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
 {{- end }}
-| where container_name == 'aro-hcp-backend'
-| where log.controller_name == 'datadump'
-| where log.resource_group == '{{ .ResourceGroup }}'
-| where log.resource_name == '{{ .ClusterResourceName }}'
-| where log.content.resourceType =~ 'microsoft.redhatopenshift/hcpopenshiftclusters/readdesires'
-| summarize content=take_any(log.content) by etag=tostring(log.content._etag)
+| where subscriptionID == '{{ .SubscriptionID }}'
+| where resourceGroup =~ '{{ .ResourceGroup }}'
+| where resourceID startswith '{{ .ClusterResourceID }}'
+| where resourceType =~ 'microsoft.redhatopenshift/hcpopenshiftclusters/readdesires'
+| summarize content=take_any(content) by etag=tostring(content._etag)
 | sort by tolong(content._ts) asc
 | extend content = parse_json(content)
 | extend manifest = content.properties.status.kubeContent

--- a/tooling/hcpctl/pkg/snapshot/queries/hypershift/nodePoolConditionTimeline/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/hypershift/nodePoolConditionTimeline/query.kql
@@ -1,15 +1,13 @@
-cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('backendLogs')
+cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('cosmosResourceSnapshots')
 | where timestamp between ({{ kqlDatetime .FullStartTime }} .. {{ kqlDatetime .FullEndTime }})
 {{- if and .ServiceClusterName .ManagementClusterName }}
 | where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
 {{- end }}
-| where container_name == 'aro-hcp-backend'
-| where log.controller_name == 'datadump'
-| where log.resource_group == '{{ .ResourceGroup }}'
-| where log.resource_name == '{{ .ClusterResourceName }}'
-| where log.content.resourceType =~ 'microsoft.redhatopenshift/hcpopenshiftclusters/nodepools/readdesires'
-| where log.content.resourceID has '{{ .ResourceName }}'
-| summarize content=take_any(log.content), observedTime=take_any(timestamp) by etag=tostring(log.content._etag)
+| where subscriptionID == '{{ .SubscriptionID }}'
+| where resourceGroup =~ '{{ .ResourceGroup }}'
+| where resourceID startswith '{{ .ResourceID }}'
+| where resourceType =~ 'microsoft.redhatopenshift/hcpopenshiftclusters/nodepools/readdesires'
+| summarize content=take_any(content), observedTime=min(timestamp) by etag=tostring(content._etag)
 | sort by tolong(content._ts) asc
 | extend content = parse_json(content)
 | extend manifest = content.properties.status.kubeContent

--- a/tooling/hcpctl/pkg/snapshot/queries/hypershift/nodePoolConditions/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/hypershift/nodePoolConditions/query.kql
@@ -1,15 +1,13 @@
-cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('backendLogs')
+cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('cosmosResourceSnapshots')
 | where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
 {{- if and .ServiceClusterName .ManagementClusterName }}
 | where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
 {{- end }}
-| where container_name == 'aro-hcp-backend'
-| where log.controller_name == 'datadump'
-| where log.resource_group == '{{ .ResourceGroup }}'
-| where log.resource_name == '{{ .ClusterResourceName }}'
-| where log.content.resourceType =~ 'microsoft.redhatopenshift/hcpopenshiftclusters/nodepools/readdesires'
-| where log.content.resourceID has '{{ .ResourceName }}'
-| summarize content=take_any(log.content), observedTime=take_any(timestamp) by etag=tostring(log.content._etag)
+| where subscriptionID == '{{ .SubscriptionID }}'
+| where resourceGroup =~ '{{ .ResourceGroup }}'
+| where resourceID startswith '{{ .ResourceID }}'
+| where resourceType =~ 'microsoft.redhatopenshift/hcpopenshiftclusters/nodepools/readdesires'
+| summarize content=take_any(content), observedTime=min(timestamp) by etag=tostring(content._etag)
 | top 1 by tolong(content._ts) desc
 | extend content = parse_json(content)
 | extend manifest = content.properties.status.kubeContent

--- a/tooling/hcpctl/pkg/snapshot/queries/partials/alertEvents.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/partials/alertEvents.kql
@@ -5,11 +5,13 @@ cluster('{{ .ClusterURI }}').database('{{ .MonitoringEventsDatabase }}').table('
         isnull(resolvedDateTime) or
         (isnotnull(resolvedDateTime) and resolvedDateTime < {{ kqlDatetime .FullEndTime }})
     )
+| extend cluster = tostring(alertContext.labels.cluster)
+| where isnotnull(cluster)
 {{- if and .ServiceClusterName .ManagementClusterName }}
-| where alertContext.labels.cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
+| where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
 {{- end }}
 {{- end -}}
 
 {{- define "alertEventsProject" -}}
-| project alert=alertContext.labels.alertname, firedDateTime, resolvedDateTime, description=alertContext.annotations.description
+| project cluster, alert=alertContext.labels.alertname, firedDateTime, resolvedDateTime, description=alertContext.annotations.description
 {{- end -}}

--- a/tooling/hcpctl/pkg/snapshot/queries/partials/bundleMap.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/partials/bundleMap.kql
@@ -20,19 +20,17 @@ let bundleMapCS = cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}'
 {{- end -}}
 
 {{- define "bundleMapBackend" -}}
-{{ if and .ResourceGroup .ClusterResourceName .ServiceProviderResourceType -}}
-let bundleMapBackend = cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('backendLogs')
+{{ if and .ClusterResourceID .ServiceProviderResourceType -}}
+let bundleMapBackend = cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('cosmosResourceSnapshots')
 | where timestamp between ({{ kqlDatetime .FullStartTime }} .. {{ kqlDatetime .FullEndTime }})
 {{- if and .ServiceClusterName .ManagementClusterName }}
 | where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
 {{- end }}
-| where container_name == 'aro-hcp-backend'
-| where log.controller_name == 'datadump'
-| where log.resource_group == '{{ .ResourceGroup }}'
-| where log.resource_name == '{{ .ClusterResourceName }}'
-| where log.content.resourceType =~ '{{ .ServiceProviderResourceType }}'
-| where log.content.resourceID has '{{ .ResourceName }}'
-| summarize content = take_any(log.content) by etag = tostring(log.content._etag)
+| where subscriptionID == '{{ .SubscriptionID }}'
+| where resourceGroup =~ '{{ .ResourceGroup }}'
+| where resourceID startswith '{{ .ClusterResourceID }}'
+| where resourceType =~ '{{ .ServiceProviderResourceType }}'
+| summarize content = take_any(content) by etag = tostring(content._etag)
 | mv-expand readOnlyBundle = content.properties.status.maestroReadonlyBundles
 | where tostring(readOnlyBundle) != ''
 | mv-expand resourceIdentifier = readOnlyBundle.resourceIdentifiers
@@ -52,9 +50,9 @@ let bundleMapBackend = cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabas
 {{ template "bundleMapBackend" . -}}
 let bundleMap = union
 {{ if .ClusterID -}}
-    (bundleMapCS | project bundleId, groupVersion, resourceKind, resourceNamespace, resourceName, source = 'clustersService', label = strcat(groupVersion, '/', resourceKind, ' ', resource)){{ if and .ResourceGroup .ClusterResourceName .ServiceProviderResourceType }},{{ end }}
+    (bundleMapCS | project bundleId, groupVersion, resourceKind, resourceNamespace, resourceName, source = 'clustersService', label = strcat(groupVersion, '/', resourceKind, ' ', resource)){{ if and .ClusterResourceID .ServiceProviderResourceType }},{{ end }}
 {{ end -}}
-{{ if and .ResourceGroup .ClusterResourceName .ServiceProviderResourceType -}}
+{{ if and .ClusterResourceID .ServiceProviderResourceType -}}
     (bundleMapBackend | project bundleId = maestroBundleId, groupVersion, resourceKind, resourceNamespace, resourceName, source = 'backend', label = strcat(groupVersion, '/', resourceKind, ' ', resourceNamespace, '/', resourceName))
 {{ end -}}
 | summarize groupVersion = take_any(groupVersion), resourceKind = take_any(resourceKind), source = take_any(source), label = take_any(label), resourceNamespace = take_any(resourceNamespace), resourceName = take_any(resourceName) by bundleId;


### PR DESCRIPTION
We want to use the purpose-driven kubernetes and cosmos resource snapshot tables over having to grab this data out of specific controller outputs in logs.

/label lgtm