### PR TITLE
docs(ci): cap prod e2e slots at 3/sub for deny-assignment limit

### DIFF
--- a/docs/ci/identity-leasing.md
+++ b/docs/ci/identity-leasing.md
@@ -221,7 +221,7 @@ This applies to **AME environments only (STG and PROD)**: the RP only creates de
 max-slots-per-sub = floor(max-hcps-per-sub / identity-container-count-per-slot)
 ```
 
-With PROD's `identity_container_count: 25` (the max HCPs a single suite run provisions concurrently), that is `floor(92 / 25) = 3` slots per subscription. PROD pools in `test/e2e-config/e2e-slots.yaml` are therefore capped at `slot_count: 3` per subscription.
+where `identity-container-count-per-slot` is the pool's `identity_container_count` (the max HCPs a single suite run provisions concurrently). The PROD `slot_count` in `test/e2e-config/e2e-slots.yaml` is sized to stay within this cap; that catalog is the source of truth for the current per-subscription values.
 
 The RP is expected to consolidate the per-cluster deny assignments into a single deny assignment with all managed identities excluded once Azure raises the excluded-principals limit from 10 to 25. When that lands, this per-subscription HCP ceiling is lifted and the PROD `slot_count` can be raised accordingly.
 

--- a/docs/ci/identity-leasing.md
+++ b/docs/ci/identity-leasing.md
@@ -206,7 +206,7 @@ max-concurrent-runs = floor(pool-size / per-job-lease-count)
 
 **Bottleneck 2: parallelism within a single run.** The per-job identity-container set still caps how many HCP clusters a single suite execution can run simultaneously. When the suite has more specs requiring HCPs than available leased containers, specs run in waves — the first wave runs, and the remaining specs block inside `AssignIdentityContainers()` until containers are released. This means adding more test specs increases total suite runtime even if the specs themselves are fast.
 
-**Bottleneck 3: deny assignments per subscription (PROD only).** The Azure Authorization RP allows at most **2000 deny assignments per subscription**. The RP currently creates *sharded* (per-cluster) deny assignments — roughly 21 per HCP — which caps a single subscription at about **92 concurrent HCP clusters**, regardless of role-assignment quota or identity-pool size:
+**Bottleneck 3: deny assignments per subscription (AME only — STG and PROD).** The Azure Authorization RP allows at most **2000 deny assignments per subscription**. The RP currently creates *sharded* (per-cluster) deny assignments — roughly 21 per HCP — which caps a single subscription at about **92 concurrent HCP clusters**, regardless of role-assignment quota or identity-pool size:
 
 ```text
 DENY_ASSIGNMENTS_PER_SUB   = 2000  (Authorization RP hard limit)
@@ -215,7 +215,7 @@ DENY_ASSIGNMENTS_PER_HCP   = 21    (current sharded, per-cluster count)
 max-hcps-per-sub = floor(DENY_ASSIGNMENTS_PER_SUB / DENY_ASSIGNMENTS_PER_HCP) ≈ 92
 ```
 
-This is **PROD-only**: the RP only creates deny assignments in AME (STG and above), and in practice this is the binding constraint for PROD slot sizing. It translates into slot count as:
+This applies to **AME environments only (STG and PROD)**: the RP only creates deny assignments in AME. In practice it is the binding constraint for PROD slot sizing — STG runs a single slot per subscription, well under the ceiling. It translates into slot count as:
 
 ```text
 max-slots-per-sub = floor(max-hcps-per-sub / identity-container-count-per-slot)

--- a/docs/ci/identity-leasing.md
+++ b/docs/ci/identity-leasing.md
@@ -192,7 +192,7 @@ For the current live capacity model:
 
 ### Scaling Constraints
 
-Two bottlenecks still matter:
+Three bottlenecks matter:
 
 **Bottleneck 1: maximum concurrent E2E runs.**
 
@@ -205,6 +205,25 @@ max-concurrent-runs = floor(pool-size / per-job-lease-count)
 - In the slot-managed DEV model, concurrency is instead bounded by the number of available slots across the shard pools that the job is allowed to consume.
 
 **Bottleneck 2: parallelism within a single run.** The per-job identity-container set still caps how many HCP clusters a single suite execution can run simultaneously. When the suite has more specs requiring HCPs than available leased containers, specs run in waves — the first wave runs, and the remaining specs block inside `AssignIdentityContainers()` until containers are released. This means adding more test specs increases total suite runtime even if the specs themselves are fast.
+
+**Bottleneck 3: deny assignments per subscription (PROD only).** The Azure Authorization RP allows at most **2000 deny assignments per subscription**. The RP currently creates *sharded* (per-cluster) deny assignments — roughly 21 per HCP — which caps a single subscription at about **92 concurrent HCP clusters**, regardless of role-assignment quota or identity-pool size:
+
+```text
+DENY_ASSIGNMENTS_PER_SUB   = 2000  (Authorization RP hard limit)
+DENY_ASSIGNMENTS_PER_HCP   = 21    (current sharded, per-cluster count)
+
+max-hcps-per-sub = floor(DENY_ASSIGNMENTS_PER_SUB / DENY_ASSIGNMENTS_PER_HCP) ≈ 92
+```
+
+This is **PROD-only**: the RP only creates deny assignments in AME (STG and above), and in practice this is the binding constraint for PROD slot sizing. It translates into slot count as:
+
+```text
+max-slots-per-sub = floor(max-hcps-per-sub / identity-container-count-per-slot)
+```
+
+With PROD's `identity_container_count: 25` (the max HCPs a single suite run provisions concurrently), that is `floor(92 / 25) = 3` slots per subscription. PROD pools in `test/e2e-config/e2e-slots.yaml` are therefore capped at `slot_count: 3` per subscription.
+
+The RP is expected to consolidate the per-cluster deny assignments into a single deny assignment with all managed identities excluded once Azure raises the excluded-principals limit from 10 to 25. When that lands, this per-subscription HCP ceiling is lifted and the PROD `slot_count` can be raised accordingly.
 
 The path to higher throughput is still adding subscription capacity, because each additional customer subscription brings its own role-assignment budget and its own managed identity container fleet. In DEV, slot-manager is what lets CI consume that extra capacity through one job family rather than through separate workflows.
 

--- a/test/e2e-config/e2e-slots.yaml
+++ b/test/e2e-config/e2e-slots.yaml
@@ -72,17 +72,26 @@ environments:
     deploy_envs:
     - prod
     pools:
+    # slot_count is capped at 3 per subscription by the Azure deny-assignment
+    # limit, not by role-assignment quota. The Authorization RP allows at most
+    # 2000 deny assignments per subscription, and the RP currently creates
+    # sharded (per-cluster) deny assignments (~21 per HCP), which caps a
+    # subscription at ~92 concurrent HCPs. With identity_container_count: 25
+    # (max HCPs per suite run), that is floor(92 / 25) = 3 slots per sub.
+    # This constraint is PROD-only: deny assignments are only created in AME
+    # (STG and above). See the "Scaling Constraints" section in
+    # docs/ci/identity-leasing.md for the full explanation.
     - subscription_name: "ARO HCP E2E Hosted Clusters - Prod - 00"
       region: uksouth
       region_mode: runtime-selected
       resource_type: aro-hcp-prod-shard0-slot
-      slot_count: 12
+      slot_count: 3
       identity_container_prefix: aro-hcp-msi-container-prod
       identity_container_count: 25
     - subscription_name: "ARO HCP E2E Hosted Clusters - Prod - 01"
       region: uksouth
       region_mode: runtime-selected
       resource_type: aro-hcp-prod-shard1-slot
-      slot_count: 12
+      slot_count: 3
       identity_container_prefix: aro-hcp-msi-container-prod
       identity_container_count: 25

--- a/test/e2e-config/e2e-slots.yaml
+++ b/test/e2e-config/e2e-slots.yaml
@@ -78,8 +78,8 @@ environments:
     # sharded (per-cluster) deny assignments (~21 per HCP), which caps a
     # subscription at ~92 concurrent HCPs. With identity_container_count: 25
     # (max HCPs per suite run), that is floor(92 / 25) = 3 slots per sub.
-    # This constraint is PROD-only: deny assignments are only created in AME
-    # (STG and above). See the "Scaling Constraints" section in
+    # This constraint is AME-only (STG and PROD): deny assignments are only
+    # created in AME. See the "Scaling Constraints" section in
     # docs/ci/identity-leasing.md for the full explanation.
     - subscription_name: "ARO HCP E2E Hosted Clusters - Prod - 00"
       region: uksouth


### PR DESCRIPTION
## Why

The ARO-HCP RP creates *sharded* (per-cluster) Azure **deny assignments** in PROD (~21 per HCP). The Authorization RP caps deny assignments at **2000 per subscription**, which limits a subscription to **~92 concurrent HCP clusters**, independent of role-assignment quota or identity-pool size.

With the PROD identity-container pool sizing (`identity_container_count: 25`, the max HCPs a single suite run provisions concurrently), the safe slot count is `floor(92 / 25) = 3` per subscription.

This constraint is **AME-only**.

## What

- Reduce both PROD pools in `test/e2e-config/e2e-slots.yaml` from `slot_count: 12` to `3`, with an inline comment explaining the cap.
- Document the constraint as **Bottleneck 3** in `docs/ci/identity-leasing.md` "Scaling Constraints".

## Depends on

- openshift/release#82011 — reduces the corresponding Boskos slot pools (`aro-hcp-prod-shard{0,1}-slot`) from 12 to 3. **That PR must merge first** so Boskos never advertises more slots than this catalog backs.

Holding this PR until the release-side change lands.