### PR TITLE
refactor(mgmt): make Swift VNet mandatory for management clusters

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -573,12 +573,6 @@
         "clusterOutboundIPAddressIPTags": {
           "$ref": "#/definitions/keyColonValueCSV"
         },
-        "enableSwiftV2Vnet": {
-          "type": "boolean"
-        },
-        "enableSwiftV2Nodepools": {
-          "type": "boolean"
-        },
         "upgradeSettings": {
           "$ref": "#/definitions/aksUpgradeSettings"
         }

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -683,8 +683,6 @@ defaults:
         zones: ""
         zoneRedundantMode: "Auto"
       clusterOutboundIPAddressIPTags: ""
-      enableSwiftV2Vnet: true
-      enableSwiftV2Nodepools: true
     prometheus:
       namespace: prometheus
       namespaceNetworkPolicyGroup: monitoring
@@ -1339,8 +1337,6 @@ clouds:
             vmSize: 'Standard_D2s_v3'
           etcd:
             softDelete: false
-          enableSwiftV2Vnet: false
-          enableSwiftV2Nodepools: false
         nsp:
           accessMode: 'Learning'
         prometheus:
@@ -1466,8 +1462,6 @@ clouds:
                 vmSize: 'Standard_D16s_v3'
                 secondaryNicCount: 7
                 osDiskSizeGB: 128
-              enableSwiftV2Vnet: true
-              enableSwiftV2Nodepools: true
           # Geneva
           geneva:
             logs:
@@ -1604,8 +1598,6 @@ clouds:
               infraAgentPool:
                 osDiskSizeGB: 64
                 vmSize: 'Standard_D4s_v3'
-              enableSwiftV2Vnet: true
-              enableSwiftV2Nodepools: true
             jaeger:
               deploy: false
             applyKubeletFixes: false
@@ -1728,8 +1720,6 @@ clouds:
               infraAgentPool:
                 vmSize: Standard_D8ds_v6
                 osDiskSizeGB: 64
-              enableSwiftV2Nodepools: true
-              enableSwiftV2Vnet: true
             jaeger:
               deploy: false
             applyKubeletFixes: false
@@ -1829,8 +1819,6 @@ clouds:
               infraAgentPool:
                 vmSize: Standard_D8ds_v6
                 osDiskSizeGB: 64
-              enableSwiftV2Nodepools: true
-              enableSwiftV2Vnet: true
             jaeger:
               deploy: false
             applyKubeletFixes: false

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -603,8 +603,6 @@ maestro:
 mgmt:
   aks:
     clusterOutboundIPAddressIPTags: ""
-    enableSwiftV2Nodepools: true
-    enableSwiftV2Vnet: true
     etcd:
       name: ah-ci00-me-j7654321-1
       private: true

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -603,8 +603,6 @@ maestro:
 mgmt:
   aks:
     clusterOutboundIPAddressIPTags: ""
-    enableSwiftV2Nodepools: true
-    enableSwiftV2Vnet: true
     etcd:
       name: ah-ci01-me-j7654321-1
       private: true

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -603,8 +603,6 @@ maestro:
 mgmt:
   aks:
     clusterOutboundIPAddressIPTags: ""
-    enableSwiftV2Nodepools: true
-    enableSwiftV2Vnet: true
     etcd:
       name: ah-cspr-me-usw3-1
       private: true

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -603,8 +603,6 @@ maestro:
 mgmt:
   aks:
     clusterOutboundIPAddressIPTags: ""
-    enableSwiftV2Nodepools: false
-    enableSwiftV2Vnet: false
     etcd:
       name: ah-dev-me-usw3-1
       private: true

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -603,8 +603,6 @@ maestro:
 mgmt:
   aks:
     clusterOutboundIPAddressIPTags: ""
-    enableSwiftV2Nodepools: false
-    enableSwiftV2Vnet: false
     etcd:
       name: ah-perf-me-usw3ptest-1
       private: true

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -603,8 +603,6 @@ maestro:
 mgmt:
   aks:
     clusterOutboundIPAddressIPTags: ""
-    enableSwiftV2Nodepools: true
-    enableSwiftV2Vnet: true
     etcd:
       name: ah-pers-me-usw3test-1
       private: true

--- a/dev-infrastructure/configurations/mgmt-cluster.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/mgmt-cluster.tmpl.bicepparam
@@ -37,8 +37,6 @@ param infraZoneRedundantMode = '{{ .mgmt.aks.infraAgentPool.zoneRedundantMode }}
 param aksClusterOutboundIPAddressIPTags = '{{ .mgmt.aks.clusterOutboundIPAddressIPTags }}'
 param aksNetworkDataplane = '{{ .mgmt.aks.networkDataplane }}'
 param aksNetworkPolicy = '{{ .mgmt.aks.networkDataplane }}'
-param aksEnableSwiftVnet = {{ .mgmt.aks.enableSwiftV2Vnet }}
-param aksEnableSwiftNodepools = {{ .mgmt.aks.enableSwiftV2Nodepools }}
 param aksUpgradeSettingsMaxSurge = '{{ .mgmt.aks.upgradeSettings.maxSurge }}'
 param aksUpgradeSettingsMaxUnavailable = '{{ .mgmt.aks.upgradeSettings.maxUnavailable }}'
 

--- a/dev-infrastructure/configurations/swift-vnet-permissions.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/swift-vnet-permissions.tmpl.bicepparam
@@ -1,4 +1,3 @@
 using '../templates/swift-vnet-permissions.bicep'
 
 param deploymentMsiId = '__deploymentMsiId__'
-param enableSwift = {{ .mgmt.aks.enableSwiftV2Vnet }}

--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -303,11 +303,8 @@ resourceGroups:
       maximumRetryCount: 3
       durationBetweenRetries: 1m
   # Build the MC
-  # The swift-vnet-permissions step runs unconditionally so the EV2 step graph is
-  # stable, but the Swift VNet RBAC grant inside it is gated at the Bicep layer via
-  # the enableSwift bicepparam (mgmt.aks.enableSwiftV2Vnet). A pipeline-level Go
-  # template guard would not work here: EV2 manifest generation renders pipeline
-  # config values as placeholders, so the guard would always evaluate truthy.
+  # Swift VNet is mandatory for management clusters, so this step grants the Swift
+  # VNet RBAC unconditionally.
   - name: swift-vnet-permissions
     action: ARM
     template: templates/swift-vnet-permissions.bicep
@@ -325,8 +322,7 @@ resourceGroups:
   # Create/tag the Swift VNet. The tag stampcreatorserviceinfo=true must be written by the
   # Swift-registered globalMSI, so this step launches a container group assigned globalMSI and
   # runs the create/tag AS globalMSI from inside it (scripts/swift-vnet.sh). Create, wait, log
-  # and cleanup all happen in this single Shell step, so there is no cross-step async race. The
-  # script is a no-op when ENABLE_SWIFT is false, keeping the EV2 step graph stable.
+  # and cleanup all happen in this single Shell step, so there is no cross-step async race.
   - name: swift-vnet
     action: Shell
     command: ./swift-vnet.sh
@@ -337,8 +333,6 @@ resourceGroups:
         step: output
         name: globalMSIId
     variables:
-    - name: ENABLE_SWIFT
-      configRef: mgmt.aks.enableSwiftV2Vnet
     - name: VNET_NAME
       value: aks-net
     - name: VNET_ADDRESS_PREFIX

--- a/dev-infrastructure/scripts/swift-vnet.sh
+++ b/dev-infrastructure/scripts/swift-vnet.sh
@@ -18,17 +18,11 @@ set -euo pipefail
 # inside it.
 #
 # Inputs via environment variables:
-#   ENABLE_SWIFT          - Whether Swift VNet creation/tagging should run ("true"/"false")
 #   VNET_NAME             - Name of the Swift VNet to create/tag
 #   VNET_ADDRESS_PREFIX   - Address space used when the VNet must be created
 #   RESOURCE_GROUP        - Resource group that holds the VNet and the container group
 #   SUBSCRIPTION_ID       - Subscription that holds the resource group
 #   DEPLOYMENT_MSI_ID     - Resource ID of the Swift-registered managed identity (globalMSI)
-
-if [ "${ENABLE_SWIFT:-false}" != "true" ]; then
-  echo "Swift VNet is disabled; skipping."
-  exit 0
-fi
 
 CONTAINER_IMAGE="mcr.microsoft.com/azure-cli:2.53.1"
 CONTAINER_GROUP_NAME="swift-vnet-${VNET_NAME}"

--- a/dev-infrastructure/templates/mgmt-cluster.bicep
+++ b/dev-infrastructure/templates/mgmt-cluster.bicep
@@ -131,12 +131,6 @@ param aksEtcdKVEnableSoftDelete bool = true
 @description('IPTags to be set on the cluster outbound IP address in the format of ipTagType:tag,ipTagType:tag')
 param aksClusterOutboundIPAddressIPTags string = ''
 
-@description('Enable Swift V2 for the AKS cluster VNET')
-param aksEnableSwiftVnet bool
-
-@description('Enable Swift V2 for the AKS cluster nodepools')
-param aksEnableSwiftNodepools bool
-
 @description('Maximum surge for AKS node pool upgrades')
 param aksUpgradeSettingsMaxSurge string
 
@@ -338,7 +332,7 @@ module vnetCreation '../modules/network/vnet.bicep' = {
     location: location
     vnetName: vnetName
     vnetAddressPrefix: vnetAddressPrefix
-    enableSwift: aksEnableSwiftVnet
+    enableSwift: true
   }
 }
 
@@ -410,7 +404,7 @@ module mgmtCluster '../modules/aks-cluster-base.bicep' = {
     networkDataplane: aksNetworkDataplane
     networkPolicy: aksNetworkPolicy
     deploymentMsiId: globalMSIId
-    enableSwiftV2Nodepools: aksEnableSwiftNodepools
+    enableSwiftV2Nodepools: true
     upgradeSettingsMaxSurge: aksUpgradeSettingsMaxSurge
     upgradeSettingsMaxUnavailable: aksUpgradeSettingsMaxUnavailable
     owningTeamTagValue: owningTeamTagValue

--- a/dev-infrastructure/templates/swift-vnet-permissions.bicep
+++ b/dev-infrastructure/templates/swift-vnet-permissions.bicep
@@ -1,10 +1,7 @@
 @description('The resource ID of the user-assigned managed identity that manages the Swift VNet')
 param deploymentMsiId string
 
-@description('Whether Swift VNet is enabled. Gates the Swift VNet RBAC role assignments so they are only created when Swift is in use.')
-param enableSwift bool
-
-module swiftVnetRbac '../modules/network/vnet-rbac.bicep' = if (enableSwift) {
+module swiftVnetRbac '../modules/network/vnet-rbac.bicep' = {
   name: 'swift-vnet-rbac'
   params: {
     deploymentMsiId: deploymentMsiId


### PR DESCRIPTION
[AROSLSRE-1548](https://redhat.atlassian.net/browse/AROSLSRE-1548)

### What

Makes Swift V2 VNet mandatory for **management clusters** and removes the
non-Swift code path for them.

- Removes `mgmt.aks.enableSwiftV2Vnet` / `mgmt.aks.enableSwiftV2Nodepools` from
  `config/config.yaml` (default, the dev override, and all env overlays) and from
  `config/config.schema.json`; re-materialized `config/rendered/`.
- Hardcodes `enableSwift`/`enableSwiftV2Nodepools = true` at the
  `mgmt-cluster.bicep` module call sites and removes the now-unused
  `aksEnableSwiftVnet` / `aksEnableSwiftNodepools` params + their tmpl.bicepparam
  values.
- `swift-vnet-permissions.bicep` now grants the Swift VNet RBAC unconditionally
  (dropped the `enableSwift` param + gate).
- Drops the `ENABLE_SWIFT` gate from the `mgmt-pipeline` `swift-vnet` step and
  `scripts/swift-vnet.sh` so the VNet create/tag always runs.

Service and opstool clusters are **not** management clusters and keep passing
`enableSwift`/`enableSwiftV2Nodepools = false`; the shared
`aks-cluster-base` / `network/vnet` / `aks/pool` modules retain the toggle for them.

### Why

Management clusters already run Swift V2 in int/stg/prod — only the dev cloud
overrode the flags to `false`. Keeping a mgmt-level Swift toggle means carrying a
config knob that must never be flipped in production and a non-Swift code path
that is never exercised for management clusters. Removing it makes Swift the
single, enforced management-cluster networking mode and shrinks the config
surface. The dev-cloud blocker (SwiftV2 mgmt-node bring-up) has been cleared with
the owner, so dev/CSPR can move onto Swift.

### Testing

- `bicep build` of `mgmt-cluster.bicep` and `swift-vnet-permissions.bicep` compiles
  clean (pre-existing BCP334 warning in `aks/pool.bicep` is unrelated).
- `bash -n scripts/swift-vnet.sh` passes.
- `cd config && make materialize` re-renders with the flags removed; confirmed no
  `enableSwiftV2Vnet`/`enableSwiftV2Nodepools` config keys remain anywhere in the
  repo, and only management-cluster call sites are affected.

No automated test covers the mgmt bootstrap pipeline directly; validated via bicep
build + materialize + config-schema validation.

### Special notes for your reviewer

The shared `network/vnet.bicep` and `aks-cluster-base.bicep` modules intentionally
keep their `enableSwift`/`enableSwiftV2Nodepools` params — service and opstool
clusters still deploy non-Swift. Only the management-cluster path is now
Swift-only.
