### PR TITLE
mark a create operation timedout even if cluster-service and cosmos disagree on state

### DIFF
--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_create.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_create.go
@@ -164,22 +164,20 @@ func (c *operationClusterCreate) SynchronizeOperation(ctx context.Context, key c
 	}
 	logger.Info("new status via cosmos", "newStatus", cosmosNewOperationState.ProvisioningState, "newOperationMessage", cosmosNewOperationState.Message)
 
-	newOperationStatus, opError, err := convertClusterStatus(ctx, c.clusterServiceClient, operation, clusterStatus, clusterServiceID)
+	clusterServiceNewOperationStatus, opError, err := convertClusterStatus(ctx, c.clusterServiceClient, operation, clusterStatus, clusterServiceID)
 	if err != nil {
 		return utils.TrackError(err)
 	}
-	logger.Info("new status via cluster-service", "newStatus", newOperationStatus, "newOperationError", opError)
+	logger.Info("new status via cluster-service", "newStatus", clusterServiceNewOperationStatus, "newOperationError", opError)
 
-	if newOperationStatus == arm.ProvisioningStateSucceeded && cosmosNewOperationState.ProvisioningState != arm.ProvisioningStateSucceeded {
-		// we want to require that the cosmos view of cluster creation is also complete before we mark it.  This ensures (among other things)
-		// that our ability to read maestro is successful.
-		// Once we have confidence in our ability to determine that cluster is functional, we'll stop checking cluster-service at all.
-		return fmt.Errorf("cosmos operation status is %q, but cluster-service operation status is %q: %s", cosmosNewOperationState.ProvisioningState, newOperationStatus, cosmosNewOperationState.Message)
-	}
+	operationIsSuccessful := clusterServiceNewOperationStatus == arm.ProvisioningStateSucceeded && cosmosNewOperationState.ProvisioningState == arm.ProvisioningStateSucceeded
+	operationIsFailed := clusterServiceNewOperationStatus == arm.ProvisioningStateFailed && cosmosNewOperationState.ProvisioningState == arm.ProvisioningStateFailed
+	operationIsTerminal := operationIsSuccessful || operationIsFailed
 
-	if !newOperationStatus.IsTerminal() &&
+	if !operationIsTerminal &&
 		cluster.ServiceProviderProperties.CreateOperationCompletionDeadline != nil &&
 		c.clock.Now().After(cluster.ServiceProviderProperties.CreateOperationCompletionDeadline.Time) {
+
 		message := "cluster creation did not complete before the deadline"
 		if len(cosmosNewOperationState.Message) > 0 {
 			message = cosmosNewOperationState.Message
@@ -187,15 +185,22 @@ func (c *operationClusterCreate) SynchronizeOperation(ctx context.Context, key c
 		logger.Info("create operation deadline exceeded, marking as failed",
 			"deadline", cluster.ServiceProviderProperties.CreateOperationCompletionDeadline.Time,
 			"message", message)
-		newOperationStatus = arm.ProvisioningStateFailed
+		clusterServiceNewOperationStatus = arm.ProvisioningStateFailed
 		opError = &arm.CloudErrorBody{
 			Code:    arm.CloudErrorCodeInternalServerError,
 			Message: message,
 		}
 	}
 
+	if clusterServiceNewOperationStatus == arm.ProvisioningStateSucceeded && cosmosNewOperationState.ProvisioningState != arm.ProvisioningStateSucceeded {
+		// we want to require that the cosmos view of cluster creation is also complete before we mark it.  This ensures (among other things)
+		// that our ability to read maestro is successful.
+		// Once we have confidence in our ability to determine that cluster is functional, we'll stop checking cluster-service at all.
+		return fmt.Errorf("cosmos operation status is %q, but cluster-service operation status is %q: %s", cosmosNewOperationState.ProvisioningState, clusterServiceNewOperationStatus, cosmosNewOperationState.Message)
+	}
+
 	logger.Info("updating status")
-	err = UpdateOperationStatus(ctx, c.clock, c.resourcesDBClient, operation, newOperationStatus, opError, postAsyncNotificationFn(c.notificationClient))
+	err = UpdateOperationStatus(ctx, c.clock, c.resourcesDBClient, operation, clusterServiceNewOperationStatus, opError, postAsyncNotificationFn(c.notificationClient))
 	if database.IsPreconditionFailedError(err) {
 		return nil
 	}

--- a/backend/pkg/controllers/operationcontrollers/operation_cluster_create_test.go
+++ b/backend/pkg/controllers/operationcontrollers/operation_cluster_create_test.go
@@ -80,6 +80,7 @@ func TestOperationClusterCreate_SynchronizeOperation(t *testing.T) {
 		clock             utilsclock.PassiveClock
 		existingCluster   *api.HCPOpenShiftCluster
 		existingOperation *api.Operation
+		readDesireLister  dblisters.ReadDesireLister
 		setupCSMock       func(ctrl *gomock.Controller, fixture *clusterTestFixture) ocm.ClusterServiceClientSpec
 		wantErr           bool
 		verifyDB          func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient)
@@ -215,6 +216,36 @@ func TestOperationClusterCreate_SynchronizeOperation(t *testing.T) {
 			},
 		},
 		{
+			name:  "deadline exceeded with CS succeeded but cosmos provisioning marks as failed",
+			clock: clocktesting.NewFakePassiveClock(mustParseTime("2025-01-15T12:00:00Z")),
+			existingCluster: func() *api.HCPOpenShiftCluster {
+				cluster := newClusterWithAPIURL("https://api.example.com", &createdAt)
+				deadline := metav1.NewTime(mustParseTime("2025-01-15T11:30:00Z"))
+				cluster.ServiceProviderProperties.CreateOperationCompletionDeadline = &deadline
+				return cluster
+			}(),
+			existingOperation: fixture.newOperation(database.OperationRequestCreate),
+			readDesireLister:  &internallistertesting.SliceReadDesireLister{},
+			setupCSMock: func(ctrl *gomock.Controller, fixture *clusterTestFixture) ocm.ClusterServiceClientSpec {
+				mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
+				clusterStatus, err := arohcpv1alpha1.NewClusterStatus().
+					State(arohcpv1alpha1.ClusterStateReady).
+					Build()
+				require.NoError(t, err)
+				mockCSClient.EXPECT().
+					GetClusterStatus(gomock.Any(), fixture.clusterInternalID).
+					Return(clusterStatus, nil)
+				return mockCSClient
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				op, err := db.Operations(testSubscriptionID).Get(ctx, testOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, arm.ProvisioningStateFailed, op.Status)
+				require.NotNil(t, op.Error)
+				assert.Equal(t, arm.CloudErrorCodeInternalServerError, op.Error.Code)
+			},
+		},
+		{
 			name:  "deadline not yet exceeded continues with provisioning",
 			clock: clocktesting.NewFakePassiveClock(mustParseTime("2025-01-15T11:00:00Z")),
 			existingCluster: func() *api.HCPOpenShiftCluster {
@@ -273,9 +304,14 @@ func TestOperationClusterCreate_SynchronizeOperation(t *testing.T) {
 				clusterLister: &listertesting.SliceClusterLister{
 					Clusters: []*api.HCPOpenShiftCluster{tc.existingCluster},
 				},
-				readDesireLister: &internallistertesting.SliceReadDesireLister{
-					Desires: []*kubeapplier.ReadDesire{succeededDesire(t)},
-				},
+				readDesireLister: func() dblisters.ReadDesireLister {
+					if tc.readDesireLister != nil {
+						return tc.readDesireLister
+					}
+					return &internallistertesting.SliceReadDesireLister{
+						Desires: []*kubeapplier.ReadDesire{succeededDesire(t)},
+					}
+				}(),
 			}
 
 			err = controller.SynchronizeOperation(ctx, fixture.operationKey())


### PR DESCRIPTION
Turns out that in the practical sense, when we had "operation didn't finish" it was because `backend` detected that HCP had not reported that it reached a level.  Cluster-service just assumed the cluster was ready. And so there was an error before we reached the code that timed out and failed.  This adds a test for it and does the checks in the other order.