### PR TITLE
fix(informers): recover resourceID for legacy change-feed documents (AROSLSRE-1522)

### DIFF
--- a/internal/database/convert_generic.go
+++ b/internal/database/convert_generic.go
@@ -122,6 +122,13 @@ func CosmosGenericToInternal[InternalAPIType any](cosmosObj *GenericDocument[Int
 	if ret.GetResourceID() == nil {
 		if cosmosObj.ResourceID != nil {
 			ret.SetResourceID(cosmosObj.ResourceID)
+		} else if resourceIDFromOldCosmosID, err := oldCosmosIDToResourceID(cosmosObj.ID); err == nil {
+			// Recover the ResourceID for old data that predates the field, the
+			// same way CosmosToInternal does for the bare TypedDocument. Without
+			// this, a legacy nil-resourceID document poisons the change feed
+			// (processDocument errors, the continuation token never advances) and
+			// stalls every informer built on it. See AROSLSRE-1521.
+			ret.SetResourceID(resourceIDFromOldCosmosID)
 		} else {
 			return nil, fmt.Errorf("internalObj is missing a resourceID: %T: %q", cosmosObj, cosmosObj.ID)
 		}

--- a/internal/database/convert_generic_resourceid_test.go
+++ b/internal/database/convert_generic_resourceid_test.go
@@ -1,0 +1,101 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/utils/ptr"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+)
+
+// TestCosmosGenericToInternalRecoversResourceID verifies that a legacy Cosmos
+// document whose ResourceID field is nil (it predates that field) has its
+// ResourceID recovered from the old pipe-delimited cosmos ID, the same way
+// CosmosToInternal already does for the bare TypedDocument. Without this, the
+// change feed errors on the document, never advances its continuation token,
+// and stalls every informer built on it. Regression guard for AROSLSRE-1521.
+func TestCosmosGenericToInternalRecoversResourceID(t *testing.T) {
+	const resourceIDStr = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster/nodePools/np"
+	// Legacy documents stored the ARM path in the cosmos ID with "/" replaced
+	// by "|" and carried no ResourceID field.
+	legacyCosmosID := strings.ReplaceAll(resourceIDStr, "/", "|")
+
+	preExistingDoc := &GenericDocument[api.HCPOpenShiftClusterNodePool]{
+		TypedDocument: TypedDocument{
+			BaseDocument: BaseDocument{ID: legacyCosmosID},
+			// ResourceID intentionally nil — this is the poison-doc shape.
+			ResourceID: nil,
+		},
+		Content: api.HCPOpenShiftClusterNodePool{
+			CosmosMetadata: arm.CosmosMetadata{
+				// ResourceID intentionally nil.
+				ResourceID: nil,
+			},
+			Properties: api.HCPOpenShiftClusterNodePoolProperties{
+				ProvisioningState: arm.ProvisioningStateSucceeded,
+			},
+			ServiceProviderProperties: api.HCPOpenShiftClusterNodePoolServiceProviderProperties{
+				ClusterServiceID: ptr.To(api.Must(api.NewInternalID("/api/aro_hcp/v1alpha1/clusters/test-cluster/node_pools/test-np"))),
+			},
+		},
+	}
+
+	internalNodePool, err := CosmosGenericToInternal(preExistingDoc)
+	if err != nil {
+		t.Fatalf("CosmosGenericToInternal returned error for recoverable legacy document: %v", err)
+	}
+
+	got := internalNodePool.GetResourceID()
+	if got == nil {
+		t.Fatalf("expected recovered ResourceID, got nil")
+	}
+	want := api.Must(azcorearm.ParseResourceID(resourceIDStr))
+	if !strings.EqualFold(got.String(), want.String()) {
+		t.Errorf("recovered ResourceID = %q, want %q", got.String(), want.String())
+	}
+}
+
+// TestCosmosGenericToInternalUnrecoverableResourceID verifies that a document
+// with neither a ResourceID nor a parseable legacy cosmos ID still returns an
+// error, so genuinely malformed data is surfaced rather than silently accepted.
+func TestCosmosGenericToInternalUnrecoverableResourceID(t *testing.T) {
+	preExistingDoc := &GenericDocument[api.HCPOpenShiftClusterNodePool]{
+		TypedDocument: TypedDocument{
+			BaseDocument: BaseDocument{ID: "not-a-parseable-resource-id"},
+			ResourceID:   nil,
+		},
+		Content: api.HCPOpenShiftClusterNodePool{
+			CosmosMetadata: arm.CosmosMetadata{
+				ResourceID: nil,
+			},
+			Properties: api.HCPOpenShiftClusterNodePoolProperties{
+				ProvisioningState: arm.ProvisioningStateSucceeded,
+			},
+			ServiceProviderProperties: api.HCPOpenShiftClusterNodePoolServiceProviderProperties{
+				ClusterServiceID: ptr.To(api.Must(api.NewInternalID("/api/aro_hcp/v1alpha1/clusters/test-cluster/node_pools/test-np"))),
+			},
+		},
+	}
+
+	if _, err := CosmosGenericToInternal(preExistingDoc); err == nil {
+		t.Fatalf("expected error for unrecoverable document, got nil")
+	}
+}

--- a/internal/database/informers/changefeed_list_watch.go
+++ b/internal/database/informers/changefeed_list_watch.go
@@ -382,12 +382,6 @@ func (c *ChangeFeedWatcher[InternalAPIType, InternalAPITypePointer, CosmosAPITyp
 		return nil
 	}
 
-	if objAsTypedDocument.ResourceID == nil {
-		// intentionally skipping malformed object
-		utilruntime.HandleError(fmt.Errorf("missing resourceID for document ID: %q", objAsTypedDocument.ID))
-		return nil
-	}
-
 	var cosmosObj CosmosAPIType
 	if err := json.Unmarshal(document, &cosmosObj); err != nil {
 		return utils.TrackError(err)
@@ -396,7 +390,16 @@ func (c *ChangeFeedWatcher[InternalAPIType, InternalAPITypePointer, CosmosAPITyp
 	var err error
 	internalObj, err = database.CosmosToInternal[InternalAPIType, CosmosAPIType](&cosmosObj)
 	if err != nil {
-		return utils.TrackError(err)
+		// A single unprocessable document must never halt the feed. Returning an
+		// error here leaves the continuation token unadvanced, so the change feed
+		// re-reads the same document forever and every informer built on it
+		// stalls (AROSLSRE-1521). CosmosToInternal already recovers a missing
+		// resourceID from the legacy pipe-delimited cosmos ID; if a document is
+		// still unconvertible, log it and skip so the feed keeps making progress.
+		logger.Error(utils.TrackError(err), "skipping unprocessable change feed document",
+			"resourceType", objAsTypedDocument.ResourceType,
+			"id", objAsTypedDocument.ID)
+		return nil
 	}
 
 	canonicalResourceID := strings.ToLower(internalObj.GetResourceID().String())


### PR DESCRIPTION
<!-- [AROSLSRE-1521](https://redhat.atlassian.net/browse/AROSLSRE-1521) / [AROSLSRE-1522](https://redhat.atlassian.net/browse/AROSLSRE-1522) -->
Jira: [AROSLSRE-1522](https://redhat.atlassian.net/browse/AROSLSRE-1522) (fix) · [AROSLSRE-1521](https://redhat.atlassian.net/browse/AROSLSRE-1521) (incident)

### What

Make the Cosmos change feed tolerate legacy documents whose `resourceID` field is null, by recovering the `resourceID` from the document's legacy pipe-delimited `id`. Two changes in `internal/database`:

1. **`CosmosGenericToInternal`** (`convert_generic.go`): when the object has no `resourceID`, recover it from the old cosmos `id` via `oldCosmosIDToResourceID` — the same recovery `CosmosToInternal` already does for the bare `TypedDocument`.
2. **`processDocument`** (`informers/changefeed_list_watch.go`): remove the hard `missing resourceID` error, and log + skip any document that is *still* unconvertible after recovery, so a single bad document can never halt a feed range again.

### Why

This is the root cause of the prod uksouth incident ([AROSLSRE-1521](https://redhat.atlassian.net/browse/AROSLSRE-1521)): every nodepool create hung service-wide at `provisioningState=Accepted`.

The backend informers read the `Resources` container's Cosmos change feed. A legacy document predates the `resourceID` field and stores the ARM path in a pipe-delimited `id` (`|subscriptions|…|nodePools|np`) with `resourceID = null`. The two read converters disagreed on how to handle that:

```
CosmosToInternal        (TypedDocument) -> recovers resourceID from the old id   ✅
CosmosGenericToInternal (generic types) -> returns "internalObj is missing a resourceID" ❌
```

The change feed converts nodepool / external-auth / controller documents through the **generic** path, so it errored on that one document. The critical part is what happens next in `readFeedRange`: on any processing error it returns **without advancing the continuation token** (by design, so a transient error retries instead of dropping data). For this document the error is *permanent*, so the same poison document is re-read forever and the feed never makes progress. Every informer built on that feed stalls, and all nodepool creates queue behind it.

Why the old **list** path never hit this: it queried `SELECT … WHERE LENGTH(c.resourceID) > 0`, so Cosmos filtered the null-`resourceID` document out server-side. The change feed has no such filter.

```mermaid
flowchart TD
    A[Change feed reads a document] --> B{resourceID present?}
    B -- yes --> H[Convert and deliver]

    B -- no --> D1[BEFORE: processDocument returns error 'missing resourceID']
    D1 --> E1[readFeedRange returns, continuation token NOT advanced]
    E1 --> F1[Same poison document re-read forever]
    F1 --> G1[Informer stalls, nodepool creates hang at Accepted]

    B -- no --> I2[AFTER: recover resourceID from legacy pipe-delimited id]
    I2 -- recovered --> H
    I2 -- unrecoverable --> J2[Log and skip document, token advances]
    J2 --> K[Feed keeps flowing]
    H --> K

    classDef bad fill:#ffe0e0,stroke:#d33;
    classDef good fill:#e0f5e0,stroke:#2a2;
    class D1,E1,F1,G1 bad;
    class I2,J2,K,H good;
```

Recovering the `resourceID` (change 1) makes these legacy documents convert and deliver normally. The log-and-skip guard (change 2) is defense-in-depth: even a genuinely corrupt document is stepped over instead of wedging the feed, and its `id`/`resourceType` are logged so the offending record can be identified. This also protects the fleet informers, which are already on the shared change feed (#6140).

### Testing

`GOTOOLCHAIN=auto`:

- `go test ./internal/database/...` ✅ — includes new `TestCosmosGenericToInternalRecoversResourceID` (recovers from a legacy `|`-delimited id) and `TestCosmosGenericToInternalUnrecoverableResourceID` (genuinely bad id still errors).
- `go build ./internal/...` · `go vet ./internal/database/...` · `gofmt -l` — clean.
- `test-integration`: `go test ./backend/changefeed/... -run 'TestChangeFeedListWatcher|TestActiveOperationInformer'` ✅ 47.9s.

### Special notes for your reviewer

- Immediate prod mitigation is the surgical revert #6155 (backend informers back to the list path). This PR is the permanent fix that lets the backend safely re-adopt the change feed afterward (separate follow-up, tracked under [AROSLSRE-1521](https://redhat.atlassian.net/browse/AROSLSRE-1521)).
- The specific prod rogue record can't be read directly (Cosmos data-plane is AAD-only and our identity lacks the query role). Once this fix deploys, the new skip log prints the record's `id` and `resourceType`, which identifies it without a Cosmos query.

### PR Checklist

- [x] Tests added/updated
- [x] Verified locally (build, vet, tests, gofmt)
- [x] Linked Jira issue
