### PR TITLE
chore: bump maestro image (ARO-28432)

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -993,7 +993,7 @@ defaults:
     image:
       registry: quay.io
       repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
-      digest: sha256:b8e3add1c986d90c84d929f85c3ffadf25e4c5664c12e9594e9a52e532794f56 # a3341e83cfa3be63bca43a5d01171d23799b19aa (2026-07-15 06:12)
+      digest: sha256:b7f0c3062306cc4f956342b4d2ac4a6eba4113d4f615dabe584fa666bf5d71d5 # cb6f04e6518950f3486dc086148aafb0d82958c5 (2026-07-16 09:57)
   # ACM
   acm:
     operator:

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -560,7 +560,7 @@ maestro:
     name: arohcp-ci00-maestro-j7654321
     private: false
   image:
-    digest: sha256:b8e3add1c986d90c84d929f85c3ffadf25e4c5664c12e9594e9a52e532794f56
+    digest: sha256:b7f0c3062306cc4f956342b4d2ac4a6eba4113d4f615dabe584fa666bf5d71d5
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -560,7 +560,7 @@ maestro:
     name: arohcp-ci01-maestro-j7654321
     private: false
   image:
-    digest: sha256:b8e3add1c986d90c84d929f85c3ffadf25e4c5664c12e9594e9a52e532794f56
+    digest: sha256:b7f0c3062306cc4f956342b4d2ac4a6eba4113d4f615dabe584fa666bf5d71d5
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -560,7 +560,7 @@ maestro:
     name: arohcp-cspr-maestro-usw3
     private: false
   image:
-    digest: sha256:b8e3add1c986d90c84d929f85c3ffadf25e4c5664c12e9594e9a52e532794f56
+    digest: sha256:b7f0c3062306cc4f956342b4d2ac4a6eba4113d4f615dabe584fa666bf5d71d5
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -560,7 +560,7 @@ maestro:
     name: arohcp-dev-maestro-usw3
     private: false
   image:
-    digest: sha256:b8e3add1c986d90c84d929f85c3ffadf25e4c5664c12e9594e9a52e532794f56
+    digest: sha256:b7f0c3062306cc4f956342b4d2ac4a6eba4113d4f615dabe584fa666bf5d71d5
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -560,7 +560,7 @@ maestro:
     name: arohcp-perf-maestro-usw3ptest
     private: false
   image:
-    digest: sha256:b8e3add1c986d90c84d929f85c3ffadf25e4c5664c12e9594e9a52e532794f56
+    digest: sha256:b7f0c3062306cc4f956342b4d2ac4a6eba4113d4f615dabe584fa666bf5d71d5
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -560,7 +560,7 @@ maestro:
     name: arohcp-pers-maestro-usw3test
     private: false
   image:
-    digest: sha256:b8e3add1c986d90c84d929f85c3ffadf25e4c5664c12e9594e9a52e532794f56
+    digest: sha256:b7f0c3062306cc4f956342b4d2ac4a6eba4113d4f615dabe584fa666bf5d71d5
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:


### PR DESCRIPTION
[ARO-28432](https://redhat.atlassian.net/browse/ARO-28432)

### What

Bump the maestro server image digest:

| Name | Old Digest | New Digest | Tag | Date | Status |
| --- | --- | --- | --- | --- | --- |
| maestro | `b8e3add1c986…` | `b7f0c3062306…` | `cb6f04e6518950f3486dc086148aafb0d82958c5` | 2026-07-16 09:57 | updated |

### Why

Picks up [openshift-online/maestro#557](https://github.com/openshift-online/maestro/pull/557) ([ARO-28432](https://redhat.atlassian.net/browse/ARO-28432): *stop orphaning applied resources on resource-bundle delete*). The new image is built from maestro commit `cb6f04e6`, which is the **merge commit** of that PR — so the bump contains the fix exactly.

### Testing

- `make -C tooling/image-updater update COMPONENTS=maestro` — digest resolved and written to `config/config.yaml`.
- `make -C config materialize` — rendered configs + helm fixtures regenerated; the only change is the maestro server digest across the 6 dev rendered configs.
- `make -C config detect-change` — **No changes detected** (config/fixtures up to date).
- `make verify-yamlfmt` — clean.

### Special notes for your reviewer

Config-only image digest bump (`maestro` component). No ACM/MCE bundle change, so no `acm/` helm-chart regeneration needed.
