### PR TITLE
feat: do not error when identity migration and base domain prefix controllers replace fail due to 412 precondition failed

### DIFF
--- a/backend/pkg/controllers/clusterpropertiescontroller/cluster_base_domain_prefix_sync.go
+++ b/backend/pkg/controllers/clusterpropertiescontroller/cluster_base_domain_prefix_sync.go
@@ -114,7 +114,12 @@ func (c *clusterBaseDomainPrefixSyncer) SyncOnce(ctx context.Context, key contro
 		return nil
 	}
 
-	if _, err := clusterCRUD.Replace(ctx, replacement, nil); err != nil {
+	_, err = clusterCRUD.Replace(ctx, replacement, nil)
+	if database.IsPreconditionFailedError(err) {
+		// if we have a conflict error, then we're guaranteed that our informer will eventually see an update and trigger us again.
+		return nil
+	}
+	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to replace Cluster: %w", err))
 	}
 

--- a/backend/pkg/controllers/clusterpropertiescontroller/identity_migration.go
+++ b/backend/pkg/controllers/clusterpropertiescontroller/identity_migration.go
@@ -199,7 +199,12 @@ func (c *identityMigrationSyncer) SyncOnce(ctx context.Context, key controllerut
 	replacement.Identity.UserAssignedIdentities = userAssignedIdentities
 
 	// Write the updated cluster back to Cosmos
-	if _, err := clusterCRUD.Replace(ctx, replacement, nil); err != nil {
+	_, err = clusterCRUD.Replace(ctx, replacement, nil)
+	if database.IsPreconditionFailedError(err) {
+		// if we have a conflict error, then we're guaranteed that our informer will eventually see an update and trigger us again.
+		return nil
+	}
+	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to replace Cluster: %w", err))
 	}
 


### PR DESCRIPTION
It is common to have outdated database content. Instead of returning an error we return normally. The informer will eventually see there's an update and trigger the controller again.

<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

### Why

<!-- Briefly explain why this change is needed -->

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
