### PR TITLE
feat: add new API field nodeSshPublicKeys

### DIFF
--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/examples/2026-09-01-preview/HcpOpenShiftClusters_CreateOrUpdate_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/examples/2026-09-01-preview/HcpOpenShiftClusters_CreateOrUpdate_MaximumSet_Gen.json
@@ -88,7 +88,10 @@
         "clusterImageRegistry": {
           "state": "Enabled"
         },
-        "cryptoRestrictions": "None"
+        "cryptoRestrictions": "None",
+        "nodeSshPublicKeys": [
+          "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl user@host"
+        ]
       },
       "identity": {
         "type": "UserAssigned",
@@ -188,7 +191,10 @@
           "clusterImageRegistry": {
             "state": "Enabled"
           },
-          "cryptoRestrictions": "None"
+          "cryptoRestrictions": "None",
+          "nodeSshPublicKeys": [
+            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl user@host"
+          ]
         },
         "identity": {
           "principalId": "e5867472-f0ed-4fc1-80e1-59b4c0256adb",
@@ -306,7 +312,10 @@
           "clusterImageRegistry": {
             "state": "Enabled"
           },
-          "cryptoRestrictions": "None"
+          "cryptoRestrictions": "None",
+          "nodeSshPublicKeys": [
+            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl user@host"
+          ]
         },
         "identity": {
           "principalId": "e5867472-f0ed-4fc1-80e1-59b4c0256adb",

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/examples/2026-09-01-preview/HcpOpenShiftClusters_Get_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/examples/2026-09-01-preview/HcpOpenShiftClusters_Get_MaximumSet_Gen.json
@@ -97,7 +97,10 @@
           "clusterImageRegistry": {
             "state": "Enabled"
           },
-          "cryptoRestrictions": "None"
+          "cryptoRestrictions": "None",
+          "nodeSshPublicKeys": [
+            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl user@host"
+          ]
         },
         "identity": {
           "principalId": "e5867472-f0ed-4fc1-80e1-59b4c0256adb",

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/examples/2026-09-01-preview/HcpOpenShiftClusters_ListByResourceGroup_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/examples/2026-09-01-preview/HcpOpenShiftClusters_ListByResourceGroup_MaximumSet_Gen.json
@@ -94,7 +94,10 @@
               "clusterImageRegistry": {
                 "state": "Enabled"
               },
-              "cryptoRestrictions": "None"
+              "cryptoRestrictions": "None",
+              "nodeSshPublicKeys": [
+                "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl user@host"
+              ]
             },
             "identity": {
               "principalId": "e5867472-f0ed-4fc1-80e1-59b4c0256adb",

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/examples/2026-09-01-preview/HcpOpenShiftClusters_ListBySubscription_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/examples/2026-09-01-preview/HcpOpenShiftClusters_ListBySubscription_MaximumSet_Gen.json
@@ -93,7 +93,10 @@
               "clusterImageRegistry": {
                 "state": "Enabled"
               },
-              "cryptoRestrictions": "None"
+              "cryptoRestrictions": "None",
+              "nodeSshPublicKeys": [
+                "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl user@host"
+              ]
             },
             "identity": {
               "principalId": "e5867472-f0ed-4fc1-80e1-59b4c0256adb",

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/hcpCluster-models.tsp
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/hcpCluster-models.tsp
@@ -137,6 +137,20 @@ model HcpOpenShiftClusterProperties {
   @visibility(Lifecycle.Read, Lifecycle.Create)
   clusterImageRegistry?: ClusterImageRegistryProfile;
 
+  /** One or more SSH public keys used for secure access to worker nodes. When set,
+   * these keys are distributed to all nodes, enabling SSH access for debugging
+   * and maintenance purposes. If changed, all keys previously set will be replaced.
+   *
+   * WARNING: Setting or changing this field currently causes the recreation of all worker nodes.
+   * This behavior is subject to change in a future OpenShift release.
+   *
+   * SSH public key format: <algorithm> <base64-encoded-key> [comment]
+   * Key constraints: algorithm + space + base64 blob required; comment optional; no newlines within key.
+   */
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
+  @added(Versions.v2026_09_01_preview)
+  nodeSshPublicKeys?: string[];
+
   /** Status of the cluster resource */
   @visibility(Lifecycle.Read)
   @added(Versions.v2026_06_30_preview)

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2026-09-01-preview/examples/HcpOpenShiftClusters_CreateOrUpdate_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2026-09-01-preview/examples/HcpOpenShiftClusters_CreateOrUpdate_MaximumSet_Gen.json
@@ -88,7 +88,10 @@
         "clusterImageRegistry": {
           "state": "Enabled"
         },
-        "cryptoRestrictions": "None"
+        "cryptoRestrictions": "None",
+        "nodeSshPublicKeys": [
+          "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl user@host"
+        ]
       },
       "identity": {
         "type": "UserAssigned",
@@ -188,7 +191,10 @@
           "clusterImageRegistry": {
             "state": "Enabled"
           },
-          "cryptoRestrictions": "None"
+          "cryptoRestrictions": "None",
+          "nodeSshPublicKeys": [
+            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl user@host"
+          ]
         },
         "identity": {
           "principalId": "e5867472-f0ed-4fc1-80e1-59b4c0256adb",
@@ -306,7 +312,10 @@
           "clusterImageRegistry": {
             "state": "Enabled"
           },
-          "cryptoRestrictions": "None"
+          "cryptoRestrictions": "None",
+          "nodeSshPublicKeys": [
+            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl user@host"
+          ]
         },
         "identity": {
           "principalId": "e5867472-f0ed-4fc1-80e1-59b4c0256adb",

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2026-09-01-preview/examples/HcpOpenShiftClusters_Get_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2026-09-01-preview/examples/HcpOpenShiftClusters_Get_MaximumSet_Gen.json
@@ -97,7 +97,10 @@
           "clusterImageRegistry": {
             "state": "Enabled"
           },
-          "cryptoRestrictions": "None"
+          "cryptoRestrictions": "None",
+          "nodeSshPublicKeys": [
+            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl user@host"
+          ]
         },
         "identity": {
           "principalId": "e5867472-f0ed-4fc1-80e1-59b4c0256adb",

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2026-09-01-preview/examples/HcpOpenShiftClusters_ListByResourceGroup_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2026-09-01-preview/examples/HcpOpenShiftClusters_ListByResourceGroup_MaximumSet_Gen.json
@@ -94,7 +94,10 @@
               "clusterImageRegistry": {
                 "state": "Enabled"
               },
-              "cryptoRestrictions": "None"
+              "cryptoRestrictions": "None",
+              "nodeSshPublicKeys": [
+                "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl user@host"
+              ]
             },
             "identity": {
               "principalId": "e5867472-f0ed-4fc1-80e1-59b4c0256adb",

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2026-09-01-preview/examples/HcpOpenShiftClusters_ListBySubscription_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2026-09-01-preview/examples/HcpOpenShiftClusters_ListBySubscription_MaximumSet_Gen.json
@@ -93,7 +93,10 @@
               "clusterImageRegistry": {
                 "state": "Enabled"
               },
-              "cryptoRestrictions": "None"
+              "cryptoRestrictions": "None",
+              "nodeSshPublicKeys": [
+                "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl user@host"
+              ]
             },
             "identity": {
               "principalId": "e5867472-f0ed-4fc1-80e1-59b4c0256adb",

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2026-09-01-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2026-09-01-preview/openapi.json
@@ -2400,6 +2400,18 @@
             "create"
           ]
         },
+        "nodeSshPublicKeys": {
+          "type": "array",
+          "description": "One or more SSH public keys used for secure access to worker nodes. When set,\nthese keys are distributed to all nodes, enabling SSH access for debugging\nand maintenance purposes. If changed, all keys previously set will be replaced.\n\nWARNING: Setting or changing this field currently causes the recreation of all worker nodes.\nThis behavior is subject to change in a future OpenShift release.\n\nSSH public key format: <algorithm> <base64-encoded-key> [comment]\nKey constraints: algorithm + space + base64 blob required; comment optional; no newlines within key.",
+          "items": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        },
         "status": {
           "$ref": "#/definitions/ResourceStatus",
           "description": "Status of the cluster resource",
@@ -2502,6 +2514,18 @@
           "description": "nodeDrainTimeoutMinutes is the grace period for how long Pod Disruption Budget-protected workloads will be\nrespected during any node draining operation. After this grace period, any workloads protected by Pod Disruption\nBudgets that have not been successfully drained from a node will be forcibly evicted. This is\nespecially relevant to cluster upgrades.\n\nValid values are in minutes and from 0 to 10080 minutes (1 week).\n0 means that the MachinePool can be drained without any time limitation.\n\nThis is the value is used a default for all NodePools. It can be overridden\nby specifying nodeDrainTimeoutMinutes for a given NodePool",
           "minimum": 0,
           "maximum": 10080,
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        },
+        "nodeSshPublicKeys": {
+          "type": "array",
+          "description": "One or more SSH public keys used for secure access to worker nodes. When set,\nthese keys are distributed to all nodes, enabling SSH access for debugging\nand maintenance purposes. If changed, all keys previously set will be replaced.\n\nWARNING: Setting or changing this field currently causes the recreation of all worker nodes.\nThis behavior is subject to change in a future OpenShift release.\n\nSSH public key format: <algorithm> <base64-encoded-key> [comment]\nKey constraints: algorithm + space + base64 blob required; comment optional; no newlines within key.",
+          "items": {
+            "type": "string"
+          },
           "x-ms-mutability": [
             "read",
             "update",

--- a/docs/cosmos-data-flow.md
+++ b/docs/cosmos-data-flow.md
@@ -1321,6 +1321,16 @@ Each entry links to every actor that writes the field.
 | [Frontend: PUT Cluster (Create)](#put-cluster-create) | Sets from request body |
 | [ClusterBaseDomainPrefixSync](#clusterbasedomainprefixsync) | Backfills from CS if empty |
 
+### `HCPOpenShiftCluster.CustomerProperties.NodeSshPublicKeys`
+
+| Actor | When |
+|-------|------|
+| [Frontend: PUT Cluster (Create)](#put-cluster-create) | Sets from request body (requires API version `2026-09-01-preview` or later) |
+| [Frontend: PUT Cluster (Update)](#put-cluster-update) | Replaces from request body; older API versions preserve existing value via `preserveUnknownClusterFields` |
+| [Frontend: PATCH Cluster (Update)](#patch-cluster-update) | Merged from PATCH body; older API versions preserve existing value via `preserveUnknownClusterFields` |
+
+Single writer (frontend only). Stored in Cosmos but not dispatched to Cluster Service — no backend controller forwards this field. Exposed only in API version `2026-09-01-preview` and later.
+
 ### `HCPOpenShiftCluster.Identity.UserAssignedIdentities`
 
 | Actor | When |

--- a/internal/api/coreapi/types_cluster.go
+++ b/internal/api/coreapi/types_cluster.go
@@ -92,6 +92,8 @@ type HCPOpenShiftClusterCustomerProperties struct {
 	// Written by: Frontend PUT/PATCH Cluster
 	NodeDrainTimeoutMinutes int32 `json:"nodeDrainTimeoutMinutes,omitempty"`
 	// Written by: Frontend PUT/PATCH Cluster
+	NodeSshPublicKeys []string `json:"nodeSshPublicKeys,omitempty"`
+	// Written by: Frontend PUT/PATCH Cluster
 	Etcd EtcdProfile `json:"etcd,omitempty"`
 	// Written by: Frontend PUT/PATCH Cluster
 	ClusterImageRegistry ClusterImageRegistryProfile `json:"clusterImageRegistry,omitempty"`

--- a/internal/api/coreapi/zz_generated.deepcopy.go
+++ b/internal/api/coreapi/zz_generated.deepcopy.go
@@ -837,6 +837,11 @@ func (in *HCPOpenShiftClusterCustomerProperties) DeepCopyInto(out *HCPOpenShiftC
 	out.Ingress = in.Ingress
 	in.Platform.DeepCopyInto(&out.Platform)
 	out.Autoscaling = in.Autoscaling
+	if in.NodeSshPublicKeys != nil {
+		in, out := &in.NodeSshPublicKeys, &out.NodeSshPublicKeys
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	in.Etcd.DeepCopyInto(&out.Etcd)
 	out.ClusterImageRegistry = in.ClusterImageRegistry
 	if in.ImageDigestMirrors != nil {

--- a/internal/azureapi/v20240610preview/conversion_fuzz_test.go
+++ b/internal/azureapi/v20240610preview/conversion_fuzz_test.go
@@ -36,12 +36,13 @@ func TestRoundTripInternalExternalInternal(t *testing.T) {
 	t.Logf("seed: %d", seed)
 
 	fuzzer := coreapitesting.FuzzerFor(append(coreapitesting.CommonRoundTripFuzzFuncs(),
-		// ImageDigestMirrors, Ingress, and CryptoRestrictions do not exist in v20240610preview.
+		// ImageDigestMirrors, Ingress, CryptoRestrictions, and NodeSshPublicKeys do not exist in v20240610preview.
 		func(j *coreapi.HCPOpenShiftClusterCustomerProperties, c randfill.Continue) {
 			c.FillNoCustom(j)
 			j.ImageDigestMirrors = nil
 			j.Ingress = coreapi.CustomerIngressProfile{}
 			j.CryptoRestrictions = metadataapi.CryptoRestrictionsNone
+			j.NodeSshPublicKeys = nil
 		},
 		// VnetIntegrationSubnetID was added in v20251223preview and does not exist in v20240610preview.
 		func(j *coreapi.CustomerPlatformProfile, c randfill.Continue) {

--- a/internal/azureapi/v20240610preview/hcpopenshiftclusters_methods.go
+++ b/internal/azureapi/v20240610preview/hcpopenshiftclusters_methods.go
@@ -440,6 +440,8 @@ func preserveUnknownClusterFields(from, to *coreapi.HCPOpenShiftCluster) {
 	to.CustomerProperties.Platform.VnetIntegrationSubnetID = from.CustomerProperties.Platform.VnetIntegrationSubnetID
 	// Ingress was added in v2026_06_30_preview.
 	to.CustomerProperties.Ingress = from.CustomerProperties.Ingress
+	// NodeSshPublicKeys was added in v2026_09_01_preview.
+	to.CustomerProperties.NodeSshPublicKeys = from.CustomerProperties.NodeSshPublicKeys
 	// Visibility was added in v2025_12_23_preview.
 	if from.CustomerProperties.Etcd.DataEncryption.CustomerManaged != nil && from.CustomerProperties.Etcd.DataEncryption.CustomerManaged.Kms != nil {
 		if to.CustomerProperties.Etcd.DataEncryption.CustomerManaged == nil {

--- a/internal/azureapi/v20251223preview/conversion_fuzz_test.go
+++ b/internal/azureapi/v20251223preview/conversion_fuzz_test.go
@@ -36,11 +36,12 @@ func TestRoundTripInternalExternalInternal(t *testing.T) {
 	t.Logf("seed: %d", seed)
 
 	fuzzer := coreapitesting.FuzzerFor(append(coreapitesting.CommonRoundTripFuzzFuncs(),
-		// Ingress and CryptoRestrictions were added in v20260630preview and do not exist in v20251223preview.
+		// Ingress, CryptoRestrictions, and NodeSshPublicKeys were added after v20251223preview.
 		func(j *coreapi.HCPOpenShiftClusterCustomerProperties, c randfill.Continue) {
 			c.FillNoCustom(j)
 			j.Ingress = coreapi.CustomerIngressProfile{}
 			j.CryptoRestrictions = metadataapi.CryptoRestrictionsNone
+			j.NodeSshPublicKeys = nil
 		},
 	), rand.NewSource(seed))
 

--- a/internal/azureapi/v20251223preview/hcpopenshiftclusters_methods.go
+++ b/internal/azureapi/v20251223preview/hcpopenshiftclusters_methods.go
@@ -494,6 +494,8 @@ func preserveUnknownClusterFields(from, to *coreapi.HCPOpenShiftCluster) {
 	to.CustomerProperties.Ingress = from.CustomerProperties.Ingress
 	// CryptoRestrictions was added in v2026_06_30_preview
 	to.CustomerProperties.CryptoRestrictions = from.CustomerProperties.CryptoRestrictions
+	// NodeSshPublicKeys was added in v2026_09_01_preview.
+	to.CustomerProperties.NodeSshPublicKeys = from.CustomerProperties.NodeSshPublicKeys
 }
 
 func normalizeManagedIdentity(identity *generated.ManagedServiceIdentity) *coreapi.ManagedServiceIdentity {

--- a/internal/azureapi/v20260630preview/conversion_fuzz_test.go
+++ b/internal/azureapi/v20260630preview/conversion_fuzz_test.go
@@ -24,6 +24,8 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/equality"
 
+	"sigs.k8s.io/randfill"
+
 	"github.com/Azure/ARO-HCP/internal/api/coreapi"
 	"github.com/Azure/ARO-HCP/internal/apitesting/coreapitesting"
 )
@@ -32,10 +34,13 @@ func TestRoundTripInternalExternalInternal(t *testing.T) {
 	seed := rand.Int63()
 	t.Logf("seed: %d", seed)
 
-	fuzzer := coreapitesting.FuzzerFor(
-		coreapitesting.CommonRoundTripFuzzFuncs(),
-		rand.NewSource(seed),
-	)
+	fuzzer := coreapitesting.FuzzerFor(append(coreapitesting.CommonRoundTripFuzzFuncs(),
+		// NodeSshPublicKeys was added in v20260901preview and does not exist in v20260630preview.
+		func(j *coreapi.HCPOpenShiftClusterCustomerProperties, c randfill.Continue) {
+			c.FillNoCustom(j)
+			j.NodeSshPublicKeys = nil
+		},
+	), rand.NewSource(seed))
 
 	for i := 0; i < 200; i++ {
 		original := &coreapi.HCPOpenShiftCluster{}

--- a/internal/azureapi/v20260630preview/hcpopenshiftclusters_methods.go
+++ b/internal/azureapi/v20260630preview/hcpopenshiftclusters_methods.go
@@ -544,9 +544,10 @@ func (c *HcpOpenShiftCluster) ConvertToInternal(existing *coreapi.HCPOpenShiftCl
 }
 
 // preserveUnknownClusterFields copies customer-facing fields from existing that
-// this API version doesn't know about. Currently empty — no cross-version
-// customer fields exist yet between v20240610preview and v20260630preview.
+// this API version doesn't expose, so round-trips via older versions don't
+// silently drop data set by newer API versions.
 func preserveUnknownClusterFields(from, to *coreapi.HCPOpenShiftCluster) {
+	to.CustomerProperties.NodeSshPublicKeys = from.CustomerProperties.NodeSshPublicKeys
 }
 
 func normalizeManagedIdentity(identity *generated.ManagedServiceIdentity) *coreapi.ManagedServiceIdentity {

--- a/internal/azureapi/v20260901preview/generated/models.go
+++ b/internal/azureapi/v20260901preview/generated/models.go
@@ -383,6 +383,15 @@ type HcpOpenShiftClusterProperties struct {
 	// given NodePool
 	NodeDrainTimeoutMinutes *int32
 
+	// One or more SSH public keys used for secure access to worker nodes. When set, these keys are distributed to all nodes,
+	// enabling SSH access for debugging and maintenance purposes. If changed, all keys
+	// previously set will be replaced.
+	// WARNING: Setting or changing this field currently causes the recreation of all worker nodes. This behavior is subject to
+	// change in a future OpenShift release.
+	// SSH public key format: [comment] Key constraints: algorithm + space + base64 blob required; comment optional; no newlines
+	// within key.
+	NodeSSHPublicKeys []*string
+
 	// READ-ONLY; Shows the cluster web console information
 	Console *ConsoleProfile
 
@@ -414,6 +423,15 @@ type HcpOpenShiftClusterPropertiesUpdate struct {
 	// This is the value is used a default for all NodePools. It can be overridden by specifying nodeDrainTimeoutMinutes for a
 	// given NodePool
 	NodeDrainTimeoutMinutes *int32
+
+	// One or more SSH public keys used for secure access to worker nodes. When set, these keys are distributed to all nodes,
+	// enabling SSH access for debugging and maintenance purposes. If changed, all keys
+	// previously set will be replaced.
+	// WARNING: Setting or changing this field currently causes the recreation of all worker nodes. This behavior is subject to
+	// change in a future OpenShift release.
+	// SSH public key format: [comment] Key constraints: algorithm + space + base64 blob required; comment optional; no newlines
+	// within key.
+	NodeSSHPublicKeys []*string
 
 	// Azure platform configuration
 	Platform *PlatformProfileUpdate

--- a/internal/azureapi/v20260901preview/generated/models_serde.go
+++ b/internal/azureapi/v20260901preview/generated/models_serde.go
@@ -1018,6 +1018,7 @@ func (h HcpOpenShiftClusterProperties) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "ingress", h.Ingress)
 	populate(objectMap, "network", h.Network)
 	populate(objectMap, "nodeDrainTimeoutMinutes", h.NodeDrainTimeoutMinutes)
+	populate(objectMap, "nodeSshPublicKeys", h.NodeSSHPublicKeys)
 	populate(objectMap, "platform", h.Platform)
 	populate(objectMap, "provisioningState", h.ProvisioningState)
 	populate(objectMap, "status", h.Status)
@@ -1067,6 +1068,9 @@ func (h *HcpOpenShiftClusterProperties) UnmarshalJSON(data []byte) error {
 		case "nodeDrainTimeoutMinutes":
 			err = unpopulate(val, "NodeDrainTimeoutMinutes", &h.NodeDrainTimeoutMinutes)
 			delete(rawMsg, key)
+		case "nodeSshPublicKeys":
+			err = unpopulate(val, "NodeSSHPublicKeys", &h.NodeSSHPublicKeys)
+			delete(rawMsg, key)
 		case "platform":
 			err = unpopulate(val, "Platform", &h.Platform)
 			delete(rawMsg, key)
@@ -1096,6 +1100,7 @@ func (h HcpOpenShiftClusterPropertiesUpdate) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "etcd", h.Etcd)
 	populate(objectMap, "imageDigestMirrors", h.ImageDigestMirrors)
 	populate(objectMap, "nodeDrainTimeoutMinutes", h.NodeDrainTimeoutMinutes)
+	populate(objectMap, "nodeSshPublicKeys", h.NodeSSHPublicKeys)
 	populate(objectMap, "platform", h.Platform)
 	populate(objectMap, "version", h.Version)
 	return json.Marshal(objectMap)
@@ -1121,6 +1126,9 @@ func (h *HcpOpenShiftClusterPropertiesUpdate) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		case "nodeDrainTimeoutMinutes":
 			err = unpopulate(val, "NodeDrainTimeoutMinutes", &h.NodeDrainTimeoutMinutes)
+			delete(rawMsg, key)
+		case "nodeSshPublicKeys":
+			err = unpopulate(val, "NodeSSHPublicKeys", &h.NodeSSHPublicKeys)
 			delete(rawMsg, key)
 		case "platform":
 			err = unpopulate(val, "Platform", &h.Platform)

--- a/internal/azureapi/v20260901preview/hcpopenshiftclusters_methods.go
+++ b/internal/azureapi/v20260901preview/hcpopenshiftclusters_methods.go
@@ -397,6 +397,7 @@ func (v version) NewHCPOpenShiftCluster(from *coreapi.HCPOpenShiftCluster) corea
 				Autoscaling:       metadataapi.PtrOrNil(newClusterAutoscalingProfile(&from.CustomerProperties.Autoscaling)),
 				// Use Ptr (not PtrOrNil) to ensure int32 zero value is preserved in JSON response.
 				NodeDrainTimeoutMinutes: metadataapi.Ptr(from.CustomerProperties.NodeDrainTimeoutMinutes),
+				NodeSSHPublicKeys:       metadataapi.StringSliceToStringPtrSlice(from.CustomerProperties.NodeSshPublicKeys),
 				ClusterImageRegistry:    metadataapi.PtrOrNil(newClusterImageRegistryProfile(&from.CustomerProperties.ClusterImageRegistry)),
 				Etcd:                    metadataapi.PtrOrNil(newEtcdProfile(&from.CustomerProperties.Etcd)),
 				ImageDigestMirrors:      newImageDigestMirrors(from.CustomerProperties.ImageDigestMirrors),
@@ -522,6 +523,7 @@ func (c *HcpOpenShiftCluster) ConvertToInternal(existing *coreapi.HCPOpenShiftCl
 			normalizeAutoscaling(c.Properties.Autoscaling, &out.CustomerProperties.Autoscaling)
 		}
 		out.CustomerProperties.NodeDrainTimeoutMinutes = metadataapi.Deref(c.Properties.NodeDrainTimeoutMinutes)
+		out.CustomerProperties.NodeSshPublicKeys = metadataapi.StringPtrSliceToStringSlice(c.Properties.NodeSSHPublicKeys)
 		if c.Properties.ClusterImageRegistry != nil {
 			normalizeClusterImageRegistry(c.Properties.ClusterImageRegistry, &out.CustomerProperties.ClusterImageRegistry)
 		}
@@ -544,9 +546,9 @@ func (c *HcpOpenShiftCluster) ConvertToInternal(existing *coreapi.HCPOpenShiftCl
 }
 
 // preserveUnknownClusterFields copies customer-facing fields from existing that
-// this API version doesn't know about. Currently empty — no cross-version
-// customer fields exist yet between v20240610preview and v20260630preview.
-func preserveUnknownClusterFields(from, to *coreapi.HCPOpenShiftCluster) {
+// this API version doesn't know about.
+func preserveUnknownClusterFields(_, _ *coreapi.HCPOpenShiftCluster) {
+	// All fields introduced up to v2026_06_30_preview are known to this version.
 }
 
 func normalizeManagedIdentity(identity *generated.ManagedServiceIdentity) *coreapi.ManagedServiceIdentity {

--- a/internal/go.mod
+++ b/internal/go.mod
@@ -34,6 +34,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
 	go.uber.org/mock v0.6.0
+	golang.org/x/crypto v0.52.0
 	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.35.3
 	k8s.io/apimachinery v0.35.3
@@ -136,7 +137,6 @@ require (
 	go.uber.org/zap v1.28.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/exp v0.0.0-20260218203240-3dfff04db8fa // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect

--- a/internal/validation/validate_cluster.go
+++ b/internal/validation/validate_cluster.go
@@ -290,6 +290,15 @@ func validateClusterCustomerProperties(ctx context.Context, op operation.Operati
 	errs = append(errs, validate.Minimum(ctx, op, fldPath.Child("nodeDrainTimeoutMinutes"), &newObj.NodeDrainTimeoutMinutes, safe.Field(oldObj, toNodeDrainTimeoutMinutes), 0)...)
 	errs = append(errs, Maximum(ctx, op, fldPath.Child("nodeDrainTimeoutMinutes"), &newObj.NodeDrainTimeoutMinutes, safe.Field(oldObj, toNodeDrainTimeoutMinutes), 10080)...)
 
+	//NodeSshPublicKeys       []string                    `json:"nodeSshPublicKeys,omitempty"`
+	if len(newObj.NodeSshPublicKeys) > 5 {
+		errs = append(errs, field.TooMany(fldPath.Child("nodeSshPublicKeys"), len(newObj.NodeSshPublicKeys), 5))
+	}
+	for i, key := range newObj.NodeSshPublicKeys {
+		keyCopy := key
+		errs = append(errs, ValidateSSHPublicKey(ctx, op, fldPath.Child("nodeSshPublicKeys").Index(i), &keyCopy, nil)...)
+	}
+
 	//Etcd                    EtcdProfile                 `json:"etcd,omitempty"`
 	errs = append(errs, validateEtcdProfile(ctx, op, fldPath.Child("etcd"), &newObj.Etcd, safe.Field(oldObj, toEtcd))...)
 

--- a/internal/validation/validate_cluster_test.go
+++ b/internal/validation/validate_cluster_test.go
@@ -889,3 +889,169 @@ func TestURL(t *testing.T) {
 		})
 	}
 }
+
+func TestNodeSshPublicKeys_SingleKey(t *testing.T) {
+	ctx := context.Background()
+	op := operation.Operation{Type: operation.Create}
+	fldPath := field.NewPath("properties").Child("nodeSshPublicKeys").Index(0)
+
+	tests := []struct {
+		name         string
+		value        *string
+		expectErrors []utils.ExpectedError
+	}{
+		{
+			name:         "ed25519 with comment - valid",
+			value:        ptr.To("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC+CCSx9qBeY2LgtUvA9n8g6mfIy5mCPHVkWWy58gFoW user@host"),
+			expectErrors: []utils.ExpectedError{},
+		},
+		{
+			name:         "rsa without comment - valid",
+			value:        ptr.To("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC/1sbNodHNDCS9pADpvAGtEo7hm+8x3YElbVt3nISjT+8GdMgwD8hjoU9mgWPbHCmsekoIBesaXSLgjZnXUE9fSR2ijSnPaQsEZ5CvCoO9WWc0PI6Lq680XGZ2CZYN2gqqgvvicy1l/rJmkMhiVH0F+jBplzgh2gFwiuHfIPtfHslZpFT4TWityXtG3ru+tVEmrHDlxIe4H1gccn8Axvx8LchnBUF2GZQ9l1KFdfjpXeKLcgu7t5NEfoMiX/sdlzT+MqmNz3K1F8BNn6wSQd0Jtv4OLwbTMPLkTaYgNbdOXcO+8EhYVm7Q7VyrSl1lbqG7j2S33XEQ8kzUcuUHH4Tv"),
+			expectErrors: []utils.ExpectedError{},
+		},
+		{
+			name:  "type only without key data - invalid",
+			value: ptr.To("ssh-ed25519"),
+			expectErrors: []utils.ExpectedError{
+				{FieldPath: "properties.nodeSshPublicKeys[0]", Message: "no key found"},
+			},
+		},
+		{
+			name:  "raw base64 without type - invalid",
+			value: ptr.To("AAAAC3NzaC1lZDI1NTE5AAAAITestKey"),
+			expectErrors: []utils.ExpectedError{
+				{FieldPath: "properties.nodeSshPublicKeys[0]", Message: "no key found"},
+			},
+		},
+		{
+			name:  "arbitrary string - invalid",
+			value: ptr.To("not-an-ssh-key"),
+			expectErrors: []utils.ExpectedError{
+				{FieldPath: "properties.nodeSshPublicKeys[0]", Message: "no key found"},
+			},
+		},
+		{
+			name:  "key exceeding 8192 bytes - invalid",
+			value: ptr.To("ssh-ed25519 " + strings.Repeat("A", 8192)),
+			expectErrors: []utils.ExpectedError{
+				{FieldPath: "properties.nodeSshPublicKeys[0]", Message: "Too long"},
+			},
+		},
+		{
+			name:  "empty string - invalid",
+			value: ptr.To(""),
+			expectErrors: []utils.ExpectedError{
+				{FieldPath: "properties.nodeSshPublicKeys[0]", Message: "SSH public key must not be empty"},
+			},
+		},
+		{
+			name:  "whitespace-only string - invalid",
+			value: ptr.To("   "),
+			expectErrors: []utils.ExpectedError{
+				{FieldPath: "properties.nodeSshPublicKeys[0]", Message: "SSH public key must not be empty"},
+			},
+		},
+		{
+			name:  "two keys in one string - invalid",
+			value: ptr.To("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC+CCSx9qBeY2LgtUvA9n8g6mfIy5mCPHVkWWy58gFoW user@host\nssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJj/ylWtVtAQRw7GkVNI8M7+NUG6qBXfjEALlD8EP6Pg"),
+			expectErrors: []utils.ExpectedError{
+				{FieldPath: "properties.nodeSshPublicKeys[0]", Message: "SSH public key must contain exactly one key"},
+			},
+		},
+		{
+			name:         "nil pointer - valid (field is optional)",
+			value:        nil,
+			expectErrors: []utils.ExpectedError{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := ValidateSSHPublicKey(ctx, op, fldPath, tt.value, nil)
+			utils.VerifyErrorsMatch(t, tt.expectErrors, errs)
+		})
+	}
+}
+
+func TestNodeSshPublicKeys_SliceValidation(t *testing.T) {
+	ctx := context.Background()
+	op := operation.Operation{Type: operation.Create}
+	fldPath := field.NewPath("properties")
+
+	validKey1 := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIApY9GkD07ixdNdt3J8cCKdYx5bwqkE903Zs4+YjDMj+ user@host"
+	validKey2 := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJj/ylWtVtAQRw7GkVNI8M7+NUG6qBXfjEALlD8EP6Pg"
+	validKey3 := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMurp3WD9S5lLS3oTzEJgGrjJCcA7RQF1zY4uzWD756N"
+	validKey4 := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOoQloOr3gBW35+IXgKmVrpCmwvbm/bNs9X8kOAoxkVT"
+	validKey5 := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAVY2sEsQ8tqOy7nZThsO8Jb1SU/pAZnp9M9gmhBXbr6"
+	validKey6 := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEla7k6AHSblApnjokAvPGrFJzzgS8jMnSZlNBXYyn+X"
+
+	tests := []struct {
+		name         string
+		keys         []string
+		expectErrors []utils.ExpectedError
+	}{
+		{
+			name:         "nil slice - valid",
+			keys:         nil,
+			expectErrors: []utils.ExpectedError{},
+		},
+		{
+			name:         "single valid key - valid",
+			keys:         []string{validKey1},
+			expectErrors: []utils.ExpectedError{},
+		},
+		{
+			name:         "two valid keys - valid",
+			keys:         []string{validKey1, validKey2},
+			expectErrors: []utils.ExpectedError{},
+		},
+		{
+			name:         "five keys (max) - valid",
+			keys:         []string{validKey1, validKey2, validKey3, validKey4, validKey5},
+			expectErrors: []utils.ExpectedError{},
+		},
+		{
+			name: "six keys - too many",
+			keys: []string{validKey1, validKey2, validKey3, validKey4, validKey5, validKey6},
+			expectErrors: []utils.ExpectedError{
+				{FieldPath: "properties.nodeSshPublicKeys", Message: "Too many"},
+			},
+		},
+		{
+			name: "second key invalid",
+			keys: []string{validKey1, "not-an-ssh-key"},
+			expectErrors: []utils.ExpectedError{
+				{FieldPath: "properties.nodeSshPublicKeys[1]", Message: "no key found"},
+			},
+		},
+		{
+			name: "empty string element - invalid",
+			keys: []string{validKey1, ""},
+			expectErrors: []utils.ExpectedError{
+				{FieldPath: "properties.nodeSshPublicKeys[1]", Message: "SSH public key must not be empty"},
+			},
+		},
+		{
+			name: "element with two keys - invalid",
+			keys: []string{validKey1, validKey2 + "\n" + validKey3},
+			expectErrors: []utils.ExpectedError{
+				{FieldPath: "properties.nodeSshPublicKeys[1]", Message: "SSH public key must contain exactly one key"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := field.ErrorList{}
+			if len(tt.keys) > 5 {
+				errs = append(errs, field.TooMany(fldPath.Child("nodeSshPublicKeys"), len(tt.keys), 5))
+			}
+			for i, key := range tt.keys {
+				keyCopy := key
+				errs = append(errs, ValidateSSHPublicKey(ctx, op, fldPath.Child("nodeSshPublicKeys").Index(i), &keyCopy, nil)...)
+			}
+			utils.VerifyErrorsMatch(t, tt.expectErrors, errs)
+		})
+	}
+}

--- a/internal/validation/validators.go
+++ b/internal/validation/validators.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/blang/semver/v4"
 	"github.com/google/uuid"
+	"golang.org/x/crypto/ssh"
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/operation"
@@ -383,6 +384,26 @@ func MatchesRegex(_ context.Context, _ operation.Operation, fldPath *field.Path,
 		return nil
 	}
 	return field.ErrorList{field.Invalid(fldPath, *value, errorString)}
+}
+
+func ValidateSSHPublicKey(_ context.Context, _ operation.Operation, fldPath *field.Path, value, _ *string) field.ErrorList {
+	if value == nil {
+		return nil
+	}
+	if len(strings.TrimSpace(*value)) == 0 {
+		return field.ErrorList{field.Invalid(fldPath, *value, "SSH public key must not be empty")}
+	}
+	if len(*value) > 8192 {
+		return field.ErrorList{field.TooLong(fldPath, *value, 8192)}
+	}
+	_, _, _, remainder, err := ssh.ParseAuthorizedKey([]byte(*value))
+	if err != nil {
+		return field.ErrorList{field.Invalid(fldPath, *value, err.Error())}
+	}
+	if len(strings.TrimSpace(string(remainder))) > 0 {
+		return field.ErrorList{field.Invalid(fldPath, *value, "SSH public key must contain exactly one key")}
+	}
+	return nil
 }
 
 func ValidateUUID(_ context.Context, _ operation.Operation, fldPath *field.Path, value, _ *string) field.ErrorList {

--- a/test-integration/frontend/artifacts/VersionCompliance/Cluster/cluster-with-ssh-key/expected/get/2024-06-10-preview.json
+++ b/test-integration/frontend/artifacts/VersionCompliance/Cluster/cluster-with-ssh-key/expected/get/2024-06-10-preview.json
@@ -1,0 +1,61 @@
+{
+	"id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/vc-cluster-ssh-key",
+	"identity": {
+		"type": "UserAssigned"
+	},
+	"location": "fake-location",
+	"name": "vc-cluster-ssh-key",
+	"properties": {
+		"api": {
+			"visibility": "Public"
+		},
+		"autoscaling": {
+			"maxNodeProvisionTimeSeconds": 900,
+			"maxPodGracePeriodSeconds": 600,
+			"podPriorityThreshold": -10
+		},
+		"clusterImageRegistry": {
+			"state": "Enabled"
+		},
+		"etcd": {
+			"dataEncryption": {
+				"customerManaged": {
+					"encryptionType": "KMS",
+					"kms": {
+						"activeKey": {
+							"name": "ssh-encryption-key",
+							"vaultName": "ssh-key-vault",
+							"version": "2026-06-30"
+						}
+					}
+				},
+				"keyManagementMode": "CustomerManaged"
+			}
+		},
+		"network": {
+			"hostPrefix": 23,
+			"machineCidr": "10.0.0.0/16",
+			"networkType": "OVNKubernetes",
+			"podCidr": "10.128.0.0/14",
+			"serviceCidr": "172.30.0.0/16"
+		},
+		"platform": {
+			"managedResourceGroup": "managed-rg-vc-ssh-key",
+			"networkSecurityGroupId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/networkSecurityGroups/nsg",
+			"outboundType": "LoadBalancer",
+			"subnetId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
+		},
+		"provisioningState": "Succeeded",
+		"version": {
+			"channelGroup": "stable",
+			"id": "4.20"
+		}
+	},
+	"systemData": {
+		"createdBy": "Unknown-ARO-HCP-frontend",
+		"createdByType": "Application",
+		"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+		"lastModifiedByType": "Application"
+	},
+	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters"
+}

--- a/test-integration/frontend/artifacts/VersionCompliance/Cluster/cluster-with-ssh-key/expected/get/2025-12-23-preview.json
+++ b/test-integration/frontend/artifacts/VersionCompliance/Cluster/cluster-with-ssh-key/expected/get/2025-12-23-preview.json
@@ -1,0 +1,64 @@
+{
+	"id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/vc-cluster-ssh-key",
+	"identity": {
+		"type": "UserAssigned"
+	},
+	"location": "fake-location",
+	"name": "vc-cluster-ssh-key",
+	"properties": {
+		"api": {
+			"visibility": "Public"
+		},
+		"autoscaling": {
+			"maxNodeProvisionTimeSeconds": 900,
+			"maxPodGracePeriodSeconds": 600,
+			"podPriorityThreshold": -10
+		},
+		"clusterImageRegistry": {
+			"state": "Enabled"
+		},
+		"etcd": {
+			"dataEncryption": {
+				"customerManaged": {
+					"encryptionType": "KMS",
+					"kms": {
+						"activeKey": {
+							"name": "ssh-encryption-key",
+							"version": "2026-06-30"
+						},
+						"vaultName": "ssh-key-vault",
+						"visibility": "Public"
+					}
+				},
+				"keyManagementMode": "CustomerManaged"
+			}
+		},
+		"network": {
+			"hostPrefix": 23,
+			"machineCidr": "10.0.0.0/16",
+			"networkType": "OVNKubernetes",
+			"podCidr": "10.128.0.0/14",
+			"serviceCidr": "172.30.0.0/16"
+		},
+		"nodeDrainTimeoutMinutes": 0,
+		"platform": {
+			"managedResourceGroup": "managed-rg-vc-ssh-key",
+			"networkSecurityGroupId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/networkSecurityGroups/nsg",
+			"outboundType": "LoadBalancer",
+			"subnetId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet",
+			"vnetIntegrationSubnetId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/swift-subnet"
+		},
+		"provisioningState": "Succeeded",
+		"version": {
+			"channelGroup": "stable",
+			"id": "4.20"
+		}
+	},
+	"systemData": {
+		"createdBy": "Unknown-ARO-HCP-frontend",
+		"createdByType": "Application",
+		"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+		"lastModifiedByType": "Application"
+	},
+	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters"
+}

--- a/test-integration/frontend/artifacts/VersionCompliance/Cluster/cluster-with-ssh-key/expected/get/2026-06-30-preview.json
+++ b/test-integration/frontend/artifacts/VersionCompliance/Cluster/cluster-with-ssh-key/expected/get/2026-06-30-preview.json
@@ -1,0 +1,68 @@
+{
+	"id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/vc-cluster-ssh-key",
+	"identity": {
+		"type": "UserAssigned"
+	},
+	"location": "fake-location",
+	"name": "vc-cluster-ssh-key",
+	"properties": {
+		"api": {
+			"visibility": "Public"
+		},
+		"autoscaling": {
+			"maxNodeProvisionTimeSeconds": 900,
+			"maxPodGracePeriodSeconds": 600,
+			"podPriorityThreshold": -10
+		},
+		"clusterImageRegistry": {
+			"state": "Enabled"
+		},
+		"cryptoRestrictions": "None",
+		"etcd": {
+			"dataEncryption": {
+				"customerManaged": {
+					"encryptionType": "KMS",
+					"kms": {
+						"activeKey": {
+							"name": "ssh-encryption-key",
+							"version": "2026-06-30"
+						},
+						"vaultName": "ssh-key-vault",
+						"visibility": "Public"
+					}
+				},
+				"keyManagementMode": "CustomerManaged"
+			}
+		},
+		"ingress": {
+			"type": "Public"
+		},
+		"network": {
+			"hostPrefix": 23,
+			"machineCidr": "10.0.0.0/16",
+			"networkType": "OVNKubernetes",
+			"podCidr": "10.128.0.0/14",
+			"serviceCidr": "172.30.0.0/16"
+		},
+		"nodeDrainTimeoutMinutes": 0,
+		"platform": {
+			"managedResourceGroup": "managed-rg-vc-ssh-key",
+			"networkSecurityGroupId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/networkSecurityGroups/nsg",
+			"outboundType": "LoadBalancer",
+			"subnetId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet",
+			"vnetIntegrationSubnetId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/swift-subnet"
+		},
+		"provisioningState": "Succeeded",
+		"version": {
+			"channelGroup": "stable",
+			"id": "4.20"
+		}
+	},
+	"systemData": {
+		"createdBy": "Unknown-ARO-HCP-frontend",
+		"createdByType": "Application",
+		"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+		"lastModifiedByType": "Application"
+	},
+	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters"
+}

--- a/test-integration/frontend/artifacts/VersionCompliance/Cluster/cluster-with-ssh-key/expected/get/2026-09-01-preview.json
+++ b/test-integration/frontend/artifacts/VersionCompliance/Cluster/cluster-with-ssh-key/expected/get/2026-09-01-preview.json
@@ -1,0 +1,72 @@
+{
+	"id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/vc-cluster-ssh-key",
+	"identity": {
+		"type": "UserAssigned"
+	},
+	"location": "fake-location",
+	"name": "vc-cluster-ssh-key",
+	"properties": {
+		"api": {
+			"visibility": "Public"
+		},
+		"autoscaling": {
+			"maxNodeProvisionTimeSeconds": 900,
+			"maxPodGracePeriodSeconds": 600,
+			"podPriorityThreshold": -10
+		},
+		"clusterImageRegistry": {
+			"state": "Enabled"
+		},
+		"cryptoRestrictions": "None",
+		"etcd": {
+			"dataEncryption": {
+				"customerManaged": {
+					"encryptionType": "KMS",
+					"kms": {
+						"activeKey": {
+							"name": "ssh-encryption-key",
+							"version": "2026-06-30"
+						},
+						"vaultName": "ssh-key-vault",
+						"visibility": "Public"
+					}
+				},
+				"keyManagementMode": "CustomerManaged"
+			}
+		},
+		"ingress": {
+			"type": "Public"
+		},
+		"network": {
+			"hostPrefix": 23,
+			"machineCidr": "10.0.0.0/16",
+			"networkType": "OVNKubernetes",
+			"podCidr": "10.128.0.0/14",
+			"serviceCidr": "172.30.0.0/16"
+		},
+		"nodeDrainTimeoutMinutes": 0,
+		"nodeSshPublicKeys": [
+			"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIApY9GkD07ixdNdt3J8cCKdYx5bwqkE903Zs4+YjDMj+ user@host",
+			"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJj/ylWtVtAQRw7GkVNI8M7+NUG6qBXfjEALlD8EP6Pg"
+		],
+		"platform": {
+			"managedResourceGroup": "managed-rg-vc-ssh-key",
+			"networkSecurityGroupId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/networkSecurityGroups/nsg",
+			"outboundType": "LoadBalancer",
+			"subnetId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet",
+			"vnetIntegrationSubnetId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/swift-subnet"
+		},
+		"provisioningState": "Succeeded",
+		"version": {
+			"channelGroup": "stable",
+			"id": "4.20"
+		}
+	},
+	"systemData": {
+		"createdBy": "Unknown-ARO-HCP-frontend",
+		"createdByType": "Application",
+		"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+		"lastModifiedByType": "Application"
+	},
+	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters"
+}

--- a/test-integration/frontend/artifacts/VersionCompliance/Cluster/cluster-with-ssh-key/expected/list/2024-06-10-preview.json
+++ b/test-integration/frontend/artifacts/VersionCompliance/Cluster/cluster-with-ssh-key/expected/list/2024-06-10-preview.json
@@ -1,0 +1,61 @@
+{
+	"id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/vc-cluster-ssh-key",
+	"identity": {
+		"type": "UserAssigned"
+	},
+	"location": "fake-location",
+	"name": "vc-cluster-ssh-key",
+	"properties": {
+		"api": {
+			"visibility": "Public"
+		},
+		"autoscaling": {
+			"maxNodeProvisionTimeSeconds": 900,
+			"maxPodGracePeriodSeconds": 600,
+			"podPriorityThreshold": -10
+		},
+		"clusterImageRegistry": {
+			"state": "Enabled"
+		},
+		"etcd": {
+			"dataEncryption": {
+				"customerManaged": {
+					"encryptionType": "KMS",
+					"kms": {
+						"activeKey": {
+							"name": "ssh-encryption-key",
+							"vaultName": "ssh-key-vault",
+							"version": "2026-06-30"
+						}
+					}
+				},
+				"keyManagementMode": "CustomerManaged"
+			}
+		},
+		"network": {
+			"hostPrefix": 23,
+			"machineCidr": "10.0.0.0/16",
+			"networkType": "OVNKubernetes",
+			"podCidr": "10.128.0.0/14",
+			"serviceCidr": "172.30.0.0/16"
+		},
+		"platform": {
+			"managedResourceGroup": "managed-rg-vc-ssh-key",
+			"networkSecurityGroupId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/networkSecurityGroups/nsg",
+			"outboundType": "LoadBalancer",
+			"subnetId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
+		},
+		"provisioningState": "Succeeded",
+		"version": {
+			"channelGroup": "stable",
+			"id": "4.20"
+		}
+	},
+	"systemData": {
+		"createdBy": "Unknown-ARO-HCP-frontend",
+		"createdByType": "Application",
+		"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+		"lastModifiedByType": "Application"
+	},
+	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters"
+}

--- a/test-integration/frontend/artifacts/VersionCompliance/Cluster/cluster-with-ssh-key/expected/list/2025-12-23-preview.json
+++ b/test-integration/frontend/artifacts/VersionCompliance/Cluster/cluster-with-ssh-key/expected/list/2025-12-23-preview.json
@@ -1,0 +1,64 @@
+{
+	"id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/vc-cluster-ssh-key",
+	"identity": {
+		"type": "UserAssigned"
+	},
+	"location": "fake-location",
+	"name": "vc-cluster-ssh-key",
+	"properties": {
+		"api": {
+			"visibility": "Public"
+		},
+		"autoscaling": {
+			"maxNodeProvisionTimeSeconds": 900,
+			"maxPodGracePeriodSeconds": 600,
+			"podPriorityThreshold": -10
+		},
+		"clusterImageRegistry": {
+			"state": "Enabled"
+		},
+		"etcd": {
+			"dataEncryption": {
+				"customerManaged": {
+					"encryptionType": "KMS",
+					"kms": {
+						"activeKey": {
+							"name": "ssh-encryption-key",
+							"version": "2026-06-30"
+						},
+						"vaultName": "ssh-key-vault",
+						"visibility": "Public"
+					}
+				},
+				"keyManagementMode": "CustomerManaged"
+			}
+		},
+		"network": {
+			"hostPrefix": 23,
+			"machineCidr": "10.0.0.0/16",
+			"networkType": "OVNKubernetes",
+			"podCidr": "10.128.0.0/14",
+			"serviceCidr": "172.30.0.0/16"
+		},
+		"nodeDrainTimeoutMinutes": 0,
+		"platform": {
+			"managedResourceGroup": "managed-rg-vc-ssh-key",
+			"networkSecurityGroupId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/networkSecurityGroups/nsg",
+			"outboundType": "LoadBalancer",
+			"subnetId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet",
+			"vnetIntegrationSubnetId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/swift-subnet"
+		},
+		"provisioningState": "Succeeded",
+		"version": {
+			"channelGroup": "stable",
+			"id": "4.20"
+		}
+	},
+	"systemData": {
+		"createdBy": "Unknown-ARO-HCP-frontend",
+		"createdByType": "Application",
+		"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+		"lastModifiedByType": "Application"
+	},
+	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters"
+}

--- a/test-integration/frontend/artifacts/VersionCompliance/Cluster/cluster-with-ssh-key/expected/list/2026-06-30-preview.json
+++ b/test-integration/frontend/artifacts/VersionCompliance/Cluster/cluster-with-ssh-key/expected/list/2026-06-30-preview.json
@@ -1,0 +1,68 @@
+{
+	"id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/vc-cluster-ssh-key",
+	"identity": {
+		"type": "UserAssigned"
+	},
+	"location": "fake-location",
+	"name": "vc-cluster-ssh-key",
+	"properties": {
+		"api": {
+			"visibility": "Public"
+		},
+		"autoscaling": {
+			"maxNodeProvisionTimeSeconds": 900,
+			"maxPodGracePeriodSeconds": 600,
+			"podPriorityThreshold": -10
+		},
+		"clusterImageRegistry": {
+			"state": "Enabled"
+		},
+		"cryptoRestrictions": "None",
+		"etcd": {
+			"dataEncryption": {
+				"customerManaged": {
+					"encryptionType": "KMS",
+					"kms": {
+						"activeKey": {
+							"name": "ssh-encryption-key",
+							"version": "2026-06-30"
+						},
+						"vaultName": "ssh-key-vault",
+						"visibility": "Public"
+					}
+				},
+				"keyManagementMode": "CustomerManaged"
+			}
+		},
+		"ingress": {
+			"type": "Public"
+		},
+		"network": {
+			"hostPrefix": 23,
+			"machineCidr": "10.0.0.0/16",
+			"networkType": "OVNKubernetes",
+			"podCidr": "10.128.0.0/14",
+			"serviceCidr": "172.30.0.0/16"
+		},
+		"nodeDrainTimeoutMinutes": 0,
+		"platform": {
+			"managedResourceGroup": "managed-rg-vc-ssh-key",
+			"networkSecurityGroupId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/networkSecurityGroups/nsg",
+			"outboundType": "LoadBalancer",
+			"subnetId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet",
+			"vnetIntegrationSubnetId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/swift-subnet"
+		},
+		"provisioningState": "Succeeded",
+		"version": {
+			"channelGroup": "stable",
+			"id": "4.20"
+		}
+	},
+	"systemData": {
+		"createdBy": "Unknown-ARO-HCP-frontend",
+		"createdByType": "Application",
+		"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+		"lastModifiedByType": "Application"
+	},
+	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters"
+}

--- a/test-integration/frontend/artifacts/VersionCompliance/Cluster/cluster-with-ssh-key/expected/list/2026-09-01-preview.json
+++ b/test-integration/frontend/artifacts/VersionCompliance/Cluster/cluster-with-ssh-key/expected/list/2026-09-01-preview.json
@@ -1,0 +1,72 @@
+{
+	"id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/vc-cluster-ssh-key",
+	"identity": {
+		"type": "UserAssigned"
+	},
+	"location": "fake-location",
+	"name": "vc-cluster-ssh-key",
+	"properties": {
+		"api": {
+			"visibility": "Public"
+		},
+		"autoscaling": {
+			"maxNodeProvisionTimeSeconds": 900,
+			"maxPodGracePeriodSeconds": 600,
+			"podPriorityThreshold": -10
+		},
+		"clusterImageRegistry": {
+			"state": "Enabled"
+		},
+		"cryptoRestrictions": "None",
+		"etcd": {
+			"dataEncryption": {
+				"customerManaged": {
+					"encryptionType": "KMS",
+					"kms": {
+						"activeKey": {
+							"name": "ssh-encryption-key",
+							"version": "2026-06-30"
+						},
+						"vaultName": "ssh-key-vault",
+						"visibility": "Public"
+					}
+				},
+				"keyManagementMode": "CustomerManaged"
+			}
+		},
+		"ingress": {
+			"type": "Public"
+		},
+		"network": {
+			"hostPrefix": 23,
+			"machineCidr": "10.0.0.0/16",
+			"networkType": "OVNKubernetes",
+			"podCidr": "10.128.0.0/14",
+			"serviceCidr": "172.30.0.0/16"
+		},
+		"nodeDrainTimeoutMinutes": 0,
+		"nodeSshPublicKeys": [
+			"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIApY9GkD07ixdNdt3J8cCKdYx5bwqkE903Zs4+YjDMj+ user@host",
+			"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJj/ylWtVtAQRw7GkVNI8M7+NUG6qBXfjEALlD8EP6Pg"
+		],
+		"platform": {
+			"managedResourceGroup": "managed-rg-vc-ssh-key",
+			"networkSecurityGroupId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/networkSecurityGroups/nsg",
+			"outboundType": "LoadBalancer",
+			"subnetId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet",
+			"vnetIntegrationSubnetId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/swift-subnet"
+		},
+		"provisioningState": "Succeeded",
+		"version": {
+			"channelGroup": "stable",
+			"id": "4.20"
+		}
+	},
+	"systemData": {
+		"createdBy": "Unknown-ARO-HCP-frontend",
+		"createdByType": "Application",
+		"lastModifiedBy": "Unknown-ARO-HCP-frontend",
+		"lastModifiedByType": "Application"
+	},
+	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters"
+}

--- a/test-integration/frontend/artifacts/VersionCompliance/Cluster/cluster-with-ssh-key/request.json
+++ b/test-integration/frontend/artifacts/VersionCompliance/Cluster/cluster-with-ssh-key/request.json
@@ -1,0 +1,51 @@
+{
+	"identity": {
+		"type": "UserAssigned",
+		"userAssignedIdentities": {}
+	},
+	"name": "vc-cluster-ssh-key",
+	"properties": {
+		"api": {
+			"visibility": "Public"
+		},
+		"etcd": {
+			"dataEncryption": {
+				"customerManaged": {
+					"encryptionType": "KMS",
+					"kms": {
+						"activeKey": {
+							"name": "ssh-encryption-key",
+							"version": "2026-06-30"
+						},
+						"vaultName": "ssh-key-vault",
+						"visibility": "Public"
+					}
+				},
+				"keyManagementMode": "CustomerManaged"
+			}
+		},
+		"network": {
+			"hostPrefix": 23,
+			"machineCidr": "10.0.0.0/16",
+			"networkType": "OVNKubernetes",
+			"podCidr": "10.128.0.0/14",
+			"serviceCidr": "172.30.0.0/16"
+		},
+		"nodeSshPublicKeys": [
+			"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIApY9GkD07ixdNdt3J8cCKdYx5bwqkE903Zs4+YjDMj+ user@host",
+			"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJj/ylWtVtAQRw7GkVNI8M7+NUG6qBXfjEALlD8EP6Pg"
+		],
+		"platform": {
+			"managedResourceGroup": "managed-rg-vc-ssh-key",
+			"networkSecurityGroupId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/networkSecurityGroups/nsg",
+			"outboundType": "LoadBalancer",
+			"subnetId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet",
+			"vnetIntegrationSubnetId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/swift-subnet"
+		},
+		"version": {
+			"channelGroup": "stable",
+			"id": "4.20"
+		}
+	},
+	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters"
+}

--- a/test-integration/frontend/artifacts/VersionCompliance/Cluster/cluster-with-ssh-key/scenario.json
+++ b/test-integration/frontend/artifacts/VersionCompliance/Cluster/cluster-with-ssh-key/scenario.json
@@ -1,0 +1,7 @@
+{
+	"createVersion": "2026-09-01-preview",
+	"description": "Cluster with nodeSshPublicKeys created on v4, verify all versions produce valid response",
+	"id": "de278622-7d27-5f77-ba14-afb3f4a3e8b5",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/vc-cluster-ssh-key",
+	"resourceType": "cluster"
+}

--- a/test-integration/frontend/cross_version_roundtrip_test.go
+++ b/test-integration/frontend/cross_version_roundtrip_test.go
@@ -415,7 +415,7 @@ func clusterCreatePayload(clusterName, apiVersion string) []byte {
 }`, clusterName, subscriptionID, subscriptionID, subscriptionID))
 
 	case v20260901:
-		// v20260901 payload
+		// v20260901 payload — v20260630 plus nodeSshPublicKeys (the new field introduced in this version)
 		return []byte(fmt.Sprintf(`{
   "identity": {
     "type": "UserAssigned",
@@ -455,6 +455,7 @@ func clusterCreatePayload(clusterName, apiVersion string) []byte {
       "type": "Private"
     },
     "nodeDrainTimeoutMinutes": 15,
+	"nodeSshPublicKeys": ["ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIApY9GkD07ixdNdt3J8cCKdYx5bwqkE903Zs4+YjDMj+ user@host"],
     "network": {
       "hostPrefix": 23,
       "machineCidr": "10.0.0.0/16",

--- a/test/e2e/cluster_node_ssh.go
+++ b/test/e2e/cluster_node_ssh.go
@@ -1,0 +1,117 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+
+	"github.com/Azure/ARO-HCP/test/util/framework"
+	"github.com/Azure/ARO-HCP/test/util/labels"
+)
+
+var _ = Describe("Customer", func() {
+	// Deadline for v20260901preview API deployment in non-dev environments
+	timeBombDeadline := framework.Must(time.Parse(time.RFC3339, "2026-10-31T00:00:00Z"))
+
+	It("should persist nodeSshPublicKeys set at cluster creation and return them via ARM GET",
+		labels.RequireNothing,
+		labels.Critical,
+		labels.Positive,
+		labels.AroRpApiCompatible,
+		labels.CreateCluster,
+		labels.MIContainers(1),
+		func(ctx context.Context) {
+			const customerClusterName = "node-ssh"
+
+			tc := framework.NewTestContext()
+
+			if tc.UsePooledIdentities() {
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
+				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
+			}
+
+			By("creating a resource group")
+			resourceGroup, err := tc.NewResourceGroup(ctx, "node-ssh", tc.Location())
+			Expect(err).NotTo(HaveOccurred(), "failed to create resource group for node SSH test")
+
+			By("creating cluster parameters with nodeSshPublicKeys")
+			sshKey1, _, err := framework.GenerateSSHKeyPair()
+			Expect(err).NotTo(HaveOccurred(), "failed to generate first SSH key pair for node SSH test")
+			sshKey2, _, err := framework.GenerateSSHKeyPair()
+			Expect(err).NotTo(HaveOccurred(), "failed to generate second SSH key pair for node SSH test")
+			sshPublicKeys := []*string{
+				to.Ptr(sshKey1),
+				to.Ptr(sshKey2),
+			}
+			clusterParams := framework.NewDefaultClusterParams20260901()
+			clusterParams.ClusterName = customerClusterName
+			clusterParams.ManagedResourceGroupName = framework.SuffixName(*resourceGroup.Name, "-managed", 64)
+			clusterParams.NodeSSHPublicKeys = sshPublicKeys
+
+			By("creating customer resources (infrastructure and managed identities)")
+			clusterParams, err = tc.CreateClusterCustomerResources20260901(ctx,
+				resourceGroup,
+				clusterParams,
+				map[string]interface{}{},
+				TestArtifactsFS,
+				framework.RBACScopeResourceGroup,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to create customer resources for node SSH cluster")
+
+			By("creating the HCP cluster with nodeSshPublicKeys via v20260901preview")
+			err = tc.CreateHCPClusterFromParam20260901(ctx,
+				GinkgoLogr,
+				*resourceGroup.Name,
+				clusterParams,
+				nil,
+				framework.ClusterCreationTimeout,
+			)
+			if isAPINotDeployedError(err) {
+				if time.Now().Before(timeBombDeadline) {
+					Skip(fmt.Sprintf("v20260901preview API not yet deployed; skipping until %s", timeBombDeadline.Format(time.RFC3339)))
+				}
+				Fail(fmt.Sprintf("v20260901preview API still not deployed as of %s deadline", timeBombDeadline.Format(time.RFC3339)))
+			}
+			Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster %q with nodeSshPublicKeys", customerClusterName)
+
+			By("verifying nodeSshPublicKeys are returned unchanged via ARM GET")
+			clientFactory := tc.Get20260901ClientFactoryOrDie(ctx)
+			cluster, err := clientFactory.NewHcpOpenShiftClustersClient().Get(
+				ctx,
+				*resourceGroup.Name,
+				customerClusterName,
+				nil,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to get cluster %q to verify nodeSshPublicKeys", customerClusterName)
+			Expect(cluster.Properties).ToNot(BeNil(), "cluster %q Properties was nil", customerClusterName)
+			Expect(cluster.Properties.NodeSSHPublicKeys).To(HaveLen(len(sshPublicKeys)),
+				"cluster %q Properties.NodeSSHPublicKeys length mismatch", customerClusterName)
+			for i, key := range sshPublicKeys {
+				Expect(cluster.Properties.NodeSSHPublicKeys[i]).ToNot(BeNil(),
+					"cluster %q Properties.NodeSSHPublicKeys[%d] was nil", customerClusterName, i)
+				Expect(*cluster.Properties.NodeSSHPublicKeys[i]).To(Equal(*key),
+					"cluster %q nodeSshPublicKeys[%d] should match what was set at creation", customerClusterName, i)
+			}
+			GinkgoLogr.Info("Cluster nodeSshPublicKeys verified", "clusterName", customerClusterName)
+		},
+	)
+})

--- a/test/sdk/v20260901preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/models.go
+++ b/test/sdk/v20260901preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/models.go
@@ -436,6 +436,10 @@ type HcpOpenShiftClusterProperties struct {
 	// given NodePool
 	NodeDrainTimeoutMinutes *int32
 
+	// One or more SSH public keys used for secure access to cluster nodes. When set, these keys are distributed to all nodes,
+	// enabling SSH access for debugging and maintenance purposes.
+	NodeSSHPublicKeys []*string
+
 	// READ-ONLY; Shows the cluster web console information
 	Console *ConsoleProfile
 
@@ -467,6 +471,10 @@ type HcpOpenShiftClusterPropertiesUpdate struct {
 	// This is the value is used a default for all NodePools. It can be overridden by specifying nodeDrainTimeoutMinutes for a
 	// given NodePool
 	NodeDrainTimeoutMinutes *int32
+
+	// One or more SSH public keys used for secure access to cluster nodes. When set, these keys are distributed to all nodes,
+	// enabling SSH access for debugging and maintenance purposes.
+	NodeSSHPublicKeys []*string
 
 	// Azure platform configuration
 	Platform *PlatformProfileUpdate

--- a/test/sdk/v20260901preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/models_serde.go
+++ b/test/sdk/v20260901preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/models_serde.go
@@ -1106,6 +1106,7 @@ func (h HcpOpenShiftClusterProperties) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "ingress", h.Ingress)
 	populate(objectMap, "network", h.Network)
 	populate(objectMap, "nodeDrainTimeoutMinutes", h.NodeDrainTimeoutMinutes)
+	populate(objectMap, "nodeSshPublicKeys", h.NodeSSHPublicKeys)
 	populate(objectMap, "platform", h.Platform)
 	populate(objectMap, "provisioningState", h.ProvisioningState)
 	populate(objectMap, "status", h.Status)
@@ -1155,6 +1156,9 @@ func (h *HcpOpenShiftClusterProperties) UnmarshalJSON(data []byte) error {
 		case "nodeDrainTimeoutMinutes":
 			err = unpopulate(val, "NodeDrainTimeoutMinutes", &h.NodeDrainTimeoutMinutes)
 			delete(rawMsg, key)
+		case "nodeSshPublicKeys":
+			err = unpopulate(val, "NodeSSHPublicKeys", &h.NodeSSHPublicKeys)
+			delete(rawMsg, key)
 		case "platform":
 			err = unpopulate(val, "Platform", &h.Platform)
 			delete(rawMsg, key)
@@ -1182,6 +1186,7 @@ func (h HcpOpenShiftClusterPropertiesUpdate) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "etcd", h.Etcd)
 	populate(objectMap, "imageDigestMirrors", h.ImageDigestMirrors)
 	populate(objectMap, "nodeDrainTimeoutMinutes", h.NodeDrainTimeoutMinutes)
+	populate(objectMap, "nodeSshPublicKeys", h.NodeSSHPublicKeys)
 	populate(objectMap, "platform", h.Platform)
 	populate(objectMap, "version", h.Version)
 	return json.Marshal(objectMap)
@@ -1207,6 +1212,9 @@ func (h *HcpOpenShiftClusterPropertiesUpdate) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		case "nodeDrainTimeoutMinutes":
 			err = unpopulate(val, "NodeDrainTimeoutMinutes", &h.NodeDrainTimeoutMinutes)
+			delete(rawMsg, key)
+		case "nodeSshPublicKeys":
+			err = unpopulate(val, "NodeSSHPublicKeys", &h.NodeSSHPublicKeys)
 			delete(rawMsg, key)
 		case "platform":
 			err = unpopulate(val, "Platform", &h.Platform)

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_dev_cd_check_paralleldev_cd_check_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_dev_cd_check_paralleldev_cd_check_parallel.txt
@@ -16,6 +16,7 @@ Create HCPOpenShiftCluster with Private KeyVault should create a cluster with pr
 Customer should create a cluster using v20260901preview API and verify cluster health
 ARO HCP Service should successfully provision cluster when MI role assignments are added after cluster creation
 FIPS Mode Support with v2026-06-30 API should create an HCP cluster with FIPS mode enabled via cryptoRestrictions property
+Customer should persist nodeSshPublicKeys set at cluster creation and return them via ARM GET
 Customer should be able to create an HCP cluster and manage pull secrets
 Update HCPOpenShiftCluster Positive creates a cluster and updates tags with a PATCH request
 Customer should be able to create an HCP cluster with back-level version 4.19

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
@@ -15,6 +15,7 @@ Customer should create a cluster using v20260901preview API and verify cluster h
 ARO HCP Service should successfully provision cluster when MI role assignments are added after cluster creation
 Customer should be able to create an HCP cluster then delete it by deleting the customer resource group
 FIPS Mode Support with v2026-06-30 API should create an HCP cluster with FIPS mode enabled via cryptoRestrictions property
+Customer should persist nodeSshPublicKeys set at cluster creation and return them via ARM GET
 Customer should be able to create an HCP cluster and manage pull secrets
 Customer should create an HCP cluster and validate TLS certificates
 Update HCPOpenShiftCluster Negative creates a cluster and fails to update its name with a PATCH request

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
@@ -15,6 +15,7 @@ Customer should create a cluster using v20260901preview API and verify cluster h
 ARO HCP Service should successfully provision cluster when MI role assignments are added after cluster creation
 Customer should be able to create an HCP cluster then delete it by deleting the customer resource group
 FIPS Mode Support with v2026-06-30 API should create an HCP cluster with FIPS mode enabled via cryptoRestrictions property
+Customer should persist nodeSshPublicKeys set at cluster creation and return them via ARM GET
 Customer should be able to create an HCP cluster and manage pull secrets
 Customer should create an HCP cluster and validate TLS certificates
 Update HCPOpenShiftCluster Negative creates a cluster and fails to update its name with a PATCH request

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
@@ -18,6 +18,7 @@ Create HCPOpenShiftCluster with Private KeyVault should create a cluster with pr
 Customer should create a cluster using v20260901preview API and verify cluster health
 ARO HCP Service should successfully provision cluster when MI role assignments are added after cluster creation
 FIPS Mode Support with v2026-06-30 API should create an HCP cluster with FIPS mode enabled via cryptoRestrictions property
+Customer should persist nodeSshPublicKeys set at cluster creation and return them via ARM GET
 Customer should be able to create an HCP cluster and manage pull secrets
 Update HCPOpenShiftCluster Positive creates a cluster and updates tags with a PATCH request
 Customer should be able to create an HCP cluster with back-level version 4.19

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
@@ -15,6 +15,7 @@ Create HCPOpenShiftCluster with Private KeyVault should create a cluster with pr
 Customer should create a cluster using v20260901preview API and verify cluster health
 ARO HCP Service should successfully provision cluster when MI role assignments are added after cluster creation
 FIPS Mode Support with v2026-06-30 API should create an HCP cluster with FIPS mode enabled via cryptoRestrictions property
+Customer should persist nodeSshPublicKeys set at cluster creation and return them via ARM GET
 Customer should be able to create an HCP cluster and manage pull secrets
 Update HCPOpenShiftCluster Positive creates a cluster and updates tags with a PATCH request
 Customer should be able to create an HCP cluster with back-level version 4.19

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
@@ -15,6 +15,7 @@ Customer should create a cluster using v20260901preview API and verify cluster h
 ARO HCP Service should successfully provision cluster when MI role assignments are added after cluster creation
 Customer should be able to create an HCP cluster then delete it by deleting the customer resource group
 FIPS Mode Support with v2026-06-30 API should create an HCP cluster with FIPS mode enabled via cryptoRestrictions property
+Customer should persist nodeSshPublicKeys set at cluster creation and return them via ARM GET
 Customer should be able to create an HCP cluster and manage pull secrets
 Customer should create an HCP cluster and validate TLS certificates
 Update HCPOpenShiftCluster Negative creates a cluster and fails to update its name with a PATCH request

--- a/test/util/framework/helpers_v20260901preview.go
+++ b/test/util/framework/helpers_v20260901preview.go
@@ -74,6 +74,7 @@ type ClusterParams20260901 struct {
 	Autoscaling                   *hcpsdk20260901preview.ClusterAutoscalingProfile
 	CryptoRestrictions            *hcpsdk20260901preview.CryptoRestrictions
 	Tags                          map[string]*string
+	NodeSSHPublicKeys             []*string
 }
 
 type NodePoolParams20260901 struct {
@@ -524,6 +525,7 @@ func BuildHCPClusterFromParams20260901(
 				},
 			},
 			ImageDigestMirrors: imageDigestMirrors,
+			NodeSSHPublicKeys:  parameters.NodeSSHPublicKeys,
 		},
 	}, nil
 }


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-26939

### What

New (ARO-HCP) API version exposing the nodeSshPublicKeys field to customers, as part of an effort to provide ssh access to cluster nodes for customers ( https://redhat.atlassian.net/browse/ARO-26935 ).

ARM API publication and transmission to CS not part of this story, will be handled in a follow-up.

### Why

To allow the customer to provide ssh public keys, which can then be forwarded to HyperShift via Backend and CS - to ultimately enable the customer to log into cluster nodes via ssh.

### Testing

- Unit tests (for helper methods and validations)
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration) (to make sure the API functions as expected, also with different API versions)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md) (which can later on be extended to test ssh login)
    - run test against personal-dev-env: `make e2e-local/run-test TEST_NAME="Customer should persist nodeSshPublicKeys set at cluster creation and return them via ARM GET"`

### Special notes for your reviewer

* limit to 5 keys as per Jeromes request (can be changed later, as this is not part of the public API
* parse SSH keys to make sure they are valid (allows for accepting newer algorithms by using the latest crypto lib version)

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
