### PR TITLE
fix: prevent race condition in ChangeFeedWatcher.Stop() which causing TestKubeApplierIntegration/read_mirrors_configmap to fail

### DIFF
--- a/internal/database/informers/changefeed_list_watch.go
+++ b/internal/database/informers/changefeed_list_watch.go
@@ -227,8 +227,9 @@ type ChangeFeedWatcher[InternalAPIType any, InternalAPITypePointer arm.CosmosMet
 	beginDelivery               chan struct{}
 	resourceIDToInstanceVersion *sync.Map
 
-	result chan watch.Event
-	done   chan struct{}
+	result   chan watch.Event
+	done     chan struct{}
+	stopOnce sync.Once
 	// finished closes after Run and all of its child goroutines have fully
 	// returned (including their deferred logging). Callers that need to be
 	// sure no further work — especially logging through a test-bound logger
@@ -454,11 +455,9 @@ func (c *ChangeFeedWatcher[InternalAPIType, InternalAPITypePointer, CosmosAPITyp
 }
 
 func (c *ChangeFeedWatcher[InternalAPIType, InternalAPITypePointer, CosmosAPIType]) Stop() {
-	select {
-	case <-c.done:
-	default:
+	c.stopOnce.Do(func() {
 		close(c.done)
-	}
+	})
 }
 
 func (c *ChangeFeedWatcher[InternalAPIType, InternalAPITypePointer, CosmosAPIType]) ResultChan() <-chan watch.Event {


### PR DESCRIPTION
### What

fix: prevent race condition in ChangeFeedWatcher.Stop() which was causing TestKubeApplierIntegration/read_mirrors_configmap to fail

### Why

Replace select-based idempotency check with sync.Once to prevent double-close panic when Stop() is called concurrently from multiple goroutines.

Fixes panic observed in CI: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/Azure_ARO-HCP/5752/pull-ci-Azure-ARO-HCP-main-integration/2077627135031250944

```
  {"time":"2026-07-16T05:54:45.898091472Z","level":"INFO","source":{"function":"github.com/Azure/ARO-HCP/internal/database/informers.(*ChangeFeedWatche
  r[...]).Run","file":"/opt/app-root/src/github.com/Azure/ARO-HCP/internal/database/informers/changefeed_list_watch.go","line":342},"msg":"finished
  change feed watchers","resourceType":"microsoft.redhatopenshift/hcpopenshiftclusters/applydesires","resourceType":"microsoft.redhatopenshift/hcpopens
  hiftclusters/nodepools/applydesires","resourceType":"microsoft.redhatopenshift/hcpopenshiftclusters/applydesires","resourceType":"microsoft.redhatope
  nshift/hcpopenshiftclusters/nodepools/applydesires"}
  E0716 05:54:45.898342   46944 chan.go:425] "Observed a panic" panic="close of closed channel" panicGoValue="close of closed channel" stacktrace=<
      goroutine 273 [running]:
      k8s.io/apimachinery/pkg/util/runtime.logPanic({0x313d6c0, 0xc00090e150}, {0x2c99000, 0x3120060})
          /opt/app-root/pkg/mod/k8s.io/apimachinery@v0.35.3/pkg/util/runtime/runtime.go:132 +0xdc
      k8s.io/apimachinery/pkg/util/runtime.handleCrash({0x313dc80, 0xc0008aa380}, {0x2c99000, 0x3120060}, {0x0, 0x0, 0x4941fa?})
          /opt/app-root/pkg/mod/k8s.io/apimachinery@v0.35.3/pkg/util/runtime/runtime.go:107 +0x185
      k8s.io/apimachinery/pkg/util/runtime.HandleCrashWithContext({0x313dc80, 0xc0008aa380}, {0x0, 0x0, 0x0})
          /opt/app-root/pkg/mod/k8s.io/apimachinery@v0.35.3/pkg/util/runtime/runtime.go:78 +0x5f
      panic({0x2c99000?, 0x3120060?})
          /usr/lib/golang/src/runtime/panic.go:860 +0x13a
      github.com/Azure/ARO-HCP/internal/database/informers.(*ChangeFeedWatcher[...]).Stop(...)
          /opt/app-root/src/github.com/Azure/ARO-HCP/internal/database/informers/changefeed_list_watch.go:460
```

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
