### PR TITLE
fix: reject missing JWT claim headers in sessiongate proxy authorization

### DIFF
--- a/sessiongate/pkg/server/middleware/authorization.go
+++ b/sessiongate/pkg/server/middleware/authorization.go
@@ -38,6 +38,12 @@ func WithSessionProxyClaimHeaderAuthorization(owner sessiongatev1alpha1.Principa
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		logger := klog.FromContext(r.Context()).WithValues("identity", owner.Name, "identityType", owner.Type)
 		claimValue := r.Header.Get(claimName)
+		if claimValue == "" {
+			logger.Error(fmt.Errorf("missing claim header"), "unauthorized",
+				"header", claimName)
+			http.Error(w, "unauthorized: missing claim header", http.StatusUnauthorized)
+			return
+		}
 		if claimValue != owner.Name {
 			logger.Error(fmt.Errorf("claim validation failed"), "unauthorized",
 				"expected", fmt.Sprintf("%s=%s", claimName, owner.Name), "got", fmt.Sprintf("%s=%s", claimName, claimValue))

--- a/sessiongate/pkg/server/middleware/authorization_test.go
+++ b/sessiongate/pkg/server/middleware/authorization_test.go
@@ -1,0 +1,118 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	sessiongatev1alpha1 "github.com/Azure/ARO-HCP/sessiongate/pkg/apis/sessiongate/v1alpha1"
+)
+
+func TestWithSessionProxyClaimHeaderAuthorization(t *testing.T) {
+	okHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	tests := []struct {
+		name       string
+		owner      sessiongatev1alpha1.Principal
+		headers    map[string]string
+		wantStatus int
+	}{
+		{
+			name: "azure user missing header",
+			owner: sessiongatev1alpha1.Principal{
+				Type: sessiongatev1alpha1.PrincipalTypeAzureUser,
+				Name: "alice@example.com",
+			},
+			headers:    map[string]string{},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "azure user empty header",
+			owner: sessiongatev1alpha1.Principal{
+				Type: sessiongatev1alpha1.PrincipalTypeAzureUser,
+				Name: "alice@example.com",
+			},
+			headers:    map[string]string{"X-JWT-Claim-Upn": ""},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "azure user wrong value",
+			owner: sessiongatev1alpha1.Principal{
+				Type: sessiongatev1alpha1.PrincipalTypeAzureUser,
+				Name: "alice@example.com",
+			},
+			headers:    map[string]string{"X-JWT-Claim-Upn": "mallory@example.com"},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "azure user correct value",
+			owner: sessiongatev1alpha1.Principal{
+				Type: sessiongatev1alpha1.PrincipalTypeAzureUser,
+				Name: "alice@example.com",
+			},
+			headers:    map[string]string{"X-JWT-Claim-Upn": "alice@example.com"},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "service principal correct value",
+			owner: sessiongatev1alpha1.Principal{
+				Type: sessiongatev1alpha1.PrincipalTypeAzureServicePrincipal,
+				Name: "00000000-0000-0000-0000-000000000001",
+			},
+			headers:    map[string]string{"X-JWT-Claim-Oid": "00000000-0000-0000-0000-000000000001"},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "service principal wrong header name",
+			owner: sessiongatev1alpha1.Principal{
+				Type: sessiongatev1alpha1.PrincipalTypeAzureServicePrincipal,
+				Name: "00000000-0000-0000-0000-000000000001",
+			},
+			headers:    map[string]string{"X-JWT-Claim-Upn": "00000000-0000-0000-0000-000000000001"},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "unexpected owner type",
+			owner: sessiongatev1alpha1.Principal{
+				Type: "unknownType",
+				Name: "alice@example.com",
+			},
+			headers:    map[string]string{"X-JWT-Claim-Upn": "alice@example.com"},
+			wantStatus: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := WithSessionProxyClaimHeaderAuthorization(tt.owner, okHandler)
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			for k, v := range tt.headers {
+				req.Header.Set(k, v)
+			}
+
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Errorf("got status %d, want %d", rec.Code, tt.wantStatus)
+			}
+		})
+	}
+}

--- a/sessiongate/pkg/server/middleware/authorization_test.go
+++ b/sessiongate/pkg/server/middleware/authorization_test.go
@@ -111,7 +111,14 @@ func TestWithSessionProxyClaimHeaderAuthorization(t *testing.T) {
 			handler.ServeHTTP(rec, req)
 
 			if rec.Code != tt.wantStatus {
-				t.Errorf("got status %d, want %d", rec.Code, tt.wantStatus)
+				t.Fatalf("got status %d, want %d", rec.Code, tt.wantStatus)
+			}
+
+			if tt.name == "azure user missing header" || tt.name == "azure user empty header" {
+				const wantBody = "unauthorized: missing claim header\n"
+				if gotBody := rec.Body.String(); gotBody != wantBody {
+					t.Fatalf("got body %q, want %q", gotBody, wantBody)
+				}
 			}
 		})
 	}

--- a/sessiongate/pkg/server/middleware/authorization_test.go
+++ b/sessiongate/pkg/server/middleware/authorization_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Microsoft Corporation
+// Copyright 2026 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -49,6 +49,15 @@ func TestWithSessionProxyClaimHeaderAuthorization(t *testing.T) {
 				Name: "alice@example.com",
 			},
 			headers:    map[string]string{"X-JWT-Claim-Upn": ""},
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "azure user empty owner name with missing header",
+			owner: sessiongatev1alpha1.Principal{
+				Type: sessiongatev1alpha1.PrincipalTypeAzureUser,
+				Name: "",
+			},
+			headers:    map[string]string{},
 			wantStatus: http.StatusUnauthorized,
 		},
 		{


### PR DESCRIPTION
Add an explicit empty-header rejection before the owner comparison as defense in depth, and add unit tests for the middleware. The header pattern only exists when local dev is true, but we can still harden this to prevent any accidental situations in the future.

Ref:  ARO-28371


### What

Makes local dev more secure.

### Why

Defense in depth hardening.

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
