### PR TITLE
test: track deletion times, use step IDs

### DIFF
--- a/test/cmd/aro-hcp-tests/visualize/options.go
+++ b/test/cmd/aro-hcp-tests/visualize/options.go
@@ -180,6 +180,7 @@ func (o *ValidatedOptions) Complete(logger logr.Logger) (*Options, error) {
 				continue
 			}
 			steps = append(steps, StepTimingMetadata{
+				ID:         step.ID,
 				Name:       step.Name,
 				StartedAt:  stepStarted,
 				FinishedAt: stepFinished,
@@ -312,6 +313,7 @@ type TestInfo struct {
 }
 
 type StepTimingMetadata struct {
+	ID         string
 	Name       string
 	StartedAt  time.Time
 	FinishedAt time.Time

--- a/test/util/framework/deployment_helper.go
+++ b/test/util/framework/deployment_helper.go
@@ -201,7 +201,7 @@ func (tc *perItOrDescribeTestContext) CreateBicepTemplateAndWait(
 	startTime := time.Now()
 	defer func() {
 		finishTime := time.Now()
-		tc.RecordTestStep(fmt.Sprintf("Deploy ARM template %s/%s", cfg.resourceGroup, cfg.deploymentName), startTime, finishTime)
+		tc.RecordTestStep(StepIDDeployARMTemplate, fmt.Sprintf("Deploy ARM template %s/%s", cfg.resourceGroup, cfg.deploymentName), startTime, finishTime)
 	}()
 	tc.RecordKnownDeployment(cfg.resourceGroup, cfg.deploymentName)
 
@@ -346,7 +346,7 @@ func (tc *perItOrDescribeTestContext) CreateHCPClusterFromParam20240610(
 	startTime := time.Now()
 	defer func() {
 		finishTime := time.Now()
-		tc.RecordTestStep(fmt.Sprintf("Deploy HCP cluster %s/%s", resourceGroupName, clusterName), startTime, finishTime)
+		tc.RecordTestStep(StepIDDeployHCPCluster, fmt.Sprintf("Deploy HCP cluster %s/%s", resourceGroupName, clusterName), startTime, finishTime)
 	}()
 
 	cluster := BuildHCPClusterFromParams20240610(parameters, tc.Location())
@@ -386,7 +386,7 @@ func (tc *perItOrDescribeTestContext) CreateHCPClusterFromParam20251223(
 	startTime := time.Now()
 	defer func() {
 		finishTime := time.Now()
-		tc.RecordTestStep(fmt.Sprintf("Deploy HCP cluster %s/%s (v20251223preview)", resourceGroupName, clusterName), startTime, finishTime)
+		tc.RecordTestStep(StepIDDeployHCPCluster, fmt.Sprintf("Deploy HCP cluster %s/%s (v20251223preview)", resourceGroupName, clusterName), startTime, finishTime)
 	}()
 
 	cluster, err := BuildHCPClusterFromParams20251223(parameters, tc.Location(), imageDigestMirrors)
@@ -426,7 +426,7 @@ func (tc *perItOrDescribeTestContext) CreateNodePoolFromParam20240610(
 	startTime := time.Now()
 	defer func() {
 		finishTime := time.Now()
-		tc.RecordTestStep(fmt.Sprintf("Deploy node pool %s", parameters.NodePoolName), startTime, finishTime)
+		tc.RecordTestStep(StepIDDeployNodePool, fmt.Sprintf("Deploy node pool %s", parameters.NodePoolName), startTime, finishTime)
 	}()
 
 	nodePoolName := parameters.NodePoolName
@@ -500,7 +500,7 @@ func (tc *perItOrDescribeTestContext) CreateNodePoolFromParam20251223(
 	startTime := time.Now()
 	defer func() {
 		finishTime := time.Now()
-		tc.RecordTestStep(fmt.Sprintf("Deploy node pool %s", parameters.NodePoolName), startTime, finishTime)
+		tc.RecordTestStep(StepIDDeployNodePool, fmt.Sprintf("Deploy node pool %s", parameters.NodePoolName), startTime, finishTime)
 	}()
 
 	nodePoolName := parameters.NodePoolName
@@ -577,7 +577,7 @@ func (tc *perItOrDescribeTestContext) CreateHCPClusterFromParam20260630(
 	startTime := time.Now()
 	defer func() {
 		finishTime := time.Now()
-		tc.RecordTestStep(fmt.Sprintf("Deploy HCP cluster %s/%s (v20260630preview)", resourceGroupName, clusterName), startTime, finishTime)
+		tc.RecordTestStep(StepIDDeployHCPCluster, fmt.Sprintf("Deploy HCP cluster %s/%s (v20260630preview)", resourceGroupName, clusterName), startTime, finishTime)
 	}()
 
 	cluster, err := BuildHCPClusterFromParams20260630(parameters, tc.Location(), imageDigestMirrors)
@@ -617,7 +617,7 @@ func (tc *perItOrDescribeTestContext) CreateNodePoolFromParam20260630(
 	startTime := time.Now()
 	defer func() {
 		finishTime := time.Now()
-		tc.RecordTestStep(fmt.Sprintf("Deploy node pool %s", parameters.NodePoolName), startTime, finishTime)
+		tc.RecordTestStep(StepIDDeployNodePool, fmt.Sprintf("Deploy node pool %s", parameters.NodePoolName), startTime, finishTime)
 	}()
 
 	nodePoolName := parameters.NodePoolName

--- a/test/util/framework/deployment_params.go
+++ b/test/util/framework/deployment_params.go
@@ -808,7 +808,7 @@ func (tc *perItOrDescribeTestContext) CreateClusterCustomerResources20240610(ctx
 	startTime := time.Now()
 	defer func() {
 		finishTime := time.Now()
-		tc.RecordTestStep(fmt.Sprintf("Deploy customer resources in resource group %s", *resourceGroup.Name), startTime, finishTime)
+		tc.RecordTestStep(StepIDDeployCustomerResources, fmt.Sprintf("Deploy customer resources in resource group %s", *resourceGroup.Name), startTime, finishTime)
 	}()
 
 	// Generate unique deployment names by combining cluster name with random suffix
@@ -869,7 +869,7 @@ func (tc *perItOrDescribeTestContext) CreateClusterCustomerResources20251223(ctx
 	startTime := time.Now()
 	defer func() {
 		finishTime := time.Now()
-		tc.RecordTestStep(fmt.Sprintf("Deploy customer resources in resource group %s", *resourceGroup.Name), startTime, finishTime)
+		tc.RecordTestStep(StepIDDeployCustomerResources, fmt.Sprintf("Deploy customer resources in resource group %s", *resourceGroup.Name), startTime, finishTime)
 	}()
 
 	// Generate unique deployment names by combining cluster name with random suffix
@@ -930,7 +930,7 @@ func (tc *perItOrDescribeTestContext) CreateClusterCustomerResources20260630(ctx
 	startTime := time.Now()
 	defer func() {
 		finishTime := time.Now()
-		tc.RecordTestStep(fmt.Sprintf("Deploy customer resources in resource group %s", *resourceGroup.Name), startTime, finishTime)
+		tc.RecordTestStep(StepIDDeployCustomerResources, fmt.Sprintf("Deploy customer resources in resource group %s", *resourceGroup.Name), startTime, finishTime)
 	}()
 
 	// Generate unique deployment names by combining cluster name with random suffix

--- a/test/util/framework/hcp_helper.go
+++ b/test/util/framework/hcp_helper.go
@@ -94,7 +94,7 @@ func (tc *perItOrDescribeTestContext) GetAdminRESTConfigForHCPCluster20240610(
 	startTime := time.Now()
 	defer func() {
 		finishTime := time.Now()
-		tc.RecordTestStep("Collect admin credentials for cluster", startTime, finishTime)
+		tc.RecordTestStep(StepIDCollectAdminCredentials, "Collect admin credentials for cluster", startTime, finishTime)
 	}()
 
 	adminCredentialRequestPoller, err := hcpClient.BeginRequestAdminCredential(
@@ -152,7 +152,7 @@ func (tc *perItOrDescribeTestContext) RevokeCredentialsAndWait20240610(
 	startTime := time.Now()
 	defer func() {
 		finishTime := time.Now()
-		tc.RecordTestStep("Collect revoke admin credentials for cluster", startTime, finishTime)
+		tc.RecordTestStep(StepIDRevokeAdminCredentials, "Collect revoke admin credentials for cluster", startTime, finishTime)
 	}()
 
 	poller, err := hcpClient.BeginRevokeCredentials(ctx, resourceGroupName, hcpClusterName, nil)

--- a/test/util/framework/identities_helper.go
+++ b/test/util/framework/identities_helper.go
@@ -260,7 +260,7 @@ func (tc *perItOrDescribeTestContext) AssignIdentityContainers(ctx context.Conte
 	startTime := time.Now()
 	defer func() {
 		finishTime := time.Now()
-		tc.RecordTestStep(fmt.Sprintf("Assign %d identity containers", count), startTime, finishTime)
+		tc.RecordTestStep(StepIDAssignIdentityContainers, fmt.Sprintf("Assign %d identity containers", count), startTime, finishTime)
 	}()
 
 	ginkgo.GinkgoLogr.Info("Starting identity container acquisition", "count", count, "specID", specID())
@@ -304,7 +304,7 @@ func (tc *perItOrDescribeTestContext) getLeasedIdentities() (LeasedIdentityPool,
 	startTime := time.Now()
 	defer func() {
 		finishTime := time.Now()
-		tc.RecordTestStep("Lease identity container", startTime, finishTime)
+		tc.RecordTestStep(StepIDLeaseIdentityContainer, "Lease identity container", startTime, finishTime)
 	}()
 
 	state, err := tc.perBinaryInvocationTestContext.getLeasedIdentityPoolState()
@@ -355,7 +355,7 @@ func (tc *perItOrDescribeTestContext) releaseLeasedIdentities(ctx context.Contex
 	startTime := time.Now()
 	defer func() {
 		finishTime := time.Now()
-		tc.RecordTestStep("Release leased identities", startTime, finishTime)
+		tc.RecordTestStep(StepIDReleaseIdentities, "Release leased identities", startTime, finishTime)
 	}()
 
 	if !tc.UsePooledIdentities() {
@@ -1182,7 +1182,7 @@ func (tc *perItOrDescribeTestContext) EnsureIdentityRoleAssignments(
 	startTime := time.Now()
 	defer func() {
 		finishTime := time.Now()
-		tc.RecordTestStep(fmt.Sprintf("Validate role bindings for %s identity %s", identityType, identityName), startTime, finishTime)
+		tc.RecordTestStep(StepIDValidateIdentityRBACBindings, fmt.Sprintf("Validate role bindings for %s identity %s", identityType, identityName), startTime, finishTime)
 	}()
 
 	// Get expected role configuration for this identity

--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -193,10 +193,11 @@ func (tc *perItOrDescribeTestContext) BeforeEach(ctx context.Context) {
 	// In addition, AfterEach will not be called if a test never gets here.
 	// We are doing this because there's a serious bug.  I haven't got an ETA on a fix, but if we fail to correct it, we definitely need to know.
 	// If we haven't fixed the deletion timeout after Labor Day, this intentional time bomb will explode and start failing again.
+	// Registered first so it runs last (FILO): re-write timing data to disk
+	// after deletion completes, capturing deletion timing nodes.
+	ginkgo.DeferCleanup(tc.recommitTimingMetadata, AnnotatedLocation("update timing info after deletion"))
+
 	cleanupTimeout := 45 * time.Minute
-	if time.Now().Before(Must(time.Parse(time.RFC3339, "2025-09-02T15:04:05Z"))) {
-		cleanupTimeout = 90 * time.Minute
-	}
 	ginkgo.DeferCleanup(tc.deleteCreatedResources, AnnotatedLocation("tear down test context"), ginkgo.NodeTimeout(cleanupTimeout))
 
 	// Registered later and thus runs before deleting namespaces.
@@ -234,7 +235,7 @@ func (tc *perItOrDescribeTestContext) deleteCreatedResources(ctx context.Context
 	startTime := time.Now()
 	defer func() {
 		finishTime := time.Now()
-		tc.RecordTestStep("Delete created resources", startTime, finishTime)
+		tc.RecordTestStep(StepIDDeleteCreatedResources, "Delete created resources", startTime, finishTime)
 	}()
 
 	if tc.perBinaryInvocationTestContext.skipCleanup {
@@ -266,14 +267,18 @@ func (tc *perItOrDescribeTestContext) deleteCreatedResources(ctx context.Context
 		}
 	}
 
+	cleanupAppRegistrationsStart := time.Now()
 	err = CleanupAppRegistrations(ctx, graphClient, appRegistrations)
+	tc.RecordTestStep(StepIDCleanupAppRegistrations, "Clean up app registrations", cleanupAppRegistrationsStart, time.Now())
 	if err != nil {
 		ginkgo.GinkgoLogr.Error(err, "at least one app registration failed to delete")
 	}
 
+	releaseLeasedIdentitiesStart := time.Now()
 	if err := tc.releaseLeasedIdentities(ctx); err != nil {
 		ginkgo.GinkgoLogr.Error(err, "failed to release leased identities")
 	}
+	tc.RecordTestStep(StepIDReleaseIdentities, "Release leased identities", releaseLeasedIdentitiesStart, time.Now())
 
 	ginkgo.GinkgoLogr.Info("finished deleting created resources")
 	// Register error to ginkgo reporter to ensure the test fails if any errors occur except for not found resource group or resource.
@@ -514,7 +519,7 @@ func (tc *perItOrDescribeTestContext) cleanupResourceGroup(ctx context.Context, 
 	startTime := time.Now()
 	defer func() {
 		finishTime := time.Now()
-		tc.RecordTestStep(fmt.Sprintf("Clean up resource group %s", resourceGroupName), startTime, finishTime)
+		tc.RecordTestStep(StepIDCleanupResourceGroup, fmt.Sprintf("Clean up resource group %s", resourceGroupName), startTime, finishTime)
 	}()
 
 	resourceClientFactory, err := tc.GetARMResourcesClientFactory(ctx)
@@ -534,7 +539,9 @@ func (tc *perItOrDescribeTestContext) cleanupResourceGroup(ctx context.Context, 
 
 	var nonConformantErr error
 	ginkgo.GinkgoLogr.Info("deleting all hcp clusters in resource group", "resourceGroup", resourceGroupName)
+	deleteClustersStart := time.Now()
 	if err := DeleteAllHCPClusters20240610(ctx, hcpClientFactory.NewHcpOpenShiftClustersClient(), resourceGroupName, timeout); err != nil {
+		tc.RecordTestStep(StepIDDeleteHCPClusters, fmt.Sprintf("Delete HCP clusters in %s", resourceGroupName), deleteClustersStart, time.Now())
 		if errors.Is(err, &NonConformingClustersError{}) {
 			nonConformantErr = err
 		} else if isResourceGroupNotFoundError(err) {
@@ -543,6 +550,8 @@ func (tc *perItOrDescribeTestContext) cleanupResourceGroup(ctx context.Context, 
 		} else {
 			return fmt.Errorf("failed to cleanup resource group: %w", err)
 		}
+	} else {
+		tc.RecordTestStep(StepIDDeleteHCPClusters, fmt.Sprintf("Delete HCP clusters in %s", resourceGroupName), deleteClustersStart, time.Now())
 	}
 
 	managedResourceGroups, err := tc.findManagedResourceGroups(ctx, resourceGroupName)
@@ -553,7 +562,9 @@ func (tc *perItOrDescribeTestContext) cleanupResourceGroup(ctx context.Context, 
 	if len(managedResourceGroups) > 0 {
 		ginkgo.GinkgoLogr.Info("managed resource groups still present, waiting for deletion",
 			"resourceGroup", resourceGroupName, "managedResourceGroups", managedResourceGroups)
+		waitManagedRGStart := time.Now()
 		managedResourceGroups, err = tc.waitForManagedResourceGroupsDeletion(ctx, resourceGroupName, 10*time.Minute)
+		tc.RecordTestStep(StepIDWaitManagedResourceGroupDeletion, fmt.Sprintf("Wait for managed resource group deletion in %s", resourceGroupName), waitManagedRGStart, time.Now())
 		if err != nil {
 			if len(managedResourceGroups) > 0 {
 				return fmt.Errorf("found %d managed resource groups left behind HCP clusters in %s: %v: %w", len(managedResourceGroups), resourceGroupName, managedResourceGroups, err)
@@ -565,9 +576,12 @@ func (tc *perItOrDescribeTestContext) cleanupResourceGroup(ctx context.Context, 
 	}
 
 	ginkgo.GinkgoLogr.Info("deleting resource group", "resourceGroup", resourceGroupName)
+	deleteRGStart := time.Now()
 	if err := DeleteResourceGroup(ctx, resourceClientFactory.NewResourceGroupsClient(), networkClientFactory, resourceGroupName, false, timeout); err != nil {
+		tc.RecordTestStep(StepIDDeleteResourceGroup, fmt.Sprintf("Delete resource group %s", resourceGroupName), deleteRGStart, time.Now())
 		return fmt.Errorf("failed to cleanup resource group: %w", err)
 	}
+	tc.RecordTestStep(StepIDDeleteResourceGroup, fmt.Sprintf("Delete resource group %s", resourceGroupName), deleteRGStart, time.Now())
 
 	// we want non-conformant clusters to be visible at the end, without impeding our ability to clean up the resource group
 	return nonConformantErr
@@ -583,7 +597,7 @@ func (tc *perItOrDescribeTestContext) cleanupResourceGroupNoRP(ctx context.Conte
 	startTime := time.Now()
 	defer func() {
 		finishTime := time.Now()
-		tc.recordTestStepUnlocked(fmt.Sprintf("Clean up resource group %s (no RP)", resourceGroupName), startTime, finishTime)
+		tc.recordTestStepUnlocked(StepIDCleanupResourceGroupNoRP, fmt.Sprintf("Clean up resource group %s (no RP)", resourceGroupName), startTime, finishTime)
 	}()
 
 	managedResourceGroups, err := tc.findManagedResourceGroups(ctx, resourceGroupName)
@@ -637,7 +651,7 @@ func (tc *perItOrDescribeTestContext) collectDebugInfoForResourceGroup(ctx conte
 	startTime := time.Now()
 	defer func() {
 		finishTime := time.Now()
-		tc.RecordTestStep(fmt.Sprintf("Collect debug info for resource group %s", resourceGroupName), startTime, finishTime)
+		tc.RecordTestStep(StepIDCollectDebugInfo, fmt.Sprintf("Collect debug info for resource group %s", resourceGroupName), startTime, finishTime)
 	}()
 
 	errs := []error{}
@@ -736,7 +750,7 @@ func (tc *perItOrDescribeTestContext) runOCAdmInspect(ctx context.Context, clust
 
 	startTime := time.Now()
 	defer func() {
-		tc.RecordTestStep(fmt.Sprintf("oc adm inspect %s", clusterKey), startTime, time.Now())
+		tc.RecordTestStep(StepIDOCAdmInspect, fmt.Sprintf("oc adm inspect %s", clusterKey), startTime, time.Now())
 	}()
 
 	kubeconfigContent, err := GenerateKubeconfig(restConfig)
@@ -1203,15 +1217,16 @@ func (tc *perItOrDescribeTestContext) RecordKnownDeployment(resourceGroup, deplo
 	})
 }
 
-func (tc *perItOrDescribeTestContext) RecordTestStep(name string, startTime, finishTime time.Time) {
+func (tc *perItOrDescribeTestContext) RecordTestStep(id, name string, startTime, finishTime time.Time) {
 	tc.contextLock.Lock()
 	defer tc.contextLock.Unlock()
 
-	tc.recordTestStepUnlocked(name, startTime, finishTime)
+	tc.recordTestStepUnlocked(id, name, startTime, finishTime)
 }
 
-func (tc *perItOrDescribeTestContext) recordTestStepUnlocked(name string, startTime, finishTime time.Time) {
+func (tc *perItOrDescribeTestContext) recordTestStepUnlocked(id, name string, startTime, finishTime time.Time) {
 	tc.timingMetadata.Steps = append(tc.timingMetadata.Steps, timing.StepTimingMetadata{
+		ID:         id,
 		Name:       name,
 		StartedAt:  startTime.Format(time.RFC3339),
 		FinishedAt: finishTime.Format(time.RFC3339),
@@ -1253,7 +1268,12 @@ func (tc *perItOrDescribeTestContext) commitTimingMetadata(ctx context.Context) 
 		}
 		tc.recordDeploymentOperationsUnlocked(resourceGroupName, deploymentName, operations)
 	}
+	tc.writeTimingMetadataToDiskUnlocked()
+}
 
+// writeTimingMetadataToDiskUnlocked serializes and writes the current timing metadata to disk.
+// The caller must hold tc.contextLock.
+func (tc *perItOrDescribeTestContext) writeTimingMetadataToDiskUnlocked() {
 	tc.timingMetadata.FinishedAt = time.Now().Format(time.RFC3339)
 	encoded, err := yaml.Marshal(tc.timingMetadata)
 	if err != nil {
@@ -1298,6 +1318,7 @@ func (tc *perItOrDescribeTestContext) commitTimingMetadata(ctx context.Context) 
 			ginkgo.GinkgoLogr.Error(err, "Failed to create directory for timing metadata")
 			continue
 		}
+
 		if err := os.WriteFile(output, outputData, 0644); err != nil {
 			ginkgo.GinkgoLogr.Error(err, "Failed to write timing metadata")
 			continue
@@ -1305,4 +1326,15 @@ func (tc *perItOrDescribeTestContext) commitTimingMetadata(ctx context.Context) 
 
 		ginkgo.GinkgoLogr.Info("Wrote timing metadata", "path", output)
 	}
+}
+
+// recommitTimingMetadata re-writes timing metadata to disk after deletion completes,
+// capturing any timing nodes recorded during the deletion phase.
+func (tc *perItOrDescribeTestContext) recommitTimingMetadata() {
+	ginkgo.GinkgoLogr.Info("Re-committing timing metadata after deletion.")
+
+	tc.contextLock.Lock()
+	defer tc.contextLock.Unlock()
+
+	tc.writeTimingMetadataToDiskUnlocked()
 }

--- a/test/util/framework/step_ids.go
+++ b/test/util/framework/step_ids.go
@@ -1,0 +1,50 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+// Step IDs are machine-readable identifiers for timing steps, suitable for
+// post-hoc aggregation. Steps with the same ID represent the same logical
+// operation across different test runs, regardless of the human-readable
+// name (which may contain dynamic resource names).
+const (
+	// Deployment steps
+	StepIDDeployARMTemplate       = "deploy-arm-template"
+	StepIDDeployHCPCluster        = "deploy-hcp-cluster"
+	StepIDDeployNodePool          = "deploy-node-pool"
+	StepIDDeployCustomerResources = "deploy-customer-resources"
+
+	// Credential steps
+	StepIDCollectAdminCredentials = "collect-admin-credentials"
+	StepIDRevokeAdminCredentials  = "revoke-admin-credentials"
+
+	// Identity steps
+	StepIDAssignIdentityContainers     = "assign-identity-containers"
+	StepIDLeaseIdentityContainer       = "lease-identity-container"
+	StepIDReleaseIdentities            = "release-identities"
+	StepIDValidateIdentityRBACBindings = "validate-identity-rbac-bindings"
+
+	// Deletion / cleanup steps
+	StepIDDeleteCreatedResources           = "delete-created-resources"
+	StepIDDeleteHCPClusters                = "delete-hcp-clusters"
+	StepIDWaitManagedResourceGroupDeletion = "wait-managed-resource-group-deletion"
+	StepIDDeleteResourceGroup              = "delete-resource-group"
+	StepIDCleanupResourceGroup             = "cleanup-resource-group"
+	StepIDCleanupResourceGroupNoRP         = "cleanup-resource-group-no-rp"
+	StepIDCleanupAppRegistrations          = "cleanup-app-registrations"
+
+	// Debug / inspection steps
+	StepIDCollectDebugInfo = "collect-debug-info"
+	StepIDOCAdmInspect     = "oc-adm-inspect"
+)

--- a/tooling/utilitytypes/timing/types.go
+++ b/tooling/utilitytypes/timing/types.go
@@ -26,6 +26,9 @@ type SpecTimingMetadata struct {
 }
 
 type StepTimingMetadata struct {
+	// ID is a machine-readable identifier for the step, suitable for post-hoc aggregation.
+	// Steps with the same ID represent the same logical operation across different test runs.
+	ID   string `json:"id"`
 	Name string `json:"name"`
 	// StartedAt is the time at which the step started, formatted as RFC3339 date+time: 2025-11-05T13:16:20.624264+00:00
 	StartedAt string `json:"startedAt"`


### PR DESCRIPTION
We want to track also the time taken to delete as seen by the client and to use machine-readable markers, so we can do post-hoc analysis on this.

/label lgtm