### PR TITLE
chore: bump maestro image

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1002,7 +1002,7 @@ defaults:
     image:
       registry: quay.io
       repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
-      digest: sha256:31b203da421cc2ee2125a86be5168f096e236a3a9125404cb326a718a0d34727 # 6593d85435939d8d50bf976712784e4870cd0227 (2026-07-20 13:58)
+      digest: sha256:52294527040a60b07748175c19184eb110da6b0152208eff0271ea4010880904 # 3717fc674f6532617743a46b165280d235dee2be (2026-07-21 21:24)
   # ACM
   acm:
     operator:

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -560,7 +560,7 @@ maestro:
     name: arohcp-ci00-maestro-j7654321
     private: false
   image:
-    digest: sha256:31b203da421cc2ee2125a86be5168f096e236a3a9125404cb326a718a0d34727
+    digest: sha256:52294527040a60b07748175c19184eb110da6b0152208eff0271ea4010880904
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -560,7 +560,7 @@ maestro:
     name: arohcp-ci01-maestro-j7654321
     private: false
   image:
-    digest: sha256:31b203da421cc2ee2125a86be5168f096e236a3a9125404cb326a718a0d34727
+    digest: sha256:52294527040a60b07748175c19184eb110da6b0152208eff0271ea4010880904
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -560,7 +560,7 @@ maestro:
     name: arohcp-cspr-maestro-usw3
     private: false
   image:
-    digest: sha256:31b203da421cc2ee2125a86be5168f096e236a3a9125404cb326a718a0d34727
+    digest: sha256:52294527040a60b07748175c19184eb110da6b0152208eff0271ea4010880904
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -560,7 +560,7 @@ maestro:
     name: arohcp-dev-maestro-usw3
     private: false
   image:
-    digest: sha256:31b203da421cc2ee2125a86be5168f096e236a3a9125404cb326a718a0d34727
+    digest: sha256:52294527040a60b07748175c19184eb110da6b0152208eff0271ea4010880904
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -560,7 +560,7 @@ maestro:
     name: arohcp-perf-maestro-usw3ptest
     private: false
   image:
-    digest: sha256:31b203da421cc2ee2125a86be5168f096e236a3a9125404cb326a718a0d34727
+    digest: sha256:52294527040a60b07748175c19184eb110da6b0152208eff0271ea4010880904
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -560,7 +560,7 @@ maestro:
     name: arohcp-pers-maestro-usw3test
     private: false
   image:
-    digest: sha256:31b203da421cc2ee2125a86be5168f096e236a3a9125404cb326a718a0d34727
+    digest: sha256:52294527040a60b07748175c19184eb110da6b0152208eff0271ea4010880904
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:


### PR DESCRIPTION
Bumps maestro to the merge of openshift-online/maestro#562, which fixes the
Delete-event starvation of the spec-event controller behind the prod
brazilsouth 100% cluster-creation failure ([AROSLSRE-1547](https://redhat.atlassian.net/browse/AROSLSRE-1547)).

| Name | Old Digest | New Digest | Tag | Date | Status |
| --- | --- | --- | --- | --- | --- |
| maestro | 31b203da421c… | 52294527040a… | 3717fc674f6532617743a46b165280d235dee2be | 2026-07-21 21:24 | updated |

Source: https://github.com/openshift-online/maestro/pull/562
Jira: https://redhat.atlassian.net/browse/AROSLSRE-1547