### PR TITLE
test: validate upgrade-e2e-parallel catches upgrade-only Cosmos backup-policy regression

### DIFF
--- a/dev-infrastructure/modules/rp-cosmos-account.bicep
+++ b/dev-infrastructure/modules/rp-cosmos-account.bicep
@@ -10,10 +10,22 @@ resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2024-11-15' = {
   name: name
   location: location
   properties: {
+    // UPGRADE-PATH REGRESSION TEST (not for merge): the Cosmos DB backup
+    // policy type is immutable once an account exists. Azure allows a
+    // one-way Periodic -> Continuous migration but rejects switching a
+    // Continuous account back to Periodic with a BadRequest. A fresh RP
+    // deploy creates the account directly as Periodic and succeeds, so
+    // e2e-parallel stays green; an upgrade over a baseline provisioned
+    // from main (which uses Continuous) hits the disallowed
+    // Continuous -> Periodic transition and fails the
+    // aro-hcp-upgrade-environment step. This validates that the
+    // upgrade-e2e-parallel job catches upgrade-only infra regressions.
     backupPolicy: {
-      type: 'Continuous'
-      continuousModeProperties: {
-        tier: 'Continuous7Days'
+      type: 'Periodic'
+      periodicModeProperties: {
+        backupIntervalInMinutes: 240
+        backupRetentionIntervalInHours: 8
+        backupStorageRedundancy: 'Local'
       }
     }
     consistencyPolicy: {


### PR DESCRIPTION
## ⚠️ NOT FOR MERGE — validation of the `upgrade-e2e-parallel` job

This PR intentionally introduces an **upgrade-only** infrastructure regression to test that the new optional presubmit `upgrade-e2e-parallel` (added in openshift/release#81044) actually catches regressions that a fresh provision cannot.

### The change

`dev-infrastructure/modules/rp-cosmos-account.bicep` — switch the RP Cosmos DB account `backupPolicy.type` from `Continuous` to `Periodic`.

### Why this fails only on upgrade

The Cosmos DB backup policy type is **immutable** once an account exists. Azure permits a one-way `Periodic → Continuous` migration but rejects `Continuous → Periodic` with a `BadRequest`.

| Job | Behavior | Expected result |
|---|---|---|
| `e2e-parallel` (fresh deploy) | Provision creates the account **directly** as `Periodic` | ✅ pass |
| `upgrade-e2e-parallel` | `provision-from-main` creates it as `Continuous`; the PR's `aro-hcp-upgrade-environment` step tries to flip the existing account to `Periodic` | ❌ fail (BadRequest) |

The failure lands in the `aro-hcp-upgrade-environment` step — exactly the "upgrade-path regression" bucket the workflow documents, distinct from a `provision-from-main` (broken-main) failure.

### How to exercise

```
/test e2e-parallel            # expect PASS  (fresh deploy)
/test upgrade-e2e-parallel    # expect FAIL at aro-hcp-upgrade-environment
```

### Validation done

- `az bicep build` compiles cleanly; compiled ARM shows the `Periodic` policy.

**Do not merge.** Revert before closing.
