### PR TITLE
fix(topology): add missing stamped: true to standalone mgmt services

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -34,4 +34,4 @@ The tree of pipelines making up the ARO HCP service are documented here from the
 - Microsoft.Azure.ARO.HCP.Observability ([ref](https://github.com/Azure/ARO-HCP/tree/main/observability/tracing/pipeline.yaml)): Deploy the development tracing stack.
 - Microsoft.Azure.ARO.HCP.Kusto.Delete ([ref](https://github.com/Azure/ARO-HCP/tree/main/dev-infrastructure/cleanup/delete.kusto.instance.pipeline.yaml)): Delete the kusto instance.
 - Microsoft.Azure.ARO.HCP.Service.Kubeconfig ([ref](https://github.com/Azure/ARO-HCP/tree/main/dev-infrastructure/svc-kubeconfig.yaml)): Grant access to AKS SVC AKS Clusters, mainly intended for E2E test setup.
-- Microsoft.Azure.ARO.HCP.Management.Kubeconfig ([ref](https://github.com/Azure/ARO-HCP/tree/main/dev-infrastructure/mgmt-kubeconfig.yaml)): Grant access to AKS SVC AKS Clusters, mainly intended for E2E test setup.
+- Microsoft.Azure.ARO.HCP.Management.Kubeconfig ([ref](https://github.com/Azure/ARO-HCP/tree/main/dev-infrastructure/mgmt-kubeconfig.yaml)): Grant access to AKS Management Clusters, mainly intended for E2E test setup.

--- a/topology.yaml
+++ b/topology.yaml
@@ -104,6 +104,7 @@ services:
   purpose: Deploy global shared infrastructure (STG V2).
 # Cleanup pipelines
 - serviceGroup: Microsoft.Azure.ARO.HCP.Management.Delete
+  stamped: true
   pipelinePath: dev-infrastructure/cleanup/delete.mgmt.pipeline.yaml
   purpose: Delete the management resources and management resource group
 - serviceGroup: Microsoft.Azure.ARO.HCP.Service.Delete
@@ -117,6 +118,7 @@ services:
   pipelinePath: dev-infrastructure/grafana-pipeline.yaml
   purpose: Test pipeline for Grafana reconciliation.
 - serviceGroup: Microsoft.Azure.ARO.HCP.Observability
+  stamped: true
   pipelinePath: observability/tracing/pipeline.yaml
   purpose: Deploy the development tracing stack.
 # Kusto Infra pipeline
@@ -127,5 +129,6 @@ services:
   pipelinePath: dev-infrastructure/svc-kubeconfig.yaml
   purpose: Grant access to AKS SVC AKS Clusters, mainly intended for E2E test setup.
 - serviceGroup: Microsoft.Azure.ARO.HCP.Management.Kubeconfig
+  stamped: true
   pipelinePath: dev-infrastructure/mgmt-kubeconfig.yaml
-  purpose: Grant access to AKS SVC AKS Clusters, mainly intended for E2E test setup.
+  purpose: Grant access to AKS Management Clusters, mainly intended for E2E test setup.


### PR DESCRIPTION
Jira: [AROSLSRE-1518](https://redhat.atlassian.net/browse/AROSLSRE-1518)

## Summary
- Add `stamped: true` to three standalone services in `topology.yaml` that define stamped resource groups but were missing the topology-level annotation
- Fix copy-paste error in `Management.Kubeconfig` purpose field ("SVC" → "Management")

## Problem
PR #6085 bumped ARO-Tools and added `stamped: true` to all management-cluster resource groups in pipeline files. The new ARO-Tools validation ([Azure/ARO-Tools#268](https://github.com/Azure/ARO-Tools/pull/268)) rejects unstamped services that define stamped resource groups.

Three standalone services sit outside the `Management.Infra` subtree (which has `stamped: true`) and don't inherit it:

| Service | Pipeline | Stamped RG |
|---------|----------|------------|
| `Microsoft.Azure.ARO.HCP.Observability` | `observability/tracing/pipeline.yaml` | `management` |
| `Microsoft.Azure.ARO.HCP.Management.Delete` | `dev-infrastructure/cleanup/delete.mgmt.pipeline.yaml` | `management` |
| `Microsoft.Azure.ARO.HCP.Management.Kubeconfig` | `dev-infrastructure/mgmt-kubeconfig.yaml` | `mgmt` |

This broke the CSPR postsubmit: [build 2077956455041863680](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/branch-ci-Azure-ARO-HCP-main-cspr-pipeline-postsubmit/2077956455041863680)

## Test plan
- [x] `templatize entrypoint graph --service-group Microsoft.Azure.ARO.HCP.Observability` fails before fix, passes after
- [x] `templatize entrypoint graph --service-group Microsoft.Azure.ARO.HCP.Management.Delete` fails before fix, passes after
- [x] `templatize entrypoint graph --service-group Microsoft.Azure.ARO.HCP.Management.Kubeconfig` fails before fix, passes after
- [x] `templatize pipeline validate` passes with all changes applied