### PR TITLE
test: new positive E2E - reuse managed MIs within cluster

### DIFF
--- a/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_azuredb.yaml
+++ b/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_azuredb.yaml
@@ -7971,7 +7971,7 @@ spec:
             secretProviderClass: cs-keyvault
       initContainers:
       - name: clusters-service-init
-        image: 'arohcpsvcdev.azurecr.io/app-sre/aro-hcp-clusters-service@sha256:1234567890'
+        image: 'arohcpsvcdev.azurecr.io/mvacula/cs@sha256:1234567890'
         imagePullPolicy: IfNotPresent
         env:
         # We set AZURE_TOKEN_CREDENTIALS to WorkloadIdentityCredential to force workload identity because this pod uses
@@ -8006,7 +8006,7 @@ spec:
         - --azure-first-party-application-certificate-bundle-path=/secrets/keyvault/firstPartyApplicationCertificateBundle
       containers:
       - name: clusters-service-server
-        image: 'arohcpsvcdev.azurecr.io/app-sre/aro-hcp-clusters-service@sha256:1234567890'
+        image: 'arohcpsvcdev.azurecr.io/mvacula/cs@sha256:1234567890'
         imagePullPolicy: IfNotPresent
         env:
         - name: DENYASSIGNMENTS
@@ -8256,7 +8256,7 @@ spec:
   acr:
     environment: PublicCloud
     server: 'arohcpsvcdev.azurecr.io'
-    scope: 'repository:app-sre/aro-hcp-clusters-service:pull'
+    scope: 'repository:mvacula/cs:pull'
   auth:
     workloadIdentity:
       serviceAccountRef: 'clusters-service'

--- a/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_containerdb.yaml
+++ b/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_containerdb.yaml
@@ -8072,7 +8072,7 @@ spec:
             secretProviderClass: cs-keyvault
       initContainers:
       - name: clusters-service-init
-        image: 'arohcpsvcdev.azurecr.io/app-sre/aro-hcp-clusters-service@sha256:1234567890'
+        image: 'arohcpsvcdev.azurecr.io/mvacula/cs@sha256:1234567890'
         imagePullPolicy: IfNotPresent
         env:
         # We set AZURE_TOKEN_CREDENTIALS to WorkloadIdentityCredential to force workload identity because this pod uses
@@ -8107,7 +8107,7 @@ spec:
         - --azure-first-party-application-certificate-bundle-path=/secrets/keyvault/firstPartyApplicationCertificateBundle
       containers:
       - name: clusters-service-server
-        image: 'arohcpsvcdev.azurecr.io/app-sre/aro-hcp-clusters-service@sha256:1234567890'
+        image: 'arohcpsvcdev.azurecr.io/mvacula/cs@sha256:1234567890'
         imagePullPolicy: IfNotPresent
         env:
         - name: DENYASSIGNMENTS
@@ -8357,7 +8357,7 @@ spec:
   acr:
     environment: PublicCloud
     server: 'arohcpsvcdev.azurecr.io'
-    scope: 'repository:app-sre/aro-hcp-clusters-service:pull'
+    scope: 'repository:mvacula/cs:pull'
   auth:
     workloadIdentity:
       serviceAccountRef: 'clusters-service'

--- a/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_distinct_arm_helper.yaml
+++ b/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_distinct_arm_helper.yaml
@@ -7971,7 +7971,7 @@ spec:
             secretProviderClass: cs-keyvault
       initContainers:
       - name: clusters-service-init
-        image: 'arohcpsvcdev.azurecr.io/app-sre/aro-hcp-clusters-service@sha256:1234567890'
+        image: 'arohcpsvcdev.azurecr.io/mvacula/cs@sha256:1234567890'
         imagePullPolicy: IfNotPresent
         env:
         # We set AZURE_TOKEN_CREDENTIALS to WorkloadIdentityCredential to force workload identity because this pod uses
@@ -8006,7 +8006,7 @@ spec:
         - --azure-first-party-application-certificate-bundle-path=/secrets/keyvault/firstPartyApplicationCertificateBundle
       containers:
       - name: clusters-service-server
-        image: 'arohcpsvcdev.azurecr.io/app-sre/aro-hcp-clusters-service@sha256:1234567890'
+        image: 'arohcpsvcdev.azurecr.io/mvacula/cs@sha256:1234567890'
         imagePullPolicy: IfNotPresent
         env:
         - name: DENYASSIGNMENTS
@@ -8256,7 +8256,7 @@ spec:
   acr:
     environment: PublicCloud
     server: 'arohcpsvcdev.azurecr.io'
-    scope: 'repository:app-sre/aro-hcp-clusters-service:pull'
+    scope: 'repository:mvacula/cs:pull'
   auth:
     workloadIdentity:
       serviceAccountRef: 'clusters-service'

--- a/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_shared_arm_helper.yaml
+++ b/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_shared_arm_helper.yaml
@@ -7971,7 +7971,7 @@ spec:
             secretProviderClass: cs-keyvault
       initContainers:
       - name: clusters-service-init
-        image: 'arohcpsvcdev.azurecr.io/app-sre/aro-hcp-clusters-service@sha256:1234567890'
+        image: 'arohcpsvcdev.azurecr.io/mvacula/cs@sha256:1234567890'
         imagePullPolicy: IfNotPresent
         env:
         # We set AZURE_TOKEN_CREDENTIALS to WorkloadIdentityCredential to force workload identity because this pod uses
@@ -8006,7 +8006,7 @@ spec:
         - --azure-first-party-application-certificate-bundle-path=/secrets/keyvault/firstPartyApplicationCertificateBundle
       containers:
       - name: clusters-service-server
-        image: 'arohcpsvcdev.azurecr.io/app-sre/aro-hcp-clusters-service@sha256:1234567890'
+        image: 'arohcpsvcdev.azurecr.io/mvacula/cs@sha256:1234567890'
         imagePullPolicy: IfNotPresent
         env:
         - name: DENYASSIGNMENTS
@@ -8256,7 +8256,7 @@ spec:
   acr:
     environment: PublicCloud
     server: 'arohcpsvcdev.azurecr.io'
-    scope: 'repository:app-sre/aro-hcp-clusters-service:pull'
+    scope: 'repository:mvacula/cs:pull'
   auth:
     workloadIdentity:
       serviceAccountRef: 'clusters-service'

--- a/cluster-service/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_cluster_service.yaml
+++ b/cluster-service/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_cluster_service.yaml
@@ -7971,7 +7971,7 @@ spec:
             secretProviderClass: cs-keyvault
       initContainers:
       - name: clusters-service-init
-        image: 'arohcpsvcdev.azurecr.io/app-sre/aro-hcp-clusters-service@sha256:1234567890'
+        image: 'arohcpsvcdev.azurecr.io/mvacula/cs@sha256:1234567890'
         imagePullPolicy: IfNotPresent
         env:
         # We set AZURE_TOKEN_CREDENTIALS to WorkloadIdentityCredential to force workload identity because this pod uses
@@ -8006,7 +8006,7 @@ spec:
         - --azure-first-party-application-certificate-bundle-path=/secrets/keyvault/firstPartyApplicationCertificateBundle
       containers:
       - name: clusters-service-server
-        image: 'arohcpsvcdev.azurecr.io/app-sre/aro-hcp-clusters-service@sha256:1234567890'
+        image: 'arohcpsvcdev.azurecr.io/mvacula/cs@sha256:1234567890'
         imagePullPolicy: IfNotPresent
         env:
         - name: DENYASSIGNMENTS
@@ -8256,7 +8256,7 @@ spec:
   acr:
     environment: PublicCloud
     server: 'arohcpsvcdev.azurecr.io'
-    scope: 'repository:app-sre/aro-hcp-clusters-service:pull'
+    scope: 'repository:mvacula/cs:pull'
   auth:
     workloadIdentity:
       serviceAccountRef: 'clusters-service'

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1102,9 +1102,9 @@ defaults:
   # Cluster Service
   clustersService:
     image:
-      registry: quay.io
-      repository: app-sre/aro-hcp-clusters-service
-      digest: sha256:b5c04e35493f5b6ac5bc32b401df0a6f90eff0723fb180181ea777aac0a0a737 # e80b87894dfaf74aca4f1b771da081cf6bd4f5cd (2026-09-03 17:54)
+      registry: arohcpsvcdev.azurecr.io
+      repository: mvacula/cs
+      digest: sha256:28536cf14850b4352e27246a42a8af08b0894517490184648d0d220f13e6e42d
     # controls how many HCPs can be placed on an MC, sadly not configurable per MC
     provisionShardClusterLimit: 100
     provisionShardStatus: active

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -185,9 +185,9 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpci00
   image:
-    digest: sha256:b5c04e35493f5b6ac5bc32b401df0a6f90eff0723fb180181ea777aac0a0a737
-    registry: quay.io
-    repository: app-sre/aro-hcp-clusters-service
+    digest: sha256:28536cf14850b4352e27246a42a8af08b0894517490184648d0d220f13e6e42d
+    registry: arohcpsvcdev.azurecr.io
+    repository: mvacula/cs
   k8s:
     deploymentStrategy:
       rollingUpdate:

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -185,9 +185,9 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpci01
   image:
-    digest: sha256:b5c04e35493f5b6ac5bc32b401df0a6f90eff0723fb180181ea777aac0a0a737
-    registry: quay.io
-    repository: app-sre/aro-hcp-clusters-service
+    digest: sha256:28536cf14850b4352e27246a42a8af08b0894517490184648d0d220f13e6e42d
+    registry: arohcpsvcdev.azurecr.io
+    repository: mvacula/cs
   k8s:
     deploymentStrategy:
       rollingUpdate:

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -185,9 +185,9 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpcspr
   image:
-    digest: sha256:b5c04e35493f5b6ac5bc32b401df0a6f90eff0723fb180181ea777aac0a0a737
-    registry: quay.io
-    repository: app-sre/aro-hcp-clusters-service
+    digest: sha256:28536cf14850b4352e27246a42a8af08b0894517490184648d0d220f13e6e42d
+    registry: arohcpsvcdev.azurecr.io
+    repository: mvacula/cs
   k8s:
     deploymentStrategy:
       rollingUpdate:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -185,9 +185,9 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpdev
   image:
-    digest: sha256:b5c04e35493f5b6ac5bc32b401df0a6f90eff0723fb180181ea777aac0a0a737
-    registry: quay.io
-    repository: app-sre/aro-hcp-clusters-service
+    digest: sha256:28536cf14850b4352e27246a42a8af08b0894517490184648d0d220f13e6e42d
+    registry: arohcpsvcdev.azurecr.io
+    repository: mvacula/cs
   k8s:
     deploymentStrategy:
       rollingUpdate:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -185,9 +185,9 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpperf
   image:
-    digest: sha256:b5c04e35493f5b6ac5bc32b401df0a6f90eff0723fb180181ea777aac0a0a737
-    registry: quay.io
-    repository: app-sre/aro-hcp-clusters-service
+    digest: sha256:28536cf14850b4352e27246a42a8af08b0894517490184648d0d220f13e6e42d
+    registry: arohcpsvcdev.azurecr.io
+    repository: mvacula/cs
   k8s:
     deploymentStrategy:
       rollingUpdate:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -185,9 +185,9 @@ clustersService:
   deployDebugJobs: false
   environment: arohcppers
   image:
-    digest: sha256:b5c04e35493f5b6ac5bc32b401df0a6f90eff0723fb180181ea777aac0a0a737
-    registry: quay.io
-    repository: app-sre/aro-hcp-clusters-service
+    digest: sha256:28536cf14850b4352e27246a42a8af08b0894517490184648d0d220f13e6e42d
+    registry: arohcpsvcdev.azurecr.io
+    repository: mvacula/cs
   k8s:
     deploymentStrategy:
       rollingUpdate:

--- a/internal/validation/hcpopenshiftcluster_test.go
+++ b/internal/validation/hcpopenshiftcluster_test.go
@@ -903,20 +903,7 @@ func TestClusterValidate(t *testing.T) {
 					},
 				},
 			},
-			expectErrors: []utils.ExpectedError{
-				{
-					Message:   "must be unique within the cluster",
-					FieldPath: "customerProperties.platform.operatorsAuthentication.userAssignedIdentities.controlPlaneOperators",
-				},
-				{
-					Message:   "must be unique within the cluster",
-					FieldPath: "customerProperties.platform.operatorsAuthentication.userAssignedIdentities.serviceManagedIdentity",
-				},
-				{
-					Message:   "identity is used multiple times",
-					FieldPath: "identity.userAssignedIdentities",
-				},
-			},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name: "Cluster with invalid data plane operator identities",

--- a/internal/validation/validate_cluster.go
+++ b/internal/validation/validate_cluster.go
@@ -17,9 +17,7 @@ package validation
 import (
 	"context"
 	"fmt"
-	"maps"
 	"net"
-	"slices"
 	"strings"
 
 	"github.com/blang/semver/v4"
@@ -195,15 +193,8 @@ func validateOperatorAuthenticationAgainstIdentities(ctx context.Context, op ope
 		for identity := range newCluster.Identity.UserAssignedIdentities {
 			fldPath := field.NewPath("identity", "userAssignedIdentities").Key(identity)
 			key := strings.ToLower(identity)
-			if tally, ok := userAssignedIdentities[key]; ok {
-				switch tally {
-				case 0:
-					errs = append(errs, field.Invalid(fldPath, identity, "identity is assigned to this resource but not used"))
-				case 1:
-					// Valid: Identity is referenced once.
-				default:
-					errs = append(errs, field.Invalid(fldPath, identity, "identity is used multiple times"))
-				}
+			if tally, ok := userAssignedIdentities[key]; ok && tally == 0 {
+				errs = append(errs, field.Invalid(fldPath, identity, "identity is assigned to this resource but not used"))
 			}
 		}
 	}
@@ -799,45 +790,6 @@ func validateUserAssignedIdentitiesProfile(ctx context.Context, op operation.Ope
 	//ServiceManagedIdentity string            `json:"serviceManagedIdentity,omitempty"`
 	errs = append(errs, immutableByReflect(ctx, op, fldPath.Child("serviceManagedIdentity"), newObj.ServiceManagedIdentity, safe.Field(oldObj, toUserAssignedIdentitiesServiceManagedIdentity))...)
 	errs = append(errs, RestrictedResourceIDWithResourceGroup(ctx, op, fldPath.Child("serviceManagedIdentity"), newObj.ServiceManagedIdentity, safe.Field(oldObj, toUserAssignedIdentitiesServiceManagedIdentity), "Microsoft.ManagedIdentity/userAssignedIdentities")...)
-
-	// Managed identity resource IDs must be unique across control-plane operators,
-	// data-plane operators, and the service managed identity within a cluster
-	errs = append(errs, validateManagedIdentitiesUniqueWithinCluster(fldPath, newObj)...)
-
-	return errs
-}
-
-// validateManagedIdentitiesUniqueWithinCluster ensures that each managed identity
-// resource ID used by control-plane operators, data-plane operators, or the
-// service managed identity appears at most once within the cluster.
-// This restriction may be relaxed in the future following investigation and decisions in ARO-21615.
-func validateManagedIdentitiesUniqueWithinCluster(fldPath *field.Path, newObj *coreapi.UserAssignedIdentitiesProfile) field.ErrorList {
-	observed := map[string]*field.Path{}
-	var errs field.ErrorList
-
-	record := func(identity *azcorearm.ResourceID, identityPath *field.Path) {
-		if identity == nil {
-			return
-		}
-		key := strings.ToLower(identity.String())
-		if _, ok := observed[key]; ok {
-			errs = append(errs, field.Invalid(
-				identityPath,
-				identity.String(),
-				fmt.Sprintf("managed identity with resource id '%s' must be unique within the cluster", identity.String()),
-			))
-			return
-		}
-		observed[key] = identityPath
-	}
-
-	for _, operatorName := range slices.Sorted(maps.Keys(newObj.ControlPlaneOperators)) {
-		record(newObj.ControlPlaneOperators[operatorName], fldPath.Child("controlPlaneOperators").Key(operatorName))
-	}
-	for _, operatorName := range slices.Sorted(maps.Keys(newObj.DataPlaneOperators)) {
-		record(newObj.DataPlaneOperators[operatorName], fldPath.Child("dataPlaneOperators").Key(operatorName))
-	}
-	record(newObj.ServiceManagedIdentity, fldPath.Child("serviceManagedIdentity"))
 
 	return errs
 }

--- a/internal/validation/validate_cluster_comprehensive_test.go
+++ b/internal/validation/validate_cluster_comprehensive_test.go
@@ -730,7 +730,7 @@ func TestValidateClusterCreate(t *testing.T) {
 			},
 		},
 		{
-			name: "identity used multiple times - create",
+			name: "identity reused by multiple operators - create",
 			cluster: func() *coreapi.HCPOpenShiftCluster {
 				c := createValidCluster()
 				identityID := "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/shared-identity"
@@ -740,7 +740,6 @@ func TestValidateClusterCreate(t *testing.T) {
 						identityID: {},
 					},
 				}
-				// Use the same identity in multiple places
 				identityResourceID := metadataapi.Must(azcorearm.ParseResourceID(identityID))
 				c.CustomerProperties.Platform.OperatorsAuthentication.UserAssignedIdentities.ControlPlaneOperators = map[string]*azcorearm.ResourceID{
 					"operator1": identityResourceID,
@@ -748,10 +747,7 @@ func TestValidateClusterCreate(t *testing.T) {
 				}
 				return c
 			}(),
-			expectErrors: []utils.ExpectedError{
-				{Message: "must be unique within the cluster", FieldPath: "customerProperties.platform.operatorsAuthentication.userAssignedIdentities.controlPlaneOperators"},
-				{Message: "identity is used multiple times", FieldPath: "identity.userAssignedIdentities[/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/shared-identity]"},
-			},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name: "duplicate managed identity across data plane operators - create",
@@ -765,9 +761,7 @@ func TestValidateClusterCreate(t *testing.T) {
 				}
 				return c
 			}(),
-			expectErrors: []utils.ExpectedError{
-				{Message: "must be unique within the cluster", FieldPath: "customerProperties.platform.operatorsAuthentication.userAssignedIdentities.dataPlaneOperators"},
-			},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name: "duplicate managed identity between control plane and service managed identity - create",
@@ -787,10 +781,7 @@ func TestValidateClusterCreate(t *testing.T) {
 				c.CustomerProperties.Platform.OperatorsAuthentication.UserAssignedIdentities.ServiceManagedIdentity = identityResourceID
 				return c
 			}(),
-			expectErrors: []utils.ExpectedError{
-				{Message: "must be unique within the cluster", FieldPath: "customerProperties.platform.operatorsAuthentication.userAssignedIdentities.serviceManagedIdentity"},
-				{Message: "identity is used multiple times", FieldPath: "identity.userAssignedIdentities[/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/resourceGroups/some-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/shared-identity]"},
-			},
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			name: "data plane operator uses assigned identity - create",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/peer-field-validation/01-httpCreate-cluster/expected-error.txt
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/peer-field-validation/01-httpCreate-cluster/expected-error.txt
@@ -45,11 +45,6 @@
       }
       {
         "code": "InvalidRequestContent",
-        "message": "Invalid value: \"/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/some-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/shared-identity\": identity is used multiple times",
-        "target": "identity.userAssignedIdentities[/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/some-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/shared-identity]"
-      }
-      {
-        "code": "InvalidRequestContent",
         "message": "Invalid value: \"/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/some-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/unused-identity\": identity is assigned to this resource but not used",
         "target": "identity.userAssignedIdentities[/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/some-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/unused-identity]"
       }

--- a/test/cmd/aro-hcp-tests/main.go
+++ b/test/cmd/aro-hcp-tests/main.go
@@ -717,7 +717,7 @@ func setupCli() *cobra.Command {
 	// 	specs = specs.AddLabel("SLOW")
 
 	// Specs can be globally filtered...
-	// specs = specs.MustFilter([]string{`name.contains("filter")`})
+	specs = specs.MustFilter([]string{`name.contains("reused managed identities")`})
 
 	// Or walked...
 	// specs = specs.Walk(func(spec *extensiontests.ExtensionTestSpec) {

--- a/test/cmd/aro-hcp-tests/main.go
+++ b/test/cmd/aro-hcp-tests/main.go
@@ -717,7 +717,7 @@ func setupCli() *cobra.Command {
 	// 	specs = specs.AddLabel("SLOW")
 
 	// Specs can be globally filtered...
-	specs = specs.MustFilter([]string{`name.contains("reused managed identities")`})
+	// specs = specs.MustFilter([]string{`name.contains("filter")`})
 
 	// Or walked...
 	// specs = specs.Walk(func(spec *extensiontests.ExtensionTestSpec) {

--- a/test/e2e/cluster_create_mi_reuse.go
+++ b/test/e2e/cluster_create_mi_reuse.go
@@ -16,8 +16,6 @@ package e2e
 
 import (
 	"context"
-	"strings"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -27,14 +25,14 @@ import (
 )
 
 var _ = Describe("Customer", func() {
-	It("should not be able to reuse managed identities within the same cluster",
+	It("should be able to create a cluster with reused managed identities",
 		labels.RequireNothing,
 		labels.Medium,
-		labels.Negative,
+		labels.Positive,
 		labels.AroRpApiCompatible,
 		labels.CreateCluster,
 		func(ctx context.Context) {
-			const clusterName = "mi-reuse-cluster"
+			const clusterName = "cluster-mi-reuse"
 
 			tc := framework.NewTestContext()
 
@@ -66,19 +64,14 @@ var _ = Describe("Customer", func() {
 			cpOps := clusterParams.UserAssignedIdentitiesProfile.ControlPlaneOperators
 			cpOps["ingress"] = cpOps["cluster-api-azure"]
 
-			By("attempting to create the cluster with reused managed identity")
+			By("creating a cluster with reused managed identity")
 			err = tc.CreateHCPClusterFromParam20240610(
 				ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
 				clusterParams,
-				5*time.Minute,
+				framework.ClusterCreationTimeout,
 			)
-
-			Expect(err).To(HaveOccurred(), "expected error when creating cluster with reused managed identity")
-			Expect(strings.ToLower(err.Error())).To(
-				ContainSubstring("must be unique within the cluster"),
-				"error should indicate managed identity must be unique within the cluster",
-			)
+			Expect(err).NotTo(HaveOccurred(), "failed to create cluster with reused managed identity")
 		})
 })

--- a/test/e2e/cluster_create_mi_reuse.go
+++ b/test/e2e/cluster_create_mi_reuse.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/Azure/ARO-HCP/test/util/framework"
+	"github.com/Azure/ARO-HCP/test/util/labels"
+)
+
+var _ = Describe("Customer", func() {
+	It("should not be able to reuse managed identities within the same cluster",
+		labels.RequireNothing,
+		labels.Medium,
+		labels.Negative,
+		labels.AroRpApiCompatible,
+		labels.CreateCluster,
+		func(ctx context.Context) {
+			const clusterName = "mi-reuse-cluster"
+
+			tc := framework.NewTestContext()
+
+			if tc.UsePooledIdentities() {
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
+				Expect(err).NotTo(HaveOccurred(), "failed to assign identity containers")
+			}
+
+			By("creating a resource group")
+			resourceGroup, err := tc.NewResourceGroup(ctx, "rg-mi-reuse", tc.Location())
+			Expect(err).NotTo(HaveOccurred(), "failed to create resource group")
+
+			By("creating cluster parameters")
+			clusterParams := framework.NewDefaultClusterParams20240610()
+			clusterParams.ClusterName = clusterName
+			clusterParams.ManagedResourceGroupName = framework.SuffixName(*resourceGroup.Name, "-managed", 64)
+
+			By("creating customer resources (infrastructure and managed identities)")
+			clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,
+				resourceGroup,
+				clusterParams,
+				map[string]any{},
+				TestArtifactsFS,
+				framework.RBACScopeResourceGroup,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to create customer resources")
+
+			By("reusing the same managed identity for two control plane operators")
+			cpOps := clusterParams.UserAssignedIdentitiesProfile.ControlPlaneOperators
+			cpOps["ingress"] = cpOps["cluster-api-azure"]
+
+			By("attempting to create the cluster with reused managed identity")
+			err = tc.CreateHCPClusterFromParam20240610(
+				ctx,
+				GinkgoLogr,
+				*resourceGroup.Name,
+				clusterParams,
+				5*time.Minute,
+			)
+
+			Expect(err).To(HaveOccurred(), "expected error when creating cluster with reused managed identity")
+			Expect(strings.ToLower(err.Error())).To(
+				ContainSubstring("must be unique within the cluster"),
+				"error should indicate managed identity must be unique within the cluster",
+			)
+		})
+})

--- a/test/e2e/cluster_create_mi_reuse.go
+++ b/test/e2e/cluster_create_mi_reuse.go
@@ -49,7 +49,6 @@ var _ = Describe("Customer", func() {
 			clusterParams := framework.NewDefaultClusterParams20240610()
 			clusterParams.ClusterName = clusterName
 			clusterParams.ManagedResourceGroupName = framework.SuffixName(*resourceGroup.Name, "-managed", 64)
-			clusterParams.Tags = nil
 
 			By("creating customer resources (infrastructure and managed identities)")
 			clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,

--- a/test/e2e/cluster_create_mi_reuse.go
+++ b/test/e2e/cluster_create_mi_reuse.go
@@ -49,6 +49,7 @@ var _ = Describe("Customer", func() {
 			clusterParams := framework.NewDefaultClusterParams20240610()
 			clusterParams.ClusterName = clusterName
 			clusterParams.ManagedResourceGroupName = framework.SuffixName(*resourceGroup.Name, "-managed", 64)
+			clusterParams.Tags = nil
 
 			By("creating customer resources (infrastructure and managed identities)")
 			clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,

--- a/test/e2e/cluster_create_mi_reuse.go
+++ b/test/e2e/cluster_create_mi_reuse.go
@@ -63,7 +63,9 @@ var _ = Describe("Customer", func() {
 
 			By("reusing the same managed identity for two control plane operators")
 			cpOps := clusterParams.UserAssignedIdentitiesProfile.ControlPlaneOperators
+			originalIngressMI := *cpOps["ingress"]
 			cpOps["ingress"] = cpOps["cluster-api-azure"]
+			delete(clusterParams.Identity.UserAssignedIdentities, originalIngressMI)
 
 			By("creating a cluster with reused managed identity")
 			err = tc.CreateHCPClusterFromParam20240610(

--- a/test/e2e/cluster_create_mi_reuse.go
+++ b/test/e2e/cluster_create_mi_reuse.go
@@ -31,6 +31,7 @@ var _ = Describe("Customer", func() {
 		labels.Positive,
 		labels.AroRpApiCompatible,
 		labels.CreateCluster,
+		labels.MIContainers(1),
 		func(ctx context.Context) {
 			const clusterName = "cluster-mi-reuse"
 

--- a/test/e2e/cluster_create_mi_reuse.go
+++ b/test/e2e/cluster_create_mi_reuse.go
@@ -70,7 +70,9 @@ var _ = Describe("Customer", func() {
 				}
 				originalMI := *cpOps[name]
 				cpOps[name] = sharedMI
-				delete(clusterParams.Identity.UserAssignedIdentities, originalMI)
+				if originalMI != *sharedMI {
+					delete(clusterParams.Identity.UserAssignedIdentities, originalMI)
+				}
 			}
 
 			By("creating a cluster with reused managed identity among all control plane operators")

--- a/test/e2e/cluster_create_mi_reuse.go
+++ b/test/e2e/cluster_create_mi_reuse.go
@@ -61,13 +61,19 @@ var _ = Describe("Customer", func() {
 			)
 			Expect(err).NotTo(HaveOccurred(), "failed to create customer resources")
 
-			By("reusing the same managed identity for two control plane operators")
+			By("reusing the same managed identity for all control plane operators")
 			cpOps := clusterParams.UserAssignedIdentitiesProfile.ControlPlaneOperators
-			originalIngressMI := *cpOps["ingress"]
-			cpOps["ingress"] = cpOps["cluster-api-azure"]
-			delete(clusterParams.Identity.UserAssignedIdentities, originalIngressMI)
+			sharedMI := cpOps["cluster-api-azure"]
+			for name := range cpOps {
+				if name == "cluster-api-azure" {
+					continue
+				}
+				originalMI := *cpOps[name]
+				cpOps[name] = sharedMI
+				delete(clusterParams.Identity.UserAssignedIdentities, originalMI)
+			}
 
-			By("creating a cluster with reused managed identity")
+			By("creating a cluster with reused managed identity among all control plane operators")
 			err = tc.CreateHCPClusterFromParam20240610(
 				ctx,
 				GinkgoLogr,

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_dev_cd_check_paralleldev_cd_check_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_dev_cd_check_paralleldev_cd_check_parallel.txt
@@ -1,4 +1,4 @@
-Customer should be able to list available HCP OpenShift versions and validate response content
+Customer should be able to create several HCP clusters in their customer resource group, but not in the same managed resource group
 SRE should be able to log into a cluster via a breakglass session
 SRE should be able to retrieve serial console logs for a VM
 Customer should be able to test admin credentials before cluster ready, then full admin credential lifecycle
@@ -7,19 +7,16 @@ Authorized CIDRs Connectivity should allow API access only from authorized VM IP
 Customer should be able to create an HCP cluster with custom autoscaling and update the autoscaling configuration
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
-Customer should be able to create a cluster and node pools with aggregated advanced features
-ARO-HCP HyperShift Presubmit should create a cluster and nodepool to completion
+Customer should be able to create a cluster with reused managed identities
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Customer should create a cluster with private ingress using v20260630preview and verify the ingress is internal
-Customer should create a cluster with private KAS and verify API server is only reachable from VNet while ingress remains public
 Create HCPOpenShiftCluster with Private KeyVault should create a cluster with private keyvault using v20251223preview API
 Customer should create a cluster using v20260901preview API and verify cluster health
 ARO HCP Service should successfully provision cluster when MI role assignments are added after cluster creation
 FIPS Mode Support with v2026-06-30 API should create an HCP cluster with FIPS mode enabled via cryptoRestrictions property
 Customer should be able to create an HCP cluster and manage pull secrets
 Update HCPOpenShiftCluster Positive creates a cluster and updates tags with a PATCH request
-Customer should be able to create an HCP cluster with back-level version 4.20
-Customer should be able to create several HCP clusters in their customer resource group, but not in the same managed resource group
+Customer should be able to create an HCP cluster with back-level version 4.19
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.20
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.21
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.22
@@ -37,23 +34,11 @@ ARO-HCP should be able to perform a control plane and node pool install with OCP
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 5.10
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 5.11
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 5.12
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.19
 Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.20
 Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.21
 Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.22
 Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.23
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.0
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.1
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.2
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.3
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.4
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.5
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.6
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.7
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.8
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.9
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.10
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.11
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.12
 Customer should be able to successfully upgrade control plane minor version from 4.20 minor to 4.21 minor
 Customer should be able to successfully upgrade control plane minor version from 4.21 minor to 4.22 minor
 Customer should be able to successfully upgrade control plane minor version from 4.22 minor to 4.23 minor
@@ -70,13 +55,8 @@ Customer should be able to successfully upgrade control plane minor version from
 Customer should be able to successfully upgrade control plane minor version from 5.9 minor to 5.10 minor
 Customer should be able to successfully upgrade control plane minor version from 5.10 minor to 5.11 minor
 Customer should be able to successfully upgrade control plane minor version from 5.11 minor to 5.12 minor
-Engineering should be able to retrieve expected metrics from the /metrics endpoint
 Customer should be able to create a cluster with an external auth config and get the external auth config
 Customer should be able to lifecycle and confirm external auth on a cluster
-Fleet should have registered stamps with ready management clusters
-Fleet should have HCP resource requirements data
-Fleet should have scheduling data for ready management clusters
-SRE can pause schedules to stop backup execution for an HCP cluster
 Customer should be able to create an HCP cluster and manage ImageDigestMirrors
 Customer should be able to create an HCP cluster with Image Registry not present
 Customer should be able to rotate KMS key for a cluster with version >= 4.22
@@ -91,5 +71,7 @@ Customer should upgrade and update a nodepool from 4.20.z to 4.20.zLatest
 Customer should upgrade a nodepool to a version without Cincinnati upgrade edge z-stream upgrade without Cincinnati edge in 4.20
 Customer should upgrade a nodepool skipping one minor version (+2) from 4.20.z to 4.22.zLatest
 Customer should downgrade a nodepool version z-stream downgrade from 4.21.zLatest to 4.21.zPrevious
-Customer should downgrade a nodepool to a lower minor version from 4.22.zLatest to 4.20.zLatest
+Customer should downgrade a nodepool to a lower minor version from 4.21.zLatest to 4.19.zLatest
 Customer should be able to use workload identity via the cluster OIDC issuer URL
+Customer should be able to list available HCP OpenShift versions and validate response content
+Fleet should have registered stamps with ready management clusters

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_dev_cd_check_paralleldev_cd_check_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_dev_cd_check_paralleldev_cd_check_parallel.txt
@@ -7,9 +7,11 @@ Authorized CIDRs Connectivity should allow API access only from authorized VM IP
 Customer should be able to create an HCP cluster with custom autoscaling and update the autoscaling configuration
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
+Customer should be able to create a cluster and node pools with aggregated advanced features
 Customer should be able to create a cluster with reused managed identities
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Customer should create a cluster with private ingress using v20260630preview and verify the ingress is internal
+Customer should create a cluster with private KAS and verify API server is only reachable from VNet while ingress remains public
 Create HCPOpenShiftCluster with Private KeyVault should create a cluster with private keyvault using v20251223preview API
 Customer should create a cluster using v20260901preview API and verify cluster health
 ARO HCP Service should successfully provision cluster when MI role assignments are added after cluster creation
@@ -74,4 +76,5 @@ Customer should downgrade a nodepool version z-stream downgrade from 4.21.zLates
 Customer should downgrade a nodepool to a lower minor version from 4.21.zLatest to 4.19.zLatest
 Customer should be able to use workload identity via the cluster OIDC issuer URL
 Customer should be able to list available HCP OpenShift versions and validate response content
+Engineering should be able to retrieve expected metrics from the /metrics endpoint
 Fleet should have registered stamps with ready management clusters

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
@@ -1,4 +1,5 @@
-Customer should be able to list available HCP OpenShift versions and validate response content
+Customer should be able to create several HCP clusters in their customer resource group, but not in the same managed resource group
+Customer should not be able to reuse subnets and NSGs between clusters
 Customer should be able to test admin credentials before cluster ready, then full admin credential lifecycle
 Customer should be able to create node pools with ARM64-based VMs
 Authorized CIDRs Connectivity should allow API access only from authorized VM IP
@@ -13,13 +14,11 @@ Customer should create a cluster using v20260901preview API and verify cluster h
 ARO HCP Service should successfully provision cluster when MI role assignments are added after cluster creation
 Customer should be able to create an HCP cluster then delete it by deleting the customer resource group
 FIPS Mode Support with v2026-06-30 API should create an HCP cluster with FIPS mode enabled via cryptoRestrictions property
-Customer should not be able to reuse subnets and NSGs between clusters
 Customer should be able to create an HCP cluster and manage pull secrets
 Customer should create an HCP cluster and validate TLS certificates
 Update HCPOpenShiftCluster Negative creates a cluster and fails to update its name with a PATCH request
 Update HCPOpenShiftCluster Positive creates a cluster and updates tags with a PATCH request
-Customer should be able to create an HCP cluster with back-level version 4.20
-Customer should be able to create several HCP clusters in their customer resource group, but not in the same managed resource group
+Customer should be able to create an HCP cluster with back-level version 4.19
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.20
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.21
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.22
@@ -37,23 +36,11 @@ ARO-HCP should be able to perform a control plane and node pool install with OCP
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 5.10
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 5.11
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 5.12
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.19
 Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.20
 Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.21
 Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.22
 Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.23
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.0
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.1
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.2
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.3
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.4
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.5
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.6
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.7
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.8
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.9
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.10
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.11
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.12
 Customer should be able to successfully upgrade control plane minor version from 4.20 minor to 4.21 minor
 Customer should be able to successfully upgrade control plane minor version from 4.21 minor to 4.22 minor
 Customer should be able to successfully upgrade control plane minor version from 4.22 minor to 4.23 minor
@@ -85,6 +72,8 @@ Customer should upgrade and update a nodepool from 4.20.z to 4.20.zLatest
 Customer should upgrade a nodepool to a version without Cincinnati upgrade edge z-stream upgrade without Cincinnati edge in 4.20
 Customer should upgrade a nodepool skipping one minor version (+2) from 4.20.z to 4.22.zLatest
 Customer should downgrade a nodepool version z-stream downgrade from 4.21.zLatest to 4.21.zPrevious
-Customer should downgrade a nodepool to a lower minor version from 4.22.zLatest to 4.20.zLatest
+Customer should downgrade a nodepool to a lower minor version from 4.21.zLatest to 4.19.zLatest
 Customer should be able to use workload identity via the cluster OIDC issuer URL
 Customer should not be able to perform various invalid operations on cluster resources
+Customer should be able to list available HCP OpenShift versions and validate response content
+Customer should be able to create a cluster with reused managed identities

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
@@ -5,7 +5,7 @@ Authorized CIDRs Connectivity should allow API access only from authorized VM IP
 Customer should be able to create an HCP cluster with custom autoscaling and update the autoscaling configuration
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
-Customer should not be able to reuse managed identities within the same cluster
+Customer should be able to create a cluster with reused managed identities
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Customer should create a cluster with private ingress using v20260630preview and verify the ingress is internal
 Create HCPOpenShiftCluster with Private KeyVault should create a cluster with private keyvault using v20251223preview API

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
@@ -76,4 +76,3 @@ Customer should downgrade a nodepool to a lower minor version from 4.21.zLatest 
 Customer should be able to use workload identity via the cluster OIDC issuer URL
 Customer should not be able to perform various invalid operations on cluster resources
 Customer should be able to list available HCP OpenShift versions and validate response content
-Customer should be able to create a cluster with reused managed identities

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
@@ -6,9 +6,11 @@ Authorized CIDRs Connectivity should allow API access only from authorized VM IP
 Customer should be able to create an HCP cluster with custom autoscaling and update the autoscaling configuration
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
+Customer should be able to create a cluster and node pools with aggregated advanced features
 Customer should be able to create a cluster with reused managed identities
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Customer should create a cluster with private ingress using v20260630preview and verify the ingress is internal
+Customer should create a cluster with private KAS and verify API server is only reachable from VNet while ingress remains public
 Create HCPOpenShiftCluster with Private KeyVault should create a cluster with private keyvault using v20251223preview API
 Customer should create a cluster using v20260901preview API and verify cluster health
 ARO HCP Service should successfully provision cluster when MI role assignments are added after cluster creation

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
@@ -5,10 +5,9 @@ Authorized CIDRs Connectivity should allow API access only from authorized VM IP
 Customer should be able to create an HCP cluster with custom autoscaling and update the autoscaling configuration
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
-Customer should be able to create a cluster and node pools with aggregated advanced features
+Customer should not be able to reuse managed identities within the same cluster
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Customer should create a cluster with private ingress using v20260630preview and verify the ingress is internal
-Customer should create a cluster with private KAS and verify API server is only reachable from VNet while ingress remains public
 Create HCPOpenShiftCluster with Private KeyVault should create a cluster with private keyvault using v20251223preview API
 Customer should create a cluster using v20260901preview API and verify cluster health
 ARO HCP Service should successfully provision cluster when MI role assignments are added after cluster creation

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
@@ -5,7 +5,7 @@ Authorized CIDRs Connectivity should allow API access only from authorized VM IP
 Customer should be able to create an HCP cluster with custom autoscaling and update the autoscaling configuration
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
-Customer should not be able to reuse managed identities within the same cluster
+Customer should be able to create a cluster with reused managed identities
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Customer should create a cluster with private ingress using v20260630preview and verify the ingress is internal
 Create HCPOpenShiftCluster with Private KeyVault should create a cluster with private keyvault using v20251223preview API

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
@@ -76,4 +76,3 @@ Customer should be able to use workload identity via the cluster OIDC issuer URL
 Customer should be able to forward control plane logs to a storage account and Event Hub via shoebox diagnostic settings
 Customer should not be able to perform various invalid operations on cluster resources
 Customer should be able to list available HCP OpenShift versions and validate response content
-Customer should be able to create a cluster with reused managed identities

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
@@ -1,4 +1,5 @@
-Customer should be able to list available HCP OpenShift versions and validate response content
+Customer should be able to create several HCP clusters in their customer resource group, but not in the same managed resource group
+Customer should not be able to reuse subnets and NSGs between clusters
 Customer should be able to test admin credentials before cluster ready, then full admin credential lifecycle
 Customer should be able to create node pools with ARM64-based VMs
 Authorized CIDRs Connectivity should allow API access only from authorized VM IP
@@ -12,15 +13,12 @@ Create HCPOpenShiftCluster with Private KeyVault should create a cluster with pr
 Customer should create a cluster using v20260901preview API and verify cluster health
 ARO HCP Service should successfully provision cluster when MI role assignments are added after cluster creation
 Customer should be able to create an HCP cluster then delete it by deleting the customer resource group
-Customer should be able to delete an HCP cluster whose managed identities were deleted first
 FIPS Mode Support with v2026-06-30 API should create an HCP cluster with FIPS mode enabled via cryptoRestrictions property
-Customer should not be able to reuse subnets and NSGs between clusters
 Customer should be able to create an HCP cluster and manage pull secrets
 Customer should create an HCP cluster and validate TLS certificates
 Update HCPOpenShiftCluster Negative creates a cluster and fails to update its name with a PATCH request
 Update HCPOpenShiftCluster Positive creates a cluster and updates tags with a PATCH request
-Customer should be able to create an HCP cluster with back-level version 4.20
-Customer should be able to create several HCP clusters in their customer resource group, but not in the same managed resource group
+Customer should be able to create an HCP cluster with back-level version 4.19
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.20
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.21
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.22
@@ -38,23 +36,11 @@ ARO-HCP should be able to perform a control plane and node pool install with OCP
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 5.10
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 5.11
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 5.12
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.19
 Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.20
 Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.21
 Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.22
 Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.23
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.0
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.1
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.2
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.3
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.4
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.5
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.6
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.7
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.8
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.9
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.10
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.11
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.12
 Customer should be able to successfully upgrade control plane minor version from 4.20 minor to 4.21 minor
 Customer should be able to successfully upgrade control plane minor version from 4.21 minor to 4.22 minor
 Customer should be able to successfully upgrade control plane minor version from 4.22 minor to 4.23 minor
@@ -85,7 +71,9 @@ Customer should upgrade and update a nodepool from 4.20.z to 4.20.zLatest
 Customer should upgrade a nodepool to a version without Cincinnati upgrade edge z-stream upgrade without Cincinnati edge in 4.20
 Customer should upgrade a nodepool skipping one minor version (+2) from 4.20.z to 4.22.zLatest
 Customer should downgrade a nodepool version z-stream downgrade from 4.21.zLatest to 4.21.zPrevious
-Customer should downgrade a nodepool to a lower minor version from 4.22.zLatest to 4.20.zLatest
+Customer should downgrade a nodepool to a lower minor version from 4.21.zLatest to 4.19.zLatest
 Customer should be able to use workload identity via the cluster OIDC issuer URL
 Customer should be able to forward control plane logs to a storage account and Event Hub via shoebox diagnostic settings
 Customer should not be able to perform various invalid operations on cluster resources
+Customer should be able to list available HCP OpenShift versions and validate response content
+Customer should be able to create a cluster with reused managed identities

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
@@ -6,9 +6,11 @@ Authorized CIDRs Connectivity should allow API access only from authorized VM IP
 Customer should be able to create an HCP cluster with custom autoscaling and update the autoscaling configuration
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
+Customer should be able to create a cluster and node pools with aggregated advanced features
 Customer should be able to create a cluster with reused managed identities
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Customer should create a cluster with private ingress using v20260630preview and verify the ingress is internal
+Customer should create a cluster with private KAS and verify API server is only reachable from VNet while ingress remains public
 Create HCPOpenShiftCluster with Private KeyVault should create a cluster with private keyvault using v20251223preview API
 Customer should create a cluster using v20260901preview API and verify cluster health
 ARO HCP Service should successfully provision cluster when MI role assignments are added after cluster creation

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
@@ -5,10 +5,9 @@ Authorized CIDRs Connectivity should allow API access only from authorized VM IP
 Customer should be able to create an HCP cluster with custom autoscaling and update the autoscaling configuration
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
-Customer should be able to create a cluster and node pools with aggregated advanced features
+Customer should not be able to reuse managed identities within the same cluster
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Customer should create a cluster with private ingress using v20260630preview and verify the ingress is internal
-Customer should create a cluster with private KAS and verify API server is only reachable from VNet while ingress remains public
 Create HCPOpenShiftCluster with Private KeyVault should create a cluster with private keyvault using v20251223preview API
 Customer should create a cluster using v20260901preview API and verify cluster health
 ARO HCP Service should successfully provision cluster when MI role assignments are added after cluster creation

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
@@ -1,4 +1,5 @@
-Customer should be able to list available HCP OpenShift versions and validate response content
+Customer should be able to create several HCP clusters in their customer resource group, but not in the same managed resource group
+Customer should not be able to reuse subnets and NSGs between clusters
 SRE should be able to log into a cluster via a breakglass session
 SRE should be able to retrieve serial console logs for a VM
 SRE should return 409 when boot diagnostics is disabled on a VM
@@ -8,20 +9,16 @@ Authorized CIDRs Connectivity should allow API access only from authorized VM IP
 Customer should be able to create an HCP cluster with custom autoscaling and update the autoscaling configuration
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
-Customer should be able to create a cluster and node pools with aggregated advanced features
-ARO-HCP HyperShift Presubmit should create a cluster and nodepool to completion
+Customer should not be able to reuse managed identities within the same cluster
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Customer should create a cluster with private ingress using v20260630preview and verify the ingress is internal
-Customer should create a cluster with private KAS and verify API server is only reachable from VNet while ingress remains public
 Create HCPOpenShiftCluster with Private KeyVault should create a cluster with private keyvault using v20251223preview API
 Customer should create a cluster using v20260901preview API and verify cluster health
 ARO HCP Service should successfully provision cluster when MI role assignments are added after cluster creation
 FIPS Mode Support with v2026-06-30 API should create an HCP cluster with FIPS mode enabled via cryptoRestrictions property
-Customer should not be able to reuse subnets and NSGs between clusters
 Customer should be able to create an HCP cluster and manage pull secrets
 Update HCPOpenShiftCluster Positive creates a cluster and updates tags with a PATCH request
-Customer should be able to create an HCP cluster with back-level version 4.20
-Customer should be able to create several HCP clusters in their customer resource group, but not in the same managed resource group
+Customer should be able to create an HCP cluster with back-level version 4.19
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.20
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.21
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.22
@@ -39,23 +36,11 @@ ARO-HCP should be able to perform a control plane and node pool install with OCP
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 5.10
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 5.11
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 5.12
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.19
 Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.20
 Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.21
 Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.22
 Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.23
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.0
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.1
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.2
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.3
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.4
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.5
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.6
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.7
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.8
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.9
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.10
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.11
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.12
 Customer should be able to successfully upgrade control plane minor version from 4.20 minor to 4.21 minor
 Customer should be able to successfully upgrade control plane minor version from 4.21 minor to 4.22 minor
 Customer should be able to successfully upgrade control plane minor version from 4.22 minor to 4.23 minor
@@ -72,17 +57,10 @@ Customer should be able to successfully upgrade control plane minor version from
 Customer should be able to successfully upgrade control plane minor version from 5.9 minor to 5.10 minor
 Customer should be able to successfully upgrade control plane minor version from 5.10 minor to 5.11 minor
 Customer should be able to successfully upgrade control plane minor version from 5.11 minor to 5.12 minor
-Engineering should be able to retrieve expected metrics from the /metrics endpoint
 Customer should be able to create a cluster with an external auth config and get the external auth config
 Customer should be able to lifecycle and confirm external auth on a cluster
-Fleet should have registered stamps with ready management clusters
-Fleet should have HCP resource requirements data
-Fleet should have scheduling data for ready management clusters
-SRE can pause schedules to stop backup execution for an HCP cluster
 Customer should be able to create an HCP cluster and manage ImageDigestMirrors
 Customer should be able to create an HCP cluster with Image Registry not present
-Image Registry Policy should deny pods with images from disallowed registries
-Image Registry Policy should allow pods with images from allowed registries and have a valid allowlist
 Customer should be able to rotate KMS key for a cluster with version >= 4.22
 Engineering should be able to retrieve kusto logs for a cluster and services
 Customer should be able to create a cluster with default autoscaling and a nodepool with autoscaling enabled up to replica limits
@@ -96,6 +74,10 @@ Customer should upgrade and update a nodepool from 4.20.z to 4.20.zLatest
 Customer should upgrade a nodepool to a version without Cincinnati upgrade edge z-stream upgrade without Cincinnati edge in 4.20
 Customer should upgrade a nodepool skipping one minor version (+2) from 4.20.z to 4.22.zLatest
 Customer should downgrade a nodepool version z-stream downgrade from 4.21.zLatest to 4.21.zPrevious
-Customer should downgrade a nodepool to a lower minor version from 4.22.zLatest to 4.20.zLatest
+Customer should downgrade a nodepool to a lower minor version from 4.21.zLatest to 4.19.zLatest
 Customer should be able to use workload identity via the cluster OIDC issuer URL
 Customer should not be able to perform various invalid operations on cluster resources
+Customer should be able to list available HCP OpenShift versions and validate response content
+Fleet should have registered stamps with ready management clusters
+Image Registry Policy should deny pods with images from disallowed registries
+Image Registry Policy should allow pods with images from allowed registries and have a valid allowlist

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
@@ -9,7 +9,7 @@ Authorized CIDRs Connectivity should allow API access only from authorized VM IP
 Customer should be able to create an HCP cluster with custom autoscaling and update the autoscaling configuration
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
-Customer should not be able to reuse managed identities within the same cluster
+Customer should be able to create a cluster with reused managed identities
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Customer should create a cluster with private ingress using v20260630preview and verify the ingress is internal
 Create HCPOpenShiftCluster with Private KeyVault should create a cluster with private keyvault using v20251223preview API

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
@@ -9,9 +9,11 @@ Authorized CIDRs Connectivity should allow API access only from authorized VM IP
 Customer should be able to create an HCP cluster with custom autoscaling and update the autoscaling configuration
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
+Customer should be able to create a cluster and node pools with aggregated advanced features
 Customer should be able to create a cluster with reused managed identities
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Customer should create a cluster with private ingress using v20260630preview and verify the ingress is internal
+Customer should create a cluster with private KAS and verify API server is only reachable from VNet while ingress remains public
 Create HCPOpenShiftCluster with Private KeyVault should create a cluster with private keyvault using v20251223preview API
 Customer should create a cluster using v20260901preview API and verify cluster health
 ARO HCP Service should successfully provision cluster when MI role assignments are added after cluster creation
@@ -78,6 +80,7 @@ Customer should downgrade a nodepool to a lower minor version from 4.21.zLatest 
 Customer should be able to use workload identity via the cluster OIDC issuer URL
 Customer should not be able to perform various invalid operations on cluster resources
 Customer should be able to list available HCP OpenShift versions and validate response content
+Engineering should be able to retrieve expected metrics from the /metrics endpoint
 Fleet should have registered stamps with ready management clusters
 Image Registry Policy should deny pods with images from disallowed registries
 Image Registry Policy should allow pods with images from allowed registries and have a valid allowlist

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
@@ -1,24 +1,21 @@
-Customer should be able to list available HCP OpenShift versions and validate response content
+Customer should be able to create several HCP clusters in their customer resource group, but not in the same managed resource group
+Customer should not be able to reuse subnets and NSGs between clusters
 Customer should be able to test admin credentials before cluster ready, then full admin credential lifecycle
 Customer should be able to create node pools with ARM64-based VMs
 Authorized CIDRs Connectivity should allow API access only from authorized VM IP
 Customer should be able to create an HCP cluster with custom autoscaling and update the autoscaling configuration
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
-Customer should be able to create a cluster and node pools with aggregated advanced features
-ARO-HCP HyperShift Presubmit should create a cluster and nodepool to completion
+Customer should not be able to reuse managed identities within the same cluster
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Customer should create a cluster with private ingress using v20260630preview and verify the ingress is internal
-Customer should create a cluster with private KAS and verify API server is only reachable from VNet while ingress remains public
 Create HCPOpenShiftCluster with Private KeyVault should create a cluster with private keyvault using v20251223preview API
 Customer should create a cluster using v20260901preview API and verify cluster health
 ARO HCP Service should successfully provision cluster when MI role assignments are added after cluster creation
 FIPS Mode Support with v2026-06-30 API should create an HCP cluster with FIPS mode enabled via cryptoRestrictions property
-Customer should not be able to reuse subnets and NSGs between clusters
 Customer should be able to create an HCP cluster and manage pull secrets
 Update HCPOpenShiftCluster Positive creates a cluster and updates tags with a PATCH request
-Customer should be able to create an HCP cluster with back-level version 4.20
-Customer should be able to create several HCP clusters in their customer resource group, but not in the same managed resource group
+Customer should be able to create an HCP cluster with back-level version 4.19
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.20
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.21
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.22
@@ -36,23 +33,11 @@ ARO-HCP should be able to perform a control plane and node pool install with OCP
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 5.10
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 5.11
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 5.12
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.19
 Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.20
 Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.21
 Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.22
 Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.23
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.0
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.1
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.2
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.3
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.4
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.5
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.6
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.7
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.8
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.9
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.10
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.11
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.12
 Customer should be able to successfully upgrade control plane minor version from 4.20 minor to 4.21 minor
 Customer should be able to successfully upgrade control plane minor version from 4.21 minor to 4.22 minor
 Customer should be able to successfully upgrade control plane minor version from 4.22 minor to 4.23 minor
@@ -83,6 +68,7 @@ Customer should upgrade and update a nodepool from 4.20.z to 4.20.zLatest
 Customer should upgrade a nodepool to a version without Cincinnati upgrade edge z-stream upgrade without Cincinnati edge in 4.20
 Customer should upgrade a nodepool skipping one minor version (+2) from 4.20.z to 4.22.zLatest
 Customer should downgrade a nodepool version z-stream downgrade from 4.21.zLatest to 4.21.zPrevious
-Customer should downgrade a nodepool to a lower minor version from 4.22.zLatest to 4.20.zLatest
+Customer should downgrade a nodepool to a lower minor version from 4.21.zLatest to 4.19.zLatest
 Customer should be able to use workload identity via the cluster OIDC issuer URL
 Customer should not be able to perform various invalid operations on cluster resources
+Customer should be able to list available HCP OpenShift versions and validate response content

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
@@ -72,4 +72,3 @@ Customer should downgrade a nodepool to a lower minor version from 4.21.zLatest 
 Customer should be able to use workload identity via the cluster OIDC issuer URL
 Customer should not be able to perform various invalid operations on cluster resources
 Customer should be able to list available HCP OpenShift versions and validate response content
-Customer should be able to create a cluster with reused managed identities

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
@@ -6,7 +6,7 @@ Authorized CIDRs Connectivity should allow API access only from authorized VM IP
 Customer should be able to create an HCP cluster with custom autoscaling and update the autoscaling configuration
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
-Customer should not be able to reuse managed identities within the same cluster
+Customer should be able to create a cluster with reused managed identities
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Customer should create a cluster with private ingress using v20260630preview and verify the ingress is internal
 Create HCPOpenShiftCluster with Private KeyVault should create a cluster with private keyvault using v20251223preview API

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
@@ -6,9 +6,11 @@ Authorized CIDRs Connectivity should allow API access only from authorized VM IP
 Customer should be able to create an HCP cluster with custom autoscaling and update the autoscaling configuration
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
+Customer should be able to create a cluster and node pools with aggregated advanced features
 Customer should be able to create a cluster with reused managed identities
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Customer should create a cluster with private ingress using v20260630preview and verify the ingress is internal
+Customer should create a cluster with private KAS and verify API server is only reachable from VNet while ingress remains public
 Create HCPOpenShiftCluster with Private KeyVault should create a cluster with private keyvault using v20251223preview API
 Customer should create a cluster using v20260901preview API and verify cluster health
 ARO HCP Service should successfully provision cluster when MI role assignments are added after cluster creation

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
@@ -72,3 +72,4 @@ Customer should downgrade a nodepool to a lower minor version from 4.21.zLatest 
 Customer should be able to use workload identity via the cluster OIDC issuer URL
 Customer should not be able to perform various invalid operations on cluster resources
 Customer should be able to list available HCP OpenShift versions and validate response content
+Customer should be able to create a cluster with reused managed identities

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
@@ -5,7 +5,7 @@ Authorized CIDRs Connectivity should allow API access only from authorized VM IP
 Customer should be able to create an HCP cluster with custom autoscaling and update the autoscaling configuration
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
-Customer should not be able to reuse managed identities within the same cluster
+Customer should be able to create a cluster with reused managed identities
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Customer should create a cluster with private ingress using v20260630preview and verify the ingress is internal
 Create HCPOpenShiftCluster with Private KeyVault should create a cluster with private keyvault using v20251223preview API

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
@@ -76,4 +76,3 @@ Customer should be able to use workload identity via the cluster OIDC issuer URL
 Customer should be able to forward control plane logs to a storage account and Event Hub via shoebox diagnostic settings
 Customer should not be able to perform various invalid operations on cluster resources
 Customer should be able to list available HCP OpenShift versions and validate response content
-Customer should be able to create a cluster with reused managed identities

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
@@ -1,4 +1,5 @@
-Customer should be able to list available HCP OpenShift versions and validate response content
+Customer should be able to create several HCP clusters in their customer resource group, but not in the same managed resource group
+Customer should not be able to reuse subnets and NSGs between clusters
 Customer should be able to test admin credentials before cluster ready, then full admin credential lifecycle
 Customer should be able to create node pools with ARM64-based VMs
 Authorized CIDRs Connectivity should allow API access only from authorized VM IP
@@ -12,15 +13,12 @@ Create HCPOpenShiftCluster with Private KeyVault should create a cluster with pr
 Customer should create a cluster using v20260901preview API and verify cluster health
 ARO HCP Service should successfully provision cluster when MI role assignments are added after cluster creation
 Customer should be able to create an HCP cluster then delete it by deleting the customer resource group
-Customer should be able to delete an HCP cluster whose managed identities were deleted first
 FIPS Mode Support with v2026-06-30 API should create an HCP cluster with FIPS mode enabled via cryptoRestrictions property
-Customer should not be able to reuse subnets and NSGs between clusters
 Customer should be able to create an HCP cluster and manage pull secrets
 Customer should create an HCP cluster and validate TLS certificates
 Update HCPOpenShiftCluster Negative creates a cluster and fails to update its name with a PATCH request
 Update HCPOpenShiftCluster Positive creates a cluster and updates tags with a PATCH request
-Customer should be able to create an HCP cluster with back-level version 4.20
-Customer should be able to create several HCP clusters in their customer resource group, but not in the same managed resource group
+Customer should be able to create an HCP cluster with back-level version 4.19
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.20
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.21
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.22
@@ -38,23 +36,11 @@ ARO-HCP should be able to perform a control plane and node pool install with OCP
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 5.10
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 5.11
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 5.12
+Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.19
 Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.20
 Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.21
 Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.22
 Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.23
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.0
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.1
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.2
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.3
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.4
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.5
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.6
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.7
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.8
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.9
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.10
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.11
-Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 5.12
 Customer should be able to successfully upgrade control plane minor version from 4.20 minor to 4.21 minor
 Customer should be able to successfully upgrade control plane minor version from 4.21 minor to 4.22 minor
 Customer should be able to successfully upgrade control plane minor version from 4.22 minor to 4.23 minor
@@ -85,7 +71,9 @@ Customer should upgrade and update a nodepool from 4.20.z to 4.20.zLatest
 Customer should upgrade a nodepool to a version without Cincinnati upgrade edge z-stream upgrade without Cincinnati edge in 4.20
 Customer should upgrade a nodepool skipping one minor version (+2) from 4.20.z to 4.22.zLatest
 Customer should downgrade a nodepool version z-stream downgrade from 4.21.zLatest to 4.21.zPrevious
-Customer should downgrade a nodepool to a lower minor version from 4.22.zLatest to 4.20.zLatest
+Customer should downgrade a nodepool to a lower minor version from 4.21.zLatest to 4.19.zLatest
 Customer should be able to use workload identity via the cluster OIDC issuer URL
 Customer should be able to forward control plane logs to a storage account and Event Hub via shoebox diagnostic settings
 Customer should not be able to perform various invalid operations on cluster resources
+Customer should be able to list available HCP OpenShift versions and validate response content
+Customer should be able to create a cluster with reused managed identities

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
@@ -6,9 +6,11 @@ Authorized CIDRs Connectivity should allow API access only from authorized VM IP
 Customer should be able to create an HCP cluster with custom autoscaling and update the autoscaling configuration
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
+Customer should be able to create a cluster and node pools with aggregated advanced features
 Customer should be able to create a cluster with reused managed identities
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Customer should create a cluster with private ingress using v20260630preview and verify the ingress is internal
+Customer should create a cluster with private KAS and verify API server is only reachable from VNet while ingress remains public
 Create HCPOpenShiftCluster with Private KeyVault should create a cluster with private keyvault using v20251223preview API
 Customer should create a cluster using v20260901preview API and verify cluster health
 ARO HCP Service should successfully provision cluster when MI role assignments are added after cluster creation

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
@@ -5,10 +5,9 @@ Authorized CIDRs Connectivity should allow API access only from authorized VM IP
 Customer should be able to create an HCP cluster with custom autoscaling and update the autoscaling configuration
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
-Customer should be able to create a cluster and node pools with aggregated advanced features
+Customer should not be able to reuse managed identities within the same cluster
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Customer should create a cluster with private ingress using v20260630preview and verify the ingress is internal
-Customer should create a cluster with private KAS and verify API server is only reachable from VNet while ingress remains public
 Create HCPOpenShiftCluster with Private KeyVault should create a cluster with private keyvault using v20251223preview API
 Customer should create a cluster using v20260901preview API and verify cluster health
 ARO HCP Service should successfully provision cluster when MI role assignments are added after cluster creation


### PR DESCRIPTION
[ARO-28671](https://redhat.atlassian.net/browse/ARO-28671)

### What

adding a new positive E2E test case that reuses managed identities within a cluster. The test assigns the same managed identity resource ID to two different control plane operators (ingress and cluster-api-azure) and verifies that cluster creation completes successfully. 

removing validation that prevents MI reuse within cluster. 

Depends on https://gitlab.cee.redhat.com/service/aro-hcp-clusters-service/-/merge_requests/401

### Why

MI reuse within a cluster is a valid scenario. This test demonstrates that a cluster provisions successfully when two operators share the same managed identity, providing justification to remove the validateManagedIdentitiesUniqueWithinCluster validation added in ~~#6082~~ https://github.com/Azure/ARO-HCP/pull/6121 

### Testing

The PR adds an E2E test for existing feature.

### PR Checklist

- [ ] restore MustFilter and config
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [x] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
