### PR TITLE
chore(ci): migrate resource cleaner MI and CS PR auth SP to Bicep

### DIFF
--- a/cluster-service/Makefile
+++ b/cluster-service/Makefile
@@ -42,30 +42,35 @@ deploy-pr-env-deps:
 		-p MSI_MOCK_CLIENT_ID=${AZURE_MI_MOCK_SERVICE_PRINCIPAL_CLIENT_ID} \
 		-p MSI_MOCK_PRINCIPAL_ID=${AZURE_MI_MOCK_SERVICE_PRINCIPAL_PRINCIPAL_ID} | oc apply -f -
 	oc process --local -f cspr/orphaned-namespace-cleaner.yaml | oc apply -f -
-	./cspr/deploy-resource-cleaner.sh \
+	az deployment group create \
+		--name resource-cleaner-infra \
 		--resource-group "${RESOURCEGROUP}" \
-		--cx-keyvault "${CX_SECRETS_KV_NAME}" \
-		--mi-keyvault "${CX_MI_KV_NAME}" \
-		--acr-name "${OCP_ACR_NAME}"
+		--parameters ../dev-infrastructure/configurations/resource-cleaner.bicepparam
+	CLEANER_OUTPUTS=$$(az deployment group show \
+		--name resource-cleaner-infra \
+		--resource-group "${RESOURCEGROUP}" \
+		--query 'properties.outputs.{principalId:principalId.value,clientId:clientId.value,tenantId:tenantId.value}' -o json) && \
+	CLEANER_PRINCIPAL_ID=$$(echo "$${CLEANER_OUTPUTS}" | jq -r '.principalId') && \
+	az deployment sub create \
+		--name "resource-cleaner-sub-${RESOURCEGROUP}" \
+		--location "$$(az group show -n "${RESOURCEGROUP}" --query location -o tsv)" \
+		--template-file ../dev-infrastructure/templates/dev-resource-cleaner-subscription.bicep \
+		--parameters principalId="$${CLEANER_PRINCIPAL_ID}" && \
+	AZURE_CLIENT_ID=$$(echo "$${CLEANER_OUTPUTS}" | jq -r '.clientId') \
+	AZURE_TENANT_ID=$$(echo "$${CLEANER_OUTPUTS}" | jq -r '.tenantId') \
+	./cspr/deploy-resource-cleaner.sh \
+		--resource-group "${RESOURCEGROUP}"
 
 cspr-jenkins-kubeconfig:
 	./cspr-kubeconfig.sh cluster-service-admin cluster-service-mgmt ./cspr.kubeconfig
 
 create-pr-env-sp:
-	CLUSTER_ID=$(shell az aks show -g ${RESOURCEGROUP} -n ${AKS_NAME} --query id -o tsv) && \
-	az ad sp create-for-rbac \
-	--display-name "cs-pr-authentication" \
-	--role 'Contributor' \
-	--scopes "$${CLUSTER_ID}"
-	az role assignment create \
-	--role "Key Vault Certificate User" \
-	--assignee "$(shell az ad sp list --display-name cs-pr-authentication --query [0].appId -o tsv)" \
-	--scope "$(shell az keyvault show --name ${SERVICE_KV} --query id -o tsv)"
-	echo "cs-pr-authentication requires 'Microsoft.Authorization/roleAssignments/write' action granted via 'User Access Administrator'. This role assignment requires elevated permissions, please add it in the case of re-creation of this service principal."
-#	az role assignment create \
-#	--role "User Access Administrator" \
-#	--assignee "$(shell az ad sp list --display-name cs-pr-authentication --query [0].appId -o tsv)" \
-#	--scope "$${CLUSTER_ID}"
+	az deployment group create \
+		--name cs-pr-auth-app \
+		--resource-group "${RESOURCEGROUP}" \
+		--parameters ../dev-infrastructure/configurations/cs-pr-auth-app.bicepparam
+	@echo "NOTE: cs-pr-authentication may also need User Access Administrator on the AKS cluster."
+	@echo "This requires elevated permissions and must be assigned manually if the SP is re-created."
 
 local-deploy-provision-shard:
 	@ZONE_RESOURCE_ID=$(shell az network dns zone show -n ${ZONE_NAME} -g ${REGIONAL_RESOURCEGROUP} --query id -o tsv) && \

--- a/cluster-service/cspr/deploy-resource-cleaner.sh
+++ b/cluster-service/cspr/deploy-resource-cleaner.sh
@@ -11,14 +11,19 @@ set -euo pipefail
 # Usage:
 #   ./deploy-resource-cleaner.sh [OPTIONS]
 #
+# The managed identity, federated credential, and role assignments are created
+# by dev-infrastructure/templates/dev-resource-cleaner.bicep. This script only
+# deploys the Kubernetes resources (namespace, ConfigMap, CronJob).
+#
 # Options:
-#   --resource-group <rg>      Azure Resource Group where the managed identity will be created (required)
-#   --cx-keyvault <name>       CX Key Vault name (required)
-#   --mi-keyvault <name>       MI Key Vault name (required)
-#   --acr-name <name>          Azure Container Registry name (required)
+#   --resource-group <rg>      Azure Resource Group (required, for logging only)
 #   --maestro-url <url>        Maestro API URL (default: http://maestro.maestro.svc.cluster.local:8000)
 #   --retention-hours <hours>  Retention period in hours (default: 3)
 #   --help                     Show this help message
+#
+# Environment variables:
+#   AZURE_CLIENT_ID   Client ID of the cspr-cleaner-mi managed identity (required)
+#   AZURE_TENANT_ID   Azure tenant ID (required)
 ###############################################################################
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -26,31 +31,15 @@ RESOURCE_CLEANER_DIR="${SCRIPT_DIR}/resource-cleaner"
 
 # Default values
 RESOURCE_GROUP=""
-CX_KEYVAULT=""
-MI_KEYVAULT=""
-ACR_NAME=""
 MAESTRO_URL="http://maestro.maestro.svc.cluster.local:8000"
 RETENTION_HOURS="3"
 NAMESPACE="resource-cleaner"
-MI_NAME="cspr-cleaner-mi"
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
     case $1 in
         --resource-group)
             RESOURCE_GROUP="$2"
-            shift 2
-            ;;
-        --cx-keyvault)
-            CX_KEYVAULT="$2"
-            shift 2
-            ;;
-        --mi-keyvault)
-            MI_KEYVAULT="$2"
-            shift 2
-            ;;
-        --acr-name)
-            ACR_NAME="$2"
             shift 2
             ;;
         --maestro-url)
@@ -62,7 +51,7 @@ while [[ $# -gt 0 ]]; do
             shift 2
             ;;
         --help)
-            head -n 22 "$0" | grep "^#" | sed 's/^# //' | sed 's/^#//'
+            head -n 28 "$0" | grep "^#" | sed 's/^# //' | sed 's/^#//'
             exit 0
             ;;
         *)
@@ -73,152 +62,20 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# Validate required parameters
 if [[ -z "${RESOURCE_GROUP}" ]]; then
     echo "ERROR: --resource-group is required"
-    echo "Use --help for usage information"
     exit 1
 fi
 
-if [[ -z "${CX_KEYVAULT}" ]]; then
-    echo "ERROR: --cx-keyvault is required"
-    echo "Use --help for usage information"
+if [[ -z "${AZURE_CLIENT_ID:-}" ]]; then
+    echo "ERROR: AZURE_CLIENT_ID env var is required (from dev-resource-cleaner.bicep output)"
     exit 1
 fi
 
-if [[ -z "${MI_KEYVAULT}" ]]; then
-    echo "ERROR: --mi-keyvault is required"
-    echo "Use --help for usage information"
+if [[ -z "${AZURE_TENANT_ID:-}" ]]; then
+    echo "ERROR: AZURE_TENANT_ID env var is required (from dev-resource-cleaner.bicep output)"
     exit 1
 fi
-
-if [[ -z "${ACR_NAME}" ]]; then
-    echo "ERROR: --acr-name is required"
-    echo "Use --help for usage information"
-    exit 1
-fi
-
-# Create or get managed identity
-echo "========================================"
-echo "Setting up managed identity: ${MI_NAME}"
-echo "========================================"
-
-# Create managed identity if it doesn't exist
-if ! az identity show -g "${RESOURCE_GROUP}" -n "${MI_NAME}" &>/dev/null; then
-    echo "Creating managed identity ${MI_NAME} in resource group ${RESOURCE_GROUP}..."
-    az identity create -g "${RESOURCE_GROUP}" -n "${MI_NAME}"
-    echo "✓ Managed identity created"
-else
-    echo "✓ Managed identity ${MI_NAME} already exists"
-fi
-
-# Get managed identity details
-AZURE_CLIENT_ID=$(az identity show -g "${RESOURCE_GROUP}" -n "${MI_NAME}" --query clientId -o tsv)
-AZURE_TENANT_ID=$(az account show --query tenantId -o tsv)
-MI_PRINCIPAL_ID=$(az identity show -g "${RESOURCE_GROUP}" -n "${MI_NAME}" --query principalId -o tsv)
-
-echo "  Client ID: ${AZURE_CLIENT_ID}"
-echo "  Tenant ID: ${AZURE_TENANT_ID}"
-echo "  Principal ID: ${MI_PRINCIPAL_ID}"
-echo ""
-
-# Get OIDC issuer URL from the cluster
-echo "Fetching OIDC issuer URL from cluster..."
-ISSUER_URL=$(kubectl get --raw /.well-known/openid-configuration | jq -r '.issuer')
-if [[ -z "${ISSUER_URL}" ]]; then
-    echo "ERROR: Failed to fetch OIDC issuer URL from cluster"
-    echo "Make sure kubectl is configured and the cluster is accessible"
-    exit 1
-fi
-echo "  OIDC Issuer URL: ${ISSUER_URL}"
-echo ""
-
-# Create federated credential for workload identity
-echo "Creating federated credential for workload identity..."
-FEDCRED_NAME="resource-cleaner-fedcred"
-SUBJECT="system:serviceaccount:${NAMESPACE}:resource-cleaner-cronjob"
-
-# Check if federated credential already exists
-if az identity federated-credential show \
-    --name "${FEDCRED_NAME}" \
-    --identity-name "${MI_NAME}" \
-    --resource-group "${RESOURCE_GROUP}" &>/dev/null; then
-    echo "  Federated credential ${FEDCRED_NAME} already exists, updating..."
-    az identity federated-credential update \
-        --name "${FEDCRED_NAME}" \
-        --identity-name "${MI_NAME}" \
-        --resource-group "${RESOURCE_GROUP}" \
-        --issuer "${ISSUER_URL}" \
-        --subject "${SUBJECT}"
-    echo "  ✓ Federated credential updated"
-else
-    echo "  Creating federated credential ${FEDCRED_NAME}..."
-    az identity federated-credential create \
-        --name "${FEDCRED_NAME}" \
-        --identity-name "${MI_NAME}" \
-        --resource-group "${RESOURCE_GROUP}" \
-        --issuer "${ISSUER_URL}" \
-        --subject "${SUBJECT}" \
-        --audience "api://AzureADTokenExchange"
-    echo "  ✓ Federated credential created"
-fi
-echo ""
-
-# Assign permissions
-echo "Assigning permissions to managed identity..."
-
-# 1a. Key Vault Certificates Officer role on CX Key Vault (read/delete certificates)
-echo "  Assigning Key Vault Certificates Officer role on CX Key Vault (${CX_KEYVAULT})..."
-CX_KV_ID=$(az keyvault show -n "${CX_KEYVAULT}" --query id -o tsv)
-az role assignment create \
-    --role "Key Vault Certificates Officer" \
-    --assignee-object-id "${MI_PRINCIPAL_ID}" \
-    --assignee-principal-type ServicePrincipal \
-    --scope "${CX_KV_ID}" \
-    --output none 2>/dev/null || echo "    (role may already be assigned)"
-
-# 1b. Key Vault Secrets Officer role on CX Key Vault (read/delete secrets)
-echo "  Assigning Key Vault Secrets Officer role on CX Key Vault (${CX_KEYVAULT})..."
-az role assignment create \
-    --role "Key Vault Secrets Officer" \
-    --assignee-object-id "${MI_PRINCIPAL_ID}" \
-    --assignee-principal-type ServicePrincipal \
-    --scope "${CX_KV_ID}" \
-    --output none 2>/dev/null || echo "    (role may already be assigned)"
-
-# 2. Key Vault Secrets Officer role on MI Key Vault (read/delete secrets)
-echo "  Assigning Key Vault Secrets Officer role on MI Key Vault (${MI_KEYVAULT})..."
-MI_KV_ID=$(az keyvault show -n "${MI_KEYVAULT}" --query id -o tsv)
-az role assignment create \
-    --role "Key Vault Secrets Officer" \
-    --assignee-object-id "${MI_PRINCIPAL_ID}" \
-    --assignee-principal-type ServicePrincipal \
-    --scope "${MI_KV_ID}" \
-    --output none 2>/dev/null || echo "    (role may already be assigned)"
-
-# 3. AcrDelete role on ACR (read/delete tokens)
-echo "  Assigning AcrDelete role on ACR (${ACR_NAME})..."
-ACR_ID=$(az acr show -n "${ACR_NAME}" --query id -o tsv)
-az role assignment create \
-    --role "AcrDelete" \
-    --assignee-object-id "${MI_PRINCIPAL_ID}" \
-    --assignee-principal-type ServicePrincipal \
-    --scope "${ACR_ID}" \
-    --output none 2>/dev/null || echo "    (role may already be assigned)"
-
-# 4. Contributor role on subscription (for resource group management)
-# Note: The identity may already have this permission
-echo "  Verifying Contributor permissions for resource group management..."
-SUBSCRIPTION_ID=$(az account show --query id -o tsv)
-az role assignment create \
-    --role "Contributor" \
-    --assignee-object-id "${MI_PRINCIPAL_ID}" \
-    --assignee-principal-type ServicePrincipal \
-    --scope "/subscriptions/${SUBSCRIPTION_ID}" \
-    --output none 2>/dev/null || echo "    (role may already be assigned)"
-
-echo "✓ Permissions assigned"
-echo ""
 
 # Verify script directory exists
 if [[ ! -d "${RESOURCE_CLEANER_DIR}" ]]; then
@@ -252,13 +109,8 @@ echo "========================================"
 echo "Deployment Configuration"
 echo "========================================"
 echo "  Resource Group: ${RESOURCE_GROUP}"
-echo "  Managed Identity: ${MI_NAME}"
 echo "  Azure Client ID: ${AZURE_CLIENT_ID}"
 echo "  Azure Tenant ID: ${AZURE_TENANT_ID}"
-echo "  OIDC Issuer URL: ${ISSUER_URL}"
-echo "  CX Key Vault: ${CX_KEYVAULT}"
-echo "  MI Key Vault: ${MI_KEYVAULT}"
-echo "  ACR Name: ${ACR_NAME}"
 echo "  Maestro URL: ${MAESTRO_URL}"
 echo "  Retention Hours: ${RETENTION_HOURS}"
 echo "  Namespace: ${NAMESPACE}"

--- a/dev-infrastructure/configurations/cs-pr-auth-app.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/cs-pr-auth-app.tmpl.bicepparam
@@ -1,0 +1,5 @@
+using '../templates/dev-cs-pr-auth-app.bicep'
+
+param aksClusterName = '{{ .svc.aks.name }}'
+param serviceKeyVaultName = '{{ .serviceKeyVault.name }}'
+param serviceKeyVaultResourceGroup = '{{ .serviceKeyVault.rg }}'

--- a/dev-infrastructure/configurations/resource-cleaner.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/resource-cleaner.tmpl.bicepparam
@@ -1,0 +1,9 @@
+using '../templates/dev-resource-cleaner.bicep'
+
+param clusterName = '{{ .svc.aks.name }}'
+param cxKeyVaultName = '{{ .cxKeyVault.name }}'
+param cxKeyVaultResourceGroup = '{{ .mgmt.rg }}'
+param miKeyVaultName = '{{ .msiKeyVault.name }}'
+param miKeyVaultResourceGroup = '{{ .mgmt.rg }}'
+param ocpAcrName = '{{ .acr.ocp.name }}'
+param ocpAcrResourceGroup = '{{ .global.rg }}'

--- a/dev-infrastructure/modules/acr/acr-permissions.bicep
+++ b/dev-infrastructure/modules/acr/acr-permissions.bicep
@@ -6,6 +6,9 @@ param principalIds array
 @description('Whether to grant push access to the ACR')
 param grantPushAccess bool = false
 
+@description('Whether to grant delete access to the ACR independently of push access')
+param grantDeleteAccess bool = false
+
 @description('Whether to grant pull access from the ACR')
 param grantPullAccess bool = false
 
@@ -68,7 +71,7 @@ resource acrPushRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = [
 ]
 
 resource acrDeleteRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = [
-  for principalId in principalIds: if (grantPushAccess) {
+  for principalId in principalIds: if (grantPushAccess || grantDeleteAccess) {
     name: guid(acrName, principalId, acrDeleteRoleDefinitionId)
     scope: acrInstance
     properties: {

--- a/dev-infrastructure/templates/dev-cs-pr-auth-app.bicep
+++ b/dev-infrastructure/templates/dev-cs-pr-auth-app.bicep
@@ -26,7 +26,7 @@ var contributorRoleDefinitionId = subscriptionResourceId(
 )
 
 resource aksContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(aksCluster.id, 'cs-pr-authentication', contributorRoleDefinitionId)
+  name: guid(aksCluster.id, csAuthApp.outputs.principalId, contributorRoleDefinitionId)
   scope: aksCluster
   properties: {
     principalId: csAuthApp.outputs.principalId

--- a/dev-infrastructure/templates/dev-cs-pr-auth-app.bicep
+++ b/dev-infrastructure/templates/dev-cs-pr-auth-app.bicep
@@ -1,0 +1,46 @@
+@description('Name of the AKS cluster')
+param aksClusterName string
+
+@description('Name of the service Key Vault')
+param serviceKeyVaultName string
+
+@description('Resource group of the service Key Vault')
+param serviceKeyVaultResourceGroup string
+
+resource aksCluster 'Microsoft.ContainerService/managedClusters@2025-07-02-preview' existing = {
+  name: aksClusterName
+}
+
+module csAuthApp '../modules/entra/app.bicep' = {
+  name: 'cs-pr-auth-app'
+  params: {
+    applicationName: 'cs-pr-authentication'
+    uniqueName: toLower(replace('cs-pr-authentication', ' ', '-'))
+    manageSp: true
+  }
+}
+
+var contributorRoleDefinitionId = subscriptionResourceId(
+  'Microsoft.Authorization/roleDefinitions',
+  'b24988ac-6180-42a0-ab88-20f7382dd24c'
+)
+
+resource aksContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(aksCluster.id, 'cs-pr-authentication', contributorRoleDefinitionId)
+  scope: aksCluster
+  properties: {
+    principalId: csAuthApp.outputs.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: contributorRoleDefinitionId
+  }
+}
+
+module kvCertUser '../modules/keyvault/keyvault-secret-access.bicep' = {
+  name: 'cs-pr-auth-kv-cert-user'
+  scope: resourceGroup(serviceKeyVaultResourceGroup)
+  params: {
+    keyVaultName: serviceKeyVaultName
+    roleName: 'Key Vault Certificate User'
+    managedIdentityPrincipalIds: [csAuthApp.outputs.principalId]
+  }
+}

--- a/dev-infrastructure/templates/dev-resource-cleaner-subscription.bicep
+++ b/dev-infrastructure/templates/dev-resource-cleaner-subscription.bicep
@@ -1,0 +1,19 @@
+targetScope = 'subscription'
+
+@description('Principal ID of the resource cleaner managed identity')
+param principalId string
+
+var contributorRoleDefinitionId = subscriptionResourceId(
+  'Microsoft.Authorization/roleDefinitions',
+  'b24988ac-6180-42a0-ab88-20f7382dd24c'
+)
+
+resource contributorRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(subscription().id, principalId, contributorRoleDefinitionId)
+  scope: subscription()
+  properties: {
+    principalId: principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: contributorRoleDefinitionId
+  }
+}

--- a/dev-infrastructure/templates/dev-resource-cleaner.bicep
+++ b/dev-infrastructure/templates/dev-resource-cleaner.bicep
@@ -1,0 +1,89 @@
+@description('Name of the AKS cluster for OIDC issuer lookup')
+param clusterName string
+
+@description('Name of the CX Key Vault')
+param cxKeyVaultName string
+
+@description('Resource group of the CX Key Vault')
+param cxKeyVaultResourceGroup string
+
+@description('Name of the MI Key Vault')
+param miKeyVaultName string
+
+@description('Resource group of the MI Key Vault')
+param miKeyVaultResourceGroup string
+
+@description('Name of the OCP ACR')
+param ocpAcrName string
+
+@description('Resource group of the OCP ACR')
+param ocpAcrResourceGroup string
+
+param location string = resourceGroup().location
+
+var miName = 'cspr-cleaner-mi'
+
+resource aksCluster 'Microsoft.ContainerService/managedClusters@2025-07-02-preview' existing = {
+  name: clusterName
+}
+
+resource cleanerMI 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: miName
+  location: location
+}
+
+resource fedcred 'Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials@2023-01-31' = {
+  parent: cleanerMI
+  name: 'resource-cleaner-fedcred'
+  properties: {
+    audiences: [
+      'api://AzureADTokenExchange'
+    ]
+    issuer: aksCluster.properties.oidcIssuerProfile.issuerURL
+    subject: 'system:serviceaccount:resource-cleaner:resource-cleaner-cronjob'
+  }
+}
+
+module cxKvCertOfficer '../modules/keyvault/keyvault-secret-access.bicep' = {
+  name: 'cleaner-cx-kv-cert-officer'
+  scope: resourceGroup(cxKeyVaultResourceGroup)
+  params: {
+    keyVaultName: cxKeyVaultName
+    roleName: 'Key Vault Certificates Officer'
+    managedIdentityPrincipalIds: [cleanerMI.properties.principalId]
+  }
+}
+
+module cxKvSecretOfficer '../modules/keyvault/keyvault-secret-access.bicep' = {
+  name: 'cleaner-cx-kv-secret-officer'
+  scope: resourceGroup(cxKeyVaultResourceGroup)
+  params: {
+    keyVaultName: cxKeyVaultName
+    roleName: 'Key Vault Secrets Officer'
+    managedIdentityPrincipalIds: [cleanerMI.properties.principalId]
+  }
+}
+
+module miKvSecretOfficer '../modules/keyvault/keyvault-secret-access.bicep' = {
+  name: 'cleaner-mi-kv-secret-officer'
+  scope: resourceGroup(miKeyVaultResourceGroup)
+  params: {
+    keyVaultName: miKeyVaultName
+    roleName: 'Key Vault Secrets Officer'
+    managedIdentityPrincipalIds: [cleanerMI.properties.principalId]
+  }
+}
+
+module acrDelete '../modules/acr/acr-permissions.bicep' = {
+  name: 'cleaner-acr-delete'
+  scope: resourceGroup(ocpAcrResourceGroup)
+  params: {
+    acrName: ocpAcrName
+    principalIds: [cleanerMI.properties.principalId]
+    grantDeleteAccess: true
+  }
+}
+
+output principalId string = cleanerMI.properties.principalId
+output clientId string = cleanerMI.properties.clientId
+output tenantId string = tenant().tenantId


### PR DESCRIPTION
[AROSLSRE-1351](https://redhat.atlassian.net/browse/AROSLSRE-1351) | [ARO-27252](https://redhat.atlassian.net/browse/ARO-27252)

### What

Replaces bash-managed identity creation in `deploy-resource-cleaner.sh` and `create-pr-env-sp` Makefile target with declarative Bicep templates.

- **Resource cleaner**: `dev-resource-cleaner.bicep` creates the managed identity, federated credential, KV roles (Certificates Officer, Secrets Officer), ACR delete access, and subscription Contributor via a separate `dev-resource-cleaner-subscription.bicep`
- **CS PR auth**: `dev-cs-pr-auth-app.bicep` creates the Entra app + SP via `entra/app.bicep`, with AKS Contributor and KV Certificate User roles
- **acr-permissions.bicep**: added `grantDeleteAccess` param (backward-compatible)
- `deploy-resource-cleaner.sh` stripped to K8s-only (namespace, ConfigMap, CronJob); receives `AZURE_CLIENT_ID`/`AZURE_TENANT_ID` from Bicep output

### Why

These were the last two bash-managed identity resources in the CSPR path. Moving them to Bicep makes them declarative, idempotent, and auditable — consistent with the rest of the IaC model.

### Testing

No unit/integration/E2E tests — this is infrastructure-as-code. Verification is deployment-time:

- `az bicep lint` passes on all new templates
- `az deployment group what-if` confirms correct resource creation
- `make deploy-pr-env-deps` in a personal dev env verifies MSI + fedcred + CronJob works end-to-end

### Special notes for your reviewer

- `cs-pr-authentication` app needs a one-time `uniqueName` backfill before first Bicep deploy (added to the backfill script in PR #5976)
- Cross-resource-group scope is explicitly set on all KV and ACR module calls (KVs in mgmt.rg, ACR in global.rg, service KV in regionRG)
- User Access Administrator role was commented out in the old Makefile target; preserved as an echo warning in the new target

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows Conventional Commits format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes) — N/A
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide) — draft, pending CI
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented — N/A
- [ ] Specific reviewers tagged — will tag when ready for review
- [ ] All comment threads resolved before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)