### PR TITLE
Fix: Replace bash shell-out with Go-native parameter expansion in templati…

### DIFF
--- a/tooling/templatize/cmd/configuration/render/options.go
+++ b/tooling/templatize/cmd/configuration/render/options.go
@@ -124,7 +124,7 @@ func (o *RawOptions) Validate(ctx context.Context) (*ValidatedOptions, error) {
 			return nil, fmt.Errorf("failed to load developer settings: %w", err)
 		}
 
-		env, err := devSettings.Resolve(ctx, o.Cloud, o.Environment)
+		env, err := devSettings.Resolve(o.Cloud, o.Environment)
 		if err != nil {
 			return nil, fmt.Errorf("failed to resolve environment %s in cloud %s: %w", o.Environment, o.Cloud, err)
 		}

--- a/tooling/templatize/cmd/configuration/validate/options.go
+++ b/tooling/templatize/cmd/configuration/validate/options.go
@@ -209,7 +209,7 @@ func (opts *Options) ValidateServiceConfig(ctx context.Context) error {
 				continue
 			}
 
-			env, err := settings.Resolve(ctx, environment)
+			env, err := settings.Resolve(environment)
 			if err != nil {
 				return fmt.Errorf("failed to resolve region context: %w", err)
 			}

--- a/tooling/templatize/cmd/rolloutoptions.go
+++ b/tooling/templatize/cmd/rolloutoptions.go
@@ -145,7 +145,7 @@ func (o *RawRolloutOptions) Validate(ctx context.Context) (*ValidatedRolloutOpti
 			return nil, fmt.Errorf("failed to load developer settings: %w", err)
 		}
 
-		env, err := devSettings.Resolve(ctx, o.BaseOptions.Cloud, o.DevEnvironment)
+		env, err := devSettings.Resolve(o.BaseOptions.Cloud, o.DevEnvironment)
 		if err != nil {
 			return nil, fmt.Errorf("failed to resolve developer environment %s: %w", o.DevEnvironment, err)
 		}

--- a/tooling/templatize/pkg/settings/settings.go
+++ b/tooling/templatize/pkg/settings/settings.go
@@ -15,10 +15,9 @@
 package settings
 
 import (
-	"context"
 	"fmt"
 	"os"
-	"os/exec"
+	"strconv"
 	"strings"
 
 	"sigs.k8s.io/yaml"
@@ -45,9 +44,9 @@ type Parameters struct {
 	Region string `json:"region"`
 	// CxStamp is the stamp for which this environment is rendered.
 	CxStamp string `json:"cxStamp"`
-	// RegionShortOverride is a shell-ism that, when run through `echo`, outputs a replacement for the short region variable from the EV2 central config.
+	// RegionShortOverride is a bash parameter expression that expands to a replacement for the short region variable from the EV2 central config.
 	RegionShortOverride string `json:"regionShortOverride"`
-	// RegionShortSuffix is a shell-ism that, when run through `echo`, outputs a suffix for the short region variable.
+	// RegionShortSuffix is a bash parameter expression that expands to a suffix for the short region variable.
 	RegionShortSuffix string `json:"regionShortSuffix"`
 }
 
@@ -71,7 +70,7 @@ type EnvironmentParameters struct {
 	RegionShortSuffix   string
 }
 
-func (s *Settings) Resolve(ctx context.Context, cloud, environment string) (EnvironmentParameters, error) {
+func (s *Settings) Resolve(cloud, environment string) (EnvironmentParameters, error) {
 	var env *Environment
 	for _, e := range s.Environments {
 		if e.Defaults.Cloud == cloud && e.Name == environment {
@@ -82,10 +81,10 @@ func (s *Settings) Resolve(ctx context.Context, cloud, environment string) (Envi
 		return EnvironmentParameters{}, fmt.Errorf("cloud %s environment %s not found", cloud, environment)
 	}
 
-	return Resolve(ctx, *env)
+	return Resolve(*env)
 }
 
-func Resolve(ctx context.Context, environment Environment) (EnvironmentParameters, error) {
+func Resolve(environment Environment) (EnvironmentParameters, error) {
 	out := EnvironmentParameters{
 		Cloud:       environment.Defaults.Cloud,
 		Ev2Cloud:    environment.Defaults.Ev2Cloud,
@@ -94,22 +93,91 @@ func Resolve(ctx context.Context, environment Environment) (EnvironmentParameter
 		Stamp:       environment.Defaults.CxStamp,
 	}
 	if environment.Defaults.RegionShortSuffix != "" {
-		evaluator := exec.CommandContext(ctx, "bash", "-c", fmt.Sprintf("echo %s", environment.Defaults.RegionShortSuffix))
-		evaluator.Env = os.Environ()
-		evaluated, err := evaluator.CombinedOutput()
+		expanded, err := expandBashSubstring(environment.Defaults.RegionShortSuffix)
 		if err != nil {
-			return EnvironmentParameters{}, fmt.Errorf("failed to evaluate region short suffix: %w; output: %s", err, string(evaluated))
+			return EnvironmentParameters{}, fmt.Errorf("expanding region short suffix %q: %w", environment.Defaults.RegionShortSuffix, err)
 		}
-		out.RegionShortSuffix = strings.TrimSpace(string(evaluated))
+		out.RegionShortSuffix = expanded
 	}
 	if environment.Defaults.RegionShortOverride != "" {
-		evaluator := exec.CommandContext(ctx, "bash", "-c", fmt.Sprintf("echo %s", environment.Defaults.RegionShortOverride))
-		evaluator.Env = os.Environ()
-		evaluated, err := evaluator.CombinedOutput()
+		expanded, err := expandBashSubstring(environment.Defaults.RegionShortOverride)
 		if err != nil {
-			return EnvironmentParameters{}, fmt.Errorf("failed to evaluate region short override: %w; output: %s", err, string(evaluated))
+			return EnvironmentParameters{}, fmt.Errorf("expanding region short override %q: %w", environment.Defaults.RegionShortOverride, err)
 		}
-		out.RegionShortOverride = strings.TrimSpace(string(evaluated))
+		out.RegionShortOverride = expanded
 	}
 	return out, nil
+}
+
+// expandBashSubstring expands a string containing bash-style parameter
+// expressions. It supports plain variable expansion ($VAR, ${VAR}) and
+// substring extraction (${VAR:offset}, ${VAR:offset:length}).
+// Negative offsets count from the end of the value (${VAR: -3}).
+func expandBashSubstring(s string) (string, error) {
+	var expandErr error
+	result := os.Expand(s, func(key string) string {
+		if expandErr != nil {
+			return ""
+		}
+
+		colonIdx := strings.IndexByte(key, ':')
+		if colonIdx == -1 {
+			return os.Getenv(key)
+		}
+
+		varName := key[:colonIdx]
+		substringExpr := key[colonIdx+1:]
+		value := os.Getenv(varName)
+		if value == "" {
+			return ""
+		}
+
+		expanded, err := applySubstring(value, substringExpr)
+		if err != nil {
+			expandErr = fmt.Errorf("variable %q: %w", varName, err)
+			return ""
+		}
+		return expanded
+	})
+	if expandErr != nil {
+		return "", expandErr
+	}
+	return result, nil
+}
+
+func applySubstring(value, expr string) (string, error) {
+	parts := strings.SplitN(expr, ":", 2)
+
+	offset, err := strconv.Atoi(strings.TrimSpace(parts[0]))
+	if err != nil {
+		return "", fmt.Errorf("invalid offset %q: %w", parts[0], err)
+	}
+
+	if offset < 0 {
+		offset = len(value) + offset
+		if offset < 0 {
+			offset = 0
+		}
+	}
+	if offset > len(value) {
+		return "", nil
+	}
+
+	if len(parts) == 1 {
+		return value[offset:], nil
+	}
+
+	length, err := strconv.Atoi(strings.TrimSpace(parts[1]))
+	if err != nil {
+		return "", fmt.Errorf("invalid length %q: %w", parts[1], err)
+	}
+
+	end := offset + length
+	if end > len(value) {
+		end = len(value)
+	}
+	if end < offset {
+		return "", nil
+	}
+	return value[offset:end], nil
 }

--- a/tooling/templatize/pkg/settings/settings.go
+++ b/tooling/templatize/pkg/settings/settings.go
@@ -109,10 +109,11 @@ func Resolve(environment Environment) (EnvironmentParameters, error) {
 	return out, nil
 }
 
-// expandBashSubstring expands a string containing bash-style parameter
-// expressions. It supports plain variable expansion ($VAR, ${VAR}) and
+// expandBashSubstring expands a limited subset of bash-style parameter
+// expansions. It supports plain variable expansion ($VAR, ${VAR}) and
 // substring extraction (${VAR:offset}, ${VAR:offset:length}).
-// Negative offsets count from the end of the value (${VAR: -3}).
+// Note: negative offsets require a space after the colon (${VAR: -3});
+// ${VAR:-3} is bash default-value syntax and is not supported here.
 func expandBashSubstring(s string) (string, error) {
 	var expandErr error
 	result := os.Expand(s, func(key string) string {

--- a/tooling/templatize/pkg/settings/settings_test.go
+++ b/tooling/templatize/pkg/settings/settings_test.go
@@ -1,0 +1,188 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package settings
+
+import (
+	"testing"
+)
+
+func TestExpandBashSubstring(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		env     map[string]string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "plain variable",
+			input: "${USER}",
+			env:   map[string]string{"USER": "testuser"},
+			want:  "testuser",
+		},
+		{
+			name:  "plain variable short form",
+			input: "$USER",
+			env:   map[string]string{"USER": "testuser"},
+			want:  "testuser",
+		},
+		{
+			name:  "substring offset and length",
+			input: "${USER:0:4}",
+			env:   map[string]string{"USER": "testuser"},
+			want:  "test",
+		},
+		{
+			name:  "negative offset",
+			input: "${BUILD_ID: -7}",
+			env:   map[string]string{"BUILD_ID": "1234567890"},
+			want:  "4567890",
+		},
+		{
+			name:  "literal prefix with substring",
+			input: "p${USER:0:4}",
+			env:   map[string]string{"USER": "testuser"},
+			want:  "ptest",
+		},
+		{
+			name:  "literal prefix with negative offset",
+			input: "j${BUILD_ID: -7}",
+			env:   map[string]string{"BUILD_ID": "1234567890"},
+			want:  "j4567890",
+		},
+		{
+			name:  "offset only no length",
+			input: "${VAR:3}",
+			env:   map[string]string{"VAR": "abcdefgh"},
+			want:  "defgh",
+		},
+		{
+			name:  "unset variable returns empty",
+			input: "${NONEXISTENT:0:4}",
+			env:   map[string]string{},
+			want:  "",
+		},
+		{
+			name:  "offset beyond string length",
+			input: "${VAR:100:4}",
+			env:   map[string]string{"VAR": "short"},
+			want:  "",
+		},
+		{
+			name:  "length exceeds remaining",
+			input: "${VAR:3:100}",
+			env:   map[string]string{"VAR": "abcde"},
+			want:  "de",
+		},
+		{
+			name:  "negative offset exceeds string length clamps to zero",
+			input: "${VAR: -100}",
+			env:   map[string]string{"VAR": "abc"},
+			want:  "abc",
+		},
+		{
+			name:  "no expansion needed",
+			input: "literal-string",
+			env:   map[string]string{},
+			want:  "literal-string",
+		},
+		{
+			name:  "empty input",
+			input: "",
+			env:   map[string]string{},
+			want:  "",
+		},
+		{
+			name:  "shell metacharacters are not executed",
+			input: "$(whoami)",
+			env:   map[string]string{},
+			want:  "$(whoami)",
+		},
+		{
+			name:  "backtick injection is literal",
+			input: "prefix-`whoami`-suffix",
+			env:   map[string]string{},
+			want:  "prefix-`whoami`-suffix",
+		},
+		{
+			name:  "semicolon injection is literal",
+			input: "value; rm -rf /",
+			env:   map[string]string{},
+			want:  "value; rm -rf /",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+
+			got, err := expandBashSubstring(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("expandBashSubstring(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("expandBashSubstring(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolve(t *testing.T) {
+	t.Setenv("USER", "hlipsig1")
+	t.Setenv("BUILD_ID", "build-1234567")
+
+	env := Environment{
+		Name: "pers",
+		Defaults: Parameters{
+			Cloud:             "dev",
+			Ev2Cloud:          "public",
+			Region:            "westus3",
+			CxStamp:           "1",
+			RegionShortSuffix: "${USER:0:4}",
+		},
+	}
+
+	got, err := Resolve(env)
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if got.RegionShortSuffix != "hlip" {
+		t.Errorf("RegionShortSuffix = %q, want %q", got.RegionShortSuffix, "hlip")
+	}
+	if got.Cloud != "dev" {
+		t.Errorf("Cloud = %q, want %q", got.Cloud, "dev")
+	}
+
+	env2 := Environment{
+		Name: "prow",
+		Defaults: Parameters{
+			Cloud:               "dev",
+			Ev2Cloud:            "public",
+			Region:              "westus3",
+			CxStamp:             "1",
+			RegionShortOverride: "j${BUILD_ID: -7}",
+		},
+	}
+
+	got2, err := Resolve(env2)
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if got2.RegionShortOverride != "j1234567" {
+		t.Errorf("RegionShortOverride = %q, want %q", got2.RegionShortOverride, "j1234567")
+	}
+}


### PR DESCRIPTION
…ze settings

In local dev, the Resolve function passed RegionShortSuffix and RegionShortOverride values into bash -c "echo <value>" unquoted, allowing shell metacharacter injection from the settings YAML. Replace with a Go-native expandBashSubstring function that handles ${VAR:offset:length} substring extraction using os.Expand, eliminating the shell dependency entirely.

<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

### Why

<!-- Briefly explain why this change is needed -->

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
