### PR TITLE
fix(cleanup-sweeper): purge orphaned soft-deleted Key Vaults

### DIFF
--- a/tooling/cleanup-sweeper/pkg/engine/role_assignments_sweeper.go
+++ b/tooling/cleanup-sweeper/pkg/engine/role_assignments_sweeper.go
@@ -21,12 +21,18 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v3"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 
 	"github.com/Azure/ARO-HCP/tooling/cleanup-sweeper/pkg/engine/runner"
+	kvsteps "github.com/Azure/ARO-HCP/tooling/cleanup-sweeper/pkg/engine/steps/keyvault"
 	roleassignmentsteps "github.com/Azure/ARO-HCP/tooling/cleanup-sweeper/pkg/engine/steps/roleassignments"
 )
 
-const orphanedRoleAssignmentStepRetries = 3
+const (
+	orphanedRoleAssignmentStepRetries = 3
+	orphanedVaultStepRetries          = 3
+)
 
 // RoleAssignmentsSweeperWorkflow builds the shared-leftovers cleanup workflow.
 func RoleAssignmentsSweeperWorkflow(
@@ -49,6 +55,22 @@ func RoleAssignmentsSweeperWorkflow(
 		return nil, fmt.Errorf("failed to create role assignments client: %w", err)
 	}
 
+	vaultsClient, err := armkeyvault.NewVaultsClient(subscriptionID, credential, clientOptions)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create vaults client: %w", err)
+	}
+	rgClient, err := armresources.NewResourceGroupsClient(subscriptionID, credential, clientOptions)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create resource groups client: %w", err)
+	}
+	resourceGroupExists := func(ctx context.Context, resourceGroupName string) (bool, error) {
+		resp, err := rgClient.CheckExistence(ctx, resourceGroupName, nil)
+		if err != nil {
+			return false, err
+		}
+		return resp.Success, nil
+	}
+
 	return &runner.Engine{
 		Parallelism: opts.Parallelism,
 		DryRun:      opts.DryRun,
@@ -61,6 +83,13 @@ func RoleAssignmentsSweeperWorkflow(
 				Name:                        "Delete orphaned role assignments",
 				Retries:                     orphanedRoleAssignmentStepRetries,
 				ContinueOnTargetDeleteError: true,
+			}),
+			kvsteps.MustNewPurgeOrphanedDeletedStep(kvsteps.PurgeOrphanedDeletedStepConfig{
+				VaultsClient:        vaultsClient,
+				ResourceGroupExists: resourceGroupExists,
+				Name:                "Purge orphaned soft-deleted Key Vaults",
+				Retries:             orphanedVaultStepRetries,
+				ContinueOnError:     true,
 			}),
 		},
 	}, nil

--- a/tooling/cleanup-sweeper/pkg/engine/runner/engine.go
+++ b/tooling/cleanup-sweeper/pkg/engine/runner/engine.go
@@ -39,6 +39,11 @@ type Target struct {
 	ID   string
 	Name string
 	Type string
+	// Location is optional metadata some steps need to delete the target
+	// (e.g. purging a soft-deleted Key Vault requires its Azure location).
+	// It is carried on the Target so a step need not stash side state between
+	// Discover and Delete.
+	Location string
 }
 
 // Step defines one ordered cleanup stage in the engine execution model.

--- a/tooling/cleanup-sweeper/pkg/engine/steps/keyvault/purge_deleted.go
+++ b/tooling/cleanup-sweeper/pkg/engine/steps/keyvault/purge_deleted.go
@@ -133,7 +133,10 @@ func (s *purgeDeletedStep) Discover(ctx context.Context) ([]runner.Target, error
 				continue
 			}
 			vaultID := *vault.Properties.VaultID
-			if !strings.Contains(vaultID, fmt.Sprintf("/resourceGroups/%s/", s.cfg.ResourceGroupName)) {
+			// ARM resource group names are case-insensitive, so match casing-insensitively
+			// to avoid skipping vaults whose ID segment casing differs from the configured name.
+			rgSegment := fmt.Sprintf("/resourceGroups/%s/", s.cfg.ResourceGroupName)
+			if !strings.Contains(strings.ToLower(vaultID), strings.ToLower(rgSegment)) {
 				continue
 			}
 			targets = append(targets, runner.Target{

--- a/tooling/cleanup-sweeper/pkg/engine/steps/keyvault/purge_deleted.go
+++ b/tooling/cleanup-sweeper/pkg/engine/steps/keyvault/purge_deleted.go
@@ -156,7 +156,14 @@ func (s *purgeDeletedStep) Delete(ctx context.Context, target runner.Target, wai
 	if !ok {
 		return fmt.Errorf("missing purge metadata for vault %s", target.Name)
 	}
-	poller, err := s.cfg.VaultsClient.BeginPurgeDeleted(ctx, target.Name, location, nil)
+	return purgeDeletedVault(ctx, s.cfg.VaultsClient, target.Name, location, wait)
+}
+
+// purgeDeletedVault purges a single soft-deleted Key Vault. A 404 is treated as
+// success because it means the vault is already gone (concurrently purged or
+// expired out of soft-delete retention).
+func purgeDeletedVault(ctx context.Context, client *armkeyvault.VaultsClient, name, location string, wait bool) error {
+	poller, err := client.BeginPurgeDeleted(ctx, name, location, nil)
 	if err != nil {
 		var respErr *azcore.ResponseError
 		if errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound {

--- a/tooling/cleanup-sweeper/pkg/engine/steps/keyvault/purge_deleted.go
+++ b/tooling/cleanup-sweeper/pkg/engine/steps/keyvault/purge_deleted.go
@@ -50,7 +50,6 @@ type purgeDeletedStep struct {
 	retries         int
 	continueOnError bool
 	verify          runner.VerifyFn
-	targetLocations map[string]string
 }
 
 var _ runner.Step = (*purgeDeletedStep)(nil)
@@ -75,7 +74,6 @@ func NewPurgeDeletedStep(cfg PurgeDeletedStepConfig) (runner.Step, error) {
 		retries:         cfg.Retries,
 		continueOnError: cfg.ContinueOnError,
 		verify:          cfg.Verify,
-		targetLocations: map[string]string{},
 	}, nil
 }
 
@@ -118,8 +116,6 @@ func (s *purgeDeletedStep) Discover(ctx context.Context) ([]runner.Target, error
 	skipReporter := common.NewDiscoverySkipReporter(s.Name())
 	defer skipReporter.Flush(logger)
 
-	s.targetLocations = map[string]string{}
-
 	pager := s.cfg.VaultsClient.NewListDeletedPager(nil)
 	targets := []runner.Target{}
 	for pager.More() {
@@ -141,22 +137,21 @@ func (s *purgeDeletedStep) Discover(ctx context.Context) ([]runner.Target, error
 				continue
 			}
 			targets = append(targets, runner.Target{
-				ID:   vaultID,
-				Name: *vault.Name,
-				Type: DeletedVaultsResourceType,
+				ID:       vaultID,
+				Name:     *vault.Name,
+				Type:     DeletedVaultsResourceType,
+				Location: *vault.Properties.Location,
 			})
-			s.targetLocations[*vault.Name] = *vault.Properties.Location
 		}
 	}
 	return targets, nil
 }
 
 func (s *purgeDeletedStep) Delete(ctx context.Context, target runner.Target, wait bool) error {
-	location, ok := s.targetLocations[target.Name]
-	if !ok {
-		return fmt.Errorf("missing purge metadata for vault %s", target.Name)
+	if target.Location == "" {
+		return fmt.Errorf("missing location for vault %s", target.Name)
 	}
-	return purgeDeletedVault(ctx, s.cfg.VaultsClient, target.Name, location, wait)
+	return purgeDeletedVault(ctx, s.cfg.VaultsClient, target.Name, target.Location, wait)
 }
 
 // purgeDeletedVault purges a single soft-deleted Key Vault. A 404 is treated as

--- a/tooling/cleanup-sweeper/pkg/engine/steps/keyvault/purge_orphaned_deleted.go
+++ b/tooling/cleanup-sweeper/pkg/engine/steps/keyvault/purge_orphaned_deleted.go
@@ -151,7 +151,7 @@ func (s *purgeOrphanedDeletedStep) Discover(ctx context.Context) ([]runner.Targe
 				// If we cannot determine the owning resource group we cannot
 				// prove the vault is orphaned, so skip it rather than risk
 				// purging a vault whose resource group still exists.
-				skipReporter.Record(logger, "unparseable_vault_id", "vault", *vault.Name)
+				skipReporter.Record(logger, "unparseable_vault_id", "vault", *vault.Name, "vaultID", vaultID, "error", err)
 				continue
 			}
 			resourceGroupName := parsed.ResourceGroupName
@@ -174,7 +174,7 @@ func (s *purgeOrphanedDeletedStep) Discover(ctx context.Context) ([]runner.Targe
 					// re-running CheckExistence (avoids amplifying API load / log
 					// noise under transient ARM throttling). A later sweep retries.
 					existingRGs.Insert(rgKey)
-					skipReporter.Record(logger, "resource_group_existence_check_failed", "vault", *vault.Name, "resourceGroup", resourceGroupName)
+					skipReporter.Record(logger, "resource_group_existence_check_failed", "vault", *vault.Name, "resourceGroup", resourceGroupName, "error", err)
 					continue
 				}
 				if exists {

--- a/tooling/cleanup-sweeper/pkg/engine/steps/keyvault/purge_orphaned_deleted.go
+++ b/tooling/cleanup-sweeper/pkg/engine/steps/keyvault/purge_orphaned_deleted.go
@@ -1,0 +1,194 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keyvault
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/go-logr/logr"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault"
+
+	"github.com/Azure/ARO-HCP/tooling/cleanup-sweeper/pkg/engine/runner"
+	"github.com/Azure/ARO-HCP/tooling/cleanup-sweeper/pkg/engine/steps/common"
+)
+
+// ResourceGroupExistsFn reports whether a resource group still exists in the
+// subscription. It is injected so the step can be unit-tested without Azure.
+type ResourceGroupExistsFn func(ctx context.Context, resourceGroupName string) (bool, error)
+
+// PurgeOrphanedDeletedStepConfig configures orphaned deleted Key Vault purge behavior.
+//
+// Unlike PurgeDeletedStep, which is scoped to a single (still-existing) resource
+// group, this step operates subscription-wide and only targets soft-deleted
+// vaults whose backing resource group has already been deleted. Deleting a
+// resource group only soft-deletes its Key Vaults, and Azure keeps the globally
+// unique vault name reserved for the soft-delete retention window (up to 90
+// days). Because names derived deterministically from the resource group id
+// (e.g. the e2e customer vault cust-kv-${uniqueString(resourceGroup().id, ...)})
+// would then collide with VaultAlreadyExists on a later run, these orphans must
+// be purged even though no resource group remains for the rg-ordered workflow to
+// sweep.
+type PurgeOrphanedDeletedStepConfig struct {
+	VaultsClient        *armkeyvault.VaultsClient
+	ResourceGroupExists ResourceGroupExistsFn
+
+	Name            string
+	Retries         int
+	ContinueOnError bool
+	Verify          runner.VerifyFn
+}
+
+type purgeOrphanedDeletedStep struct {
+	cfg             PurgeOrphanedDeletedStepConfig
+	name            string
+	retries         int
+	continueOnError bool
+	verify          runner.VerifyFn
+	targetLocations map[string]string
+}
+
+var _ runner.Step = (*purgeOrphanedDeletedStep)(nil)
+
+// NewPurgeOrphanedDeletedStep builds the orphaned deleted Key Vault purge step.
+func NewPurgeOrphanedDeletedStep(cfg PurgeOrphanedDeletedStepConfig) (runner.Step, error) {
+	if cfg.VaultsClient == nil {
+		return nil, fmt.Errorf("vaults client is required")
+	}
+	if cfg.ResourceGroupExists == nil {
+		return nil, fmt.Errorf("resource group existence check is required")
+	}
+
+	stepName := cfg.Name
+	if strings.TrimSpace(stepName) == "" {
+		stepName = "Purge orphaned soft-deleted Key Vaults"
+	}
+
+	return &purgeOrphanedDeletedStep{
+		cfg:             cfg,
+		name:            stepName,
+		retries:         cfg.Retries,
+		continueOnError: cfg.ContinueOnError,
+		verify:          cfg.Verify,
+		targetLocations: map[string]string{},
+	}, nil
+}
+
+// MustNewPurgeOrphanedDeletedStep builds the step and panics on invalid config.
+func MustNewPurgeOrphanedDeletedStep(cfg PurgeOrphanedDeletedStepConfig) runner.Step {
+	step, err := NewPurgeOrphanedDeletedStep(cfg)
+	if err != nil {
+		panic(err)
+	}
+	return step
+}
+
+func (s *purgeOrphanedDeletedStep) Name() string {
+	return s.name
+}
+
+func (s *purgeOrphanedDeletedStep) RetryLimit() int {
+	if s.retries < runner.DefaultRetries {
+		return runner.DefaultRetries
+	}
+	return s.retries
+}
+
+func (s *purgeOrphanedDeletedStep) ContinueOnError() bool {
+	return s.continueOnError
+}
+
+func (s *purgeOrphanedDeletedStep) Verify(ctx context.Context) error {
+	if s.verify == nil {
+		return nil
+	}
+	return s.verify(ctx)
+}
+
+func (s *purgeOrphanedDeletedStep) Discover(ctx context.Context) ([]runner.Target, error) {
+	logger, err := logr.FromContext(ctx)
+	if err != nil {
+		panic(err)
+	}
+	skipReporter := common.NewDiscoverySkipReporter(s.Name())
+	defer skipReporter.Flush(logger)
+
+	s.targetLocations = map[string]string{}
+
+	// Cache resource-group existence lookups so subscriptions with many
+	// soft-deleted vaults sharing a resource group only pay one API call each.
+	rgExists := map[string]bool{}
+
+	pager := s.cfg.VaultsClient.NewListDeletedPager(nil)
+	targets := []runner.Target{}
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list deleted vaults: %w", err)
+		}
+		for i, vault := range page.Value {
+			if vault == nil || vault.Name == nil || vault.Properties == nil || vault.Properties.Location == nil || vault.Properties.VaultID == nil {
+				skipReporter.Record(logger, "invalid_deleted_vault_payload", "index", i)
+				continue
+			}
+			vaultID := *vault.Properties.VaultID
+			parsed, err := azcorearm.ParseResourceID(vaultID)
+			if err != nil {
+				// If we cannot determine the owning resource group we cannot
+				// prove the vault is orphaned, so skip it rather than risk
+				// purging a vault whose resource group still exists.
+				skipReporter.Record(logger, "unparseable_vault_id", "vault", *vault.Name)
+				continue
+			}
+			resourceGroupName := parsed.ResourceGroupName
+
+			exists, cached := rgExists[strings.ToLower(resourceGroupName)]
+			if !cached {
+				exists, err = s.cfg.ResourceGroupExists(ctx, resourceGroupName)
+				if err != nil {
+					// Be conservative on lookup failure: skip so we never purge a
+					// vault whose resource group might still exist.
+					skipReporter.Record(logger, "resource_group_existence_check_failed", "vault", *vault.Name, "resourceGroup", resourceGroupName)
+					continue
+				}
+				rgExists[strings.ToLower(resourceGroupName)] = exists
+			}
+			if exists {
+				// Resource group still exists; the rg-ordered workflow owns
+				// purging vaults in live resource groups.
+				continue
+			}
+
+			targets = append(targets, runner.Target{
+				ID:   vaultID,
+				Name: *vault.Name,
+				Type: DeletedVaultsResourceType,
+			})
+			s.targetLocations[*vault.Name] = *vault.Properties.Location
+		}
+	}
+	return targets, nil
+}
+
+func (s *purgeOrphanedDeletedStep) Delete(ctx context.Context, target runner.Target, wait bool) error {
+	location, ok := s.targetLocations[target.Name]
+	if !ok {
+		return fmt.Errorf("missing purge metadata for vault %s", target.Name)
+	}
+	return purgeDeletedVault(ctx, s.cfg.VaultsClient, target.Name, location, wait)
+}

--- a/tooling/cleanup-sweeper/pkg/engine/steps/keyvault/purge_orphaned_deleted.go
+++ b/tooling/cleanup-sweeper/pkg/engine/steps/keyvault/purge_orphaned_deleted.go
@@ -157,16 +157,20 @@ func (s *purgeOrphanedDeletedStep) Discover(ctx context.Context) ([]runner.Targe
 			}
 			resourceGroupName := parsed.ResourceGroupName
 
-			exists, cached := rgExists[strings.ToLower(resourceGroupName)]
+			rgKey := strings.ToLower(resourceGroupName)
+			exists, cached := rgExists[rgKey]
 			if !cached {
 				exists, err = s.cfg.ResourceGroupExists(ctx, resourceGroupName)
 				if err != nil {
-					// Be conservative on lookup failure: skip so we never purge a
-					// vault whose resource group might still exist.
+					// Be conservative on lookup failure: cache the resource group
+					// as existing so we skip this and any sibling vaults without
+					// re-running CheckExistence (avoids amplifying API load / log
+					// noise under transient ARM throttling). A later sweep retries.
+					rgExists[rgKey] = true
 					skipReporter.Record(logger, "resource_group_existence_check_failed", "vault", *vault.Name, "resourceGroup", resourceGroupName)
 					continue
 				}
-				rgExists[strings.ToLower(resourceGroupName)] = exists
+				rgExists[rgKey] = exists
 			}
 			if exists {
 				// Resource group still exists; the rg-ordered workflow owns

--- a/tooling/cleanup-sweeper/pkg/engine/steps/keyvault/purge_orphaned_deleted.go
+++ b/tooling/cleanup-sweeper/pkg/engine/steps/keyvault/purge_orphaned_deleted.go
@@ -24,6 +24,8 @@ import (
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	"github.com/Azure/ARO-HCP/tooling/cleanup-sweeper/pkg/engine/runner"
 	"github.com/Azure/ARO-HCP/tooling/cleanup-sweeper/pkg/engine/steps/common"
 )
@@ -60,7 +62,6 @@ type purgeOrphanedDeletedStep struct {
 	retries         int
 	continueOnError bool
 	verify          runner.VerifyFn
-	targetLocations map[string]string
 }
 
 var _ runner.Step = (*purgeOrphanedDeletedStep)(nil)
@@ -85,7 +86,6 @@ func NewPurgeOrphanedDeletedStep(cfg PurgeOrphanedDeletedStepConfig) (runner.Ste
 		retries:         cfg.Retries,
 		continueOnError: cfg.ContinueOnError,
 		verify:          cfg.Verify,
-		targetLocations: map[string]string{},
 	}, nil
 }
 
@@ -128,11 +128,10 @@ func (s *purgeOrphanedDeletedStep) Discover(ctx context.Context) ([]runner.Targe
 	skipReporter := common.NewDiscoverySkipReporter(s.Name())
 	defer skipReporter.Flush(logger)
 
-	s.targetLocations = map[string]string{}
-
 	// Cache resource-group existence lookups so subscriptions with many
 	// soft-deleted vaults sharing a resource group only pay one API call each.
-	rgExists := map[string]bool{}
+	checkedRGs := sets.New[string]()
+	existingRGs := sets.New[string]()
 
 	pager := s.cfg.VaultsClient.NewListDeletedPager(nil)
 	targets := []runner.Target{}
@@ -158,41 +157,42 @@ func (s *purgeOrphanedDeletedStep) Discover(ctx context.Context) ([]runner.Targe
 			resourceGroupName := parsed.ResourceGroupName
 
 			rgKey := strings.ToLower(resourceGroupName)
-			exists, cached := rgExists[rgKey]
-			if !cached {
-				exists, err = s.cfg.ResourceGroupExists(ctx, resourceGroupName)
+			if !checkedRGs.Has(rgKey) {
+				checkedRGs.Insert(rgKey)
+				exists, err := s.cfg.ResourceGroupExists(ctx, resourceGroupName)
 				if err != nil {
-					// Be conservative on lookup failure: cache the resource group
+					// Be conservative on lookup failure: treat the resource group
 					// as existing so we skip this and any sibling vaults without
 					// re-running CheckExistence (avoids amplifying API load / log
 					// noise under transient ARM throttling). A later sweep retries.
-					rgExists[rgKey] = true
+					existingRGs.Insert(rgKey)
 					skipReporter.Record(logger, "resource_group_existence_check_failed", "vault", *vault.Name, "resourceGroup", resourceGroupName)
 					continue
 				}
-				rgExists[rgKey] = exists
+				if exists {
+					existingRGs.Insert(rgKey)
+				}
 			}
-			if exists {
+			if existingRGs.Has(rgKey) {
 				// Resource group still exists; the rg-ordered workflow owns
 				// purging vaults in live resource groups.
 				continue
 			}
 
 			targets = append(targets, runner.Target{
-				ID:   vaultID,
-				Name: *vault.Name,
-				Type: DeletedVaultsResourceType,
+				ID:       vaultID,
+				Name:     *vault.Name,
+				Type:     DeletedVaultsResourceType,
+				Location: *vault.Properties.Location,
 			})
-			s.targetLocations[*vault.Name] = *vault.Properties.Location
 		}
 	}
 	return targets, nil
 }
 
 func (s *purgeOrphanedDeletedStep) Delete(ctx context.Context, target runner.Target, wait bool) error {
-	location, ok := s.targetLocations[target.Name]
-	if !ok {
-		return fmt.Errorf("missing purge metadata for vault %s", target.Name)
+	if target.Location == "" {
+		return fmt.Errorf("missing location for vault %s", target.Name)
 	}
-	return purgeDeletedVault(ctx, s.cfg.VaultsClient, target.Name, location, wait)
+	return purgeDeletedVault(ctx, s.cfg.VaultsClient, target.Name, target.Location, wait)
 }

--- a/tooling/cleanup-sweeper/pkg/engine/steps/keyvault/purge_orphaned_deleted.go
+++ b/tooling/cleanup-sweeper/pkg/engine/steps/keyvault/purge_orphaned_deleted.go
@@ -155,6 +155,14 @@ func (s *purgeOrphanedDeletedStep) Discover(ctx context.Context) ([]runner.Targe
 				continue
 			}
 			resourceGroupName := parsed.ResourceGroupName
+			if resourceGroupName == "" {
+				// A parsed ID without a resource group is not an RG-scoped ARM ID,
+				// so we cannot prove the vault is orphaned. Skip it rather than
+				// probing an empty resource group name (which would fail and cache
+				// unrelated malformed IDs under one empty-string key).
+				skipReporter.Record(logger, "vault_id_missing_resource_group", "vault", *vault.Name)
+				continue
+			}
 
 			rgKey := strings.ToLower(resourceGroupName)
 			if !checkedRGs.Has(rgKey) {

--- a/tooling/cleanup-sweeper/pkg/engine/steps/keyvault/purge_orphaned_deleted.go
+++ b/tooling/cleanup-sweeper/pkg/engine/steps/keyvault/purge_orphaned_deleted.go
@@ -21,10 +21,10 @@ import (
 
 	"github.com/go-logr/logr"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault"
-
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/Azure/ARO-HCP/tooling/cleanup-sweeper/pkg/engine/runner"
 	"github.com/Azure/ARO-HCP/tooling/cleanup-sweeper/pkg/engine/steps/common"

--- a/tooling/cleanup-sweeper/pkg/engine/steps/keyvault/purge_orphaned_deleted_test.go
+++ b/tooling/cleanup-sweeper/pkg/engine/steps/keyvault/purge_orphaned_deleted_test.go
@@ -1,0 +1,123 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keyvault
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault"
+)
+
+func noopResourceGroupExists(_ context.Context, _ string) (bool, error) { return false, nil }
+
+func TestPurgeOrphanedDeletedStepConfig_ExecutionOptions(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name         string
+		cfg          PurgeOrphanedDeletedStepConfig
+		wantStepName string
+	}{
+		{
+			name: "step options projection",
+			cfg: PurgeOrphanedDeletedStepConfig{
+				VaultsClient:        &armkeyvault.VaultsClient{},
+				ResourceGroupExists: noopResourceGroupExists,
+				Name:                "custom-name",
+				Retries:             4,
+				ContinueOnError:     true,
+			},
+			wantStepName: "custom-name",
+		},
+		{
+			name: "default step name",
+			cfg: PurgeOrphanedDeletedStepConfig{
+				VaultsClient:        &armkeyvault.VaultsClient{},
+				ResourceGroupExists: noopResourceGroupExists,
+			},
+			wantStepName: "Purge orphaned soft-deleted Key Vaults",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			step, err := NewPurgeOrphanedDeletedStep(tc.cfg)
+			if err != nil {
+				t.Fatalf("expected constructor to succeed, got error: %v", err)
+			}
+			if got := step.Name(); got != tc.wantStepName {
+				t.Fatalf("expected step name %q, got %q", tc.wantStepName, got)
+			}
+			expectedRetryLimit := tc.cfg.Retries
+			if expectedRetryLimit < 1 {
+				expectedRetryLimit = 1
+			}
+			if got := step.RetryLimit(); got != expectedRetryLimit {
+				t.Fatalf("expected retry limit %d, got %d", expectedRetryLimit, got)
+			}
+			if got := step.ContinueOnError(); got != tc.cfg.ContinueOnError {
+				t.Fatalf("expected continueOnError %t, got %t", tc.cfg.ContinueOnError, got)
+			}
+		})
+	}
+}
+
+func TestNewPurgeOrphanedDeletedStep_ReturnsErrorWhenInvalid(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		cfg  PurgeOrphanedDeletedStepConfig
+	}{
+		{
+			name: "missing vaults client",
+			cfg: PurgeOrphanedDeletedStepConfig{
+				ResourceGroupExists: noopResourceGroupExists,
+			},
+		},
+		{
+			name: "missing resource group existence check",
+			cfg: PurgeOrphanedDeletedStepConfig{
+				VaultsClient: &armkeyvault.VaultsClient{},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if _, err := NewPurgeOrphanedDeletedStep(tc.cfg); err == nil {
+				t.Fatalf("expected validation error for %s", tc.name)
+			}
+		})
+	}
+}
+
+func TestMustNewPurgeOrphanedDeletedStep_PanicsWhenInvalid(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if recover() == nil {
+			t.Fatalf("expected panic for invalid config")
+		}
+	}()
+	_ = MustNewPurgeOrphanedDeletedStep(PurgeOrphanedDeletedStepConfig{
+		VaultsClient: nil,
+	})
+}

--- a/tooling/cleanup-sweeper/pkg/engine/workflows_test.go
+++ b/tooling/cleanup-sweeper/pkg/engine/workflows_test.go
@@ -37,7 +37,7 @@ func TestWorkflowBuilders(t *testing.T) {
 		assertions func(t *testing.T, workflow interface{}, err error)
 	}{
 		{
-			name: "role assignments workflow builds single step",
+			name: "role assignments workflow builds shared-leftovers steps",
 			execute: func(_ *testing.T) (interface{}, error) {
 				return RoleAssignmentsSweeperWorkflow(
 					context.Background(),
@@ -59,8 +59,8 @@ func TestWorkflowBuilders(t *testing.T) {
 				if !ok || builtWorkflow == nil {
 					t.Fatalf("expected *runner.Engine workflow")
 				}
-				if len(builtWorkflow.Steps) != 1 {
-					t.Fatalf("expected one step, got %d", len(builtWorkflow.Steps))
+				if len(builtWorkflow.Steps) != 2 {
+					t.Fatalf("expected two steps, got %d", len(builtWorkflow.Steps))
 				}
 				if builtWorkflow.Parallelism != 7 || !builtWorkflow.DryRun || !builtWorkflow.Wait {
 					t.Fatalf("unexpected workflow options: %+v", builtWorkflow)


### PR DESCRIPTION
Jira: [AROSLSRE-1536](https://redhat.atlassian.net/browse/AROSLSRE-1536) · subtask [AROSLSRE-1538](https://redhat.atlassian.net/browse/AROSLSRE-1538)

### What

Add a subscription-wide **"Purge orphaned soft-deleted Key Vaults"** step to the `cleanup-sweeper` `shared-leftovers` workflow:

- Lists all soft-deleted vaults in the subscription and purges only those whose backing resource group **no longer exists** (checked via `ResourceGroupsClient.CheckExistence`, cached per resource group). Vaults in live resource groups are left to the `rg-ordered` workflow.
- Conservative: if the resource group existence check or the vault-id parse fails, the vault is **skipped** (never purged), so a vault whose resource group may still exist is never removed. Existence-lookup errors cache the resource group as existing to avoid repeated `CheckExistence` under ARM throttling.
- Best-effort (`ContinueOnError`) and 404-tolerant, sharing the same `purgeDeletedVault` helper as the existing step.
- Unit tests cover the new step's construction/validation; the shared-leftovers workflow builder test now expects both steps.

### Why

The INT e2e gate intermittently fails cluster provisioning with `Conflict / VaultAlreadyExists` for `cust-kv-<hash>`. The e2e customer Key Vault name is derived deterministically from the resource group id (`cust-kv-${uniqueString(resourceGroup().id, ...)}`). Deleting the customer resource group only **soft-deletes** the vault; Azure keeps the globally-unique name reserved for up to 90 days, so a later run that reuses a colliding resource-group suffix collides on the vault name.

The `cleanup-sweeper` already purges soft-deleted Key Vaults, but **only inside the `rg-ordered` workflow while the backing resource group still exists** — `ResourceGroupOrderedCleanupWorkflow` returns early when the resource group is already gone (`resourcegroup_ordered_cleanup.go` 404 short-circuit). So a vault whose resource group has already been deleted (the exact flake case) is an **orphan** that nothing ever purges.

### Testing

- Unit: new `purge_orphaned_deleted_test.go`; `go build ./...`, `go vet ./...`, `go test ./pkg/engine/...` all pass (cleanup-sweeper module, go1.25).

### Special notes for your reviewer

- Complements the e2e-side purge-on-teardown in #6176: the test fix purges immediately after each run, and the sweeper reaps any orphans that slip through (aborted runs, missing purge permission on the test identity, pre-existing leftovers).
- The new step is wired into the existing `RoleAssignmentsSweeperWorkflow` builder (kept the function name to avoid scope creep); it now returns 2 steps.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
