### PR TITLE
feat(ci): add 'diskEncryptionSets/read' permission to CI roles

### DIFF
--- a/dev-infrastructure/templates/e2e-subscription-rbac-assignment-subscription.bicep
+++ b/dev-infrastructure/templates/e2e-subscription-rbac-assignment-subscription.bicep
@@ -102,6 +102,7 @@ resource msiMockRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
           'Microsoft.Network/virtualNetworks/subnets/join/action'
           'Microsoft.Network/virtualNetworks/subnets/read'
           'Microsoft.Network/virtualNetworks/subnets/write'
+          'Microsoft.Compute/diskEncryptionSets/read'
         ]
         notActions: []
       }

--- a/dev-infrastructure/templates/mock-identities.bicep
+++ b/dev-infrastructure/templates/mock-identities.bicep
@@ -189,6 +189,7 @@ resource msiCustomRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
           'Microsoft.Network/virtualNetworks/subnets/join/action' // create private load balancer and join to subnet
           'Microsoft.Network/virtualNetworks/subnets/read' // validate CIDR & existance
           'Microsoft.Network/virtualNetworks/subnets/write' // attach the NSG to subnet
+          'Microsoft.Compute/diskEncryptionSets/read' // validate DES if provided
         ]
         notActions: []
       }

--- a/dev-infrastructure/templates/mock-identity-roles.bicep
+++ b/dev-infrastructure/templates/mock-identity-roles.bicep
@@ -77,6 +77,7 @@ resource msiCustomRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
           'Microsoft.Network/virtualNetworks/subnets/join/action'
           'Microsoft.Network/virtualNetworks/subnets/read'
           'Microsoft.Network/virtualNetworks/subnets/write'
+          'Microsoft.Compute/diskEncryptionSets/read'
         ]
         notActions: []
       }


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-27738

### What

- Add 'diskEncryptionSets/read' permission to CI roles

### Why

- This is required by PR#5682, since it adds support for / fixes BYOK for node pool OS Disks, and adds an associated e2e test that was not there previously.
- The permission is required by cluster service (service managed identity) to perform basic validation on a disk encryption set when provided. From there, CAPZ handles the actual provisioning.

### Testing

- Testing is covered in PR#5682
### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [x] All comment threads resolved before merge
