### PR TITLE
fix(observability): harden INT mgmt Prometheus against single-agent OOM blackout

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -30,8 +30,9 @@ clouds:
           #  - requests.memory 2Gi: keeps all 8 pods schedulable across 4 nodes
           #    (2 x 2Gi + ~2Gi infra baseline = ~6Gi/node of ~11.8Gi).
           mgmt:
-            infraAgentPool:
-              minCount: 2
+            aks:
+              infraAgentPool:
+                minCount: 2
             prometheus:
               prometheusSpec:
                 shards: 4

--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -16,22 +16,30 @@ clouds:
           mise:
             audit:
               connectSocket: true
-          # Prometheus mgmt-cluster survival tuning (AROSLSRE-1553/1554).
-          # INT mgmt has only 2x ~11.8Gi infra nodes and a single prom-agent
-          # OOM-crashloop blacked out the cluster for ~37h. shards=4 halves the
-          # per-shard series/WAL so a remote-write stall replay stays bounded;
-          # the 4Gi limit caps a runaway pod so it OOMs itself instead of taking
-          # the node down; the 1.5Gi request keeps all 8 pods (4 shards x 2
-          # replicas) schedulable on the 2 nodes (4 x 1.5Gi = 6Gi/node).
+          # Prometheus mgmt-cluster survival tuning (AROSLSRE-1553/1554/1555).
+          # A single prom-agent OOM-crashloop blacked out int-uksouth-mgmt-1 for
+          # ~37h. Mitigations, all scoped to the INT mgmt clusters:
+          #  - infraAgentPool.minCount 1 -> 2: raise the guaranteed infra floor
+          #    from 2 to 4 nodes (poolCount 2 x minCount 2) so the 8 prom pods
+          #    (4 shards x 2 replicas) sit ~2/node with room to breathe; the
+          #    autoscaler ceiling (maxCount 3/pool) is unchanged.
+          #  - shards 2 -> 4: halves per-shard series/WAL so a remote-write stall
+          #    replay after a restart stays bounded.
+          #  - limits.memory 5Gi: caps a runaway pod so it OOM-kills itself
+          #    instead of taking the ~11.8Gi node down.
+          #  - requests.memory 2Gi: keeps all 8 pods schedulable across 4 nodes
+          #    (2 x 2Gi + ~2Gi infra baseline = ~6Gi/node of ~11.8Gi).
           mgmt:
+            infraAgentPool:
+              minCount: 2
             prometheus:
               prometheusSpec:
                 shards: 4
                 resources:
                   requests:
-                    memory: 1.5Gi
+                    memory: 2Gi
                   limits:
-                    memory: 4Gi
+                    memory: 5Gi
       stg:
         # this is the MSFT STAGE environment
         defaults:

--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -16,6 +16,22 @@ clouds:
           mise:
             audit:
               connectSocket: true
+          # Prometheus mgmt-cluster survival tuning (AROSLSRE-1553/1554).
+          # INT mgmt has only 2x ~11.8Gi infra nodes and a single prom-agent
+          # OOM-crashloop blacked out the cluster for ~37h. shards=4 halves the
+          # per-shard series/WAL so a remote-write stall replay stays bounded;
+          # the 4Gi limit caps a runaway pod so it OOMs itself instead of taking
+          # the node down; the 1.5Gi request keeps all 8 pods (4 shards x 2
+          # replicas) schedulable on the 2 nodes (4 x 1.5Gi = 6Gi/node).
+          mgmt:
+            prometheus:
+              prometheusSpec:
+                shards: 4
+                resources:
+                  requests:
+                    memory: 1.5Gi
+                  limits:
+                    memory: 4Gi
       stg:
         # this is the MSFT STAGE environment
         defaults:

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arohcp_monitor.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arohcp_monitor.yaml
@@ -68630,6 +68630,7 @@ spec:
     maxSkew: 1
     topologyKey: kubernetes.io/hostname
     whenUnsatisfiable: ScheduleAnyway
+    additionalLabelSelectors: OnShard
   walCompression: true
   externalLabels:
     cluster: 'dev-westus3-mgmt-1'

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_arohcp_monitor.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_arohcp_monitor.yaml
@@ -68511,6 +68511,7 @@ spec:
     maxSkew: 1
     topologyKey: kubernetes.io/hostname
     whenUnsatisfiable: ScheduleAnyway
+    additionalLabelSelectors: OnShard
   walCompression: true
   externalLabels:
     cluster: 'dev-westus3-svc-1'

--- a/observability/prometheus/deploy/templates/prometheus.yaml
+++ b/observability/prometheus/deploy/templates/prometheus.yaml
@@ -97,6 +97,13 @@ spec:
     maxSkew: 1
     topologyKey: kubernetes.io/hostname
     whenUnsatisfiable: ScheduleAnyway
+    {{- /*
+      Spread the replicas of each individual shard across nodes so losing one
+      node cannot take down both replicas of a shard. OnShard makes the operator
+      append the per-shard label to the selector above. Soft (ScheduleAnyway) so
+      it never blocks scheduling when nodes are scarce.
+    */}}
+    additionalLabelSelectors: OnShard
   walCompression: true
   externalLabels:
     cluster: '{{ .Values.prometheusSpec.externalLabels.cluster }}'

--- a/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_mgmt_resources.yaml
+++ b/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_mgmt_resources.yaml
@@ -68636,6 +68636,7 @@ spec:
     maxSkew: 1
     topologyKey: kubernetes.io/hostname
     whenUnsatisfiable: ScheduleAnyway
+    additionalLabelSelectors: OnShard
   walCompression: true
   externalLabels:
     cluster: 'dev-westus3-mgmt-1'

--- a/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_mgmt_resources_unset.yaml
+++ b/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_mgmt_resources_unset.yaml
@@ -68630,6 +68630,7 @@ spec:
     maxSkew: 1
     topologyKey: kubernetes.io/hostname
     whenUnsatisfiable: ScheduleAnyway
+    additionalLabelSelectors: OnShard
   walCompression: true
   externalLabels:
     cluster: 'dev-westus3-mgmt-1'

--- a/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_svc_resources.yaml
+++ b/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_svc_resources.yaml
@@ -68517,6 +68517,7 @@ spec:
     maxSkew: 1
     topologyKey: kubernetes.io/hostname
     whenUnsatisfiable: ScheduleAnyway
+    additionalLabelSelectors: OnShard
   walCompression: true
   externalLabels:
     cluster: 'dev-westus3-svc-1'

--- a/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_svc_resources_unset.yaml
+++ b/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_svc_resources_unset.yaml
@@ -68511,6 +68511,7 @@ spec:
     maxSkew: 1
     topologyKey: kubernetes.io/hostname
     whenUnsatisfiable: ScheduleAnyway
+    additionalLabelSelectors: OnShard
   walCompression: true
   externalLabels:
     cluster: 'dev-westus3-svc-1'


### PR DESCRIPTION
## What

Durable resilience mitigations for the INT management-cluster Prometheus agents, following the ~37h metrics blackout on `int-uksouth-mgmt-1` ([AROSLSRE-1530](https://redhat.atlassian.net/browse/AROSLSRE-1530)). A single `prom-agent` OOM-crashloop took down all monitoring for that cluster; nothing alerted because the per-cluster dead-man's-switch was never deployed (fixed separately in #6186).

This PR addresses the *cause* (unbounded single-agent memory + coarse sharding + a scheduling gap + a too-tight 2-node infra pool), scoped to the INT mgmt clusters, plus one small chart-wide HA fix.

## Changes

**INT mgmt (`config.msft.clouds-overlay.yaml`, `clouds.public.environments.int`):**
- `infraAgentPool.minCount: 1 -> 2` — raises the guaranteed infra floor from **2 to 4 nodes** (poolCount 2 × minCount 2). Autoscaler ceiling (maxCount 3/pool) unchanged. **Cost: +2 × Standard_D4ds_v5 ≈ +\$330/mo for INT.**
- `shards: 2 -> 4` — halves per-shard series/WAL, so a remote-write stall replay after a restart stays bounded instead of ballooning past node memory.
- `resources.limits.memory: 4Gi -> 5Gi` — caps a runaway pod so it OOM-kills *itself* rather than starving the infra node.
- `resources.requests.memory: 1.5Gi -> 2Gi` — keeps all 8 pods (4 shards × 2 replicas) comfortably schedulable across the 4 nodes.

**Chart (all envs), `observability/prometheus/deploy/templates/prometheus.yaml`:**
- Add `additionalLabelSelectors: OnShard` to the `kubernetes.io/hostname` topologySpreadConstraint so the two replicas of *each shard* spread across nodes. Soft (`ScheduleAnyway`) so it can never block scheduling. Fixes an observed bug on INT where **both** replicas of shard-1 landed on the same infra node, defeating replica HA.

## Feasibility (live INT data)

- Before: 2 infra nodes (`Standard_D4ds_v5`, ~11.8Gi allocatable each); agent memory effectively unbounded; 3 of 4 prom pods pinned to one node.
- After: 4 nodes × ~11.8Gi = ~47Gi allocatable. 8 prom pods over 4 nodes ≈ 2/node. Requests: 2 × 2Gi + ~2Gi infra baseline ≈ 6Gi/node (~50%), headroom retained. OnShard guarantees each shard's replicas land on different nodes.

## Scope / safety

- Memory + node-floor tuning is INT-mgmt-only via the overlay; svc/stg/prod configs unchanged.
- The chart anti-affinity change is a **soft** constraint (strict HA improvement, never blocks scheduling); it regenerates the committed helm fixtures only.
- `make -C observability verify`, `make verify-schema`, and `make -C config materialize` pass.

## Rollout

INT mgmt ships via `sdp-pipelines` EV2 (mgmt-pipeline). The `minCount` bump *adds* nodes (non-disruptive); no SKU change (which would be node-pool recreation).

Tracking: AROSLSRE-1552, AROSLSRE-1553, AROSLSRE-1554, [AROSLSRE-1555](https://redhat.atlassian.net/browse/AROSLSRE-1555) (Story AROSLSRE-1549, INFRA epic [AROSLSRE-798](https://redhat.atlassian.net/browse/AROSLSRE-798)).