### PR TITLE
feat(kusto): add aroHCPPurpose tag, global MSI role, and kustoctl entity-groups

### DIFF
--- a/dev-infrastructure/configurations/kusto-stg.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/kusto-stg.tmpl.bicepparam
@@ -30,3 +30,5 @@ param autoScaleMin = {{ .kusto.autoScaleMin }}
 param autoScaleMax = {{ .kusto.autoScaleMax }}
 
 param enableAutoScale = {{ .kusto.enableAutoScale }}
+
+param globalMSIId = '__globalMSIId__'

--- a/dev-infrastructure/configurations/kusto.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/kusto.tmpl.bicepparam
@@ -26,3 +26,5 @@ param autoScaleMin = {{ .kusto.autoScaleMin }}
 param autoScaleMax = {{ .kusto.autoScaleMax }}
 
 param enableAutoScale = {{ .kusto.enableAutoScale }}
+
+param globalMSIId = '__globalMSIId__'

--- a/dev-infrastructure/geography-pipeline-stg.yaml
+++ b/dev-infrastructure/geography-pipeline-stg.yaml
@@ -15,6 +15,17 @@ $schema: pipeline.schema.v1
 rolloutName: Geography Rollout (STG V2)
 serviceGroup: Microsoft.Azure.ARO.HCP.Geography.StgGlobal
 resourceGroups:
+- name: global
+  resourceGroup: '{{ .global.rg }}'
+  # Hardcoded on purpose — see global-pipeline-stg.yaml. Removed at decommission.
+  subscription: 'hcp-stg-global'
+  steps:
+  - name: output
+    action: ARM
+    template: templates/output-global.bicep
+    parameters: configurations/output-global-stg.tmpl.bicepparam
+    deploymentLevel: ResourceGroup
+    outputOnly: true
 - name: kusto-infra
   resourceGroup: '{{ .kusto.rg }}'
   # Hardcoded on purpose — see global-pipeline-stg.yaml. Removed at decommission.

--- a/dev-infrastructure/geography-pipeline-stg.yaml
+++ b/dev-infrastructure/geography-pipeline-stg.yaml
@@ -32,6 +32,15 @@ resourceGroups:
     template: templates/kusto.bicep
     parameters: configurations/kusto-stg.tmpl.bicepparam
     deploymentLevel: ResourceGroup
+    variables:
+    - name: globalMSIId
+      input:
+        resourceGroup: global
+        step: output
+        name: globalMSIId
+    dependsOn:
+    - resourceGroup: global
+      step: output
     automatedRetry:
       errorContainsAny:
       - "InternalServerError"

--- a/dev-infrastructure/geography-pipeline.yaml
+++ b/dev-infrastructure/geography-pipeline.yaml
@@ -2,6 +2,16 @@ $schema: pipeline.schema.v1
 rolloutName: Geography Rollout
 serviceGroup: Microsoft.Azure.ARO.HCP.Geography
 resourceGroups:
+- name: global
+  resourceGroup: '{{ .global.rg }}'
+  subscription: '{{ .global.subscription.key }}'
+  steps:
+  - name: output
+    action: ARM
+    template: templates/output-global.bicep
+    parameters: configurations/output-global.tmpl.bicepparam
+    deploymentLevel: ResourceGroup
+    outputOnly: true
 - name: kusto-infra
   resourceGroup: '{{ .kusto.rg }}'
   subscription: '{{ .global.subscription.key }}'

--- a/dev-infrastructure/geography-pipeline.yaml
+++ b/dev-infrastructure/geography-pipeline.yaml
@@ -39,6 +39,15 @@ resourceGroups:
     template: templates/kusto.bicep
     parameters: configurations/kusto.tmpl.bicepparam
     deploymentLevel: ResourceGroup
+    variables:
+    - name: globalMSIId
+      input:
+        resourceGroup: global
+        step: output
+        name: globalMSIId
+    dependsOn:
+    - resourceGroup: global
+      step: output
     automatedRetry:
       errorContainsAny:
       - "InternalServerError"

--- a/dev-infrastructure/modules/logs/kusto/cluster.bicep
+++ b/dev-infrastructure/modules/logs/kusto/cluster.bicep
@@ -66,6 +66,9 @@ resource kusto 'Microsoft.Kusto/clusters@2024-04-13' = {
     name: sku
     tier: tier
   }
+  tags: {
+    aroHCPPurpose: 'logs'
+  }
   identity: {
     type: 'SystemAssigned'
   }

--- a/dev-infrastructure/modules/logs/kusto/main.bicep
+++ b/dev-infrastructure/modules/logs/kusto/main.bicep
@@ -40,6 +40,9 @@ param autoScaleMax int
 @description('Toggle if autoscale should be enabled')
 param enableAutoScale bool
 
+@description('Resource ID of the global MSI for entity group management (Database Admin role)')
+param globalMSIId string
+
 var db = {
   serviceLogs: serviceLogsDatabase
   hostedControlPlaneLogs: hostedControlPlaneLogsDatabase
@@ -209,6 +212,35 @@ module removePermission 'script.bicep' = [
     ]
   }
 ]
+
+// Database Admin role for the global MSI on each database (required for kustoctl entity-groups sync)
+var globalMSIPrincipalId = reference(globalMSIId, '2023-01-31').principalId
+
+resource serviceLogsAdmin 'Microsoft.Kusto/clusters/databases/principalAssignments@2024-04-13' = {
+  name: '${kustoName}/${db.serviceLogs}/globalMSI-admin'
+  properties: {
+    principalId: globalMSIPrincipalId
+    principalType: 'App'
+    role: 'Admin'
+    tenantId: tenant().tenantId
+  }
+  dependsOn: [
+    serviceLogs
+  ]
+}
+
+resource hostedControlPlaneLogsAdmin 'Microsoft.Kusto/clusters/databases/principalAssignments@2024-04-13' = {
+  name: '${kustoName}/${db.hostedControlPlaneLogs}/globalMSI-admin'
+  properties: {
+    principalId: globalMSIPrincipalId
+    principalType: 'App'
+    role: 'Admin'
+    tenantId: tenant().tenantId
+  }
+  dependsOn: [
+    hostedControlPlaneLogs
+  ]
+}
 
 // Outputs mirror original contract
 output id string = cluster.outputs.id

--- a/dev-infrastructure/templates/kusto.bicep
+++ b/dev-infrastructure/templates/kusto.bicep
@@ -40,6 +40,9 @@ param autoScaleMax int
 @description('Toggle if autoscale should be enabled')
 param enableAutoScale bool
 
+@description('Resource ID of the global MSI for entity group management (Database Admin role)')
+param globalMSIId string
+
 module kusto '../modules/logs/kusto/main.bicep' = if (manageInstance) {
   name: 'kusto-${location}'
   params: {
@@ -57,5 +60,6 @@ module kusto '../modules/logs/kusto/main.bicep' = if (manageInstance) {
     autoScaleMin: autoScaleMin
     autoScaleMax: autoScaleMax
     enableAutoScale: enableAutoScale
+    globalMSIId: globalMSIId
   }
 }

--- a/tooling/kustoctl/go.mod
+++ b/tooling/kustoctl/go.mod
@@ -3,6 +3,7 @@ module github.com/Azure/ARO-HCP/tooling/kustoctl
 go 1.25.5
 
 require (
+	github.com/Azure/ARO-Tools/tools/kustoctl v0.0.0-20260720175808-ca2cea2cb707
 	github.com/Azure/azure-kusto-go/azkustodata v1.2.1
 	github.com/dusted-go/logging v1.3.0
 	github.com/go-logr/logr v1.4.3
@@ -10,18 +11,18 @@ require (
 )
 
 require (
+	github.com/Azure/ARO-Tools/tools/cmdutils v0.0.0-20260227032723-11f678744bf9 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.4.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.10.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.7.0 // indirect
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/samber/lo v1.53.0 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
@@ -29,4 +30,5 @@ require (
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
+	k8s.io/apimachinery v0.35.3 // indirect
 )

--- a/tooling/kustoctl/go.mod
+++ b/tooling/kustoctl/go.mod
@@ -11,7 +11,7 @@ require (
 )
 
 require (
-	github.com/Azure/ARO-Tools/tools/cmdutils v0.0.0-20260227032723-11f678744bf9 // indirect
+	github.com/Azure/ARO-Tools/tools/cmdutils v0.0.0-20260715002326-2555e1130350 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.4.0 // indirect

--- a/tooling/kustoctl/go.sum
+++ b/tooling/kustoctl/go.sum
@@ -1,3 +1,7 @@
+github.com/Azure/ARO-Tools/tools/cmdutils v0.0.0-20260227032723-11f678744bf9 h1:Tsyb3xmWPTJplBF5g47rvp2tKjn1rX1KTLbTxykBcOY=
+github.com/Azure/ARO-Tools/tools/cmdutils v0.0.0-20260227032723-11f678744bf9/go.mod h1:bBo5YOjQf47SHTl5ohULLUin2PAEt6s5D5GQZQRgO5w=
+github.com/Azure/ARO-Tools/tools/kustoctl v0.0.0-20260720175808-ca2cea2cb707 h1:9PebQsjEluc2PlP70Joug0e9KJ7POK28/IB/V72fgB0=
+github.com/Azure/ARO-Tools/tools/kustoctl v0.0.0-20260720175808-ca2cea2cb707/go.mod h1:6eOFGWnLVSTCxOPAzY0/21bf/WppxEVhemxiz3m7gdw=
 github.com/Azure/azure-kusto-go/azkustodata v1.2.1 h1:De25JIENJVLYUMB4Z9LfAFzbgjGz1ozYJiL2zprs1KA=
 github.com/Azure/azure-kusto-go/azkustodata v1.2.1/go.mod h1:pYbM6A7z4XDU+3S0+OgoyUOuCOWPUe/hyEfnOCT6Gok=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1 h1:jHb/wfvRikGdxMXYV3QG/SzUOPYN9KEUUuC0Yd0/vC0=
@@ -8,6 +12,8 @@ github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.4.0 h1:xFaZZ+IubdftrDH
 github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.4.0/go.mod h1:mCBhUhlMjLLJKr5aqw2TNS/VqJOie8MzWq3DAMJeKso=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 h1:fhqpLE3UEXi9lPaBRpQ6XuRW0nU7hgg4zlmZZa+a9q4=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0/go.mod h1:7dCRMLwisfRH3dBupKeNCioWYUZ4SS09Z14H+7i8ZoY=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.10.0 h1:+1fJwTilk/X7inNqwREnYEOgFCdg8ut7GULxARDbu34=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.10.0/go.mod h1:EGwSLlGqrrfYQhtCi9JcIkPQKl9WxsL6ZPJd+63Vy1A=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJTmL004Abzc5wDB5VtZG2PJk5ndYDgVacGqfirKxjM=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1/go.mod h1:tCcJZ0uHAmvjsVYzEFivsRTN00oz5BEsRgQHu5JZ9WE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.7.0 h1:4iB+IesclUXdP0ICgAabvq2FYLXrJWKx1fJQ+GxSo3Y=
@@ -60,3 +66,5 @@ golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+k8s.io/apimachinery v0.35.3 h1:MeaUwQCV3tjKP4bcwWGgZ/cp/vpsRnQzqO6J6tJyoF8=
+k8s.io/apimachinery v0.35.3/go.mod h1:jQCgFZFR1F4Ik7hvr2g84RTJSZegBc8yHgFWKn//hns=

--- a/tooling/kustoctl/go.sum
+++ b/tooling/kustoctl/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/ARO-Tools/tools/cmdutils v0.0.0-20260227032723-11f678744bf9 h1:Tsyb3xmWPTJplBF5g47rvp2tKjn1rX1KTLbTxykBcOY=
-github.com/Azure/ARO-Tools/tools/cmdutils v0.0.0-20260227032723-11f678744bf9/go.mod h1:bBo5YOjQf47SHTl5ohULLUin2PAEt6s5D5GQZQRgO5w=
+github.com/Azure/ARO-Tools/tools/cmdutils v0.0.0-20260715002326-2555e1130350 h1:OKEEHnv7jJhynBgOkRTTNvKt2Nq5KyiCAeu9kx+RM24=
+github.com/Azure/ARO-Tools/tools/cmdutils v0.0.0-20260715002326-2555e1130350/go.mod h1:H9gQZNrqfswjQXfmHtTYbC8nMPdZIv8JmlME/wXjcJY=
 github.com/Azure/ARO-Tools/tools/kustoctl v0.0.0-20260720175808-ca2cea2cb707 h1:9PebQsjEluc2PlP70Joug0e9KJ7POK28/IB/V72fgB0=
 github.com/Azure/ARO-Tools/tools/kustoctl v0.0.0-20260720175808-ca2cea2cb707/go.mod h1:6eOFGWnLVSTCxOPAzY0/21bf/WppxEVhemxiz3m7gdw=
 github.com/Azure/azure-kusto-go/azkustodata v1.2.1 h1:De25JIENJVLYUMB4Z9LfAFzbgjGz1ozYJiL2zprs1KA=

--- a/tooling/kustoctl/main.go
+++ b/tooling/kustoctl/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/Azure/ARO-HCP/tooling/kustoctl/cmd/validate"
+	"github.com/Azure/ARO-Tools/tools/kustoctl/cmd/entitygroups"
 )
 
 func main() {
@@ -63,6 +64,13 @@ Kusto-related operational tasks.`,
 		os.Exit(1)
 	}
 	cmd.AddCommand(validateCmd)
+
+	entityGroupsCmd, err := entitygroups.NewEntityGroupsCommand()
+	if err != nil {
+		logger.Error(err, "failed to create entity-groups command")
+		os.Exit(1)
+	}
+	cmd.AddCommand(entityGroupsCmd)
 
 	cmd.SetHelpCommand(&cobra.Command{Hidden: true})
 

--- a/tooling/kustoctl/main.go
+++ b/tooling/kustoctl/main.go
@@ -25,8 +25,9 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 
-	"github.com/Azure/ARO-HCP/tooling/kustoctl/cmd/validate"
 	"github.com/Azure/ARO-Tools/tools/kustoctl/cmd/entitygroups"
+
+	"github.com/Azure/ARO-HCP/tooling/kustoctl/cmd/validate"
 )
 
 func main() {


### PR DESCRIPTION
[ARO-27830](https://redhat.atlassian.net/browse/ARO-27830)

### What

Enables `kustoctl entity-groups sync` to discover and manage cross-cluster entity groups:

1. Adds `aroHCPPurpose: logs` tag to Kusto clusters for Resource Graph discovery
2. Grants the global MSI Database Admin on ServiceLogs and HostedControlPlaneLogs (minimum role for `.create-or-alter entity_group`)
3. Wires `globalMSIId` from global pipeline output into geography pipeline (same pattern as `mgmt-infra.bicep`)
4. Wires `entity-groups` command from ARO-Tools into kustoctl wrapper

### Why

Cross-cluster entity groups enable federated Kusto queries across all regions. The tool in [Azure/ARO-Tools#267](https://github.com/Azure/ARO-Tools/pull/267) discovers clusters by the `aroHCPPurpose` tag and needs Database Admin to execute `.create-or-alter entity_group`.

### Patterns followed

- `globalMSIId` wiring: same as `mgmt-pipeline.yaml` -> `mgmt-infra.bicep` (`reference(globalMSIId, '2023-01-31').principalId`)
- `aroHCPPurpose` tag: same as Azure Monitor Workspaces in `monitor.bicep`
- Database `principalAssignment`: Kusto-native role assignment (least privilege per docs)

### Testing

ARM template changes only (tag, role assignment, variable wiring). No runtime code changes.

### Dependencies

- Requires [Azure/ARO-Tools#267](https://github.com/Azure/ARO-Tools/pull/267) to be merged first