### PR TITLE
feat(api): Make keyManagementMode required for etcd encryption

### DIFF
--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/hcpCluster-models.tsp
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/hcpCluster-models.tsp
@@ -627,8 +627,15 @@ model EtcdDataEncryptionProfile {
   /** Specify the key management strategy used for the encryption key that encrypts the ETCD data.
    * By default, "PlatformManaged" is used.
    */
+  @removed(Versions.v2026_06_30_preview)
+  @renamedFrom(Versions.v2026_06_30_preview, "keyManagementMode")
   @visibility(Lifecycle.Read, Lifecycle.Create)
-  keyManagementMode?: EtcdDataEncryptionKeyManagementModeType = EtcdDataEncryptionKeyManagementModeType.PlatformManaged;
+  optionalKeyManagementMode?: EtcdDataEncryptionKeyManagementModeType = EtcdDataEncryptionKeyManagementModeType.PlatformManaged;
+
+  /** Specify the key management strategy used for the encryption key that encrypts the ETCD data. */
+  @added(Versions.v2026_06_30_preview)
+  @visibility(Lifecycle.Read, Lifecycle.Create)
+  keyManagementMode: EtcdDataEncryptionKeyManagementModeType;
 
   /** Specify customer managed encryption key details.
    * Required when keyManagementMode is "CustomerManaged".
@@ -717,6 +724,7 @@ union EtcdDataEncryptionKeyManagementModeType {
   CustomerManaged: "CustomerManaged",
 
   /** Platform managed encryption key management mode type. */
+  @removed(Versions.v2026_06_30_preview)
   PlatformManaged: "PlatformManaged",
 }
 

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2026-06-30-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2026-06-30-preview/openapi.json
@@ -1774,34 +1774,31 @@
         ]
       }
     },
+    "EtcdDataEncryptionKeyManagementModeType": {
+      "type": "string",
+      "description": "The encryption key management mode types supported for ETCD data encryption.",
+      "enum": [
+        "CustomerManaged"
+      ],
+      "x-ms-enum": {
+        "name": "EtcdDataEncryptionKeyManagementModeType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "CustomerManaged",
+            "value": "CustomerManaged",
+            "description": "Customer managed encryption key management mode type."
+          }
+        ]
+      }
+    },
     "EtcdDataEncryptionProfile": {
       "type": "object",
       "description": "The ETCD data encryption settings.",
       "properties": {
         "keyManagementMode": {
-          "type": "string",
-          "description": "Specify the key management strategy used for the encryption key that encrypts the ETCD data.\nBy default, \"PlatformManaged\" is used.",
-          "default": "PlatformManaged",
-          "enum": [
-            "CustomerManaged",
-            "PlatformManaged"
-          ],
-          "x-ms-enum": {
-            "name": "EtcdDataEncryptionKeyManagementModeType",
-            "modelAsString": true,
-            "values": [
-              {
-                "name": "CustomerManaged",
-                "value": "CustomerManaged",
-                "description": "Customer managed encryption key management mode type."
-              },
-              {
-                "name": "PlatformManaged",
-                "value": "PlatformManaged",
-                "description": "Platform managed encryption key management mode type."
-              }
-            ]
-          },
+          "$ref": "#/definitions/EtcdDataEncryptionKeyManagementModeType",
+          "description": "Specify the key management strategy used for the encryption key that encrypts the ETCD data.",
           "x-ms-mutability": [
             "read",
             "create"
@@ -1816,7 +1813,10 @@
             "create"
           ]
         }
-      }
+      },
+      "required": [
+        "keyManagementMode"
+      ]
     },
     "EtcdDataEncryptionProfileUpdate": {
       "type": "object",

--- a/internal/api/defaults_test.go
+++ b/internal/api/defaults_test.go
@@ -72,7 +72,6 @@ func TestTypeSpecDefaultsConsistency(t *testing.T) {
 		{"Visibility", "ApiProfile", "visibility", string(VisibilityPublic)},
 		{"OutboundType", "PlatformProfile", "outboundType", string(OutboundTypeLoadBalancer)},
 		{"DiskStorageAccountType", "OsDiskProfile", "diskStorageAccountType", string(DiskStorageAccountTypePremium_LRS)},
-		{"EtcdKeyManagementMode", "EtcdDataEncryptionProfile", "keyManagementMode", string(EtcdDataEncryptionKeyManagementModeTypePlatformManaged)},
 		{"ClusterImageRegistryState", "ClusterImageRegistryProfile", "state", string(ClusterImageRegistryStateEnabled)},
 		// Numeric defaults
 		{"HostPrefix", "NetworkProfile", "hostPrefix", DefaultClusterNetworkHostPrefix},

--- a/internal/api/testhelpers.go
+++ b/internal/api/testhelpers.go
@@ -50,6 +50,9 @@ const (
 	TestVirtualNetworkName        = "testVirtualNetwork"
 	TestSubnetName                = "testSubnet"
 	TestVnetIntegrationSubnetName = "testVnetIntegrationSubnet"
+	TestKMSKeyName                = "testKMSKeyName"
+	TestKMSKeyVaultName           = "testKMSKeyVaultName"
+	TestKMSKeyVersion             = "testKMSKeyVersion"
 )
 
 var (
@@ -78,6 +81,18 @@ func MinimumValidClusterTestCase() *HCPOpenShiftCluster {
 	resource := NewDefaultHCPOpenShiftCluster(Must(azcorearm.ParseResourceID(TestClusterResourceID)), TestLocation)
 	resource.CustomerProperties.Version.ID = "4.20"
 	resource.CustomerProperties.DNS.BaseDomainPrefix = "testcluster"
+	resource.CustomerProperties.Etcd.DataEncryption.KeyManagementMode = EtcdDataEncryptionKeyManagementModeTypeCustomerManaged
+	resource.CustomerProperties.Etcd.DataEncryption.CustomerManaged = &CustomerManagedEncryptionProfile{
+		EncryptionType: CustomerManagedEncryptionTypeKMS,
+		Kms: &KmsEncryptionProfile{
+			Visibility: KeyVaultVisibilityPublic,
+			ActiveKey: KmsKey{
+				Name:      TestKMSKeyName,
+				VaultName: TestKMSKeyVaultName,
+				Version:   TestKMSKeyVersion,
+			},
+		},
+	}
 	resource.CustomerProperties.Platform.ManagedResourceGroup = TestManagedResourceGroupName
 	resource.CustomerProperties.Platform.SubnetID = Must(azcorearm.ParseResourceID(TestSubnetResourceID))
 	resource.CustomerProperties.Platform.VnetIntegrationSubnetID = Must(azcorearm.ParseResourceID(TestVnetIntegrationSubnetResourceID))

--- a/internal/api/types_cluster.go
+++ b/internal/api/types_cluster.go
@@ -324,15 +324,6 @@ func NewDefaultHCPOpenShiftCluster(resourceID *azcorearm.ResourceID, azureLocati
 				MaxNodeProvisionTimeSeconds: DefaultClusterMaxNodeProvisionTimeSeconds,
 				PodPriorityThreshold:        DefaultClusterPodPriorityThreshold,
 			},
-			// PlatformManaged is still the default for absent values (EnsureDefaults / Cosmos
-			// documents), but it is rejected by ValidEtcdDataEncryptionKeyManagementModeType
-			// until platform-managed etcd encryption is supported. CustomerManaged must be set
-			// for a create request to succeed.
-			Etcd: EtcdProfile{
-				DataEncryption: EtcdDataEncryptionProfile{
-					KeyManagementMode: EtcdDataEncryptionKeyManagementModeTypePlatformManaged,
-				},
-			},
 			ClusterImageRegistry: ClusterImageRegistryProfile{
 				State: ClusterImageRegistryStateEnabled,
 			},
@@ -364,9 +355,6 @@ func (cluster *HCPOpenShiftCluster) EnsureDefaults() {
 	}
 	if len(cluster.CustomerProperties.ClusterImageRegistry.State) == 0 {
 		cluster.CustomerProperties.ClusterImageRegistry.State = ClusterImageRegistryStateEnabled
-	}
-	if len(cluster.CustomerProperties.Etcd.DataEncryption.KeyManagementMode) == 0 {
-		cluster.CustomerProperties.Etcd.DataEncryption.KeyManagementMode = EtcdDataEncryptionKeyManagementModeTypePlatformManaged
 	}
 	if len(cluster.CustomerProperties.CryptoRestrictions) == 0 {
 		cluster.CustomerProperties.CryptoRestrictions = CryptoRestrictionsNone

--- a/internal/api/v20260630preview/generated/constants.go
+++ b/internal/api/v20260630preview/generated/constants.go
@@ -156,22 +156,18 @@ func PossibleEffectValues() []Effect {
 	}
 }
 
-// EtcdDataEncryptionKeyManagementModeType - Specify the key management strategy used for the encryption key that encrypts
-// the ETCD data. By default, "PlatformManaged" is used.
+// EtcdDataEncryptionKeyManagementModeType - The encryption key management mode types supported for ETCD data encryption.
 type EtcdDataEncryptionKeyManagementModeType string
 
 const (
 	// EtcdDataEncryptionKeyManagementModeTypeCustomerManaged - Customer managed encryption key management mode type.
 	EtcdDataEncryptionKeyManagementModeTypeCustomerManaged EtcdDataEncryptionKeyManagementModeType = "CustomerManaged"
-	// EtcdDataEncryptionKeyManagementModeTypePlatformManaged - Platform managed encryption key management mode type.
-	EtcdDataEncryptionKeyManagementModeTypePlatformManaged EtcdDataEncryptionKeyManagementModeType = "PlatformManaged"
 )
 
 // PossibleEtcdDataEncryptionKeyManagementModeTypeValues returns the possible values for the EtcdDataEncryptionKeyManagementModeType const type.
 func PossibleEtcdDataEncryptionKeyManagementModeTypeValues() []EtcdDataEncryptionKeyManagementModeType {
 	return []EtcdDataEncryptionKeyManagementModeType{
 		EtcdDataEncryptionKeyManagementModeTypeCustomerManaged,
-		EtcdDataEncryptionKeyManagementModeTypePlatformManaged,
 	}
 }
 

--- a/internal/api/v20260630preview/generated/models.go
+++ b/internal/api/v20260630preview/generated/models.go
@@ -122,12 +122,11 @@ type DNSProfile struct {
 
 // EtcdDataEncryptionProfile - The ETCD data encryption settings.
 type EtcdDataEncryptionProfile struct {
+	// REQUIRED; Specify the key management strategy used for the encryption key that encrypts the ETCD data.
+	KeyManagementMode *EtcdDataEncryptionKeyManagementModeType
+
 	// Specify customer managed encryption key details. Required when keyManagementMode is "CustomerManaged".
 	CustomerManaged *CustomerManagedEncryptionProfile
-
-	// Specify the key management strategy used for the encryption key that encrypts the ETCD data. By default, "PlatformManaged"
-	// is used.
-	KeyManagementMode *EtcdDataEncryptionKeyManagementModeType
 }
 
 // EtcdDataEncryptionProfileUpdate - The ETCD data encryption settings.

--- a/internal/api/v20260630preview/hcpopenshiftclusters_methods.go
+++ b/internal/api/v20260630preview/hcpopenshiftclusters_methods.go
@@ -105,16 +105,11 @@ func SetDefaultValuesCluster(obj *HcpOpenShiftCluster) {
 	if obj.Properties.Autoscaling.PodPriorityThreshold == nil {
 		obj.Properties.Autoscaling.PodPriorityThreshold = ptr.To(api.DefaultClusterPodPriorityThreshold)
 	}
-	//Even though PlatformManaged Mode is currently not supported by CS . This is the default value .
-	// TODO cannot change the default value for this version, but why keep it in our new version?
 	if obj.Properties.Etcd == nil {
 		obj.Properties.Etcd = &generated.EtcdProfile{}
 	}
 	if obj.Properties.Etcd.DataEncryption == nil {
 		obj.Properties.Etcd.DataEncryption = &generated.EtcdDataEncryptionProfile{}
-	}
-	if obj.Properties.Etcd.DataEncryption.KeyManagementMode == nil {
-		obj.Properties.Etcd.DataEncryption.KeyManagementMode = ptr.To(generated.EtcdDataEncryptionKeyManagementModeTypePlatformManaged)
 	}
 	if obj.Properties.ClusterImageRegistry == nil {
 		obj.Properties.ClusterImageRegistry = &generated.ClusterImageRegistryProfile{}

--- a/internal/database/convert_cluster_test.go
+++ b/internal/database/convert_cluster_test.go
@@ -40,7 +40,6 @@ func TestClusterEnsureDefaults(t *testing.T) {
 			wantVisibility:    api.VisibilityPublic,
 			wantOutboundType:  api.OutboundTypeLoadBalancer,
 			wantImageRegState: api.ClusterImageRegistryStateEnabled,
-			wantKeyMgmtMode:   api.EtcdDataEncryptionKeyManagementModeTypePlatformManaged,
 		},
 		{
 			name:               "explicit values preserved",

--- a/internal/database/convert_defaults_consistency_test.go
+++ b/internal/database/convert_defaults_consistency_test.go
@@ -143,11 +143,6 @@ func TestEnsureDefaultsConsistencyCluster(t *testing.T) {
 			internalVal:  string(internalDefault.CustomerProperties.ClusterImageRegistry.State),
 		},
 		{
-			name:         "Etcd.DataEncryption.KeyManagementMode",
-			canonicalVal: string(ensuredDefault.CustomerProperties.Etcd.DataEncryption.KeyManagementMode),
-			internalVal:  string(internalDefault.CustomerProperties.Etcd.DataEncryption.KeyManagementMode),
-		},
-		{
 			name:         "Ingress.Type",
 			canonicalVal: string(ensuredDefault.CustomerProperties.Ingress.Type),
 			internalVal:  string(internalDefault.CustomerProperties.Ingress.Type),
@@ -176,7 +171,6 @@ func TestEnsureDefaultsConsistencyCluster(t *testing.T) {
 			{"Visibility", string(ensuredDefault.CustomerProperties.API.Visibility), stringPtrFromGenerated(externalDefault.Properties.API.Visibility)},
 			{"OutboundType", string(ensuredDefault.CustomerProperties.Platform.OutboundType), stringPtrFromGenerated(externalDefault.Properties.Platform.OutboundType)},
 			{"ClusterImageRegistry.State", string(ensuredDefault.CustomerProperties.ClusterImageRegistry.State), stringPtrFromGenerated(externalDefault.Properties.ClusterImageRegistry.State)},
-			{"Etcd.DataEncryption.KeyManagementMode", string(ensuredDefault.CustomerProperties.Etcd.DataEncryption.KeyManagementMode), stringPtrFromGenerated(externalDefault.Properties.Etcd.DataEncryption.KeyManagementMode)},
 		}
 		for _, c := range checks {
 			t.Run(c.name, func(t *testing.T) {
@@ -201,7 +195,6 @@ func TestEnsureDefaultsConsistencyCluster(t *testing.T) {
 			{"Visibility", string(ensuredDefault.CustomerProperties.API.Visibility), stringPtrFromGenerated(externalDefault.Properties.API.Visibility)},
 			{"OutboundType", string(ensuredDefault.CustomerProperties.Platform.OutboundType), stringPtrFromGenerated(externalDefault.Properties.Platform.OutboundType)},
 			{"ClusterImageRegistry.State", string(ensuredDefault.CustomerProperties.ClusterImageRegistry.State), stringPtrFromGenerated(externalDefault.Properties.ClusterImageRegistry.State)},
-			{"Etcd.DataEncryption.KeyManagementMode", string(ensuredDefault.CustomerProperties.Etcd.DataEncryption.KeyManagementMode), stringPtrFromGenerated(externalDefault.Properties.Etcd.DataEncryption.KeyManagementMode)},
 		}
 		for _, c := range checks {
 			t.Run(c.name, func(t *testing.T) {
@@ -226,7 +219,6 @@ func TestEnsureDefaultsConsistencyCluster(t *testing.T) {
 			{"Visibility", string(ensuredDefault.CustomerProperties.API.Visibility), stringPtrFromGenerated(externalDefault.Properties.API.Visibility)},
 			{"OutboundType", string(ensuredDefault.CustomerProperties.Platform.OutboundType), stringPtrFromGenerated(externalDefault.Properties.Platform.OutboundType)},
 			{"ClusterImageRegistry.State", string(ensuredDefault.CustomerProperties.ClusterImageRegistry.State), stringPtrFromGenerated(externalDefault.Properties.ClusterImageRegistry.State)},
-			{"Etcd.DataEncryption.KeyManagementMode", string(ensuredDefault.CustomerProperties.Etcd.DataEncryption.KeyManagementMode), stringPtrFromGenerated(externalDefault.Properties.Etcd.DataEncryption.KeyManagementMode)},
 			{"Ingress.Type", string(ensuredDefault.CustomerProperties.Ingress.Type), stringPtrFromGenerated(externalDefault.Properties.Ingress.Type)},
 		}
 		for _, c := range checks {
@@ -286,7 +278,6 @@ func TestPreExistingDataCluster(t *testing.T) {
 		{"Visibility", string(internalCluster.CustomerProperties.API.Visibility), string(api.VisibilityPublic)},
 		{"OutboundType", string(internalCluster.CustomerProperties.Platform.OutboundType), string(api.OutboundTypeLoadBalancer)},
 		{"ClusterImageRegistry.State", string(internalCluster.CustomerProperties.ClusterImageRegistry.State), string(api.ClusterImageRegistryStateEnabled)},
-		{"Etcd.DataEncryption.KeyManagementMode", string(internalCluster.CustomerProperties.Etcd.DataEncryption.KeyManagementMode), string(api.EtcdDataEncryptionKeyManagementModeTypePlatformManaged)},
 		{"Ingress.Type", string(internalCluster.CustomerProperties.Ingress.Type), string(api.IngressTypePublic)},
 	}
 	for _, c := range checks {
@@ -457,9 +448,6 @@ func TestCanonicalDefaultsConsistencyCluster(t *testing.T) {
 	}
 	if internalDefault.CustomerProperties.Platform.OutboundType != api.OutboundTypeLoadBalancer {
 		t.Errorf("OutboundType = %q, want %q", internalDefault.CustomerProperties.Platform.OutboundType, api.OutboundTypeLoadBalancer)
-	}
-	if internalDefault.CustomerProperties.Etcd.DataEncryption.KeyManagementMode != api.EtcdDataEncryptionKeyManagementModeTypePlatformManaged {
-		t.Errorf("KeyManagementMode = %q, want %q", internalDefault.CustomerProperties.Etcd.DataEncryption.KeyManagementMode, api.EtcdDataEncryptionKeyManagementModeTypePlatformManaged)
 	}
 	if internalDefault.CustomerProperties.ClusterImageRegistry.State != api.ClusterImageRegistryStateEnabled {
 		t.Errorf("ClusterImageRegistryState = %q, want %q", internalDefault.CustomerProperties.ClusterImageRegistry.State, api.ClusterImageRegistryStateEnabled)

--- a/internal/validation/hcpopenshiftcluster_test.go
+++ b/internal/validation/hcpopenshiftcluster_test.go
@@ -218,6 +218,10 @@ func TestClusterRequired(t *testing.T) {
 				},
 				{
 					Message:   "Required value",
+					FieldPath: "customerProperties.etcd.dataEncryption.keyManagementMode",
+				},
+				{
+					Message:   "Required value",
 					FieldPath: "serviceProviderProperties.managedIdentitiesDataPlaneIdentityURL",
 				},
 				{
@@ -643,10 +647,9 @@ func TestClusterValidate(t *testing.T) {
 		{
 			name: "Customer managed ETCD key management mode requires CustomerManaged fields",
 			resource: func() *api.HCPOpenShiftCluster {
-				c := api.MinimumValidClusterTestCase()
-				c.CustomerProperties.Etcd.DataEncryption.KeyManagementMode = api.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged
-				c.CustomerProperties.Etcd.DataEncryption.CustomerManaged = nil
-				return c
+				r := api.MinimumValidClusterTestCase()
+				r.CustomerProperties.Etcd.DataEncryption.CustomerManaged = nil
+				return r
 			}(),
 			expectErrors: []utils.ExpectedError{
 				{
@@ -656,37 +659,11 @@ func TestClusterValidate(t *testing.T) {
 			},
 		},
 		{
-			name: "Platform managed ETCD key management mode is not supported",
-			resource: func() *api.HCPOpenShiftCluster {
-				c := api.MinimumValidClusterTestCase()
-				c.CustomerProperties.Etcd.DataEncryption.KeyManagementMode = api.EtcdDataEncryptionKeyManagementModeTypePlatformManaged
-				c.CustomerProperties.Etcd.DataEncryption.CustomerManaged = &api.CustomerManagedEncryptionProfile{}
-				return c
-			}(),
-			expectErrors: []utils.ExpectedError{
-				{
-					Message:   "Unsupported value",
-					FieldPath: "customerProperties.etcd.dataEncryption.keyManagementMode",
-				},
-				{
-					Message:   "may only be specified when `keyManagementMode` is \"CustomerManaged\"",
-					FieldPath: "customerProperties.etcd.dataEncryption.customerManaged",
-				},
-				{
-					Message:   "supported values: \"KMS\"",
-					FieldPath: "customerProperties.etcd.dataEncryption.customerManaged.encryptionType",
-				},
-			},
-		},
-		{
 			name: "Customer managed Key Management Service (KMS) requires Kms fields",
 			resource: func() *api.HCPOpenShiftCluster {
-				c := api.MinimumValidClusterTestCase()
-				c.CustomerProperties.Etcd.DataEncryption.KeyManagementMode = api.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged
-				c.CustomerProperties.Etcd.DataEncryption.CustomerManaged = &api.CustomerManagedEncryptionProfile{
-					EncryptionType: api.CustomerManagedEncryptionTypeKMS,
-				}
-				return c
+				r := api.MinimumValidClusterTestCase()
+				r.CustomerProperties.Etcd.DataEncryption.CustomerManaged.Kms = nil
+				return r
 			}(),
 			expectErrors: []utils.ExpectedError{
 				{
@@ -699,13 +676,10 @@ func TestClusterValidate(t *testing.T) {
 			// FIXME Use a valid alternate EncryptionType once we have one.
 			name: "Alternate customer managed ETCD encyption type excludes Kms fields",
 			resource: func() *api.HCPOpenShiftCluster {
-				c := api.MinimumValidClusterTestCase()
-				c.CustomerProperties.Etcd.DataEncryption.KeyManagementMode = api.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged
-				c.CustomerProperties.Etcd.DataEncryption.CustomerManaged = &api.CustomerManagedEncryptionProfile{
-					EncryptionType: "Alternate",
-					Kms:            &api.KmsEncryptionProfile{},
-				}
-				return c
+				r := api.MinimumValidClusterTestCase()
+				r.CustomerProperties.Etcd.DataEncryption.CustomerManaged.EncryptionType = "Alternate"
+				r.CustomerProperties.Etcd.DataEncryption.CustomerManaged.Kms = &api.KmsEncryptionProfile{}
+				return r
 			}(),
 			expectErrors: []utils.ExpectedError{
 				{

--- a/internal/validation/validate_cluster_comprehensive_test.go
+++ b/internal/validation/validate_cluster_comprehensive_test.go
@@ -400,18 +400,6 @@ func TestValidateClusterCreate(t *testing.T) {
 			},
 		},
 		{
-			name: "platform managed etcd encryption is not supported - create",
-			cluster: func() *api.HCPOpenShiftCluster {
-				c := createValidCluster()
-				c.CustomerProperties.Etcd.DataEncryption.KeyManagementMode = api.EtcdDataEncryptionKeyManagementModeTypePlatformManaged
-				c.CustomerProperties.Etcd.DataEncryption.CustomerManaged = nil
-				return c
-			}(),
-			expectErrors: []utils.ExpectedError{
-				{Message: "Unsupported value", FieldPath: "customerProperties.etcd.dataEncryption.keyManagementMode"},
-			},
-		},
-		{
 			name: "customer managed without customer managed profile - create",
 			cluster: func() *api.HCPOpenShiftCluster {
 				c := createValidCluster()
@@ -1753,8 +1741,7 @@ func TestValidateClusterUpdate(t *testing.T) {
 			name: "immutable etcd profile - update",
 			newCluster: func() *api.HCPOpenShiftCluster {
 				c := createValidCluster()
-				c.CustomerProperties.Etcd.DataEncryption.KeyManagementMode = api.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged
-				c.CustomerProperties.Etcd.DataEncryption.CustomerManaged = nil
+				c.CustomerProperties.Etcd.DataEncryption.KeyManagementMode = "Invalid"
 				return c
 			}(),
 			oldCluster: func() *api.HCPOpenShiftCluster {
@@ -1762,7 +1749,9 @@ func TestValidateClusterUpdate(t *testing.T) {
 				return c
 			}(),
 			expectErrors: []utils.ExpectedError{
-				{Message: "must be specified when `keyManagementMode` is \"CustomerManaged\"", FieldPath: "customerProperties.etcd.dataEncryption.customerManaged"},
+				{Message: "field is immutable", FieldPath: "customerProperties.etcd.dataEncryption.keyManagementMode"},
+				{Message: "\"Invalid\": supported values: \"CustomerManaged\"", FieldPath: "customerProperties.etcd.dataEncryption.keyManagementMode"},
+				{Message: "may only be specified when `keyManagementMode` is \"CustomerManaged\"", FieldPath: "customerProperties.etcd.dataEncryption.customerManaged"},
 			},
 		},
 		{
@@ -2564,6 +2553,18 @@ func createValidCluster() *api.HCPOpenShiftCluster {
 	cluster.Location = "eastus"                    // Required for TrackedResource validation
 	cluster.CustomerProperties.Version.ID = "4.20" // Use MAJOR.MINOR format, must be at least 4.20
 	cluster.CustomerProperties.DNS.BaseDomainPrefix = "testcluster"
+	cluster.CustomerProperties.Etcd.DataEncryption.KeyManagementMode = api.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged
+	cluster.CustomerProperties.Etcd.DataEncryption.CustomerManaged = &api.CustomerManagedEncryptionProfile{
+		EncryptionType: api.CustomerManagedEncryptionTypeKMS,
+		Kms: &api.KmsEncryptionProfile{
+			Visibility: api.KeyVaultVisibilityPublic,
+			ActiveKey: api.KmsKey{
+				Name:      api.TestKMSKeyName,
+				VaultName: api.TestKMSKeyVaultName,
+				Version:   api.TestKMSKeyVersion,
+			},
+		},
+	}
 	// Use different resource group for subnet to ensure same subscription validation
 	cluster.CustomerProperties.Platform.SubnetID = api.Must(azcorearm.ParseResourceID("/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-subnet"))
 	cluster.CustomerProperties.Platform.VnetIntegrationSubnetID = api.Must(azcorearm.ParseResourceID("/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-vnet-integration-subnet"))

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/peer-field-validation/01-httpCreate-cluster/cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/peer-field-validation/01-httpCreate-cluster/cluster.json
@@ -18,7 +18,7 @@
 		"dns": {},
 		"etcd": {
 			"dataEncryption": {
-				"keyManagementMode": "PlatformManaged"
+				"keyManagementMode": "CustomerManaged"
 			}
 		},
 		"network": {


### PR DESCRIPTION
[ARO-28448 - Make keyManagementMode required](https://redhat.atlassian.net/browse/ARO-28448)

### What

For version `2026-06-30-preview` only, make the `keyManagementMode` field required (no default) and remove the `PlatformManaged` option for this field.


### Why

Platform-managed etcd encryption keys is still not supported today, yet it is the default etcd encryption key management mode.  This makes for a bad customer experience.  It was decided to not expose an unfinished feature in the API, and also to make the key management mode field required (which it effectively already is today since the default value is rejected).

### Testing

Updated existing default tests.

### Special notes for your reviewer

Interestingly, our frontend validation was already treating the `keyManagementMode` field as required, so no additional version-specific validation logic was needed.  Validation of this field for older API versions is _technically_ incorrect but the flaw is inconsequential in practice so I'm leaving it be.

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
