### PR TITLE
fix(e2e): treat all-zone-restricted SKUs as unavailable in region

### DIFF
--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -1161,7 +1161,8 @@ func (tc *perItOrDescribeTestContext) AvailableZones(ctx context.Context, vmSize
 		if skuRestrictedInLocation(sku, location) {
 			return nil, nil
 		}
-		return availableZones(sku, location), nil
+		_, available := zonesInLocation(sku, location)
+		return available, nil
 	}
 	return nil, fmt.Errorf("VM size %q not found in Resource SKUs for location %q", vmSize, location)
 }

--- a/test/util/framework/vm_sku_selection.go
+++ b/test/util/framework/vm_sku_selection.go
@@ -25,6 +25,8 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 )
 
@@ -281,8 +283,10 @@ func skuUsable(sku *armcompute.ResourceSKU, location string, selector VMSizeSele
 			return false
 		}
 	}
-	if selector.RequireZones && len(availableZones(sku, location)) == 0 {
-		return false
+	if selector.RequireZones {
+		if _, available := zonesInLocation(sku, location); len(available) == 0 {
+			return false
+		}
 	}
 	if selector.RequireEphemeralOSDisk {
 		val, ok := skuCapabilityString(sku, capabilityEphemeralOSDiskSupported)
@@ -309,8 +313,16 @@ func skuAdvertisedInLocation(sku *armcompute.ResourceSKU, location string) bool 
 }
 
 // skuRestrictedInLocation reports whether the SKU is entirely unavailable in the
-// location, e.g. NotAvailableForSubscription or a Location-type restriction
-// covering the region.
+// location. This covers both a Location-type restriction (SKU banned from the
+// whole region, e.g. NotAvailableForSubscription) and the case where the SKU
+// advertises availability zones in the location but Zone-type restrictions
+// remove all of them.
+//
+// The second case is not merely theoretical: Azure commonly expresses a full
+// subscription/region ban as a Zone-type restriction listing every zone (reason
+// NotAvailableForSubscription) rather than a Location-type restriction. A SKU in
+// that state is effectively unusable in the region, so it must be filtered out
+// even for selectors that do not set RequireZones.
 func skuRestrictedInLocation(sku *armcompute.ResourceSKU, location string) bool {
 	for _, restriction := range sku.Restrictions {
 		if restriction == nil || restriction.Type == nil {
@@ -323,24 +335,40 @@ func skuRestrictedInLocation(sku *armcompute.ResourceSKU, location string) bool 
 			return true
 		}
 	}
+
+	// A zonal SKU whose every advertised zone is removed by Zone-type
+	// restrictions is unusable. Comparing the advertised count against the
+	// remaining zones lets us tell that apart from a genuinely non-zonal SKU
+	// (advertised == 0), which must not be treated as restricted. A restriction
+	// listing zones beyond those advertised (Azure sometimes lists zones the SKU
+	// does not even offer) still empties the available set.
+	advertised, available := zonesInLocation(sku, location)
+	if advertised > 0 && len(available) == 0 {
+		return true
+	}
+
 	return false
 }
 
-// availableZones returns the availability zones for the SKU in the location
-// minus any zones removed by Zone-type restrictions.
-func availableZones(sku *armcompute.ResourceSKU, location string) []string {
-	zones := map[string]struct{}{}
+// zonesInLocation returns, in a single pass, how many availability zones the SKU
+// advertises in the location and the sorted subset that remains usable after
+// Zone-type restrictions are applied. Returning both lets callers distinguish a
+// non-zonal SKU (advertised == 0) from a zonal SKU whose every zone is
+// restricted (advertised > 0, available empty).
+func zonesInLocation(sku *armcompute.ResourceSKU, location string) (advertised int, available []string) {
+	advertisedZones := sets.New[string]()
 	for _, info := range sku.LocationInfo {
 		if info == nil || info.Location == nil || !strings.EqualFold(*info.Location, location) {
 			continue
 		}
 		for _, zone := range info.Zones {
 			if zone != nil {
-				zones[*zone] = struct{}{}
+				advertisedZones.Insert(*zone)
 			}
 		}
 	}
 
+	restrictedZones := sets.New[string]()
 	for _, restriction := range sku.Restrictions {
 		if restriction == nil || restriction.Type == nil || *restriction.Type != armcompute.ResourceSKURestrictionsTypeZone {
 			continue
@@ -350,17 +378,12 @@ func availableZones(sku *armcompute.ResourceSKU, location string) []string {
 		}
 		for _, zone := range restriction.RestrictionInfo.Zones {
 			if zone != nil {
-				delete(zones, *zone)
+				restrictedZones.Insert(*zone)
 			}
 		}
 	}
 
-	remaining := make([]string, 0, len(zones))
-	for zone := range zones {
-		remaining = append(remaining, zone)
-	}
-	sort.Strings(remaining)
-	return remaining
+	return advertisedZones.Len(), sets.List(advertisedZones.Difference(restrictedZones))
 }
 
 func restrictionCoversLocation(restriction *armcompute.ResourceSKURestrictions, location string) bool {

--- a/test/util/framework/vm_sku_selection_test.go
+++ b/test/util/framework/vm_sku_selection_test.go
@@ -295,6 +295,54 @@ func TestSelectVMSize(t *testing.T) {
 			},
 			want: "Standard_D8s_v3",
 		},
+		{
+			name: "SKU with all advertised zones restricted is excluded even without RequireZones",
+			skus: []*armcompute.ResourceSKU{
+				makeSKU("Standard_D8s_v3", testLocation,
+					withCapability(capabilityVCPUs, "8"),
+					withZones(testLocation, "1", "2", "3"),
+					withZoneRestriction(testLocation, "1", "2", "3"),
+				),
+			},
+			selector: VMSizeSelector{
+				Name:      "default-worker",
+				Preferred: []string{"Standard_D8s_v3"},
+				MinVCPUs:  8,
+			},
+			wantErr: ErrNoUsableVMSize,
+		},
+		{
+			name: "SKU with a surviving zone is usable when only some zones are restricted",
+			skus: []*armcompute.ResourceSKU{
+				makeSKU("Standard_D8s_v3", testLocation,
+					withCapability(capabilityVCPUs, "8"),
+					withZones(testLocation, "1", "2", "3"),
+					withZoneRestriction(testLocation, "1", "2"),
+				),
+			},
+			selector: VMSizeSelector{
+				Name:      "default-worker",
+				Preferred: []string{"Standard_D8s_v3"},
+				MinVCPUs:  8,
+			},
+			want: "Standard_D8s_v3",
+		},
+		{
+			name: "restriction listing more zones than advertised still excludes the SKU",
+			skus: []*armcompute.ResourceSKU{
+				makeSKU("Standard_NV12s_v3", testLocation,
+					withCapability(capabilityVCPUs, "12"),
+					withZones(testLocation, "2", "3"),
+					withZoneRestriction(testLocation, "1", "2", "3"),
+				),
+			},
+			selector: VMSizeSelector{
+				Name:      "gpu",
+				Preferred: []string{"Standard_NV12s_v3"},
+				MinVCPUs:  8,
+			},
+			wantErr: ErrNoUsableVMSize,
+		},
 	}
 
 	for _, tt := range tests {
@@ -486,5 +534,74 @@ func TestWorkerSelectorPreferredEntriesAreAllowlisted(t *testing.T) {
 				t.Errorf("selector %q Preferred entry %q does not match its NamePattern %q; Preferred must stay within the RP allowlist", sel.Name, name, sel.NamePattern.String())
 			}
 		}
+	}
+}
+
+// TestSkuRestrictedInLocation covers the zone-aware restriction detection added
+// for zone-level SKU bans. Azure often expresses a full subscription/region ban
+// as a Zone-type restriction listing every zone rather than a Location-type
+// restriction, so a SKU whose every advertised zone is restricted must be
+// reported as restricted even though no Location-type restriction is present.
+func TestSkuRestrictedInLocation(t *testing.T) {
+	tests := []struct {
+		name string
+		sku  *armcompute.ResourceSKU
+		want bool
+	}{
+		{
+			name: "no restrictions is not restricted",
+			sku:  makeSKU("Standard_D8s_v3", testLocation, withZones(testLocation, "1", "2", "3")),
+			want: false,
+		},
+		{
+			name: "location-type restriction is restricted",
+			sku:  makeSKU("Standard_D8s_v3", testLocation, withLocationRestriction(testLocation)),
+			want: true,
+		},
+		{
+			name: "all advertised zones restricted is restricted",
+			sku: makeSKU("Standard_D8s_v3", testLocation,
+				withZones(testLocation, "1", "2", "3"),
+				withZoneRestriction(testLocation, "1", "2", "3"),
+			),
+			want: true,
+		},
+		{
+			name: "some zones restricted is not restricted",
+			sku: makeSKU("Standard_D8s_v3", testLocation,
+				withZones(testLocation, "1", "2", "3"),
+				withZoneRestriction(testLocation, "1", "2"),
+			),
+			want: false,
+		},
+		{
+			name: "restriction covering more zones than advertised is restricted",
+			sku: makeSKU("Standard_NV12s_v3", testLocation,
+				withZones(testLocation, "2", "3"),
+				withZoneRestriction(testLocation, "1", "2", "3"),
+			),
+			want: true,
+		},
+		{
+			name: "non-zonal SKU with no restrictions is not restricted",
+			sku:  makeSKU("Standard_D8s_v3", testLocation),
+			want: false,
+		},
+		{
+			name: "zone restriction for a different location is ignored",
+			sku: makeSKU("Standard_D8s_v3", testLocation,
+				withZones(testLocation, "1", "2", "3"),
+				withZoneRestriction("westeurope", "1", "2", "3"),
+			),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := skuRestrictedInLocation(tt.sku, testLocation); got != tt.want {
+				t.Fatalf("skuRestrictedInLocation = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Why

The E2E VM SKU selector (`SelectVMSize` / `skuRestrictedInLocation` in `test/util/framework/vm_sku_selection.go`) only filtered out **Location-type** SKU restrictions. It ignored the case where a SKU advertises availability zones in a region but **Zone-type** restrictions remove *all* of them.

This is not theoretical: Azure commonly expresses a full subscription/region ban as a **Zone-type** restriction listing every zone (reason `NotAvailableForSubscription`) rather than a Location-type restriction. Verified against the STG E2E subscription in `uksouth`: of 904 `virtualMachines` SKUs there were **0** Location-type restrictions but **5** SKUs whose every advertised zone was Zone-restricted (e.g. `Standard_D15_v2` — zones `[1,2,3]` all `NotAvailableForSubscription`).

Because selectors like `default-worker` do not set `RequireZones`, such a SKU passed filtering, got selected, and then failed at deploy time with `SkuNotAvailable`.

## What

- `skuRestrictedInLocation()` now also returns `true` when a SKU advertises zones in the location but has zero available zones after applying Zone-type restrictions.
- Guarded on `len(advertisedZones) > 0` so genuinely **non-zonal** SKUs are not misclassified as restricted.
- Extracted an `advertisedZones()` helper shared with `availableZones()`. The subset relationship is handled naturally by subtraction, so a restriction listing zones beyond those advertised (Azure sometimes does this, e.g. `NV12s_v3` advertises `[2,3]` but the restriction lists `[1,2,3]`) still empties the set.
- Added unit tests: 3 new `TestSelectVMSize` table cases + a new `TestSkuRestrictedInLocation` (none / location / all-zones / partial / over-listing / non-zonal / other-location).

https://redhat.atlassian.net/browse/AROSLSRE-1390