### PR TITLE
Fleet controller hot loop

### DIFF
--- a/fleet/pkg/controllers/base/registration_condition.go
+++ b/fleet/pkg/controllers/base/registration_condition.go
@@ -25,28 +25,45 @@ import (
 // reconcile result. Once True, the condition never regresses to False —
 // errors after a successful registration are recorded as True/CheckFailed
 // so operators can observe the problem without losing the registration state.
+//
+// When the condition already carries the target Status and Reason, the
+// update is skipped even if the Message differs. External API errors
+// embed per-request fields (operation IDs, timestamps) that change on
+// every call; writing a new Message each retry would bump the Cosmos
+// etag, trigger an informer update event, and enqueue the key via Add()
+// — bypassing the workqueue rate limiter and creating a hot retry loop.
+// The full error is still logged by the workqueue error handler, so no
+// debugging information is lost.
 func SetRegistrationCondition(conditions *[]metav1.Condition, conditionType string, syncErr error) {
+	var desired metav1.Condition
 	switch {
 	case syncErr == nil:
-		apimeta.SetStatusCondition(conditions, metav1.Condition{
+		desired = metav1.Condition{
 			Type:    conditionType,
 			Status:  metav1.ConditionTrue,
 			Reason:  string(fleetapi.ManagementClusterConditionReasonRegistered),
 			Message: "Registration successful",
-		})
+		}
 	case apimeta.IsStatusConditionTrue(*conditions, conditionType):
-		apimeta.SetStatusCondition(conditions, metav1.Condition{
+		desired = metav1.Condition{
 			Type:    conditionType,
 			Status:  metav1.ConditionTrue,
 			Reason:  string(fleetapi.ManagementClusterConditionReasonRegistrationCheckFailed),
 			Message: syncErr.Error(),
-		})
+		}
 	default:
-		apimeta.SetStatusCondition(conditions, metav1.Condition{
+		desired = metav1.Condition{
 			Type:    conditionType,
 			Status:  metav1.ConditionFalse,
 			Reason:  string(fleetapi.ManagementClusterConditionReasonRegistrationFailed),
 			Message: syncErr.Error(),
-		})
+		}
 	}
+
+	existing := apimeta.FindStatusCondition(*conditions, conditionType)
+	if existing != nil && existing.Status == desired.Status && existing.Reason == desired.Reason {
+		return
+	}
+
+	apimeta.SetStatusCondition(conditions, desired)
 }

--- a/fleet/pkg/controllers/base/registration_condition_test.go
+++ b/fleet/pkg/controllers/base/registration_condition_test.go
@@ -66,18 +66,34 @@ func TestSetRegistrationCondition(t *testing.T) {
 			expectedMessage: "connection refused",
 		},
 		{
-			name: "error after previous False stays False/RegistrationFailed",
+			name: "error after previous False/RegistrationFailed preserves existing message",
 			existingConditions: []metav1.Condition{
 				{
-					Type:   conditionType,
-					Status: metav1.ConditionFalse,
-					Reason: string(fleetapi.ManagementClusterConditionReasonRegistrationFailed),
+					Type:    conditionType,
+					Status:  metav1.ConditionFalse,
+					Reason:  string(fleetapi.ManagementClusterConditionReasonRegistrationFailed),
+					Message: "first error",
 				},
 			},
-			syncErr:         errors.New("still broken"),
+			syncErr:         errors.New("second error with different operation ID"),
 			expectedStatus:  metav1.ConditionFalse,
 			expectedReason:  string(fleetapi.ManagementClusterConditionReasonRegistrationFailed),
-			expectedMessage: "still broken",
+			expectedMessage: "first error",
+		},
+		{
+			name: "error after previous True/CheckFailed preserves existing message",
+			existingConditions: []metav1.Condition{
+				{
+					Type:    conditionType,
+					Status:  metav1.ConditionTrue,
+					Reason:  string(fleetapi.ManagementClusterConditionReasonRegistrationCheckFailed),
+					Message: "first check failure",
+				},
+			},
+			syncErr:         errors.New("second check failure with different timestamp"),
+			expectedStatus:  metav1.ConditionTrue,
+			expectedReason:  string(fleetapi.ManagementClusterConditionReasonRegistrationCheckFailed),
+			expectedMessage: "first check failure",
 		},
 		{
 			name: "no error after previous False transitions to True",

--- a/fleet/pkg/controllers/clustersserviceregistration/controller.go
+++ b/fleet/pkg/controllers/clustersserviceregistration/controller.go
@@ -94,6 +94,10 @@ func (s *clustersServiceRegistrationSyncer) SyncOnce(ctx context.Context, key fl
 
 	stamp, err := s.stampLister.Get(ctx, key.StampIdentifier)
 	if err != nil {
+		if database.IsNotFoundError(err) {
+			utils.LoggerFromContext(ctx).Info("stamp not found in lister, skipping")
+			return nil
+		}
 		return utils.TrackError(err)
 	}
 

--- a/fleet/pkg/controllers/clustersserviceregistration/controller_test.go
+++ b/fleet/pkg/controllers/clustersserviceregistration/controller_test.go
@@ -33,6 +33,7 @@ import (
 	fleetcontrollers "github.com/Azure/ARO-HCP/fleet/pkg/controllers/base"
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/fleet"
+	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/databasetesting"
 	"github.com/Azure/ARO-HCP/internal/ocm"
 )
@@ -400,8 +401,8 @@ func TestSyncOnce(t *testing.T) {
 	tests := []struct {
 		name                   string
 		stamp                  *fleet.Stamp
+		stampMissingFromLister bool
 		managementCluster      *fleet.ManagementCluster
-		excludeStampFromLister bool
 		setupCS                func(ctrl *gomock.Controller) ProvisionShardClient
 		wantErr                bool
 		wantCondition          string
@@ -417,14 +418,13 @@ func TestSyncOnce(t *testing.T) {
 			},
 		},
 		{
-			name:                   "stamp lister error: returns error",
+			name:                   "stamp not found in lister: no-op",
 			stamp:                  testStamp(stampID, true),
+			stampMissingFromLister: true,
 			managementCluster:      testManagementCluster(stampID),
-			excludeStampFromLister: true,
 			setupCS: func(ctrl *gomock.Controller) ProvisionShardClient {
 				return ocm.NewMockClusterServiceClientSpec(ctrl)
 			},
-			wantErr: true,
 		},
 		{
 			name:              "stamp not approved: sets condition false",
@@ -537,7 +537,7 @@ func TestSyncOnce(t *testing.T) {
 			}
 
 			stamps := map[string]*fleet.Stamp{}
-			if !tt.excludeStampFromLister {
+			if !tt.stampMissingFromLister {
 				stamps[tt.stamp.GetStampIdentifier()] = tt.stamp
 			}
 			stampLister := &fakeStampLister{stamps: stamps}
@@ -598,7 +598,7 @@ func (f *fakeStampLister) List(ctx context.Context) ([]*fleet.Stamp, error) {
 func (f *fakeStampLister) Get(ctx context.Context, stampIdentifier string) (*fleet.Stamp, error) {
 	s, ok := f.stamps[stampIdentifier]
 	if !ok {
-		return nil, fmt.Errorf("stamp %q not found", stampIdentifier)
+		return nil, database.NewNotFoundError()
 	}
 	return s, nil
 }

--- a/fleet/pkg/controllers/maestroregistration/controller.go
+++ b/fleet/pkg/controllers/maestroregistration/controller.go
@@ -76,6 +76,10 @@ func (s *maestroRegistrationSyncer) SyncOnce(ctx context.Context, key fleetcontr
 
 	stamp, err := s.stampLister.Get(ctx, key.StampIdentifier)
 	if err != nil {
+		if database.IsNotFoundError(err) {
+			utils.LoggerFromContext(ctx).Info("stamp not found in lister, skipping")
+			return nil
+		}
 		return utils.TrackError(err)
 	}
 

--- a/fleet/pkg/controllers/maestroregistration/controller_test.go
+++ b/fleet/pkg/controllers/maestroregistration/controller_test.go
@@ -30,6 +30,7 @@ import (
 	fleetcontrollers "github.com/Azure/ARO-HCP/fleet/pkg/controllers/base"
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/fleet"
+	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/databasetesting"
 )
 
@@ -111,7 +112,7 @@ func (f *fakeStampLister) List(ctx context.Context) ([]*fleet.Stamp, error) {
 func (f *fakeStampLister) Get(ctx context.Context, stampIdentifier string) (*fleet.Stamp, error) {
 	stamp, ok := f.stamps[stampIdentifier]
 	if !ok {
-		return nil, fmt.Errorf("stamp %q not found", stampIdentifier)
+		return nil, database.NewNotFoundError()
 	}
 	return stamp, nil
 }
@@ -209,19 +210,29 @@ func TestSyncOnce(t *testing.T) {
 	const stampID = "s1"
 
 	tests := []struct {
-		name              string
-		stamp             *fleet.Stamp
-		managementCluster *fleet.ManagementCluster
-		setupClient       func() MaestroConsumerClient
-		wantErr           bool
-		wantCondition     string
-		wantCondStatus    metav1.ConditionStatus
-		wantCondReason    string
+		name                   string
+		stamp                  *fleet.Stamp
+		stampMissingFromLister bool
+		managementCluster      *fleet.ManagementCluster
+		setupClient            func() MaestroConsumerClient
+		wantErr                bool
+		wantCondition          string
+		wantCondStatus         metav1.ConditionStatus
+		wantCondReason         string
 	}{
 		{
 			name:              "MC not found in DB: no-op",
 			stamp:             testStamp(stampID, true),
 			managementCluster: nil,
+			setupClient: func() MaestroConsumerClient {
+				return &fakeMaestroConsumerClient{}
+			},
+		},
+		{
+			name:                   "stamp not found in lister: no-op",
+			stamp:                  testStamp(stampID, true),
+			stampMissingFromLister: true,
+			managementCluster:      testManagementCluster(stampID),
 			setupClient: func() MaestroConsumerClient {
 				return &fakeMaestroConsumerClient{}
 			},
@@ -329,9 +340,11 @@ func TestSyncOnce(t *testing.T) {
 				t.Fatalf("failed to create mock DB: %v", err)
 			}
 
-			stampLister := &fakeStampLister{stamps: map[string]*fleet.Stamp{
-				tt.stamp.GetStampIdentifier(): tt.stamp,
-			}}
+			stamps := map[string]*fleet.Stamp{}
+			if !tt.stampMissingFromLister {
+				stamps[tt.stamp.GetStampIdentifier()] = tt.stamp
+			}
+			stampLister := &fakeStampLister{stamps: stamps}
 
 			syncer := &maestroRegistrationSyncer{
 				fleetDBClient:                mockDB,


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

- **Break hot retry loop in registration controllers**: `SetRegistrationCondition` now skips the condition update when Status and Reason are unchanged. OCM and Maestro API errors embed per-request fields (operation IDs, timestamps) that produce a different condition Message on every retry. Writing that changing Message bumps the Cosmos etag, the informer detects it as a real change etc etc
- **Skip requeue when stamp not found in lister**: Both registration controllers now return nil instead of an error when the stamp lister returns NotFound, matching the existing management cluster NotFound handling. A missing stamp is not retriable — the informer add event will re-enqueue when it appears.

### Why

<!-- Briefly explain why this change is needed -->

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
