### PR TITLE
handle ARO-Tools SafeFly step type in templatize

### DIFF
--- a/tooling/templatize/cmd/pipeline/validate/options.go
+++ b/tooling/templatize/cmd/pipeline/validate/options.go
@@ -457,6 +457,15 @@ func handleService(logger logr.Logger, context string, group *errgroup.Group, t 
 						variable: types.Value{Input: &specificStep.IdentityFrom},
 						ref:      fmt.Sprintf("resourceGroups[%d].steps[%d].identityFrom", i, j),
 					})
+				case "SafeFly":
+					specificStep, ok := step.(*types.SafeFlyStep)
+					if !ok {
+						return fmt.Errorf("%s: resourceGroups[%d].steps[%d]: have action %q, expected *types.SafeFlyStep, but got %T", service.ServiceGroup, i, j, step.ActionType(), step)
+					}
+					variables = append(variables, variableRef{
+						variable: specificStep.ShellIdentity,
+						ref:      fmt.Sprintf("resourceGroups[%d].steps[%d].shellIdentity", i, j),
+					})
 				}
 			}
 		}

--- a/tooling/templatize/pkg/pipeline/run.go
+++ b/tooling/templatize/pkg/pipeline/run.go
@@ -929,6 +929,9 @@ func RunStep(id graph.Identifier, s types.Step, ctx context.Context, executionTa
 		output := buf.String()
 		fmt.Println(output)
 		return ShellOutput(output), nil, nil
+	case *types.SafeFlyStep:
+		logger.Info("SafeFly submission requires a live EV2 rollout, skipping in templatize", "step", step.StepName())
+		return nil, nil, nil
 	case *types.SecretSyncStep:
 		if err := runSecretSyncStep(step, ctx, options); err != nil {
 			return nil, nil, fmt.Errorf("error running secret sync Step, %v", err)


### PR DESCRIPTION
### What

<!-- Briefly describe what this PR does -->

Add an explicit SafeFlyStep case that logs and skips instead of the generic default. And add a SafeFly case so shellIdentity config references are checked

### Why

SafeFly submission needs a live EV2 rollout, so templatize can't run it, so skipping at runtime. No accompanying Aro-Tools bump since the actual step bump landed on this PR https://github.com/Azure/ARO-HCP/pull/6201

### Testing

go build and go test pass in tooling/templatize

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
