### PR TITLE
feat(observability): deploy PrometheusMetricsAbsentPerCluster dead-man's-switch (AROSLSRE-1551)

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedMsftPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedMsftPrometheusAlertingRules.bicep
@@ -696,6 +696,52 @@ resource msftKubernetesStorage 'Microsoft.AlertsManagement/prometheusRuleGroups@
   }
 }
 
+resource msftPrometheusWipRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'msft-prometheus-wip-rules'
+  location: location
+  properties: {
+    interval: 'PT1M'
+    rules: [
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'PrometheusMetricsAbsentPerCluster'
+        enabled: true
+        labels: {
+          severity: 'critical'
+        }
+        annotations: {
+          correlationId: 'PrometheusMetricsAbsentPerCluster/{{ $labels.cluster }}'
+          description: '''Prometheus on cluster {{ $labels.cluster }} has not reported any up metrics in the last 10 minutes, but was reporting within the last 7 days.
+This indicates the Prometheus agent on this specific cluster is dead or its remote write pipeline is broken.
+Check the PrometheusAgent pod status and remote write configuration on the affected cluster.
+'''
+          info: '''Prometheus on cluster {{ $labels.cluster }} has not reported any up metrics in the last 10 minutes, but was reporting within the last 7 days.
+This indicates the Prometheus agent on this specific cluster is dead or its remote write pipeline is broken.
+Check the PrometheusAgent pod status and remote write configuration on the affected cluster.
+'''
+          runbook_url: 'https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md'
+          summary: 'Prometheus metrics absent for cluster {{ $labels.cluster }}.'
+          title: 'Prometheus metrics absent for cluster {{ $labels.cluster }}.'
+        }
+        expression: 'count by (cluster) (count_over_time(up{job="prometheus/prometheus",namespace="prometheus"}[1w])) unless count by (cluster) (count_over_time(up{job="prometheus/prometheus",namespace="prometheus"}[10m]))'
+        for: 'PT10M'
+        severity: severityCeiling > 0 ? max(2, severityCeiling) : 2
+      }
+    ]
+    scopes: [
+      azureMonitoring
+    ]
+  }
+}
+
 resource msftMise 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
   name: 'msft-mise'
   location: location

--- a/observability/alerts-msft-services.yaml
+++ b/observability/alerts-msft-services.yaml
@@ -57,6 +57,9 @@ prometheusRules:
   - groupName: mise
     alerts:
     - MiseEnvoyScrapeDown
+  - groupName: prometheus-wip-rules
+    alerts:
+    - PrometheusMetricsAbsentPerCluster
   labelsToExtract:
   - persistentvolumeclaim
   - persistentvolume


### PR DESCRIPTION
## Why

When the `prom-agent` PrometheusAgent on `int-uksouth-mgmt-1` OOM-crashlooped, the cluster stopped shipping **all** metrics for ~37h and **no alert paged**. Investigation showed the dead-man's-switch we would want — `PrometheusMetricsAbsentPerCluster` — **already exists and is unit-tested** in `observability/alerts/prometheus-prometheusRule.yaml` (group `prometheus-wip-rules`):

```
count by (cluster) (count_over_time(up{job="prometheus/prometheus",namespace="prometheus"}[7d]))
  unless count by (cluster) (count_over_time(up{...}[10m]))
```

It fires (severity `critical`, `for: 10m`) precisely when a cluster reported within the last 7 days but has gone silent for 10 minutes — exactly the INT scenario. But the group was **never added to `includedAlertsByGroup`** in `alerts-msft-services.yaml`, which is the explicit allowlist controlling what the generator emits into `generatedMsftPrometheusAlertingRules.bicep`. So it was excluded from the deployed Azure Monitor / IcM rules and never paged.

## What

- Add `PrometheusMetricsAbsentPerCluster` (group `prometheus-wip-rules`) to `includedAlertsByGroup` in `observability/alerts-msft-services.yaml`.
- Regenerate `dev-infrastructure/modules/metrics/rules/generatedMsftPrometheusAlertingRules.bicep` (`make -C observability alerts`). The alert now emits as Azure group `msft-prometheus-wip-rules` with IcM actions, `for: PT10M`, Sev2, runbook `docs/alerts/Prometheus.md`.

Scope is intentionally limited to the single total-absence dead-man's-switch. The remaining `prometheus-wip-rules` alerts (uptime SLO, pending/failed rate, etc.) stay WIP and can be graduated separately.

Jira: [AROSLSRE-1551](https://redhat.atlassian.net/browse/AROSLSRE-1551) (sub-task of [AROSLSRE-1549](https://redhat.atlassian.net/browse/AROSLSRE-1549), INT Prometheus resilience).