### PR TITLE
Prefer latest if no gateway from minor for active versions and all candidates

### DIFF
--- a/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
@@ -460,6 +460,12 @@ func FindAllUpgradeTargetVersionsInMinor(
 // This method implements the core version selection logic for all upgrade scenarios (both Y-stream and Z-stream).
 // It prioritizes versions that have an upgrade path to the next minor version (gateway versions).
 //
+// When preferLatestOverGateway is true (y-stream upgrades), the latest candidate is returned even if
+// no gateway to the next minor exists. When false (z-stream upgrades), nil is returned only when an
+// active version already has a next-minor path that would be lost by moving to a non-gateway
+// candidate; if neither candidates nor active versions can reach the next minor, the latest
+// candidate is returned instead — there is no existing next-minor path to preserve.
+//
 // Version selection algorithm:
 //  1. Query Cincinnati for all available updates from EACH active version in the target minor channel
 //  2. Filter candidates: only include versions within the target minor
@@ -472,16 +478,21 @@ func FindAllUpgradeTargetVersionsInMinor(
 //     - If yes: return this version (latest gateway found)
 //     - If no: continue checking older versions
 //  8. If no gateway found and preferLatestOverGateway (y-stream): return the latest candidate
-//  9. If no gateway found and !preferLatestOverGateway (z-stream): return nil
+//  9. If no gateway found and !preferLatestOverGateway (z-stream):
+//     - If any active version is already a gateway to the next minor: return nil
+//     (preserve the existing next-minor path)
+//     - Otherwise return the latest candidate (there is no next-minor path to preserve)
 //
 // Examples:
-//   - Z-stream (4.19.15 → 4.19.z): Find latest 4.19.z with path to 4.20, or nil if none
+//   - Z-stream (4.19.15 → 4.19.z): Find latest 4.19.z with path to 4.20; if none, keep current
+//     path when an active version is already a gateway, else take the latest 4.19.z
 //   - Y-stream (4.19.x → 4.20.z): Find latest 4.20.z with path to 4.21, or latest 4.20.z
 //
 // When multiple active versions are provided, this method ensures that the selected version
 // is reachable from ALL active versions by intersecting the upgrade paths.
 //
-// Returns nil if no suitable version is found.
+// Returns nil when no candidates exist, or when a z-stream selection would break an existing
+// next-minor gateway on an active version.
 func FindBestVersionInMinor(
 	ctx context.Context,
 	cincinnatiClient cincinnati.Client,
@@ -496,7 +507,7 @@ func FindBestVersionInMinor(
 		return nil, utils.TrackError(err)
 	}
 
-	return selectBestVersionFromCandidates(ctx, cincinnatiClient, graphClient, channelGroup, targetMinorVersion, commonCandidates, preferLatestOverGateway)
+	return selectBestVersionFromCandidates(ctx, cincinnatiClient, graphClient, channelGroup, targetMinorVersion, commonCandidates, activeVersions, preferLatestOverGateway)
 }
 
 // selectBestVersionFromCandidates finds the best version to upgrade to from a list of candidate versions.
@@ -504,8 +515,10 @@ func FindBestVersionInMinor(
 // that are gateways to the next minor version.
 //
 // When preferLatestOverGateway is true (y-stream upgrades), the latest candidate is returned even if
-// no gateway to the next minor exists. When false (z-stream upgrades), nil is returned if no gateway
-// exists, preserving upgradeability to the next minor.
+// no gateway to the next minor exists. When false (z-stream upgrades), nil is returned only when an
+// active version already has a next-minor path that would be lost by moving to a non-gateway
+// candidate; if neither candidates nor active versions can reach the next minor, the latest
+// candidate is returned instead.
 //
 // Algorithm:
 //  1. Sort candidates by version (descending - latest first)
@@ -513,7 +526,9 @@ func FindBestVersionInMinor(
 //  3. If next minor doesn't exist: return the latest candidate
 //  4. If next minor exists: iterate through candidates to find a gateway version to the next minor
 //  5. If no gateway found and preferLatestOverGateway: return the latest candidate
-//  6. If no gateway found and !preferLatestOverGateway: return nil
+//  6. If no gateway found and !preferLatestOverGateway:
+//     - If any active version is a gateway to the next minor: return nil
+//     - Otherwise return the latest candidate
 func selectBestVersionFromCandidates(
 	ctx context.Context,
 	cincinnatiClient cincinnati.Client,
@@ -521,6 +536,7 @@ func selectBestVersionFromCandidates(
 	channelGroup string,
 	targetMinorVersion semver.Version,
 	candidates []semver.Version,
+	activeVersions []semver.Version,
 	preferLatestOverGateway bool,
 ) (*semver.Version, error) {
 	if len(candidates) == 0 {
@@ -561,10 +577,20 @@ func selectBestVersionFromCandidates(
 		return &candidates[0], nil
 	}
 
-	// TODO: If the next minor exists but none of the candidates have a gateway to it,
-	// and none of the active versions have a gateway to it either, prefer the latest
-	// candidate instead of returning nil — there is no existing next-minor path to preserve.
-	return nil, nil
+	// Z-stream: only withhold an upgrade when an active version already has a
+	// next-minor path we would break. If nobody can reach the next minor today,
+	// prefer the latest candidate — there is no existing path to preserve.
+	for _, active := range activeVersions {
+		isGateway, err := isGatewayToNextMinor(ctx, active, cincinnatiClient, channelGroup, nextMinor)
+		if err != nil {
+			return nil, utils.TrackError(err)
+		}
+		if isGateway {
+			return nil, nil
+		}
+	}
+
+	return &candidates[0], nil
 }
 
 // shouldDetermineDesiredVersion decides whether the syncer should compute a

--- a/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller_test.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller_test.go
@@ -135,6 +135,14 @@ func TestDesiredControlPlaneZVersion_ZStreamManagedUpgrade(t *testing.T) {
 					[]configv1.ConditionalUpdate{},
 					nil,
 				)
+
+				// Active 4.19.15 itself is still a gateway — withhold the upgrade to preserve that path
+				mc.EXPECT().GetUpdates(gomock.AssignableToTypeOf(context.Background()), api.Must(cincinnati.GetCincinnatiURI("stable")), "multi", "multi", "stable-4.20", semver.MustParse("4.19.15")).Return(
+					configv1.Release{Version: "4.19.15"},
+					[]configv1.Release{{Version: "4.20.1"}},
+					[]configv1.ConditionalUpdate{},
+					nil,
+				)
 			},
 			expectedVersion: nil, // Z-stream: preserve upgradeability, don't select version without gateway
 			expectedError:   false,
@@ -180,7 +188,7 @@ func TestDesiredControlPlaneZVersion_ZStreamManagedUpgrade(t *testing.T) {
 			activeVersions:       []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.19.10")), State: configv1.CompletedUpdate}},
 			customerDesiredMinor: "4.19",
 			channelGroup:         "stable",
-			channelExistence:     channelExistence{"stable": {"4.20": false}},
+			channelExistence:     channelExistence{"stable": {"4.20": true}},
 			mockSetup: func(mc *cincinnati.MockClient) {
 				// Query for 4.19 versions from 4.19.10
 				mc.EXPECT().GetUpdates(gomock.AssignableToTypeOf(context.Background()), api.Must(cincinnati.GetCincinnatiURI("stable")), "multi", "multi", "stable-4.19", semver.MustParse("4.19.10")).Return(
@@ -189,8 +197,39 @@ func TestDesiredControlPlaneZVersion_ZStreamManagedUpgrade(t *testing.T) {
 					[]configv1.ConditionalUpdate{},
 					nil,
 				)
+
+				mc.EXPECT().GetUpdates(gomock.AssignableToTypeOf(context.Background()), api.Must(cincinnati.GetCincinnatiURI("stable")), "multi", "multi", "stable-4.20", semver.MustParse("4.19.18")).Return(
+					configv1.Release{Version: "4.19.18"},
+					[]configv1.Release{}, // Candidate is not a gateway
+					[]configv1.ConditionalUpdate{},
+					nil,
+				)
+
+				mc.EXPECT().GetUpdates(gomock.AssignableToTypeOf(context.Background()), api.Must(cincinnati.GetCincinnatiURI("stable")), "multi", "multi", "stable-4.20", semver.MustParse("4.19.10")).Return(
+					configv1.Release{Version: "4.19.10"},
+					[]configv1.Release{}, // Active is not a gateway either — nothing to preserve
+					[]configv1.ConditionalUpdate{},
+					nil,
+				)
 			},
 			expectedVersion: ptr.To(semver.MustParse("4.19.18")), // Safe to upgrade - no existing path to break
+			expectedError:   false,
+		},
+		{
+			name:                 "Z-stream upgrade - next minor channel does not exist",
+			activeVersions:       []api.HCPClusterActiveVersion{{Version: ptr.To(semver.MustParse("4.19.10")), State: configv1.CompletedUpdate}},
+			customerDesiredMinor: "4.19",
+			channelGroup:         "stable",
+			channelExistence:     channelExistence{"stable": {"4.20": false}},
+			mockSetup: func(mc *cincinnati.MockClient) {
+				mc.EXPECT().GetUpdates(gomock.AssignableToTypeOf(context.Background()), api.Must(cincinnati.GetCincinnatiURI("stable")), "multi", "multi", "stable-4.19", semver.MustParse("4.19.10")).Return(
+					configv1.Release{Version: "4.19.10"},
+					[]configv1.Release{{Version: "4.19.18"}},
+					[]configv1.ConditionalUpdate{},
+					nil,
+				)
+			},
+			expectedVersion: ptr.To(semver.MustParse("4.19.18")),
 			expectedError:   false,
 		},
 		{


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

fix: prefer latest z-stream candidate when no next-minor path exists

### Why


When the next-minor channel exists but neither candidates nor active
versions are gateways, return the latest candidate instead of nil —
there is no existing next-minor path to preserve. Preferring the latest
candidate prioritizes security and bug fixes over withholding an upgrade
that cannot unlock the next minor anyway.

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

Review the second commit only; the first commit comes from https://github.com/Azure/ARO-HCP/pull/6110


### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
