### PR TITLE
feat: add controller to identify and clean up cosmos records without resourceID

### DIFF
--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -542,6 +542,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		unionKubeApplierInformers,
 	)
 	deleteOrphanedCosmosResourcesController := mismatchcontrollers.NewDeleteOrphanedCosmosResourcesController(b.options.ResourcesDBClient, b.options.KubeApplierDBClients, subscriptionLister, managementClusterLister)
+	missingResourceIDController := mismatchcontrollers.NewMissingResourceIDController(b.options.ResourcesDBClient)
 	backfillClusterUIDController := controllerutils.NewClusterWatchingController(
 		"BackfillClusterUID", b.options.ResourcesDBClient, backendInformers, unionKubeApplierInformers, 60*time.Minute,
 		mismatchcontrollers.NewBackfillClusterUIDController(b.clock, b.options.ResourcesDBClient, b.options.BillingDBClient, clusterLister))
@@ -853,6 +854,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 				go clusterServiceMatchingClusterController.Run(ctx, 20)
 				go alwaysSuccessClusterValidationController.Run(ctx, 20)
 				go deleteOrphanedCosmosResourcesController.Run(ctx, 20)
+				go missingResourceIDController.Run(ctx, 20)
 				go backfillClusterUIDController.Run(ctx, 20)
 				go orphanedBillingCleanupController.Run(ctx, 20)
 				go createBillingDocController.Run(ctx, 20)

--- a/backend/pkg/controllers/mismatchcontrollers/missing_resource_id.go
+++ b/backend/pkg/controllers/mismatchcontrollers/missing_resource_id.go
@@ -1,0 +1,192 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mismatchcontrollers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+const MissingResourceIDControllerName = "MissingResourceID"
+
+type missingResourceIDController struct {
+	name string
+
+	resourcesDBClient database.ResourcesDBClient
+
+	queue workqueue.TypedRateLimitingInterface[string]
+}
+
+func NewMissingResourceIDController(
+	resourcesDBClient database.ResourcesDBClient,
+) controllerutils.Controller {
+	c := &missingResourceIDController{
+		name:              MissingResourceIDControllerName,
+		resourcesDBClient: resourcesDBClient,
+		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Name: MissingResourceIDControllerName,
+			},
+		),
+	}
+
+	return c
+}
+
+// shouldDelete returns true if a document without a resourceID should be deleted.
+func shouldDelete(doc *database.TypedDocument) bool {
+	resourceType := strings.ToLower(doc.ResourceType)
+	if len(resourceType) == 0 {
+		return false
+	}
+
+	switch {
+	case strings.Contains(resourceType, "controller"):
+		return true
+	case strings.Contains(resourceType, "operation"):
+		return true
+	}
+
+	return false
+}
+
+func (c *missingResourceIDController) sweep(ctx context.Context) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	allDocs, err := database.ListAll[database.TypedDocument](ctx, 100, c.resourcesDBClient.ListMissingResourceID)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("listing documents missing resourceID: %w", err))
+	}
+
+	logger.Info("found documents missing resourceID", "count", len(allDocs))
+
+	errs := []error{}
+	for _, doc := range allDocs {
+		docLogger := logger.WithValues(
+			utils.LogValues{}.
+				AddCosmosResourceID(doc.CosmosResourceID)...)
+		docLogger = docLogger.WithValues(
+			"cosmosID", doc.ID,
+			"partitionKey", doc.PartitionKey,
+			"resourceType", doc.ResourceType,
+		)
+
+		docLogger.Info("document missing resourceID",
+			"snapshotType", "cosmos-missing-resource-id",
+			"content", doc,
+		)
+
+		if shouldDelete(doc) {
+			docLogger.Info("deleting document missing resourceID")
+			if err := deleteByItemID(ctx, c.resourcesDBClient, doc.PartitionKey, doc.ID); err != nil {
+				docLogger.Error(err, "unable to delete document missing resourceID")
+				errs = append(errs, utils.TrackError(fmt.Errorf("unable to delete %v: %w", doc.ID, err)))
+			}
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+func deleteByItemID(ctx context.Context, resourcesDBClient database.ResourcesDBClient, partitionKey, cosmosID string) error {
+	subscriptionResourceID, err := arm.ToSubscriptionResourceID(partitionKey)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("parsing partition key %q as subscription ID: %w", partitionKey, err))
+	}
+	crud, err := resourcesDBClient.UntypedCRUD(*subscriptionResourceID)
+	if err != nil {
+		return utils.TrackError(err)
+	}
+	return crud.DeleteByCosmosID(ctx, partitionKey, cosmosID)
+}
+
+func (c *missingResourceIDController) QueueForInformers(resyncDuration time.Duration, notifiers ...controllerutils.Notifier) error {
+	panic("not implemented")
+}
+
+func (c *missingResourceIDController) SyncOnce(ctx context.Context, keyObj any) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	syncErr := c.sweep(ctx)
+	if syncErr != nil {
+		logger.Error(syncErr, "sweep for documents missing resourceID had errors")
+	}
+
+	return nil // never requeue
+}
+
+func (c *missingResourceIDController) queueSweep(ctx context.Context) {
+	c.queue.Add("default")
+}
+
+func (c *missingResourceIDController) Run(ctx context.Context, threadiness int) {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	ctx = utils.ContextWithControllerName(ctx, c.name)
+	logger := utils.LoggerFromContext(ctx)
+	logger = logger.WithValues(utils.LogValues{}.AddControllerName(c.name)...)
+	ctx = utils.ContextWithLogger(ctx, logger)
+	logger.Info("Starting")
+
+	for i := 0; i < threadiness; i++ {
+		go wait.UntilWithContext(ctx, c.runWorker, time.Second)
+	}
+
+	go wait.JitterUntilWithContext(ctx, c.queueSweep, 60*time.Minute, 0.1, true)
+
+	logger.Info("Started workers")
+
+	<-ctx.Done()
+	logger.Info("Shutting down")
+}
+
+func (c *missingResourceIDController) runWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
+	}
+}
+
+func (c *missingResourceIDController) processNextWorkItem(ctx context.Context) bool {
+	ref, shutdown := c.queue.Get()
+	if shutdown {
+		return false
+	}
+	defer c.queue.Done(ref)
+
+	controllerutils.ReconcileTotal.WithLabelValues(c.name).Inc()
+	err := c.SyncOnce(ctx, ref)
+	if err == nil {
+		c.queue.Forget(ref)
+		return true
+	}
+
+	utilruntime.HandleErrorWithContext(ctx, err, "Error syncing; requeuing for later retry", "objectReference", ref)
+	c.queue.AddRateLimited(ref)
+
+	return true
+}

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -21,6 +21,8 @@ import (
 	"net/http"
 	"strings"
 
+	"k8s.io/utils/ptr"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
@@ -132,6 +134,11 @@ type ResourcesDBClient interface {
 
 	ServiceProviderClusters(subscriptionID, resourceGroupName, clusterName string) ResourceCRUD[api.ServiceProviderCluster, *api.ServiceProviderCluster]
 
+	// ListMissingResourceID returns documents in the Resources container that lack a resourceID field.
+	// These are typically old records created before the resourceID field was introduced.
+	// The returned iterator yields raw TypedDocuments without CosmosToInternal conversion.
+	ListMissingResourceID(ctx context.Context, options *DBClientListResourceDocsOptions) (DBClientIterator[TypedDocument], error)
+
 	// ResourcesGlobalListers returns interfaces for listing ARM resource documents across all partitions
 	// (Resources container only), intended for feeding SharedInformers.
 	ResourcesGlobalListers() ResourcesGlobalListers
@@ -202,6 +209,28 @@ func (d *resourcesCosmosDBClient) ServiceProviderNodePools(subscriptionID, resou
 
 func (d *resourcesCosmosDBClient) UntypedCRUD(parentResourceID azcorearm.ResourceID) (UntypedResourceCRUD, error) {
 	return NewUntypedCRUD(d.resources, parentResourceID), nil
+}
+
+func (d *resourcesCosmosDBClient) ListMissingResourceID(ctx context.Context, options *DBClientListResourceDocsOptions) (DBClientIterator[TypedDocument], error) {
+	query := "SELECT * FROM c WHERE (NOT IS_DEFINED(c.resourceID) OR IS_NULL(c.resourceID))"
+
+	queryOptions := azcosmos.QueryOptions{
+		PageSizeHint: -1,
+	}
+	if options != nil {
+		if options.PageSizeHint != nil {
+			queryOptions.PageSizeHint = max(*options.PageSizeHint, -1)
+		}
+		queryOptions.ContinuationToken = options.ContinuationToken
+	}
+
+	partitionKey := azcosmos.NewPartitionKey()
+	pager := d.resources.NewQueryItemsPager(query, partitionKey, &queryOptions)
+
+	if options != nil && ptr.Deref(options.PageSizeHint, -1) > 0 {
+		return newQueryTypedDocumentSinglePageIterator(pager), nil
+	}
+	return newQueryTypedDocumentIterator(pager), nil
 }
 
 func (d *resourcesCosmosDBClient) ResourcesGlobalListers() ResourcesGlobalListers {

--- a/internal/database/iterators.go
+++ b/internal/database/iterators.go
@@ -158,6 +158,57 @@ func (iter *queryBillingIterator) GetError() error {
 	return iter.err
 }
 
+type queryTypedDocumentIterator struct {
+	pager             *runtime.Pager[azcosmos.QueryItemsResponse]
+	singlePage        bool
+	continuationToken string
+	err               error
+}
+
+func newQueryTypedDocumentIterator(pager *runtime.Pager[azcosmos.QueryItemsResponse]) DBClientIterator[TypedDocument] {
+	return &queryTypedDocumentIterator{pager: pager}
+}
+
+func newQueryTypedDocumentSinglePageIterator(pager *runtime.Pager[azcosmos.QueryItemsResponse]) DBClientIterator[TypedDocument] {
+	return &queryTypedDocumentIterator{pager: pager, singlePage: true}
+}
+
+func (iter *queryTypedDocumentIterator) Items(ctx context.Context) DBClientIteratorItem[TypedDocument] {
+	return func(yield func(string, *TypedDocument) bool) {
+		for iter.pager.More() {
+			response, err := iter.pager.NextPage(ctx)
+			if err != nil {
+				iter.err = err
+				return
+			}
+			if iter.singlePage && response.ContinuationToken != nil {
+				iter.continuationToken = *response.ContinuationToken
+			}
+			for _, itemJSON := range response.Items {
+				var doc TypedDocument
+				if err := json.Unmarshal(itemJSON, &doc); err != nil {
+					iter.err = err
+					return
+				}
+				if !yield(doc.ID, &doc) {
+					return
+				}
+			}
+			if iter.singlePage {
+				return
+			}
+		}
+	}
+}
+
+func (iter *queryTypedDocumentIterator) GetContinuationToken() string {
+	return iter.continuationToken
+}
+
+func (iter *queryTypedDocumentIterator) GetError() error {
+	return iter.err
+}
+
 // ListAll accumulates all pages from a DB GlobalLister into a slice.
 // It calls listFn with a page size hint of pageSize and follows continuation tokens
 // until all items have been collected.

--- a/internal/databasetesting/mock_resources_db_client.go
+++ b/internal/databasetesting/mock_resources_db_client.go
@@ -97,6 +97,27 @@ func (m *MockResourcesDBClient) Subscriptions() database.ResourceCRUD[arm.Subscr
 	return newMockSubscriptionCRUD(m)
 }
 
+// ListMissingResourceID returns documents that lack a resourceID field.
+func (m *MockResourcesDBClient) ListMissingResourceID(ctx context.Context, options *database.DBClientListResourceDocsOptions) (database.DBClientIterator[database.TypedDocument], error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	var ids []string
+	var items []*database.TypedDocument
+	for _, data := range m.documents {
+		var typedDoc database.TypedDocument
+		if err := json.Unmarshal(data, &typedDoc); err != nil {
+			continue
+		}
+		if typedDoc.ResourceID != nil {
+			continue
+		}
+		ids = append(ids, typedDoc.ID)
+		items = append(items, &typedDoc)
+	}
+	return newMockIterator(ids, items), nil
+}
+
 // ResourcesGlobalListers returns interfaces for listing all resources of a particular
 // type across all partitions. If a custom ResourcesGlobalListers was set via SetResourcesGlobalListers,
 // that is returned instead.


### PR DESCRIPTION
Old records in Cosmos may lack a resourceID field. This adds a MissingResourceID controller that runs every hour, lists all such records via a new ListMissingResourceID method on ResourcesDBClient, dumps each to the log, and deletes items whose resourceType contains "controller" or "operation".
