### PR TITLE
docs(ci): remove reference to deleted openshift/release README

### DIFF
--- a/docs/.prow-docs-maintenance.md
+++ b/docs/.prow-docs-maintenance.md
@@ -60,7 +60,6 @@ Do not reintroduce:
 - https://github.com/openshift/release/blob/master/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__periodic.yaml
 - https://github.com/openshift/release/blob/master/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__periodic-cleanup.yaml
 - https://github.com/openshift/release/blob/master/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__image-updater.yaml
-- https://github.com/openshift/release/blob/master/ci-operator/config/Azure/ARO-HCP/README.md
 
 ### ARO HCP Repository Wiring
 


### PR DESCRIPTION
### What

Removes a stale reference to `ci-operator/config/Azure/ARO-HCP/README.md` from the CI docs maintenance guide.

### Why

The README is being deleted from `openshift/release` (https://github.com/openshift/release/pull/TBD) because it documented an obsolete workflow with step names that no longer exist. All ARO-HCP CI documentation now lives in `docs/ci/`.

### Testing

No tests needed — documentation-only change removing a dead link.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows Conventional Commits format
- [x] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [x] Commit history is clean (rebased/squashed)