### PR TITLE
feat: switch fleet informers to Cosmos change feed

### DIFF
--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -387,7 +387,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 	operationPhaseMetricsController := metricscontrollers.NewController(
 		"OperationPhaseMetrics", backendInformers.AllOperations(), operationPhaseHandler)
 
-	fleetInformers := dbinformers.NewFleetInformers(ctx, b.options.FleetDBClient.GlobalListers())
+	fleetInformers := dbinformers.NewFleetInformers(ctx, b.options.FleetDBClient.GlobalListers(), b.options.FleetDBClient)
 	managementClusterInformer, managementClusterLister := fleetInformers.ManagementClusters()
 
 	// Union kube-applier informers: one aggregator surface that fans out

--- a/fleet/pkg/manager/manager.go
+++ b/fleet/pkg/manager/manager.go
@@ -162,8 +162,7 @@ func (m *Manager) runControllersUnderLeaderElection(
 ) error {
 	logger := utils.LoggerFromContext(ctx)
 
-	relistDuration := 10 * time.Second
-	fleetInformers := informers.NewFleetInformersWithRelistDuration(ctx, m.FleetDBClient.GlobalListers(), &relistDuration)
+	fleetInformers := informers.NewFleetInformers(ctx, m.FleetDBClient.GlobalListers(), m.FleetDBClient)
 
 	stampInformer, stampLister := fleetInformers.Stamps()
 	managementClusterInformer, managementClusterLister := fleetInformers.ManagementClusters()

--- a/internal/database/fleet_client.go
+++ b/internal/database/fleet_client.go
@@ -15,6 +15,7 @@
 package database
 
 import (
+	"context"
 	"fmt"
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
@@ -33,6 +34,7 @@ const fleetContainer = "Fleet"
 // container holds management cluster inventory data with its own access
 // patterns and credential scoping.
 type FleetDBClient interface {
+	ChangeFeedClient
 	Stamps() StampsCRUD
 	GlobalListers() FleetGlobalListers
 }
@@ -75,6 +77,14 @@ func NewFleetDBClient(database *azcosmos.DatabaseClient) (FleetDBClient, error) 
 // NewFleetDBClientFromContainer wraps an already-opened container client.
 func NewFleetDBClientFromContainer(container *azcosmos.ContainerClient) FleetDBClient {
 	return &cosmosFleetDBClient{container: container}
+}
+
+func (c *cosmosFleetDBClient) GetChangeFeed(ctx context.Context, options *azcosmos.ChangeFeedOptions) (azcosmos.ChangeFeedResponse, error) {
+	return c.container.GetChangeFeed(ctx, options)
+}
+
+func (c *cosmosFleetDBClient) GetFeedRanges(ctx context.Context) ([]azcosmos.FeedRange, error) {
+	return c.container.GetFeedRanges(ctx)
 }
 
 func (c *cosmosFleetDBClient) Stamps() StampsCRUD {

--- a/internal/database/informers/fleet_informers.go
+++ b/internal/database/informers/fleet_informers.go
@@ -15,18 +15,16 @@
 package informers
 
 import (
-	"context"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
+	utilsclock "k8s.io/utils/clock"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
 	"github.com/Azure/ARO-HCP/internal/api/fleet"
 	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/database/listers"
-	"github.com/Azure/ARO-HCP/internal/utils"
 )
 
 const (
@@ -36,42 +34,23 @@ const (
 
 // NewStampInformer creates an unstarted SharedIndexInformer for stamps
 // with the default relist duration.
-func NewStampInformer(lister database.GlobalLister[fleet.Stamp]) cache.SharedIndexInformer {
-	return NewStampInformerWithRelistDuration(lister, StampRelistDuration)
+func NewStampInformer(lister database.GlobalLister[fleet.Stamp], cosmosClient database.ChangeFeedClient) cache.SharedIndexInformer {
+	return NewStampInformerWithRelistDuration(lister, cosmosClient, StampRelistDuration)
 }
 
 // NewStampInformerWithRelistDuration creates an unstarted SharedIndexInformer for stamps
 // with a configurable relist duration.
-func NewStampInformerWithRelistDuration(lister database.GlobalLister[fleet.Stamp], relistDuration time.Duration) cache.SharedIndexInformer {
-	lw := &cache.ListWatch{
-		ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
-			logger := utils.LoggerFromContext(ctx)
-			logger.Info("listing stamps")
-			defer logger.Info("finished listing stamps")
-
-			iter, err := lister.List(ctx, nil)
-			if err != nil {
-				return nil, err
-			}
-
-			list := &fleet.StampList{}
-			list.ResourceVersion = "0"
-			for _, s := range iter.Items(ctx) {
-				list.Items = append(list.Items, *s)
-			}
-			if err := iter.GetError(); err != nil {
-				return nil, err
-			}
-
-			return list, nil
-		},
-		WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
-			return newExpiringWatcher(ctx, relistDuration), nil
-		},
-	}
+func NewStampInformerWithRelistDuration(lister database.GlobalLister[fleet.Stamp], cosmosClient database.ChangeFeedClient, relistDuration time.Duration) cache.SharedIndexInformer {
+	lw := NewChangeFeedListWatcher[fleet.Stamp, *fleet.Stamp, database.GenericDocument[fleet.Stamp]](
+		[]azcorearm.ResourceType{fleet.StampResourceType},
+		utilsclock.RealClock{},
+		lister,
+		cosmosClient,
+		relistDuration,
+	)
 
 	return cache.NewSharedIndexInformerWithOptions(
-		&listWatchWithoutWatchListSemantics{lw},
+		&listWatchWithoutWatchListSemantics{lw.ToListWatch()},
 		&fleet.Stamp{},
 		cache.SharedIndexInformerOptions{
 			ResyncPeriod:      1 * time.Hour,
@@ -82,42 +61,23 @@ func NewStampInformerWithRelistDuration(lister database.GlobalLister[fleet.Stamp
 
 // NewManagementClusterInformer creates an unstarted SharedIndexInformer for management clusters
 // with the default relist duration.
-func NewManagementClusterInformer(lister database.GlobalLister[fleet.ManagementCluster]) cache.SharedIndexInformer {
-	return NewManagementClusterInformerWithRelistDuration(lister, ManagementClusterRelistDuration)
+func NewManagementClusterInformer(lister database.GlobalLister[fleet.ManagementCluster], cosmosClient database.ChangeFeedClient) cache.SharedIndexInformer {
+	return NewManagementClusterInformerWithRelistDuration(lister, cosmosClient, ManagementClusterRelistDuration)
 }
 
 // NewManagementClusterInformerWithRelistDuration creates an unstarted SharedIndexInformer for management clusters
 // with a configurable relist duration.
-func NewManagementClusterInformerWithRelistDuration(lister database.GlobalLister[fleet.ManagementCluster], relistDuration time.Duration) cache.SharedIndexInformer {
-	lw := &cache.ListWatch{
-		ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
-			logger := utils.LoggerFromContext(ctx)
-			logger.Info("listing management clusters")
-			defer logger.Info("finished listing management clusters")
-
-			iter, err := lister.List(ctx, nil)
-			if err != nil {
-				return nil, err
-			}
-
-			list := &fleet.ManagementClusterList{}
-			list.ResourceVersion = "0"
-			for _, mc := range iter.Items(ctx) {
-				list.Items = append(list.Items, *mc)
-			}
-			if err := iter.GetError(); err != nil {
-				return nil, err
-			}
-
-			return list, nil
-		},
-		WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
-			return newExpiringWatcher(ctx, relistDuration), nil
-		},
-	}
+func NewManagementClusterInformerWithRelistDuration(lister database.GlobalLister[fleet.ManagementCluster], cosmosClient database.ChangeFeedClient, relistDuration time.Duration) cache.SharedIndexInformer {
+	lw := NewChangeFeedListWatcher[fleet.ManagementCluster, *fleet.ManagementCluster, database.GenericDocument[fleet.ManagementCluster]](
+		[]azcorearm.ResourceType{fleet.ManagementClusterResourceType},
+		utilsclock.RealClock{},
+		lister,
+		cosmosClient,
+		relistDuration,
+	)
 
 	return cache.NewSharedIndexInformerWithOptions(
-		&listWatchWithoutWatchListSemantics{lw},
+		&listWatchWithoutWatchListSemantics{lw.ToListWatch()},
 		&fleet.ManagementCluster{},
 		cache.SharedIndexInformerOptions{
 			ResyncPeriod: 1 * time.Hour,

--- a/internal/database/informers/fleet_types.go
+++ b/internal/database/informers/fleet_types.go
@@ -17,7 +17,6 @@ package informers
 import (
 	"context"
 	"sync"
-	"time"
 
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
@@ -28,9 +27,9 @@ import (
 )
 
 // FleetInformers bundles one SharedIndexInformer per fleet type plus the
-// matching listers. Both the fleet management binary (future) and the
-// backend (cross-partition) construct one of these with the appropriate
-// database.FleetGlobalListers — the factory does not care which.
+// matching listers. Both the fleet management binary and the backend
+// construct one of these with the appropriate database.FleetGlobalListers
+// and database.FleetDBClient — the factory does not care which.
 type FleetInformers interface {
 	Stamps() (cache.SharedIndexInformer, listers.StampLister)
 	ManagementClusters() (cache.SharedIndexInformer, listers.ManagementClusterLister)
@@ -53,23 +52,11 @@ func (f *fleetInformers) ManagementClusters() (cache.SharedIndexInformer, lister
 }
 
 // NewFleetInformers creates FleetInformers with default relist durations.
-func NewFleetInformers(ctx context.Context, gl database.FleetGlobalListers) FleetInformers {
-	return NewFleetInformersWithRelistDuration(ctx, gl, nil)
-}
-
-// NewFleetInformersWithRelistDuration creates FleetInformers with a configurable relist duration.
-func NewFleetInformersWithRelistDuration(ctx context.Context, gl database.FleetGlobalListers, relistDuration *time.Duration) FleetInformers {
-	stampRelistDuration := StampRelistDuration
-	managementClusterRelistDuration := ManagementClusterRelistDuration
-	if relistDuration != nil {
-		stampRelistDuration = *relistDuration
-		managementClusterRelistDuration = *relistDuration
-	}
-
+func NewFleetInformers(ctx context.Context, globalListers database.FleetGlobalListers, fleetDBClient database.FleetDBClient) FleetInformers {
 	ret := &fleetInformers{}
-	ret.stampInformer = NewStampInformerWithRelistDuration(gl.Stamps(), stampRelistDuration)
+	ret.stampInformer = NewStampInformer(globalListers.Stamps(), fleetDBClient)
 	ret.stampLister = listers.NewStampLister(ret.stampInformer.GetIndexer())
-	ret.managementClusterInformer = NewManagementClusterInformerWithRelistDuration(gl.ManagementClusters(), managementClusterRelistDuration)
+	ret.managementClusterInformer = NewManagementClusterInformer(globalListers.ManagementClusters(), fleetDBClient)
 	ret.managementClusterLister = listers.NewManagementClusterLister(ret.managementClusterInformer.GetIndexer())
 
 	return ret

--- a/internal/database/informers/list_watch.go
+++ b/internal/database/informers/list_watch.go
@@ -19,71 +19,15 @@
 package informers
 
 import (
-	"context"
-	"net/http"
-	"time"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
 )
 
 // listWatchWithoutWatchListSemantics opts out of WatchListClient semantics.
 // Mirrors the unexported wrapper from client-go/tools/cache/listwatch.go.
-// Cosmos-backed informers use newExpiringWatcher which does not support
+// Cosmos-backed informers use ChangeFeedWatcher which does not support
 // the bookmark protocol that WatchListClient requires.
 type listWatchWithoutWatchListSemantics struct {
 	*cache.ListWatch
 }
 
 func (listWatchWithoutWatchListSemantics) IsWatchListSemanticsUnSupported() bool { return true }
-
-// expiringWatcher implements watch.Interface and sends an expired error after
-// the configured duration to cause the reflector to relist. This drives
-// SharedInformers backed by non-Kubernetes data sources like Cosmos that have
-// no native watch protocol. It is structurally identical to the backend's
-// expiring watcher; we copy it here so this package has no dependency on
-// backend/.
-type expiringWatcher struct {
-	result chan watch.Event
-	done   chan struct{}
-}
-
-// newExpiringWatcher creates a watcher that terminates after the given
-// duration by sending an HTTP 410 Gone / StatusReasonExpired error.
-func newExpiringWatcher(ctx context.Context, expiry time.Duration) watch.Interface {
-	w := &expiringWatcher{
-		result: make(chan watch.Event),
-		done:   make(chan struct{}),
-	}
-	go func() {
-		defer utilruntime.HandleCrash()
-		select {
-		case <-time.After(expiry):
-			w.result <- watch.Event{
-				Type: watch.Error,
-				Object: &metav1.Status{
-					Status:  metav1.StatusFailure,
-					Code:    http.StatusGone,
-					Reason:  metav1.StatusReasonExpired,
-					Message: "watch expired",
-				},
-			}
-		case <-w.done:
-		case <-ctx.Done():
-		}
-		close(w.result)
-	}()
-	return w
-}
-
-func (w *expiringWatcher) Stop() {
-	select {
-	case <-w.done:
-	default:
-		close(w.done)
-	}
-}
-
-func (w *expiringWatcher) ResultChan() <-chan watch.Event { return w.result }

--- a/internal/databasetesting/mock_fleet_client.go
+++ b/internal/databasetesting/mock_fleet_client.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
 
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
@@ -35,8 +36,9 @@ import (
 // production has the fleet container live in a different Cosmos container
 // (and behind different credentials), and the mock mirrors that boundary.
 type MockFleetDBClient struct {
-	mu        sync.RWMutex
-	documents map[string]json.RawMessage
+	mu         sync.RWMutex
+	documents  map[string]json.RawMessage
+	changeFeed mockChangeFeed
 }
 
 var _ database.FleetDBClient = &MockFleetDBClient{}
@@ -107,6 +109,20 @@ func (m *MockFleetDBClient) StoreDocument(cosmosID string, data json.RawMessage)
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.documents[strings.ToLower(cosmosID)] = data
+	m.changeFeed.record(data)
+}
+
+func (m *MockFleetDBClient) GetChangeFeed(ctx context.Context, options *azcosmos.ChangeFeedOptions) (azcosmos.ChangeFeedResponse, error) {
+	var continuation string
+	if options != nil && options.Continuation != nil {
+		continuation = *options.Continuation
+	}
+	docs, nextToken, hasNew := m.changeFeed.read(continuation)
+	return buildMockChangeFeedResponse(docs, nextToken, hasNew), nil
+}
+
+func (m *MockFleetDBClient) GetFeedRanges(ctx context.Context) ([]azcosmos.FeedRange, error) {
+	return []azcosmos.FeedRange{mockChangeFeedFeedRange}, nil
 }
 
 func (m *MockFleetDBClient) DeleteDocument(cosmosID string) {

--- a/test-integration/backend/unionkubeapplierinformers/integration_test.go
+++ b/test-integration/backend/unionkubeapplierinformers/integration_test.go
@@ -134,14 +134,13 @@ func TestUnionKubeApplierInformersController_E2E(t *testing.T) {
 		fleetClient := databasetesting.NewMockFleetDBClient()
 		require.NoError(t, createStamp(ctx, fleetClient, stampIdentifier))
 
-		relistDuration := fastRelistDuration
-		fleetInformers := dbinformers.NewFleetInformersWithRelistDuration(ctx, fleetClient.GlobalListers(), &relistDuration)
+		fleetInformers := dbinformers.NewFleetInformers(ctx, fleetClient.GlobalListers(), fleetClient)
 		managementClusterInformer, managementClusterLister := fleetInformers.ManagementClusters()
 
 		// Factory bridges the controller to the kube-applier registry.
 		factory := &cosmosKubeApplierFactory{
 			kubeApplierClients: kubeApplierClients,
-			relistDuration:     relistDuration,
+			relistDuration:     fastRelistDuration,
 		}
 
 		// Create the controller. Register an event recorder BEFORE Run so


### PR DESCRIPTION
### What

Fleet informers (StampInformer, ManagementClusterInformer) used an expiringWatcher with full relist every 10 seconds. Backend and kube-applier informers already use ChangeFeedListWatcher. This unifies the codebase on a single informer pattern.

- Embed ChangeFeedClient in FleetDBClient interface
- Replace expiringWatcher with ChangeFeedListWatcher for both Stamp and ManagementCluster informers
- Remove the 10s relist override in fleet manager (change feed polls at 1s intervals, 2min relist is the safety net)
- Add change feed support to MockFleetDBClient
- Remove now-unused expiringWatcher from internal/database/informers

### Why

<!-- Briefly explain why this change is needed -->

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
