### PR TITLE
feat: add oncall shift management skill for AI-assisted operations

### DIFF
--- a/tooling/triage/skills/create-jira-issue/SKILL.md
+++ b/tooling/triage/skills/create-jira-issue/SKILL.md
@@ -1,0 +1,559 @@
+---
+name: create-jira-issue
+description: Create a well-formed JIRA issue in the AROSLSRE project with correct fields, labels, components, sprint assignment, and JIT documentation when applicable. Follows ARO HCP JIRA governance conventions.
+---
+
+## Personal Overrides
+
+If a `SKILL.local.md` file exists in this skill's directory, read it before
+proceeding. It contains personal instructions that augment (never contradict)
+the directions below. These files are gitignored and persist across upstream
+skill updates.
+
+# Create JIRA Issue
+
+## What I Do
+
+Create JIRA issues in the **AROSLSRE** (ARO HCP Service Lifecycle) project with
+correctly populated fields: issue type, priority, component(s), labels, sprint
+assignment, sizing, and a structured description. Follows the official
+[ARO HCP JIRA governance conventions][governance-doc] for hierarchy, workflows,
+definitions of ready/done, and field requirements.
+
+When Just-In-Time (JIT) cluster access is involved, I guide the user through
+documenting the JIT request per team conventions.
+
+[governance-doc]: https://docs.google.com/document/d/1jLwHt00p5EyW4hYIUlDleQGh0K96UfZrmcp-BJ3BmaM
+
+## When to Use Me
+
+- CI or Prow job failures that need tracking
+- e2e-parallel or e2e test failures
+- EV2 rollout or promotion failures
+- Oncall investigation items
+- Any interrupt-driven bug or task for the Service Lifecycle team
+- Documenting JIT access requests and outcomes
+- Creating Epics, Stories, Bugs, or Spikes per team process
+
+## JIRA Hierarchy
+
+The ARO HCP space uses a layered hierarchy. This skill primarily creates
+**Level 2** items (Task, Story, Bug, Spike) and occasionally **Level 3** (Epic).
+Higher levels (Feature/Initiative, Outcome) are managed by PMs/EMs.
+
+```
+Outcome (L5)  →  Feature/Initiative (L4)  →  Epic (L3)  →  Story/Task/Bug/Spike (L2)
+   Planning spaces (HCMSTRAT, OCPSTRAT)       Execution spaces (AROSLSRE, ARO, HOSTEDCP)
+```
+
+## Parameters
+
+The agent should collect (or infer from context) the following before creating
+an issue:
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `summary` | yes | One-line summary of the issue |
+| `description` | yes | Detailed description (see description template below) |
+| `failure_source` | yes | What failed — guides component and label selection |
+| `issue_type` | no | Task (default for investigations), Bug (confirmed defects), Story (user-facing work), Spike (time-boxed research) |
+| `priority` | no | Blocker / Critical / Major / Normal / Minor (default: Normal) |
+| `size` | no | Story points: 1, 2, 3, 5, 8, 13, 20 (see sizing guide) |
+| `parent_epic` | no | Parent Epic key if this task belongs to an Epic |
+| `jit_involved` | no | Whether JIT cluster access was requested or used |
+| `additional_labels` | no | Extra labels beyond auto-applied ones |
+
+## Directions
+
+### Step 1 — Choose the Right Issue Type
+
+Select based on the nature of the work. The governance doc defines these precisely:
+
+| Issue Type | When to Use | ID |
+|------------|-------------|-----|
+| **Task** | Finite piece of work. Oncall investigations, post-meeting follow-ups, action items. Most common for oncall. | 10014 |
+| **Bug** | A defect — error, flaw, or fault causing incorrect/unexpected results. Requires triage before development. | 10016 |
+| **Story** | A short description of a capability from the perspective of the person who desires it. User-facing work. | 10009 |
+| **Spike** | Time-boxed research to help the team make better decisions. Use for investigatory work with unclear scope. | 10009 |
+| **Epic** | Extra-large work that won't fit in a single sprint. Includes acceptance criteria from end-user perspective. | 10000 |
+| **Sub-task** | Child of an existing Task, Story, or Bug. | 10015 |
+
+> **Note**: Spikes use the Story issue type with a `spike` label to distinguish
+> them. They should have a clear time-box defined in the description.
+
+### Step 2 — Determine the Current Sprint
+
+Query for the current active sprint so the issue lands in the right iteration:
+
+```
+Tool: mcp_jira_searchJiraIssuesUsingJql
+cloudId: 2b9e35e3-6bd3-4cec-b838-f4249ee02432
+jql: project = AROSLSRE AND sprint in openSprints() ORDER BY created DESC
+maxResults: 1
+fields: ["customfield_10020"]
+```
+
+Extract the sprint **integer ID** from `customfield_10020` in the first result.
+The value is an array of sprint objects — use the `id` field from the active one.
+
+> **Gotcha**: The sprint field accepts a **bare integer**, NOT an object.
+> Passing `{"id": 67024}` will fail with _"Number value expected as the Sprint
+> id."_ — pass `67024` directly.
+
+### Step 3 — Select Component(s)
+
+**Always include `ARO-HCP` as a component** (per governance doc: "Please use the
+'ARO-HCP' component on your ARO JIRAs"). Then add a team/area-specific component
+based on the failure source.
+
+Add `aro-hcp-oncall` (84116) as a secondary component for any oncall-driven
+investigation.
+
+| Failure Source | Primary Component | ID |
+|---------------|-------------------|----|
+| e2e-parallel, e2e test failures | aro-hcp-e2e | 83786 |
+| Prow CI, PR pipeline, CI stability | aro-hcp-ci | 32027 |
+| EV2 rollout, stage/prod deploy, promotion | aro-hcp-releases | 83787 |
+| AKS cluster, nodepool, istio, infra | aro-hcp-infra | 84112 |
+| Alerts, dashboards, logging, metrics | aro-hcp-observability | 84111 |
+| CVEs, dependency bumps, security | aro-hcp-security | 84113 |
+| Tooling, image updater, CLI tools | aro-hcp-tooling | 84114 |
+| Docs, runbooks, onboarding | aro-hcp-docs | 84115 |
+
+**Team board routing** (determines which board the ticket appears on):
+
+| Team/Board | Component to Add |
+|------------|-----------------|
+| Service Lifecycle Dashboard | `aro-hcp-service-lifecycle` |
+| ARO HCP - First Party | `aro-hcp-1p` |
+| ARO HCP - Cluster Service East | `aro-hcp-clusters-service-east` |
+| ARO HCP - Cluster Service West | `aro-hcp-clusters-service-west` |
+| ARO HCP - QE | `aro-hcp-qe` |
+| ARO HCP - CI Tiger Team | `aro-hcp-ci` |
+
+Format components as an array of objects: `[{"id": "83786"}, {"id": "84116"}]`
+
+### Step 4 — Select Labels
+
+**Always apply these automatically based on context:**
+
+| Condition | Label | Notes |
+|-----------|-------|-------|
+| CI failure, e2e failure, promotion failure, rollout failure, oncall investigation | `oncall` | Lowercase. Do NOT use `on-call`. |
+| JIT cluster access requested or used | `JIT` | Uppercase. |
+| e2e test specific | `e2e` | In addition to `oncall` |
+| No QE testing needed | `no-qe` | QE assumes every ticket needs testing unless this label is present |
+| Suitable for new team members | `good-first-issue` | For straightforward onboarding-friendly tasks |
+| Microsoft backlog item | `team-msft-backlog` | For items tracked by Microsoft |
+
+Other labels to consider (apply when relevant):
+- `maestro` — Maestro-specific issues
+- `aro-hcp-ci` — CI pipeline issues
+- `ARO-HCP` — generic project label
+- `aro-hcp-service-lifecycle-team` — team label
+- `spike` — for Spike (time-boxed research) issues
+
+### Step 5 — Set Priority
+
+Priority maps to MoSCoW prioritization per the governance doc:
+
+| Impact | Priority | ID | MoSCoW |
+|--------|----------|-----|--------|
+| Service down, blocking rollout | Blocker | 10000 | Must Have |
+| Major feature broken, data loss risk | Critical | 10001 | Should Have |
+| Significant degradation | Major | 10002 | Could Have |
+| Standard work, intermittent failures | Normal | 10003 | Could Have |
+| Cosmetic, low impact | Minor | 10004 | Won't Have |
+
+### Step 6 — Size the Issue (Story Points)
+
+If the user provides sizing context, set `customfield_10028` (Story Points).
+Use the team's sizing guide:
+
+| Size | Uncertainty | Effort | Complexity | Scope |
+|------|-------------|--------|------------|-------|
+| 1 | None | Very low | Very low | Single component |
+| 2 | Very low | Very low/low | Very low/low | 1-2 components |
+| 3 | Low | Low | Low | Multiple components |
+| 5 | Low/medium | Medium | Medium | Multiple components |
+| 8 | Medium/high | Medium/high | Medium/high | Multiple components |
+| 13 | High | High | High | Consider splitting |
+| 20+ | Very high | Very high | Very high | Split into Epic or smaller items |
+
+> If the user is unsure about sizing, suggest creating the issue unsized and
+> letting the team point it during refinement.
+
+### Step 7 — Compose the Description
+
+Use markdown format (`contentFormat: "markdown"`). The governance doc requires
+these sections in all descriptions:
+
+```markdown
+## Overview
+
+<One-paragraph summary of what happened and why it matters.>
+
+## Acceptance Criteria
+
+- <Criterion 1: specific, testable condition>
+- <Criterion 2>
+
+## Definition of Done
+
+- [ ] All acceptance criteria met
+- [ ] Required tests passing (unit, integration, e2e as applicable)
+- [ ] CI and all relevant tests passing
+- [ ] PR reviewed and merged
+- [ ] Changes verified against each required environment
+- [ ] Code rolled out to all production regions (if not part of an Epic)
+
+## Evidence
+
+- **Failed job/test**: <URL or name>
+- **Error**: <Key error message or log snippet>
+- **Environment**: <int / stg / prod, region if relevant>
+- **Frequency**: <First occurrence / intermittent / persistent>
+
+## Investigation Log
+
+Each investigation step MUST be recorded as a structured entry with all four
+fields. This ensures reproducibility and allows other engineers (and bots) to
+verify findings without re-doing the work.
+
+### Entry format
+
+For each query, command, or check performed:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| **Command/Query** | yes | The exact command, KQL query, or kubectl command run. Use code blocks. |
+| **Result** | yes | The output — a summary table, key numbers, or "empty/no results". Truncate verbose output but preserve key data. |
+| **Summary** | yes | One-sentence interpretation: what does this result mean for the investigation? |
+| **Reproduce** | yes | A link or instructions to re-run: ADX deep-link for Kusto queries, full kubectl command with context/namespace, or Prow artifact URL. |
+
+### Example entry
+
+```
+### Q1: KMS container events in CI namespaces
+
+**Command**:
+\`\`\`kql
+database('ServiceLogs').kubernetesEvents
+| where eventNamespace startswith "ocm-arohcpci01-"
+| where objectName has "kms" or message has "kms"
+| summarize count() by category
+\`\`\`
+
+**Result**:
+| Category | Count | Namespaces |
+|----------|-------|------------|
+| KMS_MountFailure | 45526 | 39267 |
+| KMS_ContainerKill | 27171 | 12380 |
+
+**Summary**: KMS cert mount failures are ubiquitous across CI — the
+SecretProviderClass `managed-azure-kms` is transiently unavailable at
+pod startup in nearly every namespace.
+
+**Reproduce**: [Open in ADX Web](https://dataexplorer.azure.com/...)
+```
+
+When posting investigation comments to JIRA, use `mcp_jira_addCommentToJiraIssue`
+with `contentFormat: "markdown"` and format each step as above.
+
+## References
+
+- <Prow job URL>
+- <Slack thread>
+- <Related issues>
+```
+
+**For Bugs specifically**, also include:
+- Procedure to reproduce the problem
+- Who will test / how to verify the fix
+- Expected vs. actual behavior
+
+**For Epics**, the description should include:
+- Functionality from the end-user perspective
+- Critical child tasks/stories identified
+- T-shirt size estimate
+
+### Step 8 — Create the Issue
+
+```
+Tool: mcp_jira_createJiraIssue
+cloudId: 2b9e35e3-6bd3-4cec-b838-f4249ee02432
+projectKey: AROSLSRE
+issueTypeName: Task          # or Bug, Story, Epic
+summary: <summary>
+description: <description>
+contentFormat: markdown
+additional_fields:
+  priority:
+    name: Normal             # or Blocker, Critical, Major, Minor
+  labels:
+    - oncall
+    - JIT                    # only if JIT involved
+    - no-qe                  # only if no QE testing needed
+  components:
+    - id: "83786"            # primary component
+    - id: "84116"            # secondary if oncall
+  customfield_10020: 67024   # current sprint ID (bare integer!)
+  customfield_10028: 3       # story points (optional)
+  customfield_10014: AROSLSRE-XXX  # parent Epic (optional)
+```
+
+### Step 9 — Transition to the Correct Status
+
+New issues start in **New** status. Transition based on readiness:
+
+| Scenario | Transition | ID |
+|----------|-----------|-----|
+| Actively investigating now | In Progress | 51 |
+| Triaged, ready for development | To Do | 41 |
+| Triaged, blocked by other work (Bugs) | Backlog | 21 |
+| Needs refinement/discussion first | Refinement | 31 |
+
+```
+Tool: mcp_jira_transitionJiraIssue
+cloudId: 2b9e35e3-6bd3-4cec-b838-f4249ee02432
+issueIdOrKey: AROSLSRE-XXX
+transition:
+  id: "51"                   # In Progress
+```
+
+**Workflow by issue type** (from governance doc):
+
+**Tasks**: New → Backlog → To Do → In Progress → Review → Closed
+- "To Do" means Definition of Ready is met
+- "Review" means code review stage
+- "Closed" means Definition of Done met and PR merged
+
+**Bugs**: New → Backlog → To Do → In Progress → Review → Closed
+- "Backlog" can mean triaged but blocked by upstream fix
+- "To Do" means bug is validated, testable, and has proposed fix target
+- "Review" with QA contact set means ready for QE verification
+- If QE testing fails, move back to "In Progress"
+
+**Epics**: New → Refinement → Backlog → In Progress → Review → Closed
+- "Refinement" means description and child issues being written
+- "Backlog" means refinement complete, ready for development
+- "Closed" requires all child Tasks to be Closed
+
+### Step 10 — Handle JIT Documentation (if applicable)
+
+When `jit_involved` is true (or JIT access is mentioned anywhere in the
+context), **remind the user** to provide the following and add them as comments
+on the issue:
+
+#### JIT Request Comment
+
+```markdown
+## JIT Request
+
+- **JIT Request URL**: https://jitaccess.security.core.windows.net/...
+- **Rollout URL**: <if applicable>
+- **Slack Discussion**: <link to Slack thread>
+- **Reason**: <Why JIT access was necessary>
+```
+
+#### JIT Access Details Comment
+
+```markdown
+## JIT Access Details
+
+- **JIT Approver**: <Name> (<email>)
+- **Shadow**: <Name> (<email>)
+- **Performed By**: <Name> (<email>)
+```
+
+#### JIT Duration Comment
+
+```markdown
+## JIT Duration
+
+- **Approved**: <YYYY-MM-DD HH:MM UTC>
+- **Completed**: <YYYY-MM-DD HH:MM UTC>
+- **Total Duration**: <Xh Ym>
+```
+
+#### JIT Outcome Comment
+
+```markdown
+## JIT Outcome
+
+<What was found during JIT access. What actions were taken.
+Any corrections to initial assumptions or hypotheses.>
+```
+
+Use `mcp_jira_addCommentToJiraIssue` with `contentFormat: "markdown"` for each
+comment block.
+
+**Checklist — ask the user for any missing items:**
+- [ ] JIT request URL
+- [ ] Rollout URL (if applicable)
+- [ ] Slack thread link
+- [ ] Approver name and email
+- [ ] Shadow name and email
+- [ ] Performer name and email
+- [ ] What was done and found (outcome)
+- [ ] Start and end time of JIT session
+
+## Definition of Ready Checklist
+
+Before moving an issue to **To Do**, verify these criteria are met (from
+governance doc):
+
+- [ ] Priority field is set
+- [ ] Description has sufficient information for a developer to start
+- [ ] Story points / size determined
+- [ ] Ranked in backlog
+- [ ] Acceptance Criteria defined
+- [ ] Not blocked (`customfield_10517` = False)
+- [ ] Components set (at minimum `ARO-HCP` + team component)
+- [ ] Labels set (`no-qe` if QE testing not required)
+
+## Definition of Done Checklist
+
+Before closing an issue, verify (from governance doc):
+
+- [ ] All acceptance criteria met
+- [ ] Required tests passing (unit, integration, e2e, manual as relevant)
+- [ ] Required documentation shipped
+- [ ] Required metrics, dashboards, and alerts in place
+- [ ] Required SOPs written
+- [ ] CI and all relevant tests passing
+- [ ] Changes verified by reviewer against each required environment
+- [ ] Changes verified against each supported upgrade path
+- [ ] If client impact: JIRA created for client-side changes
+- [ ] PR merged
+- [ ] Code rolled out to all production regions (if not part of an Epic)
+
+## Reference Tables
+
+### Project
+
+| Field | Value |
+|-------|-------|
+| Project Key | AROSLSRE |
+| Project ID | 10555 |
+| Project Name | ARO HCP Service Lifecycle |
+| Cloud ID | 2b9e35e3-6bd3-4cec-b838-f4249ee02432 |
+| Instance | redhat.atlassian.net |
+
+> **Note**: There is no separate "ARO-HCP" project accessible via the API.
+> All ARO HCP Service Lifecycle work goes to **AROSLSRE**.
+
+### All AROSLSRE Components
+
+| Name | ID | Use For |
+|------|----|---------|
+| aro-hcp-ci | 32027 | Prow jobs, PR pipelines, CI stability |
+| aro-hcp-docs | 84115 | Runbooks, onboarding guides |
+| aro-hcp-e2e | 83786 | e2e test failures, flakes, resource cleanup |
+| aro-hcp-infra | 84112 | AKS clusters, nodepools, istio, capacity |
+| aro-hcp-observability | 84111 | Alerts, dashboards, Kusto, logging |
+| aro-hcp-oncall | 84116 | Oncall rotation, interrupt-driven work |
+| aro-hcp-releases | 83787 | EV2 rollouts, deployments, image bumping |
+| aro-hcp-security | 84113 | CVEs, dependency bumps, FedRAMP |
+| aro-hcp-tooling | 84114 | Image updater, CLI tools, agentic workflows |
+
+### All Issue Types
+
+| Name | ID | Level |
+|------|----|-------|
+| Task | 10014 | 2 |
+| Bug | 10016 | 2 |
+| Story | 10009 | 2 |
+| Spike | 10009 | 2 (Story + `spike` label) |
+| Epic | 10000 | 3 |
+| Sub-task | 10015 | child |
+| Feature | 10142 | 4 |
+| Vulnerability | 10172 | 2 |
+
+### Priority Values (MoSCoW Mapping)
+
+| Name | ID | MoSCoW |
+|------|----|--------|
+| Blocker | 10000 | Must Have |
+| Critical | 10001 | Should Have |
+| Major | 10002 | Could Have |
+| Normal | 10003 | Could Have |
+| Minor | 10004 | Won't Have |
+
+### Status Transitions
+
+| ID | Name | Target Status |
+|----|------|---------------|
+| 11 | New | New (To Do) |
+| 21 | Backlog | Backlog |
+| 31 | Refinement | Refinement |
+| 41 | To Do | To Do |
+| 51 | In Progress | In Progress |
+| 61 | Review | Review |
+| 71 | Release Pending | Release Pending (Done) |
+| 81 | Closed | Closed (Done) |
+
+### Notable Custom Fields
+
+| Field | Key | Value Type | Notes |
+|-------|-----|------------|-------|
+| Sprint | customfield_10020 | bare integer | **Not** an object |
+| Story Points | customfield_10028 | number | 1, 2, 3, 5, 8, 13, 20 |
+| Epic Link | customfield_10014 | string (issue key) | Parent Epic |
+| Severity | customfield_10840 | string | Critical/Important/Moderate/Low/Informational |
+| Release Blocker | customfield_10847 | string | Approved/Proposed/Rejected |
+| Blocked | customfield_10517 | string | True/False (default False) |
+| Target Start | — | date | When dev work actually begins |
+| Target End | — | date | When work completes and ships to prod |
+| Color Status | — | string | Green (on track) / Yellow (at risk) / Red (off track) |
+| Status Summary | — | text | Summarized status, risks, mitigations |
+| Fix Version | — | string | Used for planning (especially Bugs) |
+
+## Technical Notes
+
+1. **Sprint field** (`customfield_10020`) accepts a **bare integer**, not an
+   object. `67024` works; `{"id": 67024}` fails.
+
+2. **Cloud ID** is `2b9e35e3-6bd3-4cec-b838-f4249ee02432` — hardcoded for the
+   Red Hat Atlassian instance.
+
+3. **Content format**: Always use `contentFormat: "markdown"` for descriptions
+   and comments.
+
+4. **Label casing**: `oncall` (lowercase), `JIT` (uppercase). These are the
+   established conventions in the project.
+
+5. **Component format**: Pass as `[{"id": "83786"}]` — the `id` value is a
+   string representation of the integer.
+
+6. **Sprint lookup**: Always query for the current sprint at creation time
+   rather than hardcoding a sprint ID, as sprints rotate every two weeks.
+
+7. **`no-qe` label**: QE assumes every ticket needs testing unless this label
+   is present. Apply it for pure infrastructure, tooling, or internal-only
+   changes that don't need QE verification.
+
+8. **Bug triage**: Bugs follow a separate triage process. New bugs should stay
+   in **New** until the team agrees: (a) the bug is valid, (b) there's enough
+   detail to reproduce, (c) testing procedure is defined, (d) testing owner
+   assigned. Only then transition to **To Do**.
+
+9. **Epics require a parent**: Per governance, Epics should have a parent
+   Feature or Initiative. If creating an Epic, ask the user for the parent.
+
+10. **Color Status for tracked work**: For Features/Epics being tracked at
+    the program level, update weekly with Color Status (Green/Yellow/Red) and
+    a Status Summary including risks and mitigations.
+
+## MCP Tools Reference
+
+| Tool | Purpose |
+|------|---------|
+| `mcp_jira_createJiraIssue` | Create the issue |
+| `mcp_jira_addCommentToJiraIssue` | Add JIT or investigation comments |
+| `mcp_jira_transitionJiraIssue` | Change issue status |
+| `mcp_jira_searchJiraIssuesUsingJql` | Look up current sprint, find related issues |
+| `mcp_jira_getTransitionsForJiraIssue` | List available transitions |
+| `mcp_jira_getJiraIssueTypeMetaWithFields` | Inspect field metadata |
+| `mcp_jira_getVisibleJiraProjects` | Project lookup |
+| `mcp_jira_createIssueLink` | Link related issues (Blocks, Duplicate, etc.) |

--- a/tooling/triage/skills/create-jira-issue/SKILL.md
+++ b/tooling/triage/skills/create-jira-issue/SKILL.md
@@ -135,12 +135,15 @@ Format components as an array of objects: `[{"id": "83786"}, {"id": "84116"}]`
 
 ### Step 4 — Select Labels
 
+**All labels must be lowercase.** This is a team-wide convention. Never use
+uppercase or mixed-case labels (e.g. use `jit` not `JIT`, `aro` not `ARO`).
+
 **Always apply these automatically based on context:**
 
 | Condition | Label | Notes |
 |-----------|-------|-------|
 | CI failure, e2e failure, promotion failure, rollout failure, oncall investigation | `oncall` | Lowercase. Do NOT use `on-call`. |
-| JIT cluster access requested or used | `JIT` | Uppercase. |
+| JIT cluster access requested or used | `jit` | Lowercase. |
 | e2e test specific | `e2e` | In addition to `oncall` |
 | No QE testing needed | `no-qe` | QE assumes every ticket needs testing unless this label is present |
 | Suitable for new team members | `good-first-issue` | For straightforward onboarding-friendly tasks |
@@ -149,7 +152,8 @@ Format components as an array of objects: `[{"id": "83786"}, {"id": "84116"}]`
 Other labels to consider (apply when relevant):
 - `maestro` — Maestro-specific issues
 - `aro-hcp-ci` — CI pipeline issues
-- `ARO-HCP` — generic project label
+- `aro` — ARO product label (umbrella — covers both classic and HCP)
+- `hcp` — HCP-specific work (use with `aro` for ARO HCP issues)
 - `aro-hcp-service-lifecycle-team` — team label
 - `spike` — for Spike (time-boxed research) issues
 
@@ -292,7 +296,7 @@ additional_fields:
     name: Normal             # or Blocker, Critical, Major, Minor
   labels:
     - oncall
-    - JIT                    # only if JIT involved
+    - jit                    # only if JIT involved
     - no-qe                  # only if no QE testing needed
   components:
     - id: "83786"            # primary component
@@ -342,7 +346,12 @@ transition:
 ### Step 10 — Handle JIT Documentation (if applicable)
 
 When `jit_involved` is true (or JIT access is mentioned anywhere in the
-context), **remind the user** to provide the following and add them as comments
+context), **do NOT create a separate ticket just to track the JIT request**.
+Instead, add the `jit` label to the parent investigation/task ticket and
+document all JIT details as comments on that same ticket. A JIT request is
+a means to an end, not a separate work item.
+
+**Remind the user** to provide the following and add them as comments
 on the issue:
 
 #### JIT Request Comment
@@ -520,8 +529,8 @@ Before closing an issue, verify (from governance doc):
 3. **Content format**: Always use `contentFormat: "markdown"` for descriptions
    and comments.
 
-4. **Label casing**: `oncall` (lowercase), `JIT` (uppercase). These are the
-   established conventions in the project.
+4. **Label casing**: All labels must be **lowercase**. Examples: `oncall`,
+   `jit`, `e2e`, `no-qe`, `aro`, `hcp`. This is enforced by team convention.
 
 5. **Component format**: Pass as `[{"id": "83786"}]` — the `id` value is a
    string representation of the integer.

--- a/tooling/triage/skills/oncall-shift/SKILL.md
+++ b/tooling/triage/skills/oncall-shift/SKILL.md
@@ -53,8 +53,9 @@ Manage the full lifecycle of an oncall shift:
 4. **Prioritization order is fixed:**
    1. Rollouts (active, failed, blocked)
    2. Time-sensitive / important items (CCOA exceptions, approvals, deadlines)
-   3. Check alerts (proactive problem detection)
-   4. Routine monitoring (IcM, Prow, dashboards, quality call)
+   3. Dev merge queue health (unblock Tide batches)
+   4. Check alerts (proactive problem detection)
+   5. Routine monitoring (IcM, Prow, dashboards, quality call)
 
 ## Parameters
 
@@ -99,28 +100,46 @@ If the Slack link is not provided, record without it but flag:
 
 #### Step 2: Prioritize
 
-Apply the fixed priority order:
+The five categories below are standing responsibilities every shift. All
+five must appear in every action plan regardless of what the handover notes
+contain. Handover items, action items, PRs to babysit, and awareness items
+are slotted into whichever category they belong to — they do not form a
+separate list.
 
 1. **🔴 Rollouts** — Active rollouts, failed rollouts needing cancellation,
-   blocked rollouts.
+   blocked rollouts. Slot handover rollout items here.
 2. **🟠 Important / Time-Sensitive** — CCOA exceptions, approval chains,
-   PRs with deadlines, pipeline recoveries.
-3. **🟡 Alerts** — Check monitoring alerts that might catch problems early.
-4. **🟢 Awareness / Routine** — Prow status, IcM portal, quality call,
-   handover dashboard, standard monitoring.
+   PRs with deadlines, pipeline recoveries. Slot handover action items, PRs
+   to babysit, and time-sensitive requests here.
+3. **🟡 Dev Merge Queue** — Check Tide batch health and unblock if needed
+   (see Dev Merge Queue Monitoring section below). Always present even if
+   handover does not mention it.
+4. **🟡 Alerts** — Check monitoring alerts for proactive problem detection.
+   Always present even if handover does not mention it.
+5. **🟢 Routine Monitoring** — IcM portal sweep, oncall dashboard ticket
+   triage, Prow status, quality call, handover dashboard. Slot handover
+   awareness items and incidents here. Always present even if handover does
+   not mention it.
 
-Present as a numbered action sequence (not just categories):
+If the handover notes contain items that already match a standing category
+(e.g. an IcM incident is routine monitoring, a PR deadline is
+important/time-sensitive), place them in that category rather than creating
+duplicates.
+
+Present as a numbered action sequence (not just categories). Every category
+must have at least one concrete action, even if it is the standing default:
 
 ```
 ### Suggested Sequence
 
-1. <Most urgent rollout action>
+1. <Most urgent rollout action or "No active rollouts — verify none pending">
 2. <Next rollout action>
-3. <Time-sensitive item>
-4. <Check alerts>
-5. <Verify pipeline/automation>
-6. <Babysit PR>
-7. Routine monitoring (Prow, IcM, dashboard)
+3. <Time-sensitive item or "No time-sensitive items">
+4. Check Dev merge queue health (CI Health Dashboard)
+5. Check monitoring alerts
+6. <Verify pipeline/automation>
+7. <Babysit PR>
+8. Routine monitoring: IcM portal sweep, oncall dashboard triage, Prow status
 ```
 
 #### Step 3: Create Tracking JIRA
@@ -254,6 +273,41 @@ If the shift is fully complete (all items resolved or handed over):
 If items are still active:
 - Keep in **In Progress** and note in the handover that the next shift
   should continue tracking on the same ticket (or create a new one).
+
+## Dev Merge Queue Monitoring
+
+Monitoring the Dev e2e-parallel merge queue is a core oncall responsibility.
+The goal is to keep the merge queue moving by unblocking failing Tide
+batches.
+
+**CI Health Dashboard**: https://cihealth.tools.hcpsvc.osadev.cloud/
+
+All monitoring should be done via the CI Health Dashboard:
+
+### Day-to-day workflow
+
+- **Report page** (`/report`, DEV env) — watch the E2E success card (after
+  the last push of a merged PR). This is the key metric. A dropping value
+  is your alarm.
+- **Run Log** (`/run-log?date=<YYYY-MM-DD>&env=dev`) — type `batch` in the
+  search box (or use `&q=batch`) to filter for Tide batch runs. A cluster
+  of failing batches means the queue is blocked. Each row links to the Prow
+  job and shows the matched failure.
+- **Failure Patterns** (`/failure-patterns`) — this is a triage tool, not a
+  monitoring tool. Use it to rank the most impactful issues by run-impact %.
+  Category signals (Regression vs. Flake, provision & e2e only) help
+  separate a new PR-induced break from a long-standing flake.
+
+### Triage guidance
+
+- **Flake vs. regression**: Tide merges PRs in batches; every PR in a batch
+  has already passed e2e on its own. A failing Tide batch is either a flake
+  or a bad interaction between batched PRs. Don't chase every red run.
+- **Timeout patterns**: Patterns like `CreateHCPClusterAndWait`,
+  `context deadline exceeded`, etc. are generic timeouts hiding distinct
+  root causes. Occurrence count alone is meaningless. Timeouts require
+  deeper analysis from Kusto logs using `hcpctl snapshot analyze` (in
+  `tooling/hcpctl`) against the run's snapshot.
 
 ## Chat Excerpt Rules
 

--- a/tooling/triage/skills/oncall-shift/SKILL.md
+++ b/tooling/triage/skills/oncall-shift/SKILL.md
@@ -1,0 +1,316 @@
+---
+name: oncall-shift
+description: Manage an oncall shift end-to-end — accept handover, prioritize tasks, track work via JIRA with the oncall label, and generate structured handover notes for the next shift. Use whenever a user starts an oncall shift, receives handover notes, wants to update shift status, or needs to create handover notes.
+---
+
+## Personal Overrides
+
+If a `SKILL.local.md` file exists in this skill's directory, read it before
+proceeding. It contains personal instructions that augment (never contradict)
+the directions below. These files are gitignored and persist across upstream
+skill updates.
+
+# Oncall Shift Management
+
+## What I Do
+
+Manage the full lifecycle of an oncall shift:
+
+1. **Accept handover** — parse incoming handover notes (Slack pastes, text),
+   extract action items, and create a prioritized plan.
+2. **Create tracking JIRA** — create or update a shift-level JIRA ticket that
+   tracks all work during the shift.
+3. **Prioritize tasks** — order by: rollouts first, then time-sensitive /
+   important items, then alerts, then routine monitoring.
+4. **Track updates** — add JIRA comments as work progresses throughout the
+   shift, preserving chat excerpts with attribution.
+5. **Generate handover notes** — produce structured handover notes for the next
+   shift in a consistent format.
+
+## When to Use Me
+
+- User starts an oncall shift and pastes or describes handover notes
+- User wants to create a prioritized oncall plan
+- User wants to log an update to their oncall JIRA
+- User wants to generate handover notes for the next shift
+- User mentions "oncall", "handover", "shift tracking", or "on-call"
+
+## Core Principles
+
+1. **If it's not in the handover notes, it didn't happen.** Every action,
+   decision, and status change must be recorded — either in the JIRA ticket
+   or in the handover notes. Verbal-only updates are lost.
+
+2. **Every JIRA ticket created during oncall must have the `oncall` label.**
+   This is non-negotiable. It enables filtering oncall interrupt work from
+   planned sprint work.
+
+3. **Chat excerpts must include attribution.** When recording Slack messages
+   or conversations, always capture: **who** said it, **when** (timestamp),
+   and **where** (Slack link if available). Ask for the Slack link if not
+   provided.
+
+4. **Prioritization order is fixed:**
+   1. Rollouts (active, failed, blocked)
+   2. Time-sensitive / important items (CCOA exceptions, approvals, deadlines)
+   3. Check alerts (proactive problem detection)
+   4. Routine monitoring (IcM, Prow, dashboards, quality call)
+
+## Parameters
+
+Extract from user context. Only ask if required and not inferrable.
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `handover_notes` | yes (for start) | Raw handover text — Slack paste, typed notes, etc. |
+| `shift_name` | no | Timezone shift name (EMEA, NASA, APAC). Infer from context. |
+| `engineer` | no | Oncall engineer's name. Infer from git config or context. |
+| `tracking_jira` | no | Existing JIRA key if resuming a shift. Created automatically if not provided. |
+
+## Directions
+
+### Phase 1 — Accept Handover & Create Plan
+
+When the user starts a shift (pastes handover notes or describes context):
+
+#### Step 1: Parse Handover Notes
+
+Extract from the raw input:
+
+- **Rollouts** — active, completed, failed, blocked. Include EV2 links.
+- **Action items** — things explicitly assigned or requested.
+- **Awareness items** — FYIs, no action needed but carry forward.
+- **PRs to babysit** — PRs that need merging or monitoring.
+- **Incidents** — IcM incidents, capacity issues, outages.
+- **Chat excerpts** — preserve who said what and when. Flag any item
+  where a Slack link is missing and ask for it.
+
+For each chat excerpt, enforce this format:
+
+```
+- **<Person> [<time>]**: <message> ([Slack](<link>))
+```
+
+If the Slack link is not provided, record without it but flag:
+
+```
+- **<Person> [<time>]**: <message> *(Slack link not provided — ask sender)*
+```
+
+#### Step 2: Prioritize
+
+Apply the fixed priority order:
+
+1. **🔴 Rollouts** — Active rollouts, failed rollouts needing cancellation,
+   blocked rollouts.
+2. **🟠 Important / Time-Sensitive** — CCOA exceptions, approval chains,
+   PRs with deadlines, pipeline recoveries.
+3. **🟡 Alerts** — Check monitoring alerts that might catch problems early.
+4. **🟢 Awareness / Routine** — Prow status, IcM portal, quality call,
+   handover dashboard, standard monitoring.
+
+Present as a numbered action sequence (not just categories):
+
+```
+### Suggested Sequence
+
+1. <Most urgent rollout action>
+2. <Next rollout action>
+3. <Time-sensitive item>
+4. <Check alerts>
+5. <Verify pipeline/automation>
+6. <Babysit PR>
+7. Routine monitoring (Prow, IcM, dashboard)
+```
+
+#### Step 3: Create Tracking JIRA
+
+Use the `create-jira-issue` skill's conventions (same cloudId, project,
+component IDs, sprint lookup). The tracking ticket must have:
+
+- **Summary**: `Oncall shift tracking — <date> <shift_name> shift (<engineer>)`
+- **Type**: Task (ID: 10014)
+- **Labels**: `oncall`, `no-qe`
+- **Components**: `aro-hcp-oncall` (84116) + any relevant area component
+  (e.g. `aro-hcp-releases` 83787 if rollouts are primary)
+- **Priority**: Major (oncall tracking tickets are important by definition)
+- **Sprint**: Current active sprint (query with
+  `project = AROSLSRE AND sprint in openSprints()`)
+- **Description**: Full prioritized plan with all sections:
+  - Overview (shift context)
+  - Prioritized Task List (with all categories)
+  - Acceptance Criteria
+  - Definition of Done
+  - Evidence (links to rollouts, PRs, portals)
+  - Handover Chat Excerpts (with attribution)
+  - References
+
+Transition to **In Progress** (transition ID: 51).
+
+### Phase 2 — Track Updates During Shift
+
+When the user reports progress, new issues, or status changes:
+
+#### Adding Updates
+
+Post JIRA comments using `mcp_jira_addCommentToJiraIssue` with
+`contentFormat: "markdown"`. Each update comment should include:
+
+```markdown
+## Shift Update — <HH:MM>
+
+### <Topic>
+
+**Status**: <new status>
+**Action taken**: <what was done>
+**Result**: <outcome>
+
+### Chat Excerpt (if applicable)
+
+- **<Person> [<time>]**: <message> ([Slack](<link>))
+```
+
+#### Creating Sub-tickets
+
+If a new issue is discovered during the shift that warrants its own ticket:
+
+1. Use the `create-jira-issue` skill to create it
+2. **Always add the `oncall` label**
+3. Link it to the shift tracking ticket using `mcp_jira_createIssueLink`
+   (link type: "Relates")
+4. Add a comment to the tracking JIRA noting the new ticket
+
+#### Tracking Chat Excerpts
+
+When the user pastes a Slack conversation or references one:
+
+1. Extract key statements with attribution
+2. If no Slack link is provided, ask: *"Can you share the Slack link for
+   this conversation so it's traceable in the handover?"*
+3. Record in the JIRA comment with the standard format
+
+### Phase 3 — Generate Handover Notes
+
+When the user asks for handover notes (end of shift):
+
+#### Step 1: Gather State
+
+Review the tracking JIRA and all comments to compile current state of
+every tracked item.
+
+#### Step 2: Generate Handover
+
+Use this exact template:
+
+```markdown
+## ARO HCP SL Handover <FROM_SHIFT> to <TO_SHIFT> — <DATE>
+
+### Highlights
+
+<Things worth sharing with other shifts — context, learnings, process
+changes, awareness items. Things that happened or were discovered during
+the shift that the next shift should know about even if no action is needed.>
+
+*Leave blank if nothing noteworthy.*
+
+### High Priority Tasks
+
+| Item | Status | Action Needed | Links |
+|------|--------|---------------|-------|
+| <item> | <status> | <what next shift should do> | JIRA / PR / Slack |
+
+*Include JIRA tickets, PRs to merge, Slack threads to follow.*
+*Leave blank if nothing pending.*
+
+### High Priority IcM Incidents
+
+| Incident | Severity | Status | Action Needed |
+|----------|----------|--------|---------------|
+| <title> | <sev> | <status> | <next step> |
+
+*Leave blank if no active incidents.*
+
+### Low Priority Stuff
+
+<Things that are not critical but would be nice to review if the next
+shift has spare time. Monitoring items, nice-to-have PRs, cleanup tasks.>
+
+*Leave blank if nothing.*
+
+### Tracking
+
+- **Shift JIRA**: <AROSLSRE-XXXX>
+- **Oncall engineer**: <name>
+- **Shift**: <shift_name> (<start_time> — <end_time>)
+```
+
+#### Step 3: Post to JIRA
+
+Add the handover notes as a final comment on the tracking JIRA.
+
+If the shift is fully complete (all items resolved or handed over):
+- Transition to **Review** (transition ID: 61)
+
+If items are still active:
+- Keep in **In Progress** and note in the handover that the next shift
+  should continue tracking on the same ticket (or create a new one).
+
+## Chat Excerpt Rules
+
+These rules are absolute. Oncall decisions often trace back to Slack
+conversations, and without proper attribution the context is lost.
+
+1. **Always record who said it** — use their Slack display name.
+2. **Always record when** — timestamp from Slack (format: `[HH:MM AM/PM]`).
+3. **Always include the Slack link** — if not provided by the user, ask for
+   it explicitly: *"What's the Slack link for that message?"*
+4. **Preserve the original wording** for critical decisions — don't
+   paraphrase instructions like "cancel the rollout" or "get approval from X".
+5. **Flag missing attribution** — if you can't determine who said something
+   or when, record it with `*(attribution unclear — verify)*`.
+
+## JIRA Label Enforcement
+
+Every JIRA ticket created or updated during an oncall shift via this skill
+**must** have the `oncall` label. This includes:
+
+- The shift tracking ticket itself
+- Any sub-tickets created for issues found during the shift
+- Any existing tickets that are updated as part of oncall work
+
+When updating an existing ticket that doesn't have the `oncall` label, add
+it via `mcp_jira_editJiraIssue` with
+`fields: {"labels": [<existing_labels>, "oncall"]}`.
+
+## Reference: MCP Tools Used
+
+| Tool | Purpose |
+|------|---------|
+| `mcp_jira_createJiraIssue` | Create shift tracking ticket or sub-tickets |
+| `mcp_jira_addCommentToJiraIssue` | Post updates and handover notes |
+| `mcp_jira_transitionJiraIssue` | Change ticket status |
+| `mcp_jira_editJiraIssue` | Add labels, update fields |
+| `mcp_jira_searchJiraIssuesUsingJql` | Find current sprint, related tickets |
+| `mcp_jira_createIssueLink` | Link sub-tickets to tracking ticket |
+| `mcp_jira_getJiraIssue` | Read current ticket state |
+
+## Reference: Component IDs
+
+| Component | ID |
+|-----------|----|
+| aro-hcp-oncall | 84116 |
+| aro-hcp-releases | 83787 |
+| aro-hcp-e2e | 83786 |
+| aro-hcp-ci | 32027 |
+| aro-hcp-infra | 84112 |
+| aro-hcp-observability | 84111 |
+
+## Reference: Transition IDs
+
+| Transition | ID |
+|------------|----|
+| In Progress | 51 |
+| To Do | 41 |
+| Review | 61 |
+| Closed | 81 |
+| Backlog | 21 |

--- a/tooling/triage/skills/oncall-shift/SKILL.md
+++ b/tooling/triage/skills/oncall-shift/SKILL.md
@@ -27,6 +27,56 @@ Manage the full lifecycle of an oncall shift:
 5. **Generate handover notes** — produce structured handover notes for the next
    shift in a consistent format.
 
+## Coverage Model
+
+The team follows a **24x5 Follow-the-Sun (FTS)** model.
+
+- **Coverage window**: Sunday 21:00 UTC to Friday 21:00 UTC
+- **Weekend policy**: No weekend SLAs. Pager rotations and active monitoring
+  pause on Saturdays and Sundays.
+- **Shift handover**: Each region (APAC → EMEA → NASA) hands over IC
+  responsibilities at the end of their local business day.
+
+### Shift Schedule
+
+| GEO | Start (UTC) | End (UTC) |
+|-----|-------------|----------|
+| APAC East | 22:00 | 04:00 |
+| APAC West | 04:00 | 10:00 |
+| EMEA | 10:00 | 16:00 |
+| NASA | 16:00 | 22:00 |
+
+Scheduling is managed quarterly via IcM. Check your schedule at
+[IcM / MyOnCall](https://portal.microsofticm.com/).
+
+## Roles
+
+Each shift has a **Primary** and **Secondary** responder.
+
+### Primary Responder (Releases & Alerts)
+
+The Primary is the Interrupt Collector (IC). Responsibilities:
+
+1. **Release management** — execute all releases across INT, Stage, and Prod
+   per the continuous, serialized rollout model.
+2. **Quality Service Review (QSR)** — attend the QSR meeting to provide
+   release updates.
+3. **Proactive revert policy** — if a component breaks a rollout or fails a
+   gate, perform an immediate revert. Before reverting, verify the failure is
+   not infrastructure or pipeline related. Once reverted, notify the
+   responsible team to provide a fix for re-submission in a later batch.
+4. **IcM alert management** — see IcM Alert Triage section below.
+5. **Dev merge queue health** — see Dev Merge Queue Monitoring section below.
+
+### Secondary Responder (Communication & Triage)
+
+*Not currently enforced — team-based best effort.*
+
+- **Slack monitoring**: First point of contact for all IC pings in designated
+  Slack channels.
+- **Tag response**: Respond to all team @-mentions and tags related to service
+  lifecycle issues.
+
 ## When to Use Me
 
 - User starts an oncall shift and pastes or describes handover notes
@@ -56,6 +106,9 @@ Manage the full lifecycle of an oncall shift:
    3. Dev merge queue health (unblock Tide batches)
    4. Check alerts (proactive problem detection)
    5. Routine monitoring (IcM, Prow, dashboards, quality call)
+
+5. **IcM alerts have a hard SLA.** All Sev 2 and below critical alerts must
+   be acknowledged within 30 minutes. This is not optional.
 
 ## Parameters
 
@@ -274,6 +327,76 @@ If items are still active:
 - Keep in **In Progress** and note in the handover that the next shift
   should continue tracking on the same ticket (or create a new one).
 
+### Mandatory Handover Process
+
+The out-going IC is **fully accountable** for ensuring a successful transfer.
+The shift is not considered complete until all open issues are documented
+and the handover has been proactively sought and confirmed.
+
+#### 15 Minutes Before Shift End
+
+1. **Proactively contact the in-coming IC** via the automatically-created
+   Slack handover thread. Tag the incoming IC and confirm they are alert
+   and ready.
+2. **Complete the handover message** in the Slack thread using the handover
+   template above.
+3. For every unresolved issue, provide:
+   - **JIRA link** with status and next steps clearly updated
+   - **PR links** (if applicable)
+   - **Slack thread links** to relevant conversations
+   - **Current status and next steps** — a clear statement of what the
+     incoming IC needs to do
+
+#### Handover Meeting (If Needed)
+
+If the Slack message is insufficient for the complexity of open issues:
+
+1. Initiate and lead the handover meeting using the scheduled meeting link.
+2. Ensure the incoming IC attends.
+3. Document key decisions and action items in the relevant JIRA tickets.
+
+#### Accountability
+
+Failure to perform a complete and proactive handover does not guarantee a
+follow-up from the incoming GEO zone. The out-going IC owns the handover.
+
+## IcM Alert Triage
+
+IcM is the primary tool for engaging SREs to resolve service interruptions.
+Access the portal at https://portal.microsofticm.com/ (requires a properly
+set up VM or SAW device).
+
+### Acknowledgement SLA
+
+**All Sev 2 and below critical alerts must be acknowledged within 30 minutes.**
+This is the escalation policy window — missing it triggers automatic
+escalation.
+
+### Triage Process
+
+For every IcM alert:
+
+1. **Acknowledge** the alert within the 30-minute window.
+2. **Initiate investigation** — review the alert details, check related
+   dashboards and logs.
+3. **Create a JIRA ticket** with the `oncall` label documenting the issue,
+   current status, and next steps.
+4. **Route the issue**:
+   - **Component issue** → assign to the component owner's team.
+   - **Infrastructure issue** → work on resolution directly.
+5. **Document resolution** — update the JIRA ticket with the outcome.
+   If the issue is not resolved by end of shift, include it in handover
+   notes with full context.
+
+### During Routine Monitoring
+
+Even without active alerts, sweep the IcM portal once per shift to check
+for:
+
+- New alerts that may not have paged
+- Alerts assigned to the team that need attention
+- Stale alerts that should be resolved or re-assigned
+
 ## Dev Merge Queue Monitoring
 
 Monitoring the Dev e2e-parallel merge queue is a core oncall responsibility.
@@ -309,6 +432,41 @@ All monitoring should be done via the CI Health Dashboard:
   deeper analysis from Kusto logs using `hcpctl snapshot analyze` (in
   `tooling/hcpctl`) against the run's snapshot.
 
+## Escalation
+
+When the IC cannot resolve an issue, or the issue belongs to a component
+outside Service Lifecycle's responsibility:
+
+1. **Identify the owning team** using the
+   [Service Component Escalation Paths](https://docs.google.com/document/d/1fqH__2cv0GU4oiUYAnhl08x61b7CuDbVi3OkC-J58LA/edit?tab=t.0)
+   (maintained externally).
+2. **Follow the prescribed channel** — open the appropriate tickets and/or
+   engage via the documented Slack channels for that component.
+3. **Document the escalation** in the shift JIRA with: who was contacted,
+   when, via what channel, and the current status.
+
+## Swarm
+
+A Swarm should be initiated when the IC is overwhelmed by a high volume of
+complex interruptions (rollouts, critical alerts, major incidents) that make
+completing the shift unsustainable.
+
+### How to Initiate
+
+1. Use the `/Swarm` command in `#hcm-aro-team-service-lifecycle`.
+2. Select the service **"ARO SLC Swarm"**.
+3. Specify:
+   - The **region (GEO)** from which assistance is required.
+   - The **number of associates** needed.
+
+### Expectations
+
+Team members summoned by a Swarm are expected to:
+
+- Respond promptly
+- Assess the required assistance
+- Assume a portion of the on-call workload from the IC
+
 ## Chat Excerpt Rules
 
 These rules are absolute. Oncall decisions often trace back to Slack
@@ -335,6 +493,21 @@ Every JIRA ticket created or updated during an oncall shift via this skill
 When updating an existing ticket that doesn't have the `oncall` label, add
 it via `mcp_jira_editJiraIssue` with
 `fields: {"labels": [<existing_labels>, "oncall"]}`.
+
+## Associate Obligations
+
+By participating in the oncall rotation, associates agree to:
+
+- **Acknowledgement SLA**: Always acknowledge alerts within the escalation
+  policy window (typically 10–15 minutes for pages, 30 minutes for IcM).
+- **Fitness for duty**: Associates must not be impaired by alcohol or
+  medication that affects their ability to perform technical tasks.
+- **Replacement responsibility**: If unable to fulfill duties, source a
+  replacement and put in an override into IcM. If unable to find a
+  replacement (or in an emergency/illness), inform your manager and get
+  confirmation.
+- **Comp day**: Working a Recharge Day or Company-Funded Day entitles the
+  associate to one Comp Day, which must be taken within two weeks.
 
 ## Reference: MCP Tools Used
 

--- a/tooling/triage/skills/oncall-shift/SKILL.md
+++ b/tooling/triage/skills/oncall-shift/SKILL.md
@@ -272,7 +272,13 @@ every tracked item.
 
 #### Step 2: Generate Handover
 
-Use this exact template:
+Generate **two versions** of the handover notes: a JIRA version (full
+markdown with tables) and a Slack version (emoji-formatted, no tables,
+copy-paste friendly). Always produce both.
+
+##### JIRA Version
+
+Use this template for the JIRA comment:
 
 ```markdown
 ## ARO HCP SL Handover <FROM_SHIFT> to <TO_SHIFT> — <DATE>
@@ -316,9 +322,42 @@ shift has spare time. Monitoring items, nice-to-have PRs, cleanup tasks.>
 - **Shift**: <shift_name> (<start_time> — <end_time>)
 ```
 
+##### Slack Version
+
+Present the Slack version inside a code fence so the user can copy-paste
+it directly into the Slack handover thread. Keep it *condensed* — max 5
+bullet lines per category, one line per item (status + link only, no
+elaboration). Link to the JIRA handover comment for full context. Use
+Slack mrkdwn formatting (not markdown): `*bold*` for bold, no `#`
+headings, no tables.
+
+Use this template:
+
+```
+:wave: *Handover <FROM_SHIFT> → <TO_SHIFT> — <DATE>*
+
+:star: *Highlights*
+• <one-liner or "None">
+:memo: Full details: <link to JIRA handover comment>
+
+:red_circle: *High Priority*
+• <item — status — link>
+
+:rotating_light: *IcM Incidents*
+• <item or "None active">
+
+:large_green_circle: *Low Priority*
+• <item or "None">
+```
+
+Each category must appear but keep entries to one-line bullets. All
+detail, context, and chat excerpts belong in the JIRA comment only.
+
 #### Step 3: Post to JIRA
 
-Add the handover notes as a final comment on the tracking JIRA.
+Add the **JIRA version** of the handover notes as a final comment on the
+tracking JIRA. Present the **Slack version** to the user in a code fence
+for copy-paste.
 
 If the shift is fully complete (all items resolved or handed over):
 - Transition to **Review** (transition ID: 61)


### PR DESCRIPTION
## Why

The SLC on-call operations manual is a comprehensive Google Doc, but its length makes it hard to follow consistently during high-pressure shifts. Engineers miss steps (IcM 30-min ack SLA, mandatory handover process, JIRA label enforcement) or produce inconsistent handover notes.

This PR encodes the full manual into a structured AI skill so coding agents (Crush, Claude Code) can assist oncall engineers with the complete shift lifecycle.

## What

Adds `tooling/triage/skills/oncall-shift/SKILL.md` covering:

- **Coverage model** — 24x5 FTS shift schedule (APAC → EMEA → NASA)
- **Roles** — Primary IC (releases, alerts, merge queue) vs Secondary (comms, triage)
- **IcM alert triage** — 30-minute ack SLA, investigation → JIRA → routing workflow
- **Dev merge queue monitoring** — CI Health Dashboard, flake vs regression triage
- **Mandatory handover** — 15-min-prior contact, required artifacts, accountability
- **Escalation & Swarm** — when/how to escalate, `/Swarm` command procedure
- **JIRA governance** — `oncall` label enforcement, chat excerpt attribution
- **Associate obligations** — fitness for duty, replacement, comp day

## References

- [SLC On-Call Policy & Operations Manual](https://docs.google.com/document/d/1fqH__2cv0GU4oiUYAnhl08x61b7CuDbVi3OkC-J58LA/edit?tab=t.0)
- JIRA: (will be linked after creation)