### PR TITLE
fix: add DNS readiness gate to E2E tests to prevent propagation race

### DIFF
--- a/test/e2e/cluster_tls_endpoints.go
+++ b/test/e2e/cluster_tls_endpoints.go
@@ -189,6 +189,12 @@ var _ = Describe("Customer", func() {
 			}).WithContext(ctx).WithTimeout(15*time.Minute).WithPolling(10*time.Second).Should(Succeed(),
 				"expect cluster console URL to become available")
 
+			By("waiting for console hostname DNS to resolve")
+			consoleHostname, err := framework.HostnameFromURL(consoleURL)
+			Expect(err).NotTo(HaveOccurred(), "failed to parse console URL %s", consoleURL)
+			err = framework.WaitForDNSResolution(ctx, consoleHostname, framework.DNSResolutionTimeout)
+			Expect(err).NotTo(HaveOccurred(), "DNS for console host %s did not resolve within timeout", consoleHostname)
+
 			By("examining the server certificate returned by the default ingress when routing the console URL")
 			// Wait for the certificate to be loaded after console starts
 			consoleUrlWithPort := fmt.Sprintf("%s:%d", consoleURL, 443)

--- a/test/util/framework/dns.go
+++ b/test/util/framework/dns.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+)
+
+// DNSResolutionTimeout is the default timeout for waiting for DNS to resolve.
+const DNSResolutionTimeout = 10 * time.Minute
+
+// HostnameFromURL extracts the hostname (without port or scheme) from a URL
+// string. If the input has no scheme, it is treated as a bare host or host:port.
+func HostnameFromURL(rawURL string) (string, error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse URL %q: %w", rawURL, err)
+	}
+
+	hostname := parsed.Hostname()
+	if hostname == "" {
+		return "", fmt.Errorf("no hostname found in %q", rawURL)
+	}
+	return hostname, nil
+}
+
+// WaitForDNSResolution polls DNS for the given hostname until at least one
+// address record is returned, or the timeout is reached. Each poll attempt
+// uses a fresh net.Resolver with PreferGo: true to bypass negative DNS
+// caching from prior NXDOMAIN responses.
+func WaitForDNSResolution(ctx context.Context, hostname string, timeout time.Duration) error {
+	var lastErrStr string
+	startTime := time.Now()
+
+	err := wait.PollUntilContextTimeout(ctx, 10*time.Second, timeout, true, func(ctx context.Context) (done bool, err error) {
+		resolver := &net.Resolver{PreferGo: true}
+		lookupCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+
+		addrs, lookupErr := resolver.LookupHost(lookupCtx, hostname)
+		if lookupErr != nil {
+			errStr := formatDNSError(lookupErr, hostname)
+			if errStr != lastErrStr {
+				klog.Infof("DNS resolution pending for %s: %s (elapsed %s)", hostname, errStr, time.Since(startTime).Truncate(time.Second))
+				lastErrStr = errStr
+			}
+			return false, nil
+		}
+
+		klog.Infof("DNS resolved %s -> %v (elapsed %s)", hostname, addrs, time.Since(startTime).Truncate(time.Second))
+		return true, nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("DNS for %s did not resolve within %s (last error: %s): %w", hostname, timeout, lastErrStr, err)
+	}
+	return nil
+}
+
+func formatDNSError(err error, hostname string) string {
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return fmt.Sprintf("server=%s isNotFound=%v isTemporary=%v err=%s",
+			dnsErr.Server, dnsErr.IsNotFound, dnsErr.IsTemporary, dnsErr.Err)
+	}
+	return err.Error()
+}

--- a/test/util/framework/dns.go
+++ b/test/util/framework/dns.go
@@ -81,20 +81,20 @@ func WaitForDNSResolution(ctx context.Context, hostname string, timeout time.Dur
 			errStr := formatDNSError(lookupErr)
 			if errStr != lastErrStr {
 				klog.InfoS("DNS resolution pending",
-						"hostname", hostname,
-						"error", errStr,
-						"elapsed", time.Since(startTime).Truncate(time.Second),
-					)
+					"hostname", hostname,
+					"error", errStr,
+					"elapsed", time.Since(startTime).Truncate(time.Second),
+				)
 				lastErrStr = errStr
 			}
 			return false, nil
 		}
 
 		klog.InfoS("DNS resolved",
-				"hostname", hostname,
-				"addresses", addrs,
-				"elapsed", time.Since(startTime).Truncate(time.Second),
-			)
+			"hostname", hostname,
+			"addresses", addrs,
+			"elapsed", time.Since(startTime).Truncate(time.Second),
+		)
 		return true, nil
 	})
 

--- a/test/util/framework/dns.go
+++ b/test/util/framework/dns.go
@@ -80,13 +80,21 @@ func WaitForDNSResolution(ctx context.Context, hostname string, timeout time.Dur
 		if lookupErr != nil {
 			errStr := formatDNSError(lookupErr)
 			if errStr != lastErrStr {
-				klog.Infof("DNS resolution pending for %s: %s (elapsed %s)", hostname, errStr, time.Since(startTime).Truncate(time.Second))
+				klog.InfoS("DNS resolution pending",
+						"hostname", hostname,
+						"error", errStr,
+						"elapsed", time.Since(startTime).Truncate(time.Second),
+					)
 				lastErrStr = errStr
 			}
 			return false, nil
 		}
 
-		klog.Infof("DNS resolved %s -> %v (elapsed %s)", hostname, addrs, time.Since(startTime).Truncate(time.Second))
+		klog.InfoS("DNS resolved",
+				"hostname", hostname,
+				"addresses", addrs,
+				"elapsed", time.Since(startTime).Truncate(time.Second),
+			)
 		return true, nil
 	})
 

--- a/test/util/framework/dns.go
+++ b/test/util/framework/dns.go
@@ -68,7 +68,7 @@ func HostnameFromURL(rawURL string) (string, error) {
 // uses a fresh net.Resolver with PreferGo: true to bypass negative DNS
 // caching from prior NXDOMAIN responses.
 func WaitForDNSResolution(ctx context.Context, hostname string, timeout time.Duration) error {
-	var lastErrStr string
+	var lastErr error
 	startTime := time.Now()
 
 	err := wait.PollUntilContextTimeout(ctx, 10*time.Second, timeout, true, func(ctx context.Context) (done bool, err error) {
@@ -78,37 +78,49 @@ func WaitForDNSResolution(ctx context.Context, hostname string, timeout time.Dur
 
 		addrs, lookupErr := resolver.LookupHost(lookupCtx, hostname)
 		if lookupErr != nil {
-			errStr := formatDNSError(lookupErr)
-			if errStr != lastErrStr {
-				klog.InfoS("DNS resolution pending",
-					"hostname", hostname,
-					"error", errStr,
-					"elapsed", time.Since(startTime).Truncate(time.Second),
-				)
-				lastErrStr = errStr
+			if lastErr == nil || lookupErr.Error() != lastErr.Error() {
+				logDNSError(hostname, lookupErr, time.Since(startTime).Truncate(time.Second))
+				lastErr = lookupErr
 			}
 			return false, nil
 		}
 
-		klog.InfoS("DNS resolved",
-			"hostname", hostname,
-			"addresses", addrs,
-			"elapsed", time.Since(startTime).Truncate(time.Second),
-		)
+		if lastErr != nil {
+			klog.InfoS("DNS resolved",
+				"hostname", hostname,
+				"addresses", addrs,
+				"elapsed", time.Since(startTime).Truncate(time.Second),
+			)
+		}
 		return true, nil
 	})
 
 	if err != nil {
+		lastErrStr := ""
+		if lastErr != nil {
+			lastErrStr = lastErr.Error()
+		}
 		return fmt.Errorf("DNS for %s did not resolve within %s (last error: %s): %w", hostname, timeout, lastErrStr, err)
 	}
 	return nil
 }
 
-func formatDNSError(err error) string {
+func logDNSError(hostname string, err error, elapsed time.Duration) {
 	var dnsErr *net.DNSError
 	if errors.As(err, &dnsErr) {
-		return fmt.Sprintf("server=%s isNotFound=%v isTemporary=%v err=%s",
-			dnsErr.Server, dnsErr.IsNotFound, dnsErr.IsTemporary, dnsErr.Err)
+		klog.InfoS("DNS resolution pending",
+			"hostname", hostname,
+			"server", dnsErr.Server,
+			"isNotFound", dnsErr.IsNotFound,
+			"isTemporary", dnsErr.IsTemporary,
+			"error", dnsErr.Err,
+			"elapsed", elapsed,
+		)
+		return
 	}
-	return err.Error()
+	klog.InfoS("DNS resolution pending",
+		"hostname", hostname,
+		"error", err,
+		"elapsed", elapsed,
+	)
 }

--- a/test/util/framework/dns.go
+++ b/test/util/framework/dns.go
@@ -38,10 +38,22 @@ func HostnameFromURL(rawURL string) (string, error) {
 	}
 
 	hostname := parsed.Hostname()
-	if hostname == "" {
-		return "", fmt.Errorf("no hostname found in %q", rawURL)
+	if hostname != "" {
+		return hostname, nil
 	}
-	return hostname, nil
+
+	// url.Parse treats scheme-less inputs like "example.com" as a relative
+	// path and "example.com:443" as scheme:opaque, leaving Host empty in
+	// both cases. Only fall back to raw splitting when no scheme was parsed.
+	if parsed.Scheme == "" || parsed.Opaque != "" {
+		if h, _, err := net.SplitHostPort(rawURL); err == nil && h != "" {
+			return h, nil
+		}
+		if parsed.Path != "" {
+			return parsed.Path, nil
+		}
+	}
+	return "", fmt.Errorf("no hostname found in %q", rawURL)
 }
 
 // WaitForDNSResolution polls DNS for the given hostname until at least one
@@ -59,7 +71,7 @@ func WaitForDNSResolution(ctx context.Context, hostname string, timeout time.Dur
 
 		addrs, lookupErr := resolver.LookupHost(lookupCtx, hostname)
 		if lookupErr != nil {
-			errStr := formatDNSError(lookupErr, hostname)
+			errStr := formatDNSError(lookupErr)
 			if errStr != lastErrStr {
 				klog.Infof("DNS resolution pending for %s: %s (elapsed %s)", hostname, errStr, time.Since(startTime).Truncate(time.Second))
 				lastErrStr = errStr
@@ -77,7 +89,7 @@ func WaitForDNSResolution(ctx context.Context, hostname string, timeout time.Dur
 	return nil
 }
 
-func formatDNSError(err error, hostname string) string {
+func formatDNSError(err error) string {
 	var dnsErr *net.DNSError
 	if errors.As(err, &dnsErr) {
 		return fmt.Sprintf("server=%s isNotFound=%v isTemporary=%v err=%s",

--- a/test/util/framework/dns.go
+++ b/test/util/framework/dns.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -50,6 +51,11 @@ func HostnameFromURL(rawURL string) (string, error) {
 			return h, nil
 		}
 		if parsed.Path != "" {
+			// Strip any path component — "example.com/path" should
+			// return "example.com", not "example.com/path".
+			if idx := strings.IndexByte(parsed.Path, '/'); idx > 0 {
+				return parsed.Path[:idx], nil
+			}
 			return parsed.Path, nil
 		}
 	}

--- a/test/util/framework/dns.go
+++ b/test/util/framework/dns.go
@@ -43,9 +43,10 @@ func HostnameFromURL(rawURL string) (string, error) {
 		return hostname, nil
 	}
 
-	// url.Parse treats scheme-less inputs like "example.com" as a relative
-	// path and "example.com:443" as scheme:opaque, leaving Host empty in
-	// both cases. Only fall back to raw splitting when no scheme was parsed.
+	// url.Parse treats scheme-less inputs in two ways that leave Host empty:
+	// - "example.com" becomes a relative path (Scheme="", Path="example.com")
+	// - "example.com:443" becomes scheme:opaque (Scheme="example.com", Opaque="443")
+	// Fall back to raw splitting for both cases.
 	if parsed.Scheme == "" || parsed.Opaque != "" {
 		if h, _, err := net.SplitHostPort(rawURL); err == nil && h != "" {
 			return h, nil

--- a/test/util/framework/dns_test.go
+++ b/test/util/framework/dns_test.go
@@ -46,6 +46,16 @@ func TestHostnameFromURL(t *testing.T) {
 			want:  "example.com",
 		},
 		{
+			name:  "bare hostname",
+			input: "console-openshift-console.apps.example.com",
+			want:  "console-openshift-console.apps.example.com",
+		},
+		{
+			name:  "bare hostname with port",
+			input: "console-openshift-console.apps.example.com:443",
+			want:  "console-openshift-console.apps.example.com",
+		},
+		{
 			name:      "empty string",
 			input:     "",
 			expectErr: true,

--- a/test/util/framework/dns_test.go
+++ b/test/util/framework/dns_test.go
@@ -1,0 +1,78 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"testing"
+)
+
+func TestHostnameFromURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		want      string
+		expectErr bool
+	}{
+		{
+			name:  "full HTTPS URL",
+			input: "https://console-openshift-console.apps.example.com",
+			want:  "console-openshift-console.apps.example.com",
+		},
+		{
+			name:  "HTTPS URL with port",
+			input: "https://console-openshift-console.apps.example.com:443",
+			want:  "console-openshift-console.apps.example.com",
+		},
+		{
+			name:  "HTTPS URL with path",
+			input: "https://console-openshift-console.apps.example.com/path",
+			want:  "console-openshift-console.apps.example.com",
+		},
+		{
+			name:  "HTTP URL",
+			input: "http://example.com:8080",
+			want:  "example.com",
+		},
+		{
+			name:      "empty string",
+			input:     "",
+			expectErr: true,
+		},
+		{
+			name:      "scheme only",
+			input:     "https://",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := HostnameFromURL(tt.input)
+			if tt.expectErr {
+				if err == nil {
+					t.Errorf("expected error, got hostname %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/test/util/framework/dns_test.go
+++ b/test/util/framework/dns_test.go
@@ -56,6 +56,16 @@ func TestHostnameFromURL(t *testing.T) {
 			want:  "console-openshift-console.apps.example.com",
 		},
 		{
+			name:  "bare hostname with path",
+			input: "console-openshift-console.apps.example.com/some/path",
+			want:  "console-openshift-console.apps.example.com",
+		},
+		{
+			name:  "HTTPS URL with path and port",
+			input: "https://console-openshift-console.apps.example.com:8080/api/v1",
+			want:  "console-openshift-console.apps.example.com",
+		},
+		{
 			name:      "empty string",
 			input:     "",
 			expectErr: true,

--- a/test/util/verifiers/serving_app.go
+++ b/test/util/verifiers/serving_app.go
@@ -65,8 +65,8 @@ func (v verifySimpleWebApp) Verify(ctx context.Context, adminRESTConfig *rest.Co
 
 	url := "https://" + app.RouteHost
 
-	if err := framework.WaitForDNSResolution(ctx, host, framework.DNSResolutionTimeout); err != nil {
-		return fmt.Errorf("DNS for route host %s did not resolve: %w", host, err)
+	if err := framework.WaitForDNSResolution(ctx, app.RouteHost, framework.DNSResolutionTimeout); err != nil {
+		return fmt.Errorf("DNS for route host %s did not resolve: %w", app.RouteHost, err)
 	}
 
 	// First wait for app reachability using InsecureSkipVerify.

--- a/test/util/verifiers/serving_app.go
+++ b/test/util/verifiers/serving_app.go
@@ -121,8 +121,13 @@ func waitForRouteReachability(ctx context.Context, client *http.Client, url stri
 			if lastErr == nil || err.Error() != lastErr.Error() {
 				var dnsErr *net.DNSError
 				if errors.As(err, &dnsErr) {
-					klog.Infof("DNS error for route %s: server=%s isNotFound=%v isTemporary=%v err=%s",
-						url, dnsErr.Server, dnsErr.IsNotFound, dnsErr.IsTemporary, dnsErr.Err)
+					klog.InfoS("DNS error for route",
+						"url", url,
+						"server", dnsErr.Server,
+						"isNotFound", dnsErr.IsNotFound,
+						"isTemporary", dnsErr.IsTemporary,
+						"error", dnsErr.Err,
+					)
 				} else {
 					klog.InfoS("failed to get response from route",
 						"url", url,
@@ -147,8 +152,9 @@ func waitForRouteReachability(ctx context.Context, client *http.Client, url stri
 		responseByte, err := httputil.DumpResponse(resp, true)
 		if err != nil {
 			if lastErr == nil || err.Error() != lastErr.Error() {
-				klog.Info(err, "failed to read response from route",
+				klog.InfoS("failed to read response from route",
 					"url", url,
+					"error", err,
 				)
 			}
 			lastErr = err

--- a/test/util/verifiers/serving_app.go
+++ b/test/util/verifiers/serving_app.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"crypto/tls"
 	"embed"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -63,6 +64,10 @@ func (v verifySimpleWebApp) Verify(ctx context.Context, adminRESTConfig *rest.Co
 	v.namespaceName = app.Namespace
 
 	url := "https://" + app.RouteHost
+
+	if err := framework.WaitForDNSResolution(ctx, host, framework.DNSResolutionTimeout); err != nil {
+		return fmt.Errorf("DNS for route host %s did not resolve: %w", host, err)
+	}
 
 	// First wait for app reachability using InsecureSkipVerify.
 	// Cert provisioning (OneCert -> Key Vault -> ACM -> IngressController) has
@@ -114,9 +119,15 @@ func waitForRouteReachability(ctx context.Context, client *http.Client, url stri
 		resp, err := client.Get(url)
 		if err != nil {
 			if lastErr == nil || err.Error() != lastErr.Error() {
-				klog.Info(err, "failed to get response from route",
-					"url", url,
-				)
+				var dnsErr *net.DNSError
+				if errors.As(err, &dnsErr) {
+					klog.Infof("DNS error for route %s: server=%s isNotFound=%v isTemporary=%v err=%s",
+						url, dnsErr.Server, dnsErr.IsNotFound, dnsErr.IsTemporary, dnsErr.Err)
+				} else {
+					klog.Info(err, "failed to get response from route",
+						"url", url,
+					)
+				}
 			}
 			lastErr = err
 			return false, nil

--- a/test/util/verifiers/serving_app.go
+++ b/test/util/verifiers/serving_app.go
@@ -124,8 +124,9 @@ func waitForRouteReachability(ctx context.Context, client *http.Client, url stri
 					klog.Infof("DNS error for route %s: server=%s isNotFound=%v isTemporary=%v err=%s",
 						url, dnsErr.Server, dnsErr.IsNotFound, dnsErr.IsTemporary, dnsErr.Err)
 				} else {
-					klog.Info(err, "failed to get response from route",
+					klog.InfoS("failed to get response from route",
 						"url", url,
+						"error", err,
 					)
 				}
 			}


### PR DESCRIPTION
## Summary

- Add `WaitForDNSResolution()` utility that polls DNS with a fresh `net.Resolver{PreferGo: true}` per attempt to defeat Go's negative DNS caching
- Integrate DNS readiness pre-check in `cluster_tls_endpoints.go` (before ingress TLS cert verification) and `serving_app.go` (before route HTTP access)
- Enhance DNS error classification in `waitForRouteReachability()` for better CI log diagnostics

## Why

E2E tests intermittently fail (~7%) with `dial tcp: lookup <hostname>: no such host` when accessing HCP cluster routes. Root cause is a DNS propagation race: the backend constructs the console URL from `HostedCluster.Spec.DNS.BaseDomain` (string concatenation) and stores it in CosmosDB, but the actual DNS records (wildcard CNAME in a delegated subzone + NS delegation) are created by Cluster Service asynchronously and may not have propagated by the time the test dials the hostname. Go's default resolver caches NXDOMAIN responses, compounding the problem across retry iterations.

Evidence: Prow builds [2068641277968125952](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/branch-ci-Azure-ARO-HCP-main-e2e-prod-e2e-parallel/2068641277968125952) and [2068520879767162880](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/branch-ci-Azure-ARO-HCP-main-e2e-prod-e2e-parallel/2068520879767162880) each show 4 DNS "no such host" failures across console, cilium, and multiversion tests. The issue affects ALL routes on the wildcard domain, not just the console.

Resolves: [ARO-27954](https://redhat.atlassian.net/browse/ARO-27954)
Related: [AROSLSRE-1198](https://redhat.atlassian.net/browse/AROSLSRE-1198) (cert delivery latency — independent issue, being addressed separately)

## Test plan

- [x] `go test ./test/util/framework/...` — unit tests for `HostnameFromURL()` pass
- [x] `go vet` — clean on all modified packages
- [x] `go build` — all modified packages compile
- [ ] Monitor `branch-ci-Azure-ARO-HCP-main-e2e-prod-e2e-parallel` after merge for absence of DNS "no such host" failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)