### PR TITLE
docs: fix hardcoded timeout in AGENTS.md pooled identity example

### DIFF
--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -286,7 +286,7 @@ It("should create cluster successfully",
 
 - **Check if enabled**: Use `tc.UsePooledIdentities()` to check if pooled identities are enabled
 - **Assign containers**: Call `tc.AssignIdentityContainers(ctx, count, timeout)` before resource creation
-  - Example: `tc.AssignIdentityContainers(ctx, 1, 60*time.Second)`
+  - Example: `tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)`
 - **Error handling**: Expect assignment to succeed: `Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")`
 
 ## Error Handling in Negative Tests


### PR DESCRIPTION
### What

Fixes a documentation example in `test/AGENTS.md` (Pooled Identities section) that still hardcoded `60*time.Second` for the `tc.AssignIdentityContainers` example. Updates it to use the existing `framework.IdentityContainerAssignmentRetryInterval` constant, matching every real call site of `tc.AssignIdentityContainers` in `test/e2e/`.

### Why

Follow-up to #5513, which introduced the `IdentityContainerAssignmentRetryInterval` constant and updated all real `AssignIdentityContainers` call sites to use it, but left the doc example in `test/AGENTS.md` with the old raw literal. [A reviewer pointed out](https://github.com/Azure/ARO-HCP/pull/5513#pullrequestreview-4429794729) that this is a problem because LLM coding agents treat `test/AGENTS.md` as the source of truth for E2E conventions, and the stale example could trick them into reintroducing hardcoded timeout values instead of reusing the named constant.

### Testing

This is a documentation-only change (single line in `test/AGENTS.md`); no functional code is affected, so no unit/integration/E2E tests apply.

- [ ] Unit tests
- [ ] [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [ ] [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes) 
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [x] All comment threads resolved before merge