### PR TITLE
docs(ci): register Microsoft.Storage in external subscription onboarding

### DIFF
--- a/docs/ci/external-subscription-onboarding.md
+++ b/docs/ci/external-subscription-onboarding.md
@@ -63,12 +63,21 @@ For an **external** subscription:
 Register the Azure resource providers required for E2E test operations:
 
 ```sh
-for ns in Microsoft.Compute Microsoft.Network Microsoft.ManagedIdentity; do
+for ns in Microsoft.Compute Microsoft.Network Microsoft.ManagedIdentity Microsoft.Storage; do
   az provider register --namespace "$ns" --subscription <subscription-id>
 done
 ```
 
 These are needed so the CI bot and RP identities can create/manage compute resources, networking, and managed identities within the subscription.
+
+`Microsoft.Storage` (and `Microsoft.Authorization`, which is registered by default on every subscription) must additionally be `Registered` because the backend `AzureResourceProvidersRegistrationValidation` controller checks the registration state of `Microsoft.Authorization`, `Microsoft.Compute`, `Microsoft.Network`, and `Microsoft.Storage` on the customer subscription before a cluster can provision. If any of these is unregistered, the validation fails and the cluster never leaves the retry loop. Confirm all four report `Registered`:
+
+```sh
+for ns in Microsoft.Authorization Microsoft.Compute Microsoft.Network Microsoft.Storage; do
+  echo "$ns: $(az provider show --namespace "$ns" \
+    --subscription <subscription-id> --query registrationState -o tsv)"
+done
+```
 
 ### Step 1: Grant the CI Bot (Test Runner)
 


### PR DESCRIPTION
## Why

External E2E subscription onboarding (`docs/ci/external-subscription-onboarding.md`) instructs the subscription owner to register only `Microsoft.Compute`, `Microsoft.Network`, and `Microsoft.ManagedIdentity`. But the backend `AzureResourceProvidersRegistrationValidation` controller checks that **`Microsoft.Authorization`, `Microsoft.Compute`, `Microsoft.Network`, and `Microsoft.Storage`** are all `Registered` on the customer subscription before a cluster can provision.

When `Microsoft.Storage` is unregistered, the validation fails and the HCP never leaves the retry loop — surfacing as `BackendControllerRetryHotLoop` on `clustervalidationazureresourceprovidersregistrationvalidation`.

This was hit for real during the HyperShift team's ARO-HCP e2e onboarding (openshift/release #79926). Backend logs for the failing rehearsal job showed the RP-registration validation failing **21,747 times across all 47 test clusters**, every one with:

```
1 of the resource providers are not registered, or their state is empty: Microsoft.Storage
```

Notably there were **no `AuthorizationFailed`/403 errors anywhere in the run** — the first-party mock read all four providers' registration state successfully and correctly reported only `Storage` as unregistered. So this is a provider-registration gap in the docs, not an RBAC issue.

## What

- Add `Microsoft.Storage` to the prerequisite `az provider register` loop.
- Add a verification snippet that confirms all four providers the validation checks report `Registered`, with an explanation tying the requirement to the backend controller.

Docs-only change; no code or behavior affected.