### PR TITLE
Add DataMap IDs to subscriptionMetadata

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -969,6 +969,12 @@
         "airsRegisteredUserPrincipalId": {
           "type": "string"
         },
+        "dataMapAgentPrincipalId": {
+          "type": "string"
+        },
+        "dataMapAgentBlueShiftPrincipalId": {
+          "type": "string"
+        },
         "certificateDomains": {
           "type": "array",
           "items": {


### PR DESCRIPTION


[<!-- Link to Jira issue -->](https://redhat.atlassian.net/browse/ARO-27752)

@rachelvweber @stevekuznetsov

### What

Add dataMapId fields to subscription metadata.

### Why

    Required for GDPR pipeline onboarding.
    Reference: https://msazure.visualstudio.com/AzureRedHatOpenShift/_git/sdp-pipelines/pullrequest/16510595?path=/hcp/config.schema.json

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [X] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [X] Summary explains the "Why" behind the change
- [X] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [X] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [X] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [X] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
