### PR TITLE
feat(monitoring): scope Grafana Viewer role to arohcp-stg2 via stgGlobalV2.grafanaRoles

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -3523,7 +3523,9 @@
           "type": "string"
         },
         "grafanaRoles": {
-          "type": "string"
+          "type": "string",
+          "description": "A space-separated list of Service Principals IDs, Types and their desired grafana roles The format is: <principalId>/<principalType>/<role>, e.g. 12345678-1234-1234-1234-123456789012/Group/Admin",
+          "pattern": "^$|^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\\/(Group|ServicePrincipal|User)\\/(Contributor|Admin|Viewer)\\s*)+$"
         },
         "grafanaMajorVersion": {
           "type": "string"

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -3522,6 +3522,9 @@
         "grafanaName": {
           "type": "string"
         },
+        "grafanaRoles": {
+          "type": "string"
+        },
         "grafanaMajorVersion": {
           "type": "string"
         },
@@ -3545,6 +3548,7 @@
         "cxParentZoneName",
         "kustoName",
         "grafanaName",
+        "grafanaRoles",
         "grafanaMajorVersion",
         "billingKustoName",
         "billingKustoSku"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -120,6 +120,12 @@ defaults:
     cxParentZoneName: "empty-sentinel"
     kustoName: "empty-sentinel"
     grafanaName: "empty-sentinel"
+    # Space-separated "principalId/principalType/role" list scoped to the
+    # transient arohcp-stg2 Grafana. Defaults to empty (no assignments); the
+    # real value is set in the cloud overlay for stg. Kept separate from
+    # monitoring.grafanaRoles so assigning a role on arohcp-stg2 never touches
+    # the shared arohcp-stg (which already holds the grant manually).
+    grafanaRoles: ""
     grafanaMajorVersion: "empty-sentinel"
     billingKustoName: "empty-sentinel"
     billingKustoSku: "empty-sentinel"

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -950,6 +950,7 @@ stgGlobalV2:
   globalKeyVaultName: empty-sentinel
   grafanaMajorVersion: empty-sentinel
   grafanaName: empty-sentinel
+  grafanaRoles: ""
   kustoName: empty-sentinel
   oidcStorageAccountName: empty-sentinel
   svcParentZoneName: empty-sentinel

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -950,6 +950,7 @@ stgGlobalV2:
   globalKeyVaultName: empty-sentinel
   grafanaMajorVersion: empty-sentinel
   grafanaName: empty-sentinel
+  grafanaRoles: ""
   kustoName: empty-sentinel
   oidcStorageAccountName: empty-sentinel
   svcParentZoneName: empty-sentinel

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -948,6 +948,7 @@ stgGlobalV2:
   globalKeyVaultName: empty-sentinel
   grafanaMajorVersion: empty-sentinel
   grafanaName: empty-sentinel
+  grafanaRoles: ""
   kustoName: empty-sentinel
   oidcStorageAccountName: empty-sentinel
   svcParentZoneName: empty-sentinel

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -948,6 +948,7 @@ stgGlobalV2:
   globalKeyVaultName: empty-sentinel
   grafanaMajorVersion: empty-sentinel
   grafanaName: empty-sentinel
+  grafanaRoles: ""
   kustoName: empty-sentinel
   oidcStorageAccountName: empty-sentinel
   svcParentZoneName: empty-sentinel

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -948,6 +948,7 @@ stgGlobalV2:
   globalKeyVaultName: empty-sentinel
   grafanaMajorVersion: empty-sentinel
   grafanaName: empty-sentinel
+  grafanaRoles: ""
   kustoName: empty-sentinel
   oidcStorageAccountName: empty-sentinel
   svcParentZoneName: empty-sentinel

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -950,6 +950,7 @@ stgGlobalV2:
   globalKeyVaultName: empty-sentinel
   grafanaMajorVersion: empty-sentinel
   grafanaName: empty-sentinel
+  grafanaRoles: ""
   kustoName: empty-sentinel
   oidcStorageAccountName: empty-sentinel
   svcParentZoneName: empty-sentinel

--- a/dev-infrastructure/configurations/grafana-roles-stg.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/grafana-roles-stg.tmpl.bicepparam
@@ -5,5 +5,5 @@ using '../templates/grafana-roles.bicep'
 
 param grafanaName = '{{ .stgGlobalV2.grafanaName }}'
 param globalMSIName = '{{ .global.globalMSIName }}'
-param grafanaRoles = '{{ .monitoring.grafanaRoles }}'
+param grafanaRoles = '{{ .stgGlobalV2.grafanaRoles }}'
 param azureFrontDoorProfileName = '{{ .stgGlobalV2.frontDoorName }}'

--- a/dev-infrastructure/configurations/grafana-roles-stg.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/grafana-roles-stg.tmpl.bicepparam
@@ -1,6 +1,8 @@
 // TRANSIENT: STG-global "V2" copy of grafana-roles.tmpl.bicepparam. Identical to the
-// canonical file except the globally-unique resource names are sourced from the
-// transient stgGlobalV2 block. Removed at decommission.
+// canonical file except the globally-unique resource names and the grafanaRoles
+// assignments are sourced from the transient stgGlobalV2 block, so the Viewer role
+// lands on arohcp-stg2 only and never touches the shared arohcp-stg. Removed at
+// decommission.
 using '../templates/grafana-roles.bicep'
 
 param grafanaName = '{{ .stgGlobalV2.grafanaName }}'


### PR DESCRIPTION
## Why

During Step-4 STG-global-V2 validation (AROSLSRE-1201/AROSLSRE-1525) we found the human **Grafana Viewer** role for group `TM-AzureRedHatOpenShift-HCP` exists on the shared `arohcp-stg` but is **absent on the new dedicated `arohcp-stg2`**. The grant on `arohcp-stg` was made **out-of-band (manual)**, and `monitoring.grafanaRoles` is empty (`""`), so the `grafana-roles` automation assigns no human roles on any Grafana — nothing carried over.

The ticket's "preferred" fix is to codify the viewer group in `monitoring.grafanaRoles`. **That would break**, though: the canonical `grafana-roles` step (targeting the shared `arohcp-stg`) reads the same `monitoring.grafanaRoles` key, so it would re-assign the *same* principal+role that already exists there manually. The role-assignment name is deterministic —

```bicep
name: guid(grafana.id, gra.principalId, gra.role)   // dev-infrastructure/modules/grafana/instance.bicep
```

— so a second assignment for the same group+Viewer+scope collides with the manual one and fails with **`RoleAssignmentExists` (409)** on the live shared workspace. We must not touch `arohcp-stg` during coexistence.

## What

Introduce a **transient, scoped** `stgGlobalV2.grafanaRoles` key and point *only* the transient `grafana-roles-stg` step at it:

- `config/config.yaml` — add `stgGlobalV2.grafanaRoles` with a safe empty default (`""` = no assignments, same semantics as `monitoring.grafanaRoles`). Note it is `""`, not `"empty-sentinel"`, because the value is parsed by `splitOrEmptyArray(grafanaRoles, ' ')` and a sentinel would crash the bicep `split`.
- `config/config.schema.json` — add the `grafanaRoles` string property to the `stgGlobalV2` object (and its `required` list; the object is `additionalProperties: false`), mirroring the `monitoring.grafanaRoles` description + `pattern` so invalid `principalId/principalType/role` strings are rejected at validation time.
- `dev-infrastructure/configurations/grafana-roles-stg.tmpl.bicepparam` — repoint `param grafanaRoles` from `{{ .monitoring.grafanaRoles }}` to `{{ .stgGlobalV2.grafanaRoles }}`.
- `config/rendered/**` — regenerated via `cd config && make materialize`.

This lets a Viewer assignment be applied to **`arohcp-stg2` only**, without ever touching the shared `arohcp-stg`, avoiding the 409. The canonical `grafana-roles.tmpl.bicepparam` (shared workspace) is intentionally left on `monitoring.grafanaRoles`.

**No behavior change in this PR:** the default is empty. The real `<TM-AzureRedHatOpenShift-HCP objectId>/Group/Viewer` value is set separately in the stg cloud overlay by the team that owns it. This change only wires the plumbing so that value lands scoped to `arohcp-stg2`.

Transient by design — removed at STG-global decommission ([AROSLSRE-1202](https://redhat.atlassian.net/browse/AROSLSRE-1202) / Step 6), like the rest of the `stgGlobalV2` block.

## Testing

Validated locally in ARO-HCP:
- `cd config && make materialize` — re-rendered; `make verify-materialize` reports no drift.
- `make verify-schema` passes; `make verify-yamlfmt` clean.

Validated end-to-end against the **sdp-pipelines** rendering path (applied this change into the vendored `hcp/ARO-HCP`, ran the real `build-config.sh` overlay merge + `aro configuration explain` + full `aro ev2 manifests test`, then reverted):
- `build-config.sh` merges the new key cleanly and passes schema validation.
- `aro configuration explain` (stg/uksouth): `stgGlobalV2.grafanaRoles` resolves to `""` by default, and to the Viewer group when the overlay sets it — while `monitoring.grafanaRoles` (shared `arohcp-stg`) **stays `""`** ⇒ no 409.
- Generated EV2 manifest for `HCP.Global.StgGlobal`: the rendered `grafana-roles-stg` bicepparam now references `__stgGlobalV2.grafanaRoles__` against `grafanaName = arohcp-stg2`; `public/stg/ServiceConfig.json` resolves the Viewer group value; `public/int` and `public/prod` ServiceConfig carry **0** occurrences of it (scoped to stg only, no leakage).

Resolves [AROSLSRE-1525](https://redhat.atlassian.net/browse/AROSLSRE-1525).
