### PR TITLE
log kubeconfig so we can compare content

### DIFF
--- a/test/util/framework/hcp_helper.go
+++ b/test/util/framework/hcp_helper.go
@@ -123,11 +123,13 @@ func (tc *perItOrDescribeTestContext) GetAdminRESTConfigForHCPCluster20240610(
 			if m.Kubeconfig == nil {
 				return nil, fmt.Errorf("kubeconfig content is nil")
 			}
+			ginkgo.GinkgoLogr.Info("kubeconfig for cluster", "kubeconfig", *m.Kubeconfig)
 			return clientcmd.Load([]byte(*m.Kubeconfig))
 		})
 		if err != nil {
 			return nil, err
 		}
+		ginkgo.GinkgoLogr.Info("restconfig for cluster", "restconfig", restConfig)
 
 		tc.contextLock.Lock()
 		tc.hcpAdminConfigs[resourceGroupName+"/"+hcpClusterName] = restConfig


### PR DESCRIPTION
control to compare against https://github.com/Azure/ARO-HCP/pull/6124 to see what kubeconfig we're actually getting.