### PR TITLE
feat(test): add HyperShift Operator image debug link to custom-link-tools

### DIFF
--- a/test/cmd/aro-hcp-tests/custom-link-tools/cmd_test.go
+++ b/test/cmd/aro-hcp-tests/custom-link-tools/cmd_test.go
@@ -72,8 +72,8 @@ func decodeQueryFromLinkURL(t *testing.T, linkURL string) string {
 func assertAllServiceLinkQueriesContainTimeWindow(t *testing.T, links []LinkDetails, expectedStart, expectedEnd string) {
 	t.Helper()
 
-	if len(links) != 8 {
-		t.Fatalf("expected 8 service links, got %d", len(links))
+	if len(links) != 9 {
+		t.Fatalf("expected 9 service links, got %d", len(links))
 	}
 
 	startDateTime := "datetime(" + expectedStart + ")"

--- a/test/cmd/aro-hcp-tests/custom-link-tools/options.go
+++ b/test/cmd/aro-hcp-tests/custom-link-tools/options.go
@@ -525,5 +525,17 @@ func getServiceLogLinks(tw timing.TimeWindow, svcClusterName, mgmtClusterName st
 		allLinks = append(allLinks, createLink(mt.displayName, q, kustoInfo))
 	}
 
+	// HyperShift Operator image on the management cluster
+	hoImageDef, err := factory.GetCustomQueryDefinition("hypershiftOperatorImage")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get hypershift operator image query definition: %w", err)
+	}
+	hoImageData := kusto.NewTemplateDataFromOptions(mgmtOpts)
+	hoImageQuery, err := factory.BuildMerged(*hoImageDef, hoImageData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build hypershift operator image query: %w", err)
+	}
+	allLinks = append(allLinks, createLink("HyperShift Operator Image", hoImageQuery, kustoInfo))
+
 	return allLinks, nil
 }

--- a/test/cmd/testdata/zz_fixture_TestGeneratedHTMLWithoutStepsUsesTimingFallbackcustom_link_tools_no_steps.html
+++ b/test/cmd/testdata/zz_fixture_TestGeneratedHTMLWithoutStepsUsesTimingFallbackcustom_link_tools_no_steps.html
@@ -79,6 +79,12 @@
           </a>
         </li>
     
+        <li>
+          <a target="_blank" href="https://dataexplorer.azure.com/clusters/hcp-dev-us-2.eastus2/databases/ServiceLogs?query=H4sIAAAAAAAA%2F2ySz27bMAzG734Kopc6wOw4abcGGXzfsMOKZrvsEjAWE6uz%2FkCk4njoww%2BKG6cbqpOt70d%2BFMn5HL4MnsKm1XuB754Cigvw1eCB1sCt6xn6VjcttAnjhBXugumEQY8MinznBlLgLEhL2XwOBi0eyJAVaLrIQgFUDNoeEgBCLNBrq1xfwk%2Bmfexg7wIcKej9MFIogPD4VOyi7mQ0S4ndkULQajRG7ztNqsyYBKyTEG2Dop39nP2OOwqWhPiJ2MXQ0Mai59YJZy%2FQtxQIRBtiQeNhR9ITWcgVCqXrfFktPxaLZbF4%2BFHdrZf362pVVuP5NYOyhHfJ%2B%2FWiWlcPV3I2mV3aUNdw2za%2BiFZR6HAofHB9Ebm%2Fe%2F60WhXmYKRY3E5hbvdMjXzTVqXIm0enbibNoiH22NBZus7oXwJYMAj3Wlq4uUyvSIw5FnTyaBU0zgpqm8p7dSxZUCKXk7I5%2F1PqHp2E3gZtzzY1iGNJM84npUzK7EMGlzMuzbvoWXrTr%2F%2By19fir%2B%2FTbJ2Q8TLkUzhHYzDoPwTeqW3johWoQZ0%2F8rEe6JBly2niNRg85dMmzGA3vC7bC7igKKSLK66Im%2BxvAAAA%2F%2F8jC94vOAMAAA%3D%3D" title="HyperShift Operator Image">
+              HyperShift Operator Image
+          </a>
+        </li>
+    
   </ul>
 
   

--- a/test/cmd/testdata/zz_fixture_TestGeneratedHTMLcustom_link_tools.html
+++ b/test/cmd/testdata/zz_fixture_TestGeneratedHTMLcustom_link_tools.html
@@ -79,6 +79,12 @@
           </a>
         </li>
     
+        <li>
+          <a target="_blank" href="https://dataexplorer.azure.com/clusters/hcp-dev-us-2.eastus2/databases/ServiceLogs?query=H4sIAAAAAAAA%2F2ySz27bMAzG734Kopc6wOw4CbZ2GXzfsMOKZrvsEjAWE6uz%2FkCk4njoww%2BKG6cdqpOt70d%2BFMn5HL4OnsKm1XuBH54CigvwzeCB1sCt6xn6VjcttAnjhBXugumEQY8MinznBlLgLEhL2XwOBi0eyJAVaLrIQgFUDNoeEgBCLNBrq1xfwi%2Bmfexg7wIcKej9MFIogPDwWOyi7mQ0S4ndkULQajRG7ztNqsyYBKyTEG2Dop39kv2JOwqWhPiR2MXQ0Mai59YJZ8%2FQtxQIRBtiQeNhR9ITWcgVCqXrfFktl0W1KhZ3Pxd361W1rqqyGs%2FvGZQlvEt%2BXi8%2BviFnk9mlDXUNt23ji2gVhQ6HwgfXF5H71dOn%2B%2FvCHIwUi9spzO2eqJHv2qoUefPg1M2kWTTEHhs6S9cZvSWABYNwr6WFm8v0isSYY0Enj1ZB46ygtqm8F8eSBSVyOSmb8z%2Bl7tFJ6HXQ9mxTgziWNON8UsqkzD5kcDnj0ryLnqVX%2Ffove30t%2Fvo%2BzdYJGS9DPoVzNAaD%2Fkvgndo2LlqBGtT5Ix%2FrgQ5ZtpwmXoPBUz5twgx2w8uyPYMLikK6uOKKuMn%2BBQAA%2F%2F%2BHS%2FOqOAMAAA%3D%3D" title="HyperShift Operator Image">
+              HyperShift Operator Image
+          </a>
+        </li>
+    
   </ul>
 
   

--- a/tooling/hcpctl/pkg/kusto/templates/custom/debug_mgmt_pod_images.kql.gotmpl
+++ b/tooling/hcpctl/pkg/kusto/templates/custom/debug_mgmt_pod_images.kql.gotmpl
@@ -1,0 +1,19 @@
+// HyperShift Operator Image: shows which hypershift-operator image was deployed on the
+// management cluster during the test window. Useful for verifying that a PR-built image
+// override was applied.
+{{- if .NoTruncation}}
+set notruncation;
+{{end -}}
+kubernetesResourceSnapshots
+| where timestamp between ({{.TimestampMin}} .. {{.TimestampMax}})
+| where cluster == '{{.ClusterName}}'
+| where objectKind == "Pod"
+| where namespace == "hypershift"
+| where name startswith "operator-"
+| mv-expand container = object.status.containerStatuses
+| extend container_name = tostring(container.name),
+         image = tostring(container.image)
+| where container_name == "operator"
+| where isnotempty(image)
+| summarize pod_count = dcount(name), last_seen = max(timestamp) by image
+| order by last_seen desc

--- a/tooling/hcpctl/pkg/kusto/templates/custom/queries.yaml
+++ b/tooling/hcpctl/pkg/kusto/templates/custom/queries.yaml
@@ -34,6 +34,10 @@
     templatePath: templates/custom/detailed_cluster_mgmt_logs.kql.gotmpl
   - name: detailedInfraOrchestrationLogs
     templatePath: templates/custom/detailed_infra_orchestration_logs.kql.gotmpl
+- name: hypershiftOperatorImage
+  database: ServiceLogs
+  queryType: custom-logs
+  templatePath: templates/custom/debug_mgmt_pod_images.kql.gotmpl
 - name: hostedControlPlaneLogs
   database: HostedControlPlaneLogs
   queryType: custom-logs


### PR DESCRIPTION
## Summary
- Adds a "HyperShift Operator Image" Kusto deep-link to CI Spyglass artifacts
- Queries `kubernetesResourceSnapshots` for the hypershift-operator container image running on the management cluster during the test window
- One-click verification that a PR-built HO image override was deployed, or audit which HO version ran during a failure

## Changes
- New KQL template: `tooling/hcpctl/pkg/kusto/templates/custom/debug_mgmt_pod_images.kql.gotmpl`
- Registered `hypershiftOperatorImage` query definition in `templates/custom/queries.yaml`
- Wired into `getServiceLogLinks()` in `custom-link-tools/options.go`
- Updated test fixtures and expected link count

## Test plan
- [x] `go build ./test/cmd/aro-hcp-tests/...` passes
- [x] `go test ./cmd/aro-hcp-tests/custom-link-tools/...` passes with updated fixtures
- [x] Verified query returns correct results in ADX against CI cluster data
- [x] Verified debug link renders and opens correctly from CI Spyglass artifacts