### PR TITLE
CNTRLPLANE-3469: test: apply CPO image override tag in e2e default cluster params

### DIFF
--- a/test/util/framework/deployment_params.go
+++ b/test/util/framework/deployment_params.go
@@ -245,8 +245,18 @@ func DefaultOpenshiftNodePoolChannelGroup() string {
 	return channelGroup
 }
 
+// applyCPOImageOverride sets the CPO image override tag when the
+// CPO_IMAGE_OVERRIDE environment variable is present. This is set by
+// the aro-hcp-hypershift-images-push CI step to override the control
+// plane operator image with one built from a HyperShift PR.
+func applyCPOImageOverride(tags map[string]*string) {
+	if cpoImage := os.Getenv("CPO_IMAGE_OVERRIDE"); cpoImage != "" {
+		tags[api.TagClusterCPOImageOverride] = to.Ptr(cpoImage)
+	}
+}
+
 func NewDefaultClusterParams20240610() ClusterParams20240610 {
-	return ClusterParams20240610{
+	params := ClusterParams20240610{
 		OpenshiftVersionId: DefaultOpenshiftControlPlaneVersionId(),
 		Network: NetworkConfig{
 			NetworkType: "OVNKubernetes",
@@ -268,10 +278,12 @@ func NewDefaultClusterParams20240610() ClusterParams20240610 {
 			api.TagClusterMaxCreationDuration: to.Ptr((ClusterCreationTimeout - time.Minute).String()),
 		},
 	}
+	applyCPOImageOverride(params.Tags)
+	return params
 }
 
 func NewDefaultClusterParams20251223() ClusterParams20251223 {
-	return ClusterParams20251223{
+	params := ClusterParams20251223{
 		OpenshiftVersionId: DefaultOpenshiftControlPlaneVersionId(),
 		Network: NetworkConfig{
 			NetworkType: "OVNKubernetes",
@@ -293,10 +305,12 @@ func NewDefaultClusterParams20251223() ClusterParams20251223 {
 			api.TagClusterMaxCreationDuration: to.Ptr((ClusterCreationTimeout - time.Minute).String()),
 		},
 	}
+	applyCPOImageOverride(params.Tags)
+	return params
 }
 
 func NewDefaultClusterParams20260630() ClusterParams20260630 {
-	return ClusterParams20260630{
+	params := ClusterParams20260630{
 		OpenshiftVersionId: DefaultOpenshiftControlPlaneVersionId(),
 		Network: NetworkConfig{
 			NetworkType: "OVNKubernetes",
@@ -319,6 +333,8 @@ func NewDefaultClusterParams20260630() ClusterParams20260630 {
 			api.TagClusterMaxCreationDuration: to.Ptr((ClusterCreationTimeout - time.Minute).String()),
 		},
 	}
+	applyCPOImageOverride(params.Tags)
+	return params
 }
 
 type NodePoolParams20240610 struct {


### PR DESCRIPTION
### What

When the `CPO_IMAGE_OVERRIDE` environment variable is set (by the `aro-hcp-hypershift-images-push` CI step in [openshift/release](https://github.com/openshift/release)), apply it as the `TagClusterCPOImageOverride` ARM resource tag on all test clusters created during e2e runs.

### Why

The HyperShift presubmit `e2e-aro-hcp` job builds both the HyperShift Operator (HO) and Control Plane Operator (CPO) images from the PR source code. The `images-push` step pushes both to ACR and writes:
- HO override: applied via config overlay in the deploy step (already working)
- CPO override: written to `CPO_IMAGE_OVERRIDE` env var, intended to be applied as an AFEC-gated ARM tag

The test step sources the `CPO_IMAGE_OVERRIDE` env var, but the e2e framework never reads it or applies it as a cluster tag. This means hosted clusters created during HyperShift PR tests use the default CPO from the OCP release payload instead of the one built from the PR.

This was confirmed by querying the `kubernetesResourceSnapshots` Kusto table — the HO pods had the correct PR-built image digest, but all CPO pods used the default release payload images.

### How

Added `applyCPOImageOverride()` helper that conditionally sets the `TagClusterCPOImageOverride` tag when `CPO_IMAGE_OVERRIDE` is present. Called from all three API-versioned `NewDefaultClusterParams*` functions so every test cluster gets the override.

### Prerequisites

The e2e subscription must have the `ExperimentalReleaseFeatures` AFEC registered for the tag to be honored (same requirement as the existing `TagClusterSizeOverride` and `TagClusterMaxCreationDuration` tags).