### PR TITLE
fix(test): handle in-process execution when run-suite has a single upgrade spec

### DIFF
--- a/test/util/framework/upgrade_barrier.go
+++ b/test/util/framework/upgrade_barrier.go
@@ -68,10 +68,10 @@ type upgradeBarrierState struct {
 	// participating; survivors proceed once the barrier settles.
 	AbortedCount int `yaml:"aborted_count"`
 	// RunID holds the PID of the parent run-suite process (os.Getpid() in the
-	// UpgradeCoordinator, os.Getppid() in worker specs). Both values resolve to
-	// the same PID — the parent's own PID — so all participants in a single
-	// suite invocation agree on the same RunID. A new invocation spawns a new
-	// parent process with a different PID, which triggers a stale-state reset.
+	// UpgradeCoordinator). In subprocess mode (normal parallel run) worker specs
+	// match this via os.Getppid(); in in-process mode (single spec, same process)
+	// they match via os.Getpid(). A new invocation spawns a new parent process
+	// with a different PID, which triggers a stale-state reset.
 	RunID int `yaml:"run_id"`
 	// UpgradeDone is set to true by the UpgradeCoordinator once the Region
 	// entrypoint pipeline has finished (successfully or not).
@@ -123,7 +123,7 @@ type UpgradeBarrier struct {
 	statePath      string
 	lockFile       *os.File
 	total          int
-	runID          int // os.Getppid() of this worker; equals os.Getpid() of the parent run-suite process
+	runID          int // PID that identifies this suite run; set to os.Getppid() in subprocess mode or os.Getpid() in in-process mode
 	pollInterval   time.Duration
 	upgradeTimeout time.Duration
 
@@ -162,7 +162,6 @@ func NewUpgradeBarrier() (*UpgradeBarrier, error) {
 		statePath:      statePath,
 		lockFile:       lf,
 		total:          total,
-		runID:          os.Getppid(),
 		pollInterval:   defaultUpgradeBarrierPollInterval,
 		upgradeTimeout: defaultUpgradeTimeout,
 	}
@@ -173,16 +172,27 @@ func NewUpgradeBarrier() (*UpgradeBarrier, error) {
 	// same suite invocation; if the IDs differ the coordinator is out of sync
 	// with this worker and coordination will fail, so we return an error rather
 	// than silently resetting state that belongs to a running coordinator.
+	//
+	// Two execution modes are supported:
+	//  - Subprocess mode (normal parallel run): each spec runs in a separate OS
+	//    process spawned by run-suite. The coordinator's PID == os.Getppid() here.
+	//  - In-process mode (single spec): run-suite runs the spec in the same
+	//    process as the coordinator. The coordinator's PID == os.Getpid() here.
 	if err := b.withLock(func(state *upgradeBarrierState) (bool, error) {
-		if state.RunID == b.runID {
-			return false, nil // coordinator or sibling already initialised — leave it
+		switch state.RunID {
+		case os.Getppid():
+			b.runID = os.Getppid() // subprocess: parent is the coordinator
+		case os.Getpid():
+			b.runID = os.Getpid() // in-process: we share the process with the coordinator
+		default:
+			return false, fmt.Errorf(
+				"upgrade barrier: RunID mismatch (state=%d, own=%d, parent=%d); "+
+					"the UpgradeCoordinator must initialise the state file before workers start. "+
+					"If invoking via 'run-test', note that upgrade/in-place specs are not supported "+
+					"with 'run-test' — use 'run-suite upgrade/in-place' or CI instead",
+				state.RunID, os.Getpid(), os.Getppid())
 		}
-		return false, fmt.Errorf(
-			"upgrade barrier: RunID mismatch (state=%d, expected=%d); "+
-				"the UpgradeCoordinator must initialise the state file before workers start. "+
-				"If invoking via 'run-test', note that upgrade/in-place specs are not supported "+
-				"with 'run-test' — use 'run-suite upgrade/in-place' or CI instead",
-			state.RunID, b.runID)
+		return false, nil
 	}); err != nil {
 		lf.Close()
 		return nil, fmt.Errorf("initialising upgrade barrier state: %w", err)

--- a/test/util/framework/upgrade_barrier_test.go
+++ b/test/util/framework/upgrade_barrier_test.go
@@ -82,8 +82,9 @@ func newLinkedBarrier(t *testing.T, source *UpgradeBarrier) *UpgradeBarrier {
 
 // newTestCoordinator creates an UpgradeCoordinator backed by the same state
 // file and lock as the given barrier, with fast poll intervals.
-// The coordinator's runID is set to match the source barrier's runID (simulating
-// the runtime relationship where workers use os.Getppid() == parent's os.Getpid()).
+// The coordinator's runID is set to match the source barrier's runID, simulating
+// subprocess mode where the coordinator's os.Getpid() equals workers' os.Getppid().
+// (In-process mode — where both share os.Getpid() — is an edge case not exercised here.)
 // It also calls initState() synchronously, mirroring NewUpgradeCoordinator which
 // must write the state before any worker calls NewUpgradeBarrier.
 func newTestCoordinator(t *testing.T, source *UpgradeBarrier) *UpgradeCoordinator {
@@ -97,7 +98,7 @@ func newTestCoordinator(t *testing.T, source *UpgradeBarrier) *UpgradeCoordinato
 		statePath:         source.statePath,
 		lockFile:          lf,
 		total:             source.total,
-		runID:             source.runID, // must match: at runtime os.Getpid()==parent==os.Getppid() of workers
+		runID:             source.runID, // subprocess mode: coordinator.os.Getpid() == workers' os.Getppid()
 		pollInterval:      10 * time.Millisecond,
 		settleTimeout:     5 * time.Second,
 		upgradeRunTimeout: 5 * time.Second,
@@ -523,4 +524,72 @@ func TestUpgradeCoordinator_WritesUpgradeDone(t *testing.T) {
 	state, err = b0.readState()
 	require.NoError(t, err)
 	assert.Equal(t, upgradeErr.Error(), state.UpgradeError, "original error must be preserved on second call")
+}
+
+// TestNewUpgradeBarrier_SubprocessMode verifies that NewUpgradeBarrier succeeds when the
+// state file RunID matches os.Getppid() — the normal case where each spec runs as a
+// subprocess spawned by run-suite and the coordinator lives in the parent process.
+func TestNewUpgradeBarrier_SubprocessMode(t *testing.T) {
+	// Serial: NewUpgradeBarrier uses a global lock file path (os.TempDir()).
+	tmpDir := t.TempDir()
+	t.Setenv("ARTIFACT_DIR", tmpDir)
+	SetUpgradeInPlaceSpecCount(2)
+	t.Cleanup(func() { upgradeInPlaceSpecCount = 0 })
+
+	seedUpgradeState(t, &upgradeBarrierState{RunID: os.Getppid()})
+
+	b, err := NewUpgradeBarrier()
+	require.NoError(t, err, "NewUpgradeBarrier should succeed in subprocess mode")
+	if b != nil {
+		_ = b.lockFile.Close()
+	}
+	assert.Equal(t, os.Getppid(), b.runID, "runID should be os.Getppid() in subprocess mode")
+}
+
+// TestNewUpgradeBarrier_InProcessMode verifies that NewUpgradeBarrier succeeds when the
+// state file RunID matches os.Getpid() — the case where run-suite has a single spec and
+// runs it in-process alongside the coordinator goroutine.
+func TestNewUpgradeBarrier_InProcessMode(t *testing.T) {
+	// Serial: NewUpgradeBarrier uses a global lock file path (os.TempDir()).
+	tmpDir := t.TempDir()
+	t.Setenv("ARTIFACT_DIR", tmpDir)
+	SetUpgradeInPlaceSpecCount(1)
+	t.Cleanup(func() { upgradeInPlaceSpecCount = 0 })
+
+	seedUpgradeState(t, &upgradeBarrierState{RunID: os.Getpid()})
+
+	b, err := NewUpgradeBarrier()
+	require.NoError(t, err, "NewUpgradeBarrier should succeed in in-process mode")
+	if b != nil {
+		_ = b.lockFile.Close()
+	}
+	assert.Equal(t, os.Getpid(), b.runID, "runID should be os.Getpid() in in-process mode")
+}
+
+// TestNewUpgradeBarrier_RunIDMismatch verifies that NewUpgradeBarrier returns an error
+// when the state file contains a RunID that matches neither os.Getpid() nor os.Getppid(),
+// indicating a stale file from a prior run or a direct run-test invocation without a coordinator.
+func TestNewUpgradeBarrier_RunIDMismatch(t *testing.T) {
+	// Serial: NewUpgradeBarrier uses a global lock file path (os.TempDir()).
+	tmpDir := t.TempDir()
+	t.Setenv("ARTIFACT_DIR", tmpDir)
+	SetUpgradeInPlaceSpecCount(1)
+	t.Cleanup(func() { upgradeInPlaceSpecCount = 0 })
+
+	// Derive a RunID guaranteed to match neither os.Getpid() nor os.Getppid().
+	staleRunID := os.Getpid() + os.Getppid() + 1
+	seedUpgradeState(t, &upgradeBarrierState{RunID: staleRunID})
+
+	_, err := NewUpgradeBarrier()
+	require.Error(t, err, "NewUpgradeBarrier should fail on RunID mismatch")
+	assert.Contains(t, err.Error(), "RunID mismatch", "error should name the mismatch")
+}
+
+// seedUpgradeState writes state to upgradeStatePath() — the path NewUpgradeBarrier reads —
+// so tests can control what RunID the barrier finds on startup. Requires ARTIFACT_DIR to be
+// set via t.Setenv before calling so each test gets an isolated state file.
+func seedUpgradeState(t *testing.T, state *upgradeBarrierState) {
+	t.Helper()
+	b := &UpgradeBarrier{statePath: upgradeStatePath()}
+	require.NoError(t, b.writeState(state), "seeding upgrade state file")
 }

--- a/test/util/framework/upgrade_coordinator.go
+++ b/test/util/framework/upgrade_coordinator.go
@@ -106,7 +106,7 @@ func NewUpgradeCoordinator() (*UpgradeCoordinator, error) {
 		statePath:         upgradeStatePath(),
 		lockFile:          lf,
 		total:             total,
-		runID:             os.Getpid(), // parent PID; workers use os.Getppid() which equals this
+		runID:             os.Getpid(), // parent PID; subprocess workers match via os.Getppid(), in-process workers via os.Getpid()
 		pollInterval:      defaultUpgradeBarrierPollInterval,
 		settleTimeout:     defaultSettleTimeout,
 		upgradeRunTimeout: defaultUpgradeRunTimeout,


### PR DESCRIPTION
### What

Detect both execution modes in `NewUpgradeBarrier` by checking the state file RunID against both PIDs:
- **Subprocess mode** (N > 1 specs): `state.RunID == os.Getppid()` — unchanged
- **In-process mode** (1 spec): `state.RunID == os.Getpid()` — new case

Any other RunID still fails fast with an actionable error that names both PIDs and hints at the `run-test` limitation. Updated comments in `upgrade_coordinator.go` and `upgrade_barrier_test.go` to reflect both execution modes.

### Why

`openshift-tests-extension` runs specs in-process when the suite has only one spec — rather than spawning a separate `run-test` subprocess. In that mode the spec and the `UpgradeCoordinator` share the same OS process, so `os.Getppid()` (the shell's PID) never matches the coordinator's `os.Getpid()` stored in the state file. `NewUpgradeBarrier` was failing with a RunID mismatch on every single-spec run-suite invocation.

### Testing

- Ran `upgrade/in-place` suite with a single spec — coordinator and spec coordinated correctly in in-process mode
- Ran `upgrade/in-place` suite with two specs (original + copy) — subprocess mode works as before, both specs checked in and validated independently
- Framework unit tests pass: `go test ./test/util/framework/...`

### Special notes for your reviewer

Failed run https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/80778/rehearse-80778-pull-ci-Azure-ARO-HCP-main-e2e-parallel-inplace-upgrade/2079896761534517248 

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
