### PR TITLE
fix: restore cluster-service/deploy/values.yaml with minimal defaults…

### DIFF
--- a/cluster-service/deploy/values.yaml
+++ b/cluster-service/deploy/values.yaml
@@ -1,0 +1,164 @@
+# Minimal chart defaults for local helm template rendering.
+# The deployment pipeline overrides all of these via the preprocessed
+# cluster-service/values.yaml, so values here only need to be valid
+# enough for templates to render without errors.
+global:
+  imageDigest: ""
+serviceAccountName: "clusters-service"
+replicas: 1
+imageRegistry: "localhost"
+imageRepository: "clusters-service"
+imageDigest: "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+logLevel: 4
+runtimeMode: "aro-hcp"
+defaultExpiration: "0"
+maximumExpiration: "0"
+jwksUrl: "http://localhost"
+tokenUrl: "http://localhost"
+insecure: "false"
+gatewayUrl: "http://127.0.0.1:9090"
+clientScopes: "openid"
+environment: "dev"
+backplaneURL: ""
+provisionShardClusterLimit: "100"
+forceMigration: ""
+userDefinedDnsBaseDomain: ""
+batchProcessesDryRun: "false"
+batchProcesses: ""
+memoryRequest: "150Mi"
+memoryLimit: "unlimited"
+cpuRequest: "50m"
+region: "local"
+azureFirstPartyApplicationClientId: ""
+serviceKeyVaultName: ""
+tenantId: ""
+fpaCertName: ""
+databaseDisableTls: "true"
+databaseAuthMethod: "postgres"
+denyAssignments: "false"
+azureArmHelperIdentityClientId: ""
+azureArmHelperIdentityCertName: ""
+azureArmHelperMockFpaPrincipalId: ""
+azureMiMockServicePrincipalCertName: ""
+azureMiMockServicePrincipalClientId: ""
+azureMiMockServicePrincipalPrincipalId: ""
+azureCloudEnvironmentName: "AzurePublicCloud"
+azureCsMiClientId: ""
+clientId: ""
+clientSecret: ""
+useAzureDB: false
+databaseServiceName: "ocm-cs-db"
+databaseK8sSecretName: "ocm-cs-db"
+databaseVolumeCapacity: "512Mi"
+postgresqlVersion: "12"
+databaseHost: "localhost"
+databaseUser: "user"
+databasePassword: "password"
+databaseName: "clusters-service"
+databasePort: "5432"
+oidcIssuerBlobServiceUrl: ""
+oidcIssuerBaseUrl: ""
+ocpAcrResourceUrl: ""
+ocpAcrResourceId: ""
+tlsCertificatesIssuer: "Self"
+tlsCertificatesEnabled: true
+managedIdentitiesDataPlaneAudienceResource: ""
+dataPlaneHAProxyImage: ""
+tracing:
+  address: ""
+csDeploymentStrategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxSurge: 1
+    maxUnavailable: 0
+deployment:
+  zoneCount: 0
+pullBinding:
+  registry: "localhost"
+  scope: "repository:clusters-service:pull"
+  workloadIdentityClientId: ""
+  workloadIdentityTenantId: ""
+azureOperatorsMI:
+  roleSetName: "dev"
+  dev:
+    clusterApiAzure:
+      roleDefinitions:
+      - id: 88366f10-ed47-4cc0-9fab-c8a06148393e
+        name: Azure Red Hat OpenShift Hosted Control Planes Cluster API Provider
+    controlPlane:
+      roleDefinitions:
+      - id: fc0c873f-45e9-4d0d-a7d1-585aab30c6ed
+        name: Azure Red Hat OpenShift Hosted Control Planes Control Plane Operator
+    cloudControllerManager:
+      roleDefinitions:
+      - id: a1f96423-95ce-4224-ab27-4e3dc72facd4
+        name: Azure Red Hat OpenShift Cloud Controller Manager
+    ingress:
+      roleDefinitions:
+      - id: 0336e1d3-7a87-462b-b6db-342b63f7802c
+        name: Azure Red Hat OpenShift Cluster Ingress Operator
+    diskCsiDriver:
+      roleDefinitions:
+      - id: 5b7237c5-45e1-49d6-bc18-a1f62f400748
+        name: Azure Red Hat OpenShift Disk Storage Operator
+    fileCsiDriver:
+      roleDefinitions:
+      - id: 0d7aedc0-15fd-4a67-a412-efad370c947e
+        name: Azure Red Hat OpenShift File Storage Operator
+    imageRegistry:
+      roleDefinitions:
+      - id: 8b32b316-c2f5-4ddf-b05b-83dacd2d08b5
+        name: Azure Red Hat OpenShift Image Registry Operator
+    cloudNetworkConfig:
+      roleDefinitions:
+      - id: be7a6435-15ae-4171-8f30-4a343eff9e8f
+        name: Azure Red Hat OpenShift Network Operator
+    kms:
+      roleDefinitions:
+      - id: 12338af0-0e69-4776-bea7-57ae8d297424
+        name: Key Vault Crypto User
+    serviceManagedIdentity:
+      roleDefinitions:
+      - id: c0ff367d-66d8-445e-917c-583feb0ef0d4
+        name: Azure Red Hat OpenShift Hosted Control Planes Service Managed Identity
+  public:
+    clusterApiAzure:
+      roleDefinitions:
+      - id: 88366f10-ed47-4cc0-9fab-c8a06148393e
+        name: Azure Red Hat OpenShift Hosted Control Planes Cluster API Provider
+    controlPlane:
+      roleDefinitions:
+      - id: fc0c873f-45e9-4d0d-a7d1-585aab30c6ed
+        name: Azure Red Hat OpenShift Hosted Control Planes Control Plane Operator
+    cloudControllerManager:
+      roleDefinitions:
+      - id: a1f96423-95ce-4224-ab27-4e3dc72facd4
+        name: Azure Red Hat OpenShift Cloud Controller Manager
+    ingress:
+      roleDefinitions:
+      - id: 0336e1d3-7a87-462b-b6db-342b63f7802c
+        name: Azure Red Hat OpenShift Cluster Ingress Operator
+    diskCsiDriver:
+      roleDefinitions:
+      - id: 5b7237c5-45e1-49d6-bc18-a1f62f400748
+        name: Azure Red Hat OpenShift Disk Storage Operator
+    fileCsiDriver:
+      roleDefinitions:
+      - id: 0d7aedc0-15fd-4a67-a412-efad370c947e
+        name: Azure Red Hat OpenShift File Storage Operator
+    imageRegistry:
+      roleDefinitions:
+      - id: 8b32b316-c2f5-4ddf-b05b-83dacd2d08b5
+        name: Azure Red Hat OpenShift Image Registry Operator
+    cloudNetworkConfig:
+      roleDefinitions:
+      - id: be7a6435-15ae-4171-8f30-4a343eff9e8f
+        name: Azure Red Hat OpenShift Network Operator
+    kms:
+      roleDefinitions:
+      - id: 12338af0-0e69-4776-bea7-57ae8d297424
+        name: Key Vault Crypto User
+    serviceManagedIdentity:
+      roleDefinitions:
+      - id: c0ff367d-66d8-445e-917c-583feb0ef0d4
+        name: Azure Red Hat OpenShift Hosted Control Planes Service Managed Identity


### PR DESCRIPTION
….The file was accidentally emptied in commit 0c7530788

<!-- Link to Jira issue -->

### What

Restores the `cluster-service/deploy/values.yaml` file with minimal default values for local helm template rendering.

### Why

 The file was accidentally emptied in commit 0c7530788 (following commit 338122214 which moved the templated values to `cluster-service/values.yaml`).

 Without this file, `make personal-dev-env` fails because the helm chart requires a values file with valid defaults for local rendering. The deployment pipeline still uses the preprocessed `cluster-service/values.yaml` for
  actual deployments, but the `deploy/values.yaml` is needed for local helm operations with hardcoded localhost/dev defaults.

This fix unblocks developers from setting up their personal dev environments.


### Testing
  - [x] Verified `make personal-dev-env` completes successfully with restored file
  - [x] File contains all required fields with valid default values for local helm rendering

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
