### PR TITLE
observability/arobit: stop duplicating resource snapshot logs to original tags

### DIFF
--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arobit.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arobit.yaml
@@ -233,7 +233,7 @@ data:
         Name            rewrite_tag
         Alias           filter.resource_snapshot_router
         Match           mgmt-agent.logs
-        Rule            $snapshotType ^kubernetes$ resource-snapshots.logs true
+        Rule            $snapshotType ^kubernetes$ resource-snapshots.logs false
         Emitter_Name    re_emitted_resource_snapshot_router
         Emitter_Mem_Buf_Limit  20M
         Emitter_Storage.type   filesystem
@@ -244,7 +244,7 @@ data:
         Name            rewrite_tag
         Alias           filter.cosmos_snapshot_router
         Match           aro-hcp-backend.logs
-        Rule            $snapshotType ^cosmos$ cosmos-snapshots.logs true
+        Rule            $snapshotType ^cosmos$ cosmos-snapshots.logs false
         Emitter_Name    re_emitted_cosmos_snapshot_router
         Emitter_Mem_Buf_Limit  20M
         Emitter_Storage.type   filesystem
@@ -255,7 +255,7 @@ data:
         Name            rewrite_tag
         Alias           filter.cosmos_snapshot_router_frontend
         Match           aro-hcp-frontend.logs
-        Rule            $snapshotType ^cosmos$ cosmos-snapshots.logs true
+        Rule            $snapshotType ^cosmos$ cosmos-snapshots.logs false
         Emitter_Name    re_emitted_cosmos_snapshot_router_frontend
         Emitter_Mem_Buf_Limit  20M
         Emitter_Storage.type   filesystem
@@ -620,7 +620,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 246640da15cbf2b85dc23052bc940f14ca5db8612a974e1661b607a5cdd35a3f
+        checksum/configmap: 20bf883546c17dd4266cd7d93d1f0aa75caf1067da8295f2c661dee07a3bc3ad
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_arobit.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_arobit.yaml
@@ -233,7 +233,7 @@ data:
         Name            rewrite_tag
         Alias           filter.resource_snapshot_router
         Match           mgmt-agent.logs
-        Rule            $snapshotType ^kubernetes$ resource-snapshots.logs true
+        Rule            $snapshotType ^kubernetes$ resource-snapshots.logs false
         Emitter_Name    re_emitted_resource_snapshot_router
         Emitter_Mem_Buf_Limit  20M
         Emitter_Storage.type   filesystem
@@ -244,7 +244,7 @@ data:
         Name            rewrite_tag
         Alias           filter.cosmos_snapshot_router
         Match           aro-hcp-backend.logs
-        Rule            $snapshotType ^cosmos$ cosmos-snapshots.logs true
+        Rule            $snapshotType ^cosmos$ cosmos-snapshots.logs false
         Emitter_Name    re_emitted_cosmos_snapshot_router
         Emitter_Mem_Buf_Limit  20M
         Emitter_Storage.type   filesystem
@@ -255,7 +255,7 @@ data:
         Name            rewrite_tag
         Alias           filter.cosmos_snapshot_router_frontend
         Match           aro-hcp-frontend.logs
-        Rule            $snapshotType ^cosmos$ cosmos-snapshots.logs true
+        Rule            $snapshotType ^cosmos$ cosmos-snapshots.logs false
         Emitter_Name    re_emitted_cosmos_snapshot_router_frontend
         Emitter_Mem_Buf_Limit  20M
         Emitter_Storage.type   filesystem
@@ -596,7 +596,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 72b09545852347671c0e6409a6aa6816a185140220f37a49e9fda808c6b66fa1
+        checksum/configmap: 2b0b1e3197d0eb0ea3e91a3131439916ecb0b35b68b88fd21b2af21a3cdfad66
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/observability/arobit/deploy/templates/forwarder-configmap.yaml
+++ b/observability/arobit/deploy/templates/forwarder-configmap.yaml
@@ -239,7 +239,7 @@ data:
         Name            rewrite_tag
         Alias           filter.resource_snapshot_router
         Match           mgmt-agent.logs
-        Rule            $snapshotType ^kubernetes$ resource-snapshots.logs true
+        Rule            $snapshotType ^kubernetes$ resource-snapshots.logs false
         Emitter_Name    re_emitted_resource_snapshot_router
         Emitter_Mem_Buf_Limit  20M
         Emitter_Storage.type   filesystem
@@ -250,7 +250,7 @@ data:
         Name            rewrite_tag
         Alias           filter.cosmos_snapshot_router
         Match           aro-hcp-backend.logs
-        Rule            $snapshotType ^cosmos$ cosmos-snapshots.logs true
+        Rule            $snapshotType ^cosmos$ cosmos-snapshots.logs false
         Emitter_Name    re_emitted_cosmos_snapshot_router
         Emitter_Mem_Buf_Limit  20M
         Emitter_Storage.type   filesystem
@@ -261,7 +261,7 @@ data:
         Name            rewrite_tag
         Alias           filter.cosmos_snapshot_router_frontend
         Match           aro-hcp-frontend.logs
-        Rule            $snapshotType ^cosmos$ cosmos-snapshots.logs true
+        Rule            $snapshotType ^cosmos$ cosmos-snapshots.logs false
         Emitter_Name    re_emitted_cosmos_snapshot_router_frontend
         Emitter_Mem_Buf_Limit  20M
         Emitter_Storage.type   filesystem

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_buffering_disabled_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_buffering_disabled_svc.yaml
@@ -233,7 +233,7 @@ data:
         Name            rewrite_tag
         Alias           filter.resource_snapshot_router
         Match           mgmt-agent.logs
-        Rule            $snapshotType ^kubernetes$ resource-snapshots.logs true
+        Rule            $snapshotType ^kubernetes$ resource-snapshots.logs false
         Emitter_Name    re_emitted_resource_snapshot_router
         Emitter_Mem_Buf_Limit  20M
         Emitter_Storage.type   filesystem
@@ -244,7 +244,7 @@ data:
         Name            rewrite_tag
         Alias           filter.cosmos_snapshot_router
         Match           aro-hcp-backend.logs
-        Rule            $snapshotType ^cosmos$ cosmos-snapshots.logs true
+        Rule            $snapshotType ^cosmos$ cosmos-snapshots.logs false
         Emitter_Name    re_emitted_cosmos_snapshot_router
         Emitter_Mem_Buf_Limit  20M
         Emitter_Storage.type   filesystem
@@ -255,7 +255,7 @@ data:
         Name            rewrite_tag
         Alias           filter.cosmos_snapshot_router_frontend
         Match           aro-hcp-frontend.logs
-        Rule            $snapshotType ^cosmos$ cosmos-snapshots.logs true
+        Rule            $snapshotType ^cosmos$ cosmos-snapshots.logs false
         Emitter_Name    re_emitted_cosmos_snapshot_router_frontend
         Emitter_Mem_Buf_Limit  20M
         Emitter_Storage.type   filesystem
@@ -505,7 +505,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 4c70eb054d1139eef9f2cf17f73fbcb6141a31e82243ec5c251b3d40a1278897
+        checksum/configmap: 003f824129f7e41d8b77a9c0abb9a1340211ffa0b2f0cf3e588c95614a38d0b3
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_disabled_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_disabled_svc.yaml
@@ -232,7 +232,7 @@ data:
         Name            rewrite_tag
         Alias           filter.resource_snapshot_router
         Match           mgmt-agent.logs
-        Rule            $snapshotType ^kubernetes$ resource-snapshots.logs true
+        Rule            $snapshotType ^kubernetes$ resource-snapshots.logs false
         Emitter_Name    re_emitted_resource_snapshot_router
         Emitter_Mem_Buf_Limit  20M
         Emitter_Storage.type   filesystem
@@ -243,7 +243,7 @@ data:
         Name            rewrite_tag
         Alias           filter.cosmos_snapshot_router
         Match           aro-hcp-backend.logs
-        Rule            $snapshotType ^cosmos$ cosmos-snapshots.logs true
+        Rule            $snapshotType ^cosmos$ cosmos-snapshots.logs false
         Emitter_Name    re_emitted_cosmos_snapshot_router
         Emitter_Mem_Buf_Limit  20M
         Emitter_Storage.type   filesystem
@@ -254,7 +254,7 @@ data:
         Name            rewrite_tag
         Alias           filter.cosmos_snapshot_router_frontend
         Match           aro-hcp-frontend.logs
-        Rule            $snapshotType ^cosmos$ cosmos-snapshots.logs true
+        Rule            $snapshotType ^cosmos$ cosmos-snapshots.logs false
         Emitter_Name    re_emitted_cosmos_snapshot_router_frontend
         Emitter_Mem_Buf_Limit  20M
         Emitter_Storage.type   filesystem
@@ -595,7 +595,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 448f36a7f59332bf2129467e81e71eac29e9e4c7f118d2bfaae7c658d8084ff7
+        checksum/configmap: 22327a23cb5bbbabffa1eb8d5a05f88ba64dd5f550e62130bbe8700412773f46
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_unlimited_memory_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_unlimited_memory_svc.yaml
@@ -233,7 +233,7 @@ data:
         Name            rewrite_tag
         Alias           filter.resource_snapshot_router
         Match           mgmt-agent.logs
-        Rule            $snapshotType ^kubernetes$ resource-snapshots.logs true
+        Rule            $snapshotType ^kubernetes$ resource-snapshots.logs false
         Emitter_Name    re_emitted_resource_snapshot_router
         Emitter_Mem_Buf_Limit  20M
         Emitter_Storage.type   filesystem
@@ -244,7 +244,7 @@ data:
         Name            rewrite_tag
         Alias           filter.cosmos_snapshot_router
         Match           aro-hcp-backend.logs
-        Rule            $snapshotType ^cosmos$ cosmos-snapshots.logs true
+        Rule            $snapshotType ^cosmos$ cosmos-snapshots.logs false
         Emitter_Name    re_emitted_cosmos_snapshot_router
         Emitter_Mem_Buf_Limit  20M
         Emitter_Storage.type   filesystem
@@ -255,7 +255,7 @@ data:
         Name            rewrite_tag
         Alias           filter.cosmos_snapshot_router_frontend
         Match           aro-hcp-frontend.logs
-        Rule            $snapshotType ^cosmos$ cosmos-snapshots.logs true
+        Rule            $snapshotType ^cosmos$ cosmos-snapshots.logs false
         Emitter_Name    re_emitted_cosmos_snapshot_router_frontend
         Emitter_Mem_Buf_Limit  20M
         Emitter_Storage.type   filesystem
@@ -596,7 +596,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 12cda9db5062c4779892ea83f7bdade3c3fcc56bf0efa65f92b81c4869629fa7
+        checksum/configmap: 3a8e811903e33af398dfd4d6815d7b4289bb7516011bf3b13dc040c95f23f396
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_mgmt.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_mgmt.yaml
@@ -235,7 +235,7 @@ data:
         Name            rewrite_tag
         Alias           filter.resource_snapshot_router
         Match           mgmt-agent.logs
-        Rule            $snapshotType ^kubernetes$ resource-snapshots.logs true
+        Rule            $snapshotType ^kubernetes$ resource-snapshots.logs false
         Emitter_Name    re_emitted_resource_snapshot_router
         Emitter_Mem_Buf_Limit  20M
         Emitter_Storage.type   filesystem
@@ -246,7 +246,7 @@ data:
         Name            rewrite_tag
         Alias           filter.cosmos_snapshot_router
         Match           aro-hcp-backend.logs
-        Rule            $snapshotType ^cosmos$ cosmos-snapshots.logs true
+        Rule            $snapshotType ^cosmos$ cosmos-snapshots.logs false
         Emitter_Name    re_emitted_cosmos_snapshot_router
         Emitter_Mem_Buf_Limit  20M
         Emitter_Storage.type   filesystem
@@ -257,7 +257,7 @@ data:
         Name            rewrite_tag
         Alias           filter.cosmos_snapshot_router_frontend
         Match           aro-hcp-frontend.logs
-        Rule            $snapshotType ^cosmos$ cosmos-snapshots.logs true
+        Rule            $snapshotType ^cosmos$ cosmos-snapshots.logs false
         Emitter_Name    re_emitted_cosmos_snapshot_router_frontend
         Emitter_Mem_Buf_Limit  20M
         Emitter_Storage.type   filesystem
@@ -816,7 +816,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 133a0e0fd47a7579ffef2d31dc95ed2ebd5310a55af3c0a8675ddf76f949f4d2
+        checksum/configmap: 9055a2845da49142495894fa6a970304c72699b6d1e7022ab1570e18eea3c263
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_svc.yaml
@@ -233,7 +233,7 @@ data:
         Name            rewrite_tag
         Alias           filter.resource_snapshot_router
         Match           mgmt-agent.logs
-        Rule            $snapshotType ^kubernetes$ resource-snapshots.logs true
+        Rule            $snapshotType ^kubernetes$ resource-snapshots.logs false
         Emitter_Name    re_emitted_resource_snapshot_router
         Emitter_Mem_Buf_Limit  20M
         Emitter_Storage.type   filesystem
@@ -244,7 +244,7 @@ data:
         Name            rewrite_tag
         Alias           filter.cosmos_snapshot_router
         Match           aro-hcp-backend.logs
-        Rule            $snapshotType ^cosmos$ cosmos-snapshots.logs true
+        Rule            $snapshotType ^cosmos$ cosmos-snapshots.logs false
         Emitter_Name    re_emitted_cosmos_snapshot_router
         Emitter_Mem_Buf_Limit  20M
         Emitter_Storage.type   filesystem
@@ -255,7 +255,7 @@ data:
         Name            rewrite_tag
         Alias           filter.cosmos_snapshot_router_frontend
         Match           aro-hcp-frontend.logs
-        Rule            $snapshotType ^cosmos$ cosmos-snapshots.logs true
+        Rule            $snapshotType ^cosmos$ cosmos-snapshots.logs false
         Emitter_Name    re_emitted_cosmos_snapshot_router_frontend
         Emitter_Mem_Buf_Limit  20M
         Emitter_Storage.type   filesystem
@@ -596,7 +596,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: b05b040246a7737b0fe89d57aa9eaa55647384b62f63ab673a9471ae75d0edf8
+        checksum/configmap: ef52514b9791481f4b1ef06cb086e5a73671cc3324e627adfc45ad62ece9a51d
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'


### PR DESCRIPTION
Now that consumers have migrated to the dedicated kubernetesResourceSnapshots and cosmosResourceSnapshots Kusto tables, stop keeping the original log record when rewriting tags for snapshot routing. Setting the rewrite_tag keep flag to false ensures snapshot logs are only sent to their dedicated tables and no longer duplicated into the general log stream.
