### PR TITLE
feat(observability): add kube-apiserver latency recording rules

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedHCPRecordingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedHCPRecordingRules.bicep
@@ -173,6 +173,10 @@ resource hcpKasLatencyRecordingRules 'Microsoft.AlertsManagement/prometheusRuleG
         expression: 'sum by (namespace, cluster) (rate(apiserver_request_sli_duration_seconds_bucket{le="1.0",namespace=~"ocm-.*",scope=~"resource|namespace|cluster",subresource!~"proxy|attach|log|exec|portforward",verb=~"POST|PUT|PATCH|DELETE"}[5m]) or rate(apiserver_request_sli_duration_seconds_bucket{le="1.0",namespace=~"ocm-.*",scope="resource",subresource!~"proxy|attach|log|exec|portforward",verb=~"GET|LIST"}[5m]) or rate(apiserver_request_sli_duration_seconds_bucket{le="5.0",namespace=~"ocm-.*",scope="namespace",subresource!~"proxy|attach|log|exec|portforward",verb=~"GET|LIST"}[5m]) or rate(apiserver_request_sli_duration_seconds_bucket{le="30.0",namespace=~"ocm-.*",scope="cluster",subresource!~"proxy|attach|log|exec|portforward",verb=~"GET|LIST"}[5m])) / sum by (namespace, cluster) (rate(apiserver_request_sli_duration_seconds_count{namespace=~"ocm-.*",scope=~"resource|namespace|cluster",subresource!~"proxy|attach|log|exec|portforward",verb=~"POST|PUT|PATCH|DELETE|GET|LIST"}[5m]))'
       }
       {
+        record: 'kas:apiserver_request_latency:sli_ratio:rate_avg_5m'
+        expression: 'avg_over_time(kas:apiserver_request_latency:sli_ratio:rate5m[5m])'
+      }
+      {
         record: 'kas:apiserver_request_latency:sli_ratio:rate_avg_30m'
         expression: 'avg_over_time(kas:apiserver_request_latency:sli_ratio:rate5m[30m])'
       }
@@ -191,6 +195,30 @@ resource hcpKasLatencyRecordingRules 'Microsoft.AlertsManagement/prometheusRuleG
       {
         record: 'kas:apiserver_request_latency:sli_ratio:rate_avg_30d'
         expression: 'avg_over_time(kas:apiserver_request_latency:sli_ratio:rate5m[30d:5m])'
+      }
+      {
+        record: 'kas:apiserver_request_terminations:rate5m'
+        expression: 'sum by (namespace, cluster) (rate(apiserver_request_terminations_total{namespace=~"ocm-.*"}[5m]))'
+      }
+      {
+        record: 'kas:apiserver_inflight_requests:avg_5m'
+        expression: 'avg_over_time(sum by (namespace, cluster, requestKind) (apiserver_current_inflight_requests{namespace=~"ocm-.*"})[5m:1m])'
+      }
+      {
+        record: 'kas:apiserver_request_latency:sli_ratio_mutating:rate5m'
+        expression: 'sum by (namespace, cluster) (rate(apiserver_request_sli_duration_seconds_bucket{le="1.0",namespace=~"ocm-.*",scope=~"resource|namespace|cluster",subresource!~"proxy|attach|log|exec|portforward",verb=~"POST|PUT|PATCH|DELETE"}[5m])) / sum by (namespace, cluster) (rate(apiserver_request_sli_duration_seconds_count{namespace=~"ocm-.*",scope=~"resource|namespace|cluster",subresource!~"proxy|attach|log|exec|portforward",verb=~"POST|PUT|PATCH|DELETE"}[5m]))'
+      }
+      {
+        record: 'kas:apiserver_request_latency:sli_ratio_reads_resource:rate5m'
+        expression: 'sum by (namespace, cluster) (rate(apiserver_request_sli_duration_seconds_bucket{le="1.0",namespace=~"ocm-.*",scope="resource",subresource!~"proxy|attach|log|exec|portforward",verb=~"GET|LIST"}[5m])) / sum by (namespace, cluster) (rate(apiserver_request_sli_duration_seconds_count{namespace=~"ocm-.*",scope="resource",subresource!~"proxy|attach|log|exec|portforward",verb=~"GET|LIST"}[5m]))'
+      }
+      {
+        record: 'kas:apiserver_request_latency:sli_ratio_reads_namespace:rate5m'
+        expression: 'sum by (namespace, cluster) (rate(apiserver_request_sli_duration_seconds_bucket{le="5.0",namespace=~"ocm-.*",scope="namespace",subresource!~"proxy|attach|log|exec|portforward",verb=~"GET|LIST"}[5m])) / sum by (namespace, cluster) (rate(apiserver_request_sli_duration_seconds_count{namespace=~"ocm-.*",scope="namespace",subresource!~"proxy|attach|log|exec|portforward",verb=~"GET|LIST"}[5m]))'
+      }
+      {
+        record: 'kas:apiserver_request_latency:sli_ratio_reads_cluster:rate5m'
+        expression: 'sum by (namespace, cluster) (rate(apiserver_request_sli_duration_seconds_bucket{le="30.0",namespace=~"ocm-.*",scope="cluster",subresource!~"proxy|attach|log|exec|portforward",verb=~"GET|LIST"}[5m])) / sum by (namespace, cluster) (rate(apiserver_request_sli_duration_seconds_count{namespace=~"ocm-.*",scope="cluster",subresource!~"proxy|attach|log|exec|portforward",verb=~"GET|LIST"}[5m]))'
       }
     ]
   }

--- a/dev-infrastructure/modules/metrics/rules/generatedHCPRecordingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedHCPRecordingRules.bicep
@@ -181,6 +181,10 @@ resource hcpKasLatencyRecordingRules 'Microsoft.AlertsManagement/prometheusRuleG
         expression: 'sum by (namespace, cluster) (rate(apiserver_request_sli_duration_seconds_bucket{le="1.0",namespace=~"ocm-.*",scope=~"resource|namespace|cluster",subresource!~"proxy|attach|log|exec|portforward",verb=~"POST|PUT|PATCH|DELETE"}[5m]) or rate(apiserver_request_sli_duration_seconds_bucket{le="1.0",namespace=~"ocm-.*",scope="resource",subresource!~"proxy|attach|log|exec|portforward",verb=~"GET|LIST"}[5m]) or rate(apiserver_request_sli_duration_seconds_bucket{le="5.0",namespace=~"ocm-.*",scope="namespace",subresource!~"proxy|attach|log|exec|portforward",verb=~"GET|LIST"}[5m]) or rate(apiserver_request_sli_duration_seconds_bucket{le="30.0",namespace=~"ocm-.*",scope="cluster",subresource!~"proxy|attach|log|exec|portforward",verb=~"GET|LIST"}[5m])) / sum by (namespace, cluster) (rate(apiserver_request_sli_duration_seconds_count{namespace=~"ocm-.*",scope=~"resource|namespace|cluster",subresource!~"proxy|attach|log|exec|portforward",verb=~"POST|PUT|PATCH|DELETE|GET|LIST"}[5m]))'
       }
       {
+        record: 'kas:apiserver_request_latency:sli_ratio:rate_avg_5m'
+        expression: 'avg_over_time(kas:apiserver_request_latency:sli_ratio:rate5m[5m])'
+      }
+      {
         record: 'kas:apiserver_request_latency:sli_ratio:rate_avg_30m'
         expression: 'avg_over_time(kas:apiserver_request_latency:sli_ratio:rate5m[30m])'
       }
@@ -199,6 +203,30 @@ resource hcpKasLatencyRecordingRules 'Microsoft.AlertsManagement/prometheusRuleG
       {
         record: 'kas:apiserver_request_latency:sli_ratio:rate_avg_30d'
         expression: 'avg_over_time(kas:apiserver_request_latency:sli_ratio:rate5m[30d:5m])'
+      }
+      {
+        record: 'kas:apiserver_request_terminations:rate5m'
+        expression: 'sum by (namespace, cluster) (rate(apiserver_request_terminations_total{namespace=~"ocm-.*"}[5m]))'
+      }
+      {
+        record: 'kas:apiserver_inflight_requests:avg_5m'
+        expression: 'avg_over_time(sum by (namespace, cluster, requestKind) (apiserver_current_inflight_requests{namespace=~"ocm-.*"})[5m:1m])'
+      }
+      {
+        record: 'kas:apiserver_request_latency:sli_ratio_mutating:rate5m'
+        expression: 'sum by (namespace, cluster) (rate(apiserver_request_sli_duration_seconds_bucket{le="1.0",namespace=~"ocm-.*",scope=~"resource|namespace|cluster",subresource!~"proxy|attach|log|exec|portforward",verb=~"POST|PUT|PATCH|DELETE"}[5m])) / sum by (namespace, cluster) (rate(apiserver_request_sli_duration_seconds_count{namespace=~"ocm-.*",scope=~"resource|namespace|cluster",subresource!~"proxy|attach|log|exec|portforward",verb=~"POST|PUT|PATCH|DELETE"}[5m]))'
+      }
+      {
+        record: 'kas:apiserver_request_latency:sli_ratio_reads_resource:rate5m'
+        expression: 'sum by (namespace, cluster) (rate(apiserver_request_sli_duration_seconds_bucket{le="1.0",namespace=~"ocm-.*",scope="resource",subresource!~"proxy|attach|log|exec|portforward",verb=~"GET|LIST"}[5m])) / sum by (namespace, cluster) (rate(apiserver_request_sli_duration_seconds_count{namespace=~"ocm-.*",scope="resource",subresource!~"proxy|attach|log|exec|portforward",verb=~"GET|LIST"}[5m]))'
+      }
+      {
+        record: 'kas:apiserver_request_latency:sli_ratio_reads_namespace:rate5m'
+        expression: 'sum by (namespace, cluster) (rate(apiserver_request_sli_duration_seconds_bucket{le="5.0",namespace=~"ocm-.*",scope="namespace",subresource!~"proxy|attach|log|exec|portforward",verb=~"GET|LIST"}[5m])) / sum by (namespace, cluster) (rate(apiserver_request_sli_duration_seconds_count{namespace=~"ocm-.*",scope="namespace",subresource!~"proxy|attach|log|exec|portforward",verb=~"GET|LIST"}[5m]))'
+      }
+      {
+        record: 'kas:apiserver_request_latency:sli_ratio_reads_cluster:rate5m'
+        expression: 'sum by (namespace, cluster) (rate(apiserver_request_sli_duration_seconds_bucket{le="30.0",namespace=~"ocm-.*",scope="cluster",subresource!~"proxy|attach|log|exec|portforward",verb=~"GET|LIST"}[5m])) / sum by (namespace, cluster) (rate(apiserver_request_sli_duration_seconds_count{namespace=~"ocm-.*",scope="cluster",subresource!~"proxy|attach|log|exec|portforward",verb=~"GET|LIST"}[5m]))'
       }
     ]
   }

--- a/observability/alerts/HCPkasRecord-prometheusRule-latency.yaml
+++ b/observability/alerts/HCPkasRecord-prometheusRule-latency.yaml
@@ -77,6 +77,8 @@ spec:
     # correct here because the base rule already produces a dimensionless [0,1]
     # value; smoothing it preserves that bound and gives burn-rate alert
     # consumers a stable signal.
+    - record: kas:apiserver_request_latency:sli_ratio:rate_avg_5m
+      expr: avg_over_time(kas:apiserver_request_latency:sli_ratio:rate5m[5m])
     - record: kas:apiserver_request_latency:sli_ratio:rate_avg_30m
       expr: avg_over_time(kas:apiserver_request_latency:sli_ratio:rate5m[30m])
     - record: kas:apiserver_request_latency:sli_ratio:rate_avg_1h
@@ -89,3 +91,99 @@ spec:
     # Subquery step of 5m matches the base rule rate window (rate5m).
     - record: kas:apiserver_request_latency:sli_ratio:rate_avg_30d
       expr: avg_over_time(kas:apiserver_request_latency:sli_ratio:rate5m[30d:5m])
+    # Request termination rate — ADR Traffic column signal. Non-zero means KAS
+    # is killing in-flight requests due to timeout or overload.
+    - record: kas:apiserver_request_terminations:rate5m
+      expr: sum by (namespace, cluster) (rate(apiserver_request_terminations_total{namespace=~"ocm-.*"}[5m]))
+    # In-flight request saturation — ADR Saturation column signal. Smoothed
+    # gauge of concurrent requests by kind (mutating vs readOnly).
+    - record: kas:apiserver_inflight_requests:avg_5m
+      expr: |
+        avg_over_time(
+          sum by (namespace, cluster, requestKind) (
+            apiserver_current_inflight_requests{namespace=~"ocm-.*"}
+          )[5m:1m]
+        )
+    # Per-category latency SLI breakdowns — triage decomposition for the
+    # aggregate SLI ratio. When the aggregate burns budget, these show which
+    # verb/scope category is responsible.
+    - record: kas:apiserver_request_latency:sli_ratio_mutating:rate5m
+      expr: |
+        sum by (namespace, cluster) (
+          rate(apiserver_request_sli_duration_seconds_bucket{
+            namespace=~"ocm-.*",
+            verb=~"POST|PUT|PATCH|DELETE",
+            scope=~"resource|namespace|cluster",
+            subresource!~"proxy|attach|log|exec|portforward",
+            le="1.0"
+          }[5m])
+        )
+        /
+        sum by (namespace, cluster) (
+          rate(apiserver_request_sli_duration_seconds_count{
+            namespace=~"ocm-.*",
+            verb=~"POST|PUT|PATCH|DELETE",
+            scope=~"resource|namespace|cluster",
+            subresource!~"proxy|attach|log|exec|portforward"
+          }[5m])
+        )
+    - record: kas:apiserver_request_latency:sli_ratio_reads_resource:rate5m
+      expr: |
+        sum by (namespace, cluster) (
+          rate(apiserver_request_sli_duration_seconds_bucket{
+            namespace=~"ocm-.*",
+            verb=~"GET|LIST",
+            scope="resource",
+            subresource!~"proxy|attach|log|exec|portforward",
+            le="1.0"
+          }[5m])
+        )
+        /
+        sum by (namespace, cluster) (
+          rate(apiserver_request_sli_duration_seconds_count{
+            namespace=~"ocm-.*",
+            verb=~"GET|LIST",
+            scope="resource",
+            subresource!~"proxy|attach|log|exec|portforward"
+          }[5m])
+        )
+    - record: kas:apiserver_request_latency:sli_ratio_reads_namespace:rate5m
+      expr: |
+        sum by (namespace, cluster) (
+          rate(apiserver_request_sli_duration_seconds_bucket{
+            namespace=~"ocm-.*",
+            verb=~"GET|LIST",
+            scope="namespace",
+            subresource!~"proxy|attach|log|exec|portforward",
+            le="5.0"
+          }[5m])
+        )
+        /
+        sum by (namespace, cluster) (
+          rate(apiserver_request_sli_duration_seconds_count{
+            namespace=~"ocm-.*",
+            verb=~"GET|LIST",
+            scope="namespace",
+            subresource!~"proxy|attach|log|exec|portforward"
+          }[5m])
+        )
+    - record: kas:apiserver_request_latency:sli_ratio_reads_cluster:rate5m
+      expr: |
+        sum by (namespace, cluster) (
+          rate(apiserver_request_sli_duration_seconds_bucket{
+            namespace=~"ocm-.*",
+            verb=~"GET|LIST",
+            scope="cluster",
+            subresource!~"proxy|attach|log|exec|portforward",
+            le="30.0"
+          }[5m])
+        )
+        /
+        sum by (namespace, cluster) (
+          rate(apiserver_request_sli_duration_seconds_count{
+            namespace=~"ocm-.*",
+            verb=~"GET|LIST",
+            scope="cluster",
+            subresource!~"proxy|attach|log|exec|portforward"
+          }[5m])
+        )

--- a/observability/alerts/HCPkasRecord-prometheusRule-latency_test.yaml
+++ b/observability/alerts/HCPkasRecord-prometheusRule-latency_test.yaml
@@ -101,3 +101,113 @@ tests:
     exp_samples:
     - labels: '{__name__="kas:apiserver_request_latency:sli_ratio:rate5m", cluster="test-mgmt-4", namespace="ocm-aro-test-04b"}'
       value: 0.25
+# Test 5: rate_avg_5m converges to base ratio with steady input
+- interval: 1m
+  input_series:
+  - series: 'apiserver_request_sli_duration_seconds_bucket{cluster="test-mgmt-5", namespace="ocm-aro-test-05", verb="POST", scope="resource", le="1.0"}'
+    values: "0+100x15"
+  - series: 'apiserver_request_sli_duration_seconds_count{cluster="test-mgmt-5", namespace="ocm-aro-test-05", verb="POST", scope="resource"}'
+    values: "0+100x15"
+  promql_expr_test:
+  - expr: kas:apiserver_request_latency:sli_ratio:rate_avg_5m{cluster="test-mgmt-5", namespace="ocm-aro-test-05"}
+    eval_time: 10m
+    exp_samples:
+    - labels: '{__name__="kas:apiserver_request_latency:sli_ratio:rate_avg_5m", cluster="test-mgmt-5", namespace="ocm-aro-test-05"}'
+      value: 1.0
+# Test 6: Termination rate — non-zero with terminations, namespace filtered
+- interval: 1m
+  input_series:
+  - series: 'apiserver_request_terminations_total{cluster="test-mgmt-6", namespace="ocm-aro-test-06"}'
+    values: "0+10x15"
+  - series: 'apiserver_request_terminations_total{cluster="test-mgmt-6", namespace="kube-system"}'
+    values: "0+100x15"
+  promql_expr_test:
+  - expr: kas:apiserver_request_terminations:rate5m{cluster="test-mgmt-6", namespace="ocm-aro-test-06"}
+    eval_time: 5m
+    exp_samples:
+    - labels: '{__name__="kas:apiserver_request_terminations:rate5m", cluster="test-mgmt-6", namespace="ocm-aro-test-06"}'
+      value: 0.16666666666666666
+  - expr: kas:apiserver_request_terminations:rate5m{cluster="test-mgmt-6", namespace="kube-system"}
+    eval_time: 5m
+    exp_samples: []
+# Test 7: In-flight request saturation — smoothed gauge by requestKind
+- interval: 1m
+  input_series:
+  - series: 'apiserver_current_inflight_requests{cluster="test-mgmt-7", namespace="ocm-aro-test-07", requestKind="mutating"}'
+    values: "10+0x15"
+  - series: 'apiserver_current_inflight_requests{cluster="test-mgmt-7", namespace="ocm-aro-test-07", requestKind="readOnly"}'
+    values: "20+0x15"
+  promql_expr_test:
+  - expr: kas:apiserver_inflight_requests:avg_5m{cluster="test-mgmt-7", namespace="ocm-aro-test-07", requestKind="mutating"}
+    eval_time: 5m
+    exp_samples:
+    - labels: '{__name__="kas:apiserver_inflight_requests:avg_5m", cluster="test-mgmt-7", namespace="ocm-aro-test-07", requestKind="mutating"}'
+      value: 10
+  - expr: kas:apiserver_inflight_requests:avg_5m{cluster="test-mgmt-7", namespace="ocm-aro-test-07", requestKind="readOnly"}
+    eval_time: 5m
+    exp_samples:
+    - labels: '{__name__="kas:apiserver_inflight_requests:avg_5m", cluster="test-mgmt-7", namespace="ocm-aro-test-07", requestKind="readOnly"}'
+      value: 20
+# Test 8: Per-category mutating ratio — 50% within 1s, proxy subresource excluded
+- interval: 1m
+  input_series:
+  - series: 'apiserver_request_sli_duration_seconds_bucket{cluster="test-mgmt-8", namespace="ocm-aro-test-08", verb="POST", scope="resource", le="1.0"}'
+    values: "0+50x15"
+  - series: 'apiserver_request_sli_duration_seconds_count{cluster="test-mgmt-8", namespace="ocm-aro-test-08", verb="POST", scope="resource"}'
+    values: "0+100x15"
+  - series: 'apiserver_request_sli_duration_seconds_bucket{cluster="test-mgmt-8", namespace="ocm-aro-test-08", verb="POST", scope="resource", subresource="proxy", le="1.0"}'
+    values: "0+200x15"
+  - series: 'apiserver_request_sli_duration_seconds_count{cluster="test-mgmt-8", namespace="ocm-aro-test-08", verb="POST", scope="resource", subresource="proxy"}'
+    values: "0+200x15"
+  promql_expr_test:
+  - expr: kas:apiserver_request_latency:sli_ratio_mutating:rate5m{cluster="test-mgmt-8", namespace="ocm-aro-test-08"}
+    eval_time: 5m
+    exp_samples:
+    - labels: '{__name__="kas:apiserver_request_latency:sli_ratio_mutating:rate5m", cluster="test-mgmt-8", namespace="ocm-aro-test-08"}'
+      value: 0.5
+# Test 9: Per-category resource-scope reads — 75% within 1s
+- interval: 1m
+  input_series:
+  - series: 'apiserver_request_sli_duration_seconds_bucket{cluster="test-mgmt-9", namespace="ocm-aro-test-09", verb="GET", scope="resource", le="1.0"}'
+    values: "0+75x15"
+  - series: 'apiserver_request_sli_duration_seconds_count{cluster="test-mgmt-9", namespace="ocm-aro-test-09", verb="GET", scope="resource"}'
+    values: "0+100x15"
+  promql_expr_test:
+  - expr: kas:apiserver_request_latency:sli_ratio_reads_resource:rate5m{cluster="test-mgmt-9", namespace="ocm-aro-test-09"}
+    eval_time: 5m
+    exp_samples:
+    - labels: '{__name__="kas:apiserver_request_latency:sli_ratio_reads_resource:rate5m", cluster="test-mgmt-9", namespace="ocm-aro-test-09"}'
+      value: 0.75
+# Test 10: Per-category namespace-scope reads — 50% within 5s
+- interval: 1m
+  input_series:
+  - series: 'apiserver_request_sli_duration_seconds_bucket{cluster="test-mgmt-10", namespace="ocm-aro-test-10", verb="LIST", scope="namespace", le="5.0"}'
+    values: "0+50x15"
+  - series: 'apiserver_request_sli_duration_seconds_count{cluster="test-mgmt-10", namespace="ocm-aro-test-10", verb="LIST", scope="namespace"}'
+    values: "0+100x15"
+  promql_expr_test:
+  - expr: kas:apiserver_request_latency:sli_ratio_reads_namespace:rate5m{cluster="test-mgmt-10", namespace="ocm-aro-test-10"}
+    eval_time: 5m
+    exp_samples:
+    - labels: '{__name__="kas:apiserver_request_latency:sli_ratio_reads_namespace:rate5m", cluster="test-mgmt-10", namespace="ocm-aro-test-10"}'
+      value: 0.5
+# Test 11: Per-category cluster-scope reads — 25% within 30s, namespace filter
+- interval: 1m
+  input_series:
+  - series: 'apiserver_request_sli_duration_seconds_bucket{cluster="test-mgmt-11", namespace="ocm-aro-test-11", verb="LIST", scope="cluster", le="30.0"}'
+    values: "0+25x15"
+  - series: 'apiserver_request_sli_duration_seconds_count{cluster="test-mgmt-11", namespace="ocm-aro-test-11", verb="LIST", scope="cluster"}'
+    values: "0+100x15"
+  - series: 'apiserver_request_sli_duration_seconds_bucket{cluster="test-mgmt-11", namespace="default", verb="LIST", scope="cluster", le="30.0"}'
+    values: "0+100x15"
+  - series: 'apiserver_request_sli_duration_seconds_count{cluster="test-mgmt-11", namespace="default", verb="LIST", scope="cluster"}'
+    values: "0+100x15"
+  promql_expr_test:
+  - expr: kas:apiserver_request_latency:sli_ratio_reads_cluster:rate5m{cluster="test-mgmt-11", namespace="ocm-aro-test-11"}
+    eval_time: 5m
+    exp_samples:
+    - labels: '{__name__="kas:apiserver_request_latency:sli_ratio_reads_cluster:rate5m", cluster="test-mgmt-11", namespace="ocm-aro-test-11"}'
+      value: 0.25
+  - expr: kas:apiserver_request_latency:sli_ratio_reads_cluster:rate5m{cluster="test-mgmt-11", namespace="default"}
+    eval_time: 5m
+    exp_samples: []


### PR DESCRIPTION
<!-- Link to Jira issue -->
[ARO-26895](https://redhat.atlassian.net/browse/ARO-26895)

Associated bug [fix](https://github.com/openshift/hypershift/pull/8715) in hypershift. 
Related [PR](https://github.com/Azure/ARO-HCP/pull/6080) implementing alerts around KAS availability & latency. 

### What

<!-- Briefly describe what this PR does -->
Adds 7 new recording rules to `HCPkasRecord-prometheusRule-latency.yaml`:

**ADR Latency column — Fast tier short window:**
- `kas:apiserver_request_latency:sli_ratio:rate_avg_5m` — fills the gap blocking the Fast burn-rate tier alert

**ADR Traffic column:**
- `kas:apiserver_request_terminations:rate5m` — request termination rate (leading indicator of KAS overload)

**ADR Saturation column:**
- `kas:apiserver_inflight_requests:avg_5m` — smoothed in-flight request gauge by requestKind

**ADR Latency — triage decomposition (per-category SLI breakdowns):**
- `kas:apiserver_request_latency:sli_ratio_mutating:rate5m` — mutating requests (1s threshold)
- `kas:apiserver_request_latency:sli_ratio_reads_resource:rate5m` — resource-scope reads (1s threshold)
- `kas:apiserver_request_latency:sli_ratio_reads_namespace:rate5m` — namespace-scope reads (5s threshold)
- `kas:apiserver_request_latency:sli_ratio_reads_cluster:rate5m` — cluster-scope reads (30s threshold)

**[ADR-001](https://redhat.atlassian.net/browse/ADR-001) alignment**

These rules are the data layer for [ADR-001 (ARO HCP Alerting Recommendation for SRE)](https://github.com/openshift-online/architecture/pull/79). KAS is Sev 2 (SLA-bound surface, 99.95% SLO). The burn-rate tier mapping:

| Tier | Long Window | Short Window | Rules |
|---|---|---|---|
| Fast (14.4x) | 1h | 5m | `rate_avg_1h` (existing) + `rate_avg_5m` (**new**) |
| Medium (6x) | 6h | 30m | `rate_avg_6h` + `rate_avg_30m` (both existing) |
| Slow (1x) | 3d | — | `rate_avg_3d` (existing) |

Alert wiring (`userJourneyKubeApiserverLatency{1h5m,6h30m,3d}`), runbooks, and routing belong to the downstream Latency Alerting and TSG story.

### Why

<!-- Briefly explain why this change is needed -->
The existing KAS latency recording rules are missing the 5-minute short window required by [ADR-001](https://redhat.atlassian.net/browse/ADR-001)'s Fast burn-rate tier (`1h/5m`), and lack the Traffic, Saturation, and per-category triage decomposition rules needed to complete the ADR coverage matrix for kube-apiserver.

Without these rules, we cannot wire up `userJourneyKubeApiserverLatency1h5m` (Fast tier alert) and SREs have no pre-built decomposition to answer "which verb/scope category is slow?" during a latency budget burn.

### Testing

- [x] 7 new unit tests (tests 5-11) covering all new rules
- [x] Namespace filtering validated (non-`ocm-*` excluded)
- [x] Subresource exclusion validated (proxy/attach/log/exec/portforward)
- [x] Value correctness with exact binary fractions to avoid float comparison issues
- [x] `make -C tooling/prometheus-rules run-recording-rules-hcps` — all pass
- [x] `cd observability && make recording-rules` — bicep regenerated
- [ ] Create a hcp cluster in dev env to ensure existing metrics are flowing for ocm-* namespaces
- [ ] Verify that new metrics are coming in grafana for dev env
- [ ] Post-merge: verify rules produce data in INT with HCP traffic

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
