### PR TITLE
revert(backend): switch informers off the Cosmos change feed to recover prod (AROSLSRE-1521)

### DIFF
--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -376,7 +376,6 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 
 	backendInformers := informers.NewBackendInformers(ctx,
 		b.options.ResourcesDBClient.ResourcesGlobalListers(),
-		b.options.ResourcesDBClient,
 		b.options.BillingDBClient.BillingGlobalListers(),
 	)
 

--- a/backend/pkg/informers/informers.go
+++ b/backend/pkg/informers/informers.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
-	utilsclock "k8s.io/utils/clock"
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
@@ -32,7 +31,6 @@ import (
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/database"
-	dbinformers "github.com/Azure/ARO-HCP/internal/database/informers"
 	"github.com/Azure/ARO-HCP/internal/utils"
 	"github.com/Azure/ARO-HCP/internal/utils/armhelpers"
 )
@@ -52,42 +50,60 @@ func (listWatchWithoutWatchListSemantics) IsWatchListSemanticsUnSupported() bool
 const (
 	// These durations indicate the maximum time it will take for us to notice a new instance of a particular type.
 	// Remember that these will not fire in order, so it's entirely possible to get an operation for subscription we have no observed.
-	SubscriptionRelistDuration             = 30 * time.Minute
-	ClusterRelistDuration                  = 30 * time.Minute
-	NodePoolRelistDuration                 = 30 * time.Minute
-	ExternalAuthRelistDuration             = 30 * time.Minute
-	ServiceProviderClusterRelistDuration   = 30 * time.Minute
-	ServiceProviderNodePoolRelistDuration  = 30 * time.Minute
-	ControllerRelistDuration               = 30 * time.Minute
-	AllOperationsRelistDuration            = 30 * time.Minute
-	ActiveOperationsRelistDuration         = 30 * time.Minute
+	SubscriptionRelistDuration             = 30 * time.Second
+	ClusterRelistDuration                  = 30 * time.Second
+	NodePoolRelistDuration                 = 30 * time.Second
+	ExternalAuthRelistDuration             = 30 * time.Second
+	ServiceProviderClusterRelistDuration   = 30 * time.Second
+	ServiceProviderNodePoolRelistDuration  = 30 * time.Second
+	ControllerRelistDuration               = 30 * time.Second
 	ManagementClusterContentRelistDuration = 30 * time.Second
+	AllOperationsRelistDuration            = 30 * time.Second
+	ActiveOperationsRelistDuration         = 10 * time.Second
 	BillingRelistDuration                  = 30 * time.Second
 )
 
 // NewSubscriptionInformer creates an unstarted SharedIndexInformer for subscriptions
 // using the default relist duration.
-func NewSubscriptionInformer(lister database.GlobalLister[arm.Subscription], cosmosClient database.ChangeFeedClient) cache.SharedIndexInformer {
-	return NewSubscriptionInformerWithRelistDuration(lister, cosmosClient, SubscriptionRelistDuration)
+func NewSubscriptionInformer(lister database.GlobalLister[arm.Subscription]) cache.SharedIndexInformer {
+	return NewSubscriptionInformerWithRelistDuration(lister, SubscriptionRelistDuration)
 }
 
 // NewSubscriptionInformerWithRelistDuration creates an unstarted SharedIndexInformer for subscriptions
 // with a configurable relist duration.
-func NewSubscriptionInformerWithRelistDuration(lister database.GlobalLister[arm.Subscription], cosmosClient database.ChangeFeedClient, relistDuration time.Duration) cache.SharedIndexInformer {
-	lw := dbinformers.NewChangeFeedListWatcher[arm.Subscription, *arm.Subscription, database.GenericDocument[arm.Subscription]](
-		[]azcorearm.ResourceType{azcorearm.NewResourceType("Microsoft.Resources", "subscriptions")},
-		utilsclock.RealClock{},
-		lister,
-		cosmosClient,
-		relistDuration,
-	)
+func NewSubscriptionInformerWithRelistDuration(lister database.GlobalLister[arm.Subscription], relistDuration time.Duration) cache.SharedIndexInformer {
+	lw := &cache.ListWatch{
+		ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+			logger := utils.LoggerFromContext(ctx)
+			logger.Info("listing subscriptions")
+			defer logger.Info("finished listing subscriptions")
+
+			iter, err := lister.List(ctx, nil)
+			if err != nil {
+				return nil, err
+			}
+
+			list := &arm.SubscriptionList{}
+			list.ResourceVersion = "0"
+			for _, sub := range iter.Items(ctx) {
+				list.Items = append(list.Items, *sub)
+			}
+			if err := iter.GetError(); err != nil {
+				return nil, err
+			}
+
+			return list, nil
+		},
+		WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			return NewExpiringWatcher(ctx, relistDuration), nil
+		},
+	}
 
 	return cache.NewSharedIndexInformerWithOptions(
-		&listWatchWithoutWatchListSemantics{lw.ToListWatch()},
+		&listWatchWithoutWatchListSemantics{lw},
 		&arm.Subscription{},
 		cache.SharedIndexInformerOptions{
-			ResyncPeriod:      1 * time.Hour, // this is only a default.  Shorter resyncs can be added when registering handlers.
-			ObjectDescription: "Subscription",
+			ResyncPeriod: 1 * time.Hour, // this is only a default.  Shorter resyncs can be added when registering handlers.
 		},
 	)
 }
@@ -137,60 +153,96 @@ func NewBillingInformerWithRelistDuration(lister database.GlobalLister[database.
 			Indexers: cache.Indexers{
 				listers.BySubscription: billingDocSubscriptionIndexFunc,
 			},
-			ObjectDescription: "BillingDocument",
 		},
 	)
 }
 
 // NewClusterInformer creates an unstarted SharedIndexInformer for clusters
 // with a resource group index using the default relist duration.
-func NewClusterInformer(lister database.GlobalLister[api.HCPOpenShiftCluster], cosmosClient database.ChangeFeedClient) cache.SharedIndexInformer {
-	return NewClusterInformerWithRelistDuration(lister, cosmosClient, ClusterRelistDuration)
+func NewClusterInformer(lister database.GlobalLister[api.HCPOpenShiftCluster]) cache.SharedIndexInformer {
+	return NewClusterInformerWithRelistDuration(lister, ClusterRelistDuration)
 }
 
 // NewClusterInformerWithRelistDuration creates an unstarted SharedIndexInformer for clusters
 // with a resource group index and a configurable relist duration.
-func NewClusterInformerWithRelistDuration(lister database.GlobalLister[api.HCPOpenShiftCluster], cosmosClient database.ChangeFeedClient, relistDuration time.Duration) cache.SharedIndexInformer {
-	lw := dbinformers.NewChangeFeedListWatcher[api.HCPOpenShiftCluster, *api.HCPOpenShiftCluster, database.GenericDocument[api.HCPOpenShiftCluster]](
-		[]azcorearm.ResourceType{api.ClusterResourceType},
-		utilsclock.RealClock{},
-		lister,
-		cosmosClient,
-		relistDuration,
-	)
+func NewClusterInformerWithRelistDuration(lister database.GlobalLister[api.HCPOpenShiftCluster], relistDuration time.Duration) cache.SharedIndexInformer {
+	lw := &cache.ListWatch{
+		ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+			logger := utils.LoggerFromContext(ctx)
+			logger.Info("listing clusters")
+			defer logger.Info("finished listing clusters")
+
+			iter, err := lister.List(ctx, nil)
+			if err != nil {
+				return nil, err
+			}
+
+			list := &api.HCPOpenShiftClusterList{}
+			list.ResourceVersion = "0"
+			for _, cluster := range iter.Items(ctx) {
+				list.Items = append(list.Items, *cluster)
+			}
+			if err := iter.GetError(); err != nil {
+				return nil, err
+			}
+
+			return list, nil
+		},
+		WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			return NewExpiringWatcher(ctx, relistDuration), nil
+		},
+	}
 
 	return cache.NewSharedIndexInformerWithOptions(
-		&listWatchWithoutWatchListSemantics{lw.ToListWatch()},
+		&listWatchWithoutWatchListSemantics{lw},
 		&api.HCPOpenShiftCluster{},
 		cache.SharedIndexInformerOptions{
 			ResyncPeriod: 1 * time.Hour, // this is only a default.  Shorter resyncs can be added when registering handlers.
 			Indexers: cache.Indexers{
 				listers.ByResourceGroup: resourceGroupIndexFunc,
 			},
-			ObjectDescription: "HCPOpenShiftCluster",
 		},
 	)
 }
 
 // NewNodePoolInformer creates an unstarted SharedIndexInformer for node pools
 // with resource group and cluster indexes using the default relist duration.
-func NewNodePoolInformer(lister database.GlobalLister[api.HCPOpenShiftClusterNodePool], cosmosClient database.ChangeFeedClient) cache.SharedIndexInformer {
-	return NewNodePoolInformerWithRelistDuration(lister, cosmosClient, NodePoolRelistDuration)
+func NewNodePoolInformer(lister database.GlobalLister[api.HCPOpenShiftClusterNodePool]) cache.SharedIndexInformer {
+	return NewNodePoolInformerWithRelistDuration(lister, NodePoolRelistDuration)
 }
 
 // NewNodePoolInformerWithRelistDuration creates an unstarted SharedIndexInformer for node pools
 // with resource group and cluster indexes and a configurable relist duration.
-func NewNodePoolInformerWithRelistDuration(lister database.GlobalLister[api.HCPOpenShiftClusterNodePool], cosmosClient database.ChangeFeedClient, relistDuration time.Duration) cache.SharedIndexInformer {
-	lw := dbinformers.NewChangeFeedListWatcher[api.HCPOpenShiftClusterNodePool, *api.HCPOpenShiftClusterNodePool, database.GenericDocument[api.HCPOpenShiftClusterNodePool]](
-		[]azcorearm.ResourceType{api.NodePoolResourceType},
-		utilsclock.RealClock{},
-		lister,
-		cosmosClient,
-		relistDuration,
-	)
+func NewNodePoolInformerWithRelistDuration(lister database.GlobalLister[api.HCPOpenShiftClusterNodePool], relistDuration time.Duration) cache.SharedIndexInformer {
+	lw := &cache.ListWatch{
+		ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+			logger := utils.LoggerFromContext(ctx)
+			logger.Info("listing node pools")
+			defer logger.Info("finished listing node pools")
+
+			iter, err := lister.List(ctx, nil)
+			if err != nil {
+				return nil, err
+			}
+
+			list := &api.HCPOpenShiftClusterNodePoolList{}
+			list.ResourceVersion = "0"
+			for _, np := range iter.Items(ctx) {
+				list.Items = append(list.Items, *np)
+			}
+			if err := iter.GetError(); err != nil {
+				return nil, err
+			}
+
+			return list, nil
+		},
+		WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			return NewExpiringWatcher(ctx, relistDuration), nil
+		},
+	}
 
 	return cache.NewSharedIndexInformerWithOptions(
-		&listWatchWithoutWatchListSemantics{lw.ToListWatch()},
+		&listWatchWithoutWatchListSemantics{lw},
 		&api.HCPOpenShiftClusterNodePool{},
 		cache.SharedIndexInformerOptions{
 			ResyncPeriod: 1 * time.Hour, // this is only a default.  Shorter resyncs can be added when registering handlers.
@@ -198,30 +250,48 @@ func NewNodePoolInformerWithRelistDuration(lister database.GlobalLister[api.HCPO
 				listers.ByResourceGroup: resourceGroupIndexFunc,
 				listers.ByCluster:       clusterResourceIDIndexFunc,
 			},
-			ObjectDescription: "HCPOpenShiftClusterNodePool",
 		},
 	)
 }
 
 // NewExternalAuthInformer creates an unstarted SharedIndexInformer for external auths
 // with resource group and cluster indexes using the default relist duration.
-func NewExternalAuthInformer(lister database.GlobalLister[api.HCPOpenShiftClusterExternalAuth], cosmosClient database.ChangeFeedClient) cache.SharedIndexInformer {
-	return NewExternalAuthInformerWithRelistDuration(lister, cosmosClient, ExternalAuthRelistDuration)
+func NewExternalAuthInformer(lister database.GlobalLister[api.HCPOpenShiftClusterExternalAuth]) cache.SharedIndexInformer {
+	return NewExternalAuthInformerWithRelistDuration(lister, ExternalAuthRelistDuration)
 }
 
 // NewExternalAuthInformerWithRelistDuration creates an unstarted SharedIndexInformer for external auths
 // with resource group and cluster indexes and a configurable relist duration.
-func NewExternalAuthInformerWithRelistDuration(lister database.GlobalLister[api.HCPOpenShiftClusterExternalAuth], cosmosClient database.ChangeFeedClient, relistDuration time.Duration) cache.SharedIndexInformer {
-	lw := dbinformers.NewChangeFeedListWatcher[api.HCPOpenShiftClusterExternalAuth, *api.HCPOpenShiftClusterExternalAuth, database.GenericDocument[api.HCPOpenShiftClusterExternalAuth]](
-		[]azcorearm.ResourceType{api.ExternalAuthResourceType},
-		utilsclock.RealClock{},
-		lister,
-		cosmosClient,
-		relistDuration,
-	)
+func NewExternalAuthInformerWithRelistDuration(lister database.GlobalLister[api.HCPOpenShiftClusterExternalAuth], relistDuration time.Duration) cache.SharedIndexInformer {
+	lw := &cache.ListWatch{
+		ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+			logger := utils.LoggerFromContext(ctx)
+			logger.Info("listing external auths")
+			defer logger.Info("finished listing external auths")
+
+			iter, err := lister.List(ctx, nil)
+			if err != nil {
+				return nil, err
+			}
+
+			list := &api.HCPOpenShiftClusterExternalAuthList{}
+			list.ResourceVersion = "0"
+			for _, ea := range iter.Items(ctx) {
+				list.Items = append(list.Items, *ea)
+			}
+			if err := iter.GetError(); err != nil {
+				return nil, err
+			}
+
+			return list, nil
+		},
+		WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			return NewExpiringWatcher(ctx, relistDuration), nil
+		},
+	}
 
 	return cache.NewSharedIndexInformerWithOptions(
-		&listWatchWithoutWatchListSemantics{lw.ToListWatch()},
+		&listWatchWithoutWatchListSemantics{lw},
 		&api.HCPOpenShiftClusterExternalAuth{},
 		cache.SharedIndexInformerOptions{
 			ResyncPeriod: 1 * time.Hour, // this is only a default.  Shorter resyncs can be added when registering handlers.
@@ -229,37 +299,54 @@ func NewExternalAuthInformerWithRelistDuration(lister database.GlobalLister[api.
 				listers.ByResourceGroup: resourceGroupIndexFunc,
 				listers.ByCluster:       clusterResourceIDIndexFunc,
 			},
-			ObjectDescription: "HCPOpenShiftClusterExternalAuth",
 		},
 	)
 }
 
 // NewServiceProviderClusterInformer creates an unstarted SharedIndexInformer for service provider clusters
 // with a cluster index using the default relist duration.
-func NewServiceProviderClusterInformer(lister database.GlobalLister[api.ServiceProviderCluster], cosmosClient database.ChangeFeedClient) cache.SharedIndexInformer {
-	return NewServiceProviderClusterInformerWithRelistDuration(lister, cosmosClient, ServiceProviderClusterRelistDuration)
+func NewServiceProviderClusterInformer(lister database.GlobalLister[api.ServiceProviderCluster]) cache.SharedIndexInformer {
+	return NewServiceProviderClusterInformerWithRelistDuration(lister, ServiceProviderClusterRelistDuration)
 }
 
 // NewServiceProviderClusterInformerWithRelistDuration creates an unstarted SharedIndexInformer for service provider clusters
 // with a cluster index and a configurable relist duration.
-func NewServiceProviderClusterInformerWithRelistDuration(lister database.GlobalLister[api.ServiceProviderCluster], cosmosClient database.ChangeFeedClient, relistDuration time.Duration) cache.SharedIndexInformer {
-	lw := dbinformers.NewChangeFeedListWatcher[api.ServiceProviderCluster, *api.ServiceProviderCluster, database.GenericDocument[api.ServiceProviderCluster]](
-		[]azcorearm.ResourceType{api.ServiceProviderClusterResourceType},
-		utilsclock.RealClock{},
-		lister,
-		cosmosClient,
-		relistDuration,
-	)
+func NewServiceProviderClusterInformerWithRelistDuration(lister database.GlobalLister[api.ServiceProviderCluster], relistDuration time.Duration) cache.SharedIndexInformer {
+	lw := &cache.ListWatch{
+		ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+			logger := utils.LoggerFromContext(ctx)
+			logger.Info("listing service provider clusters")
+			defer logger.Info("finished listing service provider clusters")
+
+			iter, err := lister.List(ctx, nil)
+			if err != nil {
+				return nil, err
+			}
+
+			list := &api.ServiceProviderClusterList{}
+			list.ResourceVersion = "0"
+			for _, spc := range iter.Items(ctx) {
+				list.Items = append(list.Items, *spc)
+			}
+			if err := iter.GetError(); err != nil {
+				return nil, err
+			}
+
+			return list, nil
+		},
+		WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			return NewExpiringWatcher(ctx, relistDuration), nil
+		},
+	}
 
 	return cache.NewSharedIndexInformerWithOptions(
-		&listWatchWithoutWatchListSemantics{lw.ToListWatch()},
+		&listWatchWithoutWatchListSemantics{lw},
 		&api.ServiceProviderCluster{},
 		cache.SharedIndexInformerOptions{
 			ResyncPeriod: 1 * time.Hour, // this is only a default.  Shorter resyncs can be added when registering handlers.
 			Indexers: cache.Indexers{
 				listers.ByCluster: clusterResourceIDIndexFunc,
 			},
-			ObjectDescription: "ServiceProviderCluster",
 		},
 	)
 }
@@ -309,66 +396,96 @@ func NewManagementClusterContentInformerWithRelistDuration(lister database.Globa
 				listers.ByCluster:  clusterResourceIDIndexFunc,
 				listers.ByNodePool: nodePoolResourceIDIndexFunc,
 			},
-			ObjectDescription: "ManagementClusterContent",
 		},
 	)
 }
 
 // NewServiceProviderNodePoolInformer creates an unstarted SharedIndexInformer for service provider node pools
 // with a node pool index using the default relist duration.
-func NewServiceProviderNodePoolInformer(lister database.GlobalLister[api.ServiceProviderNodePool], cosmosClient database.ChangeFeedClient) cache.SharedIndexInformer {
-	return NewServiceProviderNodePoolInformerWithRelistDuration(lister, cosmosClient, ServiceProviderNodePoolRelistDuration)
+func NewServiceProviderNodePoolInformer(lister database.GlobalLister[api.ServiceProviderNodePool]) cache.SharedIndexInformer {
+	return NewServiceProviderNodePoolInformerWithRelistDuration(lister, ServiceProviderNodePoolRelistDuration)
 }
 
 // NewServiceProviderNodePoolInformerWithRelistDuration creates an unstarted SharedIndexInformer for service provider node pools
 // with a node pool index and a configurable relist duration.
-func NewServiceProviderNodePoolInformerWithRelistDuration(lister database.GlobalLister[api.ServiceProviderNodePool], cosmosClient database.ChangeFeedClient, relistDuration time.Duration) cache.SharedIndexInformer {
-	lw := dbinformers.NewChangeFeedListWatcher[api.ServiceProviderNodePool, *api.ServiceProviderNodePool, database.GenericDocument[api.ServiceProviderNodePool]](
-		[]azcorearm.ResourceType{api.ServiceProviderNodePoolResourceType},
-		utilsclock.RealClock{},
-		lister,
-		cosmosClient,
-		relistDuration,
-	)
+func NewServiceProviderNodePoolInformerWithRelistDuration(lister database.GlobalLister[api.ServiceProviderNodePool], relistDuration time.Duration) cache.SharedIndexInformer {
+	lw := &cache.ListWatch{
+		ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+			logger := utils.LoggerFromContext(ctx)
+			logger.Info("listing service provider node pools")
+			defer logger.Info("finished listing service provider node pools")
+
+			iter, err := lister.List(ctx, nil)
+			if err != nil {
+				return nil, err
+			}
+
+			list := &api.ServiceProviderNodePoolList{}
+			list.ResourceVersion = "0"
+			for _, spnp := range iter.Items(ctx) {
+				list.Items = append(list.Items, *spnp)
+			}
+			if err := iter.GetError(); err != nil {
+				return nil, err
+			}
+
+			return list, nil
+		},
+		WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			return NewExpiringWatcher(ctx, relistDuration), nil
+		},
+	}
 
 	return cache.NewSharedIndexInformerWithOptions(
-		&listWatchWithoutWatchListSemantics{lw.ToListWatch()},
+		&listWatchWithoutWatchListSemantics{lw},
 		&api.ServiceProviderNodePool{},
 		cache.SharedIndexInformerOptions{
 			ResyncPeriod: 1 * time.Hour, // this is only a default.  Shorter resyncs can be added when registering handlers.
 			Indexers: cache.Indexers{
 				listers.ByNodePool: nodePoolResourceIDIndexFunc,
 			},
-			ObjectDescription: "ServiceProviderNodePool",
 		},
 	)
 }
 
 // NewControllerInformer creates an unstarted SharedIndexInformer for controllers
 // using the default relist duration.
-func NewControllerInformer(lister database.GlobalLister[api.Controller], cosmosClient database.ChangeFeedClient) cache.SharedIndexInformer {
-	return NewControllerInformerWithRelistDuration(lister, cosmosClient, ControllerRelistDuration)
+func NewControllerInformer(lister database.GlobalLister[api.Controller]) cache.SharedIndexInformer {
+	return NewControllerInformerWithRelistDuration(lister, ControllerRelistDuration)
 }
 
 // NewControllerInformerWithRelistDuration creates an unstarted SharedIndexInformer for controllers
-// with a configurable relist duration. Controllers live under three different
-// ARM resource types (cluster-scoped, nodepool-scoped, externalauth-scoped) so
-// the change feed filter accepts all three.
-func NewControllerInformerWithRelistDuration(lister database.GlobalLister[api.Controller], cosmosClient database.ChangeFeedClient, relistDuration time.Duration) cache.SharedIndexInformer {
-	lw := dbinformers.NewChangeFeedListWatcher[api.Controller, *api.Controller, database.GenericDocument[api.Controller]](
-		[]azcorearm.ResourceType{
-			api.ClusterControllerResourceType,
-			api.NodePoolControllerResourceType,
-			api.ExternalAuthControllerResourceType,
+// with a configurable relist duration.
+func NewControllerInformerWithRelistDuration(lister database.GlobalLister[api.Controller], relistDuration time.Duration) cache.SharedIndexInformer {
+	lw := &cache.ListWatch{
+		ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+			logger := utils.LoggerFromContext(ctx)
+			logger.Info("listing controllers")
+			defer logger.Info("finished listing controllers")
+
+			iter, err := lister.List(ctx, nil)
+			if err != nil {
+				return nil, err
+			}
+
+			list := &api.ControllerList{}
+			list.ResourceVersion = "0"
+			for _, controller := range iter.Items(ctx) {
+				list.Items = append(list.Items, *controller)
+			}
+			if err := iter.GetError(); err != nil {
+				return nil, err
+			}
+
+			return list, nil
 		},
-		utilsclock.RealClock{},
-		lister,
-		cosmosClient,
-		relistDuration,
-	)
+		WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			return NewExpiringWatcher(ctx, relistDuration), nil
+		},
+	}
 
 	return cache.NewSharedIndexInformerWithOptions(
-		&listWatchWithoutWatchListSemantics{lw.ToListWatch()},
+		&listWatchWithoutWatchListSemantics{lw},
 		&api.Controller{},
 		cache.SharedIndexInformerOptions{
 			ResyncPeriod: 1 * time.Hour,
@@ -378,7 +495,6 @@ func NewControllerInformerWithRelistDuration(lister database.GlobalLister[api.Co
 				listers.ByNodePool:      nodePoolResourceIDIndexFunc,
 				listers.ByExternalAuth:  externalAuthResourceIDIndexFunc,
 			},
-			ObjectDescription: "Controller",
 		},
 	)
 }
@@ -387,27 +503,45 @@ func NewControllerInformerWithRelistDuration(lister database.GlobalLister[api.Co
 // operations (including terminal) using the default relist duration. This is
 // used by the metrics controller so that completed operations remain visible
 // in Prometheus until the 7-day Cosmos TTL removes them.
-func NewOperationInformer(lister database.GlobalLister[api.Operation], cosmosClient database.ChangeFeedClient) cache.SharedIndexInformer {
-	return NewOperationInformerWithRelistDuration(lister, cosmosClient, AllOperationsRelistDuration)
+func NewOperationInformer(lister database.GlobalLister[api.Operation]) cache.SharedIndexInformer {
+	return NewOperationInformerWithRelistDuration(lister, AllOperationsRelistDuration)
 }
 
 // NewOperationInformerWithRelistDuration creates an unstarted SharedIndexInformer
 // for all operations (including terminal) with a configurable relist duration.
-func NewOperationInformerWithRelistDuration(lister database.GlobalLister[api.Operation], cosmosClient database.ChangeFeedClient, relistDuration time.Duration) cache.SharedIndexInformer {
-	lw := dbinformers.NewChangeFeedListWatcher[api.Operation, *api.Operation, database.GenericDocument[api.Operation]](
-		[]azcorearm.ResourceType{api.OperationStatusResourceType},
-		utilsclock.RealClock{},
-		lister,
-		cosmosClient,
-		relistDuration,
-	)
+func NewOperationInformerWithRelistDuration(lister database.GlobalLister[api.Operation], relistDuration time.Duration) cache.SharedIndexInformer {
+	lw := &cache.ListWatch{
+		ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+			logger := utils.LoggerFromContext(ctx)
+			logger.Info("listing all operations")
+			defer logger.Info("finished listing all operations")
+
+			iter, err := lister.List(ctx, nil)
+			if err != nil {
+				return nil, err
+			}
+
+			list := &api.OperationList{}
+			list.ResourceVersion = "0"
+			for _, op := range iter.Items(ctx) {
+				list.Items = append(list.Items, *op)
+			}
+			if err := iter.GetError(); err != nil {
+				return nil, err
+			}
+
+			return list, nil
+		},
+		WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			return NewExpiringWatcher(ctx, relistDuration), nil
+		},
+	}
 
 	return cache.NewSharedIndexInformerWithOptions(
-		&listWatchWithoutWatchListSemantics{lw.ToListWatch()},
+		&listWatchWithoutWatchListSemantics{lw},
 		&api.Operation{},
 		cache.SharedIndexInformerOptions{
-			ResyncPeriod:      1 * time.Hour,
-			ObjectDescription: "Operation",
+			ResyncPeriod: 1 * time.Hour,
 		},
 	)
 }
@@ -415,26 +549,43 @@ func NewOperationInformerWithRelistDuration(lister database.GlobalLister[api.Ope
 // NewActiveOperationInformer creates an unstarted SharedIndexInformer for
 // active (non-terminal) operations with resource group and cluster indexes
 // using the default relist duration.
-func NewActiveOperationInformer(lister database.GlobalLister[api.Operation], cosmosClient database.ChangeFeedClient) cache.SharedIndexInformer {
-	return NewActiveOperationInformerWithRelistDuration(lister, cosmosClient, ActiveOperationsRelistDuration)
+func NewActiveOperationInformer(lister database.GlobalLister[api.Operation]) cache.SharedIndexInformer {
+	return NewActiveOperationInformerWithRelistDuration(lister, ActiveOperationsRelistDuration)
 }
 
 // NewActiveOperationInformerWithRelistDuration creates an unstarted SharedIndexInformer for
 // active (non-terminal) operations with resource group and cluster indexes
 // and a configurable relist duration.
-func NewActiveOperationInformerWithRelistDuration(lister database.GlobalLister[api.Operation], cosmosClient database.ChangeFeedClient, relistDuration time.Duration) cache.SharedIndexInformer {
-	lw := dbinformers.NewChangeFeedListWatcher[api.Operation, *api.Operation, database.GenericDocument[api.Operation]](
-		[]azcorearm.ResourceType{api.OperationStatusResourceType},
-		utilsclock.RealClock{},
-		lister,
-		cosmosClient,
-		relistDuration,
-	).WithShouldDeliverItemFn(func(obj *api.Operation) bool {
-		return !obj.Status.IsTerminal()
-	})
+func NewActiveOperationInformerWithRelistDuration(lister database.GlobalLister[api.Operation], relistDuration time.Duration) cache.SharedIndexInformer {
+	lw := &cache.ListWatch{
+		ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+			logger := utils.LoggerFromContext(ctx)
+			logger.Info("listing active operations")
+			defer logger.Info("finished listing active operations")
+
+			iter, err := lister.List(ctx, nil)
+			if err != nil {
+				return nil, err
+			}
+
+			list := &api.OperationList{}
+			list.ResourceVersion = "0"
+			for _, op := range iter.Items(ctx) {
+				list.Items = append(list.Items, *op)
+			}
+			if err := iter.GetError(); err != nil {
+				return nil, err
+			}
+
+			return list, nil
+		},
+		WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			return NewExpiringWatcher(ctx, relistDuration), nil
+		},
+	}
 
 	return cache.NewSharedIndexInformerWithOptions(
-		&listWatchWithoutWatchListSemantics{lw.ToListWatch()},
+		&listWatchWithoutWatchListSemantics{lw},
 		&api.Operation{},
 		cache.SharedIndexInformerOptions{
 			ResyncPeriod: 1 * time.Hour, // this is only a default.  Shorter resyncs can be added when registering handlers.
@@ -444,7 +595,6 @@ func NewActiveOperationInformerWithRelistDuration(lister database.GlobalLister[a
 				listers.ByNodePool:      activeOperationNodePoolIndexFunc,
 				listers.ByExternalAuth:  activeOperationExternalAuthIndexFunc,
 			},
-			ObjectDescription: "ActiveOperation",
 		},
 	)
 }

--- a/backend/pkg/informers/informers_test.go
+++ b/backend/pkg/informers/informers_test.go
@@ -258,7 +258,7 @@ func subscriptionInformerTestCase() informerTestCase {
 			require.NoError(t, err)
 		},
 		createInformer: func(mockResourcesDBClient *databasetesting.MockResourcesDBClient) cache.SharedIndexInformer {
-			return NewSubscriptionInformerWithRelistDuration(mockResourcesDBClient.ResourcesGlobalListers().Subscriptions(), mockResourcesDBClient, 1*time.Second)
+			return NewSubscriptionInformerWithRelistDuration(mockResourcesDBClient.ResourcesGlobalListers().Subscriptions(), 1*time.Second)
 		},
 		expectedInitialAdds: 2,
 		mutateDB: func(t *testing.T, ctx context.Context, mockResourcesDBClient *databasetesting.MockResourcesDBClient) {
@@ -377,7 +377,7 @@ func clusterInformerTestCase() informerTestCase {
 			require.NoError(t, err)
 		},
 		createInformer: func(mockResourcesDBClient *databasetesting.MockResourcesDBClient) cache.SharedIndexInformer {
-			return NewClusterInformerWithRelistDuration(mockResourcesDBClient.ResourcesGlobalListers().Clusters(), mockResourcesDBClient, 1*time.Second)
+			return NewClusterInformerWithRelistDuration(mockResourcesDBClient.ResourcesGlobalListers().Clusters(), 1*time.Second)
 		},
 		expectedInitialAdds: 2,
 		mutateDB: func(t *testing.T, ctx context.Context, mockResourcesDBClient *databasetesting.MockResourcesDBClient) {
@@ -519,7 +519,7 @@ func nodePoolInformerTestCase() informerTestCase {
 			require.NoError(t, err)
 		},
 		createInformer: func(mockResourcesDBClient *databasetesting.MockResourcesDBClient) cache.SharedIndexInformer {
-			return NewNodePoolInformerWithRelistDuration(mockResourcesDBClient.ResourcesGlobalListers().NodePools(), mockResourcesDBClient, 1*time.Second)
+			return NewNodePoolInformerWithRelistDuration(mockResourcesDBClient.ResourcesGlobalListers().NodePools(), 1*time.Second)
 		},
 		expectedInitialAdds: 2,
 		mutateDB: func(t *testing.T, ctx context.Context, mockResourcesDBClient *databasetesting.MockResourcesDBClient) {
@@ -627,7 +627,7 @@ func activeOperationInformerTestCase() informerTestCase {
 			require.NoError(t, err)
 		},
 		createInformer: func(mockResourcesDBClient *databasetesting.MockResourcesDBClient) cache.SharedIndexInformer {
-			return NewActiveOperationInformerWithRelistDuration(mockResourcesDBClient.ResourcesGlobalListers().ActiveOperations(), mockResourcesDBClient, 1*time.Second)
+			return NewActiveOperationInformerWithRelistDuration(mockResourcesDBClient.ResourcesGlobalListers().ActiveOperations(), 1*time.Second)
 		},
 		expectedInitialAdds: 2,
 		mutateDB: func(t *testing.T, ctx context.Context, mockResourcesDBClient *databasetesting.MockResourcesDBClient) {
@@ -811,7 +811,7 @@ func controllerInformerTestCase() informerTestCase {
 			require.NoError(t, err)
 		},
 		createInformer: func(mockResourcesDBClient *databasetesting.MockResourcesDBClient) cache.SharedIndexInformer {
-			return NewControllerInformerWithRelistDuration(mockResourcesDBClient.ResourcesGlobalListers().Controllers(), mockResourcesDBClient, 1*time.Second)
+			return NewControllerInformerWithRelistDuration(mockResourcesDBClient.ResourcesGlobalListers().Controllers(), 1*time.Second)
 		},
 		expectedInitialAdds: 4,
 		mutateDB: func(t *testing.T, ctx context.Context, mockResourcesDBClient *databasetesting.MockResourcesDBClient) {

--- a/backend/pkg/informers/types.go
+++ b/backend/pkg/informers/types.go
@@ -16,7 +16,6 @@ package informers
 
 import (
 	"context"
-	"reflect"
 	"sync"
 	"time"
 
@@ -24,9 +23,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/Azure/ARO-HCP/backend/pkg/listers"
-	"github.com/Azure/ARO-HCP/internal/api"
-	"github.com/Azure/ARO-HCP/internal/api/arm"
-	"github.com/Azure/ARO-HCP/internal/api/fleet"
 	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
@@ -126,11 +122,11 @@ func (b *backendInformers) BillingDocs() (cache.SharedIndexInformer, listers.Bil
 	return b.billingInformer, b.billingLister
 }
 
-func NewBackendInformers(ctx context.Context, resourcesGlobalListers database.ResourcesGlobalListers, resourcesDBClient database.ResourcesDBClient, billingGlobalListers database.BillingGlobalListers) BackendInformers {
-	return NewBackendInformersWithRelistDuration(ctx, resourcesGlobalListers, resourcesDBClient, billingGlobalListers, nil)
+func NewBackendInformers(ctx context.Context, resourcesGlobalListers database.ResourcesGlobalListers, billingGlobalListers database.BillingGlobalListers) BackendInformers {
+	return NewBackendInformersWithRelistDuration(ctx, resourcesGlobalListers, billingGlobalListers, nil)
 }
 
-func NewBackendInformersWithRelistDuration(ctx context.Context, resourcesGlobalListers database.ResourcesGlobalListers, resourcesDBClient database.ResourcesDBClient, billingGlobalListers database.BillingGlobalListers, relistDuration *time.Duration) BackendInformers {
+func NewBackendInformersWithRelistDuration(ctx context.Context, resourcesGlobalListers database.ResourcesGlobalListers, billingGlobalListers database.BillingGlobalListers, relistDuration *time.Duration) BackendInformers {
 	subscriptionRelistDuration := SubscriptionRelistDuration
 	clusterRelistDuration := ClusterRelistDuration
 	nodePoolRelistDuration := NodePoolRelistDuration
@@ -157,15 +153,15 @@ func NewBackendInformersWithRelistDuration(ctx context.Context, resourcesGlobalL
 	}
 
 	ret := &backendInformers{}
-	ret.subscriptionInformer = NewSubscriptionInformerWithRelistDuration(resourcesGlobalListers.Subscriptions(), resourcesDBClient, subscriptionRelistDuration)
-	ret.activeOperationInformer = NewActiveOperationInformerWithRelistDuration(resourcesGlobalListers.ActiveOperations(), resourcesDBClient, activeOperationsRelistDuration)
-	ret.allOperationInformer = NewOperationInformerWithRelistDuration(resourcesGlobalListers.Operations(), resourcesDBClient, allOperationsRelistDuration)
-	ret.clusterInformer = NewClusterInformerWithRelistDuration(resourcesGlobalListers.Clusters(), resourcesDBClient, clusterRelistDuration)
-	ret.nodePoolInformer = NewNodePoolInformerWithRelistDuration(resourcesGlobalListers.NodePools(), resourcesDBClient, nodePoolRelistDuration)
-	ret.externalAuthInformer = NewExternalAuthInformerWithRelistDuration(resourcesGlobalListers.ExternalAuths(), resourcesDBClient, externalAuthRelistDuration)
-	ret.serviceProviderClusterInformer = NewServiceProviderClusterInformerWithRelistDuration(resourcesGlobalListers.ServiceProviderClusters(), resourcesDBClient, serviceProviderClusterRelistDuration)
-	ret.serviceProviderNodePoolInformer = NewServiceProviderNodePoolInformerWithRelistDuration(resourcesGlobalListers.ServiceProviderNodePools(), resourcesDBClient, serviceProviderNodePoolRelistDuration)
-	ret.controllerInformer = NewControllerInformerWithRelistDuration(resourcesGlobalListers.Controllers(), resourcesDBClient, controllerRelistDuration)
+	ret.subscriptionInformer = NewSubscriptionInformerWithRelistDuration(resourcesGlobalListers.Subscriptions(), subscriptionRelistDuration)
+	ret.activeOperationInformer = NewActiveOperationInformerWithRelistDuration(resourcesGlobalListers.ActiveOperations(), activeOperationsRelistDuration)
+	ret.allOperationInformer = NewOperationInformerWithRelistDuration(resourcesGlobalListers.Operations(), allOperationsRelistDuration)
+	ret.clusterInformer = NewClusterInformerWithRelistDuration(resourcesGlobalListers.Clusters(), clusterRelistDuration)
+	ret.nodePoolInformer = NewNodePoolInformerWithRelistDuration(resourcesGlobalListers.NodePools(), nodePoolRelistDuration)
+	ret.externalAuthInformer = NewExternalAuthInformerWithRelistDuration(resourcesGlobalListers.ExternalAuths(), externalAuthRelistDuration)
+	ret.serviceProviderClusterInformer = NewServiceProviderClusterInformerWithRelistDuration(resourcesGlobalListers.ServiceProviderClusters(), serviceProviderClusterRelistDuration)
+	ret.serviceProviderNodePoolInformer = NewServiceProviderNodePoolInformerWithRelistDuration(resourcesGlobalListers.ServiceProviderNodePools(), serviceProviderNodePoolRelistDuration)
+	ret.controllerInformer = NewControllerInformerWithRelistDuration(resourcesGlobalListers.Controllers(), controllerRelistDuration)
 	ret.managementClusterContentInformer = NewManagementClusterContentInformerWithRelistDuration(resourcesGlobalListers.ManagementClusterContents(), managementClusterContentRelistDuration)
 	ret.billingInformer = NewBillingInformerWithRelistDuration(billingGlobalListers.BillingDocs(), billingRelistDuration)
 
@@ -195,91 +191,61 @@ func (b *backendInformers) RunWithContext(ctx context.Context) {
 	go func() {
 		defer utilruntime.HandleCrash()
 		defer wg.Done()
-		localLogger := logger.WithValues("type", reflect.TypeOf(&arm.Subscription{}).String())
-		localCtx := utils.ContextWithLogger(ctx, localLogger)
-
-		b.subscriptionInformer.RunWithContext(localCtx)
+		b.subscriptionInformer.RunWithContext(ctx)
 	}()
 	wg.Add(1)
 	go func() {
 		defer utilruntime.HandleCrash()
 		defer wg.Done()
-		localLogger := logger.WithValues("type", reflect.TypeOf(&arm.Operation{}).String())
-		localCtx := utils.ContextWithLogger(ctx, localLogger)
-
-		b.activeOperationInformer.RunWithContext(localCtx)
+		b.activeOperationInformer.RunWithContext(ctx)
 	}()
 	wg.Add(1)
 	go func() {
 		defer utilruntime.HandleCrash()
 		defer wg.Done()
-		localLogger := logger.WithValues("type", reflect.TypeOf(&arm.Operation{}).String())
-		localCtx := utils.ContextWithLogger(ctx, localLogger)
-
-		b.allOperationInformer.RunWithContext(localCtx)
+		b.allOperationInformer.RunWithContext(ctx)
 	}()
 	wg.Add(1)
 	go func() {
 		defer utilruntime.HandleCrash()
 		defer wg.Done()
-		localLogger := logger.WithValues("type", reflect.TypeOf(&api.HCPOpenShiftCluster{}).String())
-		localCtx := utils.ContextWithLogger(ctx, localLogger)
-
-		b.clusterInformer.RunWithContext(localCtx)
+		b.clusterInformer.RunWithContext(ctx)
 	}()
 	wg.Add(1)
 	go func() {
 		defer utilruntime.HandleCrash()
 		defer wg.Done()
-		localLogger := logger.WithValues("type", reflect.TypeOf(&api.HCPOpenShiftClusterNodePool{}).String())
-		localCtx := utils.ContextWithLogger(ctx, localLogger)
-
-		b.nodePoolInformer.RunWithContext(localCtx)
+		b.nodePoolInformer.RunWithContext(ctx)
 	}()
 	wg.Add(1)
 	go func() {
 		defer utilruntime.HandleCrash()
 		defer wg.Done()
-		localLogger := logger.WithValues("type", reflect.TypeOf(&api.HCPOpenShiftClusterExternalAuth{}).String())
-		localCtx := utils.ContextWithLogger(ctx, localLogger)
-
-		b.externalAuthInformer.RunWithContext(localCtx)
+		b.externalAuthInformer.RunWithContext(ctx)
 	}()
 	wg.Add(1)
 	go func() {
 		defer utilruntime.HandleCrash()
 		defer wg.Done()
-		localLogger := logger.WithValues("type", reflect.TypeOf(&api.ServiceProviderCluster{}).String())
-		localCtx := utils.ContextWithLogger(ctx, localLogger)
-
-		b.serviceProviderClusterInformer.RunWithContext(localCtx)
+		b.serviceProviderClusterInformer.RunWithContext(ctx)
 	}()
 	wg.Add(1)
 	go func() {
 		defer utilruntime.HandleCrash()
 		defer wg.Done()
-		localLogger := logger.WithValues("type", reflect.TypeOf(&api.ServiceProviderNodePool{}).String())
-		localCtx := utils.ContextWithLogger(ctx, localLogger)
-
-		b.serviceProviderNodePoolInformer.RunWithContext(localCtx)
+		b.serviceProviderNodePoolInformer.RunWithContext(ctx)
 	}()
 	wg.Add(1)
 	go func() {
 		defer utilruntime.HandleCrash()
 		defer wg.Done()
-		localLogger := logger.WithValues("type", reflect.TypeOf(&api.Controller{}).String())
-		localCtx := utils.ContextWithLogger(ctx, localLogger)
-
-		b.controllerInformer.RunWithContext(localCtx)
+		b.controllerInformer.RunWithContext(ctx)
 	}()
 	wg.Add(1)
 	go func() {
 		defer utilruntime.HandleCrash()
 		defer wg.Done()
-		localLogger := logger.WithValues("type", reflect.TypeOf(&fleet.ManagementCluster{}).String())
-		localCtx := utils.ContextWithLogger(ctx, localLogger)
-
-		b.managementClusterContentInformer.RunWithContext(localCtx)
+		b.managementClusterContentInformer.RunWithContext(ctx)
 	}()
 	wg.Add(1)
 	go func() {

--- a/test-integration/backend/changefeed/changefeed_test.go
+++ b/test-integration/backend/changefeed/changefeed_test.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -28,13 +27,10 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/tools/cache"
 	utilsclock "k8s.io/utils/clock"
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
-	backendinformers "github.com/Azure/ARO-HCP/backend/pkg/informers"
-	backendlisters "github.com/Azure/ARO-HCP/backend/pkg/listers"
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
 	"github.com/Azure/ARO-HCP/internal/database"
@@ -715,130 +711,3 @@ func drainEvents(watcher *clusterChangeFeedWatcher, within time.Duration) []watc
 		}
 	}
 }
-
-// TestActiveOperationInformer verifies that the active-operation informer
-// (which uses WithShouldDeliverItemFn to filter out terminal operations):
-//  1. Delivers an Added event and the lister finds the operation.
-//  2. Delivers a Deleted event when the operation transitions to terminal.
-//  3. The lister returns not-found after the operation becomes terminal.
-func TestActiveOperationInformer(t *testing.T) {
-	integrationutils.WithAndWithoutCosmos(t, func(t *testing.T, withMock bool) {
-		ctx, cancel := context.WithTimeout(t.Context(), 90*time.Second)
-		ctx = utils.ContextWithLogger(ctx, integrationutils.DefaultLogger(t))
-
-		var (
-			storage integrationutils.StorageIntegrationTestInfo
-			err     error
-		)
-		if withMock {
-			storage, err = integrationutils.NewMockCosmosFromTestingEnv(ctx, t)
-		} else {
-			storage, err = integrationutils.NewCosmosFromTestingEnv(ctx, t)
-		}
-		require.NoError(t, err, "create test storage")
-
-		resourcesDBClient := storage.ResourcesDBClient()
-
-		// Build the active operation informer using the same constructor
-		// the backend uses — it wires WithShouldDeliverItemFn to filter
-		// out terminal operations.
-		activeOpInformer := backendinformers.NewActiveOperationInformerWithRelistDuration(
-			resourcesDBClient.ResourcesGlobalListers().ActiveOperations(),
-			resourcesDBClient,
-			30*time.Minute,
-		)
-		activeOpLister := backendlisters.NewActiveOperationLister(activeOpInformer.GetIndexer())
-
-		// Track events delivered by the informer.
-		events := make(chan watch.Event, 10)
-		_, err = activeOpInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
-				events <- watch.Event{Type: watch.Added, Object: obj.(*api.Operation)}
-			},
-			UpdateFunc: func(_, obj interface{}) {
-				events <- watch.Event{Type: watch.Modified, Object: obj.(*api.Operation)}
-			},
-			DeleteFunc: func(obj interface{}) {
-				events <- watch.Event{Type: watch.Deleted, Object: obj.(*api.Operation)}
-			},
-		})
-		require.NoError(t, err, "AddEventHandler")
-
-		// Start the informer and wait for the initial list to sync.
-		informerDone := make(chan struct{})
-		go func() {
-			defer close(informerDone)
-			activeOpInformer.RunWithContext(ctx)
-		}()
-		defer func() {
-			cancel()
-			<-informerDone
-			cleanupCtx := utils.ContextWithLogger(context.Background(), integrationutils.DefaultLogger(t))
-			storage.Cleanup(cleanupCtx)
-		}()
-		require.True(t, cache.WaitForCacheSync(ctx.Done(), activeOpInformer.HasSynced),
-			"informer cache did not sync")
-
-		// Create an active (non-terminal) operation.
-		clusterRID := api.Must(azcorearm.ParseResourceID(fmt.Sprintf(
-			"/subscriptions/%s/resourceGroups/%s/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/active-op-test-%d",
-			testSubscriptionID, testResourceGroup, time.Now().UnixNano())))
-		opRID := api.Must(azcorearm.ParseResourceID(fmt.Sprintf(
-			"/subscriptions/%s/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/active-op-%d",
-			testSubscriptionID, time.Now().UnixNano())))
-		op := newOperationFixture(opRID, clusterRID)
-		created, err := resourcesDBClient.Operations(opRID.SubscriptionID).Create(ctx, op, nil)
-		require.NoError(t, err, "Create operation")
-
-		// Wait for the Added event from the informer.
-		evt := waitForChannelEvent(t, events, eventDeadline)
-		require.Equal(t, watch.Added, evt.Type, "expected Added for new active operation")
-		addedOp := evt.Object.(*api.Operation)
-		require.Truef(t, strings.EqualFold(addedOp.GetResourceID().String(), opRID.String()),
-			"Added event resourceID %q != created %q", addedOp.GetResourceID().String(), opRID.String())
-		require.Equal(t, arm.ProvisioningStateAccepted, addedOp.Status,
-			"Added event must carry the non-terminal status")
-
-		// The lister must find the active operation.
-		listedOp, err := activeOpLister.Get(ctx, testSubscriptionID, opRID.Name)
-		require.NoError(t, err, "lister.Get must find the active operation")
-		require.Truef(t, strings.EqualFold(listedOp.GetResourceID().String(), opRID.String()),
-			"lister returned wrong operation: %q", listedOp.GetResourceID().String())
-
-		// Transition the operation to terminal (Succeeded).
-		updated := newOperationFixture(opRID, clusterRID)
-		updated.CosmosETag = created.CosmosETag
-		updated.InstanceVersion = created.GetInstanceVersion()
-		updated.Status = arm.ProvisioningStateSucceeded
-		_, err = resourcesDBClient.Operations(opRID.SubscriptionID).Replace(ctx, updated, nil)
-		require.NoError(t, err, "Replace operation to terminal")
-
-		// The informer should deliver a Deleted event because
-		// shouldDeliverItemFn returns false for terminal operations.
-		evt = waitForChannelEvent(t, events, eventDeadline)
-		require.Equal(t, watch.Deleted, evt.Type, "expected Deleted when operation becomes terminal")
-		deletedOp := evt.Object.(*api.Operation)
-		require.Truef(t, strings.EqualFold(deletedOp.GetResourceID().String(), opRID.String()),
-			"Deleted event resourceID %q != operation %q", deletedOp.GetResourceID().String(), opRID.String())
-		require.Equal(t, arm.ProvisioningStateSucceeded, deletedOp.Status,
-			"Deleted event must carry the terminal status that caused removal")
-
-		// The lister must no longer find the operation.
-		_, err = activeOpLister.Get(ctx, testSubscriptionID, opRID.Name)
-		require.Error(t, err, "lister.Get must return an error after the operation became terminal")
-	})
-}
-
-func waitForChannelEvent(t *testing.T, ch <-chan watch.Event, timeout time.Duration) watch.Event {
-	t.Helper()
-	select {
-	case evt := <-ch:
-		return evt
-	case <-time.After(timeout):
-		t.Fatalf("no event received within %s", timeout)
-	}
-	return watch.Event{}
-}
-
-// keep imports honest if the file ever stops using sync/atomic etc.
-var _ = sync.Once{}

--- a/test-integration/backend/launch/notification_test.go
+++ b/test-integration/backend/launch/notification_test.go
@@ -79,7 +79,7 @@ func TestControllerNotifications(t *testing.T) {
 		}()
 
 		resourcesDBClient := testInfo.ResourcesDBClient()
-		backendInformers := informers.NewBackendInformersWithRelistDuration(ctx, resourcesDBClient.ResourcesGlobalListers(), resourcesDBClient, testInfo.BillingDBClient().BillingGlobalListers(), ptr.To(100*time.Millisecond))
+		backendInformers := informers.NewBackendInformersWithRelistDuration(ctx, resourcesDBClient.ResourcesGlobalListers(), testInfo.BillingDBClient().BillingGlobalListers(), ptr.To(100*time.Millisecond))
 
 		_, activeOperationLister := backendInformers.ActiveOperations()
 		testSyncer := newTestController(activeOperationLister)

--- a/test-integration/frontend/informer_test.go
+++ b/test-integration/frontend/informer_test.go
@@ -280,7 +280,7 @@ func subscriptionInformerIntegrationTestCase() informerIntegrationTestCase {
 			require.NoError(t, err)
 		},
 		createInformer: func(resourcesDBClient database.ResourcesDBClient) cache.SharedIndexInformer {
-			return informers.NewSubscriptionInformerWithRelistDuration(resourcesDBClient.ResourcesGlobalListers().Subscriptions(), resourcesDBClient, 5*time.Second)
+			return informers.NewSubscriptionInformerWithRelistDuration(resourcesDBClient.ResourcesGlobalListers().Subscriptions(), 5*time.Second)
 		},
 		expectedInitialAdds: 2,
 		mutateDB: func(t *testing.T, ctx context.Context, resourcesDBClient database.ResourcesDBClient) {
@@ -394,7 +394,7 @@ func clusterInformerIntegrationTestCase() informerIntegrationTestCase {
 			require.NoError(t, err)
 		},
 		createInformer: func(resourcesDBClient database.ResourcesDBClient) cache.SharedIndexInformer {
-			return informers.NewClusterInformerWithRelistDuration(resourcesDBClient.ResourcesGlobalListers().Clusters(), resourcesDBClient, 5*time.Second)
+			return informers.NewClusterInformerWithRelistDuration(resourcesDBClient.ResourcesGlobalListers().Clusters(), 5*time.Second)
 		},
 		expectedInitialAdds: 2,
 		mutateDB: func(t *testing.T, ctx context.Context, resourcesDBClient database.ResourcesDBClient) {
@@ -530,7 +530,7 @@ func nodePoolInformerIntegrationTestCase() informerIntegrationTestCase {
 			require.NoError(t, err)
 		},
 		createInformer: func(resourcesDBClient database.ResourcesDBClient) cache.SharedIndexInformer {
-			return informers.NewNodePoolInformerWithRelistDuration(resourcesDBClient.ResourcesGlobalListers().NodePools(), resourcesDBClient, 5*time.Second)
+			return informers.NewNodePoolInformerWithRelistDuration(resourcesDBClient.ResourcesGlobalListers().NodePools(), 5*time.Second)
 		},
 		expectedInitialAdds: 2,
 		mutateDB: func(t *testing.T, ctx context.Context, resourcesDBClient database.ResourcesDBClient) {
@@ -633,7 +633,7 @@ func activeOperationInformerIntegrationTestCase() informerIntegrationTestCase {
 			require.NoError(t, err)
 		},
 		createInformer: func(resourcesDBClient database.ResourcesDBClient) cache.SharedIndexInformer {
-			return informers.NewActiveOperationInformerWithRelistDuration(resourcesDBClient.ResourcesGlobalListers().ActiveOperations(), resourcesDBClient, 5*time.Second)
+			return informers.NewActiveOperationInformerWithRelistDuration(resourcesDBClient.ResourcesGlobalListers().ActiveOperations(), 5*time.Second)
 		},
 		expectedInitialAdds: 2,
 		mutateDB: func(t *testing.T, ctx context.Context, resourcesDBClient database.ResourcesDBClient) {
@@ -783,7 +783,6 @@ func testServiceProviderNodePoolLister(t *testing.T, withMock bool) {
 	// observes the seeded object quickly.
 	informer := informers.NewServiceProviderNodePoolInformerWithRelistDuration(
 		resourcesDBClient.ResourcesGlobalListers().ServiceProviderNodePools(),
-		resourcesDBClient,
 		1*time.Second)
 	go informer.Run(ctx.Done())
 	require.True(t, cache.WaitForCacheSync(ctx.Done(), informer.HasSynced), "timed out waiting for service provider node pool informer cache sync")


### PR DESCRIPTION
<!-- [AROSLSRE-1521](https://redhat.atlassian.net/browse/AROSLSRE-1521) -->
Jira: [AROSLSRE-1521](https://redhat.atlassian.net/browse/AROSLSRE-1521)

### What

Surgical revert of the backend informers back to the Cosmos **list** path, undoing the informer switch introduced by #6020. Scope is limited to the `backend/pkg/informers` package plus its callers/tests; the shared changefeed infrastructure is intentionally left untouched.

Reverted to pre-#6020:
- `backend/pkg/informers/informers.go` (list + `ExpiringWatcher`, no `changeFeedClient`)
- `backend/pkg/informers/types.go` (`NewBackendInformers` drops the `changeFeedClient` arg)
- `backend/pkg/informers/informers_test.go`
- `backend/pkg/app/backend.go` (drops the `ResourcesDBClient` arg to `NewBackendInformers`)
- `test-integration/backend/launch/notification_test.go`, `test-integration/frontend/informer_test.go`
- `test-integration/backend/changefeed/changefeed_test.go` — removed only `TestActiveOperationInformer` (asserted near-real-time deletes, unachievable on the list/relist path). `TestChangeFeedListWatcher` and all shared helpers are kept.

### Why

Prod uksouth nodepool creates hung at `provisioningState=Accepted` service-wide. Root cause is a regression from #6020 (`Add changefeed support for create/modify`, merge `b231113aa`), specifically the commit that wired the backend nodepool/external-auth/controller informers onto the change feed.

The old list path filters documents server-side:

```sql
SELECT * FROM c WHERE LENGTH(c.resourceID) > 0 AND (...)
```

so it never observed legacy documents with a nil `resourceID`. The change feed has **no such filter**:

```text
change feed reads poison doc (resourceID == nil)
  -> processDocument returns "missing resourceID"
  -> readFeedRange returns WITHOUT advancing the continuation token
  -> that feed range is re-read forever -> permanent stall
```

Four feeds were poisoned (NodePool / ExternalAuth / Controller / ServiceProviderCluster); Cluster and Operation feeds were healthy, which matches the observed 45-pass / 32-fail split.

### Why not a full `git revert -m 1`

A full revert of #6020 is not viable and does not compile:
- It deletes `changefeed_list_watch.go`, which #6140 now depends on (fleet informers were moved onto the shared change feed).
- It collides with the kube-applier constructor signature changes and the controller removals in #6140 / #6149 / #6127.

Trialed: `git revert -m 1 b231113aa` produces 7 conflicts across 132 files. Hence this package-scoped surgical revert that restores service without disturbing the shared infra that fleet now relies on.

### Testing

Run locally (`GOTOOLCHAIN=auto`):
- `backend`: `go build ./...` ✅, `go vet ./...` ✅, full `go test ./...` ✅ (no failures)
- `test-integration`: `go build ./...` ✅, `go vet ./backend/... ./frontend/...` ✅
- `go test ./backend/changefeed/...` (shared `TestChangeFeedListWatcher`) ✅ 46.9s
- `go test ./frontend/...` ✅ 52.3s, `go test ./backend/launch/...` ✅
- `gofmt -l` on all changed files: clean

### Special notes for your reviewer

- This is a **mitigation** to recover prod. The proper forward fix (recover `resourceID` from the legacy pipe-delimited cosmos `ID` inside `CosmosGenericToInternal`, mirroring what `CosmosToInternal` already does for bare `TypedDocument`) lands as a separate PR so the change feed can be safely re-enabled afterward.
- Shared changefeed infra (`internal/database/informers`, `changefeed_list_watch.go`) and the fleet informers are deliberately **not** touched.
- The removed `TestActiveOperationInformer` cannot pass on the list path (it asserts sub-90s Deleted events; the list path only detects deletes on relist). It is replaced in spirit by the forward fix, not by this revert.

### PR Checklist

- [x] Tests added/updated where applicable (removed a test that is invalid on the restored path)
- [x] Verified locally (build, vet, tests, gofmt)
- [x] Linked Jira issue
