### PR TITLE
feat(dev-ci): assign createdAt RG tag policy to e2e subs (AROSLSRE-1543)

### DIFF
--- a/dev-infrastructure/configurations/createdat-rg-tag-policy.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/createdat-rg-tag-policy.tmpl.bicepparam
@@ -1,0 +1,3 @@
+using '../templates/createdat-rg-tag-policy.bicep'
+
+param e2eSubscriptionIds = empty('{{ $sep := "" }}{{ range $subscription := .ci.dev.e2eSubscriptions }}{{ $sep }}{{ $subscription.id }}{{ $sep = "," }}{{ end }}') ? [] : split('{{ $sep := "" }}{{ range $subscription := .ci.dev.e2eSubscriptions }}{{ $sep }}{{ $subscription.id }}{{ $sep = "," }}{{ end }}', ',')

--- a/dev-infrastructure/dev-ci/e2e-subscription-rbac-grants/pipeline.yaml
+++ b/dev-infrastructure/dev-ci/e2e-subscription-rbac-grants/pipeline.yaml
@@ -29,6 +29,15 @@ resourceGroups:
     template: ../../templates/e2e-subscription-rbac-assignments.bicep
     parameters: ../../configurations/e2e-subscription-rbac-assignments.tmpl.bicepparam
     deploymentLevel: Subscription
+  # Assigns the createdAt resource-group tag Azure Policy to the e2e/customer
+  # subscriptions. Writing policy definitions/assignments needs
+  # Microsoft.Authorization/policy*/write, which the unattended Contributor bot
+  # lacks, so this belongs in the privileged tree alongside the RBAC grants.
+  - name: createdat-rg-tag-policy
+    action: ARM
+    template: ../../templates/createdat-rg-tag-policy.bicep
+    parameters: ../../configurations/createdat-rg-tag-policy.tmpl.bicepparam
+    deploymentLevel: Subscription
 - name: ci-bots
   resourceGroup: '{{ .global.rg }}'
   subscription: '{{ .global.subscription.key }}'

--- a/dev-infrastructure/templates/createdat-rg-tag-policy-subscription.bicep
+++ b/dev-infrastructure/templates/createdat-rg-tag-policy-subscription.bicep
@@ -1,0 +1,62 @@
+targetScope = 'subscription'
+
+// Creates the subscription-scoped Azure Policy definition + assignment that
+// appends tags.createdAt on new resource groups. cleanup-sweeper rg-ordered
+// discovery treats the createdAt tag as required for any delete rule (see
+// docs/ci/cleanup.md), so the e2e test subscriptions need this policy for the
+// sweeper to consider their resource groups. This is the declarative
+// equivalent of tooling/cleanup-sweeper/scripts/create-createdat-policy-assignment.sh;
+// the rule body below is kept in sync with that script's
+// rg-createdat-policy-rule.json, and both use the same resource names so they
+// converge on the same definition/assignment.
+
+@description('Policy definition resource name (matches create-createdat-policy-assignment.sh default)')
+param policyDefinitionName string = 'aro-rg-createdat-tag'
+
+@description('Policy assignment resource name (matches create-createdat-policy-assignment.sh default)')
+param policyAssignmentName string = 'aro-createdat-rg'
+
+@description('Display name for the policy definition and assignment')
+param displayName string = 'ARO-CreatedAt Tag'
+
+resource createdAtPolicyDefinition 'Microsoft.Authorization/policyDefinitions@2021-06-01' = {
+  name: policyDefinitionName
+  properties: {
+    policyType: 'Custom'
+    mode: 'All'
+    displayName: displayName
+    description: 'Append tags.createdAt on resource groups when missing (append + utcNow). mode=All for rg-ordered cleanup-sweeper discovery.'
+    policyRule: {
+      if: {
+        allOf: [
+          {
+            field: 'type'
+            equals: 'Microsoft.Resources/subscriptions/resourceGroups'
+          }
+          {
+            field: 'tags[\'createdAt\']'
+            exists: 'false'
+          }
+        ]
+      }
+      then: {
+        effect: 'append'
+        details: [
+          {
+            field: 'tags[\'createdAt\']'
+            value: '[utcNow()]'
+          }
+        ]
+      }
+    }
+  }
+}
+
+resource createdAtPolicyAssignment 'Microsoft.Authorization/policyAssignments@2022-06-01' = {
+  name: policyAssignmentName
+  properties: {
+    displayName: displayName
+    policyDefinitionId: createdAtPolicyDefinition.id
+    enforcementMode: 'Default'
+  }
+}

--- a/dev-infrastructure/templates/createdat-rg-tag-policy.bicep
+++ b/dev-infrastructure/templates/createdat-rg-tag-policy.bicep
@@ -1,0 +1,18 @@
+targetScope = 'subscription'
+
+// Fans the createdAt resource-group tag policy out to every e2e test
+// (hosted-cluster) subscription. Runs from the dev-ci global subscription
+// (Owner via the privileged entrypoint) and deploys the policy definition +
+// assignment into each target subscription via a subscription-scoped module.
+// Mirrors the e2e-subscription-rbac-assignments.bicep cross-subscription
+// fan-out pattern.
+
+@description('e2e test (hosted-cluster) subscription IDs that should receive the createdAt resource-group tag policy')
+param e2eSubscriptionIds array = []
+
+module createdAtPolicy './createdat-rg-tag-policy-subscription.bicep' = [
+  for (e2eSubscriptionId, index) in e2eSubscriptionIds: {
+    name: 'createdat-rg-tag-policy-${index}'
+    scope: subscription(e2eSubscriptionId)
+  }
+]

--- a/docs/ci/cleanup.md
+++ b/docs/ci/cleanup.md
@@ -96,6 +96,8 @@ Azure does not set that tag by default. Subscriptions where `rg-ordered` should 
 
 For the DEV e2e/customer subscriptions (`.ci.dev.e2eSubscriptions`), this policy is assigned declaratively by the dev-ci pipeline: `dev-infrastructure/templates/createdat-rg-tag-policy.bicep` fans the subscription-scoped definition + assignment out to each e2e subscription, wired as the `createdat-rg-tag-policy` step in `dev-infrastructure/dev-ci/e2e-subscription-rbac-grants/pipeline.yaml`. That step lives in the privileged dev-ci tree because writing policy definitions/assignments needs `Microsoft.Authorization/policy*/write`, which the unattended Contributor bot lacks; run it with `make dev-ci-privileged-local-run` as an OWNERS member. For one-off or non-dev subscriptions, `tooling/cleanup-sweeper/scripts/create-createdat-policy-assignment.sh` creates or updates the same definition and assignment imperatively.
 
+> **Keep the rule body in sync.** The policy rule is expressed in two places: `tooling/cleanup-sweeper/scripts/rg-createdat-policy-rule.json` (used by the imperative script) and, mirrored inline, in `dev-infrastructure/templates/createdat-rg-tag-policy-subscription.bicep` (used by the declarative dev-ci path). Both use the same definition/assignment resource names so they converge on one policy, but the rule body itself is duplicated: any change to the `if`/`then`/`[utcNow()]` logic must be applied to both files.
+
 This path is intentionally best-effort. If one run leaves something behind, the next run can pick it up.
 
 ## Why They Behave Differently

--- a/docs/ci/cleanup.md
+++ b/docs/ci/cleanup.md
@@ -92,7 +92,9 @@ Today that periodic layer includes:
 
 For `cleanup-sweeper` `rg-ordered`, candidate resource groups are chosen using `tooling/cleanup-sweeper/resourcegroups.policy.yaml`. Discovery treats the `createdAt` tag (RFC3339 timestamp on the resource group) as required for any `action: delete` rule: groups without a parseable tag are not candidates.
 
-Azure does not set that tag by default. Subscriptions where `rg-ordered` should run must apply an Azure Policy (or equivalent) that stamps `tags['createdAt']` when a resource group is created, using `[utcNow()]` in the policy rule. Use `tooling/cleanup-sweeper/scripts/create-createdat-policy-assignment.sh` to create or update the subscription-scoped definition and assignment. The rule body lives in `tooling/cleanup-sweeper/scripts/rg-createdat-policy-rule.json`.
+Azure does not set that tag by default. Subscriptions where `rg-ordered` should run must apply an Azure Policy (or equivalent) that stamps `tags['createdAt']` when a resource group is created, using `[utcNow()]` in the policy rule. The rule body lives in `tooling/cleanup-sweeper/scripts/rg-createdat-policy-rule.json`.
+
+For the DEV e2e/customer subscriptions (`.ci.dev.e2eSubscriptions`), this policy is assigned declaratively by the dev-ci pipeline: `dev-infrastructure/templates/createdat-rg-tag-policy.bicep` fans the subscription-scoped definition + assignment out to each e2e subscription, wired as the `createdat-rg-tag-policy` step in `dev-infrastructure/dev-ci/e2e-subscription-rbac-grants/pipeline.yaml`. That step lives in the privileged dev-ci tree because writing policy definitions/assignments needs `Microsoft.Authorization/policy*/write`, which the unattended Contributor bot lacks; run it with `make dev-ci-privileged-local-run` as an OWNERS member. For one-off or non-dev subscriptions, `tooling/cleanup-sweeper/scripts/create-createdat-policy-assignment.sh` creates or updates the same definition and assignment imperatively.
 
 This path is intentionally best-effort. If one run leaves something behind, the next run can pick it up.
 


### PR DESCRIPTION
Jira: [AROSLSRE-1543](https://redhat.atlassian.net/browse/AROSLSRE-1543) (parent story [AROSLSRE-1542](https://redhat.atlassian.net/browse/AROSLSRE-1542))

### What

Assigns the `createdAt` resource-group tag Azure Policy to the DEV e2e/customer subscriptions (`.ci.dev.e2eSubscriptions`) declaratively via dev-ci:

- `dev-infrastructure/templates/createdat-rg-tag-policy.bicep` fans a subscription-scoped policy definition + assignment out to each e2e subscription, mirroring `e2e-subscription-rbac-assignments.bicep`.
- The per-subscription child template inlines the policy rule (append `tags['createdAt']` = `[utcNow()]` when missing). It intentionally does not `loadJsonContent` across the tree into `tooling/`; the rule is kept textually in sync with the imperative `create-createdat-policy-assignment.sh` / `rg-createdat-policy-rule.json`, and both use the same policy definition/assignment names (`aro-rg-createdat-tag` / `aro-createdat-rg`) so they converge on one definition.
- Wired as the `createdat-rg-tag-policy` step in the privileged `e2e-subscription-rbac-grants` pipeline.
- `docs/ci/cleanup.md` updated to document the new dev-ci path.

### Why

`cleanup-sweeper` `rg-ordered` discovery treats the `createdAt` tag as **required** for any `action: delete` rule (`tooling/cleanup-sweeper/pkg/policy/discovery.go`). Azure never stamps that tag by default, and the e2e/customer subscriptions had no policy applying it. As a result those subscriptions were effectively invisible to `rg-ordered`, letting orphaned resource groups and soft-deleted Key Vaults accumulate (root cause behind the `VaultAlreadyExists` INT e2e flakes and the leaked-RG backlog).

The policy step lives in the **privileged** dev-ci tree because writing policy definitions/assignments needs `Microsoft.Authorization/policy*/write`, which the unattended Contributor bot deliberately lacks.

### Testing

- `bicep build` + `bicep lint` + `bicep format` clean on both new templates.
- `templatize pipeline validate` parses the modified pipeline schema successfully (the pre-existing range-loop bicepparam field-access warning is shared with the sibling `e2e-subscription-rbac-assignments.tmpl.bicepparam` and is not introduced here).
- Applied on demand via `make dev-ci-privileged-local-run` as an OWNERS member.

### Special notes for your reviewer

- This is the DEV slice (`.ci.dev.e2eSubscriptions`: EA, EA2, Dev-02, Dev-03). INT/STG/PROD e2e subscriptions are ARM-integrated and tracked as follow-ups under the parent story ([AROSLSRE-1544](https://redhat.atlassian.net/browse/AROSLSRE-1544)/[AROSLSRE-1545](https://redhat.atlassian.net/browse/AROSLSRE-1545)/[AROSLSRE-1546](https://redhat.atlassian.net/browse/AROSLSRE-1546)).
- The bicepparam intentionally mirrors the existing RBAC-assignments range-loop idiom so the two stay consistent.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
