### PR TITLE
feat: bump CIHealth and split dev-ci e2e RBAC pipeline by privilege

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -488,16 +488,16 @@ endif
 # Dev CI topology local run
 #
 dev-ci-local-run:
-	$(MAKE) local-run DEPLOY_ENV=dev-ci CONFIG_FILE=config/config-dev-ci.yaml TOPOLOGY_FILE=topology-dev-ci.yaml WHAT="--entrypoint Microsoft.Azure.ARO.HCP.DevCI.Infra" STEP_CACHE_DIR="" EXTRA_ARGS="--skip-bicepparam-validation"
+	$(MAKE) local-run DEPLOY_ENV=dev-ci CONFIG_FILE=config/config-dev-ci.yaml TOPOLOGY_FILE=topology-dev-ci.yaml WHAT="--entrypoint Microsoft.Azure.ARO.HCP.DevCI.Unprivileged" STEP_CACHE_DIR="" EXTRA_ARGS="--skip-bicepparam-validation"
 .PHONY: dev-ci-local-run
 
 # PRIVILEGED, on-demand only. Applies the subscription-scoped custom role
 # definitions and role assignments (requires Owner / User Access Administrator
 # on the target subscriptions). Not part of the dev-ci postsubmit; run by an
 # OWNERS-group member. See docs/ci/dev-ci-topology.md.
-dev-ci-e2e-rbac-grants-local-run:
-	$(MAKE) local-run DEPLOY_ENV=dev-ci CONFIG_FILE=config/config-dev-ci.yaml TOPOLOGY_FILE=topology-dev-ci.yaml WHAT="--service-group Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBACGrants" STEP_CACHE_DIR="" EXTRA_ARGS="--skip-bicepparam-validation"
-.PHONY: dev-ci-e2e-rbac-grants-local-run
+dev-ci-privileged-local-run:
+	$(MAKE) local-run DEPLOY_ENV=dev-ci CONFIG_FILE=config/config-dev-ci.yaml TOPOLOGY_FILE=topology-dev-ci.yaml WHAT="--entrypoint Microsoft.Azure.ARO.HCP.DevCI.Privileged" STEP_CACHE_DIR="" EXTRA_ARGS="--skip-bicepparam-validation"
+.PHONY: dev-ci-privileged-local-run
 
 #
 # Local Cluster Service Development Environment

--- a/Makefile
+++ b/Makefile
@@ -495,6 +495,14 @@ dev-ci-e2e-subscription-rbac-local-run:
 	$(MAKE) local-run DEPLOY_ENV=dev-ci CONFIG_FILE=config/config-dev-ci.yaml TOPOLOGY_FILE=topology-dev-ci.yaml WHAT="--service-group Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBAC" STEP_CACHE_DIR="" EXTRA_ARGS="--skip-bicepparam-validation"
 .PHONY: dev-ci-e2e-subscription-rbac-local-run
 
+# PRIVILEGED, on-demand only. Applies the subscription-scoped custom role
+# definitions and role assignments (requires Owner / User Access Administrator
+# on the target subscriptions). Not part of the dev-ci postsubmit; run by an
+# OWNERS-group member. See docs/ci/dev-ci-topology.md.
+dev-ci-e2e-rbac-grants-local-run:
+	$(MAKE) local-run DEPLOY_ENV=dev-ci CONFIG_FILE=config/config-dev-ci.yaml TOPOLOGY_FILE=topology-dev-ci.yaml WHAT="--service-group Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBACGrants" STEP_CACHE_DIR=""
+.PHONY: dev-ci-e2e-rbac-grants-local-run
+
 #
 # Local Cluster Service Development Environment
 #

--- a/Makefile
+++ b/Makefile
@@ -491,16 +491,12 @@ dev-ci-local-run:
 	$(MAKE) local-run DEPLOY_ENV=dev-ci CONFIG_FILE=config/config-dev-ci.yaml TOPOLOGY_FILE=topology-dev-ci.yaml WHAT="--entrypoint Microsoft.Azure.ARO.HCP.DevCI.Infra" STEP_CACHE_DIR="" EXTRA_ARGS="--skip-bicepparam-validation"
 .PHONY: dev-ci-local-run
 
-dev-ci-e2e-subscription-rbac-local-run:
-	$(MAKE) local-run DEPLOY_ENV=dev-ci CONFIG_FILE=config/config-dev-ci.yaml TOPOLOGY_FILE=topology-dev-ci.yaml WHAT="--service-group Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBAC" STEP_CACHE_DIR="" EXTRA_ARGS="--skip-bicepparam-validation"
-.PHONY: dev-ci-e2e-subscription-rbac-local-run
-
 # PRIVILEGED, on-demand only. Applies the subscription-scoped custom role
 # definitions and role assignments (requires Owner / User Access Administrator
 # on the target subscriptions). Not part of the dev-ci postsubmit; run by an
 # OWNERS-group member. See docs/ci/dev-ci-topology.md.
 dev-ci-e2e-rbac-grants-local-run:
-	$(MAKE) local-run DEPLOY_ENV=dev-ci CONFIG_FILE=config/config-dev-ci.yaml TOPOLOGY_FILE=topology-dev-ci.yaml WHAT="--service-group Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBACGrants" STEP_CACHE_DIR=""
+	$(MAKE) local-run DEPLOY_ENV=dev-ci CONFIG_FILE=config/config-dev-ci.yaml TOPOLOGY_FILE=topology-dev-ci.yaml WHAT="--service-group Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBACGrants" STEP_CACHE_DIR="" EXTRA_ARGS="--skip-bicepparam-validation"
 .PHONY: dev-ci-e2e-rbac-grants-local-run
 
 #

--- a/config/config-dev-ci.yaml
+++ b/config/config-dev-ci.yaml
@@ -16,6 +16,8 @@ $schema: config-dev-ci.schema.json
 clouds:
   dev:
     defaults:
+      environmentName: "{{ .ctx.environment }}"
+      region: "{{ .ctx.region }}"
       svc:
         rg: "opstool-{{ .ctx.region }}"
         subscription:

--- a/config/config-dev-ci.yaml
+++ b/config/config-dev-ci.yaml
@@ -7,7 +7,7 @@ $schema: config-dev-ci.schema.json
 #     --topology-file="${PROJECT_ROOT_DIR}/topology-dev-ci.yaml" \
 #     --dev-settings-file="${PROJECT_ROOT_DIR}/tooling/templatize/settings.yaml" \
 #     --dev-environment dev-ci \
-#     --service-group Microsoft.Azure.ARO.HCP.DevCI.Infra
+#     --service-group Microsoft.Azure.ARO.HCP.DevCI.Unprivileged
 #
 # Prerequisites for manual deployment:
 #   - Build templatize: make templatize

--- a/config/config-dev-ci.yaml
+++ b/config/config-dev-ci.yaml
@@ -127,7 +127,7 @@ clouds:
           image:
             registry: "quay.io"
             repository: "roivaz/cihealth"
-            tag: "b18f5c1"
+            tag: "0c8550b"
           disableRuntimeWorkloads: false
           app:
             replicas: 2

--- a/dev-infrastructure/dev-ci/cert-manager/pipeline.yaml
+++ b/dev-infrastructure/dev-ci/cert-manager/pipeline.yaml
@@ -63,7 +63,7 @@ resourceGroups:
     - resourceGroup: opstool
       step: build-dependencies
     externalDependsOn:
-    - serviceGroup: Microsoft.Azure.ARO.HCP.DevCI.Infra
+    - serviceGroup: Microsoft.Azure.ARO.HCP.DevCI.Unprivileged
       resourceGroup: opstool
       step: network
     identityFrom:

--- a/dev-infrastructure/dev-ci/cert-manager/pipeline.yaml
+++ b/dev-infrastructure/dev-ci/cert-manager/pipeline.yaml
@@ -12,6 +12,23 @@ resourceGroups:
     parameters: ../../configurations/output-opstool-cluster.tmpl.bicepparam
     deploymentLevel: ResourceGroup
     outputOnly: true
+  # The opstool-cert-manager chart carries the upstream cert-manager chart as a
+  # dependency (see deploy/Chart.yaml). The dependency tarball under deploy/charts/
+  # is git-ignored (**/charts/*.tgz), so it must be fetched before the Helm deploy
+  # step packages the chart. Without this, the Helm loader silently renders an empty
+  # release and cert-manager is never installed.
+  - name: build-dependencies
+    action: Shell
+    command: helm dependency build
+    workingDir: deploy
+    shellIdentity:
+      input:
+        resourceGroup: opstool
+        step: output
+        name: opstoolUAMIId
+    dependsOn:
+    - resourceGroup: opstool
+      step: output
   - name: deploy
     aksCluster: '{{ .opstool.aks.name }}'
     action: Helm
@@ -43,6 +60,8 @@ resourceGroups:
     dependsOn:
     - resourceGroup: opstool
       step: output
+    - resourceGroup: opstool
+      step: build-dependencies
     externalDependsOn:
     - serviceGroup: Microsoft.Azure.ARO.HCP.DevCI.Infra
       resourceGroup: opstool

--- a/dev-infrastructure/dev-ci/cluster/opstool-aks-pipeline.yaml
+++ b/dev-infrastructure/dev-ci/cluster/opstool-aks-pipeline.yaml
@@ -1,5 +1,5 @@
 $schema: "pipeline.schema.v1"
-serviceGroup: Microsoft.Azure.ARO.HCP.DevCI.Infra
+serviceGroup: Microsoft.Azure.ARO.HCP.DevCI.Unprivileged
 rolloutName: Opstool Network and Cluster Rollout
 resourceGroups:
 - name: opstool

--- a/dev-infrastructure/dev-ci/e2e-subscription-rbac-grants/pipeline.yaml
+++ b/dev-infrastructure/dev-ci/e2e-subscription-rbac-grants/pipeline.yaml
@@ -3,20 +3,21 @@ serviceGroup: Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBACGrants
 rolloutName: Dev CI E2E Subscription RBAC Grants Rollout
 # PRIVILEGED pipeline: every step here creates subscription-scoped custom role
 # definitions and/or role assignments, which require Owner (or an unconstrained
-# User Access Administrator) on the target subscriptions. It is deliberately
-# kept out of the Microsoft.Azure.ARO.HCP.DevCI.Infra entrypoint so the
-# unattended dev-ci postsubmit never runs it. That postsubmit runs as the
+# User Access Administrator) on the target subscriptions. It is the child of the
+# Microsoft.Azure.ARO.HCP.DevCI.Privileged entrypoint and is deliberately kept
+# out of the unattended Microsoft.Azure.ARO.HCP.DevCI.Unprivileged entrypoint
+# so the dev-ci postsubmit never runs it. That postsubmit runs as the
 # `OpenShift Release Bot` SP, which is intentionally not an Owner: it holds
 # Contributor plus a condition-constrained RBAC/User Access Administrator whose
 # ABAC condition forbids assigning the Owner, User Access Administrator, and
 # Role Based Access Control Administrator roles (one of which this pipeline
 # assigns), and on some subscriptions lacks roleDefinitions/write — so it cannot
-# apply these grants. Run it on demand as a standalone service group with
-# `make dev-ci-e2e-rbac-grants-local-run` by a member of the OWNERS group (who
-# has real Owner) when a change touches these grants.
+# apply these grants. Run the Microsoft.Azure.ARO.HCP.DevCI.Privileged
+# entrypoint on demand with `make dev-ci-privileged-local-run` as a member
+# of the OWNERS group (who has real Owner) when a change touches these grants.
 #
-# Prerequisite: the non-privileged Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBAC
-# pipeline must have run at least once so the CI bot service principals exist —
+# Prerequisite: the Microsoft.Azure.ARO.HCP.DevCI.Unprivileged entrypoint must
+# have run at least once so the CI bot service principals exist —
 # ci-bot-rbac.bicep looks them up via `existing` (by uniqueName).
 resourceGroups:
 - name: grants

--- a/dev-infrastructure/dev-ci/e2e-subscription-rbac-grants/pipeline.yaml
+++ b/dev-infrastructure/dev-ci/e2e-subscription-rbac-grants/pipeline.yaml
@@ -1,0 +1,55 @@
+$schema: "pipeline.schema.v1"
+serviceGroup: Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBACGrants
+rolloutName: Dev CI E2E Subscription RBAC Grants Rollout
+# PRIVILEGED pipeline: every step here creates subscription-scoped custom role
+# definitions and/or role assignments, which require Owner (or User Access
+# Administrator) on the target subscriptions. It is deliberately kept out of the
+# Microsoft.Azure.ARO.HCP.DevCI.Infra entrypoint so the unattended dev-ci
+# postsubmit (which has no standing Owner identity) never runs it. Run it on
+# demand as a standalone service group with `make dev-ci-e2e-rbac-grants-local-run`
+# by a member of the OWNERS group when a change touches these grants.
+#
+# Prerequisite: the non-privileged Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBAC
+# pipeline must have run at least once so the CI bot service principals exist —
+# ci-bot-rbac.bicep looks them up via `existing` (by uniqueName).
+resourceGroups:
+- name: grants
+  resourceGroup: '{{ .global.rg }}'
+  subscription: '{{ .global.subscription.key }}'
+  steps:
+  - name: customer-subscription-grants
+    action: ARM
+    template: ../../templates/e2e-subscription-rbac-assignments.bicep
+    parameters: ../../configurations/e2e-subscription-rbac-assignments.tmpl.bicepparam
+    deploymentLevel: Subscription
+- name: ci-bots
+  resourceGroup: '{{ .global.rg }}'
+  subscription: '{{ .global.subscription.key }}'
+  steps:
+  # The DEV Release Bot RBAC is still managed imperatively by the legacy
+  # grant-openshift-release-bot-dev.sh script, which created role assignments
+  # under random (non-deterministic) names. Enabling this step before those
+  # legacy assignments are removed fails with RoleAssignmentExists, because the
+  # deterministic guid()-named assignments this template creates collide with
+  # the pre-existing ones. Keep it commented until the DEV bot RBAC migration
+  # (delete legacy assignments, then enable this step) has been performed.
+  # - name: ci-bot-rbac-dev
+  #   action: ARM
+  #   template: ../../templates/ci-bot-rbac.bicep
+  #   parameters: ../../configurations/ci-bot-rbac-dev.tmpl.bicepparam
+  #   deploymentLevel: ResourceGroup
+  - name: ci-bot-rbac-int
+    action: ARM
+    template: ../../templates/ci-bot-rbac.bicep
+    parameters: ../../configurations/ci-bot-rbac-int.tmpl.bicepparam
+    deploymentLevel: ResourceGroup
+  - name: ci-bot-rbac-stg
+    action: ARM
+    template: ../../templates/ci-bot-rbac.bicep
+    parameters: ../../configurations/ci-bot-rbac-stg.tmpl.bicepparam
+    deploymentLevel: ResourceGroup
+  - name: ci-bot-rbac-prod
+    action: ARM
+    template: ../../templates/ci-bot-rbac.bicep
+    parameters: ../../configurations/ci-bot-rbac-prod.tmpl.bicepparam
+    deploymentLevel: ResourceGroup

--- a/dev-infrastructure/dev-ci/e2e-subscription-rbac-grants/pipeline.yaml
+++ b/dev-infrastructure/dev-ci/e2e-subscription-rbac-grants/pipeline.yaml
@@ -2,12 +2,18 @@ $schema: "pipeline.schema.v1"
 serviceGroup: Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBACGrants
 rolloutName: Dev CI E2E Subscription RBAC Grants Rollout
 # PRIVILEGED pipeline: every step here creates subscription-scoped custom role
-# definitions and/or role assignments, which require Owner (or User Access
-# Administrator) on the target subscriptions. It is deliberately kept out of the
-# Microsoft.Azure.ARO.HCP.DevCI.Infra entrypoint so the unattended dev-ci
-# postsubmit (which has no standing Owner identity) never runs it. Run it on
-# demand as a standalone service group with `make dev-ci-e2e-rbac-grants-local-run`
-# by a member of the OWNERS group when a change touches these grants.
+# definitions and/or role assignments, which require Owner (or an unconstrained
+# User Access Administrator) on the target subscriptions. It is deliberately
+# kept out of the Microsoft.Azure.ARO.HCP.DevCI.Infra entrypoint so the
+# unattended dev-ci postsubmit never runs it. That postsubmit runs as the
+# `OpenShift Release Bot` SP, which is intentionally not an Owner: it holds
+# Contributor plus a condition-constrained RBAC/User Access Administrator whose
+# ABAC condition forbids assigning the Owner, User Access Administrator, and
+# Role Based Access Control Administrator roles (one of which this pipeline
+# assigns), and on some subscriptions lacks roleDefinitions/write — so it cannot
+# apply these grants. Run it on demand as a standalone service group with
+# `make dev-ci-e2e-rbac-grants-local-run` by a member of the OWNERS group (who
+# has real Owner) when a change touches these grants.
 #
 # Prerequisite: the non-privileged Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBAC
 # pipeline must have run at least once so the CI bot service principals exist —

--- a/dev-infrastructure/dev-ci/e2e-subscription-rbac/pipeline.yaml
+++ b/dev-infrastructure/dev-ci/e2e-subscription-rbac/pipeline.yaml
@@ -1,16 +1,17 @@
 $schema: "pipeline.schema.v1"
 serviceGroup: Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBAC
 rolloutName: Dev CI E2E Subscription RBAC Rollout
+# NON-PRIVILEGED pipeline: only reconciles the CI bot Entra identities (Graph
+# Application.ReadWrite.OwnedBy axis, not Azure RBAC) and rotates their Key Vault
+# secrets (data-plane). None of these steps require Owner/User Access
+# Administrator on any subscription, so this pipeline runs unattended as part of
+# the Microsoft.Azure.ARO.HCP.DevCI.Infra entrypoint (dev-ci postsubmit).
+#
+# The privileged subscription-scoped role definitions and role assignments live
+# in the separate Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBACGrants
+# service group (dev-infrastructure/dev-ci/e2e-subscription-rbac-grants/), which
+# is run on demand by an OWNERS-group member.
 resourceGroups:
-- name: grants
-  resourceGroup: '{{ .global.rg }}'
-  subscription: '{{ .global.subscription.key }}'
-  steps:
-  - name: customer-subscription-grants
-    action: ARM
-    template: ../../templates/e2e-subscription-rbac-assignments.bicep
-    parameters: ../../configurations/e2e-subscription-rbac-assignments.tmpl.bicepparam
-    deploymentLevel: Subscription
 - name: ci-bots
   resourceGroup: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'
@@ -80,45 +81,6 @@ resourceGroups:
       value: prod
     - name: KEY_VAULT_NAME
       configRef: opstool.keyVault.name
-    dependsOn:
-    - resourceGroup: ci-bots
-      step: ci-bot-identity
-  # The DEV Release Bot RBAC is still managed imperatively by the legacy
-  # grant-openshift-release-bot-dev.sh script, which created role assignments
-  # under random (non-deterministic) names. Enabling this step before those
-  # legacy assignments are removed fails with RoleAssignmentExists, because the
-  # deterministic guid()-named assignments this template creates collide with
-  # the pre-existing ones. Keep it commented until the DEV bot RBAC migration
-  # (delete legacy assignments, then enable this step) has been performed.
-  # - name: ci-bot-rbac-dev
-  #   action: ARM
-  #   template: ../../templates/ci-bot-rbac.bicep
-  #   parameters: ../../configurations/ci-bot-rbac-dev.tmpl.bicepparam
-  #   deploymentLevel: ResourceGroup
-  #   dependsOn:
-  #   - resourceGroup: ci-bots
-  #     step: ci-bot-identity
-  - name: ci-bot-rbac-int
-    action: ARM
-    template: ../../templates/ci-bot-rbac.bicep
-    parameters: ../../configurations/ci-bot-rbac-int.tmpl.bicepparam
-    deploymentLevel: ResourceGroup
-    dependsOn:
-    - resourceGroup: ci-bots
-      step: ci-bot-identity
-  - name: ci-bot-rbac-stg
-    action: ARM
-    template: ../../templates/ci-bot-rbac.bicep
-    parameters: ../../configurations/ci-bot-rbac-stg.tmpl.bicepparam
-    deploymentLevel: ResourceGroup
-    dependsOn:
-    - resourceGroup: ci-bots
-      step: ci-bot-identity
-  - name: ci-bot-rbac-prod
-    action: ARM
-    template: ../../templates/ci-bot-rbac.bicep
-    parameters: ../../configurations/ci-bot-rbac-prod.tmpl.bicepparam
-    deploymentLevel: ResourceGroup
     dependsOn:
     - resourceGroup: ci-bots
       step: ci-bot-identity

--- a/dev-infrastructure/dev-ci/e2e-subscription-rbac/pipeline.yaml
+++ b/dev-infrastructure/dev-ci/e2e-subscription-rbac/pipeline.yaml
@@ -5,12 +5,12 @@ rolloutName: Dev CI E2E Subscription RBAC Rollout
 # Application.ReadWrite.OwnedBy axis, not Azure RBAC) and rotates their Key Vault
 # secrets (data-plane). None of these steps require Owner/User Access
 # Administrator on any subscription, so this pipeline runs unattended as part of
-# the Microsoft.Azure.ARO.HCP.DevCI.Infra entrypoint (dev-ci postsubmit).
+# the Microsoft.Azure.ARO.HCP.DevCI.Unprivileged entrypoint (dev-ci postsubmit).
 #
-# The privileged subscription-scoped role definitions and role assignments live
-# in the separate Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBACGrants
-# service group (dev-infrastructure/dev-ci/e2e-subscription-rbac-grants/), which
-# is run on demand by an OWNERS-group member.
+# The privileged subscription-scoped role definitions and role assignments are
+# instead applied by the separate Microsoft.Azure.ARO.HCP.DevCI.Privileged
+# entrypoint, which is run on demand by an OWNERS-group member
+# (`make dev-ci-privileged-local-run`).
 resourceGroups:
 - name: ci-bots
   resourceGroup: '{{ .global.rg }}'

--- a/dev-infrastructure/dev-ci/gateway/pipeline.yaml
+++ b/dev-infrastructure/dev-ci/gateway/pipeline.yaml
@@ -29,7 +29,7 @@ resourceGroups:
     - resourceGroup: opstool
       step: output
     externalDependsOn:
-    - serviceGroup: Microsoft.Azure.ARO.HCP.DevCI.Infra
+    - serviceGroup: Microsoft.Azure.ARO.HCP.DevCI.Unprivileged
       resourceGroup: opstool
       step: network
     - serviceGroup: Microsoft.Azure.ARO.HCP.DevCI.CertManager

--- a/dev-infrastructure/dev-ci/privileged/pipeline.yaml
+++ b/dev-infrastructure/dev-ci/privileged/pipeline.yaml
@@ -1,0 +1,16 @@
+$schema: "pipeline.schema.v1"
+serviceGroup: Microsoft.Azure.ARO.HCP.DevCI.Privileged
+rolloutName: Dev CI Privileged Grouping Rollout
+# GROUPING-ONLY, no-op pipeline. This service group exists solely to be the root
+# of the `Microsoft.Azure.ARO.HCP.DevCI.Privileged` entrypoint so the privileged,
+# Owner-only grants can be rolled out on demand separately from the unattended
+# `Microsoft.Azure.ARO.HCP.DevCI.Unprivileged` entrypoint. The topology
+# framework requires every service group to reference a pipeline, so this one
+# declares an empty step list and does no work itself — all privileged actions
+# live in the child `Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBACGrants`
+# service group. See docs/ci/dev-ci-topology.md.
+resourceGroups:
+- name: noop
+  resourceGroup: '{{ .global.rg }}'
+  subscription: '{{ .global.subscription.key }}'
+  steps: []

--- a/docs/.prow-docs-maintenance.md
+++ b/docs/.prow-docs-maintenance.md
@@ -72,6 +72,7 @@ Do not reintroduce:
 - `../test/cmd/aro-hcp-tests/slot-manager/DESIGN.md`
 - `../test/cmd/aro-hcp-tests/slot-manager/release_repo.go`
 - `../dev-infrastructure/dev-ci/e2e-subscription-rbac/pipeline.yaml`
+- `../dev-infrastructure/dev-ci/e2e-subscription-rbac-grants/pipeline.yaml`
 - `../dev-infrastructure/configurations/e2e-subscription-rbac-assignments.tmpl.bicepparam`
 - `../dev-infrastructure/configurations/dev-operator-roles.tmpl.bicepparam`
 - `../dev-infrastructure/configurations/mock-identity-roles.tmpl.bicepparam`

--- a/docs/ci/dev-ci-topology.md
+++ b/docs/ci/dev-ci-topology.md
@@ -39,9 +39,9 @@ In other words, `dev-ci` owns the persistent CI support layer, not the full runt
 
 - `Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBACGrants`
   - Manages the explicit DEV E2E customer-subscription RBAC (custom role definitions + shared-principal role assignments) and the CI bot subscription-scoped RBAC (`ci-bot-rbac-int/stg/prod`).
-  - Every step creates subscription-scoped custom role definitions and/or role assignments, which require **Owner** (or User Access Administrator) on the target subscriptions.
+  - Every step creates subscription-scoped custom role definitions and/or role assignments. This requires **Owner** (or an *unconstrained* User Access Administrator) on the target subscriptions — specifically the rights to write custom role definitions and to assign the privileged `Role Based Access Control Administrator` role to the mock arm-helper principal.
 
-Because the unattended `dev-ci` postsubmit runs the `DevCI.Infra` entrypoint and holds **no standing Owner identity**, this group is excluded from that graph. It is run manually by a member of the OWNERS group whenever a change touches these grants:
+The identity that runs the unattended `dev-ci` postsubmit (the `OpenShift Release Bot` service principal, app `38335e22-716a-4a21-bf20-15ab141823f0`) is deliberately **not** an Owner. It holds `Contributor` plus a *condition-constrained* `Role Based Access Control Administrator` / `User Access Administrator` whose Azure ABAC condition forbids assigning the `Owner`, `User Access Administrator`, and `Role Based Access Control Administrator` roles. That is exactly one of the assignments this group makes, and on some target subscriptions the bot also lacks `Microsoft.Authorization/roleDefinitions/write` — so the grants would fail if the postsubmit tried to apply them. This group is therefore excluded from the `DevCI.Infra` entrypoint graph and is run manually by a member of the OWNERS group (who has real Owner) whenever a change touches these grants:
 
 ```bash
 make dev-ci-e2e-rbac-grants-local-run

--- a/docs/ci/dev-ci-topology.md
+++ b/docs/ci/dev-ci-topology.md
@@ -23,7 +23,7 @@ Today `topology-dev-ci.yaml` contains one entrypoint, `Microsoft.Azure.ARO.HCP.D
 - `Microsoft.Azure.ARO.HCP.DevCI.TenantQuota`
   - Deploys the `tenant-quota-collector` workload that monitors Azure quotas relevant to CI capacity.
 - `Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBAC`
-  - Manages explicit DEV E2E customer-subscription RBAC and the shared custom-role assignable scopes used by those subscriptions.
+  - Reconciles the non-privileged CI bot Entra identities (Graph `Application.ReadWrite.OwnedBy` axis) and rotates their Key Vault secrets. Requires no subscription Owner, so it runs unattended as part of the `DevCI.Infra` entrypoint.
 - `Microsoft.Azure.ARO.HCP.DevCI.Gateway`
   - Deploys the shared Istio gateway and DNS wiring for `opstool`.
 - `Microsoft.Azure.ARO.HCP.DevCI.CertManager`
@@ -32,6 +32,24 @@ Today `topology-dev-ci.yaml` contains one entrypoint, `Microsoft.Azure.ARO.HCP.D
   - Deploys the CIHealth runtime at `cihealth.tools.hcpsvc.osadev.cloud`.
 
 In other words, `dev-ci` owns the persistent CI support layer, not the full runtime behavior of every CI job.
+
+## The Privileged Grants Service Group
+
+`topology-dev-ci.yaml` also declares one **standalone, on-demand** service group that is deliberately **not** a child of the `DevCI.Infra` entrypoint and has **no entrypoint of its own**:
+
+- `Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBACGrants`
+  - Manages the explicit DEV E2E customer-subscription RBAC (custom role definitions + shared-principal role assignments) and the CI bot subscription-scoped RBAC (`ci-bot-rbac-int/stg/prod`).
+  - Every step creates subscription-scoped custom role definitions and/or role assignments, which require **Owner** (or User Access Administrator) on the target subscriptions.
+
+Because the unattended `dev-ci` postsubmit runs the `DevCI.Infra` entrypoint and holds **no standing Owner identity**, this group is excluded from that graph. It is run manually by a member of the OWNERS group whenever a change touches these grants:
+
+```bash
+make dev-ci-e2e-rbac-grants-local-run
+```
+
+Its pipeline (`dev-infrastructure/dev-ci/e2e-subscription-rbac-grants/pipeline.yaml`) looks up the CI bot service principals via `existing`, so the non-privileged `DevCI.E2ESubscriptionRBAC` pipeline must have run at least once first (it creates those identities).
+
+This split keeps the blast radius of the standing CI automation small: the postsubmit reconciles everything that does not need Owner, and the rare Owner-only changes are applied on demand.
 
 ## What It Does Not Manage
 
@@ -48,7 +66,7 @@ For the runtime lease model itself, see [CI Identity Leasing](identity-leasing.m
 
 The sharpest mixed-management boundary today is the DEV MSI mock service-principal pool used by local E2E jobs.
 
-- `Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBAC` owns the customer-subscription RBAC side for the pooled principals, using principal IDs from `config/config-dev-ci.yaml`.
+- `Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBACGrants` owns the customer-subscription RBAC side for the pooled principals, using principal IDs from `config/config-dev-ci.yaml`. Because those grants require subscription Owner, they are applied on demand rather than by the postsubmit (see [The Privileged Grants Service Group](#the-privileged-grants-service-group)).
 - `make create-msi-mock-pool` is still a hybrid operator path:
   - `dev-infrastructure/templates/mock-identity-pool.bicep` ensures the Key Vault certificate footprint.
   - `dev-infrastructure/scripts/create-sp-for-rbac.sh` and `dev-infrastructure/Makefile` still create or update the Entra app and service principal objects and apply the home-subscription grants.
@@ -74,9 +92,10 @@ Useful local entry points for the current topology:
 ```bash
 make dev-ci-local-run
 make dev-ci-e2e-subscription-rbac-local-run
+make dev-ci-e2e-rbac-grants-local-run
 ```
 
-Use the first command for the full standalone `dev-ci` entrypoint and the second when only the customer-subscription RBAC rollout needs to be reconciled.
+Use the first command for the full standalone `dev-ci` entrypoint. Use the second when only the non-privileged CI bot identity/secret rollout needs to be reconciled. Use the third — **an Owner-only, on-demand run performed by an OWNERS-group member** — when the subscription-scoped custom roles and role assignments need to be applied.
 
 ## Where To Look
 
@@ -86,6 +105,7 @@ When you need to change or debug the standalone `dev-ci` topology, start here:
 - `topology-dev-ci.yaml`
 - `dev-infrastructure/dev-ci/cluster/opstool-aks-pipeline.yaml`
 - `dev-infrastructure/dev-ci/e2e-subscription-rbac/pipeline.yaml`
+- `dev-infrastructure/dev-ci/e2e-subscription-rbac-grants/pipeline.yaml`
 - `dev-infrastructure/configurations/e2e-subscription-rbac-assignments.tmpl.bicepparam`
 - `dev-infrastructure/Makefile`
 - `dev-infrastructure/openshift-ci/populate-msi-mock-pool.sh`

--- a/docs/ci/dev-ci-topology.md
+++ b/docs/ci/dev-ci-topology.md
@@ -9,21 +9,21 @@ Use this document to understand what the `dev-ci` rollout owns today, what it de
 `dev-ci` exists because some CI dependencies need to be long-lived and shared across many jobs, but they are not part of the normal product environment topology:
 
 - `config/config-dev-ci.yaml` carries standalone configuration for these CI-supporting resources.
-- `topology-dev-ci.yaml` defines a separate rollout graph rooted at `Microsoft.Azure.ARO.HCP.DevCI.Infra`.
+- `topology-dev-ci.yaml` defines a separate rollout graph with two entrypoints: `Microsoft.Azure.ARO.HCP.DevCI.Unprivileged` (the unattended postsubmit surface) and `Microsoft.Azure.ARO.HCP.DevCI.Privileged` (the on-demand, Owner-only grants surface).
 - The long-term goal is for `openshift/release` jobs to consume this shared foundation without defining or deploying the `dev-ci` topology themselves, but that handoff is not complete yet.
 
 This keeps persistent CI-support infrastructure separate from the per-job RP footprint that DEV local E2E provisions on demand.
 
 ## What The Topology Manages Today
 
-Today `topology-dev-ci.yaml` contains one entrypoint, `Microsoft.Azure.ARO.HCP.DevCI.Infra`, plus five child service groups:
+Today `topology-dev-ci.yaml`'s `Microsoft.Azure.ARO.HCP.DevCI.Unprivileged` entrypoint contains one root service group plus five child service groups:
 
-- `Microsoft.Azure.ARO.HCP.DevCI.Infra`
+- `Microsoft.Azure.ARO.HCP.DevCI.Unprivileged`
   - Deploys shared dev/CI network resources, the `opstool` AKS cluster, and the shared Prometheus monitoring stack.
 - `Microsoft.Azure.ARO.HCP.DevCI.TenantQuota`
   - Deploys the `tenant-quota-collector` workload that monitors Azure quotas relevant to CI capacity.
 - `Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBAC`
-  - Reconciles the non-privileged CI bot Entra identities (Graph `Application.ReadWrite.OwnedBy` axis) and rotates their Key Vault secrets. Requires no subscription Owner, so it runs unattended as part of the `DevCI.Infra` entrypoint.
+  - Reconciles the non-privileged CI bot Entra identities (Graph `Application.ReadWrite.OwnedBy` axis) and rotates their Key Vault secrets. Requires no subscription Owner, so it runs unattended as part of the `DevCI.Unprivileged` entrypoint.
 - `Microsoft.Azure.ARO.HCP.DevCI.Gateway`
   - Deploys the shared Istio gateway and DNS wiring for `opstool`.
 - `Microsoft.Azure.ARO.HCP.DevCI.CertManager`
@@ -33,21 +33,19 @@ Today `topology-dev-ci.yaml` contains one entrypoint, `Microsoft.Azure.ARO.HCP.D
 
 In other words, `dev-ci` owns the persistent CI support layer, not the full runtime behavior of every CI job.
 
-## The Privileged Grants Service Group
+## The Privileged Entrypoint
 
-`topology-dev-ci.yaml` also declares one **standalone, on-demand** service group that is deliberately **not** a child of the `DevCI.Infra` entrypoint and has **no entrypoint of its own**:
+`topology-dev-ci.yaml` also declares a **standalone, on-demand** privileged tree rooted at the `Microsoft.Azure.ARO.HCP.DevCI.Privileged` entrypoint, deliberately kept **separate** from the unattended `Microsoft.Azure.ARO.HCP.DevCI.Unprivileged` entrypoint. It applies the DEV E2E customer-subscription RBAC (custom role definitions + shared-principal role assignments) and the CI bot subscription-scoped RBAC. Every step creates subscription-scoped custom role definitions and/or role assignments, which require **Owner** (or an *unconstrained* User Access Administrator) on the target subscriptions — specifically the rights to write custom role definitions and to assign the privileged `Role Based Access Control Administrator` role to the mock arm-helper principal.
 
-- `Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBACGrants`
-  - Manages the explicit DEV E2E customer-subscription RBAC (custom role definitions + shared-principal role assignments) and the CI bot subscription-scoped RBAC (`ci-bot-rbac-int/stg/prod`).
-  - Every step creates subscription-scoped custom role definitions and/or role assignments. This requires **Owner** (or an *unconstrained* User Access Administrator) on the target subscriptions — specifically the rights to write custom role definitions and to assign the privileged `Role Based Access Control Administrator` role to the mock arm-helper principal.
+> Implementation detail: because the topology framework requires every service group to reference a pipeline, the `DevCI.Privileged` root is a **no-op grouping pipeline** (`dev-infrastructure/dev-ci/privileged/pipeline.yaml`, empty step list) and the actual grants live in a child service group. Operators never target that child directly — always use the entrypoint via the make target below.
 
-The identity that runs the unattended `dev-ci` postsubmit (the `OpenShift Release Bot` service principal, app `38335e22-716a-4a21-bf20-15ab141823f0`) is deliberately **not** an Owner. It holds `Contributor` plus a *condition-constrained* `Role Based Access Control Administrator` / `User Access Administrator` whose Azure ABAC condition forbids assigning the `Owner`, `User Access Administrator`, and `Role Based Access Control Administrator` roles. That is exactly one of the assignments this group makes, and on some target subscriptions the bot also lacks `Microsoft.Authorization/roleDefinitions/write` — so the grants would fail if the postsubmit tried to apply them. This group is therefore excluded from the `DevCI.Infra` entrypoint graph and is run manually by a member of the OWNERS group (who has real Owner) whenever a change touches these grants:
+The identity that runs the unattended `dev-ci` postsubmit (the `OpenShift Release Bot` service principal, app `38335e22-716a-4a21-bf20-15ab141823f0`) is deliberately **not** an Owner. It holds `Contributor` plus a *condition-constrained* `Role Based Access Control Administrator` / `User Access Administrator` whose Azure ABAC condition forbids assigning the `Owner`, `User Access Administrator`, and `Role Based Access Control Administrator` roles. That is exactly one of the assignments this entrypoint makes, and on some target subscriptions the bot also lacks `Microsoft.Authorization/roleDefinitions/write` — so the grants would fail if the postsubmit tried to apply them. The `DevCI.Privileged` entrypoint is therefore never wired into the unattended `DevCI.Unprivileged` graph and is run manually by a member of the OWNERS group (who has real Owner) whenever a change touches these grants:
 
 ```bash
-make dev-ci-e2e-rbac-grants-local-run
+make dev-ci-privileged-local-run
 ```
 
-Its pipeline (`dev-infrastructure/dev-ci/e2e-subscription-rbac-grants/pipeline.yaml`) looks up the CI bot service principals via `existing`, so the non-privileged `DevCI.E2ESubscriptionRBAC` pipeline must have run at least once first (it creates those identities).
+This grants rollout looks up the CI bot service principals via `existing`, so the `DevCI.Unprivileged` entrypoint must have run at least once first — it creates those identities.
 
 This split keeps the blast radius of the standing CI automation small: the postsubmit reconciles everything that does not need Owner, and the rare Owner-only changes are applied on demand.
 
@@ -66,7 +64,7 @@ For the runtime lease model itself, see [CI Identity Leasing](identity-leasing.m
 
 The sharpest mixed-management boundary today is the DEV MSI mock service-principal pool used by local E2E jobs.
 
-- `Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBACGrants` owns the customer-subscription RBAC side for the pooled principals, using principal IDs from `config/config-dev-ci.yaml`. Because those grants require subscription Owner, they are applied on demand rather than by the postsubmit (see [The Privileged Grants Service Group](#the-privileged-grants-service-group)).
+- The `Microsoft.Azure.ARO.HCP.DevCI.Privileged` entrypoint owns the customer-subscription RBAC side for the pooled principals, using principal IDs from `config/config-dev-ci.yaml`. Because those grants require subscription Owner, they are applied on demand rather than by the postsubmit (see [The Privileged Entrypoint](#the-privileged-entrypoint)).
 - `make create-msi-mock-pool` is still a hybrid operator path:
   - `dev-infrastructure/templates/mock-identity-pool.bicep` ensures the Key Vault certificate footprint.
   - `dev-infrastructure/scripts/create-sp-for-rbac.sh` and `dev-infrastructure/Makefile` still create or update the Entra app and service principal objects and apply the home-subscription grants.
@@ -91,7 +89,7 @@ Useful local entry points for the current topology:
 
 ```bash
 make dev-ci-local-run
-make dev-ci-e2e-rbac-grants-local-run
+make dev-ci-privileged-local-run
 ```
 
 Use the first command for the full standalone `dev-ci` entrypoint, which includes the non-privileged CI bot identity/secret rollout. Use the second — **an Owner-only, on-demand run performed by an OWNERS-group member** — when the subscription-scoped custom roles and role assignments need to be applied.

--- a/docs/ci/dev-ci-topology.md
+++ b/docs/ci/dev-ci-topology.md
@@ -91,11 +91,10 @@ Useful local entry points for the current topology:
 
 ```bash
 make dev-ci-local-run
-make dev-ci-e2e-subscription-rbac-local-run
 make dev-ci-e2e-rbac-grants-local-run
 ```
 
-Use the first command for the full standalone `dev-ci` entrypoint. Use the second when only the non-privileged CI bot identity/secret rollout needs to be reconciled. Use the third — **an Owner-only, on-demand run performed by an OWNERS-group member** — when the subscription-scoped custom roles and role assignments need to be applied.
+Use the first command for the full standalone `dev-ci` entrypoint, which includes the non-privileged CI bot identity/secret rollout. Use the second — **an Owner-only, on-demand run performed by an OWNERS-group member** — when the subscription-scoped custom roles and role assignments need to be applied.
 
 ## Where To Look
 

--- a/docs/ci/dev-mock-identities.md
+++ b/docs/ci/dev-mock-identities.md
@@ -121,9 +121,11 @@ because they bundle a bespoke set of actions with no single built-in equivalent.
 
 ## How The Roles Are Assigned
 
-Role definitions and assignments are reconciled by the `dev-ci` rollout's
-`Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBAC` service group
-(`dev-infrastructure/dev-ci/e2e-subscription-rbac/pipeline.yaml`):
+Role definitions and assignments are reconciled by the `dev-ci` topology's
+**Owner-only, on-demand** `Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBACGrants`
+service group (`dev-infrastructure/dev-ci/e2e-subscription-rbac-grants/pipeline.yaml`),
+run by an OWNERS-group member with `make dev-ci-e2e-rbac-grants-local-run` (it is
+excluded from the unattended `dev-ci` postsubmit because it needs subscription Owner):
 
 - `templates/e2e-subscription-rbac-assignments.bicep` fans out over the onboarded
   E2E customer subscriptions (the DEV home subscription is intentionally excluded —
@@ -157,7 +159,7 @@ Principal IDs and the subscription list are supplied by
   — inline custom role definitions + all assignments
 - `dev-infrastructure/templates/mock-identity-roles.bicep` — home-subscription role
   definitions (legacy; deployed by the `dev-infrastructure/Makefile`, not this pipeline)
-- `dev-infrastructure/dev-ci/e2e-subscription-rbac/pipeline.yaml`
+- `dev-infrastructure/dev-ci/e2e-subscription-rbac-grants/pipeline.yaml`
 - `backend/pkg/azure/client/hardcoded_identity_mi_dataplane_client.go` — the mock MSI
 - `internal/azure/cluster_scoped_identities_config.go` — product operator-role mapping
 - `cluster-service/helm-charts/cluster-service/templates/deployment.yaml` — how CS

--- a/docs/ci/dev-mock-identities.md
+++ b/docs/ci/dev-mock-identities.md
@@ -122,9 +122,8 @@ because they bundle a bespoke set of actions with no single built-in equivalent.
 ## How The Roles Are Assigned
 
 Role definitions and assignments are reconciled by the `dev-ci` topology's
-**Owner-only, on-demand** `Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBACGrants`
-service group (`dev-infrastructure/dev-ci/e2e-subscription-rbac-grants/pipeline.yaml`),
-run by an OWNERS-group member with `make dev-ci-e2e-rbac-grants-local-run` (it is
+**Owner-only, on-demand** `Microsoft.Azure.ARO.HCP.DevCI.Privileged` entrypoint,
+run by an OWNERS-group member with `make dev-ci-privileged-local-run` (it is
 excluded from the unattended `dev-ci` postsubmit because it needs subscription Owner):
 
 - `templates/e2e-subscription-rbac-assignments.bicep` fans out over the onboarded

--- a/docs/ci/e2e-subscription-onboarding.md
+++ b/docs/ci/e2e-subscription-onboarding.md
@@ -33,7 +33,7 @@ The current implementation is split across two layers:
   - `aro-hcp-tests slot-manager` manages Boskos sync/validation, acquire/release, and slot-managed identity-container provisioning.
 - **DEV bootstrap access**
   - `config/config-dev-ci.yaml` records the explicit DEV E2E customer subscriptions that receive shared bootstrap grants.
-  - `Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBACGrants` reconciles the custom roles and shared-principal assignments for those subscriptions. Because those are subscription-scoped role definitions and role assignments, this is an **Owner-only, on-demand** rollout run by an OWNERS-group member — it is deliberately kept out of the unattended `dev-ci` postsubmit. The companion non-privileged `Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBAC` pipeline (CI bot identities + Key Vault secrets) runs automatically.
+  - The **Owner-only, on-demand** `Microsoft.Azure.ARO.HCP.DevCI.Privileged` entrypoint reconciles the custom roles and shared-principal assignments for those subscriptions. Because those are subscription-scoped role definitions and role assignments, it is run by an OWNERS-group member (`make dev-ci-privileged-local-run`) — it is deliberately kept out of the unattended `dev-ci` postsubmit. The non-privileged CI bot identities + Key Vault secrets are reconciled automatically by the `Microsoft.Azure.ARO.HCP.DevCI.Unprivileged` entrypoint.
 
 The bootstrap layer is about the shared dev identities used by the DEV services and by local E2E provisioning, not the per-cluster managed identities created for a specific HCP during a test run.
 
@@ -113,7 +113,7 @@ az provider show --namespace Microsoft.Compute \
    - In the same `config/config-dev-ci.yaml`, also add the subscription to the `opstool.tenantQuota` tenant's `subscriptions` list so the `tenant-quota-collector` tracks it. Set `roleAssignmentLimit: 8000` and list the same `regions` the pool runs in, matching the Role Assignment quota requested in step 2.
    - In a normal onboarding flow, `homeSubscription`, `sharedPrincipals`, and `msiMockPool.principals` should not need to change.
    - Apply the **privileged** customer-subscription grants (custom roles + shared-principal role assignments on the new subscription). This requires **Owner** on the target subscription, so it is **not** run by the `dev-ci` postsubmit — ask an OWNERS-group member to run it from the repo root:
-     - `make dev-ci-e2e-rbac-grants-local-run`
+     - `make dev-ci-privileged-local-run`
 
 7. Validate the end-to-end path.
    - Confirm `slot-manager acquire` can resolve the new pool using the updated cluster profile inventory.
@@ -219,7 +219,7 @@ AFEC registration is a two-step process: first initiate the registration from th
 
 1. Add the subscription to `config/config-dev-ci.yaml` under the appropriate `ci.<env>.e2eSubscriptions` section.
 
-2. Run the `Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBACGrants` service group to grant the environment's CI bot (e.g. `OpenShift Release Bot - STG`) the required RBAC on the new subscription (`make dev-ci-e2e-rbac-grants-local-run`). This creates subscription-scoped role assignments and therefore requires **Owner** on the target subscription — run it on demand via an OWNERS-group member, not the `dev-ci` postsubmit.
+2. Run the `Microsoft.Azure.ARO.HCP.DevCI.Privileged` entrypoint to grant the environment's CI bot (e.g. `OpenShift Release Bot - STG`) the required RBAC on the new subscription (`make dev-ci-privileged-local-run`). This creates subscription-scoped role assignments and therefore requires **Owner** on the target subscription — run it on demand via an OWNERS-group member, not the `dev-ci` postsubmit.
 
 3. Add the pool to `test/e2e-config/e2e-slots.yaml` under the environment's `pools` list.
 

--- a/docs/ci/e2e-subscription-onboarding.md
+++ b/docs/ci/e2e-subscription-onboarding.md
@@ -33,7 +33,7 @@ The current implementation is split across two layers:
   - `aro-hcp-tests slot-manager` manages Boskos sync/validation, acquire/release, and slot-managed identity-container provisioning.
 - **DEV bootstrap access**
   - `config/config-dev-ci.yaml` records the explicit DEV E2E customer subscriptions that receive shared bootstrap grants.
-  - `Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBAC` reconciles the custom roles and shared-principal assignments for those subscriptions.
+  - `Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBACGrants` reconciles the custom roles and shared-principal assignments for those subscriptions. Because those are subscription-scoped role definitions and role assignments, this is an **Owner-only, on-demand** rollout run by an OWNERS-group member — it is deliberately kept out of the unattended `dev-ci` postsubmit. The companion non-privileged `Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBAC` pipeline (CI bot identities + Key Vault secrets) runs automatically.
 
 The bootstrap layer is about the shared dev identities used by the DEV services and by local E2E provisioning, not the per-cluster managed identities created for a specific HCP during a test run.
 
@@ -112,8 +112,8 @@ az provider show --namespace Microsoft.Compute \
    - That list now feeds the `dev-ci` RBAC parameter templates directly, so a brand-new subscription does not require extra per-index template edits.
    - In the same `config/config-dev-ci.yaml`, also add the subscription to the `opstool.tenantQuota` tenant's `subscriptions` list so the `tenant-quota-collector` tracks it. Set `roleAssignmentLimit: 8000` and list the same `regions` the pool runs in, matching the Role Assignment quota requested in step 2.
    - In a normal onboarding flow, `homeSubscription`, `sharedPrincipals`, and `msiMockPool.principals` should not need to change.
-   - Run the rollout from the repo root:
-     - `make dev-ci-e2e-subscription-rbac-local-run`
+   - Apply the **privileged** customer-subscription grants (custom roles + shared-principal role assignments on the new subscription). This requires **Owner** on the target subscription, so it is **not** run by the `dev-ci` postsubmit — ask an OWNERS-group member to run it from the repo root:
+     - `make dev-ci-e2e-rbac-grants-local-run`
 
 7. Validate the end-to-end path.
    - Confirm `slot-manager acquire` can resolve the new pool using the updated cluster profile inventory.
@@ -139,6 +139,7 @@ Those steps only become necessary if the shared identities or the Boskos-backed 
 - `test/cmd/aro-hcp-tests/slot-manager/identity-pool/`
 - `config/config-dev-ci.yaml`
 - `dev-infrastructure/dev-ci/e2e-subscription-rbac/pipeline.yaml`
+- `dev-infrastructure/dev-ci/e2e-subscription-rbac-grants/pipeline.yaml`
 - `dev-infrastructure/configurations/e2e-subscription-rbac-assignments.tmpl.bicepparam`
 - [Dev-CI Topology](dev-ci-topology.md)
 - [CI Identity Leasing](identity-leasing.md)
@@ -218,7 +219,7 @@ AFEC registration is a two-step process: first initiate the registration from th
 
 1. Add the subscription to `config/config-dev-ci.yaml` under the appropriate `ci.<env>.e2eSubscriptions` section.
 
-2. Run the `Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBAC` pipeline to grant the environment's CI bot (e.g. `OpenShift Release Bot - STG`) the required RBAC on the new subscription.
+2. Run the `Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBACGrants` service group to grant the environment's CI bot (e.g. `OpenShift Release Bot - STG`) the required RBAC on the new subscription (`make dev-ci-e2e-rbac-grants-local-run`). This creates subscription-scoped role assignments and therefore requires **Owner** on the target subscription — run it on demand via an OWNERS-group member, not the `dev-ci` postsubmit.
 
 3. Add the pool to `test/e2e-config/e2e-slots.yaml` under the environment's `pools` list.
 

--- a/docs/ci/external-subscription-onboarding.md
+++ b/docs/ci/external-subscription-onboarding.md
@@ -36,8 +36,6 @@ Resource groups left behind by failed or timed-out tests are garbage-collected b
 
 ## How It Differs From Internal Onboarding
 
-In a standard DEV subscription onboarding, a member of the ARO-HCP OWNERS group has Owner access and applies the RBAC, custom role assignments, and identity containers on demand (via the privileged `Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBACGrants` service group). The unattended `dev-ci` postsubmit itself holds no standing Owner identity.
-
 For an **external** subscription:
 
 - The subscription is **not listed** in `config/config-dev-ci.yaml` — the ARO-HCP pipeline does not interact with it at all

--- a/docs/ci/external-subscription-onboarding.md
+++ b/docs/ci/external-subscription-onboarding.md
@@ -36,7 +36,7 @@ Resource groups left behind by failed or timed-out tests are garbage-collected b
 
 ## How It Differs From Internal Onboarding
 
-In a standard DEV subscription onboarding, the ARO-HCP pipeline identity (`aro-hcp-owners` group) has Owner access and can deploy RBAC, custom role assignments, and identity containers directly.
+In a standard DEV subscription onboarding, a member of the ARO-HCP OWNERS group has Owner access and applies the RBAC, custom role assignments, and identity containers on demand (via the privileged `Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBACGrants` service group). The unattended `dev-ci` postsubmit itself holds no standing Owner identity.
 
 For an **external** subscription:
 

--- a/docs/ci/identity-leasing.md
+++ b/docs/ci/identity-leasing.md
@@ -270,13 +270,13 @@ Personal development environments continue using the existing single `miMockClie
 
 ### Infrastructure Setup
 
-The pool currently uses a mixed-management setup. `MSI_MOCK_POOL_SIZE` in `dev-infrastructure/Makefile` still controls the local helper defaults, but customer-subscription RBAC is now reconciled from `config/config-dev-ci.yaml` through the standalone, **Owner-only** `Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBACGrants` rollout (run on demand by an OWNERS-group member; it is not part of the `dev-ci` postsubmit).
+The pool currently uses a mixed-management setup. `MSI_MOCK_POOL_SIZE` in `dev-infrastructure/Makefile` still controls the local helper defaults, but customer-subscription RBAC is now reconciled from `config/config-dev-ci.yaml` through the standalone, **Owner-only** `Microsoft.Azure.ARO.HCP.DevCI.Privileged` entrypoint (run on demand by an OWNERS-group member with `make dev-ci-privileged-local-run`; it is not part of the `dev-ci` postsubmit).
 
 Typical maintainer flow:
 
 1. From `dev-infrastructure/`, run `make create-msi-mock-pool`.
 2. If any pooled principal object IDs changed, update `config/config-dev-ci.yaml` under `ci.dev.devMockIdentities.msiMockPool.principals`.
-3. From the repository root, ask an OWNERS-group member to run `make dev-ci-e2e-rbac-grants-local-run` (requires subscription Owner).
+3. From the repository root, ask an OWNERS-group member to run `make dev-ci-privileged-local-run` (requires subscription Owner).
 4. From `dev-infrastructure/`, run `make populate-msi-mock-pool`.
 5. If the pool size or Boskos key set changed, update the release-side Boskos inventory and step-registry lease wiring as well.
 
@@ -285,7 +285,7 @@ In the current model:
 - `make create-msi-mock-pool` is itself hybrid:
   - `dev-infrastructure/templates/mock-identity-pool.bicep` ensures the Key Vault certificate set.
   - `dev-infrastructure/scripts/create-sp-for-rbac.sh` and the surrounding `dev-infrastructure/Makefile` loop still create or update the `aro-dev-msi-mock-pool-<i>` Entra app and service principal objects and apply the home-subscription grants.
-- `make dev-ci-e2e-rbac-grants-local-run` reconciles pooled-principal access on the DEV E2E customer subscriptions from the principal IDs recorded in `config/config-dev-ci.yaml`.
+- `make dev-ci-privileged-local-run` reconciles pooled-principal access on the DEV E2E customer subscriptions from the principal IDs recorded in `config/config-dev-ci.yaml`.
 - `dev-infrastructure/configurations/e2e-subscription-rbac-assignments.tmpl.bicepparam` still preserves legacy assignment IDs for the first DEV E2E subscription so the rollout can adopt existing grants without recreating them.
 - `make populate-msi-mock-pool` performs live Entra lookups and rewrites `dev-infrastructure/openshift-ci/msi-mock-pool.yaml`, which remains the static catalog consumed by release-side jobs.
 

--- a/docs/ci/identity-leasing.md
+++ b/docs/ci/identity-leasing.md
@@ -270,13 +270,13 @@ Personal development environments continue using the existing single `miMockClie
 
 ### Infrastructure Setup
 
-The pool currently uses a mixed-management setup. `MSI_MOCK_POOL_SIZE` in `dev-infrastructure/Makefile` still controls the local helper defaults, but customer-subscription RBAC is now reconciled from `config/config-dev-ci.yaml` through the standalone `Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBAC` rollout.
+The pool currently uses a mixed-management setup. `MSI_MOCK_POOL_SIZE` in `dev-infrastructure/Makefile` still controls the local helper defaults, but customer-subscription RBAC is now reconciled from `config/config-dev-ci.yaml` through the standalone, **Owner-only** `Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBACGrants` rollout (run on demand by an OWNERS-group member; it is not part of the `dev-ci` postsubmit).
 
 Typical maintainer flow:
 
 1. From `dev-infrastructure/`, run `make create-msi-mock-pool`.
 2. If any pooled principal object IDs changed, update `config/config-dev-ci.yaml` under `ci.dev.devMockIdentities.msiMockPool.principals`.
-3. From the repository root, run `make dev-ci-e2e-subscription-rbac-local-run`.
+3. From the repository root, ask an OWNERS-group member to run `make dev-ci-e2e-rbac-grants-local-run` (requires subscription Owner).
 4. From `dev-infrastructure/`, run `make populate-msi-mock-pool`.
 5. If the pool size or Boskos key set changed, update the release-side Boskos inventory and step-registry lease wiring as well.
 
@@ -285,7 +285,7 @@ In the current model:
 - `make create-msi-mock-pool` is itself hybrid:
   - `dev-infrastructure/templates/mock-identity-pool.bicep` ensures the Key Vault certificate set.
   - `dev-infrastructure/scripts/create-sp-for-rbac.sh` and the surrounding `dev-infrastructure/Makefile` loop still create or update the `aro-dev-msi-mock-pool-<i>` Entra app and service principal objects and apply the home-subscription grants.
-- `make dev-ci-e2e-subscription-rbac-local-run` reconciles pooled-principal access on the DEV E2E customer subscriptions from the principal IDs recorded in `config/config-dev-ci.yaml`.
+- `make dev-ci-e2e-rbac-grants-local-run` reconciles pooled-principal access on the DEV E2E customer subscriptions from the principal IDs recorded in `config/config-dev-ci.yaml`.
 - `dev-infrastructure/configurations/e2e-subscription-rbac-assignments.tmpl.bicepparam` still preserves legacy assignment IDs for the first DEV E2E subscription so the rollout can adopt existing grants without recreating them.
 - `make populate-msi-mock-pool` performs live Entra lookups and rewrites `dev-infrastructure/openshift-ci/msi-mock-pool.yaml`, which remains the static catalog consumed by release-side jobs.
 
@@ -336,7 +336,7 @@ When you need to change or debug identity leasing, start here:
 - mock-SP pool setup and mixed management:
   - `config/config-dev-ci.yaml`
   - `dev-infrastructure/Makefile`
-  - `dev-infrastructure/dev-ci/e2e-subscription-rbac/pipeline.yaml`
+  - `dev-infrastructure/dev-ci/e2e-subscription-rbac-grants/pipeline.yaml`
   - `dev-infrastructure/configurations/e2e-subscription-rbac-assignments.tmpl.bicepparam`
   - `dev-infrastructure/openshift-ci/populate-msi-mock-pool.sh`
 

--- a/docs/ops/opstool-cluster-guide.md
+++ b/docs/ops/opstool-cluster-guide.md
@@ -13,7 +13,7 @@ It uses the same `templatize` + `pipeline.yaml` rollout system as the rest of th
 | Current region | `westus3` |
 | Standalone config | `config/config-dev-ci.yaml` |
 | Standalone topology | `topology-dev-ci.yaml` |
-| Infra service group | `Microsoft.Azure.ARO.HCP.DevCI.Infra` |
+| Infra entrypoint | `Microsoft.Azure.ARO.HCP.DevCI.Unprivileged` |
 | Canonical workload example | `tooling/tenant-quota` |
 
 ## How Opstool Differs From The Main Environments
@@ -25,15 +25,15 @@ The `dev-ci` topology does not plug into that graph automatically.
 - It has its own config file: `config/config-dev-ci.yaml`.
 - It has its own topology: `topology-dev-ci.yaml`.
 - Its infra rollout lives in `dev-infrastructure/dev-ci/cluster/opstool-aks-pipeline.yaml`.
-- Workloads are added as child service groups under the `DevCI.Infra` entrypoint.
+- Workloads are added as child service groups under the `DevCI.Unprivileged` entrypoint.
 
 This means `opstool` gets all the benefits of the shared tooling, but none of the implicit shared-environment wiring. If it needs a shared resource, that dependency must be wired explicitly in the standalone config or pipeline.
 
 ## Topology And Rollout Model
 
-`topology-dev-ci.yaml` defines a single entrypoint:
+`topology-dev-ci.yaml` defines the unattended infrastructure entrypoint:
 
-- `Microsoft.Azure.ARO.HCP.DevCI.Infra`
+- `Microsoft.Azure.ARO.HCP.DevCI.Unprivileged`
 
 That infra service group owns the cluster and shared cluster-level dependencies. Workloads are added beneath it as children. Today, `tenant-quota` is the concrete example of this pattern.
 

--- a/tooling/tenant-quota/README.md
+++ b/tooling/tenant-quota/README.md
@@ -86,7 +86,7 @@ In short, a Key Vault secret update can be picked up without restarting the pod,
 
 ## Alerts
 
-Alert rules are defined in `alerting.bicep` and deployed into the `opstool` Azure Monitor Workspace. Notifications use the shared `opstool-email-alerts` Action Group provided by the `DevCI.Infra` rollout.
+Alert rules are defined in `alerting.bicep` and deployed into the `opstool` Azure Monitor Workspace. Notifications use the shared `opstool-email-alerts` Action Group provided by the `DevCI.Unprivileged` rollout.
 
 ## Local Development
 
@@ -127,7 +127,7 @@ This script is the supported path for creating and reconciling the service princ
 After adding or changing a tenant:
 
 1. Update `config/config-dev-ci.yaml`.
-2. Redeploy `Microsoft.Azure.ARO.HCP.DevCI.TenantQuota` or just run the whole topology via `make dev-ci-local-run`
+2. Redeploy the `Microsoft.Azure.ARO.HCP.DevCI.Unprivileged` entrypoint via `make dev-ci-local-run` (for a targeted redeploy, run just the `Microsoft.Azure.ARO.HCP.DevCI.TenantQuota` service group).
 
 ### Renew a client secret
 

--- a/topology-dev-ci.yaml
+++ b/topology-dev-ci.yaml
@@ -12,7 +12,7 @@ services:
     purpose: Deploy the tenant-quota-collector.
   - serviceGroup: Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBAC
     pipelinePath: dev-infrastructure/dev-ci/e2e-subscription-rbac/pipeline.yaml
-    purpose: Manage explicit dev E2E customer-subscription RBAC and shared custom-role assignable scopes.
+    purpose: Reconcile the non-privileged CI bot Entra identities and rotate their Key Vault secrets. Requires no subscription Owner, so it runs unattended in the dev-ci postsubmit.
   - serviceGroup: Microsoft.Azure.ARO.HCP.DevCI.Gateway
     pipelinePath: dev-infrastructure/dev-ci/gateway/pipeline.yaml
     purpose: Deploy the shared Istio gateway and DNS wiring for opstool.
@@ -22,3 +22,13 @@ services:
   - serviceGroup: Microsoft.Azure.ARO.HCP.DevCI.CIHealth
     pipelinePath: dev-infrastructure/dev-ci/cihealth/pipeline.yaml
     purpose: Deploy the CIHealth runtime on cihealth.tools.hcpsvc.osadev.cloud.
+# PRIVILEGED, on-demand only. This service group creates subscription-scoped
+# custom role definitions and role assignments, which require Owner (or User
+# Access Administrator) on the target subscriptions. It is intentionally NOT a
+# child of the DevCI.Infra entrypoint and has no entrypoint of its own, so the
+# unattended dev-ci postsubmit never runs it. An OWNERS-group member runs it
+# manually with `make dev-ci-e2e-rbac-grants-local-run` when a change touches
+# these grants. See docs/ci/dev-ci-topology.md.
+- serviceGroup: Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBACGrants
+  pipelinePath: dev-infrastructure/dev-ci/e2e-subscription-rbac-grants/pipeline.yaml
+  purpose: Manage explicit dev E2E customer-subscription RBAC and shared custom-role assignable scopes, plus the CI bot subscription-scoped RBAC. Owner-only; run on demand by an OWNERS-group member.

--- a/topology-dev-ci.yaml
+++ b/topology-dev-ci.yaml
@@ -1,9 +1,17 @@
 entrypoints:
-- identifier: 'Microsoft.Azure.ARO.HCP.DevCI.Infra'
+- identifier: 'Microsoft.Azure.ARO.HCP.DevCI.Unprivileged'
   metadata:
     name: Dev CI Infrastructure
+# PRIVILEGED, on-demand only. Rolls out the subscription-scoped custom role
+# definitions and role assignments that require Owner (or User Access
+# Administrator) on the target subscriptions. Kept as a separate entrypoint so
+# the unattended dev-ci postsubmit (which runs the Unprivileged entrypoint)
+# never touches it. Run manually by an OWNERS-group member.
+- identifier: 'Microsoft.Azure.ARO.HCP.DevCI.Privileged'
+  metadata:
+    name: Dev CI Privileged Grants
 services:
-- serviceGroup: Microsoft.Azure.ARO.HCP.DevCI.Infra
+- serviceGroup: Microsoft.Azure.ARO.HCP.DevCI.Unprivileged
   pipelinePath: dev-infrastructure/dev-ci/cluster/opstool-aks-pipeline.yaml
   purpose: Deploy shared dev/CI network resources, the opstool AKS cluster, and the Prometheus monitoring stack.
   children:
@@ -22,13 +30,14 @@ services:
   - serviceGroup: Microsoft.Azure.ARO.HCP.DevCI.CIHealth
     pipelinePath: dev-infrastructure/dev-ci/cihealth/pipeline.yaml
     purpose: Deploy the CIHealth runtime on cihealth.tools.hcpsvc.osadev.cloud.
-# PRIVILEGED, on-demand only. This service group creates subscription-scoped
-# custom role definitions and role assignments, which require Owner (or User
-# Access Administrator) on the target subscriptions. It is intentionally NOT a
-# child of the DevCI.Infra entrypoint and has no entrypoint of its own, so the
-# unattended dev-ci postsubmit never runs it. An OWNERS-group member runs it
-# manually with `make dev-ci-e2e-rbac-grants-local-run` when a change touches
-# these grants. See docs/ci/dev-ci-topology.md.
-- serviceGroup: Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBACGrants
-  pipelinePath: dev-infrastructure/dev-ci/e2e-subscription-rbac-grants/pipeline.yaml
-  purpose: Manage explicit dev E2E customer-subscription RBAC and shared custom-role assignable scopes, plus the CI bot subscription-scoped RBAC. Owner-only; run on demand by an OWNERS-group member.
+# PRIVILEGED, on-demand only. The `Privileged` root is a no-op grouping
+# pipeline; the actual grants live in its E2ESubscriptionRBACGrants child. An
+# OWNERS-group member runs it manually with `make dev-ci-privileged-local-run`
+# when a change touches these grants. See docs/ci/dev-ci-topology.md.
+- serviceGroup: Microsoft.Azure.ARO.HCP.DevCI.Privileged
+  pipelinePath: dev-infrastructure/dev-ci/privileged/pipeline.yaml
+  purpose: No-op grouping root for the on-demand privileged grants entrypoint. Owner-only; run manually by an OWNERS-group member.
+  children:
+  - serviceGroup: Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBACGrants
+    pipelinePath: dev-infrastructure/dev-ci/e2e-subscription-rbac-grants/pipeline.yaml
+    purpose: Manage explicit dev E2E customer-subscription RBAC and shared custom-role assignable scopes, plus the CI bot subscription-scoped RBAC. Owner-only; run on demand by an OWNERS-group member.


### PR DESCRIPTION
## Why

The CIHealth tooling needs to be bumped ([CIHealth PR #7](https://github.com/roivaz/ARO-HCP-CIHealth/pull/7)), and while wiring up the unattended **dev-ci** postsubmit Prow job ([ARO-28206](https://redhat.atlassian.net/browse/ARO-28206)) a few gaps had to be closed so the pipeline can run without a standing Owner identity.

## What

Four related changes that together let the dev-ci pipeline reconcile cleanly from an unattended job:

1. **Bump CIHealth** to include roivaz/ARO-HCP-CIHealth#7.
2. **`fix: add region and environmentName to dev-ci defaults`** — dev-ci config was missing defaults required for rendering.
3. **`fix: build cert-manager chart dependencies before deploy`** — the cert-manager dev-ci step now builds Helm chart deps before deploying.
4. **`feat: split dev-ci e2e RBAC pipeline by privilege`** ([ARO-28206](https://redhat.atlassian.net/browse/ARO-28206)) — the unattended dev-ci postsubmit has no standing Owner identity, so it cannot apply subscription-scoped role definitions/assignments. Those Owner-requiring steps move to a new standalone `Microsoft.Azure.ARO.HCP.DevCI.Privileged` entrypoint, excluded from the unattended `Microsoft.Azure.ARO.HCP.DevCI.Unprivileged` entrypoint and run on demand by an OWNERS member via `make dev-ci-privileged-local-run`. The non-privileged pipeline (identities + Key Vault secrets) stays in the `DevCI.Unprivileged` entrypoint and continues to run in the postsubmit. Onboarding procedures under `docs/ci/` are updated accordingly.

## Ticket

Ref: [ARO-28206](https://redhat.atlassian.net/browse/ARO-28206)

## Validation

- `templatize pipeline validate` on `topology-dev-ci.yaml`: passes.
- `entrypoint graph` for `DevCI.Infra` excludes the grants steps; the standalone `Grants` group contains exactly the 4 privileged steps.
- `make yamlfmt`: no churn on the changed/new YAML.

