### PR TITLE
fix(test): purge soft-deleted customer Key Vault on e2e teardown

### DIFF
--- a/test/go.mod
+++ b/test/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v3 v3.0.0-beta.2
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5 v5.7.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventhub/armeventhub v1.3.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault v1.5.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/kusto/armkusto/v2 v2.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor v0.11.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.3.0

--- a/test/go.sum
+++ b/test/go.sum
@@ -122,6 +122,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0 h1:PTFG
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0/go.mod h1:LRr2FzBTQlONPPa5HREE5+RjSCTXl7BwOvYOaWTqCaI=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v3 v3.1.1 h1:1kpY4qe+BGAH2ykv4baVSqyx+AY5VjXeJ15SldlU6hs=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v3 v3.1.1/go.mod h1:nT6cWpWdUt+g81yuKmjeYPUtI73Ak3yQIT4PVVsCEEQ=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault v1.5.0 h1:nnQ9vXH039UrEFxi08pPuZBE7VfqSJt343uJLw0rhWI=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault v1.5.0/go.mod h1:4YIVtzMFVsPwBvitCDX7J9sqthSj43QD1sP6fYc1egc=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/kusto/armkusto/v2 v2.3.0 h1:5kp5bmJwJuF0HTsPUxRWRy44FxEatQAhv03nYdjXJ3s=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/kusto/armkusto/v2 v2.3.0/go.mod h1:ULnv9Hl5nSpzNHHqJ3xX0kIZp5ZyLcLGHdXNQ8RwIk4=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/managementgroups/armmanagementgroups v1.2.0 h1:akP6VpxJGgQRpDR1P462piz/8OhYLRCreDj48AyNabc=

--- a/test/util/framework/per_invocation_framework.go
+++ b/test/util/framework/per_invocation_framework.go
@@ -81,6 +81,11 @@ var (
 const (
 	StandardPollInterval            = 10 * time.Second
 	StandardResourceGroupExpiration = 4 * time.Hour
+	// keyVaultPurgeTimeout bounds the best-effort soft-deleted Key Vault purge
+	// on resource-group teardown so a stalled purge (or Azure control-plane
+	// stall) can never hang the cleanup goroutine and flake the overall E2E
+	// teardown.
+	keyVaultPurgeTimeout = 5 * time.Minute
 )
 
 // azureRetryOptions configures the Azure SDK retry policy for e2e tests.

--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -430,7 +430,11 @@ func (tc *perItOrDescribeTestContext) NewResourceGroup(ctx context.Context, reso
 	// soft-delete holds a not-yet-purged name for up to 90 days, a repeated
 	// resource-group suffix within that window causes a VaultAlreadyExists
 	// collision on the next run. A 12-character suffix makes such a repeat
-	// effectively impossible even across the full soft-delete retention window.
+	// highly unlikely as defense in depth; the teardown purge below is the
+	// actual guarantee. (Note SuffixName only preserves the full suffix while
+	// prefix+suffix stays within maxLen; if it ever truncates, the effective
+	// entropy drops to the 32-bit hash. The short prefixes used here never
+	// trigger that path.)
 	suffix := rand.String(12)
 	resourceGroupName := SuffixName(resourceGroupPrefix, suffix, 64)
 	func() {

--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -429,12 +429,14 @@ func (tc *perItOrDescribeTestContext) NewResourceGroup(ctx context.Context, reso
 	// cust-kv-${uniqueString(resourceGroup().id, ...)}). Because Azure Key Vault
 	// soft-delete holds a not-yet-purged name for up to 90 days, a repeated
 	// resource-group suffix within that window causes a VaultAlreadyExists
-	// collision on the next run. A 12-character suffix makes such a repeat
-	// highly unlikely as defense in depth; the teardown purge below is the
-	// actual guarantee. (Note SuffixName only preserves the full suffix while
-	// prefix+suffix stays within maxLen; if it ever truncates, the effective
-	// entropy drops to the 32-bit hash. The short prefixes used here never
-	// trigger that path.)
+	// collision on the next run. The 12-character suffix is the always-on
+	// primary defense (a repeat is highly unlikely across the retention
+	// window); the best-effort teardown purge below additionally frees the
+	// name immediately whenever the identity is permitted to purge. Both are
+	// best-effort layers rather than hard guarantees. (SuffixName only
+	// preserves the full suffix while prefix+suffix stays within maxLen; if it
+	// ever truncates, effective entropy drops to a 32-bit hash — the short
+	// prefixes used here never trigger that path.)
 	suffix := rand.String(12)
 	resourceGroupName := SuffixName(resourceGroupPrefix, suffix, 64)
 	func() {
@@ -706,16 +708,33 @@ func (tc *perItOrDescribeTestContext) purgeDeletedKeyVaultsInResourceGroup(ctx c
 				"keyVault", *deleted.Name, "location", *deleted.Properties.Location, "resourceGroup", resourceGroupName)
 			poller, err := vaultsClient.BeginPurgeDeleted(ctx, *deleted.Name, *deleted.Properties.Location, nil)
 			if err != nil {
+				// A 404 means the vault was already purged or its soft-delete
+				// window expired between the list and the purge; that is the
+				// desired end state, so treat it as a no-op rather than noise.
+				if isKeyVaultNotFound(err) {
+					continue
+				}
 				ginkgo.GinkgoLogr.Error(err, "failed to start purge of soft-deleted key vault; a colliding name may block a later run until it is purged or expires",
 					"keyVault", *deleted.Name, "resourceGroup", resourceGroupName)
 				continue
 			}
 			if _, err := poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: StandardPollInterval}); err != nil {
+				if isKeyVaultNotFound(err) {
+					continue
+				}
 				ginkgo.GinkgoLogr.Error(err, "failed to purge soft-deleted key vault; a colliding name may block a later run until it is purged or expires",
 					"keyVault", *deleted.Name, "resourceGroup", resourceGroupName)
 			}
 		}
 	}
+}
+
+// isKeyVaultNotFound reports whether err is an Azure 404 response, which for a
+// purge means the vault is already gone (already purged or soft-delete window
+// expired) and can be treated as a successful no-op.
+func isKeyVaultNotFound(err error) bool {
+	var respErr *azcore.ResponseError
+	return errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound
 }
 
 func (tc *perItOrDescribeTestContext) collectDebugInfoForResourceGroup(ctx context.Context, resourceGroupName string) error {

--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -658,6 +658,11 @@ func (tc *perItOrDescribeTestContext) cleanupResourceGroupNoRP(ctx context.Conte
 // Microsoft.KeyVault/locations/deletedVaults/purge/action permission) are
 // logged but never fail cleanup.
 func (tc *perItOrDescribeTestContext) purgeDeletedKeyVaultsInResourceGroup(ctx context.Context, resourceGroupName string) {
+	// Bound the whole best-effort purge so a stuck vault purge or Azure
+	// control-plane stall cannot hang teardown indefinitely.
+	ctx, cancel := context.WithTimeout(ctx, keyVaultPurgeTimeout)
+	defer cancel()
+
 	creds, err := tc.AzureCredential()
 	if err != nil {
 		ginkgo.GinkgoLogr.Error(err, "unable to purge soft-deleted key vaults: failed to get azure credentials", "resourceGroup", resourceGroupName)

--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -44,7 +44,9 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/log"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
@@ -421,7 +423,15 @@ func (tc *perItOrDescribeTestContext) collectDebugInfo(ctx context.Context) {
 }
 
 func (tc *perItOrDescribeTestContext) NewResourceGroup(ctx context.Context, resourceGroupPrefix, location string) (*armresources.ResourceGroup, error) {
-	suffix := rand.String(6)
+	// Use a wide random suffix. Some resources created inside the group derive
+	// their globally-unique names deterministically from the resource group id
+	// (e.g. the customer Key Vault name in customer-infra.bicep is
+	// cust-kv-${uniqueString(resourceGroup().id, ...)}). Because Azure Key Vault
+	// soft-delete holds a not-yet-purged name for up to 90 days, a repeated
+	// resource-group suffix within that window causes a VaultAlreadyExists
+	// collision on the next run. A 12-character suffix makes such a repeat
+	// effectively impossible even across the full soft-delete retention window.
+	suffix := rand.String(12)
 	resourceGroupName := SuffixName(resourceGroupPrefix, suffix, 64)
 	func() {
 		tc.contextLock.Lock()
@@ -569,6 +579,11 @@ func (tc *perItOrDescribeTestContext) cleanupResourceGroup(ctx context.Context, 
 		return fmt.Errorf("failed to cleanup resource group: %w", err)
 	}
 
+	// Deleting the resource group only soft-deletes any Key Vaults it contained;
+	// their globally-unique names stay reserved until purged. Purge them so a
+	// later run reusing a colliding vault name does not hit VaultAlreadyExists.
+	tc.purgeDeletedKeyVaultsInResourceGroup(ctx, resourceGroupName)
+
 	// we want non-conformant clusters to be visible at the end, without impeding our ability to clean up the resource group
 	return nonConformantErr
 }
@@ -624,7 +639,74 @@ func (tc *perItOrDescribeTestContext) cleanupResourceGroupNoRP(ctx context.Conte
 		return fmt.Errorf("failed to cleanup resource group: %w", err)
 	}
 
+	// Purge any Key Vaults left soft-deleted by the resource group deletion so
+	// their globally-unique names are immediately reusable by later runs.
+	tc.purgeDeletedKeyVaultsInResourceGroup(ctx, resourceGroupName)
+
 	return nil
+}
+
+// purgeDeletedKeyVaultsInResourceGroup purges any soft-deleted Key Vaults that
+// belonged to the given resource group. Deleting a resource group only places
+// its vaults into a recoverable (soft-deleted) state, and Azure keeps the
+// globally-unique vault name reserved for the soft-delete retention window (up
+// to 90 days). Because the e2e customer Key Vault name is derived
+// deterministically from the resource group id
+// (cust-kv-${uniqueString(resourceGroup().id, ...)}), a not-yet-purged vault
+// would cause a VaultAlreadyExists collision on a later run that reuses the
+// name. This is best-effort: failures (including a missing
+// Microsoft.KeyVault/locations/deletedVaults/purge/action permission) are
+// logged but never fail cleanup.
+func (tc *perItOrDescribeTestContext) purgeDeletedKeyVaultsInResourceGroup(ctx context.Context, resourceGroupName string) {
+	creds, err := tc.AzureCredential()
+	if err != nil {
+		ginkgo.GinkgoLogr.Error(err, "unable to purge soft-deleted key vaults: failed to get azure credentials", "resourceGroup", resourceGroupName)
+		return
+	}
+	subscriptionID, err := tc.SubscriptionID(ctx)
+	if err != nil {
+		ginkgo.GinkgoLogr.Error(err, "unable to purge soft-deleted key vaults: failed to get subscription id", "resourceGroup", resourceGroupName)
+		return
+	}
+	vaultsClient, err := armkeyvault.NewVaultsClient(subscriptionID, creds, tc.perBinaryInvocationTestContext.getClientFactoryOptions())
+	if err != nil {
+		ginkgo.GinkgoLogr.Error(err, "unable to purge soft-deleted key vaults: failed to build key vault client", "resourceGroup", resourceGroupName)
+		return
+	}
+
+	// Soft-deleted vaults expose their original resource id via VaultID; match
+	// the resource group segment case-insensitively.
+	rgMarker := strings.ToLower("/resourcegroups/" + resourceGroupName + "/")
+
+	pager := vaultsClient.NewListDeletedPager(nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			ginkgo.GinkgoLogr.Error(err, "unable to list soft-deleted key vaults", "resourceGroup", resourceGroupName)
+			return
+		}
+		for _, deleted := range page.Value {
+			if deleted == nil || deleted.Name == nil || deleted.Properties == nil ||
+				deleted.Properties.VaultID == nil || deleted.Properties.Location == nil {
+				continue
+			}
+			if !strings.Contains(strings.ToLower(*deleted.Properties.VaultID), rgMarker) {
+				continue
+			}
+			ginkgo.GinkgoLogr.Info("purging soft-deleted key vault",
+				"keyVault", *deleted.Name, "location", *deleted.Properties.Location, "resourceGroup", resourceGroupName)
+			poller, err := vaultsClient.BeginPurgeDeleted(ctx, *deleted.Name, *deleted.Properties.Location, nil)
+			if err != nil {
+				ginkgo.GinkgoLogr.Error(err, "failed to start purge of soft-deleted key vault; a colliding name may block a later run until it is purged or expires",
+					"keyVault", *deleted.Name, "resourceGroup", resourceGroupName)
+				continue
+			}
+			if _, err := poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: StandardPollInterval}); err != nil {
+				ginkgo.GinkgoLogr.Error(err, "failed to purge soft-deleted key vault; a colliding name may block a later run until it is purged or expires",
+					"keyVault", *deleted.Name, "resourceGroup", resourceGroupName)
+			}
+		}
+	}
 }
 
 func (tc *perItOrDescribeTestContext) collectDebugInfoForResourceGroup(ctx context.Context, resourceGroupName string) error {

--- a/test/util/framework/per_test_framework_test.go
+++ b/test/util/framework/per_test_framework_test.go
@@ -94,6 +94,60 @@ func TestIsResourceGroupNotFoundError(t *testing.T) {
 	}
 }
 
+func TestIsKeyVaultNotFound(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "non-ResponseError",
+			err:  fmt.Errorf("something went wrong"),
+			want: false,
+		},
+		{
+			name: "HTTP 404 status",
+			err:  &azcore.ResponseError{StatusCode: http.StatusNotFound},
+			want: true,
+		},
+		{
+			name: "HTTP 409 Conflict",
+			err:  &azcore.ResponseError{StatusCode: http.StatusConflict, ErrorCode: "VaultAlreadyExists"},
+			want: false,
+		},
+		{
+			name: "HTTP 403 Forbidden",
+			err:  &azcore.ResponseError{StatusCode: http.StatusForbidden},
+			want: false,
+		},
+		{
+			name: "wrapped ResponseError with 404",
+			err:  fmt.Errorf("outer: %w", &azcore.ResponseError{StatusCode: http.StatusNotFound}),
+			want: true,
+		},
+		{
+			name: "wrapped non-ResponseError",
+			err:  fmt.Errorf("outer: %w", fmt.Errorf("inner")),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := isKeyVaultNotFound(tt.err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestIsIgnorableResourceGroupCleanupError(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Jira: [AROSLSRE-1536](https://redhat.atlassian.net/browse/AROSLSRE-1536) · subtask [AROSLSRE-1539](https://redhat.atlassian.net/browse/AROSLSRE-1539)

### What

- **Purge on teardown:** after a resource group is deleted (both cleanup paths in `per_test_framework.go`), purge any soft-deleted Key Vaults that belonged to it so the globally-unique name is immediately reusable. Best-effort and log-only: a missing `Microsoft.KeyVault/locations/deletedVaults/purge/action` permission or a transient error is logged but never fails cleanup, and the purge runs under a bounded 5-minute context so it can never hang teardown.
- **Entropy bump (defense in depth):** widen the resource group random suffix from `rand.String(6)` to `rand.String(12)`, making a colliding suffix highly unlikely across the full retention window.

### Why

The INT e2e gate intermittently fails the `Customer should be able to create an HCP cluster then delete it by deleting the customer resource group` spec with:

```
Conflict / VaultAlreadyExists  vault "cust-kv-<hash>"
```

The e2e customer Key Vault name is derived deterministically from the resource group id (`cust-kv-${uniqueString(resourceGroup().id, ...)}` in `customer-infra.bicep`, with a fixed literal cluster name). Deleting the customer resource group only **soft-deletes** the vault; Azure keeps the globally-unique name reserved for the soft-delete retention window (up to 90 days). The resource group suffix was only `rand.String(6)`, so a suffix repeat within that window reuses the same vault name and provisioning fails with `VaultAlreadyExists`.

### Testing

- Unit: `go build`, `go vet`, `gofmt`, `go mod tidy` + `go work sync` clean on the test module (go1.25).
- Integration/E2E: exercised by the existing INT e2e gate on this PR (the flaky spec is the one this change stabilizes).

### Special notes for your reviewer

- The purge no-ops silently if the e2e teardown identity lacks the KeyVault purge action; the entropy bump alone still prevents realistic collisions. If we want guaranteed purging, the teardown SPN needs that action granted.
- Complementary sweeper-side fix for orphaned vaults (resource group already gone): #6177.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
