### PR TITLE
fix: avoid default SA race in pull-secret e2e image pull pod

### DIFF
--- a/test/e2e/cluster_pullsecret.go
+++ b/test/e2e/cluster_pullsecret.go
@@ -259,6 +259,14 @@ var _ = Describe("Customer", func() {
 				_ = kubeClient.CoreV1().Namespaces().Delete(ctx, pullTestNamespace, metav1.DeleteOptions{})
 			})
 
+			By("creating a service account for the image pull verification pod")
+			sa, err := kubeClient.CoreV1().ServiceAccounts(pullTestNamespace).Create(ctx, &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pull-secret-test",
+				},
+			}, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred(), "failed to create service account in %s", pullTestNamespace)
+
 			By("creating a pod for image pull verification")
 			pod := &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
@@ -266,6 +274,8 @@ var _ = Describe("Customer", func() {
 					Namespace: pullTestNamespace,
 				},
 				Spec: corev1.PodSpec{
+					ServiceAccountName:           sa.Name,
+					AutomountServiceAccountToken: to.Ptr(false),
 					Containers: []corev1.Container{
 						{
 							Name:            "pull-test",


### PR DESCRIPTION
### What

fix: avoid default SA race in pull-secret e2e image pull pod

### Why

Create a dedicated ServiceAccount for the pull-secret-test pod so creation does not race on namespace default SA provisioning.

Follows a similar approach to https://github.com/Azure/ARO-HCP/pull/5973

Fixes prow failure:
https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/Azure_ARO-HCP/6058/pull-ci-Azure-ARO-HCP-main-e2e-parallel/2077580096658477056

Error:
```
{fail [github.com/Azure/ARO-HCP/test/e2e/cluster_pullsecret.go:291]: failed to create pull-secret-test pod in pullsecret-image-test
Unexpected error:
    <*errors.StatusError | 0xc0011fa280>:
    pods "pull-secret-test" is forbidden: error looking up service account pullsecret-image-test/default: serviceaccount "default" not found
    ...
occurred  fail [github.com/Azure/ARO-HCP/test/e2e/cluster_pullsecret.go:291]: failed to create pull-secret-test pod in pullsecret-image-test
Unexpected error:
    <*errors.StatusError | 0xc0011fa280>:
    pods "pull-secret-test" is forbidden: error looking up service account pullsecret-image-test/default: serviceaccount "default" not found
    ...
occurred}
```

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

I only focused on fixing this instance of e2e where the failure was observed as opposed to double checking all the other occurrence of this pattern as we can fix the issues as they arise.


### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
