### PR TITLE
feat: do not error when cs id clearer controllers replace fail due to 412 precondition failed

### DIFF
--- a/backend/pkg/controllers/clusterdeletion/cluster_cluster_service_id_clearer.go
+++ b/backend/pkg/controllers/clusterdeletion/cluster_cluster_service_id_clearer.go
@@ -123,7 +123,12 @@ func (c *clusterClusterServiceIDClearer) SyncOnce(ctx context.Context, key contr
 		// 404 - cluster-service has finished deleting the Cluster, clear the CS ID.
 		logger.Info("cluster-service Cluster gone. Clearing ClusterServiceID", "clusterServiceID", csID.String())
 		cluster.ServiceProviderProperties.ClusterServiceID = nil
-		if _, err := clusterCRUD.Replace(ctx, cluster, nil); err != nil {
+		_, err = clusterCRUD.Replace(ctx, cluster, nil)
+		if database.IsPreconditionFailedError(err) {
+			// if we have a conflict error, then we're guaranteed that our informer will eventually see an update and trigger us again.
+			return nil
+		}
+		if err != nil {
 			return utils.TrackError(fmt.Errorf("failed to clear ClusterServiceID: %w", err))
 		}
 		return nil

--- a/backend/pkg/controllers/externalauthdeletion/external_auth_cluster_service_id_clearer.go
+++ b/backend/pkg/controllers/externalauthdeletion/external_auth_cluster_service_id_clearer.go
@@ -125,7 +125,12 @@ func (c *externalAuthClusterServiceIDClearer) SyncOnce(ctx context.Context, key 
 		logger.Info("cluster-service ExternalAuth gone. Clearing ClusterServiceID", "clusterServiceID", csID.String())
 		replacement := externalAuth.DeepCopy()
 		replacement.ServiceProviderProperties.ClusterServiceID = nil
-		if _, err := externalAuthCRUD.Replace(ctx, replacement, nil); err != nil {
+		_, err = externalAuthCRUD.Replace(ctx, replacement, nil)
+		if database.IsPreconditionFailedError(err) {
+			// if we have a conflict error, then we're guaranteed that our informer will eventually see an update and trigger us again.
+			return nil
+		}
+		if err != nil {
 			return utils.TrackError(fmt.Errorf("failed to clear ClusterServiceID: %w", err))
 		}
 		return nil

--- a/backend/pkg/controllers/nodepooldeletion/node_pool_cluster_service_id_clearer.go
+++ b/backend/pkg/controllers/nodepooldeletion/node_pool_cluster_service_id_clearer.go
@@ -128,7 +128,12 @@ func (c *nodePoolClusterServiceIDClearer) SyncOnce(ctx context.Context, key cont
 		logger.Info("cluster-service NodePool gone. Clearing ClusterServiceID", "clusterServiceID", csID.String())
 		replacement := nodePool.DeepCopy()
 		replacement.ServiceProviderProperties.ClusterServiceID = nil
-		if _, err := nodePoolCRUD.Replace(ctx, replacement, nil); err != nil {
+		_, err = nodePoolCRUD.Replace(ctx, replacement, nil)
+		if database.IsPreconditionFailedError(err) {
+			// if we have a conflict error, then we're guaranteed that our informer will eventually see an update and trigger us again.
+			return nil
+		}
+		if err != nil {
 			return utils.TrackError(fmt.Errorf("failed to clear ClusterServiceID: %w", err))
 		}
 		return nil


### PR DESCRIPTION
It is common to have outdated database content. Instead of returning an error we return normally. The informer will eventually see there's an update and trigger the controller again.