### PR TITLE
fix(acr): use regex patterns in purge filters and drop quay.io/ prefix

### DIFF
--- a/dev-infrastructure/configurations/acr-svc.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/acr-svc.tmpl.bicepparam
@@ -23,8 +23,8 @@ param purgeJobs = [
   {
     name: 'sandbox-images-purge'
     purgeFilters: [
-      'quay.io/app-sre/ocm-clusters-service-sandbox:.*'
-      'quay.io/app-sre/aro-hcp-clusters-service-sandbox:.*'
+      'app-sre/ocm-clusters-service-sandbox:.*'
+      'app-sre/aro-hcp-clusters-service-sandbox:.*'
     ]
     purgeAfter: '2d'
     imagesToKeep: 1
@@ -32,12 +32,12 @@ param purgeJobs = [
   {
     name: 'service-images-purge'
     purgeFilters: [
-      'arohcp*:.*'
+      'arohcp.*:.*'
       'fleet:.*'
       'kube-applier:.*'
       'mgmt-agent:.*'
-      'test-*:.*'
-      'ci-op-*/*:.*'
+      'test-.*:.*'
+      'ci-op-.*/.*:.*'
     ]
     purgeAfter: '7d'
     imagesToKeep: 3


### PR DESCRIPTION
[ARO-27672](https://redhat.atlassian.net/browse/ARO-27672)

### What

- Fix purge filter patterns to use regex (`.*`) instead of globs (`*`) in the repository portion
- Drop `quay.io/` prefix from sandbox purge filters to match actual ACR repo names

### Why

The purge jobs from #6084 used glob wildcards (`arohcp*`, `test-*`, `ci-op-*/*`) in `--filter` repo patterns, but `acr purge` uses regex. Dry-run confirmed globs match nothing; regex matches correctly. The sandbox filters inherited a pre-existing broken `quay.io/` prefix — cached images land under `app-sre/...`, not `quay.io/app-sre/...`.

### Testing

Verified with `az acr run --cmd "acr purge --dry-run"`:
- `arohcp.*:.*` → 4,302 tags (was 0 with `arohcp*`)
- `test-.*:.*` → 4,619 tags (was 0 with `test-*`)
- `ci-op-.*/.*:.*` → 47,987 tags (was 0 with `ci-op-*/*`)
- `app-sre/...:.*` → 481 tags (was 0 with `quay.io/app-sre/...`)

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if graph/UI/metrics changes) — N/A
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [x] Commit history is clean (rebased/squashed)
- [ ] Specific reviewers tagged
- [x] All comment threads resolved before merge