### PR TITLE
fix: apply minor offset on OpenShift major version jumps

### DIFF
--- a/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
+++ b/backend/pkg/controllers/upgradecontrollers/control_plane_desired_version_controller.go
@@ -561,7 +561,8 @@ func selectBestVersionFromCandidates(
 
 	// Check if next minor channel exists before checking for gateways.
 	// Query the public graph API directly (not GetUpdates from a candidate version).
-	nextMinor := fmt.Sprintf("%d.%d", targetMinorVersion.Major, targetMinorVersion.Minor+1)
+	nextMinorVersion := api.NextMinorReleaseLine(targetMinorVersion)
+	nextMinor := fmt.Sprintf("%d.%d", nextMinorVersion.Major, nextMinorVersion.Minor)
 	nextMinorExists, err := graphClient.ChannelExists(ctx, channelGroup, nextMinor)
 	if err != nil {
 		return nil, utils.TrackError(fmt.Errorf("failed to check if channel %s-%s exists: %w", channelGroup, nextMinor, err))

--- a/internal/api/utils.go
+++ b/internal/api/utils.go
@@ -16,6 +16,7 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"iter"
 	"net/http"
 	"reflect"
@@ -23,6 +24,7 @@ import (
 	"strings"
 
 	"dario.cat/mergo"
+	"github.com/blang/semver/v4"
 	jsonpatch "github.com/evanphx/json-patch"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -63,6 +65,19 @@ var AllowedChannelGroups = sets.New("stable", "fast")
 
 // AllowedChannelGroupsWithExperimentalFlag is the set the service allows to use when using the Experimental Feature AFEC flag
 var AllowedChannelGroupsWithExperimentalFlag = sets.New("stable", "fast", "candidate", "nightly")
+
+// NextMinorReleaseLine returns the next OpenShift minor release line after v as
+// major.minor.0 (patch and pre-release metadata cleared).
+//
+// Within a major, that is major.(minor+1).0. At major boundaries that do not
+// continue as major.(minor+1), a bridged next-major line is returned instead
+// (for example 4.23.x → 5.1.0).
+func NextMinorReleaseLine(v semver.Version) semver.Version {
+	if targetReleaseLine, ok := AllowMajorUpgradePaths[fmt.Sprintf("%d.%d", v.Major, v.Minor)]; ok {
+		return Must(semver.ParseTolerant(targetReleaseLine))
+	}
+	return semver.Version{Major: v.Major, Minor: v.Minor + 1}
+}
 
 // Ptr returns a pointer to p.
 func Ptr[T any](p T) *T {

--- a/internal/api/utils_test.go
+++ b/internal/api/utils_test.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/blang/semver/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -224,6 +225,50 @@ func TestNonNilSliceValues(t *testing.T) {
 			if !reflect.DeepEqual(got, tc.want) {
 				t.Errorf("NonNilSliceValues() = %v, want %v", got, tc.want)
 			}
+		})
+	}
+}
+
+func TestNextMinorReleaseLine(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "same-major increments minor",
+			in:   "4.19.15",
+			want: "4.20.0",
+		},
+		{
+			name: "bridged cross-major jump 4.23 to 5.1",
+			in:   "4.23.0",
+			want: "5.1.0",
+		},
+		{
+			name: "bridged cross-major jump 4.22 to 5.0",
+			in:   "4.22.0",
+			want: "5.0.0",
+		},
+		{
+			name: "same-major on 5.1 increments minor",
+			in:   "5.1.0",
+			want: "5.2.0",
+		},
+		{
+			name: "nightly version increments minor and clears prerelease",
+			in:   "4.19.0-0.nightly-multi-2026-01-10-204154",
+			want: "4.20.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := NextMinorReleaseLine(Must(semver.ParseTolerant(tt.in)))
+			assert.Equal(t, Must(semver.ParseTolerant(tt.want)), got)
 		})
 	}
 }

--- a/test/util/framework/version_helper.go
+++ b/test/util/framework/version_helper.go
@@ -118,7 +118,8 @@ func GetInstallVersionForZStreamUpgrade(ctx context.Context, channelGroup string
 		return candidates[0].String(), false, nil
 	}
 
-	nextMinorStr := fmt.Sprintf("%d.%d", candidates[0].Major, candidates[0].Minor+1)
+	nextMinorVersion := api.NextMinorReleaseLine(candidates[0])
+	nextMinorStr := fmt.Sprintf("%d.%d", nextMinorVersion.Major, nextMinorVersion.Minor)
 	maxVersion, err := GetLatestVersionInMinor(ctx, channelGroup, nextMinorStr)
 	if err != nil {
 		if !cincinnati.IsCincinnatiVersionNotFoundError(err) {


### PR DESCRIPTION
### What

fix: apply minor offset on OpenShift major version jumps

### Why

The "minor+1" approach breaks at the 4→5 boundary (4.23 jumps to 5.x, not 4.24). Add a utility that accounts for that and use it in the control plane desired version controller

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

https://redhat.atlassian.net/browse/ARO-28474

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
