### PR TITLE
fix: skip queue.Add when a key is already backing off after sync errors

### DIFF
--- a/backend/pkg/controllers/billingcontrollers/orphaned_billing_cleanup.go
+++ b/backend/pkg/controllers/billingcontrollers/orphaned_billing_cleanup.go
@@ -152,7 +152,13 @@ func (c *orphanedBillingCleanup) Run(ctx context.Context, threadiness int) {
 	}
 
 	// TODO before switching to a regular informer, build a basic LRU "don't fire unless your cooldown is over"
-	go wait.JitterUntilWithContext(ctx, func(ctx context.Context) { c.queue.Add("default") }, 60*time.Minute, 0.1, true)
+	go wait.JitterUntilWithContext(ctx, func(ctx context.Context) {
+		// Skip the periodic tick while "default" is already backing off, so this doesn't preempt AddRateLimited's scheduled retry.
+		if c.queue.NumRequeues("default") > 0 {
+			return
+		}
+		c.queue.Add("default")
+	}, 60*time.Minute, 0.1, true)
 
 	logger.Info("Started workers")
 

--- a/backend/pkg/controllers/controllerutils/generic_watching_controller.go
+++ b/backend/pkg/controllers/controllerutils/generic_watching_controller.go
@@ -233,6 +233,12 @@ func (c *genericWatchingController[T]) EnqueueResourceIDAddWithMaxDepth(resource
 		return
 	}
 
+	// Skip: key is already backing off after a sync error, so a routine notification (informer resync/relist replay) must not preempt AddRateLimited's scheduled retry.
+	if c.queue.NumRequeues(key) > 0 {
+		logger.Info("Skipping notification; key is backing off after a sync error")
+		return
+	}
+
 	c.queue.Add(key)
 }
 

--- a/backend/pkg/controllers/do_nothing.go
+++ b/backend/pkg/controllers/do_nothing.go
@@ -147,11 +147,16 @@ func (c *doNothingExample) queueAllHCPClusters(ctx context.Context) {
 		}
 
 		for _, hcpCluster := range allHCPClusters.Items(ctx) {
-			c.queue.Add(controllerutils.HCPClusterKey{
+			key := controllerutils.HCPClusterKey{
 				SubscriptionID:    hcpCluster.ID.SubscriptionID,
 				ResourceGroupName: hcpCluster.ID.ResourceGroupName,
 				HCPClusterName:    hcpCluster.ID.Name,
-			})
+			}
+			// queue.Add ignores any AddRateLimited backoff already scheduled for this key; skip it here so this periodic rescan doesn't hotloop a key that's waiting. Copy this guard into any other periodic or informer-resync enqueue path you write.
+			if c.queue.NumRequeues(key) > 0 {
+				continue
+			}
+			c.queue.Add(key)
 		}
 		if err := allHCPClusters.GetError(); err != nil {
 			logger.Error(err, "unable to iterate over HCP clusters", "subscription_id", subscription.ResourceID.SubscriptionID)

--- a/backend/pkg/controllers/metricscontrollers/metrics_controller.go
+++ b/backend/pkg/controllers/metricscontrollers/metrics_controller.go
@@ -67,7 +67,7 @@ func NewController[T arm.CosmosPersistable](
 
 	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.enqueue,
-		UpdateFunc: func(_, newObj interface{}) { c.enqueue(newObj) },
+		UpdateFunc: func(_, newObj interface{}) { c.enqueueForResync(newObj) },
 		DeleteFunc: c.enqueue,
 	})
 	if err != nil {
@@ -83,6 +83,21 @@ func (c *Controller[T]) enqueue(obj interface{}) {
 		logger := utils.DefaultLogger()
 		logger = logger.WithValues(utils.LogValues{}.AddControllerName(c.name)...)
 		logger.Error(err, "failed to compute key")
+		return
+	}
+	c.queue.Add(key)
+}
+
+// enqueueForResync is used for UpdateFunc, which fires on every informer resync regardless of whether the object changed; it skips a key that's already backing off after a sync error.
+func (c *Controller[T]) enqueueForResync(obj interface{}) {
+	key, err := resourceIDStoreKeyForObject(obj)
+	if err != nil {
+		logger := utils.DefaultLogger()
+		logger = logger.WithValues(utils.LogValues{}.AddControllerName(c.name)...)
+		logger.Error(err, "failed to compute key")
+		return
+	}
+	if c.queue.NumRequeues(key) > 0 {
 		return
 	}
 	c.queue.Add(key)

--- a/backend/pkg/controllers/mismatchcontrollers/cluster_service_cluster_matching.go
+++ b/backend/pkg/controllers/mismatchcontrollers/cluster_service_cluster_matching.go
@@ -192,7 +192,13 @@ func (c *clusterServiceClusterMatching) Run(ctx context.Context, threadiness int
 	}
 
 	// TODO before switching to a regular informer, build a basic LRU "don't fire unless your cooldown is over"
-	go wait.JitterUntilWithContext(ctx, func(ctx context.Context) { c.queue.Add("default") }, 60*time.Minute, 0.1, true)
+	go wait.JitterUntilWithContext(ctx, func(ctx context.Context) {
+		// Skip the periodic tick while "default" is already backing off, so this doesn't preempt AddRateLimited's scheduled retry.
+		if c.queue.NumRequeues("default") > 0 {
+			return
+		}
+		c.queue.Add("default")
+	}, 60*time.Minute, 0.1, true)
 
 	logger.Info("Started workers")
 

--- a/backend/pkg/controllers/mismatchcontrollers/delete_orphaned_cosmos.go
+++ b/backend/pkg/controllers/mismatchcontrollers/delete_orphaned_cosmos.go
@@ -298,7 +298,12 @@ func (c *deleteOrphanedCosmosResources) queueAllSubscriptions(ctx context.Contex
 		logger.Error(err, "unable to list subscriptions")
 	}
 	for _, subscription := range allSubscriptions {
-		c.queue.Add(subscription.ResourceID.SubscriptionID)
+		key := subscription.ResourceID.SubscriptionID
+		// Skip a subscription that's already backing off, so this doesn't preempt AddRateLimited's scheduled retry.
+		if c.queue.NumRequeues(key) > 0 {
+			continue
+		}
+		c.queue.Add(key)
 	}
 }
 

--- a/backend/pkg/controllers/operationcontrollers/generic_operation.go
+++ b/backend/pkg/controllers/operationcontrollers/generic_operation.go
@@ -222,6 +222,11 @@ func (c *genericOperation) enqueueAdd(newObj interface{}) {
 		return
 	}
 
+	// Skip: key is already backing off after a sync error, so a routine notification (informer resync/relist replay) must not preempt AddRateLimited's scheduled retry.
+	if c.queue.NumRequeues(key) > 0 {
+		return
+	}
+
 	c.queue.Add(key)
 }
 

--- a/fleet/pkg/controllers/base/stamp_watching_controller.go
+++ b/fleet/pkg/controllers/base/stamp_watching_controller.go
@@ -209,6 +209,10 @@ func (c *StampWatchingController) enqueue(obj any, changed bool) {
 	if !c.cooldown.CanSync(context.TODO(), key) {
 		return
 	}
+	// Skip: key is already backing off after a sync error, so a routine notification (informer resync/relist replay) must not preempt AddRateLimited's scheduled retry.
+	if c.queue.NumRequeues(key) > 0 {
+		return
+	}
 	c.queue.Add(key)
 }
 

--- a/internal/database/unioninformers/kubeapplier/controller.go
+++ b/internal/database/unioninformers/kubeapplier/controller.go
@@ -170,6 +170,10 @@ func (c *UnionKubeApplierInformersController) Run(ctx context.Context, threadine
 		},
 		UpdateFunc: func(_, newObj any) {
 			if k, ok := managementClusterKeyFromEvent(newObj); ok {
+				// Skip: key may already be backing off after a sync error; don't let a routine informer resync preempt AddRateLimited's scheduled retry.
+				if c.queue.NumRequeues(k) > 0 {
+					return
+				}
 				c.queue.Add(k)
 			}
 		},

--- a/kube-applier/pkg/controllers/apply_desire/controller.go
+++ b/kube-applier/pkg/controllers/apply_desire/controller.go
@@ -275,6 +275,10 @@ func (c *ApplyDesireController) enqueueWithCooldown(d *kubeapplier.ApplyDesire, 
 	if !cd.CanSync(context.TODO(), key) {
 		return
 	}
+	// Skip: key is already backing off after a sync error, so a routine notification (informer resync/relist replay) must not preempt AddRateLimited's scheduled retry.
+	if c.queue.NumRequeues(key) > 0 {
+		return
+	}
 	c.queue.Add(key)
 }
 

--- a/kube-applier/pkg/controllers/read_desire_kubernetes/controller.go
+++ b/kube-applier/pkg/controllers/read_desire_kubernetes/controller.go
@@ -147,8 +147,14 @@ func NewReadDesireKubernetesController(
 	// has it before its reflector pumps the first List response. Adding it
 	// in Run() races with the initial sync.
 	if _, err := c.informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj any) { c.queue.Add(c.key) },
-		UpdateFunc: func(_, _ any) { c.queue.Add(c.key) },
+		AddFunc: func(obj any) { c.queue.Add(c.key) },
+		UpdateFunc: func(_, _ any) {
+			// Skip: key may already be backing off after a sync error; don't let a routine informer resync preempt AddRateLimited's scheduled retry.
+			if c.queue.NumRequeues(c.key) > 0 {
+				return
+			}
+			c.queue.Add(c.key)
+		},
 		DeleteFunc: func(obj any) { c.queue.Add(c.key) },
 	}); err != nil {
 		return nil, fmt.Errorf("register informer handler: %w", err)
@@ -196,6 +202,10 @@ func (c *ReadDesireKubernetesController) Run(ctx context.Context) {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
+				// Skip the periodic resync tick while the key is already backing off, so this doesn't preempt AddRateLimited's scheduled retry.
+				if c.queue.NumRequeues(c.key) > 0 {
+					continue
+				}
 				c.queue.Add(c.key)
 			}
 		}

--- a/kube-applier/pkg/controllers/read_desire_manager/controller.go
+++ b/kube-applier/pkg/controllers/read_desire_manager/controller.go
@@ -258,6 +258,10 @@ func (c *ReadDesireInformerManagingController) handleUpdate(oldObj, newObj any) 
 	if !c.cooldown.CanSync(context.TODO(), key) {
 		return
 	}
+	// Skip: key is already backing off after a sync error, so a routine notification (informer resync/relist replay) must not preempt AddRateLimited's scheduled retry.
+	if c.queue.NumRequeues(key) > 0 {
+		return
+	}
 	c.queue.Add(key)
 }
 

--- a/mgmt-agent/pkg/controller/controller.go
+++ b/mgmt-agent/pkg/controller/controller.go
@@ -93,6 +93,10 @@ func NewSwiftNICController(
 		UpdateFunc: func(old, new interface{}) {
 			key, err := cache.MetaNamespaceKeyFunc(new)
 			if err == nil {
+				// UpdateFunc fires on every resync regardless of change; skip a key that's already backing off after a sync error.
+				if c.workqueue.NumRequeues(key) > 0 {
+					return
+				}
 				c.workqueue.Add(key)
 			}
 		},

--- a/mgmt-agent/pkg/controller/ksmhcp/controller.go
+++ b/mgmt-agent/pkg/controller/ksmhcp/controller.go
@@ -111,6 +111,10 @@ func NewKSMHCPController(
 		UpdateFunc: func(old, new interface{}) {
 			key, err := cache.MetaNamespaceKeyFunc(new)
 			if err == nil {
+				// UpdateFunc fires on every resync regardless of change; skip a key that's already backing off after a sync error.
+				if c.workqueue.NumRequeues(key) > 0 {
+					return
+				}
 				c.workqueue.Add(key)
 			}
 		},
@@ -131,7 +135,7 @@ func NewKSMHCPController(
 			c.enqueueForOwner(obj)
 		},
 		UpdateFunc: func(old, new interface{}) {
-			c.enqueueForOwner(new)
+			c.enqueueForOwnerResync(new)
 		},
 		DeleteFunc: func(obj interface{}) {
 			tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
@@ -159,16 +163,38 @@ func NewKSMHCPController(
 }
 
 func (c *KSMHCPController) enqueueForOwner(obj interface{}) {
+	key, ok := c.ownerKey(obj)
+	if !ok {
+		return
+	}
+	c.workqueue.Add(key)
+}
+
+// enqueueForOwnerResync is used for UpdateFunc on owned Deployment/Service/ConfigMap/ServiceMonitor informers, which fire on every resync regardless of change; it skips a key that's already backing off.
+func (c *KSMHCPController) enqueueForOwnerResync(obj interface{}) {
+	key, ok := c.ownerKey(obj)
+	if !ok {
+		return
+	}
+	if c.workqueue.NumRequeues(key) > 0 {
+		return
+	}
+	c.workqueue.Add(key)
+}
+
+// ownerKey returns the namespace/name workqueue key for the owning
+// HostedControlPlane, and false if obj has no such owner reference.
+func (c *KSMHCPController) ownerKey(obj interface{}) (string, bool) {
 	accessor, err := meta.Accessor(obj)
 	if err != nil {
-		return
+		return "", false
 	}
 	for _, ref := range accessor.GetOwnerReferences() {
 		if ref.Kind == "HostedControlPlane" && ref.APIVersion == "hypershift.openshift.io/v1beta1" {
-			c.workqueue.Add(accessor.GetNamespace() + "/" + ref.Name)
-			return
+			return accessor.GetNamespace() + "/" + ref.Name, true
 		}
 	}
+	return "", false
 }
 
 // Run starts the controller workers and blocks until the context is cancelled.

--- a/sessiongate/pkg/controller/helpers.go
+++ b/sessiongate/pkg/controller/helpers.go
@@ -42,6 +42,10 @@ func registerInformer[T comparable](informer cache.SharedIndexInformer, keyFunc 
 			if err != nil {
 				return
 			}
+			// UpdateFunc fires on every resync regardless of change; skip a key that's already backing off after a sync error.
+			if workQueue.NumRequeues(key) > 0 {
+				return
+			}
 			workQueue.Add(key)
 		},
 		DeleteFunc: func(obj interface{}) {


### PR DESCRIPTION
## Summary

Routine enqueue paths (informer resyncs, relist replays, and periodic tickers) call `queue.Add`, which bypasses an item already waiting on `AddRateLimited` backoff. After a sync failure, that can pull a key back into the queue immediately and hotloop retries instead of honoring the rate limiter.

This change adds a `NumRequeues(key) > 0` guard before those non-urgent `Add` calls across backend, fleet, kube-applier, mgmt-agent, sessiongate, and internal union informer controllers. Real changes (`changed=true`, `AddFunc`, `DeleteFunc`) still enqueue immediately; only resync/ticker paths are skipped while a key is backing off.

Below sample code shows that queue.Add(key) bypasses the rate-limiting behavior of AddRateLimited(). The queue.Add() call does not check whether the item is already waiting in the rate limiter. https://gist.github.com/patilsuraj767/b28df1e8d042ce94300d6032066223e3
