### PR TITLE
test: skip 5.0 candidate install until HCCO ingress fix lands

### DIFF
--- a/test/e2e/complete_cluster_create_multiversion.go
+++ b/test/e2e/complete_cluster_create_multiversion.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -66,6 +67,19 @@ var _ = Describe("ARO-HCP", func() {
 				}
 			}
 			clusterParams.OpenshiftVersionId = openShiftControlPlaneVersion
+
+			// OCPBUGS-98571: HyperShift HCCO forces InternalLoadBalancer scope for
+			// PublicAndPrivate topology on ARO HCP, causing *.apps routes to point
+			// to an unreachable internal LB IP. The fix (PR #8992) merged to main
+			// on 2026-07-14 but 5.0.0-ec.4 (built 2026-07-03) does not include it.
+			// Skip 5.0 until an EC build with the fix is available.
+			if version == "5.0" {
+				timeBombDeadline := time.Date(2026, time.August, 10, 0, 0, 0, 0, time.UTC)
+				if time.Now().Before(timeBombDeadline) {
+					Skip(fmt.Sprintf("5.0 candidate releases do not yet include the HCCO ingress LB scope fix (https://issues.redhat.com/browse/OCPBUGS-98571); skipping until %s", timeBombDeadline.Format(time.RFC3339)))
+				}
+				Fail("5.0 HCCO ingress LB scope fix (OCPBUGS-98571) still not available; remove this skip or update the deadline")
+			}
 
 			tc := framework.NewTestContext()
 			if tc.UsePooledIdentities() {


### PR DESCRIPTION
## Summary

- Skip the 5.0 candidate install e2e test until a 5.0 EC build includes the HCCO ingress LB scope fix ([OCPBUGS-98571](https://issues.redhat.com/browse/OCPBUGS-98571))
- The fix ([openshift/hypershift#8992](https://github.com/openshift/hypershift/pull/8992)) merged to HyperShift main on 2026-07-14, but 5.0.0-ec.4 (built 2026-07-03) does not include it
- When CS sets `topology=PublicAndPrivate` on Swift clusters ([ARO-26913](https://redhat.atlassian.net/browse/ARO-26913)), the HCCO creates an IngressController with `InternalLoadBalancer` scope, causing `*.apps` routes to point to an unreachable internal LB IP (10.0.0.5) instead of the shared ingress public IP
- 4.22 is covered by the CPO override in [openshift/hypershift#9010](https://github.com/openshift/hypershift/pull/9010)
- Uses time-bomb pattern: skips before 2026-08-10, fails after — ensuring the skip doesn't persist silently once the fix should be available (5.0.0-ec.5 expected ~July 27)

## Test plan

- [x] Verify the skip follows existing time-bomb patterns (`nodepool_ephemeral_osdisk.go`, `cluster_create_private_ingress.go`)
- [x] e2e-parallel CI passes with the 5.0 test skipped