### PR TITLE
Change feeds need to skip documents that would not be listed by a list

### DIFF
--- a/internal/database/informers/changefeed_list_watch.go
+++ b/internal/database/informers/changefeed_list_watch.go
@@ -383,7 +383,9 @@ func (c *ChangeFeedWatcher[InternalAPIType, InternalAPITypePointer, CosmosAPITyp
 	}
 
 	if objAsTypedDocument.ResourceID == nil {
-		return utils.TrackError(fmt.Errorf("missing resourceID"))
+		// intentionally skipping malformed object
+		utilruntime.HandleError(fmt.Errorf("missing resourceID for document ID: %q", objAsTypedDocument.ID))
+		return nil
 	}
 
 	var cosmosObj CosmosAPIType


### PR DESCRIPTION
Every list includes logic that requires resourceID to be present.  It appears that some old records in production lack resourceIDs. It's not clear how this happened, but we get messages like

> | 2026-07-18T08:23:06.973Z | {"time":"2026-07-18T08:23:06.9730925Z","level":"ERROR","source":{"function":"github.com/Azure/ARO-HCP/internal/database/informers.(*ChangeFeedWatcher[...]).runReadFeedRangeFn.1","file":"/app/internal/database/informers/changefeed_list_watch.go","line":483},"msg":"error reading feed range","type":"*api.HCPOpenShiftClusterNodePool","resourceType":"microsoft.redhatopenshift/hcpopenshiftclusters/nodepools","feedRange":{"MinInclusive":"","MaxExclusive":"FF"},"err":"(wrapped at changefeed_list_watch.go:385) missing resourceID"} |

This skips and ignores those instead.

<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

### Why

<!-- Briefly explain why this change is needed -->

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
