### PR TITLE
fix(config): drop dead INT mgmt prometheus memory limit (AROSLSRE-1549)

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -25,10 +25,11 @@ clouds:
           #    autoscaler ceiling (maxCount 3/pool) is unchanged.
           #  - shards 2 -> 4: halves per-shard series/WAL so a remote-write stall
           #    replay after a restart stays bounded.
-          #  - limits.memory 5Gi: caps a runaway pod so it OOM-kills itself
-          #    instead of taking the ~11.8Gi node down.
           #  - requests.memory 2Gi: keeps all 8 pods schedulable across 4 nodes
           #    (2 x 2Gi + ~2Gi infra baseline = ~6Gi/node of ~11.8Gi).
+          # The memory limit is intentionally not set here: sdp-pipelines pins
+          # the mgmt prometheus limit to 6Gi (hcp/config.msft.sensitive.clouds-overlay.yaml)
+          # and that override wins, so any value set here is dead config.
           mgmt:
             aks:
               infraAgentPool:
@@ -39,8 +40,6 @@ clouds:
                 resources:
                   requests:
                     memory: 2Gi
-                  limits:
-                    memory: 5Gi
       stg:
         # this is the MSFT STAGE environment
         defaults:


### PR DESCRIPTION
Ref: https://redhat.atlassian.net/browse/AROSLSRE-1549

### What

Removes the `limits.memory: 5Gi` from the INT management-cluster prometheus overlay in `config.msft.clouds-overlay.yaml`. `shards: 4` and `requests.memory: 2Gi` are unchanged.

### Why

That 5Gi limit never took effect. sdp-pipelines pins the mgmt prometheus memory limit to 6Gi in `hcp/config.msft.sensitive.clouds-overlay.yaml`, and that override wins at render time, so the value here was dead config that misleadingly implied a 5Gi cap. Removing it and documenting where the real cap lives avoids future confusion. INT effectively runs at 6Gi today and stays that way.

### Testing

- `cd config && make materialize` passes with no rendered-config diff (msft rendered configs live in sdp-pipelines, not this repo).

### Special notes for your reviewer

Config-only change to a comment block plus the removal of the dead limit. No behavior change: the effective limit remains 6Gi from sdp-pipelines.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows Conventional Commits format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Commit history is clean (rebased/squashed)
